### PR TITLE
Fixed migrations for mysql2

### DIFF
--- a/db/migrate/20101018120548_create_messages.rb
+++ b/db/migrate/20101018120548_create_messages.rb
@@ -3,7 +3,7 @@ class CreateMessages < ActiveRecord::Migration
     create_table :messages do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE messages ENGINE = MYISAM"
       execute "ALTER TABLE messages ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120548_create_messages.rb
+++ b/db/migrate/20101018120548_create_messages.rb
@@ -3,7 +3,7 @@ class CreateMessages < ActiveRecord::Migration
     create_table :messages do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE messages ENGINE = MYISAM"
       execute "ALTER TABLE messages ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120603_create_sources.rb
+++ b/db/migrate/20101018120603_create_sources.rb
@@ -3,7 +3,7 @@ class CreateSources < ActiveRecord::Migration
     create_table :sources do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE sources ENGINE = MYISAM"
       execute "ALTER TABLE sources ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120603_create_sources.rb
+++ b/db/migrate/20101018120603_create_sources.rb
@@ -3,7 +3,7 @@ class CreateSources < ActiveRecord::Migration
     create_table :sources do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE sources ENGINE = MYISAM"
       execute "ALTER TABLE sources ADD FULLTEXT (value)"
     else


### PR DESCRIPTION
Fixes migration issues with CreateMessages and CreateSources

the issue stems from the fact that there is a check to see if the adapter is mysql but not if it is mysql2 which causes mysql2 to fail:

==  CreateSources: migrating ==================================================
-- create_table(:sources)
   -> 0.0025s
-- add_index(:sources, :value)
rake aborted!
An error has occurred, all later migrations canceled:

Mysql2::Error: BLOB/TEXT column 'value' used in key specification without a key length: CREATE  INDEX `index_sources_on_value` ON `sources` (`value`)

Tasks: TOP => db:migrate
(See full trace by running task with --trace)

I considered using a regex to match mysql and mysql2 but I decided to take the simple route instead
