### PR TITLE
Feature #813 Usergroups can be linked to an LDAP auth_source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "will_paginate", "~> 3.0.2"
 gem "ancestry", "~> 2.0.0"
 gem 'scoped_search', '>= 2.7.0', '< 3.0.0'
 gem 'net-ldap'
+gem 'ldap_fluff', '>= 0.3.0', '< 1.0.0'
 gem 'uuidtools'
 gem "apipie-rails", "~> 0.2.0"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'

--- a/app/controllers/external_usergroups_controller.rb
+++ b/app/controllers/external_usergroups_controller.rb
@@ -1,0 +1,24 @@
+class ExternalUsergroupsController < ApplicationController
+  before_filter :find_by_name, :only => [:refresh]
+
+  def refresh
+    if @external_usergroup.refresh
+      notice _("External user group %{name} refreshed") % { :name => @external_usergroup.name }
+    else
+      warning _("External user group %{name} could not be refreshed") % { :name => @external_usergroup.name }
+    end
+    redirect_to :usergroups
+  end
+
+  private
+
+  def action_permission
+    case params[:action]
+      when 'refresh'
+        'edit'
+      else
+        super
+    end
+  end
+
+end

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -54,6 +54,10 @@ class AuthSource < ActiveRecord::Base
     false
   end
 
+  # Called after creating a new user at login
+  def update_usergroups(login)
+  end
+
   # Try to authenticate a user not yet registered against available sources
   # Returns : user's attributes OR nil
   def self.authenticate(login, password)

--- a/app/models/external_usergroup.rb
+++ b/app/models/external_usergroup.rb
@@ -6,6 +6,36 @@ class ExternalUsergroup < ActiveRecord::Base
   validates_uniqueness_of :name, :scope => :auth_source_id
   validates_presence_of   :name, :auth_source, :usergroup
   validate :hidden_authsource_restricted
+  validate :in_auth_source?, :if => Proc.new { |eu| eu.auth_source.respond_to?(:valid_group?) }
+
+  def refresh
+    return false unless auth_source.respond_to?(:users_in_group)
+
+    current_users  = usergroup.users.map(&:login)
+    all_users      = usergroup.external_usergroups.map(&:users).flatten.uniq
+
+    # We need to make sure when we refresh a external_usergroup
+    # other external_usergroup users remain in. Otherwise refreshing
+    # a external user group with no users in will empty the user group.
+    old_users = current_users - all_users
+    new_users = users - current_users
+
+    usergroup.remove_users(old_users)
+    usergroup.add_users(new_users)
+    true
+  end
+
+  def users
+    auth_source.users_in_group(name)
+  end
+
+  private
+
+  def in_auth_source?(source = auth_source)
+    errors.add :name, _("is not found in the authentication source") unless source.valid_group?(name)
+  rescue Net::LDAP::LdapError => e
+    errors.add :auth_source_id, _("LDAP error - %{message}") % { :message => e.message }
+  end
 
   def hidden_authsource_restricted
     if auth_source_id_changed? && auth_source.kind_of?(AuthSourceHidden)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -396,11 +396,13 @@ class User < ActiveRecord::Base
 
     # user is not yet registered, try to authenticate with available sources
     if (attrs = AuthSource.authenticate(login, password))
+      attrs.delete(:dn)
       user = new(attrs)
       user.login = login
       # The default user can't auto create users, we need to change to Admin for this to work
       User.as_anonymous_admin do
         if user.save
+          AuthSource.find(attrs[:auth_source_id]).update_usergroups(login)
           logger.info "User '#{user.login}' auto-created from #{user.auth_source}"
         else
           logger.info "Failed to save User '#{user.login}' #{user.errors.full_messages}"

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -53,6 +53,15 @@ class Usergroup < ActiveRecord::Base
     users.each { |u| u.expire_topbar_cache(sweeper) }
   end
 
+  def add_users(userlist)
+    users << User.where( {:login => userlist } )
+  end
+
+  def remove_users(userlist)
+    old_users = User.select { |user| userlist.include?(user.login) }
+    self.users = self.users - old_users
+  end
+
   protected
   # Recurses down the tree of usergroups and finds the users
   # [+group_list+]: Array of Usergroups that have already been processed
@@ -70,15 +79,6 @@ class Usergroup < ActiveRecord::Base
 
   def ensure_uniq_name
     errors.add :name, _("is already used by a user account") if User.where(:login => name).first
-  end
-
-  def add_users(userlist)
-    users << User.where( {:login => userlist } )
-  end
-
-  def remove_users(userlist)
-    old_users = User.select { |user| userlist.include?(user.login) }
-    self.users = self.users - old_users
   end
 
   def ensure_last_admin_remains_admin
@@ -100,5 +100,4 @@ class Usergroup < ActiveRecord::Base
   def other_admins
     User.unscoped.only_admin.except_hidden - all_users
   end
-
 end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -630,9 +630,9 @@ Foreman::AccessControl.map do |map|
   end
 
   map.security_block :external_usergroups do |map|
-    map.permission :view_external_usergroups, { :external_usergroups => [:index, :show ] }
+    map.permission :view_external_usergroups, { :external_usergroups => [:index, :show] }
     map.permission :create_external_usergroups, { :external_usergroups => [:new, :create] }
-    map.permission :edit_external_usergroups, { :external_usergroups => [:edit, :update] }
+    map.permission :edit_external_usergroups, { :external_usergroups => [:edit, :update, :refresh] }
     map.permission :destroy_external_usergroups, { :external_usergroups => [:destroy] }
   end
 

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -16,14 +16,18 @@
       <%= text_f f, :host %>
       <%= checkbox_f(f, :tls, {:label => "LDAPS", :onchange => 'change_ldap_port(this)'}) %>
       <%= text_f f, :port, :data => {:default_ports => AuthSourceLdap::DEFAULT_PORTS} %>
+      <%= select_f f, :server_type, AuthSourceLdap::SERVER_TYPES, :first, :last,
+                    { :include_blank => _("Choose a server type") },
+                    { :label => _('Server type') } %>
     </div>
     <div class="tab-pane" id="account">
       <%= text_f f, :account, :help_inline =>_("Use this account to authenticate, <i>optional</i>").html_safe %>
       <%= password_f f, :account_password, :help_inline => _("Use this account to authenticate, <i>optional</i>").html_safe %>
       <%= text_f f, :base_dn, :label => _("Base DN"), :size => "col-md-8" %>
+      <%= text_f f, :groups_base, :label => _("Groups base DN") %>
       <%= text_f f, :ldap_filter, :label => _("LDAP filter"), :help_inline => _("Custom LDAP search filter, <i>optional</i>").html_safe, :size => "col-md-8" %>
       <%= checkbox_f f, :onthefly_register,
-                     :help_inline => _("LDAP users will have their Foreman account automatically created the first time they log into Foreman") %>
+                        :help_inline => _("LDAP users will have their Foreman account automatically created the first time they log into Foreman") %>
     </div>
     <div class="tab-pane" id="attributes">
       <%= text_f f, :attr_login, :help_inline => _("e.g. uid") %>

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -12,7 +12,6 @@
 
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
-
       <%= text_f f, :name %>
       <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
       <%= multiple_checkboxes f, :users, @usergroup, User, :label => _("Users") %>
@@ -29,11 +28,18 @@
           <tr>
             <th><%= s_("Usergroup|Name") %></th>
             <th><%= s_("Usergroup|Auth source") %></th>
+            <th></th>
           </tr>
           <% @usergroup.external_usergroups.each do |usergroup| %>
           <tr>
+            <% next if usergroup.id.nil? %>
             <td><%= h usergroup.name %></td>
             <td><%= h usergroup.auth_source %></td>
+            <td><%= display_link_if_authorized(_('Refresh'),
+                                               hash_for_refresh_external_usergroup_path(:id => usergroup.id),
+                                               :method => :put, :id => usergroup.id,
+                                               :class => "btn btn-default", :title => _('Synchronize group from authentication source')) %>
+            </td>
           </tr>
           <% end %>
         </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,6 +232,12 @@ Foreman::Application.routes.draw do
     resources :permissions, :only => [:index]
 
     resources :auth_source_ldaps, :except => [:show]
+
+    resources :external_usergroups, :except => [:index, :new, :create, :show, :edit, :update, :destroy] do
+      member do
+        put 'refresh'
+      end
+    end
   end
 
   if SETTINGS[:unattended]

--- a/db/migrate/20140320000449_add_server_type_to_auth_source.rb
+++ b/db/migrate/20140320000449_add_server_type_to_auth_source.rb
@@ -1,0 +1,5 @@
+class AddServerTypeToAuthSource < ActiveRecord::Migration
+  def change
+    add_column :auth_sources, :server_type, :string, :default => 'posix'
+  end
+end

--- a/db/migrate/20140320004050_add_groups_base_to_auth_source.rb
+++ b/db/migrate/20140320004050_add_groups_base_to_auth_source.rb
@@ -1,0 +1,5 @@
+class AddGroupsBaseToAuthSource < ActiveRecord::Migration
+  def change
+    add_column :auth_sources, :groups_base, :string
+  end
+end

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -1,0 +1,17 @@
+desc <<-END_DESC
+Refreshes LDAP usergroups. It adds to an LDAP usergroup all the foreman users that belong to it, and removes foreman users
+in that usergroup that do not belong in LDAP anymore.
+END_DESC
+
+namespace :ldap do
+  task :refresh_usergroups => :environment do
+    ExternalUsergroup.all.each do |eu|
+      begin
+        eu.refresh
+      rescue => error
+        puts "User group #{eu} could not be refreshed - LDAP source #{eu.auth_source} not available: #{error}"
+      end
+    end
+  end
+end
+

--- a/test/factories/auth_source_ldap.rb
+++ b/test/factories/auth_source_ldap.rb
@@ -1,0 +1,26 @@
+FactoryGirl.define do
+  factory :auth_source_ldap do
+    sequence(:name) { |n| "auth_source_ldap_#{n}" }
+    sequence(:host) { |n| "host_#{n}" }
+    attr_mail "some@where.com"
+    attr_login 'value'
+    attr_firstname 'ohad'
+    attr_lastname 'daho'
+    port '389'
+    server_type 'posix'
+  end
+
+  trait :posix do end
+
+  trait :free_ipa do
+    server_type 'free_ipa'
+  end
+
+  trait :active_directory do
+    server_type 'active_directory'
+  end
+
+  factory :free_ipa_auth_source,         :traits => [:free_ipa]
+  factory :active_directory_auth_source, :traits => [:active_directory]
+  factory :posix_auth_source,            :traits => [:posix]
+end

--- a/test/fixtures/auth_sources.yml
+++ b/test/fixtures/auth_sources.yml
@@ -6,6 +6,7 @@ one:
   port: 123
   account:
   account_password:
+  server_type: posix
   base_dn: dn=x,dn=y
   ldap_filter:
   attr_login: uid

--- a/test/functional/api/v1/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v1/auth_source_ldaps_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V1::AuthSourceLdapsControllerTest < ActionController::TestCase
 
-  valid_attrs = { :name => 'ldap2', :host => 'ldap2' }
+  valid_attrs = { :name => 'ldap2', :host => 'ldap2', :server_type => 'posix' }
 
   test "should get index" do
     get :index, { }

--- a/test/functional/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v2/auth_source_ldaps_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
 
-  valid_attrs = { :name => 'ldap2', :host => 'ldap2' }
+  valid_attrs = { :name => 'ldap2', :host => 'ldap2', :server_type => 'posix' }
 
   test "should get index" do
     get :index, { }

--- a/test/integration/auth_source_ldap_test.rb
+++ b/test/integration/auth_source_ldap_test.rb
@@ -18,6 +18,7 @@ class AuthSourceLdapTest < ActionDispatch::IntegrationTest
     fill_in "auth_source_ldap_attr_firstname", :with => "John"
     fill_in "auth_source_ldap_attr_lastname", :with => "Doe"
     fill_in "auth_source_ldap_attr_mail", :with => "john@example.com"
+    select 'FreeIPA', :from => "auth_source_ldap_server_type"
     assert_submit_button(auth_source_ldaps_path)
     assert page.has_link? "corporate-ldap"
     assert page.has_content? "10.0.0.77"

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -464,6 +464,7 @@ class UserTest < ActiveSupport::TestCase
 
   test ".try_to_auto_create_user" do
     AuthSourceLdap.any_instance.stubs(:authenticate).returns({ :firstname => "Foo", :lastname => "Bar", :mail => "baz@qux.com" })
+    AuthSourceLdap.any_instance.stubs(:update_usergroups).returns(true)
 
     ldap_server = AuthSource.find_by_name("ldap-server")
 
@@ -476,7 +477,7 @@ class UserTest < ActiveSupport::TestCase
     # AuthSource that forbids onthefly registration
     count = User.count
     ldap_server.update_attribute(:onthefly_register, false)
-    assert !User.try_to_auto_create_user('non_existing_user_2','password')
+    refute User.try_to_auto_create_user('non_existing_user_2','password')
     assert_equal count, User.count
 
   end

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -183,4 +183,59 @@ class UsergroupTest < ActiveSupport::TestCase
 
   # TODO test who can modify usergroup roles and who can assign users!!! possible privileges escalation
 
+  context 'external usergroups' do
+    setup do
+      @usergroup = FactoryGirl.create(:usergroup)
+      @external = @usergroup.external_usergroups.new(:auth_source_id => FactoryGirl.create(:auth_source_ldap).id,
+                                                     :name           => 'aname')
+      LdapFluff.any_instance.stubs(:ldap).returns(Net::LDAP.new)
+    end
+
+    test "can be associated with external_usergroups" do
+      LdapFluff.any_instance.stubs(:valid_group?).returns(true)
+
+      assert @external.save
+      assert @usergroup.external_usergroups.include? @external
+    end
+
+    test "won't save if usergroup is not in LDAP" do
+      LdapFluff.any_instance.stubs(:valid_group?).returns(false)
+
+      refute @external.save
+      assert_equal @external.errors.first, [:name, 'is not found in the authentication source']
+    end
+
+    test "delete user if not in LDAP directory" do
+      LdapFluff.any_instance.stubs(:valid_group?).at_least_once.with('aname').returns(false)
+      @usergroup.users << users(:one)
+      @usergroup.save
+
+      AuthSourceLdap.any_instance.expects(:users_in_group).at_least_once.with('aname').returns([])
+      @usergroup.external_usergroups.select { |eu| eu.name == 'aname'}.first.refresh
+
+      refute_includes @usergroup.users, users(:one)
+    end
+
+    test "add user if in LDAP directory" do
+      LdapFluff.any_instance.stubs(:valid_group?).at_least_once.with('aname').returns(true)
+      @usergroup.save
+
+      AuthSourceLdap.any_instance.expects(:users_in_group).at_least_once.with('aname').returns([users(:one).login])
+      @usergroup.external_usergroups.select { |eu| eu.name == 'aname'}.first.refresh
+      assert_includes @usergroup.users, users(:one)
+    end
+
+    test "keep user if in LDAP directory" do
+      LdapFluff.any_instance.stubs(:valid_group?).at_least_once.with('aname').returns(true)
+      @usergroup.users << users(:one)
+      @usergroup.save
+
+      AuthSourceLdap.any_instance.expects(:users_in_group).at_least_once.with('aname').returns([users(:one).login])
+      @usergroup.external_usergroups.select { |eu| eu.name == 'aname'}.first.refresh
+      assert_includes @usergroup.users, users(:one)
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
This pull request lets usergroups be linked to an LDAP authentication source. This allows an organization to have foreman usergroups match its LDAP user groups, so that users that belong to LDAP user groups can be automatically matched to their equivalent usergroups in Foreman. 

When you create a new usergroup and you want it to be linked to an LDAP source, It performs a check to make sure the usergroup exists in LDAP first. If it does not exist, it will not let the user create it. 

Since LDAP information can change, there is a rake task attached that updates the foreman usergroup with this information.

http://projects.theforeman.org/issues/813
