### PR TITLE
fixes #2023 - Don't try to save os=nil in the fact importer

### DIFF
--- a/app/models/facts_importer.rb
+++ b/app/models/facts_importer.rb
@@ -16,18 +16,20 @@ module Facts
 
       if os_name == "Archlinux"
         # Archlinux is rolling release, so it has no release. We use 1.0 always
-        Operatingsystem.find_or_create_by_name_and_major_and_minor os_name, "1", "0"
+        args = { :name => os_name, :major => "1", :minor => "0" }
+        Operatingsystem.where(args).first || Operatingsystem.create!(args)
       elsif orel.present?
         major, minor = orel.split(".")
         minor        ||= ""
-        os = Operatingsystem.find_or_create_by_name_and_major_and_minor os_name, major, minor
+        args = { :name => os_name, :major => major, :minor => minor }
+        os = Operatingsystem.where(args).first || Operatingsystem.create!(args)
         if os_name[/debian|ubuntu/i] or os.family == 'Debian'
           os.release_name = facts[:lsbdistcodename]
           os.save
         end
         os
       else
-        Operatingsystem.find_or_create_by_name os_name
+        Operatingsystem.find_by_name(os_name) || Operatingsystem.create!(:name => os_name)
       end
     end
 
@@ -102,7 +104,7 @@ module Facts
     private
 
     def os_name
-      facts[:operatingsystem]
+      facts[:operatingsystem].blank? ? raise("invalid facts, missing operatingsystem value") : facts[:operatingsystem]
     end
   end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -471,6 +471,9 @@ class Host < Puppet::Rails::Host
   end
 
   def populateFieldsFromFacts facts = self.facts_hash
+    # we don't import facts for host in build mode
+    return if build?
+
     importer = Facts::Importer.new facts
 
     set_non_empty_values importer, [:domain, :architecture, :operatingsystem, :model, :certname]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -116,7 +116,7 @@ class Report < ActiveRecord::Base
       r.import_log_messages report
       # if we are using storeconfigs then we already have the facts
       # so we can refresh foreman internal fields accordingly
-      host.populateFieldsFromFacts if Setting[:using_storeconfigs]
+      host.populateFieldsFromFacts if Setting[:using_storeconfigs] == false
       r.inspect_report
       return r
     rescue Exception => e

--- a/test/unit/facts_importer_test.rb
+++ b/test/unit/facts_importer_test.rb
@@ -5,7 +5,7 @@ class FactsImporter < ActiveSupport::TestCase
 
   def setup
     @importer = Facts::Importer.new facts
-    User.current = User.where(:login => "admin").first
+    User.current = User.admin
   end
 
   test "should return list of interfaces" do
@@ -18,6 +18,12 @@ class FactsImporter < ActiveSupport::TestCase
     assert_kind_of Operatingsystem, importer.operatingsystem
   end
 
+  test "should raise on an invalid os" do
+    @importer = Facts::Importer.new({})
+    assert_raise RuntimeError do
+      importer.operatingsystem
+    end
+  end
   test "should return an env" do
     assert_kind_of Environment, importer.environment
   end


### PR DESCRIPTION
I've tried to address all possible places where empty set of facts (e.g. we
dont have the facts just yet as its a brand new install) could lead to the
operating system value disappering.

i believe the issue happened because of a boolean == string compareing (e.g.
some left overs in cache might lead to if "false" which is true.

I've also ensured that we get an exception if the operating system value is empty
or if it does not pass validations.
