### PR TITLE
Foreman bug #1384 - model links

### DIFF
--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -15,7 +15,7 @@
       <td><%=link_to_if_authorized h(model.name), hash_for_edit_model_path(:id => model)%></td>
       <td><%=h(model.vendor_class)%></td>
       <td><%=h(model.hardware_model)%></td>
-      <td class="ra"><%= link_to_if model.hosts.any?, model.hosts.count, hosts_path(:search=>"model = #{model.name}") %></td>
+      <td class="ra"><%= link_to_if model.hosts.any?, model.hosts.count, hosts_path(:search=>"model = \"#{model.name}\"") %></td>
       <td class="ra">
         <%= display_link_if_authorized "Delete", hash_for_model_path(:id => model, :auth_action => :destroy), :confirm => "Delete #{model.name}?", :method => :delete %>
       </td>


### PR DESCRIPTION
Clicking the number in the Hosts column on the Hardware Models List
(http://foreman/models) will take you to a search for all the matching
models, however, a model such as "PowerEdge R310" will not match because
the search links you to model = PowerEdge R310, without the necessary
quotes.
