### PR TITLE
Fix for #1595

### DIFF
--- a/app/views/compute_resources/form/_ec2.html.erb
+++ b/app/views/compute_resources/form/_ec2.html.erb
@@ -3,6 +3,6 @@
 
 <% regions = f.object.regions rescue [] %>
 <%= selectable_f(f, :region, regions, {}, {:label => 'Region', :disabled => regions.empty?,
-                 :help_inline => link_to_function(regions.empty? ? "Load Regions" : "Test Connection", "testConnection(this)", :class => "btn",
+                 :help_inline => link_to_function(regions.empty? ? "Load Regions" : "Test Connection", "testConnection(this)",
+                 :class => "btn + #{regions.empty? ? "" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
-

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -3,5 +3,6 @@
 <%= password_f f, :password %>
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
 <%= selectable_f(f, :uuid, datacenters, {}, {:label => 'Datacenter',
-                 :help_inline => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)", :class => "btn",
+                 :help_inline => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)",
+                 :class => "btn + #{datacenters.empty? ? "" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -3,5 +3,6 @@
 <%= password_f f, :password %>
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
 <%= selectable_f(f, :uuid, datacenters, {}, {:label => 'Datacenter',
-                 :help_inline => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)", :class => "btn",
+                 :help_inline => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)",
+                 :class => "btn + #{datacenters.empty? ? "" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>

--- a/lib/foreman/model/vmware.rb
+++ b/lib/foreman/model/vmware.rb
@@ -52,9 +52,7 @@ module Foreman::Model
         :provider                     => "vsphere",
         :vsphere_username             => user,
         :vsphere_password             => password,
-        :vsphere_server               => server,
-        :vsphere_expected_pubkey_hash => '7bb2a3f661aa96b036db266aaf550f800f5b2235daae356780756eb7469d03e9'
-
+        :vsphere_server               => server
       )
     end
 


### PR DESCRIPTION
This pull request contains a fix for http://theforeman.org/issues/1595.  This fix leaves behind an issue with ec2 (and probably also vmware and rhev) where the selected region is overwritten on each attempt to test the connection.  This is due to the fact that the entire form is replaced by the result of test connection.  This should probably either be changed to be a simple true/false json style response, or the returned HTML should include the pre-selected value for region.

This pull request also contains a change to lib/foreman/model/vmware.rb, removing the hardcoded hash for :vsphere_expected_pubkey_hash.  I noticed that fog presented a very clear error message explaining uses should create a ~/.fog file containing their expected pubkey hash for invalid ssl certs (probably self-signed certs).
