### PR TITLE
fixes #2045 changed condition so there is no error in Postgresql

### DIFF
--- a/app/models/hostext/search.rb
+++ b/app/models/hostext/search.rb
@@ -67,7 +67,7 @@ module Hostext
           opts += "hosts.id IN(#{hosts.join(',')})"             unless hosts.blank?
           opts += " OR "                                        unless hosts.blank? || host_groups.blank?
           opts += "hostgroups.id IN(#{host_groups.join(',')})"  unless host_groups.blank?
-          opts = "hosts.id = 'nil'"                             if hosts.blank? && host_groups.blank?
+          opts = "hosts.id < 0"                             if hosts.blank? && host_groups.blank?
           return {:conditions => opts, :include => :hostgroup}
         end
 


### PR DESCRIPTION
@ohadlevy, I can also strip any single quotes which currently causes a SQL error and all records are returned.

Should I add to search.rb

``` ruby
def self.value_to_sql(operator, value)
+      value = value.gsub(/'/,"")   #single quotes caused SQL error in Postgres
```
