### PR TITLE
Single sign out to URL defined in Settings

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,14 +105,16 @@ class UsersController < ApplicationController
   # Clears the rails session and redirects to the login action
   def logout
     expire_fragment("tabs_and_title_records-#{User.current.id}") if User.current
+    user_id = session[:user]
     session[:user] = @user = User.current = nil
-    if flash[:notice] or flash[:error]
-      flash.keep
+    (flash[:notice] || flash[:error]) ? flash.keep : session.clear
+
+    if User.find(user_id).auth_source.type == "AuthSourceLdap"
+      redirect_to(Setting['single_sign_out_url'])
     else
-      session.clear
       notice "Logged out - See you soon"
+      redirect_to(login_users_path)
     end
-    redirect_to login_users_path
   end
 
   def auth_source_selected

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,7 +109,7 @@ class UsersController < ApplicationController
     session[:user] = @user = User.current = nil
     (flash[:notice] || flash[:error]) ? flash.keep : session.clear
 
-    if User.find(user_id).auth_source.type == "AuthSourceLdap"
+    if User.find(user_id).auth_source.type != "AuthSourceInternal"
       redirect_to(Setting['single_sign_out_url'])
     else
       notice "Logged out - See you soon"

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -80,6 +80,7 @@ module Foreman
               set('oauth_map_users', "Should foreman map users by username in request-header", true),
               set('restrict_registered_puppetmasters', 'Only known Smart Proxies with the Puppet feature can access fact/report importers and ENC output', true),
               set('require_ssl_puppetmasters', 'Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)', true),
+              set('single_sign_out_url', 'Redirect your users to this url on logout (Single Sign On (LDAP) should also be enabled)', 'https://ssologout'),
               set('ssl_client_dn_env', 'Environment variable containing the subject DN from a client SSL certificate', 'SSL_CLIENT_S_DN'),
               set('ssl_client_verify_env', 'Environment variable containing the verification status of a client SSL certificate', 'SSL_CLIENT_VERIFY')
             ].compact.each { |s| create s.update(:category => "Auth")}


### PR DESCRIPTION
Foreman currently supports LDAP SSOn. This pull request adds a new field to Settings containing the URL to which users are redirected with they sign out, so that they sign out from everywhere else (opposite of SSO). 
