### PR TITLE
fixed typo - "replay_address" should be called "reply_address"

### DIFF
--- a/app/models/host_mailer.rb
+++ b/app/models/host_mailer.rb
@@ -35,7 +35,7 @@ class HostMailer < ActionMailer::Base
     email = options[:email] || Setting[:administrator]
     raise "unable to find recipients" if email.empty?
     recipients email
-    from Setting["email_replay_address"]
+    from Setting["email_reply_address"]
     sent_on Time.now
     time = options[:time] || 1.day.ago
     host_data = Report.summarise(time, hosts.all).sort
@@ -63,7 +63,7 @@ class HostMailer < ActionMailer::Base
     email = Setting[:administrator]   if email.empty?
     raise "unable to find recipients" if email.empty?
     recipients email
-    from Setting["email_replay_address"]
+    from Setting["email_reply_address"]
     subject "Puppet error on #{host.to_label}"
     sent_on Time.now
     content_type "text/html"

--- a/db/migrate/20121029164911_rename_reply_adress_setting.rb
+++ b/db/migrate/20121029164911_rename_reply_adress_setting.rb
@@ -1,0 +1,9 @@
+class RenameReplyAdressSetting < ActiveRecord::Migration
+  def self.up
+    execute "UPDATE settings SET name='email_reply_address' WHERE name='email_replay_adress'"
+  end
+
+  def self.down
+    execute "UPDATE settings SET name='email_replay_address' WHERE name='email_reply_adress'"
+  end
+end

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -30,7 +30,7 @@ module Foreman
             [
               set('administrator', "The default administrator email address", "root@#{domain}"),
               set('foreman_url',   "The hostname where your Foreman instance is reachable", "foreman.#{domain}"),
-              set('email_replay_address', "The email reply address for emails that Foreman is sending", "Foreman-noreply@#{domain}"),
+              set('email_reply_address', "The email reply address for emails that Foreman is sending", "Foreman-noreply@#{domain}"),
               set('entries_per_page', "The amount of records shown per page in Foreman", 20),
               set('authorize_login_delegation',"Authorize login delegation with REMOTE_USER environment variable",false),
               set('authorize_login_delegation_api',"Authorize login delegation with REMOTE_USER environment variable for API calls too",false),


### PR DESCRIPTION
Hello!

i fixed the typo with the "replay_adress" variable (which gives me a headache each time i see it ;) )

unfortunately i'm a bit unsure if we should implement some kind of migration and how this can be done.

Cheers
Hannes
