### PR TITLE
Fixed 1972: Supporting search hosts by uuid

### DIFF
--- a/app/models/hostext/search.rb
+++ b/app/models/hostext/search.rb
@@ -33,6 +33,7 @@ module Hostext
         if SETTINGS[:unattended]
           scoped_search :in => :subnet,      :on => :network, :complete_value => true, :rename => :subnet
           scoped_search :on => :mac,           :complete_value => true
+          scoped_search :on => :uuid,           :complete_value => true
           scoped_search :on => :build,         :complete_value => {:true => true, :false => false}
           scoped_search :on => :installed_at,  :complete_value => true
           scoped_search :in => :operatingsystem, :on => :name, :complete_value => true, :rename => :os


### PR DESCRIPTION
This patch adds support for searching hosts by uuid.
It is useful when you have the uuid of a virtual machine, and want to
get the Foreman host properties.
