### PR TITLE
Security fix - unauthenticated  API calls

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,7 @@
 module Api
   #TODO: inherit from application controller after cleanup
   class BaseController < ActionController::Base
+    include Foreman::ThreadSession::Cleaner
 
     before_filter :set_default_response_format, :authorize, :add_version_header
 
@@ -133,6 +134,5 @@ module Api
       response.headers["Foreman_version"]= SETTINGS[:version]
       response.headers["Foreman_api_version"]= api_version
     end
-
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 require 'foreman/controller/auto_complete_search'
 
 class ApplicationController < ActionController::Base
+  include Foreman::ThreadSession::Cleaner
+
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
   rescue_from Exception, :with => :generic_exception if Rails.env.production?

--- a/lib/api/authorization.rb
+++ b/lib/api/authorization.rb
@@ -14,8 +14,9 @@ module Api
         # if authentication is disabled, the user is the build-in admin account.
         User.current = User.admin
       else
+        return true if User.current && Rails.env.test?
         authorization_method = oauth? ? :oauth : :http_basic
-        User.current       ||= send(authorization_method) || (return false)
+        User.current         = send(authorization_method) || (return false)
       end
 
       return true

--- a/test/functional/api/v1/users_controller_test.rb
+++ b/test/functional/api/v1/users_controller_test.rb
@@ -4,6 +4,10 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
 
   valid_attrs = { :login => "johnsmith" }
 
+  def setup
+    setup_users
+  end
+
   test "should get index" do
     get :index, { }
     assert_response :success

--- a/test/functional/config_templates_controller_test.rb
+++ b/test/functional/config_templates_controller_test.rb
@@ -118,6 +118,7 @@ class ConfigTemplatesControllerTest < ActionController::TestCase
   end
 
   def test_history_in_edit
+    setup_users
     ConfigTemplate.auditing_enabled = true
     ConfigTemplate.any_instance.stubs(:valid?).returns(true)
     template = ConfigTemplate.first

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -88,6 +88,8 @@ class UnattendedControllerTest < ActionController::TestCase
   end
 
   test "should not provide unattended files to hosts which don't have an assign os" do
+    setup_users
+
     hosts(:otherfullhost).update_attribute(:operatingsystem_id, nil)
     @request.env["HTTP_X_RHN_PROVISIONING_MAC_0"] = "eth0 #{hosts(:otherfullhost).mac}"
     get :kickstart

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
+  def setup
+    setup_users
+  end
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success
@@ -106,23 +110,12 @@ class UsersControllerTest < ActionController::TestCase
     assert !User.find_by_login("admin").nil?
   end
 
-  def setup_users
-    User.current = users :admin
-    user = User.find_by_login("one")
-    @request.session[:user] = user.id
-    @request.session[:expires_at] = 5.minutes.from_now
-    user.roles = [Role.find_by_name('Anonymous'), Role.find_by_name('Viewer')]
-    user.save!
-  end
-
   test 'user with viewer rights should fail to edit a user' do
-    setup_users
     get :edit, {:id => User.first.id}
     assert_equal @response.status, 403
   end
 
   test 'user with viewer rights should succeed in viewing users' do
-    setup_users
     get :index
     assert_response :success
   end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -126,4 +126,9 @@ class UsersControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test "should clear the current user after processing the request" do
+    get :index, {}, set_session_user
+    assert User.current.nil?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,15 @@ class ActiveSupport::TestCase
     as_user :admin, &block
   end
 
+  def setup_users
+    User.current = users :admin
+    user = User.find_by_login("one")
+    @request.session[:user] = user.id
+    @request.session[:expires_at] = 5.minutes.from_now
+    user.roles = [Role.find_by_name('Anonymous'), Role.find_by_name('Viewer')]
+    user.save!
+  end
+
   def setup_user operation, type=""
     @one = users(:one)
     as_admin do


### PR DESCRIPTION
Not cleaning thread values after handling request allowed unauthenticated API calls. Only develop version is affected, no need for back-porting.

How to reproduce:
1. one process deployment
2. log into the web intercase
3. try some API call with invalid credentials

The fix consists of 3 commits:
1. Clear the thread values outside of handling request

Adding an around filter to clear the thread values. Without this there
is a risk that the thread value from previous request will be used in
other request, which can lead to security issues.

We clear the current user at the beginning of the request (except the
test environment, where it's being used to simulate user being logged
in). In the production, this should never happen, but it's better safe
than sorry.
1. Ignore value of User.current when authorizing

This is the very issue that cause the insecure bahaviour
1. Fix inter-test dependencies

After the thread clean-up, some tests were failing because they
implicitly expected User.current to be set. Stating the dependencies
explicitly.
