### PR TITLE
expose domain parameters via the API

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -85,4 +85,11 @@ class Domain < ActiveRecord::Base
     Net::DNS.lookup query, proxy, resolver
   end
 
+  # returns parameters as a hash
+  def parameters include_source = false
+    hash = {}
+    domain_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => :domain} : p.value }
+    hash
+  end
+
 end

--- a/app/views/api/v1/domains/show.json.rabl
+++ b/app/views/api/v1/domains/show.json.rabl
@@ -1,2 +1,2 @@
 object @domain
-attributes :id, :name, :fullname, :dns_id, :created_at, :updated_at
+attributes :id, :name, :fullname, :dns_id, :parameters, :created_at, :updated_at


### PR DESCRIPTION
Implemented domain parameters in the same style as hostgroup parameters.

Before:
jpoppe@astray98:~/git/foremanbuddy$ ./foremanbuddy.py -d domain info 1
debug: url "http://overlord001.xx.ebuddy.com:3000/api/domains/1"
debug: method "GET"
domain : name       : xx.ebuddy.com
         created_at : 2012-12-27T21:59:48Z
         updated_at : 2012-12-28T09:04:28Z
         dns_id     : 1
         fullname   : xx.ebuddy.com
         id         : 1
jpoppe@astray98:~/git/foremanbuddy$ 

After:
jpoppe@astray98:~/git/foremanbuddy$ ./foremanbuddy.py -d domain info 1
debug: url "http://overlord001.xx.ebuddy.com:3000/api/domains/1"
debug: method "GET"
domain : name       : xx.ebuddy.com
         parameters : new: api, does: rock, in: foreman
         created_at : 2012-12-27T21:59:48Z
         updated_at : 2012-12-28T09:04:28Z
         dns_id     : 1
         fullname   : xx.ebuddy.com
         id         : 1
jpoppe@astray98:~/git/foremanbuddy$ 
