### PR TITLE
Bug #2231: Hostgroup deletion follows adopt policy

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -1,5 +1,5 @@
 class Hostgroup < ActiveRecord::Base
-  has_ancestry :orphan_strategy => :rootify
+  has_ancestry :orphan_strategy => :adopt
   include Authorization
   include Taxonomix
   include HostCommon


### PR DESCRIPTION
Given a hostgroup hierarchy like:

/base
/base/test01
/base/test01/test02
/base/test01/test03

Currently, if /base/test01 is deleted, it leads to a clunky configuration

/base
/test02
/test03

This change makes a hostgroup adopt orphans so that removing test01 would lead to:

/base
/base/test02
/base/test03

http://projects.theforeman.org/issues/2231
