### PR TITLE
Hostgroup add ancestors fix

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -59,7 +59,8 @@ class HostgroupsController < ApplicationController
     if @hostgroup.save
       # Add the new hostgroup to the user's filters
       @hostgroup.users << User.current unless User.current.admin? or @hostgroup.users.include?(User.current)
-      @hostgroup.users << @hostgroup.ancestors.map { |a| a.users }.flatten.uniq
+      @hostgroup.users << users_in_ancestors
+
       process_success
     else
       load_vars_for_ajax
@@ -110,6 +111,12 @@ class HostgroupsController < ApplicationController
     @architecture    = @hostgroup.architecture
     @operatingsystem = @hostgroup.operatingsystem
     @domain          = @hostgroup.domain
+  end
+
+  def users_in_ancestors
+    @hostgroup.ancestors.map do |ancestor|
+      ancestor.users.reject { |u| @hostgroup.users.include?(u) }
+    end.flatten.uniq
   end
 
 end


### PR DESCRIPTION
Basically this pull request fixes the problem where:

an User is creating a new hostgroup
this user owns any of its ancestors
the Hostgroup creation will work, but shows an error "User is already in this Hostgroup", because indeed the User already owns that Hostgroup (that happens in line 61) and you are trying to add the User to this Hostgroup twice. 
