### PR TITLE
Bug #1936 Allow user creation without email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,11 @@ class ApplicationController < ActionController::Base
   helper 'layout'
 
   before_filter :require_ssl, :require_login
+  before_filter :require_mail
   before_filter :session_expiry, :update_activity_time, :unless => proc {|c| c.remote_user_provided? || c.api_request? } if SETTINGS[:login]
   before_filter :welcome, :only => :index, :unless => :api_request?
   before_filter :authorize
+
 
   cache_sweeper :topbar_sweeper, :unless => :api_request?
 
@@ -87,6 +89,13 @@ class ApplicationController < ActionController::Base
         User.current = User.admin
         session[:user] = User.current.id unless api_request?
       end
+    end
+  end
+
+  def require_mail
+    if User.current && User.current.mail.blank?
+      notice "Mail is Required"
+      redirect_to edit_user_path(:id => User.current)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
+  skip_before_filter :require_mail, :only => [:edit, :update, :logout]
   skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :only => [:login, :logout]
   after_filter       :update_activity_time, :only => :login
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,16 +26,19 @@ class User < ActiveRecord::Base
 
   accepts_nested_attributes_for :user_facts, :reject_if => lambda { |a| a[:criteria].blank? }, :allow_destroy => true
 
+  validates :mail, :format => { :with => /^([^@\s]+)@((?:[-a-z0-9]+\.)*[a-z]{2,})$/i },
+                   :length => { :maximum => 60 },
+                   :allow_blank => true
+  validates :mail, :presence => true, :on => :update
+
   validates_uniqueness_of :login, :message => "already exists"
-  validates_presence_of :login, :mail, :auth_source_id
+  validates_presence_of :login, :auth_source_id
   validates_presence_of :password_hash, :if => Proc.new {|user| user.manage_password?}
   validates_confirmation_of :password,  :if => Proc.new {|user| user.manage_password?}, :unless => Proc.new {|user| user.password.empty?}
   validates_format_of :login, :with => /^[a-z0-9_\-@\.]*$/i
   validates_length_of :login, :maximum => 30
   validates_format_of :firstname, :lastname, :with => /^[\w\s\'\-\.]*$/i, :allow_nil => true
   validates_length_of :firstname, :lastname, :maximum => 30, :allow_nil => true
-  validates_format_of :mail, :with => /^([^@\s]+)@((?:[-a-z0-9]+\.)*[a-z]{2,})$/i, :allow_nil => true
-  validates_length_of :mail, :maximum => 60, :allow_nil => true
 
   before_destroy EnsureNotUsedBy.new(:hosts), :ensure_admin_is_not_deleted
   validate :name_used_in_a_usergroup, :ensure_admin_is_not_renamed


### PR DESCRIPTION
This does a couple things. 

Allows user creation without email, both from LDAP or from UI. 
When users login if they don't have an email it forwards them to their edit page and notifies them to set one. 
