### PR TITLE
fixes #1899 require HTTPS URL for oVirt API, now HTTPS-only

### DIFF
--- a/lib/foreman/model/ovirt.rb
+++ b/lib/foreman/model/ovirt.rb
@@ -2,6 +2,7 @@ module Foreman::Model
   class Ovirt < ComputeResource
 
     validates_format_of :url, :with => URI.regexp
+    validates_format_of :url, :with => /\Ahttps:/, :message => "must be HTTPS"
     validates_presence_of :user, :password
 
     def self.model_name


### PR DESCRIPTION
Replaces GH-245
