### PR TITLE
fixes ovirt 3.1 related issue.

### DIFF
--- a/app/views/compute_resources/_form.html.erb
+++ b/app/views/compute_resources/_form.html.erb
@@ -17,6 +17,7 @@
       <div class="tab-pane active" id="primary">
   <% end %>
         <%= text_f f, :name %>
+        <%= f.hidden_field(:provider, :id => '') if f.object.uuid.present? %>
         <%= selectable_f f, :provider, ComputeResource::PROVIDERS, { :include_blank => "Choose a provider"},
                          {:disabled=> f.object.uuid.present?, :'data-url'=> provider_selected_compute_resources_path, :onchange => 'providerSelected(this);'} %>
         <%= textarea_f f, :description, :rows => 3 %>

--- a/app/views/compute_resources_vms/form/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/form/_ovirt.html.erb
@@ -7,7 +7,7 @@
                :onchange    => 'ovirt_clusterSelected(this);',
                :help_inline => image_tag('spinner.gif', :id => 'cluster_indicator', :class => 'hide').html_safe } %>
 <%= f.hidden_field :cluster if !new %>
-<%= select_f f, :template, compute_resource.hardware_profiles, :id, :name, {},
+<%= select_f f, :template, compute_resource.hardware_profiles, :id, :name, {:include_blank => "Select template"},
              { :disabled    => !new, :'data-url' => hardware_profile_selected_compute_resource_path(compute_resource),
                :onchange    => 'ovirt_hwpSelected(this);',
                :help_inline => image_tag('spinner.gif', :id => 'hwp_indicator', :class => 'hide').html_safe,

--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,3 +1,4 @@
 group :fog do
-  gem 'fog', '>= 1.9'
+  gem "fog", :git => "https://github.com/fog/fog.git"
+# gem 'fog', '>= 1.9'
 end

--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem "rbovirt", ">= 0.0.15"
+  gem "rbovirt", ">= 0.0.18"
 end

--- a/public/javascripts/compute_resource.js
+++ b/public/javascripts/compute_resource.js
@@ -38,7 +38,7 @@ function testConnection(item) {
   $.ajax({
     type:'put',
     url: $(item).attr('data-url'),
-    data: $('#new_compute_resource').serialize(),
+    data: $('form').serialize(),
     success:function (result) {
       $('#compute_connection').html($(result).find("#compute_connection"));
       $('#compute_connection').prepend($(result).find(".alert-message"));


### PR DESCRIPTION
This patch includes 5 fixes:
1. Test connection was not working in Compute resource Edit page.
2. oVirt 3.1 does not include Blank template in each virtual data center, as a workaround I have included an empty template in foreman template selector.
3. oVirt 3.1 fixes limitation of earlier versions, it allows creating number of disks for a single VM in the same time, now foreman can take advantage of this fix.
4. Fix foreman issue #2224 by bumping rbovirt version to version 0.0.18 that include a fix.
5. Fix foreman issue #2163 by including fog git version that contains the fix.
