### PR TITLE
Fixes #1350 - Allows mysql2 usage with Puppet < 2.7.10

### DIFF
--- a/db/migrate/20090714132448_create_hosts.rb
+++ b/db/migrate/20090714132448_create_hosts.rb
@@ -4,7 +4,7 @@ class CreateHosts < ActiveRecord::Migration
     # we are only creating the full database if the hosts table doesn't exists, if it does, we assume that store config is already configured
     unless Host.table_exists?
       require 'puppet/rails/database/schema'
-      Puppet[:dbadapter]= ActiveRecord::Base.configurations[RAILS_ENV]["adapter"]
+      Puppet[:dbadapter]= ActiveRecord::Base.configurations[RAILS_ENV]["adapter"].sub("mysql2", "mysql")
       Puppet::Rails::Schema.init
       Puppet::Rails.migrate()
     end


### PR DESCRIPTION
mysql2 dbadapter  is not supported before Puppet-2.7.10.  [Google group discussion](https://groups.google.com/d/topic/foreman-users/NlJzvScgZZ8/discussion)
