### PR TITLE
Fixes #2199: Fix install media submit/cancel buttons when locations/orgs disabled.

### DIFF
--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -12,10 +12,10 @@
         <li><a href="#organizations" data-toggle="tab">Organizations</a></li>
       <% end %>
     </ul>
+  <% end%>
 
     <div class="tab-content">
       <div class="tab-pane active" id="primary">
-  <% end%>
         <%= text_f f, :name %>
         <%= text_f f, :path, :class => "input-xxlarge", :help_block => "The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture).
           for example <em>http://mirror.averse.net/centos/$version/os/$arch</em> where <strong>$arch</strong> will be substituted for the host's actual OS architecture and <strong>$version</strong>, <strong>$major</strong> and <strong>$minor</strong> will be substituted for the version of the operating system. Solaris and Debian media may also use <strong>$release</strong>.".html_safe %>


### PR DESCRIPTION
- When locations and Organizations are disabled, the submit/cancel Buttons are
  not well displayed when you want to add a new medium.
