### PR TITLE
Add puppet and facter as a dependency to a Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'http://rubygems.org'
 
 gem 'rails', '3.0.10'
+gem "puppet"
+gem "facter"
 gem "jquery-rails"
 gem 'json'
 gem 'rest-client', :require => 'rest_client'


### PR DESCRIPTION
Otherwise running foreman in RVM setup environment causes the packages not
being visible although they are installed.
