### PR TITLE
API nested routes for host

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -134,5 +134,20 @@ module Api
       response.headers["Foreman_api_version"]= api_version
     end
 
+    # this method is used with nested resources, where obj_id is passed into the parameters hash.
+    # it automatically updates the search text box with the relevant relationship
+    # e.g. /hosts/fqdn/reports # would add host = fqdn to the search bar
+    def setup_search_options
+      params[:search] ||= ""
+      params.keys.each do |param|
+        if param =~ /(\w+)_id$/
+          unless params[param].blank?
+            query = "#{$1} = #{params[param]}"
+            params[:search] += query unless params[:search].include? query
+          end
+        end
+      end
+    end
+
   end
 end

--- a/app/controllers/api/v1/audits_controller.rb
+++ b/app/controllers/api/v1/audits_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class AuditsController < V1::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :setup_search_options, :only => :index
 
       api :GET, "/audits/", "List all audits."
       param :search, String, :desc => "filter results"
@@ -10,7 +11,7 @@ module Api
       param :per_page, String, :desc => "number of entries per request"
 
       def index
-        @audits = Audit.search_for(*search_options).paginate(paginate_options)
+        Audit.unscoped { @audits = Audit.search_for(*search_options).paginate(paginate_options) }
       end
 
       api :GET, "/audits/:id/", "Show an audit"

--- a/app/controllers/api/v1/fact_values_controller.rb
+++ b/app/controllers/api/v1/fact_values_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class FactValuesController < V1::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :setup_search_options, :only => :index
 
       api :GET, "/fact_values/", "List all fact values."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       api :GET, "/hosts/:id/", "Show a host."
-      param :id, :identifier, :required => true
+      param :id, :identifier_dottable, :required => true
 
       def show
       end

--- a/app/controllers/api/v1/lookup_keys_controller.rb
+++ b/app/controllers/api/v1/lookup_keys_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class LookupKeysController < V1::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :setup_search_options, :only => :index
 
       api :GET, "/lookup_keys/", "List all lookup_keys."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/puppetclasses_controller.rb
+++ b/app/controllers/api/v1/puppetclasses_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class PuppetclassesController < V1::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :setup_search_options, :only => :index
 
       api :GET, "/puppetclasses/", "List all puppetclasses."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class ReportsController < V1::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :setup_search_options, :only => [:index, :last]
 
       api :GET, "/reports/", "List all reports."
       param :search, String, :desc => "filter results"
@@ -25,6 +26,21 @@ module Api
 
       def destroy
         process_response @report.destroy
+      end
+
+      def last
+        #default order is reported_at desc
+        @reports = Report.my_reports.includes(:logs => [:source, :message]).
+          search_for(*search_options).paginate(paginate_options)
+        # last (most recent report) is first in list
+        @report = @reports.first
+        # if params[:host_id].blank?
+        #    @report = Report.my_reports.includes(:logs => [:source, :message]).last
+        # else 
+        #    @reports = Report.my_reports.includes(:logs => [:source, :message]).search_for(*search_options)
+           
+        # end
+        render :show
       end
 
     end

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -29,17 +29,9 @@ module Api
       end
 
       def last
-        #default order is reported_at desc
-        @reports = Report.my_reports.includes(:logs => [:source, :message]).
-          search_for(*search_options).paginate(paginate_options)
-        # last (most recent report) is first in list
-        @report = @reports.first
-        # if params[:host_id].blank?
-        #    @report = Report.my_reports.includes(:logs => [:source, :message]).last
-        # else 
-        #    @reports = Report.my_reports.includes(:logs => [:source, :message]).search_for(*search_options)
-           
-        # end
+        conditions = { :host_id => Host.find_by_name(params[:host_id]).try(:id) } unless params[:host_id].blank?
+        params[:id] = Report.my_reports.maximum(:id, :conditions => conditions)
+        @report = Report.find(params[:id], :include => { :logs => [:message, :source] })
         render :show
       end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -25,12 +25,12 @@ class ReportsController < ApplicationController
     # are we searching for the last report?
     if params[:id] == "last"
       conditions = { :host_id => Host.find_by_name(params[:host_id]).try(:id) } unless params[:host_id].blank?
-      params[:id] = Report.maximum(:id, :conditions => conditions)
+      params[:id] = Report.my_reports.maximum(:id, :conditions => conditions)
     end
 
     return not_found if params[:id].blank?
 
-    @report = Report.my_reports.find(params[:id], :include => { :logs => [:message, :source] })
+    @report = Report.find(params[:id], :include => { :logs => [:message, :source] })
     respond_to do |format|
       format.html { @offset = @report.reported_at - @report.created_at }
       format.json { render :json => @report }

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -37,7 +37,7 @@ class LookupKey < ActiveRecord::Base
   scoped_search :on => :override, :complete_value => {:true => true, :false => false}
   scoped_search :in => :param_class, :on => :name, :rename => :puppetclass, :complete_value => true
   scoped_search :in => :lookup_values, :on => :value, :rename => :value, :complete_value => true
-
+  
   default_scope :order => 'lookup_keys.key'
   scope :override, where(:override => true)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,5 +56,8 @@
         <%= link_to 'Support', "http://theforeman.org/projects/foreman/wiki/Support", :rel => "external" %>
       </span>
     </div>
+    <% if Rails.env.development? %>
+        <%= debug(params) %>
+    <% end %>
   </body>
 </html>

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -46,6 +46,25 @@ class IdentifierValidator < Apipie::Validator::BaseValidator
 
   def description
     "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, " +
-        "space, '_', '-' with no leading or trailing space.."
+        "space, underscore(_), hypen(-) with no leading or trailing space."
+  end
+end
+
+class IdentifierDottableValidator < Apipie::Validator::BaseValidator
+
+  def validate(value)
+    value = value.to_s
+    value =~ /\A[\w| |_|-|.]*\Z/ && value.strip == value && (1..128).include?(value.length)
+  end
+
+  def self.build(param_description, argument, options, block)
+    if argument == :identifier_dottable
+      self.new(param_description)
+    end
+  end
+
+  def description
+    "Must be an identifier, string from 1 to 128 characters containing only alphanumeric characters, " +
+        "dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
   end
 end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -12,7 +12,15 @@ Foreman::Application.routes.draw do
       # add "contraint" that uncontrains and allows :id to have dot notation ex. sat.redhat.com
       constraints(:id => /[^\/]+/) do
         resources :domains, :except => [:new, :edit]
-        resources :hosts, :except => [:new, :edit]
+        resources :hosts, :except => [:new, :edit] do
+          constraints(:host_id => /[^\/]+/) do
+            resources :reports       ,:only => [:index, :show]
+            resources :audits        ,:only => :index
+            resources :facts         ,:only => :index, :controller => :fact_values
+            resources :puppetclasses ,:only => :index
+            resources :lookup_keys   ,:only => :show
+          end
+        end
         resources :compute_resources, :except => [:new, :edit] do
           resources :images, :except => [:new, :edit]
         end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -14,7 +14,9 @@ Foreman::Application.routes.draw do
         resources :domains, :except => [:new, :edit]
         resources :hosts, :except => [:new, :edit] do
           constraints(:host_id => /[^\/]+/) do
-            resources :reports       ,:only => [:index, :show]
+            resources :reports       ,:only => [:index, :show] do
+              get :last, :on => :collection
+            end
             resources :audits        ,:only => :index
             resources :facts         ,:only => :index, :controller => :fact_values
             resources :puppetclasses ,:only => :index
@@ -46,7 +48,9 @@ Foreman::Application.routes.draw do
       resources :ptables, :except => [:new, :edit]
       resources :puppetclasses, :except => [:new, :edit]
       resources :roles, :except => [:new, :edit]
-      resources :reports, :only => [:index, :show, :destroy]
+      resources :reports, :only => [:index, :show, :destroy] do
+        get :last, :on => :collection
+      end
       resources :settings, :only => [:index, :show, :update]
       resources :smart_proxies, :except => [:new, :edit]
       resources :subnets, :except => [:new, :edit]

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -20,7 +20,6 @@ Foreman::Application.routes.draw do
             resources :audits        ,:only => :index
             resources :facts         ,:only => :index, :controller => :fact_values
             resources :puppetclasses ,:only => :index
-            resources :lookup_keys   ,:only => :show
           end
         end
         resources :compute_resources, :except => [:new, :edit] do

--- a/test/functional/api/v1/fact_values_controller_test.rb
+++ b/test/functional/api/v1/fact_values_controller_test.rb
@@ -9,4 +9,11 @@ class Api::V1::FactValuesControllerTest < ActionController::TestCase
     assert !fact_values.empty?
   end
 
+  test "should get facts for given host only" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    fact_values = ActiveSupport::JSON.decode(@response.body)
+    assert !fact_values.empty?
+  end
+
 end

--- a/test/functional/api/v1/puppetclasses_controller_test.rb
+++ b/test/functional/api/v1/puppetclasses_controller_test.rb
@@ -30,4 +30,11 @@ class Api::V1::PuppetclassesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get puppetclasses for given host only" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    fact_values = ActiveSupport::JSON.decode(@response.body)
+    assert !fact_values.empty?
+  end
+
 end

--- a/test/functional/api/v1/reports_controller_test.rb
+++ b/test/functional/api/v1/reports_controller_test.rb
@@ -24,4 +24,44 @@ class Api::V1::ReportsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get reports for given host only" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    assert_not_nil assigns(:reports)
+    reports = ActiveSupport::JSON.decode(@response.body)
+    assert !reports.empty?
+    assert 1, reports.count
+  end
+
+  test "should return empty result for host with no reports" do
+    get :index, {:host_id => hosts(:two).to_param }
+    assert_response :success
+    assert_not_nil assigns(:reports)
+    reports = ActiveSupport::JSON.decode(@response.body)
+    assert reports.empty?
+    assert 0, reports.count
+  end
+
+  test "should get last report" do
+    get :last
+    assert_response :success
+    assert_not_nil assigns(:report)
+    report = ActiveSupport::JSON.decode(@response.body)
+    assert !report.empty?
+  end
+
+  test "should get last report for given host only" do
+    get :last, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    assert_not_nil assigns(:report)
+    report = ActiveSupport::JSON.decode(@response.body)
+    assert !report.empty?
+  end
+
+  test "should give error if no last report for given host" do
+    get :last, {:host_id => hosts(:two).to_param }
+    assert_response :success
+  end
+
+
 end

--- a/test/functional/api/v1/reports_controller_test.rb
+++ b/test/functional/api/v1/reports_controller_test.rb
@@ -60,8 +60,7 @@ class Api::V1::ReportsControllerTest < ActionController::TestCase
 
   test "should give error if no last report for given host" do
     get :last, {:host_id => hosts(:two).to_param }
-    assert_response :success
+    assert_response 500
   end
-
 
 end


### PR DESCRIPTION
Added nested routes
host/:id/reports
host/:id/reports/last
host/:id/audits
host/:id/puppetclasses
host/:id/facts

There is no route yet for host/:id/lookup_keys, since there is no host relation in lookup_key.rb to search_for
