### PR TITLE
API now allows for search of usergroups

### DIFF
--- a/app/controllers/api/v1/usergroups_controller.rb
+++ b/app/controllers/api/v1/usergroups_controller.rb
@@ -8,7 +8,7 @@ module Api
       param :per_page, String, :desc => "number of entries per request"
 
       def index
-        @usergroups = Usergroup.paginate(paginate_options)
+        @usergroups = Usergroup.search_for(*search_options).paginate(paginate_options)
       end
 
       api :GET, "/usergroups/:id/", "Show a usergroup."

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -12,6 +12,7 @@ class Usergroup < ActiveRecord::Base
   # The text item to see in a select dropdown menu
   alias_attribute :select_title, :to_s
   default_scope :order => 'LOWER(usergroups.name)'
+  scoped_search :on => :name, :complete_value => :true
   validate :ensure_uniq_name
 
   # This methods retrieves all user addresses in a usergroup


### PR DESCRIPTION
That's about it. Usergroups had to be filtered on the client side to look for an specific name, way too much hurdle. Consider the case when a proxy has to do this every time it wants to create a host on foreman for a certain usergroup (real case). It can be argued the client could keep a list of ids - names but I think this makes things easier for anyone that wants to use the API.

Docs need to be updated accordingly
