### PR TITLE
redirecting foreman-config log output

### DIFF
--- a/script/foreman-config
+++ b/script/foreman-config
@@ -74,6 +74,8 @@ require File.expand_path("config/application", options[:foreman_path])
 
 Rails.application.require_environment!
 
+Foreman::Application.config.logger = Logger.new("#{Rails.root}/log/foreman-config.log")
+
 require 'json'
 require 'yaml'
 


### PR DESCRIPTION
When foreman-config tool is executed under root account, logs/production.log
is created with incorrect permissions. This patch redirect Rails output to
log/foreman-config.log, so Foreman can start under non-root account after
configuration with the tool is done.
