### PR TITLE
fixes #1913 Solaris architecture fact should always be hardwareisa

### DIFF
--- a/app/models/facts_importer.rb
+++ b/app/models/facts_importer.rb
@@ -40,7 +40,7 @@ module Facts
 
     def architecture
       # On solaris architecture fact is harwareisa
-      name = facts[:architecture] || facts[:hardwareisa]
+      name = facts[:hardwareisa] || facts[:architecture]
       # ensure that we convert debian legacy to standard
       name = "x86_64" if name == "amd64"
       Architecture.find_or_create_by_name name unless name.blank?

--- a/app/models/facts_importer.rb
+++ b/app/models/facts_importer.rb
@@ -39,8 +39,14 @@ module Facts
     end
 
     def architecture
+      os_name = facts[:operatingsystem]
       # On solaris architecture fact is harwareisa
-      name = facts[:hardwareisa] || facts[:architecture]
+      name = case os_name
+               when /(sunos|solaris)/i
+                 facts[:hardwareisa]
+               else
+                 facts[:architecture] || facts[:hardwareisa]
+               end
       # ensure that we convert debian legacy to standard
       name = "x86_64" if name == "amd64"
       Architecture.find_or_create_by_name name unless name.blank?


### PR DESCRIPTION
This fixes the issue where architecture on Solaris sparc hosts is reported as sun4u or similar instead of sparc.
