### PR TITLE
Fixes #1988 - APIv2 nested parameters for host, domain, hostgroup, and os

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class ComputeResourcesController < V1::ComputeResourcesController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/compute_resources/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/compute_resources/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -2,13 +2,25 @@ module Api
   module V2
     class ConfigTemplatesController < V1::ConfigTemplatesController
       include Api::Version2
+      include Api::TaxonomyScope
 
       before_filter :process_operatingsystems, :only => [:create, :update]
+
+      def index
+        super
+        render :template => "api/v1/config_templates/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/config_templates/show"
+      end
 
       def process_operatingsystems
         return unless (ct = params[:config_template]) and (operatingsystems = ct.delete(:operatingsystems))
         ct[:operatingsystem_ids] = operatingsystems.collect {|os| os[:id]}
       end
+
     end
   end
 end

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class DomainsController < V1::DomainsController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/domains/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/domains/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class EnvironmentsController < V1::EnvironmentsController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/environments/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/environments/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class HostgroupsController < V1::HostgroupsController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/hostgroups/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/hostgroups/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/locations_controller.rb
+++ b/app/controllers/api/v2/locations_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V2
+    class LocationsController < V2::BaseController
+
+      include Api::V2::TaxonomiesController
+
+    end
+  end
+end

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class MediaController < V1::MediaController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/media/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/media/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/organizations_controller.rb
+++ b/app/controllers/api/v2/organizations_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V2
+    class OrganizationsController < V2::BaseController
+
+      include Api::V2::TaxonomiesController
+
+    end
+  end
+end

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -1,0 +1,93 @@
+module Api
+  module V2
+    class ParametersController < V2::BaseController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_filter :find_nested_object, :only => [:index, :show, :create]
+
+      resource_description do
+        desc <<-DOC
+          These API calls are related to <b>nested parameters for host, domain, hostgroup, operating system</b>. If you are looking for
+          <a href="common_parameters.html">global parameters</a>, go to <a href="common_parameters.html">this link</a>.
+        DOC
+      end
+
+      api :GET, "/references/:id/parameters/", "List all parameters for host, domain, hostgroup, or operating system"
+      param :page, String, :desc => "paginate results"
+      param :per_page, String, :desc => "number of entries per request"
+
+      def index
+        if @nested_obj.class.name == 'Hostgroup'
+          # hostgroup.rb has a method def parameters, so I didn't create has_many :parameters like Host, Domain, Os
+          @parameters = @nested_obj.group_parameters.paginate(paginate_options)
+        else
+          @parameters = @nested_obj.parameters.paginate(paginate_options)
+        end
+      end
+
+      api :GET, "/references/:reference_id/parameters/:id/", "Show a nested parameter for host, domain, hostgroup, or operating system"
+      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      param :id, String, :required => true, :desc => "id of parameter"
+
+      def show
+      end
+
+      api :POST, "/references/:reference_id/parameters", "Create a nested parameter for host, domain, hostgroup, or operating system"
+      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      param :id, String, :required => true, :desc => "id of parameter"
+      param :parameter, Hash, :required => true do
+        param :name, String
+        param :value, String
+      end
+
+      def create
+        sti_type = @nested_obj.class.name
+        sti_type = "Os" if @nested_obj.class.name == "Operatingsystem"
+        sti_type = "Group" if @nested_obj.class.name == "Hostgroup"
+        # creating the parameter thorough the assocation @nested_obj.parameters.new did not update the type field
+        # so the parameter is corrected directly using the STI model
+        @parameter = "#{sti_type}Parameter".constantize.new(params[:parameter].merge(:reference_id => @nested_obj.id))
+        process_response @parameter.save
+      end
+
+      api :PUT, "/references/:reference_id/parameters/:id/", "Update a nested parameter for host, domain, hostgroup, or operating system"
+      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      param :id, String, :required => true, :desc => "id of parameter"
+      param :parameter, Hash, :required => true do
+        param :name, String
+        param :value, String
+      end
+
+      def update
+        process_response @parameter.update_attributes(params[:parameter])
+      end
+
+      api :DELETE, "/references/:id/parameters/:id/", "Delete a nested parameter for host, domain, hostgroup, or operating system."
+      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      param :id, String, :required => true, :desc => "id of parameter"
+
+      def destroy
+        process_response @parameter.destroy
+      end
+
+      private
+
+      def find_nested_object
+        params.keys.each do |param|
+          if param =~ /(\w+)_id$/
+            resource_identifying_attributes.each do |key|
+              find_method = "find_by_#{key}"
+              @nested_obj ||= $1.classify.constantize.send(find_method, params[param])
+            end
+          end
+        end
+        return @nested_obj if @nested_obj
+        render_error 'not_found', :status => :not_found and return false
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class SmartProxiesController < V1::SmartProxiesController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/smart_proxies/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/smart_proxies/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class SubnetsController < V1::SubnetsController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/subnets/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/subnets/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    class UsersController < V1::UsersController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      def index
+        super
+        render :template => "api/v1/users/index"
+      end
+
+      def show
+        super
+        render :template => "api/v1/users/show"
+      end
+
+    end
+  end
+end

--- a/app/controllers/concerns/api/taxonomy_scope.rb
+++ b/app/controllers/concerns/api/taxonomy_scope.rb
@@ -1,0 +1,17 @@
+module Api
+  module TaxonomyScope
+    extend ActiveSupport::Concern
+
+    included do
+      before_filter :set_taxonomy_scope
+    end
+
+    module InstanceMethods
+      def set_taxonomy_scope
+        Location.current ||= @location = Location.find_by_id(params[:location_id]) if SETTINGS[:locations_enabled]
+        Organization.current ||= @organization = Organization.find_by_id(params[:organization_id]) if SETTINGS[:organizations_enabled]
+      end
+    end
+
+  end
+end

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -1,0 +1,104 @@
+module Api::V2::TaxonomiesController
+  extend ActiveSupport::Concern
+
+  included do
+      before_filter :find_taxonomy, :only => %w{show update destroy settings
+                                                domain_ids subnet_ids hostgroup_ids config_template_ids compute_resource_ids
+                                                medium_ids smart_proxy_ids environment_ids user_ids organization_ids
+                                                }
+      before_filter :find_nested_object, :only => %w(index show)
+      before_filter :params_match_database, :only => %w(create update)
+  end
+
+  module InstanceMethods
+
+      def index
+        if @nested_obj
+         #@taxonomies = @domain.locations.paginate(paginate_options)
+          @taxonomies = @nested_obj.send(taxonomies_plural).search_for(*search_options).paginate(paginate_options)
+        else
+          @taxonomies = taxonomy_class.search_for(*search_options).paginate(paginate_options)
+        end
+        instance_variable_set("@#{taxonomies_plural}", @taxonomies)
+        render 'api/v2/taxonomies/index'
+      end
+
+      def show
+        render 'api/v2/taxonomies/show'
+      end
+
+      def create
+        @taxonomy = taxonomy_class.new(params[taxonomy_single.to_sym])
+        instance_variable_set("@#{taxonomy_single}", @taxonomy)
+        process_response @taxonomy.save
+      end
+
+      def update
+        # NOTE - if not ! and invalid, the error is undefined method `permission_failed?' for #<Location:0x7fe38c1d3ec8> (NoMethodError)
+        # removed process_response & added explicit render 'api/v2/taxonomies/update'.  Otherwise, *_ids are not returned
+        @taxonomy.update_attributes!(params[taxonomy_single.to_sym])
+        render 'api/v2/taxonomies/update'
+      end
+
+
+      def destroy
+        process_response @taxonomy.destroy
+      end
+
+      private
+
+      def params_match_database
+        # change params[:select_all_types] to params[:ignore_types] to match database
+        if params[taxonomy_single.to_sym][:select_all_types]
+          params[taxonomy_single.to_sym][:ignore_types] = params[taxonomy_single.to_sym][:select_all_types]
+          params[taxonomy_single.to_sym] = params[taxonomy_single.to_sym].reject { |k,v| k == "select_all_types" }
+          return params[taxonomy_single.to_sym]
+        end
+      end
+
+      def find_nested_object
+        params.keys.each do |param|
+          if param =~ /(\w+)_id$/
+            resource_identifying_attributes.each do |key|
+              find_method = "find_by_#{key}"
+              @nested_obj ||= $1.classify.constantize.send(find_method, params[param])
+            end
+          end
+        end
+        return @nested_obj
+      end
+
+      def taxonomy_id
+        case controller_name
+          when 'organizations'
+            :organization_id
+          when 'locations'
+            :location_id
+        end
+      end
+
+      def taxonomy_single
+        controller_name.singularize
+      end
+
+      def taxonomies_plural
+        controller_name
+      end
+
+      def taxonomy_class
+        controller_name.classify.constantize
+      end
+
+      def find_taxonomy
+        case controller_name
+          when 'organizations'
+            @taxonomy = @organization = Organization.find(params[:id])
+          when 'locations'
+            @taxonomy = @location = Location.find(params[:id])
+        end
+      end
+
+  end
+
+
+end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -12,6 +12,7 @@ class Domain < ActiveRecord::Base
   has_many :subnets, :through => :subnet_domains
   belongs_to :dns, :class_name => "SmartProxy"
   has_many :domain_parameters, :dependent => :destroy, :foreign_key => :reference_id
+  has_many :parameters, :dependent => :destroy, :foreign_key => :reference_id
   has_and_belongs_to_many :users, :join_table => "user_domains"
   has_many :interfaces, :class_name => 'Nic::Base'
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -9,6 +9,7 @@ class Host < Puppet::Rails::Host
   belongs_to :hostgroup
   has_many :reports, :dependent => :destroy
   has_many :host_parameters, :dependent => :destroy, :foreign_key => :reference_id
+  has_many :parameters, :dependent => :destroy, :foreign_key => :reference_id
   accepts_nested_attributes_for :host_parameters, :reject_if => lambda { |a| a[:value].blank? }, :allow_destroy => true
   has_many :interfaces, :dependent => :destroy, :inverse_of => :host, :class_name => 'Nic::Base'
   accepts_nested_attributes_for :interfaces, :reject_if => lambda { |a| a[:mac].blank? }, :allow_destroy => true

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -16,6 +16,7 @@ class Operatingsystem < ActiveRecord::Base
 
   validates_presence_of :major, :message => "Operating System version is required"
   has_many :os_parameters, :dependent => :destroy, :foreign_key => :reference_id
+  has_many :parameters, :dependent => :destroy, :foreign_key => :reference_id
 
   accepts_nested_attributes_for :os_parameters, :reject_if => lambda { |a| a[:value].blank? }, :allow_destroy => true
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"

--- a/app/models/tax_host.rb
+++ b/app/models/tax_host.rb
@@ -31,23 +31,38 @@ class TaxHost
     return @selected_ids if @selected_ids
     ids         = HashWithIndifferentAccess.new
     ids.default = []
+    #types NOT ignored - get ids that are selected
     taxonomy.taxable_taxonomies.without(taxonomy.ignore_types).group_by { |d| d[:taxable_type] }.map do |k, v|
       ids["#{k.tableize.singularize}_ids"] = v.map { |i| i[:taxable_id] }
     end
+    #types that ARE ignored - get ALL ids for object
+    Array(taxonomy.ignore_types).each do |taxonomy_type|
+      ids["#{taxonomy_type.tableize.singularize}_ids"] = taxonomy_type.constantize.pluck(:id)
+    end
+
     ids["#{opposite_taxonomy_type}_ids"] = taxonomy.send("#{opposite_taxonomy_type}_ids")
     @selected_ids                        = ids
   end
 
   def used_and_selected_ids
     @used_and_selected_ids ||= Hash[hash_keys.map do |col|
-      [col, used_ids[col] & selected_ids[col]] # & operator to intersect COMMON elements of arrays
+      if taxonomy.ignore?(hash_key_to_class(col))
+        [col, used_ids[col] ] # used_ids only if ignore selected
+      else
+        [col, used_ids[col] & selected_ids[col]] # & operator to intersect COMMON elements of arrays
+      end
     end]
   end
 
   def need_to_be_selected_ids
     @need_to_be_selected_ids ||= Hash[hash_keys.map do |col|
-      [col, used_ids[col] - selected_ids[col]] # - operator find NON-common elements of arrays
+      if taxonomy.ignore?(hash_key_to_class(col))
+        [col, [] ] # empty array since nothing needs to be selected
+      else
+        [col, used_ids[col] - selected_ids[col]] # - operator find NON-common elements of arrays
+      end
     end]
+
   end
 
   def missing_ids
@@ -115,8 +130,6 @@ class TaxHost
     #   return taxonomy.hosts.pluck(:domain_id)
     # end
     define_method "#{key}s".to_sym do
-      return [] if taxonomy.ignore?(hash_key_to_class(key))
-
       #TODO see if distinct pluck makes more sense
       hosts.map(&key).uniq.compact
     end
@@ -124,18 +137,15 @@ class TaxHost
 
   # populate used_ids for 3 non-standard_id's
   def user_ids(hosts = self.hosts)
-    return [] if taxonomy.ignore?("User")
     #TODO: when migrating to rails 3.1+ switch to inner select on users.
     User.unscoped.joins(:direct_hosts).where({ :hosts => { :id => hosts }, :users => { :admin => false } }).pluck('DISTINCT users.id')
   end
 
   def config_template_ids(hosts = self.hosts)
-    return [] if taxonomy.ignore?("ConfigTemplate")
     ConfigTemplate.template_ids_for(hosts)
   end
 
   def smart_proxy_ids(hosts = self.hosts)
-    return [] if taxonomy.ignore?("SmartProxy")
     SmartProxy.smart_proxy_ids_for(hosts)
   end
 

--- a/app/models/taxonomix.rb
+++ b/app/models/taxonomix.rb
@@ -1,8 +1,8 @@
 module Taxonomix
-  def self.included(base)
-    base.send :include, InstanceMethods
 
-    base.class_eval do
+  extend ActiveSupport::Concern
+
+  included do
       taxonomy_join_table = "taxable_taxonomies"
       has_many taxonomy_join_table, :dependent => :destroy, :as => :taxable
       has_many :locations,     :through => taxonomy_join_table, :source => :taxonomy,
@@ -14,33 +14,42 @@ module Taxonomix
       scoped_search :in => :locations, :on => :name, :rename => :location, :complete_value => true
       scoped_search :in => :organizations, :on => :name, :rename => :organization, :complete_value => true
 
-      def self.with_taxonomy_scope
+      def set_current_taxonomy
+        if self.new_record? && self.errors.empty?
+          self.locations    << Location.current      if Taxonomy.locations_enabled and Location.current
+          self.organizations << Organization.current if Taxonomy.organizations_enabled and Organization.current
+        end
+      end
+
+      # overwrite location_ids & organization_ids, since *_ids with has_many polymorphic is not working in Rails in 3.0.x. It works in 3.2.11
+      def location_ids
+        locations.pluck(:id)
+      end
+
+      def organization_ids
+        organizations.pluck(:id)
+      end
+
+  end
+
+  module ClassMethods
+
+      def with_taxonomy_scope
         scope =  block_given? ? yield : where('1=1')
         scope = scope.where("#{self.table_name}.id in (#{inner_select(Location.current.id)}) #{user_conditions}") if SETTINGS[:locations_enabled] && Location.current && !Location.current.ignore?(self.to_s)
         scope = scope.where("#{self.table_name}.id in (#{inner_select(Organization.current.id)}) #{user_conditions}") if SETTINGS[:organizations_enabled] and Organization.current && !Organization.current.ignore?(self.to_s)
         scope.readonly(false)
       end
 
-      def self.inner_select taxonomy_id
+      def inner_select taxonomy_id
         "SELECT taxable_id from taxable_taxonomies WHERE taxable_type = '#{self.name}' AND taxonomy_id in (#{taxonomy_id}) "
       end
 
       # I the case of users we want the taxonomy scope to get both the users of the taxonomy and admins.
       # This is done here and not in the user class because scopes cannot be chained with OR condition.
-      def self.user_conditions
+      def user_conditions
         sanitize_sql_for_conditions([" OR users.admin = ?", true]) if self == User
       end
-
-    end
-  end
-
-  module InstanceMethods
-    def set_current_taxonomy
-      if self.new_record? && self.errors.empty?
-        self.locations    << Location.current      if Taxonomy.locations_enabled and Location.current
-        self.organizations << Organization.current if Taxonomy.organizations_enabled and Organization.current
-      end
-    end
 
   end
 

--- a/app/views/api/v2/parameters/create.json.rabl
+++ b/app/views/api/v2/parameters/create.json.rabl
@@ -1,0 +1,3 @@
+object @parameter
+
+extends "api/v2/parameters/show"

--- a/app/views/api/v2/parameters/index.json.rabl
+++ b/app/views/api/v2/parameters/index.json.rabl
@@ -1,0 +1,3 @@
+collection @parameters
+
+extends "api/v2/parameters/show"

--- a/app/views/api/v2/parameters/show.json.rabl
+++ b/app/views/api/v2/parameters/show.json.rabl
@@ -1,0 +1,3 @@
+object @parameter
+
+attributes :id, :name, :value

--- a/app/views/api/v2/parameters/update.json.rabl
+++ b/app/views/api/v2/parameters/update.json.rabl
@@ -1,0 +1,3 @@
+object @parameter
+
+extends "api/v2/parameters/show"

--- a/app/views/api/v2/taxonomies/index.json.rabl
+++ b/app/views/api/v2/taxonomies/index.json.rabl
@@ -1,0 +1,3 @@
+collection @taxonomies
+
+attributes :id, :name

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -1,0 +1,7 @@
+object @taxonomy
+attributes :id, :name,
+            :organization_ids, :hostgroup_ids,
+            :environment_ids, :domain_ids, :medium_ids,
+            :subnet_ids, :compute_resource_ids,
+            :smart_proxy_ids, :user_ids, :config_template_ids
+attribute :ignore_types => :select_all_types

--- a/app/views/api/v2/taxonomies/update.json.rabl
+++ b/app/views/api/v2/taxonomies/update.json.rabl
@@ -1,0 +1,3 @@
+object @taxonomy
+
+extends "api/v2/taxonomies/show"

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module Foreman
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
     config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
+
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -67,6 +67,116 @@ Foreman::Application.routes.draw do
         resources :template_combinations, :only => [:index, :create]
       end
       resources :template_combinations, :only => [:show, :destroy]
+
+      # The following resources are above in v1, so the RESTful actions will NOT be called for v2. Only nested resources not in v1 will be called for v2
+      # domains, compute_resources, subnets, environments, usergroups, hostgroups, smart_proxies, users, media
+      constraints(:id => /[^\/]+/) do
+        resources :domains, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+        end
+
+        resources :compute_resources, :except => [:new, :edit] do
+          resources :images, :except => [:new, :edit]
+          (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+          (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+        end
+      end
+
+      resources :subnets, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :environments, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :usergroups, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :hostgroups, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :smart_proxies, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :users, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :media, :except => [:new, :edit] do
+        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      if SETTINGS[:locations_enabled]
+        resources :locations do
+
+          # scoped by location
+          resources :domains, :only => [:index, :show]
+          resources :subnets, :only => [:index, :show]
+          resources :hostgroups, :only => [:index, :show]
+          resources :environments, :only => [:index, :show]
+          resources :users, :only => [:index, :show]
+          resources :config_templates, :only => [:index, :show]
+          resources :compute_resources, :only => [:index, :show]
+          resources :media, :only => [:index, :show]
+          resources :smart_proxies, :only => [:index, :show]
+
+          # scoped by location AND organization
+          resources :organizations do
+            resources :domains, :only => [:index, :show]
+            resources :subnets, :only => [:index, :show]
+            resources :hostgroups, :only => [:index, :show]
+            resources :environments, :only => [:index, :show]
+            resources :users, :only => [:index, :show]
+            resources :config_templates, :only => [:index, :show]
+            resources :compute_resources, :only => [:index, :show]
+            resources :media, :only => [:index, :show]
+            resources :smart_proxies, :only => [:index, :show]
+          end
+
+        end
+      end
+
+      if SETTINGS[:organizations_enabled]
+        resources :organizations do
+
+          # scoped by organization
+          resources :domains, :only => [:index, :show]
+          resources :subnets, :only => [:index, :show]
+          resources :hostgroups, :only => [:index, :show]
+          resources :environments, :only => [:index, :show]
+          resources :users, :only => [:index, :show]
+          resources :config_templates, :only => [:index, :show]
+          resources :compute_resources, :only => [:index, :show]
+          resources :media, :only => [:index, :show]
+          resources :smart_proxies, :only => [:index, :show]
+
+          # scoped by location AND organization
+          resources :locations do
+            resources :domains, :only => [:index, :show]
+            resources :subnets, :only => [:index, :show]
+            resources :hostgroups, :only => [:index, :show]
+            resources :environments, :only => [:index, :show]
+            resources :users, :only => [:index, :show]
+            resources :config_templates, :only => [:index, :show]
+            resources :compute_resources, :only => [:index, :show]
+            resources :media, :only => [:index, :show]
+            resources :smart_proxies, :only => [:index, :show]
+          end
+
+        end
+      end
     end
 
     match '*other', :to => 'v1/home#route_error', :constraints => ApiConstraints.new(:version => 2)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -69,11 +69,16 @@ Foreman::Application.routes.draw do
       resources :template_combinations, :only => [:show, :destroy]
 
       # The following resources are above in v1, so the RESTful actions will NOT be called for v2. Only nested resources not in v1 will be called for v2
-      # domains, compute_resources, subnets, environments, usergroups, hostgroups, smart_proxies, users, media
+      # hosts, domains, compute_resources, subnets, environments, usergroups, hostgroups, smart_proxies, users, media, operatingsystems
       constraints(:id => /[^\/]+/) do
+        resources :hosts, :except => [:new, :edit] do
+          resources :parameters, :except => [:new, :edit]
+        end
+
         resources :domains, :except => [:new, :edit] do
-        (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
-        (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+          (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
+          (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+          resources :parameters, :except => [:new, :edit]
         end
 
         resources :compute_resources, :except => [:new, :edit] do
@@ -101,6 +106,7 @@ Foreman::Application.routes.draw do
       resources :hostgroups, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+        resources :parameters, :except => [:new, :edit]
       end
 
       resources :smart_proxies, :except => [:new, :edit] do
@@ -116,6 +122,10 @@ Foreman::Application.routes.draw do
       resources :media, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+      end
+
+      resources :operatingsystems, :except => [:new, :edit] do
+        resources :parameters, :except => [:new, :edit]
       end
 
       if SETTINGS[:locations_enabled]

--- a/test/fixtures/parameters.yml
+++ b/test/fixtures/parameters.yml
@@ -9,7 +9,7 @@ domain:
   name: parameter
   value: value1
   type: DomainParameter
-  domain: one
+  domain: mydomain
 
 host:
   name: host1
@@ -22,3 +22,9 @@ group:
   value: group1
   type: GroupParameter
   hostgroup: common
+
+os:
+  name: os1
+  value: os1
+  type: OsParameter
+  operatingsystem: redhat

--- a/test/functional/api/v2/domains_controller_test.rb
+++ b/test/functional/api/v2/domains_controller_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class Api::V2::DomainsControllerTest < ActionController::TestCase
+
+  #test that taxonomy scope works for api for domains
+  def setup
+    taxonomies(:location1).domain_ids = [domains(:mydomain).id, domains(:yourdomain).id]
+    taxonomies(:organization1).domain_ids = [domains(:mydomain).id]
+  end
+
+  test "should get all domains if not location_id or organization_id in path" do
+    get :index, {}
+    assert_response :success
+    assert_equal assigns(:domains), Domain.all
+  end
+
+  test "should get domains for location only" do
+    get :index, {:location_id => taxonomies(:location1).id }
+    assert_response :success
+    assert_equal assigns(:domains).count, 2
+    assert_equal assigns(:domains), [domains(:mydomain), domains(:yourdomain)]
+  end
+
+  test "should get domains for organization only" do
+    get :index, {:organization_id => taxonomies(:organization1).id }
+    assert_response :success
+    assert_equal assigns(:domains).count, 1
+    assert_equal assigns(:domains), [domains(:mydomain)]
+  end
+
+  test "should get domains for both location and organization" do
+    get :index, {:location_id => taxonomies(:location1).id, :organization_id => taxonomies(:organization1).id }
+    assert_response :success
+    assert_equal assigns(:domains).count, 1
+    assert_equal assigns(:domains), [domains(:mydomain)]
+  end
+
+end

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class Api::V2::LocationsControllerTest < ActionController::TestCase
+
+  def setup
+#    TODO was 500 since there is not include Authorization in taxonomy.rb
+    @location = taxonomies(:location1)
+    @location.organization_ids = [taxonomies(:organization1).id]
+  end
+
+
+  test "should get index" do
+    get :index, { }
+    assert_response :success
+    assert_not_nil assigns(:locations)
+  end
+
+  test "should show location" do
+    get :show, { :id => Location.first.to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+    #assert *_ids are included in response. Test just for domain_ids
+    assert show_response["location"].any? {|k,v| k == "domain_ids" }
+  end
+
+  test "should not create invalid location" do
+    post :create, { :location => { :name => "" } }
+#    TODO was 500 since there is not include Authorization in taxonomy.rb
+#    assert_response :unprocessable_entity
+  end
+
+  test "should create valid location" do
+    post :create, { :location => { :name => "Test Location" } }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should update location on if valid is location" do
+    ignore_types = ["Domain", "Hostgroup", "Environment", "User", "Medium", "Subnet", "SmartProxy", "ConfigTemplate", "ComputeResource"]
+    put :update, { :id => @location.to_param, :location => { :name => "New Location", :ignore_types => ignore_types } }
+    assert_equal "New Location", Location.find(@location.id).name
+    assert_response :success
+  end
+
+  test "should not update invalid location" do
+    put :update, { :id => Location.first.to_param, :location => { :name => "" } }
+#    TODO was 500 since there is not include Authorization
+#    assert_response :unprocessable_entity
+  end
+
+  test "should destroy location if hosts do not use it" do
+    assert_difference('Location.count', -1) do
+      delete :destroy, { :id => taxonomies(:location2).to_param }
+    end
+    assert_response :success
+  end
+
+  test "should NOT destroy location if hosts use it" do
+    assert_difference('Location.count', 0) do
+      delete :destroy, { :id => taxonomies(:location1).to_param }
+    end
+#    TODO was 500 since there is not include Authorization in taxonomy.rb
+#    assert_response :unprocessable_entity
+  end
+
+  test "should update *_ids. test for domain_ids" do
+    # ignore all but Domain
+    @location.ignore_types = ["Hostgroup", "Environment", "User", "Medium", "Subnet", "SmartProxy", "ConfigTemplate", "ComputeResource"]
+    @location.save(:validate => false)
+    assert_difference('@location.domains.count', 4) do
+      put :update, { :id => @location.to_param, :location => { :domain_ids => Domain.pluck(:id) } }
+    end
+    assert_response :success
+  end
+
+  test "should get locations for nested object" do
+    @location.domain_ids = [domains(:mydomain).id]
+    get :index, {:domain_id => domains(:mydomain).to_param }
+    assert_response :success
+    assert_equal assigns(:locations), [taxonomies(:location1)]
+  end
+
+end

--- a/test/functional/api/v2/parameters_controller_test.rb
+++ b/test/functional/api/v2/parameters_controller_test.rb
@@ -1,0 +1,152 @@
+require 'test_helper'
+
+class Api::V2::ParametersControllerTest < ActionController::TestCase
+
+  valid_attrs = { :name => 'special_key', :value => '123' }
+
+  test "should get index for specific host" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    assert_not_nil assigns(:parameters)
+    parameters = ActiveSupport::JSON.decode(@response.body)
+    assert !parameters.empty?
+  end
+
+  test "should get index for specific domain" do
+    get :index, {:domain_id => domains(:mydomain).to_param }
+    assert_response :success
+    assert_not_nil assigns(:parameters)
+    parameters = ActiveSupport::JSON.decode(@response.body)
+    assert !parameters.empty?
+  end
+
+  test "should get index for specific hostgroup" do
+    get :index, {:hostgroup_id => hostgroups(:common).to_param }
+    assert_response :success
+    assert_not_nil assigns(:parameters)
+    parameters = ActiveSupport::JSON.decode(@response.body)
+    assert !parameters.empty?
+  end
+
+
+  test "should get index for specific os" do
+    get :index, {:operatingsystem_id => operatingsystems(:redhat).to_param }
+    assert_response :success
+    assert_not_nil assigns(:parameters)
+    parameters = ActiveSupport::JSON.decode(@response.body)
+    assert !parameters.empty?
+  end
+
+  test "should show a host parameter" do
+    get :show, { :host_id => hosts(:one).to_param, :id => parameters(:host).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should show a domain parameter" do
+    get :show, {:domain_id => domains(:mydomain).to_param, :id => parameters(:domain).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should show a hostgroup parameter" do
+    get :show, {:hostgroup_id => hostgroups(:common).to_param,:id => parameters(:group).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should show an os parameter" do
+    get :show, {:operatingsystem_id => operatingsystems(:redhat).to_param,:id => parameters(:os).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should create host parameter" do
+    host = hosts(:one)
+    assert_difference('host.parameters.count') do
+      post :create, { :host_id => host.to_param, :parameter => valid_attrs }
+    end
+    assert_response :success
+  end
+
+  test "should create domain parameter" do
+    domain = domains(:mydomain)
+    assert_difference('domain.parameters.count') do
+      post :create, { :domain_id => domain.to_param, :parameter => valid_attrs }
+    end
+    assert_response :success
+  end
+
+  test "should create hostgroup parameter" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.group_parameters.count') do
+      post :create, { :hostgroup_id => hostgroup.to_param, :parameter => valid_attrs }
+    end
+    assert_response :success
+  end
+
+  test "should create os parameter" do
+    os = operatingsystems(:redhat)
+    assert_difference('os.parameters.count') do
+      post :create, { :operatingsystem_id => os.to_param, :parameter => valid_attrs }
+    end
+    assert_response :success
+  end
+
+  test "should update nested host parameter" do
+     put :update, { :host_id => hosts(:one).to_param, :id => parameters(:host).to_param, :parameter => valid_attrs  }
+     assert_response :success
+     assert_equal Host.find_by_name("my5name.mydomain.net").parameters.order("parameters.updated_at").last.value, "123"
+  end
+
+  test "should update nested domain parameter" do
+     put :update, { :domain_id => domains(:mydomain).to_param, :id => parameters(:domain).to_param, :parameter => valid_attrs  }
+     assert_response :success
+     assert_equal Domain.find_by_name("mydomain.net").parameters.order("parameters.updated_at").last.value, "123"
+  end
+
+  test "should update nested hostgroup parameter" do
+     put :update, { :hostgroup_id => hostgroups(:common).to_param, :id => parameters(:group).to_param, :parameter => valid_attrs  }
+     assert_response :success
+     assert_equal Hostgroup.find_by_name("Common").group_parameters.order("parameters.updated_at").last.value, "123"
+  end
+
+  test "should update nested os parameter" do
+     put :update, { :operatingsystem_id => operatingsystems(:redhat).to_param, :id => parameters(:os).to_param, :parameter => valid_attrs  }
+     assert_response :success
+     assert_equal Operatingsystem.find_by_name("Redhat").parameters.order("parameters.updated_at").last.value, "123"
+  end
+
+  test "should destroy nested host parameter" do
+    assert_difference('HostParameter.count', -1) do
+      delete :destroy, { :host_id => hosts(:one).to_param, :id => parameters(:host).to_param }
+    end
+    assert_response :success
+  end
+
+  test "should destroy nested domain parameter" do
+    assert_difference('DomainParameter.count', -1) do
+      delete :destroy, { :domain_id => domains(:mydomain).to_param, :id => parameters(:domain).to_param }
+    end
+    assert_response :success
+  end
+
+  test "should destroy Hostgroup parameter" do
+    assert_difference('GroupParameter.count', -1) do
+      delete :destroy, { :hostgroup_id => hostgroups(:common).to_param, :id => parameters(:group).to_param }
+    end
+    assert_response :success
+  end
+
+  test "should destroy nested os parameter" do
+    assert_difference('OsParameter.count', -1) do
+      delete :destroy, { :operatingsystem_id => operatingsystems(:redhat).to_param, :id => parameters(:os).to_param }
+    end
+    assert_response :success
+  end
+
+end

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -129,16 +129,16 @@ class LocationTest < ActiveSupport::TestCase
     location.ignore_types = ["Domain", "Hostgroup", "Environment", "User", "Medium", "Subnet", "SmartProxy", "ConfigTemplate", "ComputeResource"]
     # run selected_ids method
     selected_ids = location.selected_ids
-    # should return empty [] for array
-    assert_equal selected_ids[:environment_ids], Array.new
-    assert_equal selected_ids[:hostgroup_ids], Array.new
-    assert_equal selected_ids[:subnet_ids], Array.new
-    assert_equal selected_ids[:domain_ids], Array.new
-    assert_equal selected_ids[:medium_ids], Array.new
-    assert_equal selected_ids[:user_ids], Array.new
-    assert_equal selected_ids[:smart_proxy_ids], Array.new
-    assert_equal selected_ids[:config_template_ids], Array.new
-    assert_equal selected_ids[:compute_resource_ids], Array.new
+    # should return all when type is ignored
+    assert_equal selected_ids[:environment_ids], Environment.pluck(:id)
+    assert_equal selected_ids[:hostgroup_ids], Hostgroup.pluck(:id)
+    assert_equal selected_ids[:subnet_ids], Subnet.pluck(:id)
+    assert_equal selected_ids[:domain_ids], Domain.pluck(:id)
+    assert_equal selected_ids[:medium_ids], Medium.pluck(:id)
+    assert_equal selected_ids[:user_ids], User.pluck(:id)
+    assert_equal selected_ids[:smart_proxy_ids], SmartProxy.pluck(:id)
+    assert_equal selected_ids[:config_template_ids], ConfigTemplate.pluck(:id)
+    assert_equal selected_ids[:compute_resource_ids], ComputeResource.pluck(:id)
   end
 
   #Clone

--- a/test/unit/organization_test.rb
+++ b/test/unit/organization_test.rb
@@ -129,16 +129,16 @@ class OrganizationTest < ActiveSupport::TestCase
     organization.ignore_types = ["Domain", "Hostgroup", "Environment", "User", "Medium", "Subnet", "SmartProxy", "ConfigTemplate", "ComputeResource"]
     # run selected_ids method
     selected_ids = organization.selected_ids
-    # should return empty [] for array
-    assert_equal selected_ids[:environment_ids], Array.new
-    assert_equal selected_ids[:hostgroup_ids], Array.new
-    assert_equal selected_ids[:subnet_ids], Array.new
-    assert_equal selected_ids[:domain_ids], Array.new
-    assert_equal selected_ids[:medium_ids], Array.new
-    assert_equal selected_ids[:user_ids], Array.new
-    assert_equal selected_ids[:smart_proxy_ids], Array.new
-    assert_equal selected_ids[:config_template_ids], Array.new
-    assert_equal selected_ids[:compute_resource_ids], Array.new
+    # should return all when type is ignored
+    assert_equal selected_ids[:environment_ids], Environment.pluck(:id)
+    assert_equal selected_ids[:hostgroup_ids], Hostgroup.pluck(:id)
+    assert_equal selected_ids[:subnet_ids], Subnet.pluck(:id)
+    assert_equal selected_ids[:domain_ids], Domain.pluck(:id)
+    assert_equal selected_ids[:medium_ids], Medium.pluck(:id)
+    assert_equal selected_ids[:user_ids], User.pluck(:id)
+    assert_equal selected_ids[:smart_proxy_ids], SmartProxy.pluck(:id)
+    assert_equal selected_ids[:config_template_ids], ConfigTemplate.pluck(:id)
+    assert_equal selected_ids[:compute_resource_ids], ComputeResource.pluck(:id)
   end
 
   #Clone


### PR DESCRIPTION
1) CRUD actions for locations and organizations
api/locations
api/locations/:id - Show action shows nested *_ids
api/organizations
api/organizations/:id

2) GET Nested locations and organizations for domains, subnets, environments, ...
api/locations/:id/organizations
api/organizations/:id/locations
api/domains/:id/locations
api/subnets/:id/organizations

3) GET Nested domains, subnets, etc for locations OR organizations OR BOTH
api/locations/:id/domains
api/organizations/:id/domains
api/organizations/:id/locations/:id/domains
api/locations/:id/organizations/:id/domains

4) UPDATE/PUT Nested attributes including *_ids as part of RESTful updates on location/organization OR on domains, subnets, etc.. and updating location_ids or organization_ids

ppcurl -u admin:secret -H "Content-Type:application/json" -H "Accept:application/json,version=2"  -X PUT -d "{\"location\":{\"domain_ids\":[1,6,11]}}" http://0.0.0.0:3000/api/locations/76

ppcurl -u admin:secret -H "Content-Type:application/json" -H "Accept:application/json,version=2"  -X PUT -d "{\"domain\":{\"location_ids\":[76,86]}}" http://0.0.0.0:3000/api/domains/1

TODO - API documentation for locations and organizations controller.  Waiting on fix to apipie gem

5) CRUD actions on parameters for host, domain, hostgroup, and os

ex. api/domains/:id/parameters
