### PR TITLE
Enforce hostgroup/role uniqueness on User relation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -140,7 +140,7 @@ class UsersController < ApplicationController
   end
 
   def update_hostgroups_owners(hostgroup_ids)
-    subhostgroups = Hostgroup.where(:id => hostgroup_ids).map(&:subtree).flatten
+    subhostgroups = Hostgroup.where(:id => hostgroup_ids).map(&:subtree).flatten.reject { |hg| hg.users.include?(@user) } 
     subhostgroups.each { |subhs| subhs.users << @user }
   end
 

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -5,7 +5,8 @@ class Hostgroup < ActiveRecord::Base
   include HostCommon
   has_many :hostgroup_classes, :dependent => :destroy
   has_many :puppetclasses, :through => :hostgroup_classes
-  has_and_belongs_to_many :users, :join_table => "user_hostgroups"
+  has_many :user_hostgroups, :dependent => :destroy
+  has_many :users, :through => :user_hostgroups
   validates_uniqueness_of :name, :scope => :ancestry, :case_sensitive => false
   validates_format_of :name, :with => /\A(\S+\s?)+\Z/, :message => "can't be blank or contain trailing white spaces."
   has_many :group_parameters, :dependent => :destroy, :foreign_key => :reference_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,8 @@ class User < ActiveRecord::Base
   has_many :roles, :through => :user_roles
   has_and_belongs_to_many :compute_resources, :join_table => "user_compute_resources"
   has_and_belongs_to_many :domains,           :join_table => "user_domains"
-  has_and_belongs_to_many :hostgroups,        :join_table => "user_hostgroups"
+  has_many :user_hostgroups
+  has_many :hostgroups, :through => :user_hostgroups
   has_many :user_facts, :dependent => :destroy
   has_many :facts, :through => :user_facts, :source => :fact_name
 

--- a/app/models/user_hostgroup.rb
+++ b/app/models/user_hostgroup.rb
@@ -1,0 +1,10 @@
+class UserHostgroup < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :hostgroup
+
+  validates_presence_of :hostgroup
+  validates_presence_of :user
+
+  validates_uniqueness_of :user_id, :scope => :hostgroup_id, :message => "has this hostgroup already"
+end
+

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -22,6 +22,8 @@ class UserRole < ActiveRecord::Base
   validates_presence_of :role
   validates_presence_of :user
 
+  validates_uniqueness_of :user_id, :scope => :role_id, :message => "has this role already"
+
   def inherited?
     !inherited_from.nil?
   end


### PR DESCRIPTION
This PR is a replacement for a composite primary key on the user_hostgroup and user_role tables. Since rails does not support this, uniqueness is programatically checked. After this is applied, an user will not be able to have duplicate hostgroups or roles. 

The little change on users_controller is because that could violate this constraint and it's better to not violate it from the beginning. 
