### PR TITLE
Upgrade to Rails 3.0.19 to mitigate CVE-2013-0156 and CVE-2013-0155

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 require File.expand_path('../config/settings', __FILE__)
 source 'http://rubygems.org'
 
-gem 'rails', '3.0.18'
+gem 'rails', '3.0.19'
 gem "jquery-rails"
 gem 'json'
 gem 'rest-client', :require => 'rest_client'


### PR DESCRIPTION
Two critical vulnerabilities were announced with the availability of Rails 3.0.19 today. This pull request bumps the required rails version to 3.0.19, which has fixes for both.
