### PR TITLE
fixes #1961 Adding JSONP support

### DIFF
--- a/bundler.d/jsonp.rb
+++ b/bundler.d/jsonp.rb
@@ -1,0 +1,3 @@
+group :jsonp do
+  gem 'rack-jsonp', :require => 'rack/jsonp' if SETTINGS[:support_jsonp]
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,9 @@ module Foreman
     # enables in memory cache store with ttl
     #config.cache_store = TimedCachedStore.new
     config.cache_store = :file_store, Rails.root.join("tmp")
+
+    # enables JSONP support in the Rack middleware
+    config.middleware.use Rack::JSONP if SETTINGS[:support_jsonp]
   end
 
   def self.setup_console

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -26,4 +26,7 @@ if File.exists?(ENV['BUNDLE_GEMFILE'])
     warn "Libvirt binding are missing - hypervisor management is disabled"
     SETTINGS[:libvirt] = false
   end
+
+  require 'rack/jsonp' if SETTINGS[:support_jsonp]
+
 end

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -2,3 +2,6 @@
 :unattended: true
 :login: false
 :require_ssl: false
+#JSONP or "JSON with padding" is a complement to the base JSON data format.
+#It provides a method to request JSON data from a server in a different domain.
+:support_jsonp: false


### PR DESCRIPTION
When using cross-domain requests, it is impossible to read the response
data, and process it.
Using JSONP allows a client, from a specific domain (for example
/domain1), to query data in another doamin (/domain2), and analyze it,
using a callback.

Such a request would be followed by "callback=" parameter. For example:
http://foreman-server:3000/statistics?format=json&callback=analyzeStats

And the response would be:
analyzeStats({"statistics":{"mem_totfree":0.0,"arch_count":{},
"env_count":{},"cpu_count":{},"mem_size":0,"swap_size":0,
"model_count":{},"mem_free":0,"swap_free":0,"klass_count":{},
"os_count":{},"mem_totsize":0.0}})

which will call the analyzeStats callback.
Whereas a regular request,
http://foreman-server:3000/statistics?format=json, will just contain the
JSON data.

More reading on JSONP:
JSONP - http://en.wikipedia.org/wiki/JSONP
JSONP Ruby impl -
www.simb.net/2012/02/06/ruby-and-jsonp
https://github.com/crohr/rack-jsonp/
