### PR TITLE
fixes 2017 - provisioning ec2 instance fails with ruby 1.9.x  

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -53,7 +53,7 @@ module Foreman
     end
     alias_method :pxe_render, :unattended_render
 
-    def unattended_render_to_temp_file content, prefix = id, options = {}
+    def unattended_render_to_temp_file content, prefix = id.to_s, options = {}
       file = ""
       Tempfile.open(prefix, Rails.root.join('tmp') ) do |f|
         f.print(unattended_render(content))


### PR DESCRIPTION
added patch from ticket
It seems that Tempfile doesn't support integer as basename anymore
