### PR TITLE
fixes #2109 - improve session token security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ db/schema.rb
 config/settings.yaml
 config/email.yaml
 config/database.yml
+config/initializers/local_secret_token.rb
 Gemfile.lock
 bundler.d/Gemfile.local.rb
 *.sw?

--- a/config/initializers/local_secret_token.rb.example
+++ b/config/initializers/local_secret_token.rb.example
@@ -1,0 +1,10 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+
+# You can use `rake security:generate_token` to regenerate this file.
+
+#Foreman::Application.config.secret_token = 'uncomment and insert token here'

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,12 @@
-# Be sure to restart your server when you modify this file.
+require 'foreman/util'
+include Foreman::Util
 
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Foreman::Application.config.secret_token = '1d53dcb00e724f72a15823d6939a2ee6f3b3ab3af7c47d074cefb1c9d3fe197cce3d0e2050a68d593f9275242d01658f3e9badd6221cf0e76e18896e4862358c'
+unless Foreman::Application.config.secret_token
+  token_store = Rails.root.join("tmp", "secret_token")
+  token = File.read(token_store) if File.exist? token_store
+  unless token
+    token = secure_token
+    File.open(token_store, "w", 0600) { |f| f.write(token) }
+  end
+  Foreman::Application.config.secret_token = token
+end

--- a/lib/foreman/util.rb
+++ b/lib/foreman/util.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Foreman
   module Util
     # searches for binaries in predefined directories and user PATH
@@ -13,6 +15,11 @@ module Foreman
     rescue StandardError => e
       logger.warn e
       return false
+    end
+
+    # Generates a URL-safe token for use with Rails for signing cookies
+    def secure_token
+      SecureRandom.base64(96).tr('+/=', '-_*')
     end
   end
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -1,0 +1,21 @@
+require 'foreman/util'
+
+namespace :security do
+  desc 'Generate new security token'
+  task :generate_token do
+    include Foreman::Util
+    File.open("config/initializers/local_secret_token.rb", "w") do |fd|
+      fd.write("# Be sure to restart your server when you modify this file.
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+
+# You can use `rake security:generate_token` to regenerate this file.
+
+Foreman::Application.config.secret_token = '#{secure_token}'
+")
+    end
+  end
+end


### PR DESCRIPTION
- adds security:generate token rake task to create static token
- generate and cache a token on startup if static token isn't present

Thanks to Sandor Szücs sandor.szuecs@fu-berlin.de
