### PR TITLE
removing ruby-debug from development group

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,11 +1,4 @@
 group :development do
-  # To use debugger
-  case RUBY_VERSION
-  when /^1\.8/
-    gem "ruby-debug", :platforms => :ruby_18, :require => false
-  when /^1\.9/
-    gem "ruby-debug19", :platforms => :ruby_19, :require => false
-  end
   gem 'maruku'
   gem 'pry'
   gem "term-ansicolor"


### PR DESCRIPTION
Removing because ruby-debug\* is not maintained anymore and does not work
with 1.9.3+ Ruby.

To use your favourite debugger, please put it in the
bundler.d/Gemfile.local.rb
