### PR TITLE
Link to host on audit entries

### DIFF
--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -1,5 +1,9 @@
 <% title "#{@audit.action.camelize} #{audited_type @audit}: #{audit_title @audit}" %>
 
+<%= title_actions link_to_if_authorized("Host details", 
+                                        hash_for_host_path(:id => @audit.auditable.id), 
+                                        :title => "Host details", 
+                                        :class => 'btn btn-info') if @audit.auditable_type == 'Host' %>
 <%= title_actions link_to 'Back', :back, :class=>'btn' %>
 <% tmplt =  audit_template?(@audit) %>
 


### PR DESCRIPTION
There is currently no way to go from an audit entry to its related host without searching for that host, etc...
This PR adds a link to the audit entries that are related to hosts so that it's easier to access a host from the audit entry.
