### PR TITLE
fixes #2275 - include ThreadSession::Cleaner only once

### DIFF
--- a/app/controllers/concerns/api/taxonomy_scope.rb
+++ b/app/controllers/concerns/api/taxonomy_scope.rb
@@ -3,7 +3,6 @@ module Api
     extend ActiveSupport::Concern
 
     included do
-      include Foreman::ThreadSession::Cleaner
       before_filter :set_taxonomy_scope
     end
 


### PR DESCRIPTION
Foreman::ThreadSession::Cleaner was included in Taxonomy concern, which
postponed the session clearing (that should be the first thing to happen in
filters) to phase after :authorize filter, effectively discarding the login
information leading to permission denied.

The ThreadSession::Cleaner should be included only in Api::BaseController.
