### PR TITLE
Pinned redcarpet to 2.1.0 or below so native extensions build

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -2,7 +2,7 @@ group :development do
   # To use debugger
   gem "ruby-debug", :platforms => :ruby_18
   gem "ruby-debug19", :platforms => :ruby_19
-  gem 'redcarpet'
+  gem 'redcarpet', '<= 2.1.0'
   gem 'single_test'
   gem 'pry'
   gem "term-ansicolor"

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -3,7 +3,7 @@ group :test do
   gem 'shoulda', "=3.0.1"
   gem 'rr'
   gem 'rake'
-  gem 'redcarpet'
+  gem 'redcarpet', '<= 2.1.0'
   gem 'single_test'
   gem 'ci_reporter', '>= 1.6.3'
 end


### PR DESCRIPTION
Redcarpet 2.2.1 throws errors when installing the gem because of a bug in the native extensions:

```
make
gcc -I. -I/usr/lib64/ruby/1.8/x86_64-linux -I/usr/lib64/ruby/1.8/x86_64-linux -I.   -fPIC -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fno-strict-aliasing  -fPIC   -c houdini_html_e.c
gcc -I. -I/usr/lib64/ruby/1.8/x86_64-linux -I/usr/lib64/ruby/1.8/x86_64-linux -I.   -fPIC -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -fno-strict-aliasing  -fPIC   -c rc_markdown.c
In file included from rc_markdown.c:16:
redcarpet.h:6:21: error: ruby/st.h: No such file or directory
rc_markdown.c: In function 'rb_redcarpet_md_render':
rc_markdown.c:126: warning: pointer targets in passing argument 2 of 'sd_markdown_render' differ in signedness
markdown.h:124: note: expected 'const uint8_t *' but argument is of type 'char *'
rc_markdown.c:129: warning: pointer targets in passing argument 1 of 'rb_str_new' differ in signedness
/usr/lib64/ruby/1.8/x86_64-linux/intern.h:435: note: expected 'const char *' but argument is of type 'uint8_t *'
make: *** [rc_markdown.o] Error 1
```
