### PR TITLE
Bug #2219 User <-> Hostgroup ACLs to follow the hostgroup hierarchy

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -59,6 +59,7 @@ class HostgroupsController < ApplicationController
     if @hostgroup.save
       # Add the new hostgroup to the user's filters
       @hostgroup.users << User.current unless User.current.admin? or @hostgroup.users.include?(User.current)
+      @hostgroup.users << @hostgroup.ancestors.map { |a| a.users }.flatten.uniq
       process_success
     else
       load_vars_for_ajax

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,6 +61,8 @@ class UsersController < ApplicationController
       # this is required, as the admin field is blacklisted above
       @user.update_attribute(:admin, admin) if User.current.admin
       @user.roles << Role.find_by_name("Anonymous") unless @user.roles.map(&:name).include? "Anonymous"
+      hostgroup_ids = params[:user]["hostgroup_ids"].reject(&:empty?).map(&:to_i) unless params[:user]["hostgroup_ids"].empty?
+      update_hostgroups_owners(hostgroup_ids) unless hostgroup_ids.empty?
       process_success editing_self ? { :success_redirect => hosts_path } : {}
     else
       process_error
@@ -145,6 +147,18 @@ class UsersController < ApplicationController
 
   def find_user
     @user = User.find(params[:id])
+  end
+
+  def update_hostgroups_owners(hostgroup_ids)
+    hostgroup_ids.each { |hs| depth_first_search(Hostgroup.find(hs)) }
+  end
+
+  def depth_first_search(hostgroup)
+    return if hostgroup.nil?
+    hostgroup.children.each do |hs|
+      hs.users << @user
+      depth_first_search(hs)
+    end
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,15 +150,8 @@ class UsersController < ApplicationController
   end
 
   def update_hostgroups_owners(hostgroup_ids)
-    hostgroup_ids.each { |hs| depth_first_search(Hostgroup.find(hs)) }
-  end
-
-  def depth_first_search(hostgroup)
-    return if hostgroup.nil?
-    hostgroup.children.each do |hs|
-      hs.users << @user
-      depth_first_search(hs)
-    end
+    subhostgroups = hostgroup_ids.map { |hs| Hostgroup.find(hs) }.map(&:subtree).flatten
+    subhostgroups.each { |subhs| subhs.users << @user }
   end
 
 end

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -107,4 +107,19 @@ class HostgroupsControllerTest < ActionController::TestCase
     get :index, {}, set_session_user.merge(:user => users(:one).id)
     assert_response :success
   end
+
+  test 'owners of a hostgroup up in the hierarchy get ownership of all children' do
+    User.current = User.first
+    sample_user = users(:one)
+
+    Hostgroup.new(:name => "root").save
+    Hostgroup.find_by_name("root").users << sample_user
+
+    post :create, {"hostgroup" => {"name"=>"first" , "parent_id"=> Hostgroup.find_by_name("root").id}}, set_session_user
+    post :create, {"hostgroup" => {"name"=>"second", "parent_id"=> Hostgroup.find_by_name("first").id}}, set_session_user
+
+    assert_equal sample_user,  Hostgroup.find_by_name("first").users.first
+    assert_equal sample_user,  Hostgroup.find_by_name("second").users.first
+  end
+
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -124,4 +124,24 @@ class UsersControllerTest < ActionController::TestCase
     get :index, {}, set_session_user
     assert User.current.nil?
   end
+
+  test "should set user as owner of hostgroup children if owner of hostgroup root" do
+    User.current = User.first
+    sample_user = users(:one) 
+
+    Hostgroup.new(:name => "root").save 
+    Hostgroup.new(:name => "first" , :parent_id => Hostgroup.find_by_name("root").id).save
+    Hostgroup.new(:name => "second", :parent_id => Hostgroup.find_by_name("first").id).save
+
+    update_hash = {"user"=>{ "login"         => sample_user.login,
+      "hostgroup_ids" => ["", Hostgroup.find_by_name("root").id.to_s] },
+      "commit"        => "Submit",
+      "id"            => sample_user.id }
+
+    put :update, update_hash , set_session_user
+
+    assert_equal Hostgroup.find_by_name("first").users.first , sample_user
+    assert_equal Hostgroup.find_by_name("second").users.first, sample_user
+  end
+
 end


### PR DESCRIPTION
In short, this pull requests ensures that given a user owns a top-level hostgroup, it will own its hostgroups subtree. 

Given a hostgroup that has lots of subhostgroups, it can be time consuming for the foreman admin to assign rights to people who own several hostgroups on a hierarchy by selecting each of the hostgroups. An example is provided in the issue tracker bug. 

http://projects.theforeman.org/issues/2219
