### PR TITLE
Do not split a host over multiple lines

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -51,7 +51,7 @@ module HostsHelper
       short = "O"
     end
     content_tag(:span, short, {:rel => "twipsy", :class => "label label-light " + style, :"data-original-title" => label} ) +
-      link_to(trunc("  #{record}",32), host_path(record))
+      "&nbsp;" + link_to(trunc("#{record}",32), host_path(record))
   end
 
   def days_ago time


### PR DESCRIPTION
When the host table has two lines and a hostname is long, it can happen
that it's split over multiple lines. By using a non-breaking space this
shouldn't happen. The problem is this:

![line](https://f.cloud.github.com/assets/155810/335679/8af0796a-9c93-11e2-84d8-65d9e47672e5.png)

Note that it's untested and just an idea how it could be solved. Maybe the optimal solution would be to not truncate at all in ruby, but just use text-overflow: ellipsis (http://quirksmode.org/css/user-interface/textoverflow.html), but I'll leave that for someone else :).
