### PR TITLE
fixes #2367 - Ruby 2.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ require File.expand_path('../lib/regexp_extensions', __FILE__)
 
 source 'https://rubygems.org'
 
+gem 'bundler', '>= 1.3.0' if RUBY_VERSION =~ /^2/
 gem 'rails', '3.2.13'
 gem 'json'
 gem 'rest-client', :require => 'rest_client'

--- a/app/models/puppet_class_importer.rb
+++ b/app/models/puppet_class_importer.rb
@@ -87,7 +87,7 @@ class PuppetClassImporter
   # Changes in the params are categorized to new parameters, removed parameters and parameters with a new
   # default value.
   def compare_classes(environment, klass, db_params)
-    return [] unless (actual_class = actual_classes(environment)[klass])
+    return nil unless (actual_class = actual_classes(environment)[klass])
     actual_params  = actual_class.parameters
     db_param_names = db_params.map(&:to_s)
 

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,6 +1,6 @@
 group :test do
   gem 'mocha', :require => false
-  gem 'minitest', '~> 3.5', :platforms => :ruby_19
+  gem 'minitest', '~> 3.5', :platforms => [:ruby_19, :ruby_20]
   gem 'single_test'
   gem 'shoulda', "3.0.1"
   gem 'rr'
@@ -11,5 +11,5 @@ group :test do
   gem 'launchy'
   gem 'spork'
   gem 'spork-testunit'
-  gem 'simplecov', :platforms => :ruby_19
+  gem 'simplecov', :platforms => [:ruby_19, :ruby_20]
 end


### PR DESCRIPTION
- require bundler 1.3, preventing ruby-debug19 getting installed on Ruby 2
- update 1.9 gems to install on 2.0 too
- don't use empty arrays in Hash constructor, causes ArgumentError

---

There's a separate Jenkins job here which tests it with Ruby 2.0.0 and Puppet 3.2.0-rc1:
http://ci.theforeman.org/job/test_develop_pull_request_rb2/

Updating to this version of Puppet also breaks Ruby 1.9.2, see [#2413](http://projects.theforeman.org/issues/2413) and the [foreman-dev thread](http://groups.google.com/group/foreman-dev/browse_thread/thread/ee16102943c6b447) for more info, but the plan is to drop support at least for the meantime.
