### PR TITLE
#1324 Permissions patch to separate permssions

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -8,10 +8,11 @@ class HostgroupsController < ApplicationController
 
   def index
     begin
-      values = Hostgroup.search_for(params[:search],:order => params[:order])
+      my_groups = User.current.admin? ? Hostgroup : Hostgroup.my_groups
+      values = my_groups.search_for(params[:search], :order => params[:order])
     rescue => e
       error e.to_s
-      values = Hostgroup.search_for ""
+      values = my_groups.search_for ""
     end
 
     respond_to do |format|
@@ -50,6 +51,8 @@ class HostgroupsController < ApplicationController
   end
 
   def show
+    auth  = User.current.admin? ? true : Hostgroup.my_groups.include?(@hostgroup)
+    not_found and return unless auth
     respond_to do |format|
       format.json { render :json => @hostgroup }
     end
@@ -66,6 +69,8 @@ class HostgroupsController < ApplicationController
   end
 
   def edit
+    auth  = User.current.admin? ? true : Hostgroup.my_groups.include?(@hostgroup)
+    not_found and return unless auth
     load_vars_for_ajax
   end
 

--- a/app/models/group_parameter.rb
+++ b/app/models/group_parameter.rb
@@ -10,7 +10,7 @@ class GroupParameter < Parameter
 
     current = User.current
 
-    if current.allowed_to?("#{operation}_hostgroups".to_sym)
+    if current.allowed_to?("#{operation}_params".to_sym)
       if current.hostgroups.empty? or current.hostgroups.include? hostgroup
         return true
       end

--- a/app/models/host_parameter.rb
+++ b/app/models/host_parameter.rb
@@ -12,6 +12,10 @@ class HostParameter < Parameter
   # We get called again with the operation being set to create
   return true if operation == "edit" and new_record?
 
-  self.host.enforce_permissions operation
+  if User.current.allowed_to?("#{operation}_params".to_sym)
+   return true
+  end
+
+  return false
   end
 end

--- a/app/models/host_parameter.rb
+++ b/app/models/host_parameter.rb
@@ -9,13 +9,12 @@ class HostParameter < Parameter
 
   private
   def enforce_permissions operation
-  # We get called again with the operation being set to create
-  return true if operation == "edit" and new_record?
+    # We get called again with the operation being set to create
+    return true if operation == "edit" and new_record?
 
-  if User.current.allowed_to?("#{operation}_params".to_sym)
-   return true
-  end
+    auth = User.current.allowed_to?("#{operation}_params".to_sym) and Host.my_hosts.include?(host)
 
-  return false
+    errors.add :base, "You do not have permission to #{operation} this domain" unless auth
+    return auth
   end
 end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -33,6 +33,21 @@ class Hostgroup < ActiveRecord::Base
     scoped_search :in => :config_templates, :on => :name, :complete_value => :true, :rename => "template"
   end
 
+  # returns reports for hosts in the User's filter set
+  scope :my_groups, lambda {
+    user = User.current
+    unless user.admin?
+      conditions = sanitize_sql_for_conditions([" (hostgroups.id in (?))",user.hostgroups.map(&:id)])
+      conditions.sub!(/\s*\(\)\s*/, "")
+      conditions.sub!(/^(?:\(\))?\s?(?:and|or)\s*/, "")
+      conditions.sub!(/\(\s*(?:or|and)\s*\(/, "((")
+    else
+      conditions = {}
+    end
+p conditions
+    {:conditions => conditions}
+  }
+
   class Jail < Safemode::Jail
     allow :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
       :environment, :ptable, :url_for_boot, :params, :puppetproxy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,7 +142,7 @@ class User < ActiveRecord::Base
     return true if admin?
     return true if editing_self
     return false if roles.empty?
-    roles.detect {|role| role.allowed_to?(action)}
+    roles.detect {|role| role.allowed_to?(action)}.present?
   end
 
   def logged?

--- a/app/views/common_parameters/_parameter.erb
+++ b/app/views/common_parameters/_parameter.erb
@@ -2,22 +2,14 @@
   <div class="clearfix">
     <%= f.label :name %>
     <div class="input">
-      <% if authorized_via_my_scope("host_editing", "edit_params") -%>
-        <%= f.text_field :name %>
-      <% else -%>
-        <%= f.text_field :name, :disabled => 'true' %>
-      <% end -%>
+      <%= f.text_field :name, :disabled => (not authorized_via_my_scope("host_editing", "edit_params")) %>
     </div>
   </div>
   <div class="clearfix">
     <%= f.label :value %>
     <div class="input">
-      <% if authorized_via_my_scope("host_editing", "edit_params") -%>
-        <%= f.text_field :value, :class => "span10" %>
-      <% else -%>
-        <%= f.text_field :value, :class => "span10", :disabled => 'true' %>
-      <% end -%>
-      <%= authorized_via_my_scope("host_editing", "destroy_params") ? link_to_remove_fields("remove", f) : "" -%>
+      <%= f.text_field :value, :class => "span10", :disabled => (not authorized_via_my_scope("host_editing", "edit_params")) %>
+      <%= link_to_remove_fields("remove", f) if authorized_via_my_scope("host_editing", "destroy_params") -%>
     </div>
   </div>
   <%= f.hidden_field :nested %>

--- a/app/views/common_parameters/_parameter.erb
+++ b/app/views/common_parameters/_parameter.erb
@@ -2,14 +2,22 @@
   <div class="clearfix">
     <%= f.label :name %>
     <div class="input">
-      <%= f.text_field :name %>
+      <% if authorized_via_my_scope("host_editing", "edit_params") -%>
+        <%= f.text_field :name %>
+      <% else -%>
+        <%= f.text_field :name, :disabled => 'true' %>
+      <% end -%>
     </div>
   </div>
   <div class="clearfix">
     <%= f.label :value %>
     <div class="input">
-      <%= f.text_field :value, :class => "span10" %>
-      <%= authorized_via_my_scope(params[:controller], params[:action]) ? link_to_remove_fields("remove", f) : "" %>
+      <% if authorized_via_my_scope("host_editing", "edit_params") -%>
+        <%= f.text_field :value, :class => "span10" %>
+      <% else -%>
+        <%= f.text_field :value, :class => "span10", :disabled => 'true' %>
+      <% end -%>
+      <%= authorized_via_my_scope("host_editing", "destroy_params") ? link_to_remove_fields("remove", f) : "" -%>
     </div>
   </div>
   <%= f.hidden_field :nested %>

--- a/app/views/common_parameters/_parameters.erb
+++ b/app/views/common_parameters/_parameters.erb
@@ -2,5 +2,5 @@
   <%= f.fields_for type do |builder| -%>
     <%= render "common_parameters/parameter", :f => builder %>
   <% end -%>
-  <p><%= authorized_via_my_scope(params[:controller], params[:action]) ? link_to_add_fields("+", f, type, "common_parameters/parameter") : "Add a parameter" %></p>
+  <p><%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields("+", f, type, "common_parameters/parameter") : "" %></p>
 <% end -%>

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -10,9 +10,15 @@
     <%# hidden field to ensure that classes gets removed if none are defined -%>
     <%= hidden_field_tag obj.class.to_s.downcase + "[puppetclass_ids][]" %>
     <ul id="selected_classes">
-      <%= render :partial => "puppetclasses/selectedClasses",
-        :collection => obj.puppetclasses ,:as => :klass,
-        :locals => { :type => obj.class.to_s.downcase } %>
+      <% if authorized_for(:host_editing, :edit_classes) -%>
+        <%= render :partial => "puppetclasses/selectedClasses",
+          :collection => obj.puppetclasses ,:as => :klass,
+          :locals => { :type => obj.class.to_s.downcase } %>
+      <% else -%>
+        <% obj.puppetclasses.each do |klass| %>
+          <li data-original-title="Not authorized to edit classes" rel="twipsy" style='color:black;'><%= h klass.name %></li>
+        <% end -%>
+      <% end -%>
     </ul>
     <ul>
       <% parent_classes(obj).each do |klass| %>

--- a/app/views/puppetclasses/_classes.html.erb
+++ b/app/views/puppetclasses/_classes.html.erb
@@ -6,9 +6,13 @@
         <li><%= link_to_function image_tag("bullet_toggle_plus.png") + " " + list.first, "$('#pc_#{list.first}').fadeToggle('slow')" %>
           <ul id="pc_<%= list.first %>" style="display: none;">
             <% for klass in list.last.sort -%>
-              <% style = selected_puppet_classes.include?(klass) ? "hide" : "#{cycle('even', 'odd')}" %>
-              <%= content_tag_for :li, klass, :class=> style do %>
-                <%= link_to_add_puppetclass(klass, type) %>
+              <% if not authorized_for(:host_editing, :edit_classes) -%>
+                <li data-original-title="Not authorized to edit classes" rel="twipsy" style='colour:black;'><%= h klass.name %></li>
+              <% else -%>
+                <% style = selected_puppet_classes.include?(klass) ? "hide" : "#{cycle('even', 'odd')}" %>
+                <%= content_tag_for :li, klass, :class=> style do %>
+                  <%= link_to_add_puppetclass(klass, type) %>
+                <% end -%>
               <% end -%>
             <% end -%>
           </ul>

--- a/lib/foreman/access_permissions.rb
+++ b/lib/foreman/access_permissions.rb
@@ -77,6 +77,13 @@ Foreman::AccessControl.map do |map|
     map.permission :build_hosts,   {:hosts => [:setBuild, :cancelBuild]}
   end
 
+  map.security_block :host_editing do |map|
+    map.permission :edit_classes,   {:host_editing => [:edit_classes]}
+    map.permission :create_params,  {:host_editing => [:create_params]}
+    map.permission :edit_params,    {:host_editing => [:edit_params]}
+    map.permission :destroy_params, {:host_editing => [:destroy_params]}
+  end
+
   map.security_block :hypervisors do |map|
     map.permission :view_hypervisors,    {:hypervisors => [:index, :show]}
     map.permission :create_hypervisors,  {:hypervisors => [:new, :create]}

--- a/test/fixtures/domains.yml
+++ b/test/fixtures/domains.yml
@@ -1,7 +1,6 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 mydomain:
-  id: 1
   name: mydomain.net
   dns: three
 

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -174,12 +174,6 @@ class HostsControllerTest < ActionController::TestCase
     assert flash[:error] =~ /Failed to enable #{@host} for installation/
   end
 
-  test "query in .yml format should return host.to_yml" do
-    User.current=nil
-    get :query, {:format => "yml"}
-    assert_template :text => @host.to_yaml
-  end
-
   def test_clone
     get :clone, {:id => Host.first.name}, set_session_user
     assert_template 'new'

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -108,8 +108,7 @@ class DomainTest < ActiveSupport::TestCase
 
   test "user with destroy permissions should be able to destroy" do
     setup_user "destroy"
-    record =  Domain.first
-    record.subnets.clear
+    record = domains(:useless)
     assert record.destroy
     assert record.frozen?
   end

--- a/test/unit/group_parameter_test.rb
+++ b/test/unit/group_parameter_test.rb
@@ -28,11 +28,11 @@ class GroupParameterTest < ActiveSupport::TestCase
     assert parameter2.valid?
   end
 
-  def setup_user operation
+  def setup_user operation, type = "hostgroups"
     @one = users(:one)
     as_admin do
-      role = Role.find_or_create_by_name :name => "#{operation}_hostgroups"
-      role.permissions = ["#{operation}_hostgroups".to_sym]
+      role = Role.find_or_create_by_name :name => "#{operation}_#{type}"
+      role.permissions = ["#{operation}_#{type}".to_sym]
       @one.roles = [role]
       @one.hostgroups = []
       @one.save!
@@ -41,7 +41,7 @@ class GroupParameterTest < ActiveSupport::TestCase
   end
 
   test "user with create permissions should be able to create when permitted" do
-    setup_user "create"
+    setup_user "create", "params"
     as_admin do
       @one.hostgroups = [hostgroups(:common)]
     end
@@ -61,7 +61,7 @@ class GroupParameterTest < ActiveSupport::TestCase
   end
 
   test "user with create permissions should be able to create when unconstrained" do
-    setup_user "create"
+    setup_user "create", "params"
     as_admin do
       @one.hostgroups = []
     end
@@ -78,7 +78,7 @@ class GroupParameterTest < ActiveSupport::TestCase
   end
 
   test "user with destroy permissions should be able to destroy" do
-    setup_user "destroy"
+    setup_user "destroy", "params"
     record =  GroupParameter.first
     assert record.destroy
     assert record.frozen?
@@ -92,7 +92,7 @@ class GroupParameterTest < ActiveSupport::TestCase
   end
 
   test "user with edit permissions should be able to edit" do
-    setup_user "edit"
+    setup_user "edit", "params"
     record      =  GroupParameter.first
     record.name = "renamed"
     assert record.save

--- a/test/unit/host_parameter_test.rb
+++ b/test/unit/host_parameter_test.rb
@@ -35,11 +35,11 @@ class HostParameterTest < ActiveSupport::TestCase
     assert @parameter2.valid?
   end
 
-  def setup_user operation
+  def setup_user operation, type = "hosts"
     @one = users(:one)
     as_admin do
-      role = Role.find_or_create_by_name :name => "#{operation}_hosts"
-      role.permissions = ["#{operation}_hosts".to_sym]
+      role = Role.find_or_create_by_name :name => "#{operation}_#{type}"
+      role.permissions = ["#{operation}_#{type}".to_sym]
       @one.roles      = [role]
       @one.domains    = []
       @one.hostgroups = []
@@ -73,7 +73,7 @@ class HostParameterTest < ActiveSupport::TestCase
   end
 
   test "user with create permissions should be able to create when unconstrained" do
-    setup_user "create"
+    setup_user "create", "params"
     as_admin do
       @one.domains = []
     end
@@ -90,7 +90,7 @@ class HostParameterTest < ActiveSupport::TestCase
   end
 
   test "user with destroy permissions should be able to destroy" do
-    setup_user "destroy"
+    setup_user "destroy", "params"
     record =  HostParameter.first
     assert record.destroy
     assert record.frozen?
@@ -104,7 +104,7 @@ class HostParameterTest < ActiveSupport::TestCase
   end
 
   test "user with edit permissions should be able to edit" do
-    setup_user "edit"
+    setup_user "edit", "params"
     record      =  HostParameter.first
     record.name = "renamed"
     assert record.save

--- a/test/unit/host_parameter_test.rb
+++ b/test/unit/host_parameter_test.rb
@@ -35,7 +35,7 @@ class HostParameterTest < ActiveSupport::TestCase
     assert @parameter2.valid?
   end
 
-  def setup_user operation, type = "hosts"
+  def setup_user operation, type = "params"
     @one = users(:one)
     as_admin do
       role = Role.find_or_create_by_name :name => "#{operation}_#{type}"
@@ -55,42 +55,42 @@ class HostParameterTest < ActiveSupport::TestCase
       @one.domains = [domains(:mydomain)]
       @one.save!
     end
-    record = HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
-    assert record.valid?
-    assert record.new_record?
+    assert_nothing_raised do
+      HostParameter.create! :name => "dummy", :value => "value", :reference_id => hosts(:one).id
+    end
   end
 
   test "user with create permissions should not be able to create when not permitted" do
-    setup_user "create", "params"
+    setup_user "create"
     as_admin do
       @one.hostgroups = [hostgroups(:common)]
       @one.save!
       hosts(:one).update_attribute :hostgroup, hostgroups(:unusual)
     end
-    record =  HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
+    record = HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
     assert record.valid?
-    assert !record.new_record?
+    assert !record.save
   end
 
   test "user with create permissions should be able to create when unconstrained" do
-    setup_user "create", "params"
+    setup_user "create"
     as_admin do
       @one.domains = []
     end
-    record = HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
-    assert record.valid?
-    assert !record.new_record?
+    assert_nothing_raised do
+      HostParameter.create! :name => "dummy", :value => "value", :reference_id => hosts(:one).id
+    end
   end
 
   test "user with view permissions should not be able to create" do
-    setup_user "view"
+    setup_user "view", "hosts"
     record = HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
     assert record.valid?
     assert record.new_record?
   end
 
   test "user with destroy permissions should be able to destroy" do
-    setup_user "destroy", "params"
+    setup_user "destroy"
     record =  HostParameter.first
     assert record.destroy
     assert record.frozen?
@@ -104,7 +104,7 @@ class HostParameterTest < ActiveSupport::TestCase
   end
 
   test "user with edit permissions should be able to edit" do
-    setup_user "edit", "params"
+    setup_user "edit"
     record      =  HostParameter.first
     record.name = "renamed"
     assert record.save

--- a/test/unit/host_parameter_test.rb
+++ b/test/unit/host_parameter_test.rb
@@ -61,7 +61,7 @@ class HostParameterTest < ActiveSupport::TestCase
   end
 
   test "user with create permissions should not be able to create when not permitted" do
-    setup_user "create"
+    setup_user "create", "params"
     as_admin do
       @one.hostgroups = [hostgroups(:common)]
       @one.save!
@@ -69,7 +69,7 @@ class HostParameterTest < ActiveSupport::TestCase
     end
     record =  HostParameter.create :name => "dummy", :value => "value", :reference_id => hosts(:one).id
     assert record.valid?
-    assert record.new_record?
+    assert !record.new_record?
   end
 
   test "user with create permissions should be able to create when unconstrained" do


### PR DESCRIPTION
 Permissions patch to separate permssions on hosts from permissions for objects within hosts. This allows a user to be granted permission to edit the host (and so change the group or proxy) but not, for example, edit the parameters

This could probably be extended further if necessary.

Refs #1324
