### PR TITLE
fixes #1915 - initialise Puppet in master context

### DIFF
--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -22,7 +22,9 @@ module Foreman
 
         def load(reset=false)
           if Puppet::PUPPETVERSION.to_i >= 3
-            Puppet.settings.initialize_global_settings(SETTINGS[:puppetconfdir])
+            # Initializing Puppet directly and not via the Faces API, so indicate
+            # the run mode to parse [master]
+            Puppet.settings.initialize_global_settings(['--confdir', SETTINGS[:puppetconfdir], '--run_mode' 'master'])
           end
 
           # We may be executing something like rake db:migrate:reset, which destroys this table; only continue if the table exists


### PR DESCRIPTION
Explicitly specify the run_mode as being 'master' to ensure the config is
parsed in a puppetmaster context.

This is based on Eric's recommendation in #1915 as the run_mode has to be explicitly set to master, so as to initialise the settings we're querying.  Without specifying the run_mode some basic settings don't get initialised if they're not explicitly listed in puppet.conf:

/usr/lib/ruby/site_ruby/1.8/puppet/settings.rb:253:in `convert': Error converting value for param 'hostcert': Error converting value for param 'certdir': Error converting value for param 'ssldir': Could not find value for $vardir (Puppet::Settings::InterpolationError)
