### PR TITLE
changed dashboard display of intervall to use time_ago_in_words function

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -380,7 +380,7 @@ class HostsController < ApplicationController
 
   def out_of_sync
     merge_search_filter("last_report < \"#{Setting[:puppet_interval] + 5} minutes ago\" and status.enabled = true")
-    index "Hosts which didn't run puppet in the last #{Setting[:puppet_interval] + 5} minutes"
+    index "Hosts which didn't run puppet in the last #{time_ago_in_words((Setting[:puppet_interval]+5).minutes.ago)}"
   end
 
   def disabled

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -27,7 +27,7 @@ module DashboardHelper
 
   def render_run_distribution data, options = {}
     bar_chart "run_distribution",
-              "Run Distribution in the last #{Setting[:puppet_interval]} minutes",
+              "Run Distribution in the last #{time_ago_in_words((Setting[:puppet_interval]).minutes.ago)}",
               "Number Of Clients",
               data[:labels],
               data[:counter],

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,7 +15,7 @@
       <td><%= @report[:bad_hosts_enabled] %> </td>
     </tr>
     <tr>
-      <td><%=searchable_links "Good Host Reports in the last #{Setting[:puppet_interval]+5} minutes", "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0" %></td>
+      <td><%=searchable_links "Good Host Reports in the last #{time_ago_in_words((Setting[:puppet_interval]+5).minutes.ago)}", "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0" %></td>
       <td> <%= "#{@report[:ok_hosts_enabled]}  / #{@report[:total_hosts]}" %> hosts (<%= @report[:percentage] %>%)</td>
     </tr>
     <tr>


### PR DESCRIPTION
Hello!

I set my puppet run intervall to 1 week and noticed that it keeps stating the time in minutes (which isn't very pretty ;-) ).

Hope the fix is not to ugly to be usable.

Cheers
Hannes
