### PR TITLE
removed deprecated option from redhat ptable - 'zerombr' no longer accepts any params

### DIFF
--- a/db/migrate/20090730152224_create_ptables.rb
+++ b/db/migrate/20090730152224_create_ptables.rb
@@ -7,7 +7,7 @@ class CreatePtables < ActiveRecord::Migration
       t.references :operatingsystem
       t.timestamps
     end
-    Ptable.create :name => "RedHat default", :layout =>"zerombr yes\nclearpart --all --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --fstype ext3 --size=1024 --grow\npart swap  --recommended"
+    Ptable.create :name => "RedHat default", :layout =>"zerombr\nclearpart --all --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --fstype ext3 --size=1024 --grow\npart swap  --recommended"
     Ptable.create :name => "Ubuntu default", :layout =>"d-i partman-auto/disk string /dev/sda\nd-i partman-auto/method string regular\nd-i partman-auto/init_automatically_partition select Guided - use entire disk\nd-i partman/confirm_write_new_label boolean true\nd-i partman/choose_partition select \\\nFinish partitioning and write changes to disk\nd-i partman/confirm boolean true\n"
 
     create_table :operatingsystems_ptables, :id => false do |t|


### PR DESCRIPTION
Under rhel 5 the option 'yes' is considered deprecated. In f17 and f18 kickstarts 'zerombr' no longer accepts any parameters.
