### PR TITLE
foreman-config - CLI tool for setting Foreman configuration

### DIFF
--- a/script/foreman-config
+++ b/script/foreman-config
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+options = {}
+defaults = {:foreman_path => "/usr/share/foreman",
+            :environment => "production"}
+
+options.merge!(defaults)
+
+parser = OptionParser.new do |opt|
+  opt.banner = <<BANNER
+Get or set the Foremen settings.
+
+Options:
+BANNER
+  opt.on("-k",
+         "--key KEY",
+         "If not specified, all keys are dispalyed") do |val|
+    options[:key] = val
+  end
+
+  opt.on("-v",
+         "--value VALUE",
+         "Set the value. The key must be specified. Complex values (hashes, arrays) are expected to be JSON encoded.") do |val|
+    options[:value] = val
+  end
+
+  opt.on("-u",
+         "--unset",
+         "Unset the key. The key must be specified") do
+    options[:unset] = true
+  end
+
+  opt.on("-h", "--help", "Show help and exit") do 
+    puts opt
+    exit
+  end
+
+  opt.on("-p",
+         "--path PATH",
+         "Path with Foreman source code (default #{defaults[:foreman_path]})") do |val|
+    options[:foreman_path] = val
+  end
+
+  opt.on("-e",
+         "--env ENV",
+         "Runtime environment (default #{defaults[:environment]})") do |val|
+    options[:environment] = val
+  end
+end
+
+parser.parse!
+
+if options.has_key?(:value) && !options.has_key?(:key)
+  STDERR.puts "A key must be specified"
+  exit 1
+end
+
+# load Rails environment
+# suppress warnings (such as some featuer being disabled)
+verbosity=$VERBOSE
+$VERBOSE=nil
+
+ENV["RAILS_ENV"] = options[:environment]
+
+require File.expand_path("config/boot", options[:foreman_path])
+require File.expand_path("config/application", options[:foreman_path])
+
+Rails.application.require_environment!
+
+# get verbose level back
+$VERBOSE=verbosity
+
+require 'json'
+require 'yaml'
+
+def complex_type?(type)
+  ["hash", "array"].include? type
+end
+
+# we expect simple values or JSON encoded hashes or arrays (if applicible)
+def typecast_value(type, value)
+  if complex_type?(type)
+    # we used JSON over custom format for input because it's easier to parse
+    JSON.parse(value).inspect
+  else
+    value
+  end
+end
+
+def format_value(type, value)
+  if complex_type?(type)
+    value.to_json
+  else
+    value
+  end
+end
+
+# show all settings
+unless options.has_key?(:key)
+  Setting.all.each do |setting|
+    puts "#{setting.name}: #{format_value(setting.settings_type, setting.value)}"
+  end
+else
+  setting = Setting.find_by_name(options[:key])
+
+  if options[:value]
+    value = typecast_value(setting.settings_type, options[:value])
+    setting.value = value
+  elsif options[:unset]
+    setting.value = nil
+  end
+  setting.save! if setting.changed?
+  puts format_value(setting.settings_type, setting.value)
+end

--- a/script/foreman-config
+++ b/script/foreman-config
@@ -2,7 +2,7 @@
 
 require 'optparse'
 options = {}
-defaults = {:foreman_path => "/usr/share/foreman",
+defaults = {:foreman_path => File.expand_path("../..", __FILE__),
             :environment => "production",
             :keys => [],
             :key_values => {}}

--- a/script/foreman-config
+++ b/script/foreman-config
@@ -3,9 +3,21 @@
 require 'optparse'
 options = {}
 defaults = {:foreman_path => "/usr/share/foreman",
-            :environment => "production"}
+            :environment => "production",
+            :keys => [],
+            :key_values => {}}
 
 options.merge!(defaults)
+
+def set_options_key_value(options, value)
+  unless options.has_key?(:key)
+    STDERR.puts("Key has to be specified first")
+    exit 2
+  end
+  options[:keys] << options[:key]
+  options[:key_values][options[:key]] = value
+  options.delete(:key)
+end
 
 parser = OptionParser.new do |opt|
   opt.banner = <<BANNER
@@ -22,13 +34,13 @@ BANNER
   opt.on("-v",
          "--value VALUE",
          "Set the value. The key must be specified. Complex values (hashes, arrays) are expected to be JSON encoded.") do |val|
-    options[:value] = val
+    set_options_key_value(options, val)
   end
 
   opt.on("-u",
          "--unset",
          "Unset the key. The key must be specified") do
-    options[:unset] = true
+    set_options_key_value(options, :unset)
   end
 
   opt.on("-h", "--help", "Show help and exit") do 
@@ -51,12 +63,6 @@ end
 
 parser.parse!
 
-if options.has_key?(:value) && !options.has_key?(:key)
-  STDERR.puts "A key must be specified"
-  exit 1
-end
-
-# load Rails environment
 # suppress warnings (such as some featuer being disabled)
 verbosity=$VERBOSE
 $VERBOSE=nil
@@ -68,11 +74,11 @@ require File.expand_path("config/application", options[:foreman_path])
 
 Rails.application.require_environment!
 
-# get verbose level back
-$VERBOSE=verbosity
-
 require 'json'
 require 'yaml'
+
+# get verbose level back
+$VERBOSE=verbosity
 
 def complex_type?(type)
   ["hash", "array"].include? type
@@ -97,19 +103,24 @@ def format_value(type, value)
 end
 
 # show all settings
-unless options.has_key?(:key)
+if options.has_key?(:key)
+  setting = Setting.find_by_name(options[:key])
+  puts format_value(setting.settings_type, setting.value)
+elsif options[:key_values].any?
+  options[:keys].each do |key|
+    value = options[:key_values][key]
+    setting = Setting.find_by_name(key)
+    if value == :unset
+      setting.value = nil
+    else
+      value = typecast_value(setting.settings_type, value)
+      setting.value = value
+    end
+    setting.save! if setting.changed?
+    puts format_value(setting.settings_type, setting.value)
+  end
+else
   Setting.all.each do |setting|
     puts "#{setting.name}: #{format_value(setting.settings_type, setting.value)}"
   end
-else
-  setting = Setting.find_by_name(options[:key])
-
-  if options[:value]
-    value = typecast_value(setting.settings_type, options[:value])
-    setting.value = value
-  elsif options[:unset]
-    setting.value = nil
-  end
-  setting.save! if setting.changed?
-  puts format_value(setting.settings_type, setting.value)
 end


### PR DESCRIPTION
Script for listing all settings and getting or setting a value for a key.

See `foreman-config -h` for details.

The main use-case for this script is in configuration time (e.g. in Puppet
manifest setting Foreman). It uses the model layer (instead of Rest API)
because some settings (such as oauth) need to be set up before API is possible
to use in some scenarios.

Loading Rails environment is quite an expensive operation. Therefore it's possible
to set more values with one command e.g.:

```
script/foreman-config -k oauth_active -v true\
                      -k oauth_consumer_key -v key\
                      -k oauth_consumer_secret -v secret
```
