### PR TITLE
fixes #2020 - PuppetSetting is an instance, not class

### DIFF
--- a/test/lib/foreman/default_settings/loader_test.rb
+++ b/test/lib/foreman/default_settings/loader_test.rb
@@ -5,10 +5,7 @@ require 'foreman/default_settings/loader'
 class DefaultSettingsLoaderTest < ActiveSupport::TestCase
   # Check one of the puppetmaster sourced settings was loaded
   test "should initialize hostcert from Puppet" do
-    PuppetSetting.stubs(:get).returns({
-        :hostcert => '/var/lib/puppet/mycert.pem',
-        :localcacert => 'foo', :hostprivkey => 'foo', :storeconfigs => 'foo'
-    })
+    PuppetSetting.any_instance.stubs(:get).returns({:hostcert => '/var/lib/puppet/mycert.pem'})
     Foreman::DefaultSettings::Loader.load
     assert_equal '/var/lib/puppet/mycert.pem', Setting.find_by_name('ssl_certificate').value
   end


### PR DESCRIPTION
Currently causing a test failure (`rake test:lib`)
