### PR TITLE
Fixes #1848 - Link non-zero report summaries to the equivalent report search

### DIFF
--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -23,7 +23,11 @@
       <% else -%>
         <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
       <% end -%>
-      <%= v %>
+      <% if v > 0 -%>
+        <%= link_to v, reports_path(:search=>"#{host} and #{m} > 0", :host => @url, :only_path => false) %>
+      <% else -%>
+        <%= v %>
+      <% end -%>
     </td>
   <% end -%>
 </tr>


### PR DESCRIPTION
I'd like to add some tests for this, but the current HostMailer tests don't load any reports, and I can't quite figure out how to add some....
