### PR TITLE
Bug #1979: Updating puppet:import:puppet_classes for parameterized classes

### DIFF
--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -99,7 +99,7 @@ namespace :puppet do
           puts "Scheduled changes to your environment"
           puts "Create/update environments"
           for env, classes in changes["new"]
-            print "%-15s: %s\n" % [env, classes.to_sentence]
+            print "%-15s: %s\n" % [env, classes.inspect]
           end
           puts "Delete environments"
           for env, classes in changes["obsolete"]


### PR DESCRIPTION
Puppet import_classes rake task doesn't work the old way doing Environment.import_classes since this method was moved onto PuppetClassesImporter.  

I'd update this pull request with better logging support. We run this as a cron job and put the output on class-import.log, it's very useful to log the changes and when were they done. If you guys deem it fit and proper I'll update the pull request.

http://theforeman.org/issues/1979
