### PR TITLE
Fix for auto_complete_search (broken since RC5 for non-admin users)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,7 @@ class ApplicationController < ActionController::Base
 
   # Authorize the user for the requested action
   def authorize(ctrl = params[:controller], action = params[:action])
+    return true if action == 'auto_complete_search' && User.current.allowed_to?({:controller => ctrl, :action => 'index'})
     allowed = User.current.allowed_to?({:controller => ctrl.gsub(/::/, "_").underscore, :action => action})
     allowed ? true : deny_access
   end


### PR DESCRIPTION
This PR makes auto complete search accessible to non-admin users. Otherwise, the action 'auto_complete_search' will get in the users model 'allowed_to?' method, and this method will never be able to find a role that allows an user to do the action 'auto_complete_search' unless this user is an admin. 
The way to fix this as it has been done previously on the users_controller is to change the action to 'index', which is an action that an user role might have on its list of allowed actions.
