### PR TITLE
Api - logging, admin-user creatinon

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,10 +84,7 @@ class ApplicationController < ActionController::Base
         end
       else
         # We assume we always have a user logged in, if authentication is disabled, the user is the build-in admin account.
-        unless (User.current = User.find_by_login("admin"))
-          error "Unable to find internal system admin account - Recreating . . ."
-          User.current = User.create_admin
-        end
+        User.current = User.admin
         session[:user] = User.current.id unless api_request?
       end
     end
@@ -121,7 +118,7 @@ class ApplicationController < ActionController::Base
   # its required for actions which are not authenticated by default
   # such as unattended notifications coming from an OS, or fact and reports creations
   def set_admin_user
-    User.current = User.find_by_login("admin")
+    User.current = User.admin
   end
 
   # searches for an object based on its name and assign it to an instance variable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,10 @@ class User < ActiveRecord::Base
     user
   end
 
+  def self.admin
+    find_by_login 'admin' or create_admin
+  end
+
   # Tries to find the user in the DB and then authenticate against their authentication source
   # If the user is not in the DB then try to login the user on each available athentication source
   # If this succeeds then copy the user's details from the authentication source into the User table

--- a/lib/api/authorization.rb
+++ b/lib/api/authorization.rb
@@ -40,13 +40,13 @@ module Api
 
     def oauth
       unless Setting['oauth_active']
-        Rails.logger.debug 'Trying to authenticate with OAuth, but OAuth is not active'
+        Rails.logger.info 'Trying to authenticate with OAuth, but OAuth is not active'
         return nil
       end
 
       unless (incoming_key = OAuth::RequestProxy.proxy(controller.request).oauth_consumer_key) ==
           Setting['oauth_consumer_key']
-        Rails.logger.debug "oauth_consumer_key should be '#{Setting['oauth_consumer_key']}'" <<
+        Rails.logger.info "oauth_consumer_key should be '#{Setting['oauth_consumer_key']}'" <<
                                "but was '#{incoming_key}'"
         return nil
       end
@@ -55,13 +55,13 @@ module Api
         user_name = controller.request.headers['foreman_user']
         if Setting['oauth_map_users'] && user_name != 'admin'
           User.find_by_login(user_name).tap do |obj|
-            Rails.logger.debug "Oauth: maping to user '#{user}' failed" if obj.nil?
+            Rails.logger.info "Oauth: maping to user '#{user}' failed" if obj.nil?
           end
         else
           User.admin
         end
       else
-        Rails.logger.debug "OAuth signature verification failed."
+        Rails.logger.info "OAuth signature verification failed."
         return nil
       end
     end

--- a/test/functional/notices_controller_test.rb
+++ b/test/functional/notices_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class NoticesControllerTest < ActionController::TestCase
   def setup
-    User.current = User.find_by_login "admin"
+    User.current = User.admin
     @notice = Notice.create :global => false, :content => "hello", :level => "message"
     @request.env['HTTP_REFERER'] = hosts_path
   end
@@ -19,7 +19,7 @@ class NoticesControllerTest < ActionController::TestCase
     if set_session_user[:user]
       user = User.find  set_session_user[:user]
     else
-      user  = User.find_by_login("admin")
+      user  = User.admin
     end
     original = user.notices.count
     delete :destroy, {:id => @notice.id}, set_session_user

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ReportsControllerTest < ActionController::TestCase
   setup do
-    User.current = User.find_by_login "admin"
+    User.current = User.admin
   end
   def test_index
     get :index, {}, set_session_user

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -100,7 +100,7 @@ class UsersControllerTest < ActionController::TestCase
   test "should recreate the admin account" do
     return true unless SETTINGS[:login]
     return true unless SETTINGS[:login] == false
-    User.find_by_login("admin").delete # Of course we only use destroy in the codebase
+    User.admin.delete # Of course we only use destroy in the codebase
     assert User.find_by_login("admin").nil?
     get :index, {}, {:user => nil}
     assert !User.find_by_login("admin").nil?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,7 @@ class ActiveSupport::TestCase
   end
 
   def set_session_user
-    SETTINGS[:login] ? {:user => User.find_by_login("admin").id, :expires_at => 5.minutes.from_now} : {}
+    SETTINGS[:login] ? {:user => User.admin.id, :expires_at => 5.minutes.from_now} : {}
   end
 
   def as_user user


### PR DESCRIPTION
- log debug info when OAuth authentication fails
- auto create admin-user when missing in API requests
- add getter for admin user User.admin which auto creates admin when missing
