### PR TITLE
fixes #1961 Adding JSONP support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'rabl', '>= 0.7.5'
 # Previous versions collide with Environment model
 gem "ruby_parser", ">= 2.3.1"
 gem 'oauth'
+gem 'rack-jsonp', :require => 'rack/jsonp'
 
 Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
  # puts "adding custom gem file #{bundle}"

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'rack/jsonp'
 
 # If you have a Gemfile, require the gems listed there, including any gems
 # you've limited to :test, :development, or :production.
@@ -66,6 +67,9 @@ module Foreman
     # enables in memory cache store with ttl
     #config.cache_store = TimedCachedStore.new
     config.cache_store = :file_store, Rails.root.join("tmp")
+
+    # enables JSONP support
+    config.middleware.use Rack::JSONP
   end
 
   def self.setup_console


### PR DESCRIPTION
When using cross-domain requests, it is impossible to read the response
data, and process it.
Using JSONP allows a client, from a specific domain (for example
/domain1), to query data in another doamin (/domain2), and analyze it,
using a callback.

Such a request would be followed by "callback=" parameter. For example:
http://foreman-server:3000/statistics?format=json&callback=analyzeStats

And the response would be:
analyzeStats({"statistics":{"mem_totfree":0.0,"arch_count":{},
"env_count":{},"cpu_count":{},"mem_size":0,"swap_size":0,
"model_count":{},"mem_free":0,"swap_free":0,"klass_count":{},
"os_count":{},"mem_totsize":0.0}})

which will call the analyzeStats callback.
Whereas a regular request,
http://foreman-server:3000/statistics?format=json, will just contain the
JSON data.

More reading on JSONP:
JSONP - http://en.wikipedia.org/wiki/JSONP
JSONP Ruby impl -
www.simb.net/2012/02/06/ruby-and-jsonp
https://github.com/crohr/rack-jsonp/
