### PR TITLE
fixing error on clean db migration

### DIFF
--- a/db/migrate/20110725142054_add_suse_templates.rb
+++ b/db/migrate/20110725142054_add_suse_templates.rb
@@ -8,6 +8,8 @@ class AddSuseTemplates < ActiveRecord::Migration
   end
 
   def self.up
+    Medium.reset_column_information
+
     TemplateKind.all.each do |kind|
       case kind.name
       when /provision/


### PR DESCRIPTION
-- Failed to migrate PGError: ERROR:  column "operatingsystem_id" of relation "media" does not exist
