### PR TITLE
Finishing tweaks to dashboard statistics. References Bug #1617

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -22,7 +22,7 @@ class DashboardController < ApplicationController
       :active_hosts_ok           => @hosts.recent.with_changes.without_error.count,
       :active_hosts_ok_enabled   => @hosts.recent.with_changes.without_error.alerts_enabled.count,
       :ok_hosts                  => @hosts.recent.successful.count,
-      :ok_hosts_enabled          => @hosts.recent.successful.count,
+      :ok_hosts_enabled          => @hosts.recent.successful.alerts_enabled.count,
       :out_of_sync_hosts         => @hosts.out_of_sync.count,
       :out_of_sync_hosts_enabled => @hosts.out_of_sync.alerts_enabled.count,
       :disabled_hosts            => @hosts.alerts_disabled.count,

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -17,7 +17,7 @@ module DashboardHelper
   def render_overview report, options = {}
     data = [[:Active,    report[:active_hosts_ok_enabled]],
             [:Error, report[:bad_hosts_enabled]],
-            [:OK, report[:ok_hosts]],
+            [:OK, report[:ok_hosts_enabled]],
             [:'Pending changes', report[:pending_hosts_enabled]],
             [:'Out of sync', report[:out_of_sync_hosts_enabled]],
             [:'No report', report[:reports_missing]],

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,7 +15,7 @@
       <td><%= @report[:bad_hosts_enabled] %> </td>
     </tr>
     <tr>
-      <td><%=searchable_links "Good Host Reports in the last #{Setting[:puppet_interval]+5} minutes", "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0" %></td>
+      <td><%=searchable_links "Good Host Reports in the last #{Setting[:puppet_interval]+5} minutes", "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0" %></td>
       <td> <%= "#{@report[:ok_hosts_enabled]}  / #{@report[:total_hosts]}" %> hosts (<%= @report[:percentage] %>%)</td>
     </tr>
     <tr>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -16,7 +16,7 @@
     </tr>
     <tr>
       <td><%=searchable_links "Good Host Reports in the last #{Setting[:puppet_interval]+5} minutes", "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0" %></td>
-      <td> <%= "#{@report[:good_hosts_enabled] - @report[:active_hosts_ok_enabled]}  / #{@report[:total_hosts]}" %> hosts (<%= @report[:percentage] %>%)</td>
+      <td> <%= "#{@report[:ok_hosts_enabled]}  / #{@report[:total_hosts]}" %> hosts (<%= @report[:percentage] %>%)</td>
     </tr>
     <tr>
       <td><%= searchable_links 'Hosts that had pending changes', 'status.pending > 0 and status.enabled = true' %></td>


### PR DESCRIPTION
Changes all the "Good hosts" dashboard references so that they exclude "pending hosts", by referencing :ok_hosts_enabled. Also fixed the scope for ok_hosts_enabled, so that it excludes hosts with notification disabled.
