### PR TITLE
fixes #2429 - Permanent OpenID secrets storage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,8 @@ class ApplicationController < ActionController::Base
           elsif available_sso.support_login?
             available_sso.authenticate!
             return
+          else
+            logger.warn("SSO failed, falling back to login form")
           end
         # Else, fall back to the standard authentication mechanism,
         # only if it's an API request.

--- a/config/initializers/rack_openid.rb
+++ b/config/initializers/rack_openid.rb
@@ -1,6 +1,8 @@
 begin
   require 'rack/openid'
-  Rails.configuration.middleware.use Rack::OpenID
+  require 'openid/store/filesystem'
+  openid_store_path = Pathname.new(Rails.root).join('db').join('openid-store')
+  Rails.configuration.middleware.use Rack::OpenID, OpenID::Store::Filesystem.new(openid_store_path)
 rescue LoadError
   nil
 end

--- a/lib/sso/signo.rb
+++ b/lib/sso/signo.rb
@@ -5,11 +5,14 @@ module SSO
     delegate :headers, :to => :controller
 
     def available?
-      Setting['signo_sso'] && defined?(Rack::OpenID)
+      Setting['signo_sso'] && defined?(Rack::OpenID) && !controller.api_request?
     end
 
+    # by default we support login however when @failed flag is set it means that first try
+    # of #authenticate! failed and we don't to try it again, because we would encounter
+    # endless loop
     def support_login?
-      true
+      !@failed
     end
 
     def support_logout?
@@ -49,6 +52,7 @@ module SSO
           return true
         else
           Rails.logger.debug response.respond_to?(:message) ? response.message : "OpenID authentication failed: #{response.status}"
+          @failed = true
           return false
       end
     end


### PR DESCRIPTION
Also fallback to form login when Signo fails and log a warning.
