### PR TITLE
changing login maximum size to 100

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ActiveRecord::Base
   validates_presence_of :password_hash, :if => Proc.new {|user| user.manage_password?}
   validates_confirmation_of :password,  :if => Proc.new {|user| user.manage_password?}, :unless => Proc.new {|user| user.password.empty?}
   validates_format_of :login, :with => /^[a-z0-9_\-@\.]*$/i
-  validates_length_of :login, :maximum => 30
+  validates_length_of :login, :maximum => 100
   validates_format_of :firstname, :lastname, :with => /^[\w\s\'\-\.]*$/i, :allow_nil => true
   validates_length_of :firstname, :lastname, :maximum => 30, :allow_nil => true
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -34,8 +34,8 @@ class UserTest < ActiveSupport::TestCase
     assert !u.valid?
   end
 
-  test "login size should not exceed the 30 characters" do
-    u = User.new :auth_source => auth_sources(:one), :login => "a" * 31, :mail => "foo@bar.com"
+  test "login size should not exceed the 100 characters" do
+    u = User.new :auth_source => auth_sources(:one), :login => "a" * 101, :mail => "foo@bar.com"
     assert !u.save
   end
 


### PR DESCRIPTION
In case of using a long login name (such as ovirt_username@domain), on
the fly login will fail. Increasing the maximum login size to 100.
