### PR TITLE
fix in compute resources api doc

### DIFF
--- a/app/controllers/api/v1/compute_resources_controller.rb
+++ b/app/controllers/api/v1/compute_resources_controller.rb
@@ -19,21 +19,6 @@ module Api
       def show
       end
 
-      api :PUT, "/compute_resources/:id/", "Update a compute resource."
-      param :id, String, :required => true
-      param :compute_resource, Hash, :required => true do
-        param :name, String
-        param :provider, String, :desc => "Providers include #{ComputeResource::PROVIDERS.join(', ')}"
-        param :url, String, :desc => "URL for Libvirt, Ovirt, and Openstack"
-        param :description, String
-        param :user, String, :desc => "Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2."
-        param :password, String, :desc => "Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2"
-        param :uuid, String, :desc => "for Ovirt, Vmware Datacenter"
-        param :region, String, :desc => "for EC2 only"
-        param :tenant, String, :desc => "for Openstack only"
-        param :server, String, :desc => "for Vmware"
-      end
-
 
       api :POST, "/compute_resources/", "Create a compute resource."
       param :compute_resource, Hash, :required => true do
@@ -54,8 +39,21 @@ module Api
           process_response @compute_resource.save
       end
 
+
       api :PUT, "/compute_resources/:id/", "Update a compute resource."
-      param :id, :identifier, :required => true
+      param :id, String, :required => true
+      param :compute_resource, Hash, :required => true do
+        param :name, String
+        param :provider, String, :desc => "Providers include #{ComputeResource::PROVIDERS.join(', ')}"
+        param :url, String, :desc => "URL for Libvirt, Ovirt, and Openstack"
+        param :description, String
+        param :user, String, :desc => "Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2."
+        param :password, String, :desc => "Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2"
+        param :uuid, String, :desc => "for Ovirt, Vmware Datacenter"
+        param :region, String, :desc => "for EC2 only"
+        param :tenant, String, :desc => "for Openstack only"
+        param :server, String, :desc => "for Vmware"
+      end
 
       def update
         process_response @compute_resource.update_attributes(params[:compute_resource])


### PR DESCRIPTION
Api doc for ComputeResourcesController#update was placed above #create. This led to mistakenly generated api bindings. More precisely, binding for create required parameter :id and was sent via put.
