### PR TITLE
Import improvements

### DIFF
--- a/lib/foreman/controller/environments.rb
+++ b/lib/foreman/controller/environments.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Environments
 
   def import_environments
     begin
-      @changed = Environment.importClasses params[:proxy]
+      @changed = Environment.importClasses(params[:proxy], params[:name])
     rescue => e
       if e.message =~ /puppet feature/i
         error "We did not find a foreman proxy that can provide the information, ensure that you have at least one Proxy with the puppet feature turned on."
@@ -14,11 +14,24 @@ module Foreman::Controller::Environments
       end
     end
 
-    if @changed["new"].size > 0 or @changed["obsolete"].size > 0
-      render "common/_puppetclasses_or_envs_changed"
-    else
-      notice "No changes to your environments detected"
-      redirect_to "/" + controller_path
+    respond_to do |format|
+      format.html do
+        if @changed["new"].size > 0 or @changed["obsolete"].size > 0
+          render "common/_puppetclasses_or_envs_changed"
+        else
+          notice "No changes to your environments detected"
+          redirect_to "/" + controller_path
+        end
+      end
+      format.json do
+        if not params[:batch]
+          process_error
+        else
+          changed = { :new => @changed["new"], :obsolete => @changed["obsolete"] } 
+          [:new, :obsolete].each { |kind| changed[kind].each_key { |k| @changed[kind.to_s][k] = @changed[kind.to_s][k].inspect } }
+          render :json => ::Environment.obsolete_and_new(changed)
+        end
+      end
     end
   end
 

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -57,14 +57,14 @@ namespace :puppet do
   namespace :import do
     desc "Update puppet environments and classes. Optional batch flag triggers run with no prompting"
     task :puppet_classes,  [:batch] => :environment do | t, args |
-      args.batch = args.batch == "true"
+      batch = args.batch == "true"
       # Evalute any changes that exist between the database of environments and puppetclasses and
       # the on-disk puppet installation
       begin
-        puts "Evaluating possible changes to your installation" unless args.batch
+        puts "Evaluating possible changes to your installation" unless batch
         changes = Environment.importClasses
       rescue => e
-        if args.batch
+        if batch
           Rails.logger.warn "Failed to refresh puppet classes: #{e}"
         else
           puts "Problems were detected during the evaluation phase"
@@ -77,9 +77,9 @@ namespace :puppet do
       end
 
       if changes["new"].empty? and changes["obsolete"].empty?
-        puts "No changes detected" unless args.batch
+        puts "No changes detected" unless batch
       else
-        unless args.batch
+        unless batch
           puts "Scheduled changes to your environment"
           puts "Create/update environments"
           for env, classes in changes["new"]
@@ -109,7 +109,7 @@ namespace :puppet do
         rescue => e
           errors = e.message + "\n" + e.backtrace.join("\n")
         end
-        unless args.batch
+        unless batch
           unless errors.empty?
             puts "Problems were detected during the execution phase"
             puts

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -56,13 +56,13 @@ namespace :puppet do
   end
   namespace :import do
     desc "Update puppet environments and classes. Optional batch flag triggers run with no prompting"
-    task :puppet_classes,  [:batch] => :environment do | t, args |
+    task :puppet_classes,  [:batch, :envname] => :environment do | t, args |
       batch = args.batch == "true"
       # Evalute any changes that exist between the database of environments and puppetclasses and
       # the on-disk puppet installation
       begin
         puts "Evaluating possible changes to your installation" unless batch
-        changes = Environment.importClasses
+        changes = Environment.importClasses args.envname
       rescue => e
         if batch
           Rails.logger.warn "Failed to refresh puppet classes: #{e}"


### PR DESCRIPTION
Task rake puppet:import:puppet_classes improved.
Batch argument fixed and new argument to only import one environment instead of everything (which can be really slow).
Fixed the import_environments REST call.
