### PR TITLE
Fix foreman features when running from subpath

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -86,7 +86,7 @@ class HostsController < ApplicationController
   def create
     @host = Host.new(params[:host])
     @host.managed = true if (params[:host] && params[:host][:managed].nil?)
-    forward_request_url
+    forward_url_options
     if @host.save
       process_success :success_redirect => host_path(@host), :redirect_xhr => request.xhr?
     else
@@ -101,7 +101,7 @@ class HostsController < ApplicationController
   end
 
   def update
-    forward_request_url
+    forward_url_options
     Taxonomy.no_taxonomy_scope do
       if @host.update_attributes(params[:host])
         process_success :success_redirect => host_path(@host), :redirect_xhr => request.xhr?
@@ -182,7 +182,7 @@ class HostsController < ApplicationController
   end
 
   def setBuild
-    forward_request_url
+    forward_url_options
     if @host.setBuild
       process_success :success_msg => "Enabled #{@host} for rebuild on next boot", :success_redirect => :back
     else
@@ -317,7 +317,7 @@ class HostsController < ApplicationController
 
   def submit_multiple_build
     @hosts.delete_if do |host|
-      host.request_url = request.host_with_port if host.respond_to?(:request_url)
+      forward_url_options(host)
       host.setBuild
     end
 
@@ -541,8 +541,8 @@ class HostsController < ApplicationController
   end
 
   # this is required for template generation (such as pxelinux) which is not done via a web request
-  def forward_request_url
-    @host.request_url = request.host_with_port if @host.respond_to?(:request_url)
+  def forward_url_options(host = @host)
+    host.url_options = url_options if @host.respond_to?(:url_options)
   end
 
   def merge_search_filter filter

--- a/app/models/host_template_helpers.rb
+++ b/app/models/host_template_helpers.rb
@@ -27,8 +27,17 @@ module HostTemplateHelpers
   def foreman_url(action = "provision")
     url_for :only_path => false, :controller => "unattended",
             :action => action,
-            :host => Setting[:foreman_url] || request_url,
-            :protocol  => 'http',
             :token => (@host.token.value unless @host.token.nil?)
   end
+
+  attr_writer(:url_options)
+
+  # used by url_for to generate the path correctly
+  def url_options
+    url_options = @url_options || {}
+    url_options[:protocol] = "http://"
+    url_options[:host] = Setting[:foreman_url] if Setting[:foreman_url]
+    url_options
+  end
+
 end

--- a/app/models/orchestration/tftp.rb
+++ b/app/models/orchestration/tftp.rb
@@ -2,7 +2,6 @@ module Orchestration::TFTP
   def self.included(base)
     base.send :include, InstanceMethods
     base.class_eval do
-      attr_accessor :request_url
       after_validation :validate_tftp, :queue_tftp
       before_destroy :queue_tftp_destroy
 

--- a/app/views/hosts/console.html.erb
+++ b/app/views/hosts/console.html.erb
@@ -18,7 +18,7 @@
     <embed type="application/x-spice" height=0 width=0>
 <!--VNC Console-->
 <% elsif @console[:proxy_port] -%>
-    <%= content_for(:head) { javascript_tag "var INCLUDE_URI = '/javascripts/noVNC/';" } %>
+    <%= content_for(:head) { javascript_tag "var INCLUDE_URI = '#{javascript_path("noVNC").sub(/\.js.*$/,"/")}';" } %>
     <%= javascript 'noVNC/vnc', 'noVNC/ui', 'noVNC' %>
 
     <div id='vnc' data-port='<%= @console[:proxy_port] %>' data-password='<%= @console[:password] %>'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
       'bootstrap.min' %>
     <%= csrf_meta_tag %>
     <%= javascript_tag "var AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery? %>
+    <%= javascript_tag "var URL_PREFIX = '#{request.script_name}';" %>
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
     <%= yield(:head) %>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -356,3 +356,8 @@ function update_puppetclasses(element) {
     }
   })
 }
+
+// generates an absolute, needed in case of running Foreman from a subpath
+function foreman_url(path) {
+  return URL_PREFIX + path;
+}

--- a/public/javascripts/host_edit.js
+++ b/public/javascripts/host_edit.js
@@ -56,7 +56,7 @@ var stop_pooling;
 
 function submit_host(form){
   var url = window.location.pathname.replace(/\/edit$|\/new$/,'');
-  if(/\/clone$/.test(window.location.pathname)){ url = '/hosts'; }
+  if(/\/clone$/.test(window.location.pathname)){ url = foreman_url('/hosts'); }
   $('#host_submit').attr('disabled', true);
   stop_pooling = false;
   $("body").css("cursor", "progress");
@@ -279,7 +279,7 @@ function subnet_selected(element){
   $.ajax({
     data: attrs,
     type:'post',
-    url:'/subnets/freeip',
+    url: foreman_url('/subnets/freeip'),
     complete: function(){$('#subnet_indicator').hide()}
   })
 }
@@ -352,7 +352,7 @@ function update_provisioning_image(){
   $.ajax({
       data:'search=' + encodeURIComponent(term),
       type:'get',
-      url:'/compute_resources/'+compute_id+'/images',
+      url: foreman_url('/compute_resources/'+compute_id+'/images'),
       dataType: 'json',
       success: function(result) {
         $.each(result, function() {

--- a/test/unit/host_observer_test.rb
+++ b/test/unit/host_observer_test.rb
@@ -24,7 +24,7 @@ class HostObserverTest < ActiveSupport::TestCase
       host = Host.create! :name => "foo", :mac => "aabbeeddccff", :ip => "2.3.4.244", :managed => true,
         :build => true, :architecture => architectures(:x86_64), :environment => Environment.first, :puppet_proxy_id => 1,
         :domain => Domain.first, :operatingsystem => operatingsystems(:centos5_3), :subnet => subnets(:one),
-        :request_url => 'http://foreman'
+        :url_options => {:host => 'foreman', :protocol => "http://"}
     end
 
     assert host.token.try(:value).present?


### PR DESCRIPTION
This PR contains a set of commits that make it possible to provision a machine from a Foreman running on a subpath, such as 'https://server.example.com/foreman'. It's possible there are other parts of the code that don't work in this set-up, I will fix them as I run into them.

This commits fix host creation, noVNC console and pxe/provision templates rendering for the build phase.

The issue in the tracker is http://theforeman.org/issues/1937
