### PR TITLE
Fixes #1789 - Parent hostgroup name is truncated when its sub-group is a...

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -2,7 +2,7 @@ module HostsAndHostgroupsHelper
   def hostgroup_name group, max_length = 1000
     return if group.blank?
     options = (group.to_s.size > max_length) ? {:'data-original-title'=> group.to_s, :rel=>'twipsy'} : {}
-    nesting = group.to_s.gsub(group.name, "")
+    nesting = group.to_s.gsub(/[^\/]+\/?$/, "")
     nesting = truncate(nesting, :length => max_length - group.name.size) if nesting.size > 0
     name =  truncate(group.name.to_s, :length => max_length - nesting.size)
     link_to_if_authorized(

--- a/test/unit/helpers/host_groups_helper_test.rb
+++ b/test/unit/helpers/host_groups_helper_test.rb
@@ -1,4 +1,14 @@
 require 'test_helper'
 
 class HostGroupsHelperTest < ActionView::TestCase
+  include ActionView::Helpers::TagHelper
+  include HostsAndHostgroupsHelper
+  include ApplicationHelper
+
+  test "should have the full string of the parent class if the child is a substring" do
+    test_group = Hostgroup.create(:name => "test/st")
+
+    assert hostgroup_name(test_group).include?("test/st")
+    assert !hostgroup_name(test_group).include?("te/st")
+  end
 end


### PR DESCRIPTION
Clearly this is extremely hard to parse if you're not a machine. Test inbound, so this isn't ready to get merged yet.
