### PR TITLE
fixes #2063 - pin minitest to 3.5+ and mocha 0.12.x

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,13 +1,9 @@
 group :test do
-  if RUBY_VERSION >= '1.9.3'
-    gem 'mocha', :require => false
-  else
-    gem 'mocha', '< 0.13.0', :require => false
-  end
+  gem 'mocha', '< 0.13.0', :require => false
   gem 'shoulda', "=3.0.1"
   gem 'rr'
   gem 'rake'
   gem 'single_test'
   gem 'ci_reporter', '>= 1.6.3'
-  gem "minitest", :platforms => :ruby_19
+  gem 'minitest', '~> 3.5', :platforms => :ruby_19
 end


### PR DESCRIPTION
Mocha 0.13.x and minitest 4.x will require Rails 3.2 (https://github.com/freerange/mocha/issues/110).
