### PR TITLE
fix trend labels for ForemanTrends

### DIFF
--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -33,9 +33,9 @@ module TrendsHelper
 
   def trend_title trend
     if trend.fact_value.blank?
-      trend.to_label.camelcase
+      trend.to_label
     else
-      "#{trend.type_name.camelcase} - #{trend.to_label}"
+      "#{trend.type_name} - #{trend.to_label}"
     end
   end
 

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -33,9 +33,9 @@ module TrendsHelper
 
   def trend_title trend
     if trend.fact_value.blank?
-      trend.type_name.camelcase
+      trend.to_label.camelcase
     else
-      "#{trend.type_name.camelcase} - #{trend.name}"
+      "#{trend.type_name.camelcase} - #{trend.to_label}"
     end
   end
 

--- a/app/models/fact_trend.rb
+++ b/app/models/fact_trend.rb
@@ -9,7 +9,11 @@ class FactTrend < Trend
   end
 
   def type_name
-    fact_name.blank? ? trendable.name : fact_name
+    if fact_value.blank?
+      name.blank? ? fact_name : name
+    else
+      fact_name
+    end
   end
 
   def create_values

--- a/app/views/trends/_trends.html.erb
+++ b/app/views/trends/_trends.html.erb
@@ -4,11 +4,10 @@
       <% group.each do |trend| -%>
         <ul class="base">
           <li>
-            <% opts = trend.name? ? trend.name : trend.fact_value %>
             <table class="table table-condensed table-layout: fixed">
               <tr>
                 <td style="width: 80%; border-top: none" >
-                  <%= link_to opts, trend_path(:id => trend), :title => "Details" %>
+                  <%= link_to trend.to_label, trend_path(:id => trend), :title => "Details" %>
                 </td>
                 <td style="width: 20%; border-top: none">
                   <% unless trend.trend_counters.blank? %><%= trend.trend_counters.last.count %><% end %>

--- a/app/views/trends/edit.html.erb
+++ b/app/views/trends/edit.html.erb
@@ -1,5 +1,5 @@
 <%= javascript 'trends' %>
-<% title "Edit Trend #{@trend.to_s.camelcase}" %>
+<% title "Edit Trend #{@trend.to_label}" %>
 <div class="span6">
   <% form_tag trend_path, :method => :put do %>
     <% if @trend.is_a?(FactTrend) %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -33,11 +33,11 @@
   </tr>
   <% @trends.each do |trend| %>
     <tr>
-      <td><%= link_to trend.type_name.capitalize, trend_path(:id => trend), :title => "Show Trends" %></td>
+      <td><%= link_to trend.type_name, trend_path(:id => trend), :title => "Show Trends" %></td>
       <td>
         <%= action_buttons(
                 display_link_if_authorized("Edit", hash_for_edit_trend_path(:id => trend), :class => "btn"),
-                display_delete_if_authorized(hash_for_trend_path(:id => trend), :confirm => "Delete all the trend history for #{trend.type_name.capitalize}?")) %>
+                display_delete_if_authorized(hash_for_trend_path(:id => trend), :confirm => "Delete all the trend history for #{trend.type_name}?")) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -4,13 +4,15 @@
 <%= trend_chart 'trend_graph', "#{trend_title(@trend)}", "last #{range} days", chart_data(@trend, range.days.ago) %>
 
 <table class="table">
-  <% head = @hosts ? "Hosts" : "Values" %>
-  <th colspan="4"><%= head %></th>
-  <tr>
-    <% if @trend.fact_value == nil %>
+  <% if @trend.fact_value == nil %>
+    <th colspan="4">Values</th>
+    <tr>
       <%= render 'trends' %>
-    <% else %>
+    </tr>
+  <% else %>
+    <th colspan="4">Hosts</th>
+    <tr>
       <%= render 'hosts' %>
-    <% end %>
-  </tr>
+    </tr>
+  <% end %>
 </table>


### PR DESCRIPTION
By default ForemanTrends don't have names but go by fact_value instead so they weren't displaying properly. 
