### PR TITLE
fixes #1799 moved REMOTE_ADDR verification to settings

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -88,7 +88,7 @@ class UnattendedController < ApplicationController
     if params.has_key? "spoof"
       ip = params.delete("spoof")
       @spoof = true
-    elsif (ip = request.env['REMOTE_ADDR']) =~ /127.0.0/
+    elsif (ip = request.env['REMOTE_ADDR']) =~ Regexp.new(Setting[:remote_addr])
       ip = request.env["HTTP_X_FORWARDED_FOR"] unless request.env["HTTP_X_FORWARDED_FOR"].nil?
     end
 

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -44,7 +44,8 @@ module Foreman
               set('ssl_priv_key', "SSL Private Key file that Foreman will use to communicate with its proxies", Puppet.settings[:hostprivkey]),
               set('manage_puppetca', "Should Foreman automate certificate signing upon provisioning new host", true),
               set('ignore_puppet_facts_for_provisioning', "Does not update ipaddress and MAC values from Puppet facts", false),
-              set('query_local_nameservers', "Should Foreman query the locally configured name server or the SOA/NS authorities", false)
+              set('query_local_nameservers', "Should Foreman query the locally configured name server or the SOA/NS authorities", false),
+              set('remote_addr', "If Foreman is running behind Passenger or a remote loadbalancer, the ip should be set here", "127.0.0")
             ].each { |s| create s.update(:category => "Provisioning")}
 
             [

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -104,3 +104,8 @@ attributes21:
   category: Provisioning
   default: false
   description: "Should Foreman query the locally configured name server or the SOA/NS authorities"
+attributes22:
+  name: remote_addr
+  category: Provisioning
+  default: "127.0.0"
+  description: "If Foreman is running behind Passenger or a remote loadbalancer, the ip should be set here"

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -14,6 +14,13 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get a kickstart even if we are behind a loadbalancer" do
+    @request.env["HTTP_X_FORWARDED_FOR"] = hosts(:redhat).ip
+    @request.env["REMOTE_ADDR"] = "127.0.0.1"
+    get :kickstart
+    assert_response :success
+  end
+
   test "should get a preseed finish script" do
     @request.env["REMOTE_ADDR"] = hosts(:ubuntu).ip
     get :preseed_finish


### PR DESCRIPTION
Hello!

This is my first pull request on foreman, please be kind :-)

I moved the remote_addr header check to the settings page to make it configurable for remote loadbalancers.

Cheers
Hannes
