### PR TITLE
fixes #1702 Use https instead of git for fog gem checkout

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,4 +1,4 @@
 group :fog do
-  gem "fog", :git => "git://github.com/fog/fog.git"
+  gem "fog", :git => "https://github.com/fog/fog.git"
   #gem "fog", ">= 1.3.2"
 end


### PR DESCRIPTION
Simple change to use https instead of git protocol
