### PR TITLE
Fixes #1439 - Foreman would only allow you select puppetmasters that had...

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -25,7 +25,7 @@
           :help_inline => image_tag("spinner.gif", :id => "indicator1", :style => "display:none;")
       } %>
       <%= select_f f, :environment_id, Environment.all, :id, :to_label, { :include_blank => true } %>
-      <%= select_f f, :puppetproxy_id,Feature.find_by_name("Puppet CA").smart_proxies, :id, :name,
+      <%= select_f f, :puppetproxy_id,Feature.find_by_name("Puppet").smart_proxies, :id, :name,
         { :include_blank => true},
         { :label => "Puppet Master Proxy"}
       %>


### PR DESCRIPTION
... the "Puppet CA" role in the smart proxy instead of "Puppet".
