### PR TITLE
Bug #2179: Wrong owner_type on the request returns 500

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -4,6 +4,7 @@ module Host
   class Base < ActiveRecord::Base
     include Foreman::STI
     self.table_name = :hosts
+    OWNER_TYPES = %w(User Usergroup)
 
     belongs_to :model
     has_many :fact_values, :dependent => :destroy, :foreign_key => :host_id
@@ -13,6 +14,10 @@ module Host
     validates_presence_of   :name
     validates_uniqueness_of :name
     validate :is_name_downcased?
+    validates_inclusion_of :owner_type,
+                           :in          => OWNER_TYPES,
+                           :allow_blank => true,
+                           :message     => (_("Owner type needs to be one of the following: %s") % OWNER_TYPES.join(', '))
 
     scope :my_hosts, lambda {
       user                 = User.current

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -148,8 +148,9 @@ class Host::Managed < Host::Base
     validates_format_of      :serial,    :with => /[01],\d{3,}n\d/, :message => N_("should follow this format: 0,9600n8"), :allow_blank => true, :allow_nil => true
   end
 
-  before_validation :set_hostgroup_defaults, :set_ip_address, :set_default_user, :normalize_addresses, :normalize_hostname, :force_lookup_value_matcher
-  after_validation :ensure_associations
+
+  before_validation :set_hostgroup_defaults, :set_ip_address, :normalize_addresses, :normalize_hostname, :force_lookup_value_matcher
+  after_validation :ensure_associations, :set_default_user
   before_validation :set_certname, :if => Proc.new {|h| h.managed? and Setting[:use_uuid_for_certificates] } if SETTINGS[:unattended]
 
   def <=>(other)
@@ -793,6 +794,7 @@ class Host::Managed < Host::Base
   end
 
   def set_default_user
+    return unless OWNER_TYPES.include?(self.owner_type)
     self.owner ||= User.current
   end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -134,6 +134,29 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "should save if owner_type is User or Usergroup" do
+    host = Host.new :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03",
+      :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
+      :subnet => subnets(:one), :architecture => architectures(:x86_64), :environment => environments(:production), :managed => true,
+      :owner_type => "User" # should be Usergroup
+    assert host.valid?
+  end
+
+  test "should not save if owner_type is not User or Usergroup" do
+    host = Host.new :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03",
+      :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
+      :subnet => subnets(:one), :architecture => architectures(:x86_64), :environment => environments(:production), :managed => true,
+      :owner_type => "UserGr(up" # should be Usergroup
+    assert !host.valid?
+  end
+
+  test "should save if owner_type is empty and Host is unmanaged" do
+    host = Host.new :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03",
+      :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
+      :subnet => subnets(:one), :architecture => architectures(:x86_64), :environment => environments(:production), :managed => false
+    assert host.valid?
+  end
+
   test "should import from external nodes output" do
     # create a dummy node
     Parameter.destroy_all


### PR DESCRIPTION
http://projects.theforeman.org/issues/2179

This pull request validates the owner type. This will fix the problem where the API returns 500 with a malformed request that contains a wrong owner_type. Instead it returns a 422 with info on how to solve the error.
