### PR TITLE
(#1853) Hostgroups cannot be listed if filter == null 

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -70,8 +70,8 @@ class HostgroupsController < ApplicationController
     if @hostgroup.save
       # Add the new hostgroup to the user's filters
       @hostgroup.users << User.current unless User.current.admin? or @hostgroup.users.include?(User.current)
+      @hostgroup.users << subscribed_users
       @hostgroup.users << users_in_ancestors
-
       process_success
     else
       load_vars_for_ajax
@@ -153,6 +153,10 @@ class HostgroupsController < ApplicationController
     @hostgroup.ancestors.map do |ancestor|
       ancestor.users.reject { |u| @hostgroup.users.include?(u) }
     end.flatten.uniq
+  end
+
+  def subscribed_users
+    User.find_all_by_subscribe_to_all_hostgroups(true)
   end
 
 end

--- a/app/views/users/_filters.html.erb
+++ b/app/views/users/_filters.html.erb
@@ -15,12 +15,18 @@
     <%= field_set_tag _("Compute resources") do %>
         <%= f.select :compute_resources_andor, [[_("must be"), "and"], [_("plus all"), "or"]], {}, :class => "input-small" %>
         <%= multiple_checkboxes f, :compute_resources, @user, ComputeResource, :label=>'' %>
-  <% end %>
+    <% end %>
 
     <%= field_set_tag _("Host group hosts") do %>
         <%= f.select :hostgroups_andor, [[_("must be"), "and"], [_("plus all"), "or"]], {}, :class => "input-small" %>
         <%= multiple_checkboxes f, :hostgroups, @user, Hostgroup, :label=>'' %>
-  <% end %>
+    <% end %>
+
+    <%= field_set_tag _("Subscribe to hostgroups") do %>
+      <div class="control-group">
+        <%= _("Automatically add new hostgroups to this user.") %> <%= f.check_box :subscribe_to_all_hostgroups %>
+      </div>
+    <% end %>
 
   <%= field_set_tag _("Fact filters") do %>
       <div class="control-group">

--- a/db/migrate/20121210214810_add_subscribe_to_all_hostgroups_to_users.rb
+++ b/db/migrate/20121210214810_add_subscribe_to_all_hostgroups_to_users.rb
@@ -1,0 +1,9 @@
+class AddSubscribeToAllHostgroupsToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :subscribe_to_all_hostgroups, :boolean unless column_exists? :users, :subscribe_to_all_hostgroups
+  end
+
+  def self.down
+    remove_column :users, :subscribe_to_all_hostgroups if column_exists? :users, :subscribe_to_all_hostgroups 
+  end
+end

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -146,4 +146,16 @@ class HostgroupsControllerTest < ActionController::TestCase
     assert_equal old_root_pass, hostgroup.root_pass
   end
 
+  test 'users subscribed to all hostgroups should be always added to hostgroup' do
+    User.current = User.first
+    one = users(:one)
+    one.update_attributes(:subscribe_to_all_hostgroups => true)
+
+    post :create, { "hostgroup" => { "name"=>"first" } }, set_session_user
+    post :create, { "hostgroup" => { "name"=>"second" } }, set_session_user
+
+    assert_equal one, Hostgroup.find_by_name("first").users.first
+    assert_equal one, Hostgroup.find_by_name("second").users.first
+  end
+
 end


### PR DESCRIPTION
http://theforeman.org/issues/1853

"There seems to be no easy way to configure a user such that they can see a list
of all hostgroups with out ticking all the host groups in the filter and maintaining that."

This pull requests adds a boolean field on users so that they can subscribe to new hostgroups instead of maintaining the list of hostgroups every time a new one is added. This is tedious and can be automated easily with this pull request, letting an user with view permissions be linked to every hostgroup. As an use case, we have a 'viewer' user that needs to be in all hostgroups so that we do stuff with it through the api. A comment on this ticket also mentions the same problem of having to add all hostgroups to the filter (bad maintainability).

Discussion time :)  
