### PR TITLE
Api

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,13 @@ require File.expand_path('../../lib/core_extensions', __FILE__)
 
 module Foreman
   class Application < Rails::Application
+    # Setup additional routes by loading all routes file from routes directory
+    config.paths.config.routes.concat Dir[Rails.root.join("config/routes/*.rb")]
+
+    # Setup api routes by loading all routes file from routes/api directory
+    config.paths.config.routes.concat Dir[Rails.root.join("config/routes/api/*.rb")]
+
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,27 +278,6 @@ Foreman::Application.routes.draw do
 
   resources :tasks, :only => [:show]
 
-  #### API Namespace from here downwards ####
-
-  restapi
-
-  namespace :api, :defaults => {:format => 'json'} do
-    scope :module => :v1, :constraints => ApiConstraints.new(:version => 1, :default => true) do
-      resources :bookmarks, :except => [:new, :edit]
-      resources :architectures, :except => [:new, :edit]
-      resources :operatingsystems, :except => [:new, :edit] do
-        member do
-          get 'bootfiles'
-        end
-      end
-
-      match '/', :to => 'home#index'
-      match 'status', :to => 'home#status', :as => "status"
-    end
-#    scope module: :v2, constraints: ApiConstraints.new(version: 2, default: true) do
-#      resources :bookmarks
-#    end
-  end
 
  #Keep this line the last route
   match '*a', :to => 'errors#routing'

--- a/config/routes/api/restapidoc.rb
+++ b/config/routes/api/restapidoc.rb
@@ -1,0 +1,4 @@
+# config/routes/api/restapidoc.rb
+Rails.application.routes.draw do |map|
+  restapi
+end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -1,0 +1,20 @@
+# config/routes/api/v1.rb
+Rails.application.routes.draw do |map|
+
+  namespace :api, :defaults => {:format => 'json'} do
+    scope :module => :v1, :constraints => ApiConstraints.new(:version => 1, :default => true) do
+      resources :bookmarks, :except => [:new, :edit]
+      resources :architectures, :except => [:new, :edit]
+      resources :operatingsystems, :except => [:new, :edit] do
+        member do
+          get 'bootfiles'
+        end
+      end
+
+      match '/', :to => 'home#index'
+      match 'status', :to => 'home#status', :as => "status"
+    end
+#
+  end
+
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -1,0 +1,11 @@
+# config/routes/api/v1.rb
+
+Rails.application.routes.draw do |map|
+
+#  namespace :api, :defaults => {:format => 'json'} do
+#    scope :module => :v2, :constraints => ApiConstraints.new(:version => 2, :default => false) do
+#      resources :bookmarks, :except => [:new, :edit]
+#    end
+#  end
+
+end


### PR DESCRIPTION
This will split the api into multiple route files so the routes file becomes a little easier to read.  Future updates can also place additional route files under config/routes and config/routes/api.  I think this makes sense given that we will have a huge routes file after the new api namespace is completed.
