### PR TITLE
Reformatted the 'all puppetclasses' page linked to from hosts

### DIFF
--- a/app/views/hosts/storeconfig_klasses.html.erb
+++ b/app/views/hosts/storeconfig_klasses.html.erb
@@ -1,7 +1,12 @@
 <% title "All Puppet Classes for #{@host}" %>
-<ul>
-  <% @host.classes_from_storeconfigs.each do |klass| -%>
-    <li><%= h klass %></li>
-  <% end -%>
-</ul>
+  <table class="table table-bordered table-striped">
+    <tr>
+      <th class="">Class</th>
+    </tr>
+    <% @host.classes_from_storeconfigs.each do |klass| %>
+      <tr>
+        <td><%= h klass %></td>
+      </tr>
+    <% end %>
+  </table>
 <%= link_to 'back', host_path(@host) %>


### PR DESCRIPTION
Fixes styling issues with that page by using a table instead of bullets to list classes assigned to a specific host.
