### PR TITLE
Fixes #2059: Completely remove email_replay_address from settings

### DIFF
--- a/db/migrate/20121219040534_remove_replay_address_setting.rb
+++ b/db/migrate/20121219040534_remove_replay_address_setting.rb
@@ -1,0 +1,8 @@
+class RemoveReplayAddressSetting < ActiveRecord::Migration
+  def self.up
+    execute "DELETE FROM settings WHERE name='email_replay_address'"
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
@ohadlevy - should this have a down migration? The only way I can think of doing this is to do an `insert from` and then `update`. Is that needed?
