### PR TITLE
Update app/views/unattended/kickstart.rhtml

### DIFF
--- a/app/views/unattended/kickstart.rhtml
+++ b/app/views/unattended/kickstart.rhtml
@@ -9,7 +9,7 @@ rootpw --iscrypted <%= root_pass %>
 firewall --service=ssh
 authconfig --useshadow --enablemd5
 timezone UTC
-bootloader --location=mbr --append="nofb quiet splash=quiet --md5pass=<%= root_pass %>"
+bootloader --location=mbr --append="nofb quiet splash=quiet" --md5pass=<%= root_pass %>
 <% if @dynamic -%>
 %include /tmp/diskpart.cfg
 <% else -%>


### PR DESCRIPTION
Fix: http://theforeman.org/issues/1878
Double quote in the wrong place includes unsupported boot param, which causes kernel panic on boot.
