### PR TITLE
fixes #1976 - fix path to Puppet to /usr/bin

### DIFF
--- a/app/views/unattended/autoyast.xml.erb
+++ b/app/views/unattended/autoyast.xml.erb
@@ -69,7 +69,7 @@
           cat > /etc/puppet/puppet.conf << EOF
 <%= snippets "puppet.conf" -%>
 EOF
-/usr/sbin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet  --no-daemonize
 /usr/bin/wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 /sbin/chkconfig puppet on -f
 ]]>

--- a/app/views/unattended/jumpstart_finish.rhtml
+++ b/app/views/unattended/jumpstart_finish.rhtml
@@ -45,7 +45,7 @@ then
     rm -f /etc/opt/csw/puppet/puppetd.conf
     ln -s /etc/puppet/puppet.conf /etc/opt/csw/puppet/puppetd.conf
 fi
-/opt/csw/sbin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet --no-daemonize
+/opt/csw/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server puppet --no-daemonize
 echo "Informing Foreman that we are built"
 /opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url %>
 exit 0

--- a/app/views/unattended/kickstart.rhtml
+++ b/app/views/unattended/kickstart.rhtml
@@ -61,7 +61,7 @@ echo "Disabling various system services"
   /sbin/chkconfig --level 345 <%= service %> off 2>/dev/null
 <% end -%>
 
-/usr/sbin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %>  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %>  --no-daemonize
 
 sync
 

--- a/app/views/unattended/snippets/_puppet.init.erb
+++ b/app/views/unattended/snippets/_puppet.init.erb
@@ -5,4 +5,4 @@
 # processname: puppet
 # config: /etc/puppet/puppet.conf
 
-/usr/sbin/puppet agent --config /etc/puppet/puppet.conf -o --ignoreschedules true --server=<%= @host.puppetmaster %> > /tmp/puppet.log 2>&1
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --ignoreschedules true --server=<%= @host.puppetmaster %> > /tmp/puppet.log 2>&1


### PR DESCRIPTION
Only puppetd was in /usr/sbin/
