### PR TITLE
fixes #2332 workaround for broken search due to STI changes

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -14,8 +14,6 @@ module Host
     validates_uniqueness_of :name
     validate :is_name_downcased?
 
-    include Hostext::Search
-
     def self.importHostAndFacts yaml
     end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,6 +1,7 @@
 class Host::Managed < Host::Base
   include Authorization
   include ReportCommon
+  include Hostext::Search
   has_many :host_classes, :dependent => :destroy, :foreign_key => :host_id
   has_many :puppetclasses, :through => :host_classes
   belongs_to :hostgroup

--- a/lib/foreman/controller/auto_complete_search.rb
+++ b/lib/foreman/controller/auto_complete_search.rb
@@ -1,7 +1,7 @@
 module Foreman::Controller::AutoCompleteSearch
   def auto_complete_search
     begin
-      @items = eval(controller_name.singularize.camelize).complete_for(params[:search])
+      @items = controller_name.singularize.camelize.constantize.complete_for(params[:search])
       @items = @items.map do |item|
         category = (['and','or','not','has'].include?(item.to_s.sub(/^.*\s+/,''))) ? 'Operators' : ''
         part = item.to_s.sub(/^.*\b(and|or)\b/i) {|match| match.sub(/^.*\s+/,'')}


### PR DESCRIPTION
I've tried breaking down the search definiton according to the actual class but it seems they are completely ignored on the child object.
