### PR TITLE
Fix ruby 1.9 compatibility issue when loading free ip

### DIFF
--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -21,7 +21,11 @@ module ProxyAPI
       params.merge!({:mac => mac}) if mac.present?
 
       params.merge!({:from => subnet.from, :to => subnet.to}) if subnet.from.present? and subnet.to.present?
-      params = "?" + params.map{|e| e.join("=")}.join("&") if params.any?
+      if params.any?
+        params = "?" + params.map{|e| e.join("=")}.join("&")
+      else
+        params = ""
+      end
       parse get("#{subnet.network}/unused_ip#{params}")
     end
 


### PR DESCRIPTION
In Ruby 1.8.7:

  {}.to_s # => ""

In Ruby 1.9.3

  {}.to_s # => "{}"

This causes the url for smart proxy to be broken.
