### PR TITLE
Fix for Debian package building

### DIFF
--- a/extras/debian/rules
+++ b/extras/debian/rules
@@ -34,7 +34,6 @@ binary-install/foreman::
 	chmod a-x debian/foreman/usr/share/foreman/vendor/rails/railties/lib/commands/generate.rb
 	chmod a-x debian/foreman/usr/share/foreman/vendor/rails/activerecord/test/cases/counter_cache_test.rb
 	chmod a-x debian/foreman/usr/share/foreman/vendor/rails/activesupport/lib/active_support/vendor/i18n-0.4.1/i18n.rb
-	chmod a-x debian/foreman/var/lib/foreman/public/stylesheets/grid.css
 	# Remove license files
 	rm -f debian/foreman/usr/share/foreman/vendor/gems/googlecharts-1.3.6/License.txt
 	rm -f debian/foreman/usr/share/foreman/vendor/gems/rack-1.1.0/COPYING


### PR DESCRIPTION
Removed `chmod` on grid.css in debian/rules file since this file doesn't exist anymore
