### PR TITLE
BMC/IPMI smart proxy actions

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -20,7 +20,7 @@ class HostsController < ApplicationController
     :update_multiple_environment, :submit_multiple_build, :submit_multiple_destroy, :update_multiple_puppetrun,
     :multiple_puppetrun]
   before_filter :find_by_name, :only => %w[show edit update destroy puppetrun setBuild cancelBuild
-    storeconfig_klasses clone pxe_config toggle_manage power console]
+    storeconfig_klasses clone pxe_config toggle_manage power console ipmi_power ipmi_boot]
   before_filter :taxonomy_scope, :only => [:hostgroup_or_environment_selected, :process_hostgroup]
   before_filter :set_host_type, :only => [:update]
   helper :hosts, :reports
@@ -213,6 +213,27 @@ class HostsController < ApplicationController
       process_success :success_redirect => :back, :success_msg => _("%{vm} is now %{state}") % { :vm => vm, :state => vm.state.capitalize }
     rescue => e
       process_error :redirect => :back, :error_msg => _("Failed to %{action} %{vm}: %{e}") % { :action => action, :vm => vm, :e => e }
+    end
+  end
+
+  def ipmi_power
+    action = params[:ipmi_action]
+    begin
+      @host.ipmi_power(action)
+      process_success :success_redirect => :back, :success_msg => "#{@host.name} is now powered #{action.downcase}"
+    rescue => e
+      process_error :redirect => :back, :error_msg => "Failed to #{action} #{@host}: #{e}"
+    end
+
+  end
+
+  def ipmi_boot
+    device = params[:ipmi_device]
+    begin
+      @host.ipmi_boot(device)
+      process_success :success_redirect => :back, :success_msg => "#{@host.name} now boots from #{device.downcase}"
+    rescue => e
+      process_error :redirect => :back, :error_msg => "Failed to boot from #{device} at #{@host}: #{e}"
     end
   end
 

--- a/app/helpers/bmc_helper.rb
+++ b/app/helpers/bmc_helper.rb
@@ -1,0 +1,54 @@
+module BmcHelper
+  def bmc_available?  
+    ipmi = @host.interfaces.select { |i| i.attrs[:provider] == "IPMI" }.first
+    if ipmi.present? 
+      true if ipmi.password.present? && ipmi.username.present? && ipmi_available? 
+    else
+      false
+    end
+  end
+
+  def ipmi_available?
+    begin 
+      timeout(15) do
+        @host.get_bmc_interface.providers
+        true
+      end
+    rescue Timeout::Error 
+      false
+    end
+  end
+
+  def power_status s
+    if s.downcase == 'on'
+      "<span class='label label-success'>On</span>".html_safe
+    else
+      "<span class='label'>Off</span>".html_safe
+    end
+  end
+
+  def power_actions 
+    controller_options = { :action => "ipmi_power", :id => @host }
+    
+    action_buttons(display_link_if_authorized("On",  controller_options.merge(:ipmi_action => 'on'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Off", controller_options.merge(:ipmi_action => 'off'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Cycle", controller_options.merge(:ipmi_action => 'cycle'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Soft", controller_options.merge(:ipmi_action => 'soft'),                                                                                      :confirm => "Are you sure?", :method => :put))
+  end
+
+  def boot_actions
+    controller_options = { :action => "ipmi_boot", :id => @host }
+    
+    action_buttons("Select device",
+                   display_link_if_authorized("Disk",  controller_options.merge(:ipmi_device => 'disk'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Cdrom", controller_options.merge(:ipmi_device => 'cdrom'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Pxe", controller_options.merge(:ipmi_device => 'pxe'),
+                                                     :confirm => "Are you sure?", :method => :put),
+                   display_link_if_authorized("Bios", controller_options.merge(:ipmi_device => 'bios'),                                                                                      :confirm => "Are you sure?", :method => :put))
+  end
+end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -2,6 +2,7 @@ module HostsHelper
   include OperatingsystemsHelper
   include HostsAndHostgroupsHelper
   include ComputeResourcesVmsHelper
+  include BmcHelper
 
   def last_report_column(record)
     time = record.last_report? ? _("%s ago") % time_ago_in_words(record.last_report.getlocal): ""

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -731,6 +731,23 @@ class Host::Managed < Host::Base
     tax_organization.import_missing_ids if organization
   end
 
+  def get_bmc_interface
+    url       = SmartProxy.select { |f| f.features.map(&:name).include? "BMC" }.first.url
+    interface = interfaces.select { |i| i.attrs[:provider] == "IPMI" }.first
+    bmc       = ProxyAPI::BMC.new( { :host_ip => interface.ip,
+                                     :url     => url,
+                                     :user    => interface.username,
+                                     :password => interface.password } )
+  end
+
+  def ipmi_power(action)
+    get_bmc_interface.power(:action => action)
+  end
+
+  def ipmi_boot(booting_device)
+    get_bmc_interface.boot({:function => 'bootdevice', :device => booting_device})
+  end
+
   private
 
   def lookup_keys_params

--- a/app/views/hosts/_bmc.html.erb
+++ b/app/views/hosts/_bmc.html.erb
@@ -1,0 +1,40 @@
+<table class="table table-bordered table-striped">
+  <tr>
+    <th>Chassis</th>
+  </tr>
+  <tr>
+    <td>Status</td>
+    <td><%= power_status(@host.get_bmc_interface.power(:action => 'status')['result']) %></td>
+  </tr>
+  <tr>
+    <td>Power</td>
+    <td><%= power_actions %></td>
+  </tr>
+  <tr>
+    <td>Boot device</td>
+    <td><%= boot_actions %></td>
+  </tr>
+
+</table>
+<table class="table table-bordered table-striped">
+  <tr>
+    <th>Lan</th>
+  </tr>
+  <tr>
+    <td>Ip</td>
+    <td><%= @host.get_bmc_interface.lan(:action => 'ip')['result'] %></td>
+  </tr>
+  <tr>
+    <td>Netmask</td>
+    <td><%= @host.get_bmc_interface.lan(:action => 'netmask')['result'] %></td>
+  </tr>
+  <tr>
+    <td>MAC</td>
+    <td><%= @host.get_bmc_interface.lan(:action => 'mac')['result'] %></td>
+  </tr>
+  <tr>
+    <td>Gateway</td>
+    <td><%= @host.get_bmc_interface.lan(:action => 'gateway')['result'] %></td>
+  </tr>
+  </tr>
+</table>

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -16,6 +16,9 @@
       <%  if @vm %>
         <li><a href="#vm" data-toggle="tab"><%= _('Virtual Machine') %></a></li>
       <% end %>
+      <% if bmc_available? %>
+        <li><a href="#bmc" data-toggle="tab">BMC</a></li>
+      <% end %>
     </ul>
     <div id="myTabContent" class="tab-content">
       <div class="tab-pane active in" id="properties">
@@ -37,6 +40,11 @@
           <%= render("compute_resources_vms/show/#{@host.compute_resource.provider.downcase}") rescue nil %>
         <% end %>
       </div>
+      <% if bmc_available? %>
+        <div class="tab-pane" id="bmc">
+         <%= render :partial => "hosts/bmc", :locals => { :host => @host } %>
+        </div>
+      <% end %>
 
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Foreman::Application.routes.draw do
         post 'environment_selected'
         put 'power'
         get 'console'
+        put 'ipmi_power'
+        put 'ipmi_boot'
       end
       collection do
         get 'multiple_actions'


### PR DESCRIPTION
This pull request contains everything that is needed to perform IPMI operations on a BMC interface. In order to test this, a smart proxy with the BMC capability should be hooked to foreman. This should facilitate the integration of a console for physical machines in foreman.

A further step down the road would be to merge this and similar actions for virtual machines into something generic. 

After this is merged a host with IPMI enabled (username and password set) and a IPMI SmartProxy available, should look like this https://docs.google.com/file/d/0Bz4WMhz8WLjnaFpzdGFEMEQzY00/edit?usp=sharing
