### PR TITLE
Adds an id primary key field to the user_hostgroup relationship

### DIFF
--- a/db/migrate/20130419145808_add_id_to_user_hostgroup.rb
+++ b/db/migrate/20130419145808_add_id_to_user_hostgroup.rb
@@ -1,0 +1,9 @@
+class AddIdToUserHostgroup < ActiveRecord::Migration
+  def self.up
+    add_column :user_hostgroups, :id, :primary_key
+  end
+
+  def self.down
+    remove_column :user_hostgroups, :id
+  end
+end


### PR DESCRIPTION
Basically after this (https://github.com/theforeman/foreman/pull/516) I noticed that operations like deleting a hostgroup would not work, because it would search in the user_hostgroups for an id, etc.. 

Rails tries to do all inner joins using the .id field so pretty much without the .id field you have to override the default behavior everywhere, so I guess it's best to do as @ohadlevy said in the aforementioned pull request and add it. 

The migration will add an auto incrementing id field to old entries on the database, so there's no need to manually tag the old entries.  
