### PR TITLE
This is the fix for the Compute Resources menu item, so that it shows up even if you have libvirt disabled

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -22,9 +22,12 @@ module HomeHelper
 
     choices += [
       [:divider],
-      ['Compute Resources',      :compute_resources],
-      ['Hypervisors',            :hypervisors]
-    ] if SETTINGS[:libvirt]
+      ['Compute Resources',      :compute_resources]
+    ] if SETTINGS[:unattended]
+
+    choices += [
+      ['Hypervisors',            :hypervisor   
+    ] if SETTINGS[:libvirt] and SETTINGS[:unatttended]
 
     choices += [
       [:divider],

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -22,7 +22,7 @@ module HomeHelper
 
     choices += [
       [:divider],
-      ['Compute Resources',      :compute_resources],
+      ['Compute Resources',      :compute_resources]
     ] if SETTINGS[:unattended]
 
     choices += [

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -23,8 +23,11 @@ module HomeHelper
     choices += [
       [:divider],
       ['Compute Resources',      :compute_resources],
-      ['Hypervisors',            :hypervisors]
-    ] if SETTINGS[:libvirt]
+    ] if SETTINGS[:unattended]
+
+    choices += [
+      ['Hypervisors',            :hypervisor   
+    ] if SETTINGS[:libvirt] and SETTINGS[:unatttended]
 
     choices += [
       [:divider],


### PR DESCRIPTION
Feel free to squash.
