### PR TITLE
Feature: #686 - Hosts can inherit environment from hostgroup

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -289,11 +289,12 @@ class HostsController < ApplicationController
       error 'No Environment selected!'
       redirect_to(select_multiple_environment_hosts_path) and return
     end
+
     ev = Environment.find(id) rescue nil
 
     #update the hosts
     @hosts.each do |host|
-      host.environment=ev
+      host.environment = (id == 'inherit' && host.hostgroup.present? ) ? host.hostgroup.environment : ev
       host.save(:validate => false)
     end
 

--- a/app/views/hosts/select_multiple_environment.html.erb
+++ b/app/views/hosts/select_multiple_environment.html.erb
@@ -1,6 +1,8 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
 <%= form_for :environment, :url => update_multiple_environment_hosts_path(:host_ids => params[:host_ids]) do |f| %>
-  <%= f.select :id, [["Select Environment", "disabled"],["*Clear environment*", "" ]] + Environment.all.map{|e| [e.name, e.id]},{},
-        :onchange => "toggle_multiple_ok_button(this)" %>
+    <%= f.select :id, [["Select Environment", "disabled"],
+                        ["*Clear environment*", "" ],
+                        ["*Inherit from hostgroup*", "inherit"]] + Environment.all.map{|e| [e.name, e.id]},{},
+                 :onchange => "toggle_multiple_ok_button(this)" %>
 <% end %>


### PR DESCRIPTION
http://projects.theforeman.org/issues/686

A better explanation:

When you select a group of hosts, there is a button to clear the environment. This leaves all of the hosts with no environment (expected behaviour of course). Nonetheless, we've been lacking of some way to inherit the environment from the hostgroups, which are sort of the 'default' properties for the hosts they own. In fact, if you edit a host and leave the environment empty, it will inherit it from its hostgroup (if any). 

This button provides this inherit behavior from the multiple hosts selection dialog.
