### PR TITLE
Fix tests broken by changing default behaviour for users

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -25,7 +25,7 @@ class ComputeResource < ActiveRecord::Base
 
   scope :my_compute_resources, lambda {
     user = User.current
-    if user.admin? or user.compute_resources.empty?
+    if user.admin?
       conditions = { }
     else
       conditions = sanitize_sql_for_conditions([" (compute_resources.id in (?))", user.compute_resources.map(&:id)])


### PR DESCRIPTION
The tests were all broken by the change in the default behaviour for users - they relied on the fact that users with no compute resource filters could see _no_ resources. We changed it so they could see _all_ resources, so any test which did not explicitly set up the compute resources had a problem.

For compactness, the setup_user method has been altered to include a compute resource, and single test altered to check that with unconstrained access, the user can still edit.
