### PR TITLE
Fixes warning in JS console - Viewport argument value "1.0;" for key "ma...

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= javascript_tag "var AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery? %>
     <%= javascript_tag "var URL_PREFIX = '#{request.script_name}';" %>
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0;" />
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <%= yield(:head) %>
   </head>
 


### PR DESCRIPTION
...ximum-scale" was truncated to its numeric prefix
