### PR TITLE
fixes #1876 fix display of instance name and dns for AWS

### DIFF
--- a/app/views/compute_resources_vms/index/_ec2.html.erb
+++ b/app/views/compute_resources_vms/index/_ec2.html.erb
@@ -11,7 +11,7 @@
   <% @compute_resource.vms.each do |vm| -%>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
-      <td><%= vm.dns_name %></td>
+      <td><%= vm.dns %></td>
       <td><%= vm.flavor_id %></td>
       <td <%= vm_power_class(vm.ready?)%>> <%= vm_state(!vm.ready?) %> </td>
       <td>

--- a/lib/fog_extensions/aws/server.rb
+++ b/lib/fog_extensions/aws/server.rb
@@ -2,11 +2,15 @@ module FogExtensions
   module AWS
     module Server
       def to_s
-        tags["Name"]
+        tags["Name"] || identity
       end
 
       def name
         to_s
+      end
+
+      def dns
+         dns_name || private_dns_name
       end
 
     end


### PR DESCRIPTION
Use instance number when instances name is not set.
Use private DNS entry when public dns is not available
