### PR TITLE
fixes #1710 - Hosts json index function returns too much

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -627,8 +627,8 @@ class Host < Puppet::Rails::Host
     end
   end
 
-  def as_json(options={})
-    super(:methods => [:host_parameters])
+  def as_json(options={:methods => [:host_parameters]})
+    super(options)
   end
 
   # no need to store anything in the db if the password is our default


### PR DESCRIPTION
This will ensure that when anyone passes in a special options hash that the as_json in the hosts model actually processes the hash instead of redefining it.
