### PR TITLE
Add a field for the ec2 private IP address, so that we can send the buil...

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -180,6 +180,7 @@ module HostsHelper
     ]
     fields += [["Owner", host.owner]] if SETTINGS[:login]
     fields += [["Certificate Name", host.certname]] if Setting[:use_uuid_for_certificates]
+    fields += [["EC2 Internal IP", host.ec2_private_ip]] if (host.compute_resource_id.present? and host.provider == "EC2")
     fields
   end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -21,7 +21,7 @@ class Host < Puppet::Rails::Host
   class Jail < ::Safemode::Jail
     allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup, :url_for_boot,
       :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture, :model, :certname, :capabilities,
-      :provider
+      :provider, :ec2_private_ip
   end
 
   attr_reader :cached_host_params, :cached_lookup_keys_params

--- a/app/models/orchestration/compute.rb
+++ b/app/models/orchestration/compute.rb
@@ -90,7 +90,10 @@ module Orchestration::Compute
       attrs = compute_resource.provided_attributes
       if attrs.keys.include?(:ip)
         logger.info "waiting for instance to acquire ip address"
-        vm.wait_for { self.send(attrs[:ip]) }
+        vm.wait_for { 
+          self.send(attrs[:ip]) 
+          self.send(attrs[:ec2_private_ip])
+        }
       end
     rescue => e
       failure "Failed to get IP for #{name}: #{e}", e.backtrace

--- a/db/migrate/20120625221144_add_ec2_private_ip_to_hosts.rb
+++ b/db/migrate/20120625221144_add_ec2_private_ip_to_hosts.rb
@@ -1,0 +1,8 @@
+class AddEc2PrivateIpToHosts < ActiveRecord::Migration
+  def self.up
+    add_column :hosts, :ec2_private_ip, :string
+  end
+
+  def self.down
+    remove_column :hosts, :ec2_private_ip  end
+end

--- a/lib/foreman/model/ec2.rb
+++ b/lib/foreman/model/ec2.rb
@@ -11,7 +11,7 @@ module Foreman::Model
     end
 
     def provided_attributes
-      super.merge({ :ip => :public_ip_address })
+      super.merge({ :ip => :public_ip_address, :ec2_private_ip => :private_ip_address })
     end
 
     def self.model_name


### PR DESCRIPTION
Add a field for the ec2 private IP address, so that we can send the built message over the ec2 IP address as well as the public address.

And it is handy to have the private IP onscreen as well, in case facter doesn't get run...
