### PR TITLE
fixes #2100 - fix regexp overflow on MRI 1.8 with older safemode/ruby_parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,20 @@ gem "will_paginate", "~> 3.0.2"
 gem "ancestry", "~> 1.3"
 gem 'scoped_search', '>= 2.4'
 gem 'net-ldap'
-gem "safemode", "~> 1.2"
-gem 'ruby_parser', '~> 3.0.0'
 gem 'uuidtools'
 gem "apipie-rails", '0.0.16'
 gem 'rabl', '>= 0.7.5'
 gem 'oauth'
+
+if RUBY_VERSION =~ /^1\.8/
+  # Older version of safemode for Ruby 1.8, as the latest causes regexp overflows (#2100)
+  gem 'safemode', '~> 1.0.1'
+  gem 'ruby_parser', '>= 2.3.1', '< 3.0'
+else
+  # Newer version of safemode contains fixes for Ruby 1.9
+  gem 'safemode', '~> 1.2'
+  gem 'ruby_parser', '~> 3.0.0'
+end
 
 Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
  # puts "adding custom gem file #{bundle}"


### PR DESCRIPTION
Could you please test the bundler install, just to make sure we don't hit version issues again like last time?  bundle updates/installs work ok here on 1.8 and 1.9.
