### PR TITLE
fixes #1917 Solaris Sparc provisioning templates fix

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -196,6 +196,7 @@ class UnattendedController < ApplicationController
       @install_type = "initial_install"
       @system_type  = "standalone"
       @cluster      = "SUNWCreq"
+      @packages     = "SUNWgzip"
       @locale       = "C"
     end
     @disk = @host.diskLayout

--- a/app/views/unattended/jumpstart.rhtml
+++ b/app/views/unattended/jumpstart.rhtml
@@ -5,5 +5,6 @@ partitioning explicit
 archive_location nfs <%=@archive_location%>
 <% else -%>
 system_type <%= @system_type %>
+package <%= @packages %> add
 cluster <%= @cluster %>
 <% end -%>

--- a/app/views/unattended/jumpstart_finish.rhtml
+++ b/app/views/unattended/jumpstart_finish.rhtml
@@ -45,7 +45,7 @@ then
     rm -f /etc/opt/csw/puppet/puppetd.conf
     ln -s /etc/puppet/puppet.conf /etc/opt/csw/puppet/puppetd.conf
 fi
-/usr/sbin/puppetd --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet --no-daemonize
+/opt/csw/sbin/puppetd --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet --no-daemonize
 echo "Informing Foreman that we are built"
 /opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url %>
 exit 0


### PR DESCRIPTION
This will fix the unattended installation on Solaris 10 Sparc hosts. I think it will also work on Solaris 8. I haven't tested on Solaris 11.
