### PR TITLE
bundler_ext support

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,7 +1,7 @@
 group :development do
   # To use debugger
-  gem "ruby-debug", :platforms => :ruby_18
-  gem "ruby-debug19", :platforms => :ruby_19
+  gem "ruby-debug", :platforms => :ruby_18, :require => false
+  gem "ruby-debug19", :platforms => :ruby_19, :require => false
   gem 'maruku'
   gem 'single_test'
   gem 'pry'

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -4,6 +4,6 @@ group :test do
   gem 'rr'
   gem 'rake'
   gem 'single_test'
-  gem 'ci_reporter', '>= 1.6.3'
+  gem 'ci_reporter', '>= 1.6.3', :require => false
   gem 'minitest', '~> 3.5', :platforms => :ruby_19
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,13 +2,27 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-# If you have a Gemfile, require the gems listed there, including any gems
-# you've limited to :test, :development, or :production.
-if defined?(Bundler)
-  Class.new Rails::Railtie do
-    console {Foreman.setup_console}
+if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
+  # If there is a Gemfile.in file, we will not use Bundler but BundlerExt
+  # gem which parses this file and loads all dependencies from the system
+  # rathern then trying to download them from rubygems.org. It always
+  # loads all gemfile groups.
+  begin
+    require 'bundler_ext'
+    BundlerExt.system_require(File.expand_path('../../Gemfile.in', __FILE__), :all)
+  rescue LoadError => e
+    raise e.exception("Gem bundler_ext is not installed, either install it" +
+                      " or rename Gemfile.in to Gemfile to use Bundler")
   end
-  Bundler.require(:default, Rails.env)
+else
+  # If you have a Gemfile, require the gems listed there, including any gems
+  # you've limited to :test, :development, or :production.
+  if defined?(Bundler)
+    Class.new Rails::Railtie do
+      console {Foreman.setup_console}
+    end
+    Bundler.require(:default, Rails.env)
+  end
 end
 
 require File.expand_path('../../lib/timed_cached_store.rb', __FILE__)


### PR DESCRIPTION
Hello,

this adds support for bundler_ext (https://github.com/aeolus-incubator/bundler_ext). The idea behind this is we want to avoid Bundler in katello foreman builds, therefore in our RPMs we are gonna rename Gemfile to Gemfile.in.

If Gemfile.in is found, bundler is not used and loading of dependencies is handed over to bundler_ext which loads only system gems. More info on the bundler_ext github page.

Please note pull request https://github.com/aeolus-incubator/bundler_ext/pull/3 must be merged before we add support in Foreman.

Please note this patch does not change Foreman default behavior. Also it was agreed Aeolus team will rename bundler_ext's namespace - in the next version it is gonna be BundlerExt only (wihtout Aeolus stuff), becuse now this project is used in three other projects. I will prepare a change once this is done.

Discuss, thanks.
