### PR TITLE
Turn off the apipie validations for now

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -7,7 +7,7 @@ Apipie.configure do |config|
   config.ignored_by_recorder = %w[]
   config.doc_base_url = "/apidoc"
   config.use_cache = Rails.env.production?
-  config.validate = true
+  config.validate = false
   config.force_dsl = true
   config.reload_controllers = Rails.env.development?
   config.markup = Apipie::Markup::Markdown.new if Rails.env.development?


### PR DESCRIPTION
The main reason for the validations to be implemented in Apipie was
the ability to be able to check the documentation against the code:
i.e. it can discover inconsistencies between the documentation and
the actual code that uses the API.

However, it seems, that for now there are some weaknesses in the
implementation. Also the duplication with the ActiveRecord validations
is not helping.

Therefore let's turn the validation off by default and have the issues
fixed outside of production environment.
