### PR TITLE
Allow find_multiple to work on all Host types

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -519,7 +519,7 @@ class HostsController < ApplicationController
   def find_multiple
   # Lets search by name or id and make sure one of them exists first
     if params[:host_names].present? or params[:host_ids].present?
-      @hosts = Host.where("id IN (?) or name IN (?)", params[:host_ids], params[:host_names] )
+      @hosts = Host::Base.where("id IN (?) or name IN (?)", params[:host_ids], params[:host_names] )
       if @hosts.empty?
         error _('No hosts were found with that id or name')
         redirect_to(hosts_path) and return false


### PR DESCRIPTION
Amos added this to allow search to work on the Discovery index page.
