### PR TITLE
fix #1932 - Allow LDAP authentication without requiring search

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -55,15 +55,15 @@ class AuthSource < ActiveRecord::Base
     AuthSource.all.each do |source|
       logger.debug "Authenticating '#{login}' against '#{source.name}'"
       begin
-        if (attrs = source.authenticate(login, password))
-          logger.debug "Authentication successful for '#{login}'"
-          attrs[:auth_source_id] = source.id
+        if source.onthefly_register? and source.authenticate(login, password)
+          logger.debug "Authentication successful for '#{login}' at '#{source}'"
+          auth = source.id
         end
       rescue => e
         logger.error "Error during authentication: #{e.message}"
-        attrs = nil
+        auth = nil
       end
-      return attrs if attrs
+      return auth if auth
     end
     nil
   end


### PR DESCRIPTION
This will allow authentication using $login in the Foreman ldap Account for environments where ldap users can't search. I've tested it in my environment (where ldap users can't search) but I can't test in an environment where they can. Also needs to be tested in an environment with on-the-fly user creation (can't do that here either). 

I also added two debug lines to the end. They'll give the ldap error code and message so you can see in log if it's a problem with your password or with your dn configuration. 
