### PR TITLE
Prefer mysql2 gem for mysql group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :sqlite do
 end
 
 group :mysql do
-  gem 'mysql'
+  gem 'mysql2'
 end
 
 group :postgresql do


### PR DESCRIPTION
mysql2 is a better driver and fully supported under rails 3.
