### PR TITLE
Add support for a Squid proxy to provide access to Foreman

### DIFF
--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -25,7 +25,9 @@ class SmartProxiesController < ApplicationController
 
   def update
     @proxy = SmartProxy.find(params[:id])
+
     if @proxy.update_attributes(params[:smart_proxy])
+      flash[:warning] = @proxy.warning if @proxy.warning
       process_success :object => @proxy
     else
       process_error :object => @proxy

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -125,6 +125,19 @@ class UnattendedController < ApplicationController
       head(:conflict) and return
     end
     logger.info "Found #{@host}"
+
+    # Now, get the subnet the host is on.
+    # Then, get the Squid proxy for that subnet, if there is one.
+    # If there is, then we'll use it to set http_proxy et al.
+    if @host.subnet_id
+      subnet      = Subnet.find( @host.subnet_id )
+      # If there is an ID in subnet.squid_proxy_id,
+      # then we know it is a smart-proxy with the Squid feature
+      if subnet.squid_proxy_id
+        smart_proxy = SmartProxy.find( subnet.squid_proxy_id )
+        @squid_url  = smart_proxy.url # for use in the unattended views
+      end
+    end
   end
 
   def allowed_to_install?

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -129,15 +129,7 @@ class UnattendedController < ApplicationController
     # Now, get the subnet the host is on.
     # Then, get the Squid proxy for that subnet, if there is one.
     # If there is, then we'll use it to set http_proxy et al.
-    if @host.subnet_id
-      subnet      = Subnet.find( @host.subnet_id )
-      # If there is an ID in subnet.squid_proxy_id,
-      # then we know it is a smart-proxy with the Squid feature
-      if subnet.squid_proxy_id
-        smart_proxy = SmartProxy.find( subnet.squid_proxy_id )
-        @squid_url  = smart_proxy.url # for use in the unattended views
-      end
-    end
+    @squid_url = SmartProxy.squid_proxy.join(:subnets).where(:subnet => {:id => host.subnet_id}).first if host.subnet_id
   end
 
   def allowed_to_install?

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -7,6 +7,7 @@ class Subnet < ActiveRecord::Base
   belongs_to :dhcp, :class_name => "SmartProxy"
   belongs_to :tftp, :class_name => "SmartProxy"
   belongs_to :dns,  :class_name => "SmartProxy"
+  belongs_to :squid_proxy, :class_name => "SmartProxy"
   has_many :subnet_domains, :dependent => :destroy
   has_many :domains, :through => :subnet_domains
   validates_presence_of   :network, :mask, :name

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -1,12 +1,12 @@
 <%= text_f f, :name %>
 <%= text_f f, :network %>
-<%= text_f f, :mask, :help_inline => "Netmask for this subnet", :label => "Netmask" %>
-<%= text_f f, :gateway, :help_inline => "Optional: Gateway for this subnet", :label => "Gateway" %>
-<%= text_f f, :dns_primary, 	:help_inline => "Optional: Primary DNS for this subnet", 	 :label => "Primary DNS" %>
-<%= text_f f, :dns_secondary, :help_inline => "Optional: Secondary DNS for this subnet", :label => "Secondary DNS" %>
-<%= text_f f, :from, :help_inline => "Optional: Starting IP Address for IP auto suggestion", :label => "From IP" %>
-<%= text_f f, :to,   :help_inline => "Optional: Ending IP Address for IP auto suggestion", :label => "To IP" %>
-<%= text_f f, :vlanid, :help_inline => "Optional: VLAN ID for this subnet", :label => "VLAN" %>
+<%= text_f f, :mask,          :label => "Netmask",       :help_inline => "Netmask for this subnet" %>
+<%= text_f f, :gateway,       :label => "Gateway",       :help_inline => "Optional: Gateway for this subnet" %>
+<%= text_f f, :dns_primary,   :label => "Primary DNS",   :help_inline => "Optional: Primary DNS for this subnet" %>
+<%= text_f f, :dns_secondary, :label => "Secondary DNS", :help_inline => "Optional: Secondary DNS for this subnet" %>
+<%= text_f f, :from,          :label => "From IP",       :help_inline => "Optional: Starting IP Address for IP auto suggestion" %>
+<%= text_f f, :to,            :label => "To IP",         :help_inline => "Optional: Ending IP Address for IP auto suggestion" %>
+<%= text_f f, :vlanid,        :label => "VLAN",          :help_inline => "Optional: VLAN ID for this subnet" %>
 <%= multiple_checkboxes f, :domain, f.object, Domain, :help_inline => "Domains in which this subnet is part", :prefix=>f.object_name %>
 
 <%= select_f f, :dhcp_id, Feature.find_by_name("DHCP").smart_proxies, :id, :name, :include_blank => "None", 

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -15,3 +15,5 @@
   :help_inline => "TFTP Proxy to use within this subnet", :label => "TFTP Proxy" %>
 <%= select_f f, :dns_id, Feature.find_by_name("DNS").smart_proxies, :id, :name, :include_blank => "None",
              :help_inline => "DNS Proxy to use within this subnet", :label => "DNS Proxy" %>
+<%= select_f f, :squid_proxy_id, Feature.find_by_name("Squid").smart_proxies, :id, :name, :include_blank => "None",
+             :help_inline => "Squid Proxy to use within this subnet", :label => "Squid Proxy" %>

--- a/app/views/unattended/autoyast.xml.erb
+++ b/app/views/unattended/autoyast.xml.erb
@@ -70,7 +70,7 @@
 <%= snippets "puppet.conf" -%>
 EOF
 /usr/sbin/puppetd --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet  --no-daemonize
-/usr/bin/wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
+<%= @squid_url ? "http_proxy=#{ @squid_url } " : "" %>/usr/bin/wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 /sbin/chkconfig puppet on -f
 ]]>
         </source>

--- a/app/views/unattended/jumpstart_finish.rhtml
+++ b/app/views/unattended/jumpstart_finish.rhtml
@@ -47,5 +47,5 @@ then
 fi
 /usr/sbin/puppetd --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet --no-daemonize
 echo "Informing Foreman that we are built"
-/opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url %>
+<%= @squid_url ? "http_proxy=#{ @squid_url } " : "" %>/opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url %>
 exit 0

--- a/app/views/unattended/kickstart.rhtml
+++ b/app/views/unattended/kickstart.rhtml
@@ -67,5 +67,5 @@ sync
 
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
-wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
+<%= @squid_url ? "http_proxy=#{ @squid_url } " : "" %>wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 exit 0

--- a/app/views/unattended/preseed_finish.rhtml
+++ b/app/views/unattended/preseed_finish.rhtml
@@ -4,4 +4,4 @@ EOF
 /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
 /bin/touch /etc/puppet/namespaceauth.conf 
 /usr/sbin/puppetd --config /etc/puppet/puppet.conf --onetime --tags no_such_tag --server <%= @host.puppetmaster %> --no-daemonize
-/usr/bin/wget --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>
+<%= @squid_url ? "http_proxy=#{ @squid_url } " : "" %>/usr/bin/wget --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>

--- a/db/migrate/20120820104254_add_squid_feature.rb
+++ b/db/migrate/20120820104254_add_squid_feature.rb
@@ -1,0 +1,14 @@
+class AddSquidFeature < ActiveRecord::Migration
+
+  class Feature < ActiveRecord::Base; end
+
+  def self.up
+    Feature.create(:name => "Squid")
+    add_column :subnets, :squid_proxy_id, :integer unless column_exists? :subnets, :squid_proxy_id
+  end
+
+  def self.down
+    Feature.first(:name => "Squid").delete
+    remove_column :subnets, :squid_proxy_id, :integer if column_exists? :subnets, :squid_proxy_id
+  end
+end

--- a/lib/proxy_api.rb
+++ b/lib/proxy_api.rb
@@ -312,7 +312,7 @@ module ProxyAPI
     #    :host => String containing the hostname
     # Returns : Boolean status
     def delete host
-      parse( post({:host => host}, 'rm') )
+      parse( delete({:host => host}, 'rm') )
     end
   end
 

--- a/lib/proxy_api.rb
+++ b/lib/proxy_api.rb
@@ -292,4 +292,28 @@ module ProxyAPI
     end
 
   end
+
+  class Squid < Resource
+    def initialize args
+      @url = args[:url] + "/squid"
+      super args
+    end
+
+    # Adds an IP to the Squid configuration, permitting proxied access to Foreman
+    # [+args+] : Hash containing
+    #    :host => String containing the hostname
+    # Returns  : Boolean status
+    def add host
+      parse( post({:host => host}, 'add') )
+    end
+
+    # Deletes a Squid configuration entry
+    # [+args+] : Hash contining
+    #    :host => String containing the hostname
+    # Returns : Boolean status
+    def delete host
+      parse( post({:host => host}, 'rm') )
+    end
+  end
+
 end

--- a/test/fixtures/features.yml
+++ b/test/fixtures/features.yml
@@ -18,3 +18,6 @@ puppetca:
 
 puppet:
   name: Puppet
+
+squid:
+  name: Squid

--- a/test/fixtures/smart_proxies.yml
+++ b/test/fixtures/smart_proxies.yml
@@ -10,6 +10,11 @@ three:
   name: DNS Proxy
   url: http://else.where:4567
 
+four:
+  name: Squid Proxy
+  url: http://squid.localdomain
+  features: squid
+
 puppetmaster:
   name: Puppetmaster Proxy
   url: http://else.where:4567


### PR DESCRIPTION
When you are provisioning hosts that cannot reach the
Foreman server due to the network's design, you may
want to have a Squid proxy running on the subnet to
provide access.

When a host is signalled to build, Foreman issues a command
to the Smart Proxy to add the host's IP to the Squid ACL.
When the build is cancelled or completed, the entry is
removed.

Each subnet may identify at most one Smart Proxy which
manages the Squid proxy for that subnet. If the Smart
Proxy feature set changes, and it no longer does the Squid
feature, then it is removed from any subnets where it was
identified as the Squid proxy.

Caveats:
- Setting the proxy for the provisioning process may be
  incomplete
- There is no test suite yet

Resolves http://theforeman.org/issues/969
