### PR TITLE
fixes #2122 - Cannot search reports on environment name

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,10 +5,12 @@ class Report < ActiveRecord::Base
   has_many :messages, :through => :logs
   has_many :sources, :through => :logs
   has_many :logs, :dependent => :destroy
+  has_one :environment, :through => :host
   validates_presence_of :host_id, :reported_at, :status
   validates_uniqueness_of :reported_at, :scope => :host_id
 
   scoped_search :in => :host,     :on => :name, :complete_value => true, :rename => :host
+  scoped_search :in => :environment, :on => :name, :complete_value => true, :rename => :environment
   scoped_search :in => :messages, :on => :value,                         :rename => :log
   scoped_search :in => :sources,  :on => :value,                         :rename => :resource
 


### PR DESCRIPTION
Can now filter the reports based on environment.
Ohad's suggested patch.
