### PR TITLE
fixes #1862 resets cookie after deleting hosts

### DIFF
--- a/app/views/hosts/multiple_destroy.html.erb
+++ b/app/views/hosts/multiple_destroy.html.erb
@@ -1,5 +1,5 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_destroy_hosts_path(:host_ids => params[:host_ids]) do -%>
+<%= form_tag submit_multiple_destroy_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do -%>
   <span class="label label-warning">Warning</span> This might take a while, as all hosts, facts and reports will be destroyed as well
 <% end %>


### PR DESCRIPTION
This is a 50% fix for #1862.  When you delete multiple hosts this will reset the selection cookie so that the selection bar doesn't show up when page reloads. 

The issue still shows up if you have a single host selected and then delete it. But this'd take over-riding the rails default :confirm javascript I think and isn't worth the effort IMO. 
