### PR TITLE
Extended information for each type of compute resources

### DIFF
--- a/app/views/api/v1/compute_resources/ec2.json.rabl
+++ b/app/views/api/v1/compute_resources/ec2.json.rabl
@@ -1,0 +1,1 @@
+attributes :user, :region

--- a/app/views/api/v1/compute_resources/openstack.json.rabl
+++ b/app/views/api/v1/compute_resources/openstack.json.rabl
@@ -1,0 +1,1 @@
+attributes :user, :tenant

--- a/app/views/api/v1/compute_resources/ovirt.json.rabl
+++ b/app/views/api/v1/compute_resources/ovirt.json.rabl
@@ -1,0 +1,1 @@
+attributes :user, :uuid

--- a/app/views/api/v1/compute_resources/rackspace.json.rabl
+++ b/app/views/api/v1/compute_resources/rackspace.json.rabl
@@ -1,0 +1,1 @@
+attributes :user, :region

--- a/app/views/api/v1/compute_resources/show.json.rabl
+++ b/app/views/api/v1/compute_resources/show.json.rabl
@@ -1,4 +1,8 @@
 object @compute_resource
 
-attributes :id, :name, :description, :url, :user, :created_at, :updated_at
-attribute :provider_friendly_name => 'provider' 
+attributes :id, :name, :description, :url, :created_at, :updated_at
+attribute :provider_friendly_name => 'provider'
+
+node do |r|
+  partial("api/v1/compute_resources/#{r.provider.downcase}.json", :object => r)
+end

--- a/app/views/api/v1/compute_resources/vmware.json.rabl
+++ b/app/views/api/v1/compute_resources/vmware.json.rabl
@@ -1,0 +1,1 @@
+attributes :user, :uuid, :server


### PR DESCRIPTION
Before this change API was returning only information common to all providers.
This patch allows to specify json fields for each provider type separately.
