### PR TITLE
Fixes puppetclasses search with pg database

### DIFF
--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -151,7 +151,7 @@ class Puppetclass < ActiveRecord::Base
 
   def self.search_by_host(key, operator, value)
     conditions  = "hosts.name #{operator} '#{value_to_sql(operator, value)}'"
-    direct      = Puppetclass.all(:conditions => conditions, :joins => :hosts, :select => 'DISTINCT puppetclasses.id').map(&:id)
+    direct      = Puppetclass.all(:conditions => conditions, :joins => :hosts, :select => 'puppetclasses.id').map(&:id)
     indirect    = Hostgroup.all(:conditions => conditions, :joins => [:hosts,:puppetclasses], :select => 'DISTINCT puppetclasses.id').map(&:id)
     return {:conditions => "1=0"} if direct.blank? && indirect.blank?
 


### PR DESCRIPTION
The request is sorting the results on a field that isn't in the SELECT DISTINCT columns and pg doesn't like it.
Fixes #1607
