### PR TITLE
fixes #2550 Puppetclass search_by_host doesn't return all classes for an unknown host

### DIFF
--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -154,7 +154,7 @@ class Puppetclass < ActiveRecord::Base
     conditions = sanitize_sql_for_conditions(["hosts.name #{operator} ?", value_to_sql(operator, value)])
     direct     = Puppetclass.joins(:hosts).where(conditions).select('puppetclasses.id').map(&:id).uniq
     hostgroup  = Hostgroup.joins(:hosts).where(conditions).first
-    indirect   = HostgroupClass.where(:hostgroup_id => hostgroup.path_ids).pluck(:puppetclass_id).uniq
+    indirect   = hostgroup.blank? ? [] : HostgroupClass.where(:hostgroup_id => hostgroup.path_ids).pluck('DISTINCT puppetclass_id')
     return { :conditions => "1=0" } if direct.blank? && indirect.blank?
 
     puppet_classes = (direct + indirect).uniq

--- a/test/functional/api/v1/puppetclasses_controller_test.rb
+++ b/test/functional/api/v1/puppetclasses_controller_test.rb
@@ -37,4 +37,11 @@ class Api::V1::PuppetclassesControllerTest < ActionController::TestCase
     assert !fact_values.empty?
   end
 
+  test "should not get puppetclasses for nonexistent host" do
+    get :index, {"search" => "host = imaginaryhost.nodomain.what" }
+    assert_response :success
+    fact_values = ActiveSupport::JSON.decode(@response.body)
+    assert fact_values.empty?
+  end
+
 end

--- a/test/unit/puppetclass_test.rb
+++ b/test/unit/puppetclass_test.rb
@@ -87,4 +87,8 @@ class PuppetclassTest < ActiveSupport::TestCase
     assert record.valid?
   end
 
+  test "looking for a nonexistent host returns no puppetclasses" do
+    assert_equal [], Puppetclass.search_for("host = imaginaryhost.nodomain.what")
+  end
+
 end


### PR DESCRIPTION
Puppetclass.search_for shows up in puppetclasses_controller and its respective method of the API. It uses scoped_search to look for all puppetclasses that a host contains. Unfortunately, in the event of a lookup of a host that either belongs to no hostgroup or a host that doesn't exist, this will return all puppetclasses.

This fix checks for this conditions and avoids returning all puppetclasses.

curl -v -k -H d"Content-Type:application/json" https://foreman/api/hosts/nonexistenthost/puppetclasses returns Puppetclass.all without this fix, after this fix it returns {}.
