### PR TITLE
Add basic support for plugin config to live in separate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ log/*.log
 tmp/
 db/schema.rb
 config/settings.yaml
+config/settings.plugins.d
 config/email.yaml
 config/database.yml
 config/initializers/local_secret_token.rb

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -6,3 +6,8 @@ SETTINGS[:unattended] = SETTINGS[:unattended].nil? || SETTINGS[:unattended]
 SETTINGS[:login]    ||= SETTINGS[:ldap]
 SETTINGS[:puppetconfdir] ||= '/etc/puppet'
 SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
+
+# Load plugin config, if any
+Dir["#{root}/config/settings.plugins.d/*.yaml"].each do |f|
+  SETTINGS.merge! YAML.load_file f
+end


### PR DESCRIPTION
This is halfway to the goal of being able to display Plugin Config in the UI - it simply reads plugin config from a sub-directory and merges it into SETTINGS. It may also be useful for plugin config which needs to be initialized before Foreman starts (just like the core settings file).
