### PR TITLE
add back logrotate file

### DIFF
--- a/extras/spec/logrotate
+++ b/extras/spec/logrotate
@@ -1,0 +1,12 @@
+/var/log/foreman/*log {
+  missingok
+  notifempty
+  create 0644 foreman foreman
+  sharedscripts
+  rotate 5
+  compress
+	daily
+  postrotate
+    [ -e /etc/init.d/foreman ] && /etc/init.d/foreman condrestart >/dev/null 2>&1 || true
+  endscript
+}


### PR DESCRIPTION
this was removed in 221445d, but logrotate is not part of rpms-spec repo
which results in:

```
+ install -Dp -m0644 foreman.sysconfig /builddir/build/BUILDROOT/foreman-1.0.1-33.13833d4.fc17.noarch/etc/sysconfig/foreman
+ install -Dp -m0755 foreman.init /builddir/build/BUILDROOT/foreman-1.0.1-33.13833d4.fc17.noarch/etc/rc.d/init.d/foreman
+ install -Dp -m0644 extras/spec/logrotate /builddir/build/BUILDROOT/foreman-1.0.1-33.13833d4.fc17.noarch/etc/logrotate.d/foreman
install: cannot stat `extras/spec/logrotate': No such file or directory
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.iAfGFP (%install)
    Bad exit status from /var/tmp/rpm-tmp.iAfGFP (%install)
```
