### PR TITLE
Load the apipie documentation when calling '/api'

### DIFF
--- a/app/controllers/api/v1/home_controller.rb
+++ b/app/controllers/api/v1/home_controller.rb
@@ -5,6 +5,8 @@ module Api
       api :GET, "/", "Show available links."
 
       def index
+        # we need to load apipie documentation to show all the links.
+        Apipie.reload_documentation if Apipie.configuration.reload_controllers?
       end
 
       api :GET, "/status/", "Show status."


### PR DESCRIPTION
The documentation is used to list the links for the resources. We make sure
it's loaded.
