### PR TITLE
Apipie versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'net-ldap'
 gem "safemode", "~> 1.1.0"
 gem 'ruby_parser', '~> 3.0.0'
 gem 'uuidtools'
-gem "apipie-rails", "= 0.0.13"
+gem "apipie-rails", '~> 0.0.14'
 gem 'rabl', '>= 0.7.5'
 gem 'oauth'
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -2,6 +2,11 @@ module Api
   module V1
     class BaseController < Api::BaseController
       include Api::Version1
+
+      resource_description do
+        api_version "v1"
+        api_version "v2"
+      end
     end
   end
 end

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -2,6 +2,11 @@ module Api
   module V2
     class BaseController < Api::BaseController
       include Api::Version2
+
+      resource_description do
+        resource_id "v2_base" # to avoid conflicts with V1::BaseController
+        api_version "v2"
+      end
     end
   end
 end

--- a/app/views/api/v1/home/index.json.rabl
+++ b/app/views/api/v1/home/index.json.rabl
@@ -2,23 +2,23 @@ object false
 child(:links => "links") do
 
   # gather index methods of resources
-  index_method_description_apis = Apipie.app.resource_descriptions.map do |name, resource_description|
-    if (description = Apipie.method_descriptions["#{name}#index"])
-      description.apis.first
+  index_method_description_apis = Apipie.app.resource_descriptions[Apipie.configuration.default_version].map do |name, resource_description|
+    if (description = Apipie.app["#{name}#index"])
+      description.method_apis_to_json.first
     end
   end.compact
 
   # add additional actions
   %w(home#status).each do |additional_action|
-    if (description = Apipie.app.method_descriptions[additional_action]) and
-        (api = description.apis.first)
+    if (description = Apipie.app[additional_action]) and
+        (api = description.method_apis_to_json.first)
       index_method_description_apis << api
     end
   end
 
   # render links
   index_method_description_apis.each do |api|
-    url, description = api.api_url, api.short_description
+    url, description = api[:api_url], api[:short_description]
     node(description.chomp(".")) { url }
   end
 end

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -2,7 +2,7 @@ group :development do
   # To use debugger
   gem "ruby-debug", :platforms => :ruby_18
   gem "ruby-debug19", :platforms => :ruby_19
-  gem 'redcarpet', '<= 2.1.0'
+  gem 'maruku'
   gem 'single_test'
   gem 'pry'
   gem "term-ansicolor"

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -3,14 +3,15 @@ Apipie.configure do |config|
   config.app_info = "The Foreman is aimed to be a single address for all machines life cycle management."
   config.copyright = ""
   config.api_base_url = "/api"
-  config.api_controllers_matcher = "#{Rails.root}/app/controllers/api/v1/*.rb"
+  config.api_controllers_matcher = "#{Rails.root}/app/controllers/api/**/*.rb"
   config.ignored_by_recorder = %w[]
   config.doc_base_url = "/apidoc"
   config.use_cache = Rails.env.production?
   config.validate = false
   config.force_dsl = true
   config.reload_controllers = Rails.env.development?
-  config.markup = Apipie::Markup::Markdown.new if Rails.env.development? and defined? Redcarpet
+  config.markup = Apipie::Markup::Markdown.new if Rails.env.development? and defined? Maruku
+  config.default_version = "v1"
 end
 
 # special type of validator: we say that it's not specified


### PR DESCRIPTION
We've released apipie-rails 0.0.14, with API versioning support. Also some other changes were introduced (switched the Markdown implementaiton from RedCarpet to Maruku and some API changes). This PR makes the code working with the new version, as well as providing documentation for both version 1 and 2.
