### PR TITLE
round_with_precision is deprecated

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,7 +62,7 @@ class Report < ActiveRecord::Base
   end
 
   def config_retrieval
-    metrics[:time][:config_retrieval].round_with_precision(2) rescue 0
+    metrics[:time][:config_retrieval].round(2) rescue 0
   end
 
   def runtime


### PR DESCRIPTION
Use round instead of round_with_precision.

runtime used round but config_retrieval used round_with_precision. This resulted in the config retrieval value of my runtime chart being 0 all the time.
