### PR TITLE
fixes bug preventing LDAP authentication in auth_source_ldap model

### DIFF
--- a/app/models/auth_source_ldap.rb
+++ b/app/models/auth_source_ldap.rb
@@ -95,11 +95,12 @@ class AuthSourceLdap < AuthSource
   end
 
   def use_user_login_for_auth?
-    !(account and account.include? "$login")
+    # returns true if account is defined and includes "$login"
+    (account and account.include? "$login")
   end
 
   def effective_user(login)
-    use_user_login_for_auth? ? account : account.sub("$login", login)
+    use_user_login_for_auth? ? account.sub("$login", login) : account
   end
 
   def required_ldap_attributes
@@ -120,7 +121,7 @@ class AuthSourceLdap < AuthSource
 
   def search_for_user_entries(login, password)
     user          = effective_user(login)
-    pass          = user == login ? password : account_password
+    pass          = use_user_login_for_auth? ? password : account_password
     ldap_con      = initialize_ldap_con(user, pass)
     login_filter  = Net::LDAP::Filter.eq(attr_login, login)
     object_filter = Net::LDAP::Filter.eq("objectClass", "*")


### PR DESCRIPTION
The logic for determining which password to send the LDAP server
was inverted in the search_for_user_entries method.  To address,
I made three changes.  First, I inverted the logic of the
use_user_login_for_auth? method so it returns true when we are
using the user login for auth.  Next, I updated the single reference
to use_user_login_for_auth? to swap the true false values on the
ternary operator in the effective_user method so it continued
to function the same way.  Finally, I updated the "pass =" line
in search_for_user_entries to use the use_user_login_for_auth?
check and made sure the appropriate values were on the correct
sides of the : symbol.  I can LDAP auth again, hooray!
