### PR TITLE
fixes #1710 - Hosts json index function returns too much

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -64,7 +64,7 @@ class HostsController < ApplicationController
         @report_summary = Report.summarise(@range.days.ago, @host)
       }
       format.yaml { render :text => params["rundeck"].nil? ? @host.info.to_yaml : @host.rundeck.to_yaml }
-      format.json { render :json => @host }
+      format.json { render :json => @host.to_json({:methods => [:host_parameters]}) }
     end
   end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -627,10 +627,6 @@ class Host < Puppet::Rails::Host
     end
   end
 
-  def as_json(options={})
-    super(:methods => [:host_parameters])
-  end
-
   # no need to store anything in the db if the password is our default
   def root_pass
     read_attribute(:root_pass) || hostgroup.try(:root_pass) || Setting[:root_pass]


### PR DESCRIPTION
Since the default show method indirectly called to_json with an options hash previously defined somewhere else in the controller I had to explicitly state I wanted the host parameters method included in json output. I also removed the as_json method since its no longer required.

By default when using format.json rails will pass in a options hash indirectly if not defined.
