### PR TITLE
fixes #2030 - define instance variables during ERB evaluation when not

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -8,6 +8,7 @@ module Foreman
         box = Safemode::Box.new self, allowed_methods
         box.eval(ERB.new(template, nil, '-').src, allowed_vars)
       else
+        allowed_vars.each { |k,v| instance_variable_set "@#{k}", v }
         ERB.new(template, nil, '-').result(binding)
       end
     end

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'foreman/renderer'
+
+class RendererTest < ActiveSupport::TestCase
+  include Foreman::Renderer
+
+  test "should evaluate template variables under safemode" do
+    Setting.expects(:[]).with(:safemode_render).returns(true)
+    tmpl = render_safe('<%= @foo -%>', [], { :foo => 'bar' })
+    assert_equal 'bar', tmpl
+  end
+
+  test "should evaluate template variables without safemode" do
+    Setting.expects(:[]).with(:safemode_render).returns(false)
+    tmpl = render_safe('<%= @foo -%>', [], { :foo => 'bar' })
+    assert_equal 'bar', tmpl
+  end
+
+  test "should evaluate renderer methods under safemode" do
+    Setting.expects(:[]).with(:safemode_render).returns(true)
+    self.expects(:foreman_url).returns('bar')
+    tmpl = render_safe('<%= foreman_url -%>', [:foreman_url])
+    assert_equal 'bar', tmpl
+  end
+
+  test "should evaluate renderer methods without safemode" do
+    Setting.expects(:[]).with(:safemode_render).returns(false)
+    self.expects(:foreman_url).returns('bar')
+    tmpl = render_safe('<%= foreman_url -%>')
+    assert_equal 'bar', tmpl
+  end
+end


### PR DESCRIPTION
fixes #2030 - define instance variables during ERB evaluation when not using safemode
