### PR TITLE
Improved spacing and active selection for dropdowns in the topbar

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -243,6 +243,14 @@ tr.open span.expander {background-image: url(../images/bullet_toggle_minus.png);
 .magic-line { position: absolute; top: 0px; left: 0; width: 100px; height: 2px; background: red; }
 .menu-dropdown {text-transform: capitalize;}
 
+.dropdown.active {
+  background-color: #222;
+}
+
+.dropdown .caret {
+  margin-left: 6px;
+}
+
 .fact_chart {
   height: 400px !important;
   width: 560px !important;


### PR DESCRIPTION
This changeset consists of two very minor alterations to the styling of the topbar:
1. If there is a dropdown menu assigned to a primary topbar item, the whole area including the caret will be the same color.
2. The caret will be further right which will make you less likely to hit it by accident (which I do all the time).
