### PR TITLE
Authenticate API calls via REMOTE_USER too

### DIFF
--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -33,6 +33,7 @@ module Foreman
               set('email_replay_address', "The email reply address for emails that Foreman is sending", "Foreman-noreply@#{domain}"),
               set('entries_per_page', "The amount of records shown per page in Foreman", 20),
               set('authorize_login_delegation',"Authorize login delegation with REMOTE_USER environment variable",false),
+              set('authorize_login_delegation_api',"Authorize login delegation with REMOTE_USER environment variable for API calls too",false),
               set('idle_timeout',"Log out idle users after a certain number of minutes",60),
             ].each { |s| create s.update(:category => "General")}
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -109,3 +109,13 @@ attributes22:
   category: Provisioning
   default: "127.0.0"
   description: "If Foreman is running behind Passenger or a remote loadbalancer, the ip should be set here"
+attributes23:
+  name: authorize_login_delegation
+  category: General
+  default: false
+  description: "Authorize login delegation with REMOTE_USER environment variable"
+attributes24:
+  name: authorize_login_delegation_api
+  category: General
+  default: false
+  description: "Authorize login delegation with REMOTE_USER environment variable for API calls"


### PR DESCRIPTION
This patch allows API requests authentication via REMOTE_USER
only if authorize_login_delegation and authorize_login_delegation_api
are enabled.
