### PR TITLE
Fixes validation for hostnames containing hyphens for NFS mounts

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -4,7 +4,7 @@ class Medium < ActiveRecord::Base
   has_many :hosts
 
   # We need to include $ in this as $arch, $release, can be in this string
-  VALID_NFS_PATH=/^([\w\d\.]+):(\/[\w\d\/\$\.]+)$/
+  VALID_NFS_PATH=/^([-\w\d\.]+):(\/[\w\d\/\$\.]+)$/
   validates_uniqueness_of :name
   validates_uniqueness_of :path
   validates_presence_of :name, :path


### PR DESCRIPTION
Small change to the regex that handles the validation for hostnames for NFS mounts.

The validation failed when the hostname contained a hyphen which is a valid character for a hostname:

http://rubular.com/r/A8dMgkPMIX

The addition of the hyphen to the regex fixes this issue.

http://rubular.com/r/2pThhobSlz
