### PR TITLE
Upgrade rails core to 3.0.17 fix a bug where single quotes aren't escaped

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rails', '3.0.15'
+gem 'rails', '3.0.17'
 gem "jquery-rails"
 gem 'json'
 gem 'rest-client', :require => 'rest_client'


### PR DESCRIPTION
(CVE-2012-3464)

This vulnerability was found by brakeman - http://ci.theforeman.org/job/test_brakeman/6/brakemanResult/type.-1784402530/
