### PR TITLE
fixes #2247 Provides an option to disable the use of gravatara

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -267,9 +267,7 @@ module ApplicationHelper
     default_image = "assets/user.jpg"
     image_url = default_image
     html_options.merge!(:onerror=>"this.src='#{default_image}'")
-    if Setting["use_gravatar"]
-      image_url = gravatar_url(email, default_image)
-    end
+    image_url = gravatar_url(email, default_image) if Setting["use_gravatar"]
     return image_tag(image_url, html_options)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -265,9 +265,8 @@ module ApplicationHelper
 
   def gravatar_image_tag(email, html_options = {})
     default_image = "assets/user.jpg"
-    image_url = default_image
     html_options.merge!(:onerror=>"this.src='#{default_image}'")
-    image_url = gravatar_url(email, default_image) if Setting["use_gravatar"]
+    image_url = Setting["use_gravatar"] ? gravatar_url(email, default_image) : default_image
     return image_tag(image_url, html_options)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -265,8 +265,12 @@ module ApplicationHelper
 
   def gravatar_image_tag(email, html_options = {})
     default_image = "assets/user.jpg"
+    image_url = default_image
     html_options.merge!(:onerror=>"this.src='#{default_image}'")
-    image_tag(gravatar_url(email, default_image), html_options)
+    if Setting["use_gravatar"]
+      image_url = gravatar_url(email, default_image)
+    end
+    return image_tag(image_url, html_options)
   end
 
   def gravatar_url(email, default_image)

--- a/lib/foreman/default_settings/loader.rb
+++ b/lib/foreman/default_settings/loader.rb
@@ -40,7 +40,8 @@ module Foreman
               set('authorize_login_delegation',"Authorize login delegation with REMOTE_USER environment variable",false),
               set('authorize_login_delegation_api',"Authorize login delegation with REMOTE_USER environment variable for API calls too",false),
               set('idle_timeout',"Log out idle users after a certain number of minutes",60),
-              set('max_trend',"Max days for Trends graphs",30)
+              set('max_trend',"Max days for Trends graphs",30),
+              set('use_gravatar',"Should Foreman use gravatar to display user icons",true)
             ].each { |s| create s.update(:category => "General")}
 
             [

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -159,3 +159,8 @@ attribute32:
   category: Auth
   default: []
   description: "Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
+attribute33:
+  name: use_gravatar
+  category: General
+  default: "true"
+  description: "Should Foreman use gravatar to display user icons"


### PR DESCRIPTION
A new setting is added, use_gravatar. It defaults to true. If it is set to false, then the gravatar
call out is not used and only the default user icon is used.
