### PR TITLE
Update lib/foreman/model/ovirt.rb

### DIFF
--- a/lib/foreman/model/ovirt.rb
+++ b/lib/foreman/model/ovirt.rb
@@ -80,7 +80,6 @@ module Foreman::Model
     def create_vm(args = {})
       #ovirt doesn't accept '.' in vm name.
       args[:name] = args[:name].parameterize
-      args[:display] = 'VNC'
       vm = super args
       begin
         create_interfaces(vm, args[:interfaces_attributes])


### PR DESCRIPTION
This line is forcing VNC for the console type and overriding the RHEV template. Foreman supports SPICE now, so there is no need to do this.
