### PR TITLE
fixes #2130 - normalize_hostname appends domain to fqdn

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -772,7 +772,7 @@ class Host::Managed < Host::Base
         old_domain = Domain.find(changed_attributes["domain_id"])
         self.name.gsub(old_domain.to_s,"")
       end
-      self.name += ".#{domain}" unless name =~ /.#{domain}$/i
+      self.name += ".#{domain}" unless name =~ /\./i
     end
   end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -39,6 +39,14 @@ class HostTest < ActiveSupport::TestCase
     assert_equal "myhost.company.com", host.name
   end
 
+  test "should not append domainname to fqdn" do
+    host = Host.create :name => "myhost.sub.comp.net", :mac => "aabbccddeeff", :ip => "123.01.02.03",
+      :domain => Domain.find_or_create_by_name("company.com"),
+      :certname => "myhost.sub.comp.net",
+      :managed => false
+    assert_equal "myhost.sub.comp.net", host.name
+  end
+
   test "should save hosts with full stop in their name" do
     host = Host.create :name => "my.host.company.com", :mac => "aabbccddeeff", :ip => "123.01.02.03",
       :domain => Domain.find_or_create_by_name("company.com")


### PR DESCRIPTION
Ok, let me know if it makes sense - we assume otherwise that hostnames are RFC952 , right? Ie, dot (.) is only allowed as delimiter between domain components.

Commit description:

When the domain part of $fqdn doesn't match $domain, the normalize_hostname
function would append $domain onto the end of $fqdn, saving the host as
$fqdn.$domain (Example: hostname.domain1.com.domain2.com).
