### PR TITLE
fixes #2021 - run test:lib from test rake task

### DIFF
--- a/lib/tasks/test_lib_dir.rake
+++ b/lib/tasks/test_lib_dir.rake
@@ -8,3 +8,7 @@ namespace :test do
   end
 
 end
+
+Rake::Task[:test].enhance do
+  Rake::Task['test:lib'].invoke
+end


### PR DESCRIPTION
The test task's defined in rails, so append onto it.
