### PR TITLE
Ruby debug ruby19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ end
 
 group :test, :development do
   # To use debugger
-  gem 'ruby-debug'
+  gem "ruby-debug", :platforms => :ruby_18
+  gem "ruby-debug19", :platforms => :ruby_19
   gem 'mocha'
   gem 'shoulda'
   gem 'rr'


### PR DESCRIPTION
Added conditional gem dependency declaration for `ruby-debug` and `ruby-debug19`.

`ruby-debug` doesn't work with Ruby 1.9 since it depends on `linecache` which depends on `rbx-require-relative` which requires Ruby 1.8.7.

This commit changes `Gemfile` so that in case of a running Ruby 1.8 Bundler will install `ruby-debug` like before and in case of a running Ruby 1.9 it will install `ruby-debug19` (which depends on `linecache19` which works on that Ruby version).
