### PR TITLE
Fixes #2058: prevents the spinner from going forever if listing fails

### DIFF
--- a/public/javascripts/compute_resource.js
+++ b/public/javascripts/compute_resource.js
@@ -3,10 +3,10 @@ $(function() {
   $('#vms, #images_list').each(function() {
     var url = $(this).attr('data-url');
     $(this).load(url + ' table', function(response, status, xhr) {
-      if (status == "error") {
-        $(this).closest("#spinner").html("Sorry but there was an error: " + xhr.status + " " + xhr.statusText);
-      }
-      $('.dropdown-toggle').dropdown();
+       if (status == "error") {
+         $(this).closest(".tab-content").find("#spinner").html("There was an error listing VM's : " + xhr.status + " " + xhr.statusText);
+       }
+       $('.dropdown-toggle').dropdown();
     });
   });
 });


### PR DESCRIPTION
This could be DRY'ed up, but I think this is a case where abstraction adds complexity. Willing to refactor, though if the error handling makes more sense to be moved into it's own function.
