### PR TITLE
Parameters Controller (API v2) can reset parameters

### DIFF
--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -6,7 +6,7 @@ module Api
       include Api::TaxonomyScope
 
       before_filter :find_resource, :only => [:show, :update, :destroy]
-      before_filter :find_nested_object, :only => [:index, :show, :create]
+      before_filter :find_nested_object, :only => [:index, :show, :create, :reset]
 
       resource_description do
         desc <<-DOC
@@ -62,6 +62,15 @@ module Api
       def destroy
         process_response @parameter.destroy
       end
+
+      api :DELETE, "/references/:id/parameters/reset", "Deletes all parameters for host, domain, hostgroup, or operating system."
+      param :id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+
+      def reset
+        @parameter = nested_obj.send(parameters_method)
+        process_response @parameter.destroy_all
+      end
+
 
       private
       attr_reader :nested_obj

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -63,7 +63,7 @@ module Api
         process_response @parameter.destroy
       end
 
-      api :DELETE, "/references/:id/parameters/reset", "Deletes all parameters for host, domain, hostgroup, or operating system."
+      api :DELETE, "/references/:id/parameters", "Deletes all parameters for host, domain, hostgroup, or operating system."
       param :id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
 
       def reset

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -70,13 +70,21 @@ Foreman::Application.routes.draw do
 
       constraints(:id => /[^\/]+/) do
         resources :hosts, :only => [] do
-          resources :parameters, :except => [:new, :edit]
+          resources :parameters, :except => [:new, :edit] do
+            collection do 
+              delete 'reset'
+            end
+          end
         end
 
         resources :domains, :only => [] do
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
-          resources :parameters, :except => [:new, :edit]
+          resources :parameters, :except => [:new, :edit] do
+            collection do 
+              delete 'reset'
+            end
+          end 
         end
 
         resources :compute_resources, :only => [] do
@@ -98,7 +106,11 @@ Foreman::Application.routes.draw do
       resources :hostgroups, :only => [] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
-        resources :parameters, :except => [:new, :edit]
+        resources :parameters, :except => [:new, :edit] do
+          collection do 
+            delete 'reset'
+          end
+        end 
       end
 
       resources :smart_proxies, :only => [] do
@@ -117,7 +129,11 @@ Foreman::Application.routes.draw do
       end
 
       resources :operatingsystems, :only => [] do
-        resources :parameters, :except => [:new, :edit]
+        resources :parameters, :except => [:new, :edit] do
+          collection do 
+            delete 'reset'
+          end
+        end 
       end
 
       if SETTINGS[:locations_enabled]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -72,7 +72,7 @@ Foreman::Application.routes.draw do
         resources :hosts, :only => [] do
           resources :parameters, :except => [:new, :edit] do
             collection do 
-              delete 'reset'
+              delete '/', :to => :reset
             end
           end
         end
@@ -82,7 +82,7 @@ Foreman::Application.routes.draw do
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
           resources :parameters, :except => [:new, :edit] do
             collection do 
-              delete 'reset'
+              delete '/', :to => :reset 
             end
           end 
         end
@@ -108,7 +108,7 @@ Foreman::Application.routes.draw do
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
         resources :parameters, :except => [:new, :edit] do
           collection do 
-            delete 'reset'
+            delete '/', :to => :reset 
           end
         end 
       end
@@ -131,7 +131,7 @@ Foreman::Application.routes.draw do
       resources :operatingsystems, :only => [] do
         resources :parameters, :except => [:new, :edit] do
           collection do 
-            delete 'reset'
+            delete '/', :to => :reset 
           end
         end 
       end

--- a/test/functional/api/v2/parameters_controller_test.rb
+++ b/test/functional/api/v2/parameters_controller_test.rb
@@ -149,4 +149,32 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should reset nested host parameter" do
+    assert_difference('HostParameter.count', -1) do
+      delete :reset, { :host_id => hosts(:one).to_param } 
+    end 
+    assert_response :success
+  end 
+
+  test "should reset nested domain parameter" do
+    assert_difference('DomainParameter.count', -1) do
+      delete :reset, { :domain_id => domains(:mydomain).to_param }
+    end 
+    assert_response :success
+  end 
+
+  test "should reset Hostgroup parameter" do
+    assert_difference('GroupParameter.count', -1) do
+      delete :reset, { :hostgroup_id => hostgroups(:common).to_param }
+    end 
+    assert_response :success
+  end 
+
+  test "should reset nested os parameters" do
+    assert_difference('OsParameter.count', -1)  do  
+      delete :reset, { :operatingsystem_id => operatingsystems(:redhat).name }
+    end 
+    assert_response :success
+  end 
+
 end


### PR DESCRIPTION
Before this pull request, there is no way to reset the parameters of a host, domain, hostgroup or operating system unless you get all of the parameters first (GET /resource/parameters) then iterate through all of them, and delete them (DELETE /resource/parameters/:parameter_id).

After this pull request this operation is simply (DELETE /resource/parameters/reset). 
