### PR TITLE
Fix loading settings in production

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,14 +1,15 @@
 class Setting < ActiveRecord::Base
   self.inheritance_column = 'category'
 
-  attr_accessible :name, :value, :description, :category, :settings_type, :default
-  # audit the changes to this model
-  audited :only => [:value], :on => [:update], :allow_mass_assignment => true
-
   TYPES= %w{ integer boolean hash array }
   FROZEN_ATTRS = %w{ name default description category }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend }
   BLANK_ATTRS = %w{ trusted_puppetmaster_hosts }
+
+  attr_accessible :name, :value, :description, :category, :settings_type, :default
+  # audit the changes to this model
+  audited :only => [:value], :on => [:update], :allow_mass_assignment => true
+
   validates_presence_of :name, :description
   validates_presence_of :default, :unless => Proc.new {|s| s.settings_type == "boolean" || BLANK_ATTRS.include?(s.name) }
   validates_inclusion_of :default, :in => [true,false], :if => Proc.new {|s| s.settings_type == "boolean"}

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -2,11 +2,11 @@ require 'foreman'
 
 # We may be executing something like rake db:migrate:reset, which destroys this table
 # only continue if the table exists
-if (Setting.first rescue(false))
-  # Avoid lazy-loading in development mode
-  %w[General Puppet Auth Provisioning].each do |c|
-    require_dependency Rails.root.join('app', 'models', 'setting', c.downcase).to_s
-  end if Rails.env.development?
+if (Setting.table_exists? rescue(false))
+  # in this phase, the classes are not fully loaded yet, load them
+  Dir[File.join(Rails.root, "app/models/setting/*.rb")].each do |f|
+    require_dependency(f)
+  end
 
   Setting.descendants.each(&:load_defaults)
 end


### PR DESCRIPTION
The Setting subclasses are not preloaded in initialization phase in 
production.

Also (if Setting.first rescue (false)) is not satisfied when the settings are
not set yet. Using table_exists? instead.
