### PR TITLE
fixes #1837 add some indexes to improve performance

### DIFF
--- a/db/migrate/20120824142048_add_some_indexes.rb
+++ b/db/migrate/20120824142048_add_some_indexes.rb
@@ -1,0 +1,23 @@
+class AddSomeIndexes < ActiveRecord::Migration
+  def self.up
+    #environments_puppetclasses
+    add_index :environments_puppetclasses, :puppetclass_id
+    add_index :environments_puppetclasses, :environment_id
+    #puppetclasses
+    add_index :puppetclasses, :name
+    #hostgroups_puppetclasses
+    add_index :hostgroups_puppetclasses, :puppetclass_id
+    add_index :hostgroups_puppetclasses, :hostgroup_id
+  end
+
+  def self.down
+    #environments_puppetclasses
+    remove_index :environments_puppetclasses, :puppetclass_id
+    remove_index :environments_puppetclasses, :environment_id
+    #puppetclasses
+    remove_index :puppetclasses, :name
+    #hostgroups_puppetclasses
+    remove_index :hostgroups_puppetclasses, :puppetclass_id
+    remove_index :hostgroups_puppetclasses, :hostgroup_id
+  end
+end


### PR DESCRIPTION
Today The foreman in my company manages 3500 puppetclasses along with 5 environments.

Doing, a simple search in the puppetclasses controller without indexes by name takes too long! more than 30 seg, as follows:

Completed in 33232ms (View: 68, DB: 33151) | 200 OK [http://puppet.globoi.com/puppetclasses?search=cocoon]

with indexes:

Completed in 92ms (View: 69, DB: 12) | 200 OK [http://puppet.globoi.com/puppetclasses?search=cocoon
