### PR TITLE
Configurable Katello SSO support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
   end
 
   def available_sso
-    @available_sso ||= Sso.get_available(self)
+    @available_sso ||= SSO.get_available(self)
   end
 
   # Force a user to login if authentication is enabled

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,10 @@ class ApplicationController < ActionController::Base
     not_found
   end
 
+  def api_request?
+    request.format.json? or request.format.yaml?
+  end
+
   protected
 
   # Authorize the user for the requested action
@@ -53,6 +57,9 @@ class ApplicationController < ActionController::Base
     redirect_to :protocol => 'https' and return if request.protocol != 'https' and not request.ssl?
   end
 
+  def available_sso
+    @available_sso ||= Sso.get_available(self)
+  end
 
   # Force a user to login if authentication is enabled
   # Sets User.current to the logged in user, or to admin if logins are not used
@@ -62,11 +69,14 @@ class ApplicationController < ActionController::Base
       if SETTINGS[:login]
         # authentication is enabled
 
-        # If REMOTE_USER is provided by the web server then
-        # authenticate the user without using password.
-        if remote_user_provided?
-          user = User.unscoped.find_by_login(@remote_user)
-          logger.warn("Failed REMOTE_USER authentication from #{request.remote_ip}") unless user
+        if available_sso.present?
+          if available_sso.authenticated?
+            user = User.unscoped.find_by_login(available_sso.user)
+            User.logout_path = available_sso.logout_path if available_sso.support_logout?
+          elsif available_sso.support_login?
+            available_sso.authenticate!
+            return
+          end
         # Else, fall back to the standard authentication mechanism,
         # only if it's an API request.
         elsif api_request?
@@ -118,10 +128,6 @@ class ApplicationController < ActionController::Base
       format.yml { head :status => 404}
     end
     true
-  end
-
-  def api_request?
-    request.format.json? or request.format.yaml?
   end
 
   # this method sets the Current user to be the Admin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -89,17 +89,14 @@ class UsersController < ApplicationController
   def login
     session[:user] = User.current = nil
     if request.post?
-      user = User.try_to_login(params[:login]['login'].downcase,  params[:login]['password'])
+      user = User.try_to_login(params[:login]['login'].downcase, params[:login]['password'])
       if user.nil?
         #failed to authenticate, and/or to generate the account on the fly
         error _("Incorrect username or password")
         redirect_to login_users_path
       else
         #valid user
-        session[:user] = user.id
-        uri = session[:original_uri]
-        session[:original_uri] = nil
-        redirect_to (uri || hosts_path)
+        login_user(user)
       end
     end
   end
@@ -118,7 +115,6 @@ class UsersController < ApplicationController
   end
 
   private
-
   def authorize(ctrl = params[:controller], action = params[:action])
     # Editing self is true when the user is granted access to just their own account details
 
@@ -142,6 +138,13 @@ class UsersController < ApplicationController
   def update_hostgroups_owners(hostgroup_ids)
     subhostgroups = Hostgroup.where(:id => hostgroup_ids).map(&:subtree).flatten.reject { |hg| hg.users.include?(@user) }
     subhostgroups.each { |subhs| subhs.users << @user }
+  end
+
+  def login_user(user)
+    session[:user]         = user.id
+    uri                    = session[:original_uri]
+    session[:original_uri] = nil
+    redirect_to (uri || hosts_path)
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -275,6 +275,10 @@ module ApplicationHelper
     "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}?d=mm&s=30"
   end
 
+  def sign_out_url
+    User.logout_path + URI.escape(logout_users_url)
+  end
+
   private
   def edit_inline(object, property, options={})
     name       = "#{type}[#{property}]"

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -2,7 +2,7 @@
   <li class="dropdown">
     <%= user_header %>
     <ul class="dropdown-menu pull-right">
-      <li><%= link_to(_("Sign Out"), logout_users_path) %></li>
+      <li><%= link_to(_("Sign Out"), sign_out_url) %></li>
       <li><%= link_to(_("My account"), edit_user_path(User.current) )%></li>
       <% if SETTINGS[:locations_enabled] %>
         <%= render 'home/location_dropdown' %>

--- a/bundler.d/openid.rb
+++ b/bundler.d/openid.rb
@@ -1,0 +1,1 @@
+gem 'rack-openid'

--- a/bundler.d/openid.rb
+++ b/bundler.d/openid.rb
@@ -1,1 +1,3 @@
-gem 'rack-openid'
+group :openid do
+  gem 'rack-openid'
+end

--- a/config/initializers/rack_openid.rb
+++ b/config/initializers/rack_openid.rb
@@ -1,0 +1,2 @@
+require 'rack/openid'
+Rails.configuration.middleware.use Rack::OpenID

--- a/config/initializers/rack_openid.rb
+++ b/config/initializers/rack_openid.rb
@@ -1,2 +1,6 @@
-require 'rack/openid'
-Rails.configuration.middleware.use Rack::OpenID
+begin
+  require 'rack/openid'
+  Rails.configuration.middleware.use Rack::OpenID
+rescue LoadError
+  nil
+end

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -32,6 +32,7 @@ module Foreman
 
           Setting.transaction do
             domain = Facter.domain
+            fqdn = Facter.fqdn
             [
               set('administrator', "The default administrator email address", "root@#{domain}"),
               set('foreman_url',   "The hostname where your Foreman instance is reachable", "foreman.#{domain}"),
@@ -85,7 +86,9 @@ module Foreman
               set('require_ssl_puppetmasters', 'Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)', true),
               set('trusted_puppetmaster_hosts', 'Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output', []),
               set('ssl_client_dn_env', 'Environment variable containing the subject DN from a client SSL certificate', 'SSL_CLIENT_S_DN'),
-              set('ssl_client_verify_env', 'Environment variable containing the verification status of a client SSL certificate', 'SSL_CLIENT_VERIFY')
+              set('ssl_client_verify_env', 'Environment variable containing the verification status of a client SSL certificate', 'SSL_CLIENT_VERIFY'),
+              set('signo_sso', 'Use Signo SSO for login', false),
+              set('signo_url', 'Signo SSO url', "https://#{fqdn}/signo")
             ].compact.each { |s| create s.update(:category => "Auth")}
           end
           true

--- a/lib/foreman/thread_session.rb
+++ b/lib/foreman/thread_session.rb
@@ -70,6 +70,20 @@ module Foreman
           ensure
             self.current = old_user
           end
+
+          # returns a logout path for the user, useful for single sign on support
+          #
+          # it's being set when user logs into a foreman and it's meant to be an url of SSO system
+          # logout page, it's appended by return url so it should contain a parameter at the end
+          # e.g. "https://localhost/signo?return_url="
+          def self.logout_path
+            Thread.current[:logout_path] || ''
+          end
+
+          # sets a logout path to be used for a current user when logging out
+          def self.logout_path=(path)
+            Thread.current[:logout_path] = path
+          end
         end
       end
     end

--- a/lib/sso.rb
+++ b/lib/sso.rb
@@ -1,0 +1,13 @@
+class Sso
+  METHODS = [Apache, Signo]
+
+  def self.get_available(controller)
+    all_methods = all.map { |method| method.new(controller) }
+    all_methods.select(&:available?).first
+  end
+
+  def self.all
+    METHODS
+  end
+
+end

--- a/lib/sso.rb
+++ b/lib/sso.rb
@@ -1,4 +1,4 @@
-class Sso
+module SSO
   METHODS = [Apache, Signo]
 
   def self.get_available(controller)

--- a/lib/sso/apache.rb
+++ b/lib/sso/apache.rb
@@ -1,0 +1,15 @@
+class Sso
+  class Apache < Base
+    def available?
+      return false unless Setting["authorize_login_delegation"]
+      return false if controller.api_request? and not Setting["authorize_login_delegation_api"]
+      true
+    end
+
+    # If REMOTE_USER is provided by the web server then
+    # authenticate the user without using password.
+    def authenticated?
+      (self.user = request.env["REMOTE_USER"]).present?
+    end
+  end
+end

--- a/lib/sso/apache.rb
+++ b/lib/sso/apache.rb
@@ -1,15 +1,16 @@
-class Sso
+module SSO
   class Apache < Base
+    CAS_USERNAME = 'REMOTE_USER'
     def available?
-      return false unless Setting["authorize_login_delegation"]
-      return false if controller.api_request? and not Setting["authorize_login_delegation_api"]
+      return false unless Setting['authorize_login_delegation']
+      return false if controller.api_request? and not Setting['authorize_login_delegation_api']
       true
     end
 
     # If REMOTE_USER is provided by the web server then
     # authenticate the user without using password.
     def authenticated?
-      (self.user = request.env["REMOTE_USER"]).present?
+      (self.user = request.env[CAS_USERNAME]).present?
     end
   end
 end

--- a/lib/sso/base.rb
+++ b/lib/sso/base.rb
@@ -1,11 +1,11 @@
-class Sso
+module SSO
   class Base
-    attr_reader :request, :controller
+    attr_reader :controller
     attr_accessor :user
+    delegate :request, :to => :controller
 
     def initialize(controller)
       @controller = controller
-      @request = controller.request
     end
 
     def support_login?

--- a/lib/sso/base.rb
+++ b/lib/sso/base.rb
@@ -1,0 +1,27 @@
+class Sso
+  class Base
+    attr_reader :request, :controller
+    attr_accessor :user
+
+    def initialize(controller)
+      @controller = controller
+      @request = controller.request
+    end
+
+    def support_login?
+      false
+    end
+
+    def support_logout?
+      false
+    end
+
+    def authenticated?
+      raise NotImplemented, 'authenticated? not implemented for this authentication method'
+    end
+
+    def authenticate!
+      raise NotImplemented, 'authenticate! not implemented for this authentication method'
+    end
+  end
+end

--- a/lib/sso/signo.rb
+++ b/lib/sso/signo.rb
@@ -1,0 +1,60 @@
+class Sso
+  class Signo < Base
+    attr_reader :env, :headers
+
+    def initialize(controller)
+      super
+      @env = request.env
+      @headers = controller.headers
+    end
+
+    def available?
+      Setting['signo_sso']
+    end
+
+    def support_login?
+      true
+    end
+
+    def support_logout?
+      true
+    end
+
+    def logout_path
+      "#{Setting['signo_url']}/logout?return_url="
+    end
+
+    def authenticated?
+      if (response = env[Rack::OpenID::RESPONSE])
+        parse_open_id(response)
+      else
+        false
+      end
+    end
+
+    def authenticate!
+      if (username = request.cookies['username'])
+        # we already have cookie
+        identifier                  = "#{Setting['signo_url']}/user/#{username}"
+        headers['WWW-Authenticate'] = Rack::OpenID.build_header({ :identifier => identifier })
+        controller.render :text => '', :status => 401
+      else
+        # we have no cookie yet so we plain redirect to OpenID provider to login
+        controller.redirect_to "#{Setting['signo_url']}?return_url=#{URI.escape(request.url)}"
+      end
+    end
+
+    private
+
+    def parse_open_id(response)
+      case response.status
+        when :success
+          self.user = response.identity_url.split('/').last
+          return true
+        else
+          Rails.logger.debug response.respond_to?(:message) ? response.message : "OpenID authentication failed: #{response.status}"
+          return false
+      end
+    end
+  end
+end

--- a/lib/sso/signo.rb
+++ b/lib/sso/signo.rb
@@ -1,15 +1,11 @@
-class Sso
+module SSO
   class Signo < Base
     attr_reader :env, :headers
-
-    def initialize(controller)
-      super
-      @env = request.env
-      @headers = controller.headers
-    end
+    delegate :env, :to => :request
+    delegate :headers, :to => :controller
 
     def available?
-      Setting['signo_sso']
+      Setting['signo_sso'] && defined?(Rack::OpenID)
     end
 
     def support_login?

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -164,3 +164,13 @@ attribute33:
   category: General
   default: "true"
   description: "Should Foreman use gravatar to display user icons"
+attribute34:
+  name: signo_sso
+  category: Auth
+  default: false
+  description: "Use SSO"
+attribute35:
+  name: signo_url
+  category: Auth
+  default: "https://localhost:3002"
+  description: "Where Signo runs"

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -167,7 +167,7 @@ attribute33:
 attribute34:
   name: signo_sso
   category: Auth
-  default: false
+  default: "false"
   description: "Use SSO"
 attribute35:
   name: signo_url

--- a/test/functional/dashboard_controller_test.rb
+++ b/test/functional/dashboard_controller_test.rb
@@ -12,4 +12,27 @@ class DashboardControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test "should redirect unknown users to signo when SSO allowed" do
+    configure_sso
+    @controller.env = @controller.request.env
+    get :index
+    assert_response :redirect
+    assert @response.redirect_url.include?(Setting['signo_url'])
+  end
+
+  test "OpenID request should be made for known users to Signo when SSO allowed" do
+    configure_sso
+    request.cookies[:username] = 'admin'
+    @controller.env = @controller.request.env
+    get :index
+    assert_response 401
+    identifier = @response.headers.try(:[],"WWW-Authenticate")
+    assert_equal "OpenID identifier=\"#{Setting['signo_url']}/user/admin\"", identifier
+  end
+
+  def configure_sso
+    Setting['signo_sso']                  = true
+    Setting["authorize_login_delegation"] = false
+  end
 end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -484,6 +484,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test "if only authorize_login_delegation is set, REMOTE_USER should be
         ignored for API requests" do
+    Setting[:signo_sso] = false
     Setting[:authorize_login_delegation] = true
     Setting[:authorize_login_delegation_api] = false
     set_remote_user_to users(:admin)
@@ -496,6 +497,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test "if both authorize_login_delegation{,_api} are unset,
         REMOTE_USER should ignored in all cases" do
+    Setting[:signo_sso] = false
     Setting[:authorize_login_delegation] = false
     Setting[:authorize_login_delegation_api] = false
     set_remote_user_to users(:admin)

--- a/test/unit/sso.rb
+++ b/test/unit/sso.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class DummyMethod < Sso::Base
+  def initialize(*args)
+  end
+end
+
+class DummyTrueMethod < DummyMethod
+  def available?
+    true
+  end
+end
+
+class DummyFalseMethod < DummyMethod
+  def available?
+    false
+  end
+end
+
+class SsoTest < ActiveSupport::TestCase
+  def test_get_available_should_find_first_available_method
+    stub(Sso).all { [ DummyFalseMethod, DummyTrueMethod, DummyFalseMethod ] }
+    available = Sso.get_available(Object.new)
+    assert_present available
+  end
+end

--- a/test/unit/sso.rb
+++ b/test/unit/sso.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class DummyMethod < Sso::Base
+class DummyMethod < SSO::Base
   def initialize(*args)
   end
 end
@@ -17,10 +17,10 @@ class DummyFalseMethod < DummyMethod
   end
 end
 
-class SsoTest < ActiveSupport::TestCase
+class SSOTest < ActiveSupport::TestCase
   def test_get_available_should_find_first_available_method
-    stub(Sso).all { [ DummyFalseMethod, DummyTrueMethod, DummyFalseMethod ] }
-    available = Sso.get_available(Object.new)
+    stub(SSO).all { [ DummyFalseMethod, DummyTrueMethod, DummyFalseMethod ] }
+    available = SSO.get_available(Object.new)
     assert_present available
   end
 end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -14,7 +14,7 @@ class ApacheTest < ActiveSupport::TestCase
     assert apache.available?
 
     Setting["authorize_login_delegation"] = false
-    refute apache.available?
+    assert !apache.available?
 
     Setting["authorize_login_delegation"] = true
     # api request
@@ -23,15 +23,15 @@ class ApacheTest < ActiveSupport::TestCase
     assert apache.available?
 
     Setting["authorize_login_delegation_api"] = false
-    refute apache.available?
+    assert !apache.available?
   end
 
   def get_apache_method(api_request = false)
-    Sso::Apache.new(get_controller(api_request))
+    SSO::Apache.new(get_controller(api_request))
   end
 
   def get_controller(api_request)
-    controller = Struct.new(:request).new(Struct.new(:env).new({'REMOTE_USER' => 'ares'}))
+    controller = Struct.new(:request).new(Struct.new(:env).new({ 'REMOTE_USER' => 'ares' }))
     stub(controller).api_request? { api_request }
     controller
   end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ApacheTest < ActiveSupport::TestCase
+  def test_user_is_set_when_authenticated
+    apache = get_apache_method
+    assert apache.authenticated?
+    assert_equal apache.user, 'ares'
+  end
+
+  def test_available?
+    # non api request
+    apache = get_apache_method(false)
+    Setting["authorize_login_delegation"] = true
+    assert apache.available?
+
+    Setting["authorize_login_delegation"] = false
+    refute apache.available?
+
+    Setting["authorize_login_delegation"] = true
+    # api request
+    apache = get_apache_method(true)
+    Setting["authorize_login_delegation_api"] = true
+    assert apache.available?
+
+    Setting["authorize_login_delegation_api"] = false
+    refute apache.available?
+  end
+
+  def get_apache_method(api_request = false)
+    Sso::Apache.new(get_controller(api_request))
+  end
+
+  def get_controller(api_request)
+    controller = Struct.new(:request).new(Struct.new(:env).new({'REMOTE_USER' => 'ares'}))
+    stub(controller).api_request? { api_request }
+    controller
+  end
+end

--- a/test/unit/sso/base_test.rb
+++ b/test/unit/sso/base_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class BaseTest < ActiveSupport::TestCase
+  def test_assigns
+    controller = get_controller
+    base = Sso::Base.new(controller)
+    assert_equal base.controller, controller
+    assert_equal base.request, 'request'
+  end
+
+  def get_controller
+    Struct.new(:request).new('request')
+  end
+end

--- a/test/unit/sso/base_test.rb
+++ b/test/unit/sso/base_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class BaseTest < ActiveSupport::TestCase
   def test_assigns
     controller = get_controller
-    base = Sso::Base.new(controller)
+    base = SSO::Base.new(controller)
     assert_equal base.controller, controller
     assert_equal base.request, 'request'
   end

--- a/test/unit/sso/signo_test.rb
+++ b/test/unit/sso/signo_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class SignoTest < ActiveSupport::TestCase
+  def test_logout_path_can_be_appended
+    assert_equal get_signo_method.logout_path.last, '='
+  end
+
+  def test_casual_request_authenticated?
+    refute get_signo_method.authenticated?
+  end
+
+  def test_openid_request_authenticated?
+    controller = get_controller
+    stub(controller.request).env { { Rack::OpenID::RESPONSE => {} } }
+    signo = get_signo_method(controller)
+
+    stub(signo).parse_open_id { false }
+    refute signo.authenticated?
+
+    stub(signo).parse_open_id { true }
+    assert signo.authenticated?
+  end
+
+  def test_parse_open_id_success
+    signo = get_signo_method
+    response = Object.new
+    stub(response).status { :success }
+    stub(response).identity_url { 'https://localhost/user/ares' }
+    assert signo.send(:parse_open_id, response)
+    assert_equal signo.user, 'ares'
+  end
+
+  def test_parse_open_id_fail
+    signo = get_signo_method
+    response = Object.new
+    stub(response).status { :fail }
+    refute signo.send(:parse_open_id, response)
+  end
+
+  def test_authenticate_without_cookie
+    controller = get_controller
+    stub(controller.request).url {'https://localhost/foreman?a=b&c=d'}
+    signo = get_signo_method(controller)
+    url = Setting['signo_url'] + "?return_url=#{URI.escape('https://localhost/foreman?a=b&c=d')}"
+    mock(controller).redirect_to(url) { 'correct redirect' }
+    assert_equal signo.authenticate!, 'correct redirect'
+  end
+
+  def test_authenticate_with_cookie
+    controller = get_controller
+    stub(controller.request).cookies { {'username' => 'ares'} }
+    stub(controller).render { 'correct render' }
+    signo = get_signo_method(controller)
+    response = signo.authenticate!
+
+    assert_equal response, 'correct render'
+    assert signo.headers.keys.include?('WWW-Authenticate')
+    assert signo.headers['WWW-Authenticate'].include?('/user/ares')
+  end
+
+  def get_signo_method(controller = nil)
+    Sso::Signo.new(controller || get_controller)
+  end
+
+  def get_controller
+    request    = Object.new
+    controller = Object.new
+    stub(request).env { {} }
+    stub(request).cookies { {} }
+    stub(controller).headers { {} }
+    stub(controller).request { request }
+    controller
+  end
+end


### PR DESCRIPTION
You can use SSO service that comes with Katello for loggin in. It's
based on OpenID protocol with slightly customized provider.
