### PR TITLE
apipie documentation of actions defined in a concern

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "ancestry", "~> 1.3"
 gem 'scoped_search', '>= 2.5'
 gem 'net-ldap'
 gem 'uuidtools'
-gem "apipie-rails", '0.0.16'
+gem "apipie-rails", "~> 0.0.20"
 gem 'rabl', '>= 0.7.5'
 gem 'oauth'
 

--- a/app/controllers/api/v2/locations_controller.rb
+++ b/app/controllers/api/v2/locations_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class LocationsController < V2::BaseController
 
+      apipie_concern_subst(:a_resource => "a location", :resource => "locations")
       include Api::V2::TaxonomiesController
 
     end

--- a/app/controllers/api/v2/organizations_controller.rb
+++ b/app/controllers/api/v2/organizations_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class OrganizationsController < V2::BaseController
 
+      apipie_concern_subst(:a_resource => "an organization", :resource => "organization")
       include Api::V2::TaxonomiesController
 
     end

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -10,6 +10,15 @@ module Api::V2::TaxonomiesController
     before_filter :params_match_database, :only => %w(create update)
   end
 
+  extend Apipie::DSL::Concern
+
+  def_param_group :resource do
+    param :resource, Hash, :required => true, :action_aware => true do
+      param :name, String, :required => true
+    end
+  end
+
+  api :GET, '/:resource_id', 'List all :resource_id'
   def index
     if @nested_obj
       #@taxonomies = @domain.locations.paginate(paginate_options)
@@ -21,16 +30,21 @@ module Api::V2::TaxonomiesController
     render 'api/v2/taxonomies/index'
   end
 
+  api :GET, '/:resource_id/:id', 'Show :a_resource'
   def show
     render 'api/v2/taxonomies/show'
   end
 
+  api :POST, '/:resource_id', 'Create :a_resource'
+  param_group :resource
   def create
     @taxonomy = taxonomy_class.new(params[taxonomy_single.to_sym])
     instance_variable_set("@#{taxonomy_single}", @taxonomy)
     process_response @taxonomy.save
   end
 
+  api :PUT, '/:resource_id/:id', 'Update :a_resource'
+  param_group :resource
   def update
     # NOTE - if not ! and invalid, the error is undefined method `permission_failed?' for #<Location:0x7fe38c1d3ec8> (NoMethodError)
     # removed process_response & added explicit render 'api/v2/taxonomies/update'.  Otherwise, *_ids are not returned
@@ -38,7 +52,7 @@ module Api::V2::TaxonomiesController
     process_response  @taxonomy.update_attributes(params[taxonomy_single.to_sym])
   end
 
-
+  api :DELETE, '/:resource_id/:id', 'Delete :a_resource'
   def destroy
     process_response @taxonomy.destroy
   end


### PR DESCRIPTION
Apipie now supports defining actions defined in module by including
`Apipie::DSL::Concern`. Some substitutions are preformed while including the
documentation in each controller, so that instead of paths like
`/:resource_id/:id`, you get `/oraganizations/:id` or
`/locations/:id` respectively. Also param names and descriptions are treated
this way. See https://github.com/pajk/apipie-rails#concerns for more details.
