### PR TITLE
Added auth to smart proxies

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -1,4 +1,5 @@
 class SmartProxy < ActiveRecord::Base
+  include Authorization
   include Taxonomix
   ProxyFeatures = %w[ TFTP BMC DNS DHCP Puppetca Puppet]
   attr_accessible :name, :url


### PR DESCRIPTION
It is necessary for the API calls. Seems no new failing tests introduced.
