### PR TITLE
Fixes #2460 - session expiration fix for SSO

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,8 @@ class ApplicationController < ActionController::Base
         if available_sso.present?
           if available_sso.authenticated?
             user = User.unscoped.find_by_login(available_sso.user)
-            User.logout_path = available_sso.logout_path if available_sso.support_logout?
+            session[:logout_path] = available_sso.logout_path if available_sso.support_logout?
+            update_activity_time
           elsif available_sso.support_login?
             available_sso.authenticate!
             return

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -294,7 +294,7 @@ module ApplicationHelper
   end
 
   def sign_out_url
-    User.logout_path + URI.escape(logout_users_url)
+    (session[:logout_path] || '') + URI.escape(logout_users_url)
   end
 
   private

--- a/lib/foreman/thread_session.rb
+++ b/lib/foreman/thread_session.rb
@@ -70,20 +70,6 @@ module Foreman
           ensure
             self.current = old_user
           end
-
-          # returns a logout path for the user, useful for single sign on support
-          #
-          # it's being set when user logs into a foreman and it's meant to be an url of SSO system
-          # logout page, it's appended by return url so it should contain a parameter at the end
-          # e.g. "https://localhost/signo?return_url="
-          def self.logout_path
-            Thread.current[:logout_path] || ''
-          end
-
-          # sets a logout path to be used for a current user when logging out
-          def self.logout_path=(path)
-            Thread.current[:logout_path] = path
-          end
         end
       end
     end


### PR DESCRIPTION
We set new expiration interval when user logs in successfully using any
kind of SSO. Also this patch moves logout path out of thread variable
and stores it into a session. This is more secure storage for threaded
servers.
