### PR TITLE
Pin mocha to versions below 0.13.0

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,5 +1,5 @@
 group :test do
-  gem 'mocha', :require => false
+  gem 'mocha', '< 0.13.0', :require => false
   gem 'shoulda', "=3.0.1"
   gem 'rr'
   gem 'rake'


### PR DESCRIPTION
This fixes an issue with Mocha version 0.13.0 and greater where loading mocha fails and subsequently a number of tests fail. You can see this issue at:

http://ci.theforeman.org/job/test_develop_pull_request/2/console
