### PR TITLE
(#402) Add noops to metric handling, and provide pending hosts for dashb...

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -20,11 +20,12 @@ class DashboardController < ApplicationController
       :active_hosts      => @hosts.recent.with_changes.count,
       :ok_hosts          => @hosts.recent.successful.count,
       :out_of_sync_hosts => @hosts.out_of_sync.count,
-      :disabled_hosts    => @hosts.alerts_disabled.count
+      :disabled_hosts    => @hosts.alerts_disabled.count,
+      :pending_hosts     => @hosts.recent.with_pending_changes.count,
     }
     @report[:good_hosts] = @report[:ok_hosts] + @report[:active_hosts]
     @report[:percentage] = (@report[:good_hosts] == 0 or @report[:total_hosts] == 0) ? 0 : @report[:good_hosts]*100 / @report[:total_hosts]
-    @report[:reports_missing] = @report[:total_hosts] - @report[:good_hosts] - @report[:bad_hosts] - @report[:out_of_sync_hosts]
+    @report[:reports_missing] = @report[:total_hosts] - @report[:good_hosts] - @report[:bad_hosts] - @report[:out_of_sync_hosts] - @report[:pending_hosts]
   end
 
 end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -349,6 +349,11 @@ class HostsController < ApplicationController
     index "Active Hosts"
   end
 
+  def pending
+    params[:search]="last_report > \"#{Setting[:puppet_interval] + 5} minutes ago\" and (status.pending > 0)"
+    index "Pending Hosts"
+  end
+
   def out_of_sync
     params[:search]="last_report < \"#{Setting[:puppet_interval] + 5} minutes ago\" and status.enabled = true"
     index "Hosts which didn't run puppet in the last #{Setting[:puppet_interval] + 5} minutes"

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -18,6 +18,7 @@ module DashboardHelper
     data = [[:Active,    report[:active_hosts]],
             [:Error, report[:bad_hosts]],
             [:OK, report[:ok_hosts]],
+            [:'Pending changes', report[:pending_hosts]],
             [:'Out of sync', report[:out_of_sync_hosts]],
             [:'No report', report[:reports_missing]],
             [:'Notification disabled', report[:disabled_hosts]]]

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -46,6 +46,10 @@ module HostsHelper
       label = "Active"
       style = "notice"
       short = "A"
+    elsif record.pending?
+      label = "Pending"
+      style = "warning"
+      short = "P"
     else
       label = "No changes"
       style = "success"

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -63,7 +63,15 @@ class Host < Puppet::Rails::Host
      ((puppet_status >> #{BIT_NUM*METRIC.index("restarted")} & #{MAX}) = 0)"
   }
 
-  named_scope :successful, lambda { without_changes.without_error.scope(:find)}
+  named_scope :with_pending_changes, { :conditions => "(puppet_status > 0) and
+    ((puppet_status >> #{BIT_NUM*METRIC.index("pending")} & #{MAX}) != 0)"
+  }
+
+  named_scope :without_pending_changes, { :conditions =>
+    "((puppet_status >> #{BIT_NUM*METRIC.index("pending")} & #{MAX}) = 0)"
+  }
+
+  named_scope :successful, lambda { without_changes.without_error.without_pending_changes.scope(:find)}
 
   named_scope :alerts_disabled, {:conditions => ["enabled = ?", false] }
 

--- a/app/models/hostext/search.rb
+++ b/app/models/hostext/search.rb
@@ -15,6 +15,7 @@ module Hostext
         scoped_search :on => :puppet_status, :offset => Report::METRIC.index("failed"),          :word_size => Report::BIT_NUM, :rename => :'status.failed'
         scoped_search :on => :puppet_status, :offset => Report::METRIC.index("failed_restarts"), :word_size => Report::BIT_NUM, :rename => :'status.failed_restarts'
         scoped_search :on => :puppet_status, :offset => Report::METRIC.index("skipped"),         :word_size => Report::BIT_NUM, :rename => :'status.skipped'
+        scoped_search :on => :puppet_status, :offset => Report::METRIC.index("pending"),           :word_size => Report::BIT_NUM, :rename => :'status.pending'
 
         scoped_search :in => :model,       :on => :name,    :complete_value => true, :rename => :model
         scoped_search :in => :hostgroup,   :on => :name,    :complete_value => true, :rename => :hostgroup

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,6 +20,7 @@ class Report < ActiveRecord::Base
   scoped_search :on => :status, :offset => METRIC.index("failed"),          :word_size => BIT_NUM, :rename => :failed
   scoped_search :on => :status, :offset => METRIC.index("failed_restarts"), :word_size => BIT_NUM, :rename => :failed_restarts
   scoped_search :on => :status, :offset => METRIC.index("skipped"),         :word_size => BIT_NUM, :rename => :skipped
+  scoped_search :on => :status, :offset => METRIC.index("pending"),         :word_size => BIT_NUM, :rename => :pending
 
   # returns recent reports
   named_scope :recent, lambda { |*args| {:conditions => ["reported_at > ?", (args.first || 1.day.ago)]} }
@@ -287,6 +288,8 @@ class Report < ActiveRecord::Base
       else
         { :type => "resources", :name => "failed_to_restart"}
       end
+    when "pending"
+      { :type => "events", :name => "noop" }
     else
       { :type => "resources", :name => metric}
     end

--- a/app/models/report_common.rb
+++ b/app/models/report_common.rb
@@ -1,5 +1,5 @@
 module ReportCommon
-  METRIC = %w[applied restarted failed failed_restarts skipped]
+  METRIC = %w[applied restarted failed failed_restarts skipped pending]
   BIT_NUM = 6
   MAX = (1 << BIT_NUM) -1 # maximum value per metric
 
@@ -30,6 +30,11 @@ module ReportCommon
   # returns true if total action metrics are > 0
   def changes?
     %w[applied restarted].sum {|f| status f} > 0
+  end
+
+  # returns true if there are any changes pending
+  def pending?
+    pending > 0
   end
 
   #returns metrics

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -11,22 +11,26 @@
       <td><%= @report[:active_hosts] %> </td>
     </tr>
     <tr class="even">
+      <td><%= link_to 'Hosts that had pending changes', 'hosts?search=status.pending+>+0' %></td>
+      <td><%= @report[:pending_hosts] %> </td>
+    </tr>
+    <tr class="odd">
       <td><%= link_to 'Hosts in Error State', errors_hosts_path %></td>
       <td><%= @report[:bad_hosts] %> </td>
     </tr>
-    <tr class="odd">
+    <tr class="even">
       <td><%=link_to "Good Host Reports in the last #{Setting[:puppet_interval]}  minutes", "hosts?search=last_report+>+'#{Setting[:puppet_interval]} minutes ago'+and+status.enabled+%3D+true+and+status.interesting++%3D+false"%></td>
       <td> <%= "#{@report[:good_hosts]} / #{@report[:total_hosts]}" %> hosts (<%= @report[:percentage] %>%)</td>
     </tr>
-    <tr class="even">
+    <tr class="odd">
       <td><%= link_to 'Out Of Sync Hosts', out_of_sync_hosts_path %></td>
       <td><%= @report[:out_of_sync_hosts] %> </td>
     </tr>
-    <tr class="odd">
+    <tr class="even">
       <td><%= link_to 'Hosts With No Reports', 'hosts?search=not+has+last_report' %></td>
       <td><%= @report[:reports_missing] %> </td>
     </tr>
-    <tr class="even">
+    <tr class="odd">
       <td><%= link_to 'Hosts With Alerts Disabled', disabled_hosts_path %></td>
       <td><%= @report[:disabled_hosts] %> </td>
     </tr>

--- a/app/views/reports/_list.html.erb
+++ b/app/views/reports/_list.html.erb
@@ -9,6 +9,7 @@
     <th class="small"><%= sort :failed %></th>
     <th class="small"><%= sort :failed_restarts, :as => "Restart<br>Failures" %></th>
     <th class="small"><%= sort :skipped %></th>
+    <th class="small"><%= sort :pending %></th>
     <th class="small"></th>
   </tr>
   <% for report in @reports %>
@@ -22,6 +23,7 @@
       <td><%= report_event_column(report.failed, "important") %></td>
       <td><%= report_event_column(report.failed_restarts, "warning") %></td>
       <td><%= report_event_column(report.skipped, "notice") %></td>
+      <td><%= report_event_column(report.pending, "notice") %></td>
       <td align="right">
         <%= display_link_if_authorized "Destroy", hash_for_report_path(:id => report.id, :auth_action => :destroy), :confirm => "Delete report for #{report.host.name}?", :method => :delete %>
       </td>

--- a/test/fixtures/report-2.6.12-noops.yaml
+++ b/test/fixtures/report-2.6.12-noops.yaml
@@ -1,0 +1,627 @@
+--- !ruby/object:Puppet::Transaction::Report
+  configuration_version: 1321590922
+  host: puppetmaster1.vm
+  kind: apply
+  logs: 
+    - !ruby/object:Puppet::Util::Log
+      level: !ruby/sym info
+      message: Caching catalog for puppetmaster1.vm
+      source: Puppet
+      tags: 
+        - info
+      time: 2011-11-18 04:35:22.791391 +00:00
+    - !ruby/object:Puppet::Util::Log
+      level: !ruby/sym info
+      message: Applying configuration version '1321590922'
+      source: Puppet
+      tags: 
+        - info
+      time: 2011-11-18 04:35:22.879717 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 14
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file8]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.889956 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 8
+      message: "current_value {md5}980fe9e4399ee8b8f553c2d3dceb0cda, should be {md5}383de0ff6f5a31731dbd27a7278bbccf (noop)"
+      source: "/Stage[main]//File[/tmp/file2]/content"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.923368 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 11
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file5]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.924941 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 13
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file7]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.926587 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 12
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file6]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.927997 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 16
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file10]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.929859 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 9
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file3]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.933014 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 10
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file4]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.935271 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 15
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file9]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.936869 +00:00
+    - !ruby/object:Puppet::Util::Log
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      line: 7
+      message: "current_value absent, should be file (noop)"
+      source: "/Stage[main]//File[/tmp/file1]/ensure"
+      tags: 
+        - notice
+        - file
+        - class
+      time: 2011-11-18 04:35:22.939037 +00:00
+    - !ruby/object:Puppet::Util::Log
+      level: !ruby/sym notice
+      message: Finished catalog run in 0.07 seconds
+      source: Puppet
+      tags: 
+        - notice
+      time: 2011-11-18 04:35:22.943074 +00:00
+  metrics: 
+    time: !ruby/object:Puppet::Util::Metric
+      label: Time
+      name: time
+      values: 
+        - 
+          - config_retrieval
+          - Config retrieval
+          - 0.845368146896362
+        - 
+          - service
+          - Service
+          - 0.007622
+        - 
+          - schedule
+          - Schedule
+          - 0.001103
+        - 
+          - total
+          - Total
+          - 0.897144146896362
+        - 
+          - file
+          - File
+          - 0.042869
+        - 
+          - filebucket
+          - Filebucket
+          - 0.000182
+    resources: !ruby/object:Puppet::Util::Metric
+      label: Resources
+      name: resources
+      values: 
+        - 
+          - total
+          - Total
+          - 18
+        - 
+          - out_of_sync
+          - Out of sync
+          - 10
+    events: !ruby/object:Puppet::Util::Metric
+      label: Events
+      name: events
+      values: 
+        - 
+          - noop
+          - Noop
+          - 10
+        - 
+          - total
+          - Total
+          - 10
+    changes: !ruby/object:Puppet::Util::Metric
+      label: Changes
+      name: changes
+      values: 
+        - 
+          - total
+          - Total
+          - 0
+  puppet_version: 2.6.12
+  report_format: 2
+  resource_statuses: 
+    "Schedule[monthly]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000211
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[monthly]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - monthly
+      time: 2011-11-18 04:35:22.931521 +00:00
+      title: monthly
+    "Filebucket[puppet]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000182
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Filebucket[puppet]"
+      resource_type: Filebucket
+      skipped: false
+      tags: 
+        - filebucket
+        - puppet
+      time: 2011-11-18 04:35:22.937584 +00:00
+      title: puppet
+    "Schedule[never]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000173
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[never]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - never
+      time: 2011-11-18 04:35:22.930444 +00:00
+      title: never
+    "File[/tmp/file9]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.001004
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.936798 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 15
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file9]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.936280 +00:00
+      title: /tmp/file9
+    "Schedule[weekly]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000236
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[weekly]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - weekly
+      time: 2011-11-18 04:35:22.880603 +00:00
+      title: weekly
+    "File[/tmp/file8]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.001106
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.889839 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 14
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file8]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.889206 +00:00
+      title: /tmp/file8
+    "File[/tmp/file7]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.001081
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.926516 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 13
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file7]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.926023 +00:00
+      title: /tmp/file7
+    "File[/tmp/file6]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000811
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.927928 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 12
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file6]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.927444 +00:00
+      title: /tmp/file6
+    "File[/tmp/file5]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.001284
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.924873 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 11
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file5]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.924291 +00:00
+      title: /tmp/file5
+    "Service[crond]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.007622
+      events: []
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 18
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Service[crond]"
+      resource_type: Service
+      skipped: false
+      tags: 
+        - service
+        - crond
+        - class
+      time: 2011-11-18 04:35:22.881104 +00:00
+      title: crond
+    "File[/tmp/file4]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.00112
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.935187 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 10
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file4]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.934516 +00:00
+      title: /tmp/file4
+    "File[/tmp/file3]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.001422
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.932902 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 9
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file3]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.932045 +00:00
+      title: /tmp/file3
+    "Schedule[puppet]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000151
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[puppet]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - puppet
+      time: 2011-11-18 04:35:22.938011 +00:00
+      title: puppet
+    "File[/tmp/file2]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.033203
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: "{md5}383de0ff6f5a31731dbd27a7278bbccf"
+          historical_value: 
+          message: "current_value {md5}980fe9e4399ee8b8f553c2d3dceb0cda, should be {md5}383de0ff6f5a31731dbd27a7278bbccf (noop)"
+          name: !ruby/sym content_changed
+          previous_value: "{md5}980fe9e4399ee8b8f553c2d3dceb0cda"
+          property: content
+          status: noop
+          time: 2011-11-18 04:35:22.923221 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 8
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file2]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.890638 +00:00
+      title: /tmp/file2
+    "Schedule[hourly]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000176
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[hourly]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - hourly
+      time: 2011-11-18 04:35:22.928808 +00:00
+      title: hourly
+    "File[/tmp/file10]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000869
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.929791 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 16
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file10]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.929280 +00:00
+      title: /tmp/file10
+    "Schedule[daily]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000156
+      events: []
+      failed: false
+      file: 
+      line: 
+      out_of_sync: false
+      out_of_sync_count: 0
+      resource: "Schedule[daily]"
+      resource_type: Schedule
+      skipped: false
+      tags: 
+        - schedule
+        - daily
+      time: 2011-11-18 04:35:22.930849 +00:00
+      title: daily
+    "File[/tmp/file1]": !ruby/object:Puppet::Resource::Status
+      change_count: 0
+      changed: false
+      evaluation_time: 0.000969
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          desired_value: !ruby/sym file
+          historical_value: 
+          message: "current_value absent, should be file (noop)"
+          name: !ruby/sym file_created
+          previous_value: !ruby/sym absent
+          property: ensure
+          status: noop
+          time: 2011-11-18 04:35:22.938972 +00:00
+      failed: false
+      file: /etc/puppet/manifests/site.pp
+      line: 7
+      out_of_sync: true
+      out_of_sync_count: 1
+      resource: "File[/tmp/file1]"
+      resource_type: File
+      skipped: false
+      tags: 
+        - file
+        - class
+      time: 2011-11-18 04:35:22.938529 +00:00
+      title: /tmp/file1
+  status: unchanged
+  time: 2011-11-18 04:35:21.413028 +00:00

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -427,6 +427,12 @@ class HostsControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
+  test "should get pending" do
+    get :pending, {}, set_session_user
+    assert_response :success
+    assert_template 'index'
+  end
+
   test "should get disabled hosts" do
     get :disabled, {}, set_session_user
     assert_response :success

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -7,18 +7,19 @@ class ReportTest < ActiveSupport::TestCase
   end
 
   test "it should not change host report status when we have skipped reports but there are no log entries" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 1}
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 1, "pending" => 0}
     assert_equal @r.failed, 0
   end
 
   test "it should save metrics as bits in status integer" do
-    @r.status={"applied" => 92, "restarted" => 300, "failed" => 4, "failed_restarts" => 12, "skipped" => 3}
+    @r.status={"applied" => 92, "restarted" => 300, "failed" => 4, "failed_restarts" => 12, "skipped" => 3, "pending" => 4}
     @r.save
     assert_equal @r.applied, Report::MAX
     assert_equal @r.restarted, Report::MAX
     assert_equal @r.failed, 4
     assert_equal @r.failed_restarts, 12
     assert_equal @r.skipped, 3
+    assert_equal @r.pending, 4
   end
 
   test "it should keep applied metrics" do
@@ -39,57 +40,69 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal 1, r.failed
   end
 
+  test "it should support noops/pending in 2.6.12 reports" do
+    return true if Facter.puppetversion < "2.6"
+    r=Report.import File.read(File.expand_path(File.dirname(__FILE__) + "/../fixtures/report-2.6.12-noops.yaml"))
+    assert_equal 10, r.pending
+  end
+
   test "it should true on error? if there were errors" do
-    @r.status={"applied" => 92, "restarted" => 300, "failed" => 4, "failed_restarts" => 12, "skipped" => 3}
+    @r.status={"applied" => 92, "restarted" => 300, "failed" => 4, "failed_restarts" => 12, "skipped" => 3, "pending" => 0}
     assert @r.error?
   end
 
   test "it should not be an error if there are only skips" do
-    @r.status={"applied" => 92, "restarted" => 300, "failed" => 0, "failed_restarts" => 0, "skipped" => 3}
+    @r.status={"applied" => 92, "restarted" => 300, "failed" => 0, "failed_restarts" => 0, "skipped" => 3, "pending" => 0}
     assert !@r.error?
   end
 
 
   test "it should false on error? if there were no errors" do
-    @r.status={"applied" => 92, "restarted" => 300, "failed" => 0, "failed_restarts" => 0, "skipped" => 0}
+    @r.status={"applied" => 92, "restarted" => 300, "failed" => 0, "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
     assert !@r.error?
   end
 
   test "with named scope should return our report with applied resources" do
-    @r.status={"applied" => 15, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 0}
+    @r.status={"applied" => 15, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
     @r.save
     assert Report.with("applied",14).include?(@r)
     assert Report.with("applied",15).include?(@r) == false
   end
 
   test "with named scope should return our report with restarted resources" do
-    @r.status={"applied" => 0, "restarted" => 5, "failed" => 0, "failed_restarts" => 0, "skipped" => 0}
+    @r.status={"applied" => 0, "restarted" => 5, "failed" => 0, "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
     @r.save
     assert Report.with("restarted").include?(@r)
   end
 
   test "with named scope should return our report with failed resources" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 9, "failed_restarts" => 0, "skipped" => 0}
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 9, "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
     @r.save
     assert Report.with("failed").include?(@r)
   end
 
   test "with named scope should return our report with failed_restarts resources" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 91, "skipped" => 0}
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 91, "skipped" => 0, "pending" => 0}
     @r.save
     assert Report.with("failed_restarts").include?(@r)
   end
 
   test "with named scope should return our report with skipped resources" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 8}
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 8, "pending" => 0}
     @r.save
     assert Report.with("skipped").include?(@r)
   end
 
   test "with named scope should return our report with skipped resources when other bits are also used" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 9, "failed_restarts" => 4, "skipped" => 8}
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 9, "failed_restarts" => 4, "skipped" => 8, "pending" => 3}
     @r.save
     assert Report.with("skipped").include?(@r)
+  end
+
+  test "with named scope should return our report with pending resources when other bits are also used" do
+    @r.status={"applied" => 0, "restarted" => 0, "failed" => 9, "failed_restarts" => 4, "skipped" => 8, "pending" => 3}
+    @r.save
+    assert Report.with("pending").include?(@r)
   end
 
   def setup_user operation


### PR DESCRIPTION
...oard views.

This change adds the ability to see noops in metric reports inside
foreman graphs, charts and lists. The business reason for this is to allow
users to run their puppet agents in noop mode, and see where nodes have
converged within the foreman dashboard and various foreman reports.

The status data was always stored in the database, we just had to modify
the views and model to get at it.

This change modifies the dashboard adding the new state 'pending' so it appears
in the pie graph, and as a report in the dashboard as well. This report is hyper-
linked to a report for viewing pending changes across all hosts.
