### PR TITLE
fixes #2318 - API v2 documentation for parameters to include real paths ...

### DIFF
--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -15,7 +15,14 @@ module Api
         DOC
       end
 
-      api :GET, "/references/:id/parameters/", "List all parameters for host, domain, hostgroup, or operating system"
+      api :GET, "/host/:host_id/parameters", "List all parameters for host"
+      api :GET, "/hostgroup/:hostgroup_id/parameters", "List all parameters for hostgroup"
+      api :GET, "/domain/:domain_id/parameters", "List all parameters for domain"
+      api :GET, "/operatingsystem/:operatingsystem_id/parameters", "List all parameters for operating system"
+      param :host_id, String, :desc => "id of host"
+      param :hostgroup_id, String, :desc => "id of hostgroup"
+      param :domain_id, String, :desc => "id of domain"
+      param :operatingsystem_id, String, :desc => "id of operating system"
       param :page, String, :desc => "paginate results"
       param :per_page, String, :desc => "number of entries per request"
 
@@ -23,15 +30,27 @@ module Api
         @parameters = nested_obj.send(parameters_method).paginate(paginate_options)
       end
 
-      api :GET, "/references/:reference_id/parameters/:id/", "Show a nested parameter for host, domain, hostgroup, or operating system"
-      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      api :GET, "/host/:host_id/parameters/:id", "Show a nested parameter for host"
+      api :GET, "/hostgroup/:hostgroup_id/parameters/:id", "Show a nested parameter for hostgroup"
+      api :GET, "/domain/:domain_id/parameters/:id", "Show a nested parameter for domain"
+      api :GET, "/operatingsystem/:operatingsystem_id/parameters/:id", "Show a nested parameter for operating system"
+      param :host_id, String, :desc => "id of host"
+      param :hostgroup_id, String, :desc => "id of hostgroup"
+      param :domain_id, String, :desc => "id of domain"
+      param :operatingsystem_id, String, :desc => "id of operating system"
       param :id, String, :required => true, :desc => "id of parameter"
 
       def show
       end
 
-      api :POST, "/references/:reference_id/parameters", "Create a nested parameter for host, domain, hostgroup, or operating system"
-      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      api :POST, "/host/:host_id/parameters/:id", "Create a nested parameter for host"
+      api :POST, "/hostgroup/:hostgroup_id/parameters/:id", "Create a nested parameter for hostgroup"
+      api :POST, "/domain/:domain_id/parameters/:id", "Create a nested parameter for domain"
+      api :POST, "/operatingsystem/:operatingsystem_id/parameters/:id", "Create a nested parameter for operating system"
+      param :host_id, String, :desc => "id of host"
+      param :hostgroup_id, String, :desc => "id of hostgroup"
+      param :domain_id, String, :desc => "id of domain"
+      param :operatingsystem_id, String, :desc => "id of operating system"
       param :id, String, :required => true, :desc => "id of parameter"
       param :parameter, Hash, :required => true do
         param :name, String
@@ -43,8 +62,14 @@ module Api
         process_response @parameter.save
       end
 
-      api :PUT, "/references/:reference_id/parameters/:id/", "Update a nested parameter for host, domain, hostgroup, or operating system"
-      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      api :PUT, "/host/:host_id/parameters/:id", "Update a nested parameter for host"
+      api :PUT, "/hostgroup/:hostgroup_id/parameters/:id", "Update a nested parameter for hostgroup"
+      api :PUT, "/domain/:domain_id/parameters/:id", "Update a nested parameter for domain"
+      api :PUT, "/operatingsystem/:operatingsystem_id/parameters/:id", "Update a nested parameter for operating system"
+      param :host_id, String, :desc => "id of host"
+      param :hostgroup_id, String, :desc => "id of hostgroup"
+      param :domain_id, String, :desc => "id of domain"
+      param :operatingsystem_id, String, :desc => "id of operating system"
       param :id, String, :required => true, :desc => "id of parameter"
       param :parameter, Hash, :required => true do
         param :name, String
@@ -55,16 +80,24 @@ module Api
         process_response @parameter.update_attributes(params[:parameter])
       end
 
-      api :DELETE, "/references/:id/parameters/:id/", "Delete a nested parameter for host, domain, hostgroup, or operating system."
-      param :reference_id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      api :DELETE, "/host/:host_id/parameters/:id", "Delete a nested parameter for host"
+      api :DELETE, "/hostgroup/:hostgroup_id/parameters/:id", "Delete a nested parameter for hostgroup"
+      api :DELETE, "/domain/:domain_id/parameters/:id", "Delete a nested parameter for domain"
+      api :DELETE, "/operatingsystem/:operatingsystem_id/parameters/:id", "Delete a nested parameter for operating system"
+      param :host_id, String, :desc => "id of host"
+      param :hostgroup_id, String, :desc => "id of hostgroup"
+      param :domain_id, String, :desc => "id of domain"
+      param :operatingsystem_id, String, :desc => "id of operating system"
       param :id, String, :required => true, :desc => "id of parameter"
 
       def destroy
         process_response @parameter.destroy
       end
 
-      api :DELETE, "/references/:id/parameters", "Deletes all parameters for host, domain, hostgroup, or operating system."
-      param :id, String, :required => true, :desc => "id of nested reference object (:i.e. host, domain, hostgroup, or operating system) results"
+      api :DELETE, "/host/:host_id/parameters", "Delete all nested parameters for host"
+      api :DELETE, "/hostgroup/:hostgroup_id/parameters", "Delete all nested parameters for hostgroup"
+      api :DELETE, "/domain/:domain_id/parameters", "Delete all nested parameters for domain"
+      api :DELETE, "/operatingsystem/:operatingsystem_id/parameters", "Delete all nested parameters for operating system"
 
       def reset
         @parameter = nested_obj.send(parameters_method)


### PR DESCRIPTION
...rather than /references/:id
