### PR TITLE
fixes #2377 - refresh column info after editing Medium

### DIFF
--- a/db/migrate/20100523141204_create_media_operatingsystems_and_migrate_data.rb
+++ b/db/migrate/20100523141204_create_media_operatingsystems_and_migrate_data.rb
@@ -24,6 +24,7 @@ class CreateMediaOperatingsystemsAndMigrateData < ActiveRecord::Migration
     medium_hash.keys.each { |os| os.media << medium_hash[os] }
 
     remove_column :media, :operatingsystem_id
+    Medium.reset_column_information
   end
 
   def self.down

--- a/db/migrate/20110725142054_add_suse_templates.rb
+++ b/db/migrate/20110725142054_add_suse_templates.rb
@@ -1,6 +1,6 @@
 class AddSuseTemplates < ActiveRecord::Migration
 
-  class Media < ActiveRecord::Base
+  class Medium < ActiveRecord::Base
     has_and_belongs_to_many :operatingsystems
   end
   class ConfigTemplate < ActiveRecord::Base


### PR DESCRIPTION
Fixes error in 20110725142054_add_suse_templates referencing non-existent
operatingsystem_id column.
