### PR TITLE
fixes #1991 - Cache not cleared prevent location / org feature to show up

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -67,7 +67,7 @@ module Foreman
 
     # enables in memory cache store with ttl
     #config.cache_store = TimedCachedStore.new
-    config.cache_store = :file_store, Rails.root.join("tmp")
+    config.cache_store = :file_store, Rails.root.join("tmp", "cache")
 
     # enables JSONP support in the Rack middleware
     config.middleware.use Rack::JSONP if SETTINGS[:support_jsonp]
@@ -78,7 +78,7 @@ module Foreman
     Wirb.start
     Hirb.enable
   rescue => e
-    warn "Failed to load console gems, startring anyway"
+    warn "Failed to load console gems, starting anyway"
   ensure
     puts "For some operations a user must be set, try User.current = User.first"
   end

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -13,6 +13,10 @@ module Foreman
         end
 
         def create opts
+          # ensures we don't have cache left overs in settings
+          Rails.logger.debug "removing #{opts[:name]} from cache"
+          Rails.cache.delete(opts[:name].to_s)
+
           if (s=Setting.first(:conditions => {:name => (opts[:name])})).nil?
             Setting.create!(opts)
           else


### PR DESCRIPTION
1. ensures settings cache is removed when app starts
   we can't remove all cache, with Rails.cache.clear as that might lead to issues
   with people using memcache with multiple foreman instances (e.g. we can clear
   the progress bar cache while restarting another foreman instance).
   The other alternative is to put a TTL on the settings, but I think this
   option for this specific case makes more sense.
2. fixed the cache directory, from /tmp to /tmp/cache.
