### PR TITLE
fixes #1673 - Foreman doesn't work with ruby_parser 2.0.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'scoped_search', '>= 2.3.7'
 gem 'net-ldap'
 gem "safemode", "~> 1.0.1"
 
+# Previous versions collide with Environment model
+gem "ruby_parser", ">= 2.3.1"
+
 group :virt do
   gem "virt", ">= 0.2.1"
   gem "rbovirt", ">= 0.0.12"


### PR DESCRIPTION
Explicitly stating the version of ruby_parser that works with Foreman.
Otherwise you might get:

```
superclass mismatch for class Environment (TypeError)
```
