### PR TITLE
fixes #2371 - removed iconv - causing deprecation notice - block in requ...

### DIFF
--- a/app/models/auth_source_ldap.rb
+++ b/app/models/auth_source_ldap.rb
@@ -16,7 +16,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'net/ldap'
-require 'iconv'
 
 class AuthSourceLdap < AuthSource
   validates_presence_of :host, :port


### PR DESCRIPTION
...ire: iconv will be deprecated in the future, use String#encode instead
