### PR TITLE
fixing transifex parse error

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -26,6 +26,7 @@ all-mo: $(MOFILES)
 	! grep -q msgid $@
 
 check: $(POXFILES)
+	msgfmt -c ${POTFILE}
 
 # Merge PO files
 update-po:

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -5,20 +5,19 @@
 # Translators:
 #
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-04-23 15:23+0200\n"
 "PO-Revision-Date: 2013-03-01 15:45-0500\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
+"Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr ""


### PR DESCRIPTION
Parse error - we had incorrect header taken from some template of something.
Changed our "check" target so the source POT file is checked as well to
prevent similar errors.
