### PR TITLE
fixes #2151 - use DN environment variable instead of CN

### DIFF
--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -80,7 +80,7 @@ module Foreman
               set('oauth_map_users', "Should foreman map users by username in request-header", true),
               set('restrict_registered_puppetmasters', 'Only known Smart Proxies with the Puppet feature can access fact/report importers and ENC output', true),
               set('require_ssl_puppetmasters', 'Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)', true),
-              set('ssl_client_cn_env', 'Environment variable containing the subject CN from a client SSL certificate', 'SSL_CLIENT_S_DN_CN'),
+              set('ssl_client_dn_env', 'Environment variable containing the subject DN from a client SSL certificate', 'SSL_CLIENT_S_DN'),
               set('ssl_client_verify_env', 'Environment variable containing the verification status of a client SSL certificate', 'SSL_CLIENT_VERIFY')
             ].compact.each { |s| create s.update(:category => "Auth")}
           end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -140,10 +140,10 @@ attribute28:
   default: true
   description: "Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)"
 attribute29:
-  name: ssl_client_cn_env
+  name: ssl_client_dn_env
   category: Auth
-  default: "SSL_CLIENT_S_DN_CN"
-  description: "Environment variable containing the subject CN from a client SSL certificate"
+  default: "SSL_CLIENT_S_DN"
+  description: "Environment variable containing the subject DN from a client SSL certificate"
 attribute30:
   name: ssl_client_verify_env
   category: Auth

--- a/test/functional/fact_values_controller_test.rb
+++ b/test/functional/fact_values_controller_test.rb
@@ -87,7 +87,7 @@ class FactValuesControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'else.where'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     post :create, {:facts => fact_fixture, :format => "yml"}
     assert_response :success
@@ -98,7 +98,7 @@ class FactValuesControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'another.host'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=another.host'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     post :create, {:facts => fact_fixture, :format => "yml"}
     assert_equal 403, @response.status
@@ -109,7 +109,7 @@ class FactValuesControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'secure.host'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=secure.host'
     @request.env['SSL_CLIENT_VERIFY'] = 'FAILED'
     post :create, {:facts => fact_fixture, :format => "yml"}
     assert_equal 403, @response.status

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -551,7 +551,7 @@ class HostsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'else.where'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     Resolv.any_instance.stubs(:getnames).returns(['else.where'])
     get :externalNodes, {:name => @host.name, :format => "yml"}
@@ -564,7 +564,7 @@ class HostsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'another.host'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=another.host'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     get :externalNodes, {:name => @host.name, :format => "yml"}
     assert_equal 403, @response.status
@@ -576,7 +576,7 @@ class HostsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'else.where'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
     @request.env['SSL_CLIENT_VERIFY'] = 'FAILURE'
     get :externalNodes, {:name => @host.name, :format => "yml"}
     assert_equal 403, @response.status

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -136,7 +136,7 @@ class ReportsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'else.where'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     post :create, {:report => create_a_puppet_transaction_report, :format => "yml"}
     assert_response :success
@@ -148,7 +148,7 @@ class ReportsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'another.host'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=another.host'
     @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
     post :create, {:report => create_a_puppet_transaction_report, :format => "yml"}
     assert_equal 403, @response.status
@@ -160,7 +160,7 @@ class ReportsControllerTest < ActionController::TestCase
     Setting[:require_ssl_puppetmasters] = true
 
     @request.env['HTTPS'] = 'on'
-    @request.env['SSL_CLIENT_S_DN_CN'] = 'else.where'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
     @request.env['SSL_CLIENT_VERIFY'] = 'FAILED'
     post :create, {:report => create_a_puppet_transaction_report, :format => "yml"}
     assert_equal 403, @response.status


### PR DESCRIPTION
nginx is unable to pass bits of the X.509 subject, only the entire DN, so
support that as a lowest common denominator.

---

I was going to change the rDNS scheme as well, but decided that I'll mention it in my e-mail to foreman-users to get feedback (will send as soon as the installer PR's merged).
