### PR TITLE
fixes #1994 - set vardir for puppet 3, use --configprint

### DIFF
--- a/config/settings.rb
+++ b/config/settings.rb
@@ -3,3 +3,5 @@ SETTINGS = YAML.load_file("#{root}/config/settings.yaml")
 SETTINGS[:version]    = File.read(root + "/VERSION").chomp rescue ("N/A")
 SETTINGS[:unattended] = SETTINGS[:unattended].nil? || SETTINGS[:unattended]
 SETTINGS[:login]    ||= SETTINGS[:ldap]
+SETTINGS[:puppetconfdir] ||= '/etc/puppet'
+SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -10,3 +10,5 @@
 #JSONP or "JSON with padding" is a complement to the base JSON data format.
 #It provides a method to request JSON data from a server in a different domain.
 :support_jsonp: false
+#:puppetconfdir: /etc/puppet
+#:puppetvardir: /var/lib/puppet

--- a/lib/foreman/util.rb
+++ b/lib/foreman/util.rb
@@ -1,0 +1,18 @@
+module Foreman
+  module Util
+    # searches for binaries in predefined directories and user PATH
+    # accepts a binary name and an array of paths to search first
+    # if path is omitted will search only in user PATH
+    def which(bin, *path)
+      path += ENV['PATH'].split(File::PATH_SEPARATOR)
+      path.flatten.uniq.each do |dir|
+        dest = File.join(dir, bin)
+        return dest if FileTest.file? dest and FileTest.executable? dest
+      end
+      return false
+    rescue StandardError => e
+      logger.warn e
+      return false
+    end
+  end
+end

--- a/lib/puppet_setting.rb
+++ b/lib/puppet_setting.rb
@@ -1,0 +1,55 @@
+require 'rubygems'
+require 'puppet'
+require 'foreman/util'
+
+class PuppetSetting
+  include Foreman::Util
+
+  def get(*name)
+    values = `#{puppetmaster} --configprint #{name.join(",")}`
+    raise "unable to get #{name.inspect} Puppet setting: #{values}" unless $?.success?
+    if name.size > 1
+      # Parse key = value lines into hash
+      values = HashWithIndifferentAccess[values.lines.map {|kv| kv.chomp.split(' = ', 2) }]
+    end
+    values
+  end
+
+  private
+
+  def puppetmaster
+    unless @puppetmaster
+      # puppetmasterd is the old method of using puppet master which is new in puppet 2.6
+      default_path = ["/usr/sbin", "/opt/puppet/bin", "/usr/bin"]
+
+      if Puppet::PUPPETVERSION.to_i < 3
+        @puppetmaster = which('puppetmasterd', default_path) || which('puppet', default_path)
+      else
+        @puppetmaster = which('puppet', default_path)
+      end
+
+      unless @puppetmaster and File.exists?(@puppetmaster)
+        logger.warn 'unable to find puppetmaster binary'
+        raise 'unable to find puppetmaster'
+      end
+
+      # Append master to the puppet command if we are not using the old puppetmasterd command
+      logger.debug "Found puppetmaster at #{@puppetmaster}"
+      @puppetmaster << ' master' unless @puppetmaster.include?('puppetmaster')
+
+      # Despite the name "dir", the default settings.yaml pointed to puppet.conf so handle both files and dirs
+      @puppetmaster << (FileTest.file?(SETTINGS[:puppetconfdir]) ? ' --config ' : ' --confdir ')
+      @puppetmaster << SETTINGS[:puppetconfdir]
+
+      # Per Puppet #16637, --vardir has to be explicitly set too for non-root users
+      if Puppet::PUPPETVERSION.to_i >= 3
+        @puppetmaster << ' --vardir ' << SETTINGS[:puppetvardir]
+      end
+    end
+    @puppetmaster
+  end
+
+  def logger
+    Rails.logger
+  end
+end

--- a/test/lib/foreman/default_settings/loader_test.rb
+++ b/test/lib/foreman/default_settings/loader_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'puppet_setting'
+require 'foreman/default_settings/loader'
+
+class DefaultSettingsLoaderTest < ActiveSupport::TestCase
+  # Check one of the puppetmaster sourced settings was loaded
+  test "should initialize hostcert from Puppet" do
+    PuppetSetting.stubs(:get).returns({
+        :hostcert => '/var/lib/puppet/mycert.pem',
+        :localcacert => 'foo', :hostprivkey => 'foo', :storeconfigs => 'foo'
+    })
+    Foreman::DefaultSettings::Loader.load
+    assert_equal '/var/lib/puppet/mycert.pem', Setting.find_by_name('ssl_certificate').value
+  end
+end
+

--- a/test/lib/foreman/util_test.rb
+++ b/test/lib/foreman/util_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'foreman/util'
+
+class UtilTest < ActiveSupport::TestCase
+  include Foreman::Util
+
+  test "should support which" do
+    assert Foreman::Util.instance_methods.include? "which"
+  end
+
+  test "should iterate over PATH env and find binary" do
+    ENV.stubs(:[]).with('PATH').returns(["/bin", "/usr/bin"])
+    FileTest.stubs(:file?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:executable?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:file?).with('/usr/bin/utiltest').returns(true)
+    FileTest.stubs(:executable?).with('/usr/bin/utiltest').returns(true)
+    assert_equal '/usr/bin/utiltest', which('utiltest')
+  end
+
+  test "should prefer binaries in user-supplied user PATH" do
+    ENV.stubs(:[]).with('PATH').returns(["/bin", "/usr/bin"])
+    FileTest.stubs(:file?).with('/custom/utiltest').returns(true)
+    FileTest.stubs(:executable?).with('/custom/utiltest').returns(true)
+    FileTest.stubs(:file?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:executable?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:file?).with('/usr/bin/utiltest').returns(true)
+    FileTest.stubs(:executable?).with('/usr/bin/utiltest').returns(true)
+    assert_equal '/custom/utiltest', which('utiltest', ['/custom'])
+  end
+
+  test "should return false when binary not found in PATH" do
+    ENV.stubs(:[]).with('PATH').returns(["/bin", "/usr/bin"])
+    FileTest.stubs(:file?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:executable?).with('/bin/utiltest').returns(false)
+    FileTest.stubs(:file?).with('/usr/bin/utiltest').returns(false)
+    FileTest.stubs(:executable?).with('/usr/bin/utiltest').returns(false)
+    assert_equal false, which('utiltest')
+  end
+end
+

--- a/test/lib/puppet_setting_test.rb
+++ b/test/lib/puppet_setting_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+require 'puppet_setting'
+
+class PuppetSettingTest < ActiveSupport::TestCase
+  test "should always have puppetconfdir available" do
+    assert_not_nil SETTINGS[:puppetconfdir]
+  end
+
+  test "should always have puppetvardir available" do
+    assert_not_nil SETTINGS[:puppetvardir]
+  end
+
+  test "should find puppetmasterd on Puppet 2.x" do
+    Puppet::PUPPETVERSION.stubs(:to_i).returns(2.7)
+    SETTINGS.stubs(:[]).with(:puppetconfdir).returns('/test/etc/puppet')
+    SETTINGS.stubs(:[]).with(:puppetvardir).returns('/test/var/puppet')
+    PuppetSetting.any_instance.expects(:which).with('puppetmasterd', kind_of(Array)).returns('/opt/puppet/bin/puppetmasterd')
+    File.stubs(:exists?).with('/opt/puppet/bin/puppetmasterd').returns(true)
+    FileTest.stubs(:file?).with('/test/etc/puppet').returns(false)
+
+    pm = PuppetSetting.new.send(:puppetmaster)
+    assert_equal "/opt/puppet/bin/puppetmasterd --confdir /test/etc/puppet", pm
+  end
+
+  test "should find 'puppet master' and use --vardir on Puppet 3.x" do
+    Puppet::PUPPETVERSION.stubs(:to_i).returns(3.0)
+    SETTINGS.stubs(:[]).with(:puppetconfdir).returns('/test/etc/puppet')
+    SETTINGS.stubs(:[]).with(:puppetvardir).returns('/test/var/puppet')
+    PuppetSetting.any_instance.expects(:which).with('puppet', kind_of(Array)).returns('/opt/puppet/bin/puppet')
+    File.stubs(:exists?).with('/opt/puppet/bin/puppet').returns(true)
+    FileTest.stubs(:file?).with('/test/etc/puppet').returns(false)
+
+    pm = PuppetSetting.new.send(:puppetmaster)
+    assert_equal "/opt/puppet/bin/puppet master --confdir /test/etc/puppet --vardir /test/var/puppet", pm
+  end
+
+  test "should use --config if puppetconfdir is a file" do
+    Puppet::PUPPETVERSION.stubs(:to_i).returns(3.0)
+    SETTINGS.stubs(:[]).with(:puppetconfdir).returns('/test/etc/puppet/puppet.conf')
+    SETTINGS.stubs(:[]).with(:puppetvardir).returns('/test/var/puppet')
+    PuppetSetting.any_instance.expects(:which).with('puppet', kind_of(Array)).returns('/opt/puppet/bin/puppet')
+    File.stubs(:exists?).with('/opt/puppet/bin/puppet').returns(true)
+    FileTest.stubs(:file?).with('/test/etc/puppet/puppet.conf').returns(true)
+
+    pm = PuppetSetting.new.send(:puppetmaster)
+    assert_equal "/opt/puppet/bin/puppet master --config /test/etc/puppet/puppet.conf --vardir /test/var/puppet", pm
+  end
+
+  test "should throw error if puppet master binary not found" do
+    Puppet::PUPPETVERSION.stubs(:to_i).returns(3.0)
+    ps = PuppetSetting.new
+    ps.expects(:which).with('puppet', kind_of(Array)).returns(false)
+    File.stubs(:exists?).with('/opt/puppet/bin/puppet').returns(false)
+    assert_raise(RuntimeError, /unable to find/) { ps.send(:puppetmaster) }
+  end
+
+  test "should use puppetmasterd --configprint to look up setting" do
+    ps = PuppetSetting.new
+    ps.instance_variable_set(:@puppetmaster, '/foo')
+    ps.expects('`').with('/foo --configprint foo').returns('bar')
+    $?.expects(:success?).returns(true)
+    assert_equal 'bar', ps.get('foo')
+  end
+
+  test "should use puppetmasterd --configprint to look up multiple settings" do
+    ps = PuppetSetting.new
+    ps.instance_variable_set(:@puppetmaster, '/foo')
+    ps.expects('`').with('/foo --configprint foo,bar_baz').returns("bar_baz = foo\nfoo = bar\n")
+    $?.expects(:success?).returns(true)
+    assert_equal({ "foo" => "bar", "bar_baz" => "foo" },
+    ps.get('foo', 'bar_baz'))
+  end
+
+  test "should report error from puppetmasterd --configprint" do
+    ps = PuppetSetting.new
+    ps.instance_variable_set(:@puppetmaster, '/foo')
+    ps.expects('`').with('/foo --configprint foo').returns('bar')
+    $?.expects(:success?).returns(false)
+    assert_raise(RuntimeError, /unable to get foo/) { ps.get('foo') }
+  end
+end


### PR DESCRIPTION
When running Puppet 3 as a non-root user (i.e. foreman), both --confdir and
--vardir have to be specified as per Puppet #16637, else SSL settings dependent
on vardir will fail.

This adds a new puppetvardir setting used with puppetconfdir, and supports
puppetconfdir being a file or directory due to historic settings.yaml examples.

It now shells out and uses `puppet master --configprint` to retrieve settings
to avoid changes in Puppet settings initialization logic across versions (e.g.
run_mode on Puppet 3).
