### PR TITLE
authorization over environment model

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,5 +1,6 @@
 class Environment < ActiveRecord::Base
   include Taxonomix
+  include Authorization
 
   has_many :environment_classes, :dependent => :destroy
   has_many :puppetclasses, :through => :environment_classes, :uniq => true

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -1,3 +1,4 @@
+require 'yaml'
 root     = File.expand_path(File.dirname(__FILE__) + "/..")
 SETTINGS = YAML.load_file("#{root}/config/settings.yaml")
 SETTINGS[:version]    = File.read(root + "/VERSION").chomp rescue ("N/A")

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -38,6 +38,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should get edit" do
+    setup_users
     environment = Environment.new :name => "some_environment"
     assert environment.save!
 
@@ -46,6 +47,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should update environment" do
+    setup_users
     environment = Environment.new :name => "some_environment"
     assert environment.save!
 
@@ -57,6 +59,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should update environment using json" do
+    setup_users
     environment = Environment.new :name => "some_environment"
     assert environment.save!
 
@@ -70,6 +73,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
 
 
   test "should destroy environment" do
+    setup_users
     environment = Environment.new :name => "some_environment"
     assert environment.save!
 
@@ -81,6 +85,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should destroy environment using json" do
+    setup_users
     environment = Environment.new :name => "some_environment"
     assert environment.save!
 


### PR DESCRIPTION
Calling

```
POST "/foreman/api/environments" {"environment"=>{"name"=>"production"} }
```

caused

```
undefined method `permission_failed?' for #<Environment:0x7f978b2ff808>
(NoMethodError)
```
