### PR TITLE
fixes #2250 API v2 add/remove puppetclasses from hosts and hostgroups

### DIFF
--- a/app/controllers/api/v2/host_classes_controller.rb
+++ b/app/controllers/api/v2/host_classes_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V2
+    class HostClassesController < V2::BaseController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      before_filter :find_host_id, :only => [:index, :create, :destroy]
+
+      api :GET, "/hosts/:host_id/puppetclass_ids/", "List all puppetclass id's for host"
+
+      def index
+        render :json => HostClass.where(:host_id => host_id).pluck('puppetclass_id')
+      end
+
+      api :POST, "/hosts/:host_id/puppetclass_ids", "Add a puppetclass to host"
+      param :host_id, String, :required => true, :desc => "id of host"
+      param :puppetclass_id, String, :required => true, :desc => "id of puppetclass"
+
+      def create
+        @host_class = HostClass.create!(:host_id => host_id, :puppetclass_id => params[:puppetclass_id].to_i)
+        render :json => {:host_id => @host_class.host_id, :puppetclass_id => @host_class.puppetclass_id}
+      end
+
+      api :DELETE, "/hosts/:host_id/puppetclass_ids/:id/", "Remove a puppetclass from host"
+      param :host_id, String, :required => true, :desc => "id of host"
+      param :id, String, :required => true, :desc => "id of puppetclass"
+
+      def destroy
+        @host_class = HostClass.where(:host_id => host_id, :puppetclass_id => params[:id])
+        process_response @host_class.destroy_all
+      end
+
+      private
+      attr_reader :host_id
+
+      def find_host_id
+        if params[:host_id] =~ /^\d+$/
+          return @host_id = params[:host_id].to_i
+        else
+          @host ||= Host::Managed.find_by_name(params[:host_id])
+          return @host_id = @host.id if @host
+          render_error 'not_found', :status => :not_found and return false
+        end
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/hostgroup_classes_controller.rb
+++ b/app/controllers/api/v2/hostgroup_classes_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module V2
+    class HostgroupClassesController < V2::BaseController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      before_filter :find_hostgroup_id, :only => [:index, :create, :destroy]
+
+      api :GET, "/hostgroups/:hostgroup_id/puppetclass_ids/", "List all puppetclass id's for hostgroup"
+
+      def index
+        render :json => HostgroupClass.where(:hostgroup_id => hostgroup_id).pluck('puppetclass_id')
+      end
+
+      api :POST, "/hostgroups/:hostgroup_id/puppetclass_ids", "Add a puppetclass to hostgroup"
+      param :hostgroup_id, String, :required => true, :desc => "id of hostgroup"
+      param :puppetclass_id, String, :required => true, :desc => "id of puppetclass"
+
+      def create
+        @hostgroup_class = HostgroupClass.create!(:hostgroup_id => hostgroup_id, :puppetclass_id => params[:puppetclass_id].to_i)
+        render :json => {:hostgroup_id => @hostgroup_class.hostgroup_id, :puppetclass_id => @hostgroup_class.puppetclass_id}
+      end
+
+      api :DELETE, "/hostgroups/:hostgroup_id/puppetclass_ids/:id/", "Remove a puppetclass from hostgroup"
+      param :hostgroup_id, String, :required => true, :desc => "id of hostgroup"
+      param :puppetclass_id, String, :required => true, :desc => "id of puppetclass"
+
+      def destroy
+        @hostgroup_class = HostgroupClass.where(:hostgroup_id => @hostgroup_id, :puppetclass_id => params[:id])
+        process_response @hostgroup_class.destroy_all
+      end
+
+      private
+      attr_reader :hostgroup_id
+
+      # params[:hostgroup_id] is "id-to_label.parameterize" and .to_i returns the id
+      def find_hostgroup_id
+        @hostgroup_id = params[:hostgroup_id].to_i
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/puppetclasses_controller.rb
+++ b/app/controllers/api/v2/puppetclasses_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V2
+    class PuppetclassesController < V1::PuppetclassesController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+
+      before_filter :find_nested_object, :only => [:index, :show]
+
+      api :GET, "/puppetclasses/", "List all puppetclasses."
+      api :GET, "/hosts/:host_id/puppetclasses", "List all puppetclasses for host"
+      api :GET, "/hostgroups/:hostgroup_id/puppetclasses", "List all puppetclasses for hostgroup"
+      api :GET, "/environments/:environment_id/puppetclasses", "List all puppetclasses for environment"
+      param :host_id, String, :desc => "id of nested host"
+      param :hostgroup_id, String, :desc => "id of nested hostgroup"
+      param :environment_id, String, :desc => "id of nested environment"
+
+      def index
+        return super unless @nested_obj
+        if @nested_obj.kind_of?(Environment)
+          values = @nested_obj.puppetclasses
+        else
+          values = @nested_obj.all_puppetclasses
+        end
+        render :json => Puppetclass.classes2hash(values)
+      end
+
+      api :GET, "/puppetclasses/:id", "Show a puppetclass"
+      api :GET, "/hosts/:host_id/puppetclasses/:id", "Show a puppetclass for host"
+      api :GET, "/hostgroups/:hostgroup_id/puppetclasses/:id", "Show a puppetclass for hostgroup"
+      api :GET, "/environments/:environment_id/puppetclasses/:id", "Show a puppetclass for environment"
+      param :host_id, String, :desc => "id of nested host"
+      param :hostgroup_id, String, :desc => "id of nested hostgroup"
+      param :environment_id, String, :desc => "id of nested environment"
+      param :id, String, :required => true, :desc => "id of puppetclass"
+
+      def show
+        if @nested_obj
+          @puppetclass = @nested_obj.puppetclasses.find(params[:id])
+        end
+      end
+
+      private
+      attr_reader :nested_obj
+
+      def find_nested_object
+        params.keys.each do |param|
+          if param =~ /(\w+)_id$/
+            resource_identifying_attributes.each do |key|
+              find_method = "find_by_#{key}"
+              @nested_obj ||= $1.classify.constantize.send(find_method, params[param])
+            end
+          end
+        end
+        return @nested_obj
+      end
+
+    end
+  end
+end

--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -1,4 +1,5 @@
 class HostClass < ActiveRecord::Base
+  include Authorization
   audited :associated_with => :host
   belongs_to :host, :foreign_key => :host_id
   belongs_to :puppetclass

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -1,4 +1,5 @@
 class HostgroupClass < ActiveRecord::Base
+  include Authorization
   audited :associated_with => :hostgroup
   belongs_to :hostgroup
   belongs_to :puppetclass

--- a/app/views/api/v2/puppetclasses/show.json.rabl
+++ b/app/views/api/v2/puppetclasses/show.json.rabl
@@ -1,0 +1,7 @@
+object @puppetclass
+
+attributes :id, :name
+
+child :lookup_keys do
+  attributes :id, :key, :default_value, :path, :default_value
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -20,7 +20,6 @@ Foreman::Application.routes.draw do
           end
           resources :audits        ,:only => :index
           resources :facts         ,:only => :index, :controller => :fact_values
-          resources :puppetclasses ,:only => :index
           get :status, :on => :member
         end
         resources :compute_resources, :except => [:new, :edit] do
@@ -40,7 +39,6 @@ Foreman::Application.routes.draw do
         end
       end
       resources :ptables, :except => [:new, :edit]
-      resources :puppetclasses, :except => [:new, :edit]
       resources :roles, :except => [:new, :edit]
       resources :reports, :only => [:index, :show, :destroy] do
         get :last, :on => :collection
@@ -75,6 +73,8 @@ Foreman::Application.routes.draw do
               delete '/', :to => :reset
             end
           end
+          resources :puppetclasses, :only => [:index, :show]
+          resources :host_classes, :path => :puppetclass_ids, :only => [:index, :create, :destroy]
         end
 
         resources :domains, :only => [] do
@@ -101,6 +101,7 @@ Foreman::Application.routes.draw do
       resources :environments, :only => [] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+        resources :puppetclasses, :only => [:index, :show]
       end
 
       resources :hostgroups, :only => [] do
@@ -111,6 +112,8 @@ Foreman::Application.routes.draw do
             delete '/', :to => :reset
           end
         end
+        resources :puppetclasses, :only => [:index, :show]
+        resources :hostgroup_classes, :path => :puppetclass_ids, :only => [:index, :create, :destroy]
       end
 
       resources :smart_proxies, :only => [] do
@@ -135,6 +138,8 @@ Foreman::Application.routes.draw do
           end
         end
       end
+
+      resources :puppetclasses, :except => [:new, :edit]
 
       if SETTINGS[:locations_enabled]
         resources :locations do

--- a/lib/foreman/access_permissions.rb
+++ b/lib/foreman/access_permissions.rb
@@ -101,7 +101,8 @@ Foreman::AccessControl.map do |map|
                                             :puppetclasses => pc_ajax_actions}
     map.permission :edit_hostgroups,       {:hostgroups => [:edit, :update, :architecture_selected, :nest].push(*ajax_actions),
                                             :host => host_ajax_actions,
-                                            :puppetclasses => pc_ajax_actions}
+                                            :puppetclasses => pc_ajax_actions,
+                                            :"api/v2/hostgroup_classes" => [:index, :create, :destroy]}
     map.permission :destroy_hostgroups,    {:hostgroups => [:destroy]}
   end
 
@@ -130,7 +131,9 @@ Foreman::AccessControl.map do |map|
                                       :select_multiple_location, :update_multiple_location].push(*ajax_actions),
                                     :compute_resources => cr_ajax_actions,
                                     :puppetclasses => pc_ajax_actions,
-                                    :subnets => subnets_ajax_actions}
+                                    :subnets => subnets_ajax_actions,
+                                    :"api/v2/host_classes" => [:index, :create, :destroy]
+                                  }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy]}
     map.permission :build_hosts,   {:hosts => [:setBuild, :cancelBuild, :multiple_build, :submit_multiple_build],
                                     :tasks => tasks_ajax_actions}

--- a/test/fixtures/puppetclasses.yml
+++ b/test/fixtures/puppetclasses.yml
@@ -5,3 +5,9 @@ one:
 
 two:
   name: apache
+
+three:
+  name: git
+
+four:
+  name: vim

--- a/test/functional/api/v2/host_classes_controller_test.rb
+++ b/test/functional/api/v2/host_classes_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Api::V2::HostClassesControllerTest < ActionController::TestCase
+
+  test "should get puppetclass ids for host" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+    assert_equal puppetclasses.length, 1
+  end
+
+  test "should add a puppetclass to a host" do
+    host = hosts(:one)
+    assert_difference('host.host_classes.count') do
+      post :create, { :host_id => host.to_param, :puppetclass_id => puppetclasses(:four).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove a puppetclass from a host" do
+    host = hosts(:one)
+    assert_difference('host.host_classes.count', -1) do
+      delete :destroy, { :host_id => host.to_param, :id => puppetclasses(:one).id }
+    end
+    assert_response :success
+  end
+
+end

--- a/test/functional/api/v2/hostgroup_class_controller_test.rb
+++ b/test/functional/api/v2/hostgroup_class_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Api::V2::HostgroupClassesControllerTest < ActionController::TestCase
+
+  test "should get puppetclass ids for hostgroup" do
+    get :index, {:hostgroup_id => hostgroups(:common).id }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+    assert_equal puppetclasses.length, 1
+  end
+
+  test "should add a puppetclass to a hostgroup" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.hostgroup_classes.count') do
+      post :create, { :hostgroup_id => hostgroup.id, :puppetclass_id => puppetclasses(:four).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove a puppetclass from a hostgroup" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.hostgroup_classes.count', -1) do
+      delete :destroy, { :hostgroup_id => hostgroup.id, :id => puppetclasses(:one).id }
+    end
+    assert_response :success
+  end
+
+end

--- a/test/functional/api/v2/puppetclasses_controller_test.rb
+++ b/test/functional/api/v2/puppetclasses_controller_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+class Api::V2::PuppetclassesControllerTest < ActionController::TestCase
+
+  valid_attrs = { :name => 'test_puppetclass' }
+
+
+  test "should get puppetclasses for host" do
+    get :index, {:host_id => hosts(:one).to_param }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+    assert_equal 1, puppetclasses.length
+  end
+
+  test "should get puppetclasses for hostgroup" do
+    get :index, {:hostgroup_id => hostgroups(:common).to_param }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+    assert_equal 1, puppetclasses.length
+  end
+
+  test "should get puppetclasses for environment" do
+    get :index, {:environment_id => environments(:production).to_param }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+    assert_equal 1, puppetclasses.length
+  end
+
+  test "should show puppetclass for host" do
+    get :show, { :host_id => hosts(:one).to_param, :id => puppetclasses(:one).id }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should show puppetclass for hostgroup" do
+    get :show, { :hostgroup_id => hostgroups(:common).to_param, :id => puppetclasses(:one).id }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should show puppetclass for environment" do
+    get :show, { :environment_id => environments(:production), :id => puppetclasses(:one).id }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should give error if puppetclass is not in nested host" do
+    get :show, { :host_id => hosts(:one).to_param, :id => puppetclasses(:four).id }
+    assert_response :error
+  end
+
+  test "should give error if puppetclass is not in nested hostgroup" do
+    get :show, { :hostgroup_id => hostgroups(:common).to_param, :id => puppetclasses(:four).id }
+    assert_response :error
+  end
+
+  test "should give error if puppetclass is not in nested environment" do
+    get :show, { :environment_id => environments(:production).to_param, :id => puppetclasses(:four).id }
+    assert_response :error
+  end
+
+  # CRUD actions - same test as V1
+  test "should get index" do
+    get :index, { }
+    assert_response :success
+    puppetclasses = ActiveSupport::JSON.decode(@response.body)
+    assert !puppetclasses.empty?
+  end
+
+  # FYI - show puppetclass doesn't work in V1
+  test "should show puppetclass with no nesting" do
+    get :show, { :id => puppetclasses(:one).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "should create puppetclass" do
+    assert_difference('Puppetclass.count') do
+      post :create, { :puppetclass => valid_attrs }
+    end
+    assert_response :success
+  end
+
+  test "should update puppetclass" do
+    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => { } }
+    assert_response :success
+  end
+
+  test "should destroy puppetclasss" do
+    assert_difference('Puppetclass.count', -1) do
+      delete :destroy, { :id => puppetclasses(:one).to_param }
+    end
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
GET puppetclasses for host, hostgroup, or environment 

/api/hosts/:id/puppetclasses
/api/hostgroups/:id/puppetclasses
/api/environments/:id/puppetclasses

ADD puppetclass to host or hostgroup (not environment)

PUT /api/hosts/:id/puppetclasses/:id
PUT /api/hostgroups/:id/puppetclasses/:id

REMOVE puppetclass from host or hostgroup (not environment)

DELETE /api/hosts/:id/puppetclasses/:id
DELETE /api/hostgroups/:id/puppetclasses/:id
