### PR TITLE
fixes #1678 - nested hostgroup selector for templates.

### DIFF
--- a/app/views/config_templates/_combination.html.erb
+++ b/app/views/config_templates/_combination.html.erb
@@ -1,5 +1,5 @@
 <div class="fields">
-  <%= select_f f, :hostgroup_id, Hostgroup.all, :id, :name, :include_blank => true %>
+  <%= select_f f, :hostgroup_id, Hostgroup.all, :id, :to_label, :include_blank => true %>
   <%= select_f f, :environment_id, Environment.all, :id, :name, {:include_blank => true},
     :help_inline => link_to_remove_fields("remove", f) %>
 </div>


### PR DESCRIPTION
Fix for http://theforeman.org/issues/1678  hostgroup selector for provision templates shows nested structure of hostgroups.
