### PR TITLE
Fixes 1978 adding oVirt authentication source

### DIFF
--- a/app/models/auth_source_ovirt.rb
+++ b/app/models/auth_source_ovirt.rb
@@ -1,0 +1,69 @@
+class AuthSourceOvirt < AuthSource
+  validates_presence_of :host, :port
+  validates_length_of :host, :port, :maximum => 60, :allow_nil => false
+
+  def authenticate(login, password)
+
+    # oVirt passes the username with "ovirt_" prefix. We remove it in this function.
+    # The login name in Foreman will include the "ovirt_" prefix, but all the other user details won't
+    # The reason for this prefix is that the login source of this user will always be the oVirt Authentication source
+    login = login.sub("ovirt_","")
+
+    userDetails = get_user_details(login, password)
+
+    return nil unless !userDetails.nil?
+
+    # In case a field is empty, we put the login as the value
+    # The oVirt login must be in the form of user@domain, so it is also valid as
+    # E-mail value
+    attrs = [:firstname => userDetails.has_key?('name') ? userDetails['name'] : login.split("@")[0],
+             :lastname => userDetails['surname'],
+             :mail => userDetails.has_key?('email') ? userDetails['email'] : login,
+             :auth_source_id => self.id ]
+    attrs
+  end
+
+  def auth_method_name
+    "OVIRT"
+  end
+  alias_method :to_label, :auth_method_name
+
+  def can_set_password?
+    false
+  end
+  
+  private
+
+  def get_user_details(login, password)
+    response = get_user_from_ovirt(login, password)
+    users = !response.nil? ? JSON.parse(response) : nil
+    userDetails = !users.nil? ? users['users'][0] : nil
+    userDetails
+  end    
+
+  def get_user_from_ovirt(login,password)
+    logger.debug "oVirt-Auth with User " + login
+    logger.debug "oVirt host name is " + host
+    logger.debug "oVirt port number is " + port.to_s()
+
+    prefix = tls ? 'https' : 'http'
+    url=prefix + '://' + host + ':' + port.to_s()
+
+    logger.debug "oVirt URL is " + url
+    session_id_str = Rack::Utils.escape(password)
+    # The password we get is the REST session ID
+    # We set it in the cookie, using the "Prefer" header
+    # to keep the session alive
+    session_id = ({ :JSESSIONID => session_id_str })
+    headers = ({ :content_type => 'application/json',
+                 :accept => 'application/json',
+                 :Prefer => "persistent-auth",
+                 :cookies => ( session_id )
+    })
+    search_query = URI.escape('search=' + login)
+
+    # We query for the user, to get its details
+    response = RestClient::Resource.new(url)['/api/users?' + search_query].get(headers)
+    response
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
   validates_presence_of :password_hash, :if => Proc.new {|user| user.manage_password?}
   validates_confirmation_of :password,  :if => Proc.new {|user| user.manage_password?}, :unless => Proc.new {|user| user.password.empty?}
   validates_format_of :login, :with => /^[a-z0-9_\-@\.]*$/i
-  validates_length_of :login, :maximum => 30
+  validates_length_of :login, :maximum => 60
   validates_format_of :firstname, :lastname, :with => /^[\w\s\'\-\.]*$/i, :allow_nil => true
   validates_length_of :firstname, :lastname, :maximum => 30, :allow_nil => true
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -34,8 +34,8 @@ class UserTest < ActiveSupport::TestCase
     assert !u.valid?
   end
 
-  test "login size should not exceed the 30 characters" do
-    u = User.new :auth_source => auth_sources(:one), :login => "a" * 31, :mail => "foo@bar.com"
+  test "login size should not exceed the 60 characters" do
+    u = User.new :auth_source => auth_sources(:one), :login => "a" * 61, :mail => "foo@bar.com"
     assert !u.save
   end
 


### PR DESCRIPTION
This patch adds an oVirt authentication source, to be used by the
oVirt-foreman UI plugin.

The login should be in the format:
ovirt_USER@DOMAIN
Where ovirt_ is a constant prefix
USER is the oVirt user
DOMAIN is the oVirt domain

The oVirt user name indeed consist of both the username and the domain,
so basically one needs to pass ovirt_USERNAME
(USERNAME=user@domain)

The password is an authentication token, which should be a valid REST
token (REST Session ID).
