### PR TITLE
fixes #2124 - only include classes from the host current environment.

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -33,10 +33,14 @@ class Classification
 
   def puppetclass_ids
     return @puppetclass_ids if @puppetclass_ids
-    @puppetclass_ids = host.host_classes.pluck(:puppetclass_id)
-    @puppetclass_ids +=  HostgroupClass.where(:hostgroup_id => hostgroup.path_ids).pluck(:puppetclass_id) if hostgroup
-
-    @puppetclass_ids
+    ids = host.host_classes.pluck(:puppetclass_id)
+    ids += HostgroupClass.where(:hostgroup_id => hostgroup.path_ids).pluck(:puppetclass_id) if hostgroup
+    @puppetclass_ids = if Setting['remove_classes_not_in_environment']
+                         EnvironmentClass.where(:environment_id => host.environment_id, :puppetclass_id => ids).
+                           pluck('DISTINCT puppetclass_id')
+                       else
+                          ids
+                       end
   end
 
   def classes

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -71,7 +71,9 @@ module Foreman
               set('Parametrized_Classes_in_ENC', "Should Foreman use the new format (2.6.5+) to answer Puppet in its ENC yaml output?", param_enc),
               set('enc_environment', "Should Foreman provide puppet environment in ENC yaml output? (this avoids the mismatch error between puppet.conf and ENC environment)", true),
               set('use_uuid_for_certificates', "Should Foreman use random UUID's for certificate signing instead of hostnames", false),
-              set('update_environment_from_facts', "Should Foreman update a host's environment from its facts", false)
+              set('update_environment_from_facts', "Should Foreman update a host's environment from its facts", false),
+              set('remove_classes_not_in_environment',
+                  "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)", false)
             ].compact.each { |s| create s.update(:category => "Puppet")}
 
             [ set('oauth_active', "Should foreman use OAuth for authorization in API", false),

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -149,3 +149,8 @@ attribute30:
   category: Auth
   default: "SSL_CLIENT_VERIFY"
   description: "Environment variable containing the verification status of a client SSL certificate"
+attribute31:
+  name: remove_classes_not_in_environment
+  category: Puppet
+  default: false
+  description: "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"


### PR DESCRIPTION
When a has classes (directly or indirectly via hostgroups) that do not
belongs to the host current environment, they would silently removed from
the class list that foreman suggests as an ENC.

NOTE: this only effects the new ENC output (/w param classes).
