### PR TITLE
Add a default setting for livbirt networks

### DIFF
--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -3,7 +3,7 @@
     <%= selectable_f f, :bridge, networks.map(&:name), { }, :class => "span2", :label => "Network",
                      :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => 'remove network interface', :class => 'label label-important' }) %>
   <% else -%>
-    <%= text_f f, :bridge, :class => "span2", :label => "Network", :help_block => "your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)",
+    <%= text_f f, :bridge, :value => Setting[:default_libvirt_interface], :class => "span2", :label => "Network", :help_block => "your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)",
                :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => 'remove network interface', :class => 'label label-important' }) %>
   <% end -%>
 </div>

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -44,7 +44,8 @@ module Foreman
               set('ssl_priv_key', "SSL Private Key file that Foreman will use to communicate with its proxies", Puppet.settings[:hostprivkey]),
               set('manage_puppetca', "Should Foreman automate certificate signing upon provisioning new host", true),
               set('ignore_puppet_facts_for_provisioning', "Does not update ipaddress and MAC values from Puppet facts", false),
-              set('query_local_nameservers', "Should Foreman query the locally configured name server or the SOA/NS authorities", false)
+              set('query_local_nameservers', "Should Foreman query the locally configured name server or the SOA/NS authorities", false),
+              set('default_libvirt_interface', "Default interface to bind libvirt NICs to (default: virbr0)", "virbr0")
             ].each { |s| create s.update(:category => "Provisioning")}
 
             [


### PR DESCRIPTION
I'm fed up of typing "virbr1" 20 times a day, so this adds a Setting for the default network to attach libvirt NICs to. 
