### PR TITLE
Stopping service when not running is considered success

### DIFF
--- a/extras/spec/foreman.init
+++ b/extras/spec/foreman.init
@@ -44,7 +44,7 @@ stop() {
         echo -n $"Foreman was not running.";
         failure $"Foreman was not running.";
         echo
-        return 1
+        return 0
     fi
     echo
     return $RETVAL


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Packaging/SysVInitScript#Exit_Codes_for_non-Status_Actions for explanation.

This causes issues when using puppet modules for installing Foreman without Passenger.
