### PR TITLE
Fix finder_needs_type check in sti mixin

### DIFF
--- a/lib/foreman/sti.rb
+++ b/lib/foreman/sti.rb
@@ -21,10 +21,11 @@ module Foreman
       end
     end
     def save_with_type(*args)
-      self.class.instance_variable_set("@finder_needs_type_condition", :false) if self.type_changed?
+      type_changed = self.type_changed?
+      self.class.instance_variable_set("@finder_needs_type_condition", :false) if type_changed
       value = save_without_type(*args)
-      self.class.instance_variable_set("@finder_needs_type_condition", :true)  if self.type_changed?
-      return value
+    ensure
+      self.class.instance_variable_set("@finder_needs_type_condition", :true) if type_changed
     end
   end
 end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -800,7 +800,7 @@ class HostsControllerTest < ActionController::TestCase
   test "can change sti type to valid subtype" do
     class Host::Valid < Host::Base ; end
     put :update, { :commit => "Update", :id => @host.name, :host => {:type => "Host::Valid"} }, set_session_user
-    @host = Host.find(@host.id)
+    @host = Host::Base.find(@host.id)
     assert_equal "Host::Valid", @host.type
   end
 


### PR DESCRIPTION
Many thanks to @witlessb for tracking down the fact that `:finder_needs_type_condition` was somehow becoming false permanently - this fixes the Discovery index for me - @ohadlevy can you try to test the /hosts index too?
