### PR TITLE
Fix mysql2 gem version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :mysql do
 end
 
 group :mysql2 do
-  gem 'mysql2'
+  gem 'mysql2', '< 0.3'
 end
 
 group :postgresql do


### PR DESCRIPTION
This is the error generated without the specificiation of '< 0.3'. 

``` ruby
Please install the mysql2 adapter: `gem install activerecord-mysql2-adapter` (no such file to load — active_record/connection_adapters/mysql2_adapter)
```

 Rails 3.1+ does not require this condition.
