### PR TITLE
Downgrade the libvirt bindings warning to print

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -18,7 +18,7 @@ if File.exists?(ENV['BUNDLE_GEMFILE'])
       SETTINGS[:libvirt] = false
     end
   rescue LoadError
-    warn "Libvirt binding are missing - hypervisor management is disabled"
+    print "Libvirt bindings are missing - hypervisor management is disabled"
     SETTINGS[:libvirt] = false
   end
 end


### PR DESCRIPTION
Currently every rake cronjob this line is sent to stderr and makes it a very noisy cronjob. This patch changes it to stdout, but maybe it should be removed altogether.
