### PR TITLE
Update for Foreman 0.4.1 Debian package

### DIFF
--- a/extras/debian/changelog
+++ b/extras/debian/changelog
@@ -1,3 +1,9 @@
+foreman (0.4.1-1) experimental; urgency=low
+
+  * New upstream release
+
+ -- Jochen Schalanda <jochen@schalanda.name>  Wed, 28 Dec 2011 13:56:00 +0100
+
 foreman (0.4-1) experimental; urgency=low
 
   * New upstream release


### PR DESCRIPTION
Trivial update for `debian/changelog` file for Foreman 0.4.1 release in the `0.4-stable` branch.
