### PR TITLE
fixes #2029 - update to safemode 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "will_paginate", "~> 3.0.2"
 gem "ancestry", "~> 1.3"
 gem 'scoped_search', '>= 2.4'
 gem 'net-ldap'
-gem "safemode", "~> 1.0.1"
+gem "safemode", "~> 1.1.0"
 gem 'uuidtools'
 gem "apipie-rails", ">= 0.0.12"
 gem 'rabl', '>= 0.7.5'


### PR DESCRIPTION
Fixes both Ruby 1.9 and ruby_parser 3.x compatability.
