### PR TITLE
Send error messages through JSON instead of just {"errors":[]}

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -268,7 +268,7 @@ class ApplicationController < ActionController::Base
           return
         end
       end
-      format.json { render :json => {"errors" => hash[:error_msg]} , :status => hash[:json_code]}
+      format.json { render :json => {"errors" => hash[:object].errors.full_messages} , :status => hash[:json_code]}
     end
   end
 


### PR DESCRIPTION
curl http://foreman/hosts/machine.domain.net -X PUT -d '{"host":{"name":"machine.domain.net","id":119,"puppetclass_ids":["449"]}}'
In the log:
  SQL (11.1ms)  SELECT 1 FROM "puppetclasses" INNER JOIN "environments_puppetclasses" ON "puppetclasses".id = "environments_puppetclasses".puppetclass_id WHERE "puppetclasses"."id" = 449 AND ("environments_puppetclasses".environment_id = 1 ) ORDER BY LOWER(puppetclasses.name) LIMIT 1
  SQL (0.4ms)  ROLLBACK
  ...
  Operatingsystem Load (0.4ms)  SELECT "operatingsystems".\* FROM "operatingsystems" WHERE "operatingsystems"."id" = 1 ORDER BY LOWER(operatingsystems.name) LIMIT 1
Failed to save: Puppetclasses foo-dummy does not belong to the production environment
Completed 422 Unprocessable Entity in 456ms (Views: 1.8ms | ActiveRecord: 244.7ms)

Result before patch:
{"errors":[]}

Result after patch:
{"errors":["Puppetclasses foo-dummy does not belong to the production environment"]}  
