### PR TITLE
fixes #2018 add forward slash to controller name of url_for() helper

### DIFF
--- a/app/controllers/api/v1/config_templates_controller.rb
+++ b/app/controllers/api/v1/config_templates_controller.rb
@@ -88,7 +88,7 @@ module Api
       end
 
       def default_template_url template, hostgroup
-        url_for :only_path => false, :action => :template, :controller => :unattended,
+        url_for :only_path => false, :action => :template, :controller => '/unattended',
                 :id        => template.name, :hostgroup => hostgroup.name
       end
 

--- a/app/controllers/config_templates_controller.rb
+++ b/app/controllers/config_templates_controller.rb
@@ -95,7 +95,7 @@ class ConfigTemplatesController < ApplicationController
   end
 
   def default_template_url template, hostgroup
-    url_for :only_path => false, :action => :template, :controller => :unattended,
+    url_for :only_path => false, :action => :template, :controller => '/unattended',
       :id => template.name, :hostgroup => hostgroup.name
   end
 

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -178,7 +178,7 @@ module HostsHelper
           content_tag(:td, "#{tmplt.template_kind} Template") +
             content_tag(:td,
           link_to_if_authorized(icon_text('pencil'), hash_for_edit_config_template_path(:id => tmplt.to_param), :title => "Edit", :rel=>"external") +
-          link_to(icon_text('eye-open'), url_for(:controller => 'unattended', :action => tmplt.template_kind.name, :spoof => @host.ip), :title => "Review", :"data-provisioning-template" => true ))
+          link_to(icon_text('eye-open'), url_for(:controller => '/unattended', :action => tmplt.template_kind.name, :spoof => @host.ip), :title => "Review", :"data-provisioning-template" => true ))
         end
       end.join(" ").html_safe
     end

--- a/app/models/host_template_helpers.rb
+++ b/app/models/host_template_helpers.rb
@@ -25,7 +25,7 @@ module HostTemplateHelpers
 
   #returns the URL for Foreman based on the required action
   def foreman_url(action = "provision")
-    url_for :only_path => false, :controller => "unattended",
+    url_for :only_path => false, :controller => "/unattended",
             :action => action,
             :token => (@host.token.value unless @host.token.nil?)
   end

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -15,7 +15,7 @@ module Foreman
 
     #returns the URL for Foreman Built status (when a host has finished the OS installation)
     def foreman_url(action = "built")
-      url_for :only_path => false, :controller => "unattended", :action => action,
+      url_for :only_path => false, :controller => "/unattended", :action => action,
               :host      => (Setting[:foreman_url] unless Setting[:foreman_url].blank?),
               :protocol  => 'http',
               :token     => (@host.token.value unless @host.token.nil?)


### PR DESCRIPTION
http://apidock.com/rails/ActionController/Base/url_for

If the controller name begins with a slash no defaults are used:

``` ruby
  url_for :controller => '/home'
```

In particular, a leading slash ensures no namespace is assumed. Thus, while url_for :controller =&gt; 'users' may resolve to Admin::UsersController if the current controller lives under that module, url_for :controller =&gt; '/users' ensures you link to ::UsersController no matter what.
