### PR TITLE
Fix for mysql2 migration issue

### DIFF
--- a/db/migrate/20090915030726_change_report_field_type_to_text.rb
+++ b/db/migrate/20090915030726_change_report_field_type_to_text.rb
@@ -1,12 +1,12 @@
 class ChangeReportFieldTypeToText < ActiveRecord::Migration
   def self.up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2" 
       execute "ALTER TABLE reports MODIFY log text;"
     end
   end
 
   def self.down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       change_column :reports, :log, :text, :limit => 50.kilobytes, :null => false
     end
   end

--- a/db/migrate/20100115021803_change_mysql_reports_column.rb
+++ b/db/migrate/20100115021803_change_mysql_reports_column.rb
@@ -1,12 +1,12 @@
 class ChangeMysqlReportsColumn < ActiveRecord::Migration
   def self.up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE reports MODIFY log mediumtext;"
     end
   end
 
   def self.down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE reports MODIFY log text;"
     end
   end

--- a/db/migrate/20100325142616_update_fact_names_and_values_to_bin.rb
+++ b/db/migrate/20100325142616_update_fact_names_and_values_to_bin.rb
@@ -1,13 +1,13 @@
 class UpdateFactNamesAndValuesToBin < ActiveRecord::Migration
   def self.up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_names MODIFY name varchar(255) COLLATE utf8_bin NOT NULL}
       execute %{ALTER TABLE fact_values MODIFY value varchar(255) COLLATE utf8_bin NOT NULL}
     end
   end
 
   def self.down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_names MODIFY name varchar(255)}
       execute %{ALTER TABLE fact_values MODIFY value varchar(255)}
     end

--- a/db/migrate/20101018120548_create_messages.rb
+++ b/db/migrate/20101018120548_create_messages.rb
@@ -3,7 +3,7 @@ class CreateMessages < ActiveRecord::Migration
     create_table :messages do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE messages ENGINE = MYISAM"
       execute "ALTER TABLE messages ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120548_create_messages.rb
+++ b/db/migrate/20101018120548_create_messages.rb
@@ -3,7 +3,7 @@ class CreateMessages < ActiveRecord::Migration
     create_table :messages do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE messages ENGINE = MYISAM"
       execute "ALTER TABLE messages ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120603_create_sources.rb
+++ b/db/migrate/20101018120603_create_sources.rb
@@ -3,7 +3,7 @@ class CreateSources < ActiveRecord::Migration
     create_table :sources do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE sources ENGINE = MYISAM"
       execute "ALTER TABLE sources ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120603_create_sources.rb
+++ b/db/migrate/20101018120603_create_sources.rb
@@ -3,7 +3,7 @@ class CreateSources < ActiveRecord::Migration
     create_table :sources do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE sources ENGINE = MYISAM"
       execute "ALTER TABLE sources ADD FULLTEXT (value)"
     else

--- a/db/migrate/20110321070954_revert_face_names_and_values_to_text_records.rb
+++ b/db/migrate/20110321070954_revert_face_names_and_values_to_text_records.rb
@@ -1,12 +1,12 @@
 class RevertFaceNamesAndValuesToTextRecords < ActiveRecord::Migration
   def self.up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE fact_values MODIFY value text COLLATE utf8_bin NOT NULL;"
     end
   end
 
   def self.down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_values MODIFY value varchar(255) COLLATE utf8_bin NOT NULL}
     end
   end


### PR DESCRIPTION
This time the right commit :(

```
RAILS_ENV=production bundle exec rake db:migrate
```

fails with :

```
<--- snip -->

==  CreateMessages: migrating =================================================
-- create_table(:messages)
```

   -> 0.0024s
    -- add_index(:messages, :value)
    rake aborted!
    An error has occurred, all later migrations canceled:

```
Mysql2::Error: BLOB/TEXT column 'value' used in key specification without a key length: CREATE  INDEX `index_messages_on_value` ON `messages` (`value`)

Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

also fails on CreateSources:

```
==  CreateSources: migrating ==================================================
-- create_table(:sources)
```

   -> 0.0025s
    -- add_index(:sources, :value)
    rake aborted!
    An error has occurred, all later migrations canceled:

```
Mysql2::Error: BLOB/TEXT column 'value' used in key specification without a key length: CREATE  INDEX `index_sources_on_value` ON `sources` (`value`)

Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```
