### PR TITLE
fixes #2092 - allow parens in Subnet description

### DIFF
--- a/public/javascripts/host_edit.js
+++ b/public/javascripts/host_edit.js
@@ -268,7 +268,7 @@ function subnet_selected(element){
   // IP that is in the selected subnet
   var drop_text = $(element).children(":selected").text();
   if (drop_text.length !=0 && drop_text.search(/^.+ \([0-9\.\/]+\)/) != -1) {
-    var details = drop_text.replace(/^[^(]+\(/, "").replace(")","").split("/");
+    var details = drop_text.replace(/^.+\(/, "").replace(")","").split("/");
     if (subnet_contains(details[0], details[1], $('#host_ip').val()))
       return;
   }


### PR DESCRIPTION
Fixes the host creat e bug where parentheses prevented proper javascript functionality for ip suggestion. Parens are now allowed in the Subnet description.

Tested by naming a subnet _Cabinet 4717 (corp/dev) ((d(((())))(()()fofjo()))))))()()_ and ip suggestion works.
