### PR TITLE
Discovery plugin

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -22,6 +22,7 @@ class HostsController < ApplicationController
   before_filter :find_by_name, :only => %w[show edit update destroy puppetrun setBuild cancelBuild
     storeconfig_klasses clone pxe_config toggle_manage power console]
   before_filter :taxonomy_scope, :only => [:hostgroup_or_environment_selected, :process_hostgroup]
+  before_filter :set_host_type, :only => [:update]
   helper :hosts, :reports
 
   def index (title = nil)
@@ -487,6 +488,15 @@ class HostsController < ApplicationController
   end
 
   private
+
+  def set_host_type
+    if params[:host] and params[:host][:type] and params[:host][:type].constantize.new.kind_of?(Host::Base)
+      @host      = @host.becomes(params[:host][:type].constantize)
+      @host.type = params[:host][:type]
+    end
+  rescue => e
+    error "Something went wrong while changing host type - #{e}"
+  end
 
   def taxonomy_scope
     @organization = params[:organization_id].blank? ? nil : Organization.find(Array.wrap(params[:organization_id]))

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1,14 +1,21 @@
 module Host
 
   def self.method_missing(method, *args, &block)
-    if [:create, :new, :create!].include?(method)
-      if args[0]
-        args[0][:type] ||= 'Host::Managed'
-      else
-        args = [{:type => 'Host::Managed'}]
+    type = "Host::Managed"
+    case method.to_s
+    when /create/, 'new'
+      if args.empty? or args[0].nil? # got no paramters
+        #set the default type
+        args = [{:type => type}]
+      else # got some parameters
+        args[0][:type] ||= type # adds the type if it doesnt exists
+        type = args[0][:type]   # stores the type for later usage.
       end
+    when /^find_by/
+      type = "Host::Base"
     end
-    Host::Managed.send(method,*args, &block)
+
+    type.constantize.send(method,*args, &block)
   end
 
   # the API base controller expects to call 'respond_to?' on this, which

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -4,5 +4,136 @@ module Host
   class Base < ActiveRecord::Base
     include Foreman::STI
     set_table_name :hosts
+
+    belongs_to :model
+    has_many :fact_values, :dependent => :destroy, :foreign_key => :host_id
+    has_many :fact_names, :through => :fact_values
+
+    alias_attribute :hostname, :name
+    validates_presence_of   :name
+    validates_uniqueness_of :name
+    validate :is_name_downcased?
+
+    include Hostext::Search
+
+    def self.importHostAndFacts yaml
+    end
+
+    # import host facts, required when running without storeconfigs.
+    # expect a Puppet::Node::Facts
+    def importFacts name, facts
+
+      # we are not importing facts for hosts in build state (e.g. waiting for a re-installation)
+      raise "Host is pending for Build" if build
+      time = facts[:_timestamp]
+      time = time.to_time if time.is_a?(String)
+
+      # we are not doing anything we already processed this fact (or a newer one)
+      if time
+        return true unless last_compile.nil? or (last_compile + 1.minute < time)
+        self.last_compile = time
+      end
+      # save all other facts
+      merge_facts(facts)
+      save(:validate => false)
+
+      populateFieldsFromFacts(facts)
+
+      # we are saving here with no validations, as we want this process to be as fast
+      # as possible, assuming we already have all the right settings in Foreman.
+      # If we don't (e.g. we never install the server via Foreman, we populate the fields from facts
+      # TODO: if it was installed by Foreman and there is a mismatch,
+      # we should probably send out an alert.
+      return self.save(:validate => false)
+
+    rescue Exception => e
+      logger.warn "Failed to save #{name}: #{e}"
+    end
+
+    # Inspired from Puppet::Rails:Host
+    def merge_facts(facts)
+      db_facts = {}
+
+      deletions = []
+      fact_values.includes(:fact_name).each do |value|
+        deletions << value['id'] and next unless facts.include?(value['name'])
+        # Now store them for later testing.
+        db_facts[value['name']] ||= []
+        db_facts[value['name']] << value
+      end
+
+      # Now get rid of any parameters whose value list is different.
+      # This might be extra work in cases where an array has added or lost
+      # a single value, but in the most common case (a single value has changed)
+      # this makes sense.
+      db_facts.each do |name, value_hashes|
+        values = value_hashes.collect { |v| v['value'] }
+
+        unless values == facts[name]
+          value_hashes.each { |v| deletions << v['id'] }
+        end
+      end
+
+      # Perform our deletions.
+      FactValue.delete(deletions) unless deletions.empty?
+
+      # Get FactNames in one call
+      fact_names = FactName.where(:name => facts.keys)
+
+      # Create any needed new FactNames
+      facts.keys.dup.delete_if { |n| fact_names.map(&:name).include? n }.each do |needed|
+        fact_names << FactName.create(:name => needed)
+      end
+
+      # Lastly, add any new parameters.
+      fact_names.each do |fact_name|
+        next if db_facts.include?(fact_name.name)
+        value = facts[fact_name.name]
+        values = value.is_a?(Array) ? value : [value]
+        values.each do |v|
+          next if v.nil?
+          fact_values.build(:value => v, :fact_name => fact_name)
+        end
+      end
+    end
+
+    def attributes_to_import_from_facts
+      attrs = [:model]
+    end
+
+    def populateFieldsFromFacts facts = self.facts_hash
+      # we don't import facts for host in build mode
+      return if build?
+
+      importer = Facts::Importer.new facts
+
+      set_non_empty_values importer, attributes_to_import_from_facts
+      importer
+    end
+
+    def set_non_empty_values importer, methods
+      methods.each do |attr|
+        value = importer.send(attr)
+        self.send("#{attr}=", value) unless value.blank?
+      end
+    end
+
+    def is_name_downcased?
+      return unless name.present?
+      errors.add(:name, "must be downcase") unless name == name.downcase
+    end
+
+    def facts_hash
+      hash = {}
+      fact_values.all(:include => :fact_name).collect do |fact|
+        hash[fact.fact_name.name] = fact.value
+      end
+      hash
+    end
+
+    def to_param
+      name
+    end
+
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,11 +1,8 @@
 class Host::Managed < Host::Base
   include Authorization
   include ReportCommon
-  belongs_to :model
   has_many :host_classes, :dependent => :destroy, :foreign_key => :host_id
   has_many :puppetclasses, :through => :host_classes
-  has_many :fact_values, :dependent => :destroy, :foreign_key => :host_id
-  has_many :fact_names, :through => :fact_values
   belongs_to :hostgroup
   has_many :reports, :dependent => :destroy, :foreign_key => :host_id
   has_many :host_parameters, :dependent => :destroy, :foreign_key => :reference_id
@@ -46,7 +43,6 @@ class Host::Managed < Host::Base
     end
   end
 
-  include Hostext::Search
   include HostCommon
 
   class Jail < ::Safemode::Jail
@@ -179,12 +175,9 @@ class Host::Managed < Host::Base
   # some shortcuts
   alias_attribute :os, :operatingsystem
   alias_attribute :arch, :architecture
-  alias_attribute :hostname, :name
   alias_attribute :fqdn, :name
 
-  validates_uniqueness_of  :name
-  validates_presence_of    :name, :environment_id
-  validate :is_name_downcased?
+  validates_presence_of :environment_id
 
   if SETTINGS[:unattended]
     # handles all orchestration of smart proxies.
@@ -234,10 +227,6 @@ class Host::Managed < Host::Base
         lookup_values.build(attr)
       end
     end
-  end
-
-  def to_param
-    name
   end
 
   def <=>(other)
@@ -457,46 +446,14 @@ class Host::Managed < Host::Base
     h.importFacts(name, values)
   end
 
-  # import host facts, required when running without storeconfigs.
-  # expect a Puppet::Node::Facts
-  def importFacts name, facts
-
-    # we are not importing facts for hosts in build state (e.g. waiting for a re-installation)
-    raise "Host is pending for Build" if build
-    time = facts[:_timestamp]
-    time = time.to_time if time.is_a?(String)
-
-    # we are not doing anything we already processed this fact (or a newer one)
-    if time
-      return true unless last_compile.nil? or (last_compile + 1.minute < time)
-      self.last_compile = time
-    end
-    # save all other facts
-    merge_facts(facts)
-    save(:validate => false)
-
-    populateFieldsFromFacts(facts)
-
-    # we are saving here with no validations, as we want this process to be as fast
-    # as possible, assuming we already have all the right settings in Foreman.
-    # If we don't (e.g. we never install the server via Foreman, we populate the fields from facts
-    # TODO: if it was installed by Foreman and there is a mismatch,
-    # we should probably send out an alert.
-    return self.save(:validate => false)
-
-  rescue Exception => e
-    logger.warn "Failed to save #{name}: #{e}"
+  def attributes_to_import_from_facts
+    attrs = []
+    attrs = [:mac, :ip] unless managed? and Setting[:ignore_puppet_facts_for_provisioning]
+    super + [:domain, :architecture, :operatingsystem, :model, :certname] + attrs
   end
 
-
   def populateFieldsFromFacts facts = self.facts_hash
-    # we don't import facts for host in build mode
-    return if build?
-
-    importer = Facts::Importer.new facts
-
-    set_non_empty_values importer, [:domain, :architecture, :operatingsystem, :model, :certname]
-    set_non_empty_values importer, [:mac, :ip] unless managed? and Setting[:ignore_puppet_facts_for_provisioning]
+    importer = super
     normalize_addresses
     if Setting[:update_environment_from_facts]
       set_non_empty_values importer, [:environment]
@@ -616,14 +573,6 @@ class Host::Managed < Host::Base
 
   def can_be_built?
     managed? and SETTINGS[:unattended] and capabilities.include?(:build) ? build == false : false
-  end
-
-  def facts_hash
-    hash = {}
-    fact_values.all(:include => :fact_name).collect do |fact|
-      hash[fact.fact_name.name] = fact.value
-    end
-    hash
   end
 
   def enforce_permissions operation
@@ -826,54 +775,6 @@ class Host::Managed < Host::Base
 
   private
 
-  # Inspired from Puppet::Rails:Host
-  def merge_facts(facts)
-    db_facts = {}
-
-    deletions = []
-    fact_values.includes(:fact_name).each do |value|
-      deletions << value['id'] and next unless facts.include?(value['name'])
-      # Now store them for later testing.
-      db_facts[value['name']] ||= []
-      db_facts[value['name']] << value
-    end
-
-    # Now get rid of any parameters whose value list is different.
-    # This might be extra work in cases where an array has added or lost
-    # a single value, but in the most common case (a single value has changed)
-    # this makes sense.
-    db_facts.each do |name, value_hashes|
-      values = value_hashes.collect { |v| v['value'] }
-
-      unless values == facts[name]
-        value_hashes.each { |v| deletions << v['id'] }
-      end
-    end
-
-    # Perform our deletions.
-    FactValue.delete(deletions) unless deletions.empty?
-
-    # Get FactNames in one call
-    fact_names = FactName.where(:name => facts.keys)
-
-    # Create any needed new FactNames
-    facts.keys.dup.delete_if { |n| fact_names.map(&:name).include? n }.each do |needed|
-      fact_names << FactName.create(:name => needed)
-    end
-
-    # Lastly, add any new parameters.
-    fact_names.each do |fact_name|
-      next if db_facts.include?(fact_name.name)
-      value = facts[fact_name.name]
-      values = value.is_a?(Array) ? value : [value]
-      values.each do |v|
-        next if v.nil?
-        fact_values.build(:value => v, :fact_name => fact_name)
-      end
-    end
-
-  end
-
   def lookup_keys_params
     return {} unless Setting["Enable_Smart_Variables_in_ENC"]
 
@@ -954,11 +855,6 @@ class Host::Managed < Host::Base
     "puppet_status"
   end
 
-  def is_name_downcased?
-    return unless name.present?
-    errors.add(:name, "must be downcase") unless name == name.downcase
-  end
-
   # converts a name into ip address using DNS.
   # if we are managing DNS, we can query the correct DNS server
   # otherwise, use normal systems dns settings to resolv
@@ -967,13 +863,6 @@ class Host::Managed < Host::Base
     return dns_ptr_record.dns_lookup(name_or_ip).ip if dns_ptr_record
     # fall back to normal dns resolution
     domain.resolver.getaddress(name_or_ip).to_s
-  end
-
-  def set_non_empty_values importer, methods
-    methods.each do |attr|
-      value = importer.send(attr)
-      self.send("#{attr}=", value) unless value.blank?
-    end
   end
 
   def set_default_user

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -1,6 +1,6 @@
 <%= javascript 'host_edit', 'compute_resource', 'lookup_keys'%>
-<%= render "conflicts" if has_conflicts?(@host.errors) %>
-<%= render "progress" %>
+<%= render "hosts/conflicts" if has_conflicts?(@host.errors) %>
+<%= render "hosts/progress" %>
 <%= form_for @host,  :html => {:'data-submit' => 'progress_bar'} do |f| %>
   <%= base_errors_for @host %>
 
@@ -68,8 +68,9 @@
 
     <%= f.hidden_field :managed %>
     <%= f.hidden_field :progress_report_id %>
+    <%= f.hidden_field :type, :value => @host.type if @host.type_changed? %>
 
-    <%= render('unattended', :f => f) if SETTINGS[:unattended] and @host.managed -%>
+    <%= render('hosts/unattended', :f => f) if SETTINGS[:unattended] and @host.managed -%>
 
     <div class="tab-pane"  id="params">
       <h6>Puppet classes Parameters</h6>

--- a/app/views/hosts/_unattended.html.erb
+++ b/app/views/hosts/_unattended.html.erb
@@ -1,5 +1,5 @@
 <div class="tab-pane"  id="compute_resource">
-  <%= render 'compute', :compute_resource => @host.compute_resource if @host.compute_resource_id %>
+  <%= render 'hosts/compute', :compute_resource => @host.compute_resource if @host.compute_resource_id %>
 </div>
 
 <div class="tab-pane"  id="network">
@@ -19,9 +19,9 @@
         <%# the following field is required to see child validations %>
         <%= f.hidden_field :updated_at, :value => Time.now.to_i %>
         <%= f.fields_for :interfaces do |interfaces| %>
-          <%= render 'interfaces', :f => interfaces  %>
+          <%= render 'hosts/interfaces', :f => interfaces  %>
         <% end %>
-        <%= new_child_fields_template(f, :interfaces, {:partial => "interfaces"})%>
+        <%= new_child_fields_template(f, :interfaces, {:partial => "hosts/interfaces"})%>
         <%= add_child_link "+ Add Interface", :interfaces, { :class => "info", :title => 'add new network interface' } %>
       </div>
     <% end %>
@@ -29,5 +29,5 @@
 </div>
 
 <div class="tab-pane"  id="os">
-  <%= render 'operating_system', :host => @host, :f => f %>
+  <%= render 'hosts/operating_system', :host => @host, :f => f %>
 </div>

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -4,4 +4,4 @@
     hash_for_toggle_manage_host_path(:id => @host.name), {:method => :put}) %>
 <% end -%>
 
-<%= render :partial => 'form' %>
+<%= render :partial => 'hosts/form' %>

--- a/lib/foreman/sti.rb
+++ b/lib/foreman/sti.rb
@@ -17,7 +17,14 @@ module Foreman
 
           alias_method_chain :new, :cast
         end
+        base.alias_method_chain :save, :type
       end
+    end
+    def save_with_type(*args)
+      self.class.instance_variable_set("@finder_needs_type_condition", :false) if self.type_changed?
+      value = save_without_type(*args)
+      self.class.instance_variable_set("@finder_needs_type_condition", :true)  if self.type_changed?
+      return value
     end
   end
 end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -779,6 +779,20 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
+  test "can change sti type to valid subtype" do
+    class Host::Valid < Host::Base ; end
+    put :update, { :commit => "Update", :id => @host.name, :host => {:type => "Host::Valid"} }, set_session_user
+    @host = Host.find(@host)
+    assert_equal "Host::Valid", @host.type
+  end
+
+  test "cannot change sti type to invalid subtype" do
+    old_type = @host.type
+    put :update, { :commit => "Update", :id => @host.name, :host => {:type => "Host::Notvalid"} }, set_session_user
+    @host = Host.find(@host)
+    assert_equal old_type, @host.type
+  end
+
   private
   def initialize_host
     User.current = users(:admin)


### PR DESCRIPTION
These are the required changes to Foreman core for the discovery plugin (so far). Hopefully each commit has enough explanation as to why it was needed, but broadly we have:

1) Changes to the STI models so Host::Discovered can inherit the right methods
2) Changes to the Hosts edit form so we can render it from another Controller
3) Setting the STI type in #update

@ohadlevy I cannot get becomes() to work right, so I've commented it for now. We can revisit when Rails 3.2 is merged
