### PR TITLE
fixes #2426 - translate model and column names to English

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -291,7 +291,7 @@ class HostsController < ApplicationController
   def update_multiple_hostgroup
     # simple validations
     unless (id=params["hostgroup"]["id"])
-      error _('No Hostgroup selected!')
+      error _('No host group selected!')
       redirect_to(select_multiple_hostgroup_hosts_path) and return
     end
     hg = Hostgroup.find(id) rescue nil
@@ -301,7 +301,7 @@ class HostsController < ApplicationController
       host.save(:validate => false)
     end
 
-    notice _('Updated hosts: Changed Hostgroup')
+    notice _('Updated hosts: changed host group')
     # We prefer to go back as this does not lose the current search
     redirect_back_or_to hosts_path
   end
@@ -312,7 +312,7 @@ class HostsController < ApplicationController
   def update_multiple_environment
     # simple validations
     if (params[:environment].nil?) or (id=params["environment"]["id"]).nil?
-      error _('No Environment selected!')
+      error _('No environment selected!')
       redirect_to(select_multiple_environment_hosts_path) and return
     end
 
@@ -324,7 +324,7 @@ class HostsController < ApplicationController
       host.save(:validate => false)
     end
 
-    notice _('Updated hosts: Changed Environment')
+    notice _('Updated hosts: changed environment')
     redirect_back_or_to hosts_path
   end
 
@@ -525,7 +525,7 @@ class HostsController < ApplicationController
         redirect_to(hosts_path) and return false
       end
     else
-      error _('No Hosts selected')
+      error _('No hosts selected')
       redirect_to(hosts_path) and return false
     end
 

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -74,7 +74,7 @@ class SubnetsController < ApplicationController
 
   def create_multiple
     if params[:subnets].empty?
-      return redirect_to subnets_path, :notice => _("No Subnets selected")
+      return redirect_to subnets_path, :notice => _("No subnets selected")
     end
 
     @subnets = Subnet.create(params[:subnets]).reject { |s| s.errors.empty? }

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -165,13 +165,13 @@ module HostsHelper
     rescue => e
       return case e.to_s
       when "Must provide an operating systems"
-        _("Unable to find templates As this Host has no Operating System")
+        _("Unable to find templates as this host has no operating system")
       else
         e.to_s
       end
     end
 
-    return _("No Template found") if templates.empty?
+    return _("No template found") if templates.empty?
     content_tag :table, :class=>"table table-bordered table-striped" do
       content_tag(:th, _("Template Type")) + content_tag(:th) +
       templates.sort{|t,x| t.template_kind <=> x.template_kind}.map do |tmplt|
@@ -193,7 +193,7 @@ module HostsHelper
       [_("Puppet Environment"), (link_to(host.environment, hosts_path(:search => "environment = #{host.environment}")) if host.environment)],
       [_("Host Architecture"), (link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}")) if host.arch)],
       [_("Operating System"), (link_to(host.os, hosts_path(:search => "os = #{host.os.name}")) if host.os)],
-      [_("Host Group"), (link_to(host.hostgroup, hosts_path(:search => "hostgroup = #{host.hostgroup}")) if host.hostgroup)],
+      [_("Host group"), (link_to(host.hostgroup, hosts_path(:search => "hostgroup = #{host.hostgroup}")) if host.hostgroup)],
     ]
     fields += [[_("Location"), (link_to(host.location.name, hosts_path(:search => "location = #{host.location}")) if host.location)]] if SETTINGS[:locations_enabled]
     fields += [[_("Organization"), (link_to(host.organization.name, hosts_path(:search => "organization = #{host.organization}")) if host.organization)]] if SETTINGS[:organizations_enabled]

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -29,16 +29,16 @@ module TaxonomyHelper
       end
   end
 
-  def taxonomies_plural
-    controller_name
+  def taxonomy_single
+    _(controller_name.singularize)
   end
 
-  def taxonomy_single
-    controller_name.singularize
+  def taxonomy_title
+    _(controller_name.singularize.titleize)
   end
 
   def taxonomy_upcase
-    controller_name.humanize.titleize
+    _(controller_name.humanize.titleize)
   end
 
   def wizard_header(current, *args)

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -3,8 +3,8 @@ module TrendsHelper
   include CommonParametersHelper
 
   def trendable_types new_record
-    options = {_('Environment') => 'Environment', _('Operating System') => 'Operatingsystem',
-     _('Model') => 'Model', _('Facts') =>'FactName',_('Host Group') => 'Hostgroup', _('Compute Resource') => 'ComputeResource'}
+    options = {_('Environment') => 'Environment', _('Operating system') => 'Operatingsystem',
+     _('Model') => 'Model', _('Facts') =>'FactName',_('Host group') => 'Hostgroup', _('Compute resource') => 'ComputeResource'}
     if new_record
       existing = ForemanTrend.includes(:trendable).types.map(&:to_s)
       options.delete_if{ |k,v|  existing.include?(v) }

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -5,7 +5,7 @@ class Parameter < ActiveRecord::Base
   validates_presence_of   :name, :value
   validates_format_of     :name,  :without => /\s/, :message => N_("can't contain white spaces")
 
-  validates_presence_of :reference_id, :message => N_("parameters require an associated domain, host or hostgroup"), :unless => Proc.new {|p| p.nested or p.is_a? CommonParameter}
+  validates_presence_of :reference_id, :message => N_("parameters require an associated domain, host or host group"), :unless => Proc.new {|p| p.nested or p.is_a? CommonParameter}
 
   attr_accessor :nested
   before_validation :strip_whitespaces

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -24,7 +24,7 @@ class Setting::Puppet < Setting
         self.set('enc_environment', N_("Should Foreman provide puppet environment in ENC yaml output? (this avoids the mismatch error between puppet.conf and ENC environment)"), true),
         self.set('use_uuid_for_certificates', N_("Should Foreman use random UUID's for certificate signing instead of hostnames"), false),
         self.set('update_environment_from_facts', N_("Should Foreman update a host's environment from its facts"), false),
-        self.set('remove_classes_not_in_environment', N_("When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"), false)
+        self.set('remove_classes_not_in_environment', N_("When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"), false)
       ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
 
       true

--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -2,7 +2,7 @@
   <%= select_f f, :operatingsystem_id, arch_oss, :id, :to_label,
     {:selected => item.operatingsystem_id, :include_blank => true},
     {:id => type + "_operatingsystem_id", :name => type + "[operatingsystem_id]",
-      :label => _("Operating Systems"),
+      :label => _("Operating system"),
       :disabled => arch_oss.empty? ? true : false,
       :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected')}
   %>

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -6,7 +6,7 @@
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => os_ptable.size > 1, :selected => item.ptable_id},
-    {:id => type + "_ptable_id", :name => type + "[ptable_id]", :label => _("Partition Table"), :disabled => os_ptable.empty?}
+    {:id => type + "_ptable_id", :name => type + "[ptable_id]", :label => _("Partition table"), :disabled => os_ptable.empty?}
   %>
 
   <% if @operatingsystem and @operatingsystem.supports_image -%>

--- a/app/views/compute_resources_vms/form/_ec2.html.erb
+++ b/app/views/compute_resources_vms/form/_ec2.html.erb
@@ -4,7 +4,7 @@
    images = possible_images(compute_resource, arch, os)
 -%>
 
-<div id='image_selection'><%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please Select an Image')}, {:disabled => images.empty? } %></div>
+<div id='image_selection'><%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')}, {:disabled => images.empty? } %></div>
 <%= selectable_f f, :groups, compute_resource.security_groups, {}, { :multiple => true, :label => _("Security Groups") } %>
-<%= selectable_f f, :availability_zone, compute_resource.zones, {:include_blank => _("No Preference")} %>
+<%= selectable_f f, :availability_zone, compute_resource.zones, {:include_blank => _("No preference")} %>
 

--- a/app/views/config_templates/_combinations.html.erb
+++ b/app/views/config_templates/_combinations.html.erb
@@ -1,6 +1,6 @@
-<%= field_set_tag _("Valid Host group and Environment Combinations"), :id => "template_combination" do -%>
+<%= field_set_tag _("Valid host group and environment combinations"), :id => "template_combination" do -%>
   <%= f.fields_for :template_combinations do |builder| -%>
     <%= render 'combination', :f => builder %>
   <% end -%>
-  <p><%= link_to_add_fields('+ ' + _("Add Combination"), f, :template_combinations, "combination") %></p>
+  <p><%= link_to_add_fields('+ ' + _("Add combination"), f, :template_combinations, "combination") %></p>
 <% end -%>

--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -3,7 +3,7 @@
 <%= form_for @config_template, :html => { :multipart => true } do |f| %>
     <%= base_errors_for @config_template %>
     <ul class="nav nav-tabs" data-tabs="tabs">
-      <li class="active"><a id="primary_tab" href="#primary" data-toggle="tab"><%= _("Config Template") %></a></li>
+      <li class="active"><a id="primary_tab" href="#primary" data-toggle="tab"><%= _("Provisioning Template") %></a></li>
       <li><a href="#template_associations" data-toggle="tab"><%= _("Association") %></a></li>
       <li><a id='history_tab' href="#history" data-toggle="tab"><%= _("History") %></a></li>
     </ul>
@@ -56,7 +56,7 @@
                   </div>
               <% end -%>
           <% else -%>
-              <%= alert :header => _('No History Found'), :text => _('Save something and try again') %>
+              <%= alert :header => _('No history found'), :text => _('Save something and try again') %>
           <% end %>
         </div>
       </div>
@@ -70,14 +70,14 @@
           <div class="alert alert-message alert-success">
             <a class="close" href="#" data-dismiss="alert">&times;</a>
 
-            <h3><%= _("How Templates are determined") %><br></h3>
+            <h3><%= _("How templates are determined") %><br></h3>
 
             <p><%= _("When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments") %></p>
 
             <p><%= _("When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:") %></p>
             <ul>
-              <li><%= _("Host-group and Environment") %></li>
-              <li><%= _("Host-group only") %></li>
+              <li><%= _("Host group and Environment") %></li>
+              <li><%= _("Host group only") %></li>
               <li><%= _("Environment only") %></li>
               <li><%= _("Operating system default") %></li>
             </ul>

--- a/app/views/config_templates/edit.html.erb
+++ b/app/views/config_templates/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit Config Template") %>
+<% title _("Edit Template") %>
 
 <%= render :partial => 'form' %>

--- a/app/views/config_templates/index.html.erb
+++ b/app/views/config_templates/index.html.erb
@@ -10,7 +10,7 @@
   <tr>
     <tr>
     <th><%= sort :name, :as => s_("ConfigTemplate|Name") %></th>
-    <th><%= _("Hostgroup / Environment") %></th>
+    <th><%= _("Host group / Environment") %></th>
     <th><%= sort :kind, :as => _("Kind") %></th>
     <th><%= sort :snippet, :as => s_("ConfigTemplate|Snippet") %></th>
     <th></th>

--- a/app/views/dashboard/_status_table.html.erb
+++ b/app/views/dashboard/_status_table.html.erb
@@ -5,11 +5,11 @@
     <h4><%= @report[:active_hosts_ok_enabled] %></h4>
   </li>
   <li>
-    <%= searchable_links _('Hosts in Error State'), "last_report > \"#{Setting[:puppet_interval] + 5} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true" %>
+    <%= searchable_links _('Hosts in error state'), "last_report > \"#{Setting[:puppet_interval] + 5} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true" %>
     <h4><%= @report[:bad_hosts_enabled] %></h4>
   </li>
   <li>
-    <%=searchable_links _("Good Host Reports in the last %s") % time_ago_in_words((Setting[:puppet_interval]+5).minutes.ago), "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0" %>
+    <%=searchable_links _("Good host reports in the last %s") % time_ago_in_words((Setting[:puppet_interval]+5).minutes.ago), "last_report > \"#{Setting[:puppet_interval]+5} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0" %>
     <h4><%= @report[:ok_hosts_enabled] %></h4>
   </li>
   <li>
@@ -17,15 +17,15 @@
     <h4><%= @report[:pending_hosts_enabled] %></h4>
   </li>
   <li>
-    <%= searchable_links _('Out Of Sync Hosts'), "last_report < \"#{Setting[:puppet_interval] + 5} minutes ago\" and status.enabled = true" %>
+    <%= searchable_links _('Out of sync Hosts'), "last_report < \"#{Setting[:puppet_interval] + 5} minutes ago\" and status.enabled = true" %>
     <h4><%= @report[:out_of_sync_hosts_enabled] %></h4>
   </li>
   <li>
-    <%= searchable_links _('Hosts With No Reports'), "not has last_report and status.enabled = true" %>
+    <%= searchable_links _('Hosts with no reports'), "not has last_report and status.enabled = true" %>
     <h4><%= @report[:reports_missing] %></h4>
   </li>
   <li>
-    <%= searchable_links _('Hosts With Alerts Disabled'), "status.enabled = false" %>
+    <%= searchable_links _('Hosts with alerts disabled'), "status.enabled = false" %>
     <h4><%= @report[:disabled_hosts] %></h4>
   </li>
   <h4 class="total"><%= _("Total Hosts: %s") % @report[:total_hosts] %></h4>

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -35,7 +35,7 @@
       <% if @environment or @hostgroup.environment -%>
         <%= render 'puppetclasses/class_selection', :obj => @hostgroup %>
       <% else -%>
-        <p class="alert alert-message">Please select an Environment first</p>
+        <p class="alert alert-message"><%= _('Please select an environment first') -%></p>
       <% end -%>
     </div>
 

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Host Groups") %>
 
-<% title_actions display_link_if_authorized(_("New Hostgroup"), hash_for_new_hostgroup_path), help_path %>
+<% title_actions display_link_if_authorized(_("New Host Group"), hash_for_new_hostgroup_path), help_path %>
 
 <table class="table table-bordered table-striped">
   <tr>

--- a/app/views/hostgroups/new.html.erb
+++ b/app/views/hostgroups/new.html.erb
@@ -1,3 +1,3 @@
-<% title _("New Hostgroup") %>
+<% title _("New Host Group") %>
 
 <%= render :partial => 'form' %>

--- a/app/views/hostgroups/welcome.html.erb
+++ b/app/views/hostgroups/welcome.html.erb
@@ -1,18 +1,18 @@
-<% title_actions link_to(_("New hostgroup"), new_hostgroup_path) %>
-<% title _("Hostgroup configuration") %>
+<% title_actions link_to(_("New Host Group"), new_hostgroup_path) %>
+<% title _("Host group configuration") %>
 <div id="welcome">
   <p>
-  <%= _('A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states.') %>
+  <%= _('A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states.') %>
 
-  <%= _('In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime.') %>
+  <%= _('In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime.') %>
 
-  <%= _("The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration.") %>
+  <%= _("The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration.") %>
   </p>
 
   <p>
-  <%= _('There are two strategies when using hostgroups.') %>
+  <%= _('There are two strategies when using host groups.') %>
 
-  <%= _('You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration.').html_safe %>
+  <%= _('You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration.').html_safe %>
 
   <%= _('These two options are personal decisions and are up to you (where the main difference would be the parameter/variables settings).') %>
   </p>

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -11,10 +11,10 @@
   <tr>
     <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :title => _("Select All") } %></th>
     <th class=''><%= sort :name %></th>
-    <th class="hidden-phone"><%= sort :os, :as => _("Operating<br>System") %></th>
+    <th class="hidden-phone"><%= sort :os, :as => _("Operating system") %></th>
     <th class="hidden-phone"><%= sort :environment %></th>
     <th class="hidden-tablet hidden-phone"><%= sort :model %></th>
-    <th class="hidden-tablet hidden-phone"><%= sort :hostgroup, :as => _("Host Group") %></th>
+    <th class="hidden-tablet hidden-phone"><%= sort :hostgroup, :as => _("Host group") %></th>
   </tr>
   <% hosts.each do |host| %>
     <tr>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -62,7 +62,7 @@
       <% if @environment or @hostgroup -%>
         <%= render 'puppetclasses/class_selection', :obj => @host %>
       <% else -%>
-        <p class="alert alert-message"><%= _('Please select an Environment first') %></p>
+        <p class="alert alert-message"><%= _('Please select an environment first') %></p>
       <% end -%>
     </div>
 

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -4,10 +4,10 @@
   <tr>
     <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
     <th class=''><%= sort :name, :as => _('Name') %></th>
-    <th class="hidden-phone"><%= sort :os, :as => _("Operating<br>system") %></th>
+    <th class="hidden-phone"><%= sort :os, :as => _("Operating system") %></th>
     <th class="hidden-phone"><%= sort :environment, :as => _('Environment') %></th>
     <th class="hidden-tablet hidden-phone"><%= sort :model, :as => _('Model') %></th>
-    <th class="hidden-tablet hidden-phone"><%= sort :hostgroup, :as => _("Host Group") %></th>
+    <th class="hidden-tablet hidden-phone"><%= sort :hostgroup, :as => _("Host group") %></th>
     <th class="hidden-tablet hidden-phone"><%= sort :last_report, :as => _('Last report') %></th>
     <th></th>
   </tr>

--- a/app/views/hosts/select_multiple_environment.html.erb
+++ b/app/views/hosts/select_multiple_environment.html.erb
@@ -1,8 +1,8 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
 <%= form_for :environment, :url => update_multiple_environment_hosts_path(:host_ids => params[:host_ids]) do |f| %>
-    <%= f.select :id, [[_("Select Environment"), "disabled"],
+    <%= f.select :id, [[_("Select environment"), "disabled"],
                         [_("*Clear environment*"), "" ],
-                        [_("*Inherit from hostgroup*"), "inherit"]] + Environment.all.map{|e| [e.name, e.id]},{},
+                        [_("*Inherit from host group*"), "inherit"]] + Environment.all.map{|e| [e.name, e.id]},{},
                  :onchange => "toggle_multiple_ok_button(this)" %>
 <% end %>

--- a/app/views/hosts/select_multiple_hostgroup.html.erb
+++ b/app/views/hosts/select_multiple_hostgroup.html.erb
@@ -1,6 +1,6 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
 <%= form_for :hostgroup, :url => update_multiple_hostgroup_hosts_path(:host_ids => params[:host_ids]) do |f| %>
-  <%= f.select :id, [[_("Select Host Group"),"disabled"],[_("*Clear Hostgroup*"), "" ]] + Hostgroup.all.map{|h| [h.to_label, h.id]}.sort,{},
+  <%= f.select :id, [[_("Select host group"),"disabled"],[_("*Clear host group*"), "" ]] + Hostgroup.all.map{|h| [h.to_label, h.id]}.sort,{},
         :onchange => "toggle_multiple_ok_button(this)" %>
 <% end %>

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -26,7 +26,7 @@
 
     <legend>Override Value For Specific Hosts</legend>
     <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :value => f.object.path,
-                   :help_inline => popover("?", _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"), :title => _("The order in which values are resolved")).html_safe
+                   :help_inline => popover("?", _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"), :title => _("The order in which values are resolved")).html_safe
     %>
 
     <%# the following field is required to see child validations %>

--- a/app/views/lookup_keys/index.html.erb
+++ b/app/views/lookup_keys/index.html.erb
@@ -4,7 +4,7 @@
   <tr>
     <th><%= sort :key, :as => _("Variable") %></th>
     <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-    <th><%= _('Number of Values') -%></th>
+    <th><%= _('Number of values') -%></th>
     <th></th>
   </tr>
 

--- a/app/views/ptables/edit.html.erb
+++ b/app/views/ptables/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit Partition table") %>
+<% title _("Edit Partition Table") %>
 
 <%= render :partial => 'form' %>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -1,11 +1,11 @@
-<% title _("Partition tables") %>
-<% title_actions display_link_if_authorized(_("New Partition table layout"), hash_for_new_ptable_path), help_path %>
+<% title _("Partition Tables") %>
+<% title_actions display_link_if_authorized(_("New Partition Table"), hash_for_new_ptable_path), help_path %>
 
 <table class="table table-bordered table-striped">
   <tr>
     <th><%= sort :name, :as => s_("Ptable|Name") %></th>
     <th><%= s_("Ptable|Os family") %></th>
-    <th><%= _("Operating Systems") %></th>
+    <th><%= _("Operating systems") %></th>
     <th></th>
   </tr>
   <% for ptable in @ptables %>

--- a/app/views/ptables/new.html.erb
+++ b/app/views/ptables/new.html.erb
@@ -1,3 +1,3 @@
-<% title _("New Partition Table layout") %>
+<% title _("New Partition Table") %>
 
 <%= render :partial => 'form' %>

--- a/app/views/ptables/welcome.html.erb
+++ b/app/views/ptables/welcome.html.erb
@@ -1,5 +1,5 @@
 <% title _("Partition table configuration") %>
-<% title_actions link_to(_("New partition table"), new_ptable_path) %>
+<% title_actions link_to(_("New Partition Table"), new_ptable_path) %>
 <div id="welcome">
   <p> <%= _("A partition table entry represents either") %> </p>
   <ul>

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -12,8 +12,8 @@
 
     <div class="tab-pane active form-horizontal" id="primary">
       <%= text_f f, :name %>
-      <%= text_f f, :environments, :value => @puppetclass.environments.to_sentence, :class=>'span4', :label=> _('Puppet Environments'), :disabled => true %>
-      <%= multiple_checkboxes f, :hostgroups,   @puppetclass, Hostgroup,   :label => _("Hostgroups") %>
+      <%= text_f f, :environments, :value => @puppetclass.environments.to_sentence, :class=>'span4', :label=> _('Puppet environments'), :disabled => true %>
+      <%= multiple_checkboxes f, :hostgroups,   @puppetclass, Hostgroup,   :label => _("Host groups") %>
     </div>
 
     <div class="tab-pane lookup-keys-container" id="smart_class_param">

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th><%= sort :name, :as => s_("Puppetclass|Name") %></th>
     <th><%= sort :environment, :as => _("Environments and documentation") %></th>
-    <th><%= _('Host Group') -%></th>
+    <th><%= _('Host group') -%></th>
     <th><%= _('Hosts') -%></th>
     <th><%= _('Keys') -%></th>
     <th></th>

--- a/app/views/taxonomies/_form.html.erb
+++ b/app/views/taxonomies/_form.html.erb
@@ -13,7 +13,7 @@
         <li><a href="#domains" data-toggle="tab"><%= _("Domains") %></a></li>
       <% end -%>
       <li><a href="#environments" data-toggle="tab"><%= _("Environments") %></a></li>
-      <li><a href="#hostgroups" data-toggle="tab"><%= _("Hostgroups") %></a></li>
+      <li><a href="#hostgroups" data-toggle="tab"><%= _("Host groups") %></a></li>
       <% if (taxonomy.is_a?(Organization) && SETTINGS[:locations_enabled]) %>
         <li><a href="#locations" data-toggle="tab"><%= _('Locations') %></a></li>
       <% elsif SETTINGS[:organizations_enabled] %>
@@ -64,9 +64,9 @@
         </div>
 
         <div class="tab-pane" id="template">
-          <%= checkbox_f(f, :ignore_types, {:label => "", :help_inline => _("All Templates"), :multiple => true, :onchange => 'ignore_checked(this)'}, _("Config Template")) %>
+          <%= checkbox_f(f, :ignore_types, {:label => "", :help_inline => _("All Templates"), :multiple => true, :onchange => 'ignore_checked(this)'}, _("Provisioning template")) %>
           <%= multiple_selects f, :config_templates, ConfigTemplate, taxonomy.selected_ids[:config_template_ids],
-            {:disabled => taxonomy.used_and_selected_ids[:config_template_ids], :label => _("Config templates")},
+            {:disabled => taxonomy.used_and_selected_ids[:config_template_ids], :label => _("Provisioning templates")},
             {'data-mismatches' => taxonomy.need_to_be_selected_ids[:config_template_ids].to_json} %>
         </div>
 
@@ -86,9 +86,9 @@
       </div>
 
       <div class="tab-pane" id="hostgroups">
-        <%= checkbox_f(f, :ignore_types, {:label => "", :help_inline => _("All Hostgroups"), :multiple => true, :onchange => 'ignore_checked(this)'}, _("Hostgroup")) %>
+        <%= checkbox_f(f, :ignore_types, {:label => "", :help_inline => _("All Host Groups"), :multiple => true, :onchange => 'ignore_checked(this)'}, _("Hostgroup")) %>
         <%= multiple_selects f, :hostgroups, Hostgroup, taxonomy.selected_ids[:hostgroup_ids],
-          {:disabled => taxonomy.used_and_selected_ids[:hostgroup_ids], :label => _("Hostgroups")},
+          {:disabled => taxonomy.used_and_selected_ids[:hostgroup_ids], :label => _("Host groups")},
           {'data-mismatches' => taxonomy.need_to_be_selected_ids[:hostgroup_ids].to_json} %>
      </div>
 

--- a/app/views/taxonomies/_step2.html.erb
+++ b/app/views/taxonomies/_step2.html.erb
@@ -1,18 +1,18 @@
-<% taxonomy_type = taxonomy.class.name %>
+<% taxonomy_type = taxonomy_single %>
 
 <%= form_for taxonomy do |f| %>
   <%= base_errors_for taxonomy %>
-    <%= wizard_header 2, _("Create %s") % taxonomy.class.name,_("Select Hosts"), _("Edit Properties") %>
+    <%= wizard_header 2, _("Create %s") % taxonomy_title, _("Select Hosts"), _("Edit Properties") %>
 
   <% if @count_nil_hosts > 0 %>
     <%= alert :header => _("Notice"),:class => 'alert-info',
-              :text => _("Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using.") % {:taxonomy_name => taxonomy.name }%>
+              :text => _("Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using.") % {:taxonomy_name => taxonomy.name }%>
     <%=  option_button _("Assign All"), assign_all_hosts_taxonomy_path(taxonomy), :class => 'btn btn-success',:method => :post,
-                       :help_inline => _("Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}") % {:count =>  @count_nil_hosts, :taxonomy_type => taxonomy_type , :taxonomy_name => taxonomy.name}%>
+      :help_inline => n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count =>  @count_nil_hosts, :taxonomy_single => taxonomy_type , :taxonomy_name => taxonomy.name}%>
     <%=  option_button _("Manually Assign"), assign_hosts_taxonomy_path(taxonomy), :class => 'btn',
-                       :help_inline => _("Manually select and assign Hosts with No %s") % taxonomy_type %>
+                       :help_inline => _("Manually select and assign hosts with no %s") % taxonomy_type %>
     <%=  option_button(_("Proceed to Edit"), edit_taxonomy_path(taxonomy), :class => 'btn',
-                       :help_inline => _("Skip Assign Hosts and Proceed to Edit %s Settings") % taxonomy_type)%>
+                       :help_inline => _("Skip assign hosts and proceed to edit %s settings") % taxonomy_type)%>
   <% end %>
 
 <% end %>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -1,12 +1,12 @@
-<% title _(taxonomy_upcase.pluralize) %>
+<% title taxonomy_upcase %>
 
-<% title_actions display_link_if_authorized((_("New %s") % _(taxonomy_upcase)), hash_for_new_taxonomy_path), link_to(_("Mismatches Report"), mismatches_taxonomies_path, :class => 'btn'), help_path %>
+<% title_actions display_link_if_authorized((_("New %s") % taxonomy_title), hash_for_new_taxonomy_path), link_to(_("Mismatches Report"), mismatches_taxonomies_path, :class => 'btn'), help_path %>
 
 <% if @count_nil_hosts > 0 %>
 <div class="alert alert-message alert-block alert">
     <strong><%= _("Notice:") %></strong>
-    <%= _('There are') %>
-    <%= link_to _("%{count} hosts with no %{taxonomy_single} assigned") % {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single }, hosts_path(:search => _("not has %s") % taxonomy_single)  %>
+    <%= n_('There is', 'There are', @count_nil_hosts) %>
+    <%= link_to n_("%{count} host with no %{taxonomy_single} assigned", "%{count} hosts with no %{taxonomy_single} assigned", @count_nil_hosts) % {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single }, hosts_path(:search => "not has #{controller_name.singularize}")  %>
 </div>
 <% end %>
 
@@ -20,14 +20,14 @@
   <% @taxonomies.each do |taxonomy| %>
     <tr class="<%= cycle("even", "odd") -%>">
       <td><%= link_to taxonomy.to_label, edit_taxonomy_path(taxonomy) %></td>
-      <td><%= link_to @counter[taxonomy.id] || 0, hosts_path(:search => "#{taxonomy_single} = #{taxonomy}") %></td>
+      <td><%= link_to @counter[taxonomy.id] || 0, hosts_path(:search => "#{controller_name.singularize} = #{taxonomy}") %></td>
       <td>
         <%= action_buttons(
           display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
           display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy) ),
           display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :confirm => _("Delete %s?") % taxonomy.name, :action => :destroy),
-          (link_to((_("Select Hosts to Assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
-          (link_to(_("Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}") % {:count =>@count_nil_hosts, :taxonomy_upcase => taxonomy_upcase, :taxonomy_name => taxonomy.name}  ,
+          (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
+          (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,
               assign_all_hosts_taxonomy_path(taxonomy),
               :method => :post) if @count_nil_hosts > 0)
           )%>

--- a/app/views/taxonomies/new.html.erb
+++ b/app/views/taxonomies/new.html.erb
@@ -1,3 +1,3 @@
-<% title(_("New %s") % _(taxonomy_upcase)) %>
+<% title(_("New %s") % taxonomy_title) %>
 
 <%= render 'taxonomies/step1' , :taxonomy => @taxonomy %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -5,7 +5,7 @@
   <div class="alert alert-message alert-info">
     <a class="close" href="#" data-dismiss="alert">&times;</a>
 
-    <p><strong><%= _("No Trend Counter Defined.") %></strong></p>
+    <p><strong><%= _("No trend counter defined.") %></strong></p>
 
     <p><%= _("To define trend counters, use the Add Trend Counter button.") %><br>
       <%= _("To start collecting trend data, set a cron job to execute 'rake trends:counter' every Puppet Interval (%s minutes).") % Setting.puppet_interval %></p>
@@ -16,7 +16,7 @@
  <div class="alert alert-message alert-info">
     <a class="close" href="#" data-dismiss="alert">&times;</a>
 
-    <p><strong><%= _("No Trend Counter Found.") %></strong></p>
+    <p><strong><%= _("No trend counter found.") %></strong></p>
 
    <p><%= ( _("To start collecting trend data, set a cron job to execute <span class='black'>RAILS_ENV=production bundle exec rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting.puppet_interval).html_safe %>
    </p>

--- a/app/views/users/_filters.html.erb
+++ b/app/views/users/_filters.html.erb
@@ -17,7 +17,7 @@
         <%= multiple_checkboxes f, :compute_resources, @user, ComputeResource, :label=>'' %>
   <% end %>
 
-    <%= field_set_tag _("Hostgroup hosts") do %>
+    <%= field_set_tag _("Host group hosts") do %>
         <%= f.select :hostgroups_andor, [[_("must be"), "and"], [_("plus all"), "or"]], {}, :class => "input-small" %>
         <%= multiple_checkboxes f, :hostgroups, @user, Hostgroup, :label=>'' %>
   <% end %>

--- a/locale/de/foreman.po
+++ b/locale/de/foreman.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-23 15:23+0200\n"
+"POT-Creation-Date: 2013-05-07 18:30+0100\n"
 "PO-Revision-Date: 2013-03-01 15:45-0500\n"
 "Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -21,6 +21,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
+msgstr ""
+
+msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
 msgid "%s Distribution"
@@ -66,13 +69,13 @@ msgid_plural "%s weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%{count} hosts with no %{taxonomy_single} assigned"
-msgstr "%{count} Hosts ohne %{taxonomy_single} Zuweisung"
+#, fuzzy
+msgid "%{count} host with no %{taxonomy_single} assigned"
+msgid_plural "%{count} hosts with no %{taxonomy_single} assigned"
+msgstr[0] "%{count} Hosts ohne %{taxonomy_single} Zuweisung"
+msgstr[1] "%{count} Hosts ohne %{taxonomy_single} Zuweisung"
 
 msgid "%{default_value} is not one of %{validator_rule}"
-msgstr ""
-
-msgid "%{host} - %{time} ago"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
@@ -106,15 +109,15 @@ msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr ""
 
 #, fuzzy
-msgid "*Clear Hostgroup*"
-msgstr "Hostgruppen"
-
-#, fuzzy
 msgid "*Clear environment*"
 msgstr "Alle Umgebungen"
 
 #, fuzzy
-msgid "*Inherit from hostgroup*"
+msgid "*Clear host group*"
+msgstr "Hostgruppen"
+
+#, fuzzy
+msgid "*Inherit from host group*"
 msgstr "Hostgruppen"
 
 msgid "<b>Description:</b> %{key}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}"
@@ -133,7 +136,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-msgid "A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
+msgid "A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
 msgstr ""
 
 msgid "A medium represents the source of one or more operating system's installation files, accessible via the network.\\n  It will probably be a mirror from the internet or a copy of one or more CD or DVDs."
@@ -181,9 +184,6 @@ msgstr "Selektiere Hosts"
 msgid "Add Bookmark"
 msgstr ""
 
-msgid "Add Combination"
-msgstr ""
-
 #, fuzzy
 msgid "Add Filter"
 msgstr "+ Filter hinzufügen"
@@ -209,6 +209,10 @@ msgstr ""
 
 msgid "Add a fact filter"
 msgstr "Fact Filter hinzufügen"
+
+#, fuzzy
+msgid "Add combination"
+msgstr "Lokation"
 
 msgid "Add:"
 msgstr ""
@@ -247,7 +251,8 @@ msgstr "Alle Domains"
 msgid "All Environments"
 msgstr "Alle Umgebungen"
 
-msgid "All Hostgroups"
+#, fuzzy
+msgid "All Host Groups"
 msgstr "Alle Hostgruppen"
 
 msgid "All Media"
@@ -298,6 +303,9 @@ msgstr ""
 msgid "An explicit layout for the partitions of your hard drive(s). E.G."
 msgstr ""
 
+msgid "Any Context"
+msgstr ""
+
 #, fuzzy
 msgid "Any Location"
 msgstr "Lokation"
@@ -338,12 +346,6 @@ msgstr ""
 msgid "Assign All"
 msgstr "Alle Zuweisen"
 
-msgid "Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}"
-msgstr "Alle %{count} Hosts ohne Zuweisung von %{taxonomy_type} zu %{taxonomy_name} sind zugewiesen"
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}"
-msgstr "Alle %{count} Hosts ohne Zuweisung von {taxonomy_upcase} zu %{taxonomy_name} sind zugewiesen"
-
 msgid "Assign Hosts to %s"
 msgstr "Zuweisung Hosts zu %s"
 
@@ -360,10 +362,16 @@ msgid "Assign Selected Hosts"
 msgstr "Selektiere Hosts"
 
 #, fuzzy
+msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
+msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
+msgstr[0] "Alle %{count} Hosts ohne Zuweisung von {taxonomy_upcase} zu %{taxonomy_name} sind zugewiesen"
+msgstr[1] "Alle %{count} Hosts ohne Zuweisung von {taxonomy_upcase} zu %{taxonomy_name} sind zugewiesen"
+
+#, fuzzy
 msgid "Assign to %s"
 msgstr "Zuweisung Hosts zu %s"
 
-msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using."
+msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using."
 msgstr ""
 
 #, fuzzy
@@ -636,6 +644,9 @@ msgstr "Umgebung"
 msgid "Change Group"
 msgstr ""
 
+msgid "Change your avatar at gravatar.com"
+msgstr ""
+
 msgid "Changed environments and puppet classes"
 msgstr ""
 
@@ -739,17 +750,9 @@ msgstr "Rechnerresource"
 msgid "Config Retrieval"
 msgstr "Konfigurationsvorlage"
 
-#, fuzzy
-msgid "Config Template"
-msgstr "Konfigurationsvorlage"
-
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
 msgid "Config template"
-msgstr "Konfigurationsvorlage"
-
-#, fuzzy
-msgid "Config templates"
 msgstr "Konfigurationsvorlage"
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -990,10 +993,6 @@ msgid "Edit Bookmark"
 msgstr ""
 
 #, fuzzy
-msgid "Edit Config Template"
-msgstr "Konfigurationsvorlage"
-
-#, fuzzy
 msgid "Edit Domain"
 msgstr "Alle Domains"
 
@@ -1003,10 +1002,6 @@ msgstr "Umgebung"
 
 msgid "Edit Global Parameter"
 msgstr ""
-
-#, fuzzy
-msgid "Edit Host"
-msgstr "Editiere %s"
 
 msgid "Edit LDAP Auth Source"
 msgstr ""
@@ -1027,8 +1022,9 @@ msgstr "Eigentschaften editieren"
 msgid "Edit Parameters"
 msgstr "Eigentschaften editieren"
 
-msgid "Edit Partition table"
-msgstr ""
+#, fuzzy
+msgid "Edit Partition Table"
+msgstr "Konfiguration Lokation"
 
 msgid "Edit Properties"
 msgstr "Eigentschaften editieren"
@@ -1050,6 +1046,10 @@ msgstr ""
 #, fuzzy
 msgid "Edit Subnet"
 msgstr "Sub-Netz"
+
+#, fuzzy
+msgid "Edit Template"
+msgstr "Konfigurationsvorlage"
 
 #, fuzzy
 msgid "Edit Trend %s"
@@ -1389,9 +1389,6 @@ msgstr ""
 msgid "Future content goes here!"
 msgstr ""
 
-msgid "General"
-msgstr ""
-
 msgid "General useful description, for example this kind of hardware needs a special BIOS setup"
 msgstr ""
 
@@ -1410,7 +1407,7 @@ msgstr ""
 msgid "Global variable or class Parameter, not both"
 msgstr ""
 
-msgid "Good Host Reports in the last %s"
+msgid "Good host reports in the last %s"
 msgstr ""
 
 msgid "Hardware"
@@ -1445,10 +1442,6 @@ msgstr ""
 msgid "Host Configuration Status"
 msgstr "Konfiguration Lokation"
 
-#, fuzzy
-msgid "Host Group"
-msgstr "Hostgruppen"
-
 msgid "Host Groups"
 msgstr "Hostgruppen"
 
@@ -1463,6 +1456,34 @@ msgstr ""
 msgid "Host details"
 msgstr "Fehlzuweisung anzeigen"
 
+#, fuzzy
+msgid "Host group"
+msgstr "Hostgruppen"
+
+#, fuzzy
+msgid "Host group / Environment"
+msgstr "Umgebung"
+
+#, fuzzy
+msgid "Host group and Environment"
+msgstr "Umgebung"
+
+#, fuzzy
+msgid "Host group configuration"
+msgstr "Konfiguration Lokation"
+
+#, fuzzy
+msgid "Host group hosts"
+msgstr "Hostgruppen Hosts"
+
+#, fuzzy
+msgid "Host group only"
+msgstr "Hostgruppen"
+
+#, fuzzy
+msgid "Host groups"
+msgstr "Hostgruppen"
+
 msgid "Host is pending for Build"
 msgstr ""
 
@@ -1471,13 +1492,6 @@ msgstr ""
 
 msgid "Host times seems to be adrift!"
 msgstr ""
-
-msgid "Host-group and Environment"
-msgstr ""
-
-#, fuzzy
-msgid "Host-group only"
-msgstr "Hostgruppen"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Build"
@@ -1568,21 +1582,6 @@ msgstr ""
 msgid "Hostgroup"
 msgstr "Hostgruppen"
 
-#, fuzzy
-msgid "Hostgroup / Environment"
-msgstr "Umgebung"
-
-#, fuzzy
-msgid "Hostgroup configuration"
-msgstr "Konfiguration Lokation"
-
-msgid "Hostgroup hosts"
-msgstr "Hostgruppen Hosts"
-
-#, fuzzy
-msgid "Hostgroups"
-msgstr "Hostgruppen"
-
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
 msgid "Hostgroup|Ancestry"
@@ -1624,13 +1623,7 @@ msgstr ""
 msgid "Hosts Inventory"
 msgstr ""
 
-msgid "Hosts With Alerts Disabled"
-msgstr ""
-
-msgid "Hosts With No Reports"
-msgstr ""
-
-msgid "Hosts in Error State"
+msgid "Hosts in error state"
 msgstr ""
 
 msgid "Hosts that had pending changes"
@@ -1645,13 +1638,19 @@ msgstr ""
 msgid "Hosts which didn't run puppet in the last %s"
 msgstr ""
 
+msgid "Hosts with alerts disabled"
+msgstr ""
+
 msgid "Hosts with errors"
+msgstr ""
+
+msgid "Hosts with no reports"
 msgstr ""
 
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-msgid "How Templates are determined"
+msgid "How templates are determined"
 msgstr ""
 
 msgid "How values are validated"
@@ -1724,6 +1723,10 @@ msgid "Image|Uuid"
 msgstr ""
 
 #, fuzzy
+msgid "Import"
+msgstr "Alle Benutzer"
+
+#, fuzzy
 msgid "Import Subnets"
 msgstr "Sub-Netze"
 
@@ -1758,7 +1761,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime."
+msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime."
 msgstr ""
 
 msgid "Include this host within Foreman reporting"
@@ -1901,7 +1904,7 @@ msgstr "Ausgeloggt - Bis bald"
 msgid "Logged-in"
 msgstr ""
 
-msgid "Login &#187;"
+msgid "Login"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1980,13 +1983,22 @@ msgid "Manage Bookmarks"
 msgstr ""
 
 #, fuzzy
+msgid "Manage Locations"
+msgstr "Lokation"
+
+#, fuzzy
+msgid "Manage Organizations"
+msgstr "Organisationen"
+
+#, fuzzy
 msgid "Manage host"
 msgstr "Eigene Hosts"
 
 msgid "Manually Assign"
 msgstr "Manuell Zuweisen"
 
-msgid "Manually select and assign Hosts with No %s"
+#, fuzzy
+msgid "Manually select and assign hosts with no %s"
 msgstr "Selektiere und weise Hosts ohne %s manuell zu"
 
 #, fuzzy
@@ -2167,7 +2179,7 @@ msgid "New Host"
 msgstr "Neuer %s"
 
 #, fuzzy
-msgid "New Hostgroup"
+msgid "New Host Group"
 msgstr "Hostgruppen"
 
 msgid "New Image"
@@ -2201,11 +2213,9 @@ msgstr "Organisationen"
 msgid "New Parameter"
 msgstr ""
 
-msgid "New Partition Table layout"
-msgstr ""
-
-msgid "New Partition table layout"
-msgstr ""
+#, fuzzy
+msgid "New Partition Table"
+msgstr "Konfiguration Lokation"
 
 msgid "New Proxy"
 msgstr ""
@@ -2248,14 +2258,7 @@ msgstr ""
 msgid "New compute resource"
 msgstr "Rechnerresource"
 
-#, fuzzy
-msgid "New hostgroup"
-msgstr "Hostgruppen"
-
 msgid "New installation medium"
-msgstr ""
-
-msgid "New partition table"
 msgstr ""
 
 #, fuzzy
@@ -2281,37 +2284,7 @@ msgstr ""
 msgid "No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings"
 msgstr ""
 
-#, fuzzy
-msgid "No Environment selected!"
-msgstr "Umgebungen"
-
-msgid "No History Found"
-msgstr ""
-
-#, fuzzy
-msgid "No Hostgroup selected!"
-msgstr "Hostgruppen Hosts"
-
-msgid "No Hosts selected"
-msgstr ""
-
-msgid "No Preference"
-msgstr ""
-
-msgid "No Subnets selected"
-msgstr ""
-
 msgid "No TFTP proxies defined, can't continue"
-msgstr ""
-
-#, fuzzy
-msgid "No Template found"
-msgstr "Vorlagen"
-
-msgid "No Trend Counter Defined."
-msgstr ""
-
-msgid "No Trend Counter Found."
 msgstr ""
 
 msgid "No changes"
@@ -2321,14 +2294,30 @@ msgstr ""
 msgid "No domains"
 msgstr "Alle Domains"
 
+#, fuzzy
+msgid "No environment selected!"
+msgstr "Umgebungen"
+
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
 
 msgid "No finish templates were found for this host, make sure you define at least one in your %s settings"
 msgstr ""
 
+#, fuzzy
+msgid "No history found"
+msgstr "Vorlagen"
+
+#, fuzzy
+msgid "No host group selected!"
+msgstr "Hostgruppen Hosts"
+
 msgid "No hosts are mismatched!"
 msgstr "Keine Hosts haben Fehlzuweisungen!"
+
+#, fuzzy
+msgid "No hosts selected"
+msgstr "Hostgruppen Hosts"
 
 msgid "No hosts were found with that id or name"
 msgstr ""
@@ -2337,6 +2326,9 @@ msgid "No new subnets found"
 msgstr ""
 
 msgid "No parameters were allocated to the selected hosts, can't mass assign."
+msgstr ""
+
+msgid "No preference"
 msgstr ""
 
 msgid "No puppet activity for this host in the last %s days"
@@ -2353,8 +2345,23 @@ msgstr ""
 msgid "No subnets"
 msgstr "Sub-Netze"
 
+#, fuzzy
+msgid "No subnets selected"
+msgstr "Umgebungen"
+
+#, fuzzy
+msgid "No template found"
+msgstr "Vorlagen"
+
 msgid "No templates found!"
 msgstr ""
+
+msgid "No trend counter defined."
+msgstr ""
+
+#, fuzzy
+msgid "No trend counter found."
+msgstr "Vorlagen"
 
 msgid "No value error"
 msgstr ""
@@ -2429,8 +2436,9 @@ msgstr ""
 msgid "Number of Hosts"
 msgstr "Neuer %s"
 
-msgid "Number of Values"
-msgstr ""
+#, fuzzy
+msgid "Number of values"
+msgstr "Neuer %s"
 
 #. host's status: first character of "OK"
 msgid "O"
@@ -2504,18 +2512,15 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
+#, fuzzy
+msgid "Operating system"
+msgstr "Eigentschaften editieren"
+
 msgid "Operating system default"
 msgstr ""
 
 msgid "Operating systems"
 msgstr ""
-
-msgid "Operating<br>System"
-msgstr ""
-
-#, fuzzy
-msgid "Operating<br>system"
-msgstr "Eigentschaften editieren"
 
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
@@ -2593,11 +2598,12 @@ msgstr ""
 msgid "Other reports for this host"
 msgstr ""
 
-msgid "Out Of Sync Hosts"
-msgstr ""
-
 msgid "Out of sync"
 msgstr ""
+
+#, fuzzy
+msgid "Out of sync Hosts"
+msgstr "Neuer %s"
 
 msgid "Override Value"
 msgstr ""
@@ -2668,11 +2674,12 @@ msgstr "Fact Filter hinzufügen"
 msgid "Parent"
 msgstr ""
 
-msgid "Partition Table"
-msgstr ""
-
 msgid "Partition Tables"
 msgstr ""
+
+#, fuzzy
+msgid "Partition table"
+msgstr "Konfiguration Lokation"
 
 #, fuzzy
 msgid "Partition table configuration"
@@ -2727,7 +2734,11 @@ msgid "Please save the Operating System first and try again."
 msgstr ""
 
 #, fuzzy
-msgid "Please select an Environment first"
+msgid "Please select an environment first"
+msgstr "Alle Umgebungen"
+
+#, fuzzy
+msgid "Please select an image"
 msgstr "Alle Umgebungen"
 
 msgid "Please try to update your request"
@@ -2788,11 +2799,23 @@ msgstr ""
 msgid "Provisioning Support is disabled or this host is not managed"
 msgstr ""
 
+#, fuzzy
+msgid "Provisioning Template"
+msgstr "Konfigurationsvorlage"
+
 msgid "Provisioning Template content changed %s"
 msgstr ""
 
 #, fuzzy
 msgid "Provisioning Templates"
+msgstr "Konfigurationsvorlage"
+
+#, fuzzy
+msgid "Provisioning template"
+msgstr "Konfigurationsvorlage"
+
+#, fuzzy
+msgid "Provisioning templates"
 msgstr "Konfigurationsvorlage"
 
 msgid "Proxies"
@@ -2812,9 +2835,6 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Os family"
-msgstr ""
-
-msgid "Puppet"
 msgstr ""
 
 msgid "Puppet CA"
@@ -2861,6 +2881,10 @@ msgstr "Eigentschaften editieren"
 
 msgid "Puppet classes and environment importer"
 msgstr ""
+
+#, fuzzy
+msgid "Puppet environments"
+msgstr "Umgebungen"
 
 msgid "Puppet error on %s"
 msgstr ""
@@ -3076,22 +3100,15 @@ msgid "Select"
 msgstr "Selektiere Hosts"
 
 #, fuzzy
+msgid "Select Action"
+msgstr "Neue Lokation"
+
+#, fuzzy
 msgid "Select All"
-msgstr "Selektiere Hosts"
-
-#, fuzzy
-msgid "Select Environment"
-msgstr "Alle Umgebungen"
-
-#, fuzzy
-msgid "Select Host Group"
 msgstr "Selektiere Hosts"
 
 msgid "Select Hosts"
 msgstr "Selektiere Hosts"
-
-msgid "Select Hosts to Assign to %s"
-msgstr "Selektiere Hosts um sie %s zu zuweisen"
 
 #, fuzzy
 msgid "Select Location"
@@ -3107,6 +3124,21 @@ msgstr ""
 #, fuzzy
 msgid "Select all"
 msgstr "Selektiere Hosts"
+
+msgid "Select all items in this page"
+msgstr ""
+
+#, fuzzy
+msgid "Select environment"
+msgstr "Alle Umgebungen"
+
+#, fuzzy
+msgid "Select host group"
+msgstr "Selektiere Hosts"
+
+#, fuzzy
+msgid "Select hosts to assign to %s"
+msgstr "Selektiere Hosts um sie %s zu zuweisen"
 
 #, fuzzy
 msgid "Select template"
@@ -3223,7 +3255,8 @@ msgstr ""
 msgid "Size (GB)"
 msgstr ""
 
-msgid "Skip Assign Hosts and Proceed to Edit %s Settings"
+#, fuzzy
+msgid "Skip assign hosts and proceed to edit %s settings"
 msgstr "Überspringe zugewiesene Hosts und fahre mit dem editieren der Einstellungen von %s fort"
 
 msgid "Skipped"
@@ -3534,7 +3567,7 @@ msgstr ""
 msgid "The full DNS Domain name"
 msgstr ""
 
-msgid "The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration."
+msgid "The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration."
 msgstr ""
 
 msgid "The hostname where your Foreman instance is reachable"
@@ -3549,7 +3582,7 @@ msgstr ""
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
+msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
 msgstr ""
 
 msgid "The order in which values are resolved"
@@ -3564,17 +3597,13 @@ msgstr ""
 msgid "The user that is used to ssh into the instance, normally ec2-user, ubuntu, root etc"
 msgstr ""
 
-msgid "There are"
+msgid "There are two strategies when using host groups."
 msgstr ""
 
-msgid "There are two strategies when using hostgroups."
-msgstr ""
-
-msgid "There aren't any locations yet."
-msgstr ""
-
-msgid "There aren't any organizations yet."
-msgstr ""
+msgid "There is"
+msgid_plural "There are"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "There was an error creating the PXE Default file: %s"
 msgstr ""
@@ -3711,7 +3740,7 @@ msgstr ""
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-msgid "Unable to find templates As this Host has no Operating System"
+msgid "Unable to find templates as this host has no operating system"
 msgstr ""
 
 msgid "Unable to generate output, Check log files\\n"
@@ -3749,10 +3778,11 @@ msgstr ""
 msgid "Updated all hosts!"
 msgstr ""
 
-msgid "Updated hosts: Changed Environment"
-msgstr ""
+#, fuzzy
+msgid "Updated hosts: changed environment"
+msgstr "Umgebung"
 
-msgid "Updated hosts: Changed Hostgroup"
+msgid "Updated hosts: changed host group"
 msgstr ""
 
 msgid "Use Signo SSO for login"
@@ -3910,10 +3940,13 @@ msgstr ""
 msgid "VCenter/Server"
 msgstr ""
 
-msgid "Valid Host group and Environment Combinations"
+msgid "VM"
 msgstr ""
 
 msgid "Valid from"
+msgstr ""
+
+msgid "Valid host group and environment combinations"
 msgstr ""
 
 msgid "Validation types"
@@ -3935,9 +3968,6 @@ msgid "Version"
 msgstr ""
 
 msgid "View last report details"
-msgstr ""
-
-msgid "Virtual Machine"
 msgstr ""
 
 msgid "Virtual Machines"
@@ -3970,13 +4000,13 @@ msgstr ""
 msgid "What is a <a href=\"%s\" rel=\"external\">Smart variable</a>?"
 msgstr ""
 
-msgid "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"
-msgstr ""
-
 msgid "When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:"
 msgstr ""
 
 msgid "When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments"
+msgstr ""
+
+msgid "When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"
 msgstr ""
 
 msgid "When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see"
@@ -4054,7 +4084,7 @@ msgstr ""
 msgid "You may also find the"
 msgstr ""
 
-msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration."
+msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration."
 msgstr ""
 
 msgid "You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host."
@@ -4283,10 +4313,17 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
+msgid "items selected. Uncheck to Clear"
+msgstr ""
+
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
 msgstr[1] ""
+
+#, fuzzy
+msgid "location"
+msgstr "Lokation"
 
 #, fuzzy
 msgid "locations"
@@ -4320,8 +4357,9 @@ msgstr ""
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-msgid "not has %s"
-msgstr "hat nicht %s"
+#, fuzzy
+msgid "organization"
+msgstr "Organisationen"
 
 msgid "organizations"
 msgstr "Organisationen"
@@ -4332,7 +4370,7 @@ msgstr ""
 msgid "page"
 msgstr ""
 
-msgid "parameters require an associated domain, host or hostgroup"
+msgid "parameters require an associated domain, host or host group"
 msgstr ""
 
 msgid "plus all"
@@ -4439,6 +4477,10 @@ msgstr ""
 #~ msgstr "Passwort"
 
 #, fuzzy
+#~ msgid "Assign all %{count} hosts with no %{taxonomy_type} to %{taxonomy_name}"
+#~ msgstr "Alle %{count} Hosts ohne Zuweisung von %{taxonomy_type} zu %{taxonomy_name} sind zugewiesen"
+
+#, fuzzy
 #~ msgid "Attr Firstname"
 #~ msgstr "Vornamen"
 
@@ -4450,6 +4492,18 @@ msgstr ""
 #~ msgid "Config Path"
 #~ msgstr "Konfigurationsvorlage"
 
+#, fuzzy
+#~ msgid "Config Template"
+#~ msgstr "Konfigurationsvorlage"
+
+#, fuzzy
+#~ msgid "Config templates"
+#~ msgstr "Konfigurationsvorlage"
+
+#, fuzzy
+#~ msgid "Edit Host"
+#~ msgstr "Editiere %s"
+
 #~ msgid "First Name"
 #~ msgstr "Vornamen"
 
@@ -4457,12 +4511,36 @@ msgstr ""
 #~ msgid "Full Name"
 #~ msgstr "Vornamen"
 
+#, fuzzy
+#~ msgid "Host Group"
+#~ msgstr "Hostgruppen"
+
+#, fuzzy
+#~ msgid "Hostgroups"
+#~ msgstr "Hostgruppen"
+
 #~ msgid "Last Name"
 #~ msgstr "Nachname"
 
 #, fuzzy
 #~ msgid "Match"
 #~ msgstr "Fehlzuweisung"
+
+#, fuzzy
+#~ msgid "New Host group"
+#~ msgstr "Hostgruppen"
+
+#, fuzzy
+#~ msgid "New Hostgroup"
+#~ msgstr "Hostgruppen"
+
+#, fuzzy
+#~ msgid "New hostgroup"
+#~ msgstr "Hostgruppen"
+
+#, fuzzy
+#~ msgid "Operating<br>system"
+#~ msgstr "Eigentschaften editieren"
 
 #, fuzzy
 #~ msgid "Release Name"
@@ -4475,3 +4553,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Template"
 #~ msgstr "Vorlagen"
+
+#~ msgid "not has %s"
+#~ msgstr "hat nicht %s"

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -1,18 +1,18 @@
-# Template file for strings which can be localized in the Foreman Application.
 #
 # This file is distributed under the same license as the Foreman.
 #
 # Translators:
-# Bryan Kearney
 #
-#, fuzzy
+#
+# Translators:
+# domcleal <dcleal@redhat.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-23 15:23+0200\n"
-"PO-Revision-Date: 2013-03-01 15:45-0500\n"
-"Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
+"POT-Creation-Date: 2013-05-07 18:30+0100\n"
+"PO-Revision-Date: 2013-05-07 13:46+0100\n"
+"Last-Translator: domcleal <dcleal@redhat.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
+msgstr ""
+
+msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
 msgid "%s Distribution"
@@ -64,13 +67,12 @@ msgid_plural "%s weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%{count} hosts with no %{taxonomy_single} assigned"
-msgstr ""
+msgid "%{count} host with no %{taxonomy_single} assigned"
+msgid_plural "%{count} hosts with no %{taxonomy_single} assigned"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "%{default_value} is not one of %{validator_rule}"
-msgstr ""
-
-msgid "%{host} - %{time} ago"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
@@ -103,13 +105,13 @@ msgstr ""
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr ""
 
-msgid "*Clear Hostgroup*"
-msgstr ""
-
 msgid "*Clear environment*"
 msgstr ""
 
-msgid "*Inherit from hostgroup*"
+msgid "*Clear host group*"
+msgstr ""
+
+msgid "*Inherit from host group*"
 msgstr ""
 
 msgid "<b>Description:</b> %{key}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}"
@@ -128,7 +130,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-msgid "A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
+msgid "A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
 msgstr ""
 
 msgid "A medium represents the source of one or more operating system's installation files, accessible via the network.\\n  It will probably be a mirror from the internet or a copy of one or more CD or DVDs."
@@ -173,9 +175,6 @@ msgstr ""
 msgid "Add Bookmark"
 msgstr ""
 
-msgid "Add Combination"
-msgstr ""
-
 msgid "Add Filter"
 msgstr ""
 
@@ -198,6 +197,9 @@ msgid "Add Volume"
 msgstr ""
 
 msgid "Add a fact filter"
+msgstr ""
+
+msgid "Add combination"
 msgstr ""
 
 msgid "Add:"
@@ -236,8 +238,9 @@ msgstr ""
 msgid "All Environments"
 msgstr ""
 
-msgid "All Hostgroups"
-msgstr ""
+#, fuzzy
+msgid "All Host Groups"
+msgstr "Host Group"
 
 msgid "All Media"
 msgstr ""
@@ -284,6 +287,9 @@ msgstr ""
 msgid "An explicit layout for the partitions of your hard drive(s). E.G."
 msgstr ""
 
+msgid "Any Context"
+msgstr ""
+
 msgid "Any Location"
 msgstr ""
 
@@ -311,18 +317,12 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Architecture|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Are you sure?"
 msgstr ""
 
 msgid "Assign All"
-msgstr ""
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}"
-msgstr ""
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}"
 msgstr ""
 
 msgid "Assign Hosts to %s"
@@ -337,10 +337,15 @@ msgstr ""
 msgid "Assign Selected Hosts"
 msgstr ""
 
+msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
+msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Assign to %s"
 msgstr ""
 
-msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using."
+msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using."
 msgstr ""
 
 msgid "Association"
@@ -357,47 +362,47 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Action"
-msgstr ""
+msgstr "Action"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Associated name"
-msgstr ""
+msgstr "Associated name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Associated type"
-msgstr ""
+msgstr "Associated type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Auditable name"
-msgstr ""
+msgstr "Auditable name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Auditable type"
-msgstr ""
+msgstr "Auditable type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Audited changes"
-msgstr ""
+msgstr "Audited changes"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Comment"
-msgstr ""
+msgstr "Comment"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Remote address"
-msgstr ""
+msgstr "Remote address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|User type"
-msgstr ""
+msgstr "User type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Username"
-msgstr ""
+msgstr "Username"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Audited::Adapters::ActiveRecord::Audit|Version"
-msgstr ""
+msgstr "Version"
 
 msgid "Audits"
 msgstr ""
@@ -408,51 +413,51 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Account"
-msgstr ""
+msgstr "Account username"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Account password"
-msgstr ""
+msgstr "Account password"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Attr firstname"
-msgstr ""
+msgstr "First name attribute"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Attr lastname"
-msgstr ""
+msgstr "Surname attribute"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Attr login"
-msgstr ""
+msgstr "Login name attribute"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Attr mail"
-msgstr ""
+msgstr "Email address attribute"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Base dn"
-msgstr ""
+msgstr "Base DN"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Host"
-msgstr ""
+msgstr "Server"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Onthefly register"
-msgstr ""
+msgstr "Automatically create accounts in Foreman"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Port"
-msgstr ""
+msgstr "Port"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Tls"
-msgstr ""
+msgstr "TLS"
 
 msgid "Authentication Source Configuration"
 msgstr ""
@@ -530,23 +535,23 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark|Controller"
-msgstr ""
+msgstr "Controller"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark|Owner type"
-msgstr ""
+msgstr "Owner type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark|Public"
-msgstr ""
+msgstr "Public"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark|Query"
-msgstr ""
+msgstr "Search query"
 
 msgid "Bootable"
 msgstr ""
@@ -603,6 +608,9 @@ msgid "Change Environment"
 msgstr ""
 
 msgid "Change Group"
+msgstr ""
+
+msgid "Change your avatar at gravatar.com"
 msgstr ""
 
 msgid "Changed environments and puppet classes"
@@ -668,56 +676,50 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Attrs"
-msgstr ""
+msgstr "Attributes"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Description"
-msgstr ""
+msgstr "Description"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Password"
-msgstr ""
+msgstr "Password"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Url"
-msgstr ""
+msgstr "URL"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|User"
-msgstr ""
+msgstr "Username"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Uuid"
-msgstr ""
+msgstr "UUID"
 
 msgid "Config Retrieval"
 msgstr ""
 
-msgid "Config Template"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Config template"
-msgstr ""
-
-msgid "Config templates"
-msgstr ""
+msgstr "Provisioning template"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ConfigTemplate|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ConfigTemplate|Snippet"
-msgstr ""
+msgstr "Snippet"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "ConfigTemplate|Template"
-msgstr ""
+msgstr "Template"
 
 msgid "Configuration"
 msgstr ""
@@ -903,11 +905,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Domain|Fullname"
-msgstr ""
+msgstr "Description"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Domain|Name"
-msgstr ""
+msgstr "DNS domain"
 
 #. host's status: first character of "error"
 msgid "E"
@@ -931,9 +933,6 @@ msgstr ""
 msgid "Edit Bookmark"
 msgstr ""
 
-msgid "Edit Config Template"
-msgstr ""
-
 msgid "Edit Domain"
 msgstr ""
 
@@ -941,9 +940,6 @@ msgid "Edit Environment"
 msgstr ""
 
 msgid "Edit Global Parameter"
-msgstr ""
-
-msgid "Edit Host"
 msgstr ""
 
 msgid "Edit LDAP Auth Source"
@@ -961,7 +957,7 @@ msgstr ""
 msgid "Edit Parameters"
 msgstr ""
 
-msgid "Edit Partition table"
+msgid "Edit Partition Table"
 msgstr ""
 
 msgid "Edit Properties"
@@ -981,6 +977,10 @@ msgstr ""
 
 msgid "Edit Subnet"
 msgstr ""
+
+#, fuzzy
+msgid "Edit Template"
+msgstr "Provisioning template"
 
 msgid "Edit Trend %s"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Environment|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Error"
 msgstr ""
@@ -1096,11 +1096,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "FactName|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "FactValue|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Facts"
 msgstr ""
@@ -1163,7 +1163,7 @@ msgid "Failed to import report"
 msgstr ""
 
 msgid "Failed to initialize the PuppetCA proxy: %s"
-msgstr ""
+msgstr "Failed to initialise the PuppetCA proxy: %s"
 
 msgid "Failed to launch script on %{name}: %{e}"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Feature|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Fetch TFTP boot files for %s"
 msgstr ""
@@ -1296,9 +1296,6 @@ msgstr ""
 msgid "Future content goes here!"
 msgstr ""
 
-msgid "General"
-msgstr ""
-
 msgid "General useful description, for example this kind of hardware needs a special BIOS setup"
 msgstr ""
 
@@ -1317,7 +1314,7 @@ msgstr ""
 msgid "Global variable or class Parameter, not both"
 msgstr ""
 
-msgid "Good Host Reports in the last %s"
+msgid "Good host reports in the last %s"
 msgstr ""
 
 msgid "Hardware"
@@ -1350,11 +1347,9 @@ msgstr ""
 msgid "Host Configuration Status"
 msgstr ""
 
-msgid "Host Group"
-msgstr ""
-
+#, fuzzy
 msgid "Host Groups"
-msgstr ""
+msgstr "Host Group"
 
 msgid "Host Parameters"
 msgstr ""
@@ -1363,6 +1358,30 @@ msgid "Host audit entries"
 msgstr ""
 
 msgid "Host details"
+msgstr ""
+
+msgid "Host group"
+msgstr ""
+
+msgid "Host group / Environment"
+msgstr ""
+
+#, fuzzy
+msgid "Host group and Environment"
+msgstr "Environment"
+
+msgid "Host group configuration"
+msgstr ""
+
+#, fuzzy
+msgid "Host group hosts"
+msgstr "Host Group"
+
+#, fuzzy
+msgid "Host group only"
+msgstr "Host Group"
+
+msgid "Host groups"
 msgstr ""
 
 msgid "Host is pending for Build"
@@ -1374,139 +1393,121 @@ msgstr ""
 msgid "Host times seems to be adrift!"
 msgstr ""
 
-msgid "Host-group and Environment"
-msgstr ""
-
-msgid "Host-group only"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Build"
-msgstr ""
+msgstr "Build mode"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
-msgstr ""
+msgstr "Certificate name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Comment"
-msgstr ""
+msgstr "Comment"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Disk"
-msgstr ""
+msgstr "Custom partition table"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Enabled"
-msgstr ""
+msgstr "Enabled"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Environment"
-msgstr ""
+msgstr "Environment"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
-msgstr ""
+msgstr "Image filename"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
-msgstr ""
+msgstr "Installed at"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Ip"
-msgstr ""
+msgstr "IP address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Last compile"
-msgstr ""
+msgstr "Last catalog compile time"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Last freshcheck"
-msgstr ""
+msgstr "Last fresh check time"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Last report"
-msgstr ""
+msgstr "Last report time"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Mac"
-msgstr ""
+msgstr "MAC address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Managed"
-msgstr ""
+msgstr "Managed mode"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Owner type"
-msgstr ""
+msgstr "Owner type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Puppet status"
-msgstr ""
+msgstr "Puppet status"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Root pass"
-msgstr ""
+msgstr "Root password"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Serial"
-msgstr ""
+msgstr "Serial number"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Use image"
-msgstr ""
+msgstr "Use an image"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Uuid"
-msgstr ""
+msgstr "UUID"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup"
-msgstr ""
-
-msgid "Hostgroup / Environment"
-msgstr ""
-
-msgid "Hostgroup configuration"
-msgstr ""
-
-msgid "Hostgroup hosts"
-msgstr ""
-
-msgid "Hostgroups"
-msgstr ""
+msgstr "Host Group"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Ancestry"
-msgstr ""
+msgstr "Ancestry"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Image file"
-msgstr ""
+msgstr "Image filename"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Label"
-msgstr ""
+msgstr "Label"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Root pass"
-msgstr ""
+msgstr "Root password"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Use image"
-msgstr ""
+msgstr "Use an image"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Vm defaults"
-msgstr ""
+msgstr "Virtual machine defaults"
 
 msgid "Hosts"
 msgstr ""
@@ -1514,13 +1515,7 @@ msgstr ""
 msgid "Hosts Inventory"
 msgstr ""
 
-msgid "Hosts With Alerts Disabled"
-msgstr ""
-
-msgid "Hosts With No Reports"
-msgstr ""
-
-msgid "Hosts in Error State"
+msgid "Hosts in error state"
 msgstr ""
 
 msgid "Hosts that had pending changes"
@@ -1535,13 +1530,19 @@ msgstr ""
 msgid "Hosts which didn't run puppet in the last %s"
 msgstr ""
 
+msgid "Hosts with alerts disabled"
+msgstr ""
+
 msgid "Hosts with errors"
+msgstr ""
+
+msgid "Hosts with no reports"
 msgstr ""
 
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-msgid "How Templates are determined"
+msgid "How templates are determined"
 msgstr ""
 
 msgid "How values are validated"
@@ -1598,18 +1599,21 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Image|Iam role"
-msgstr ""
+msgstr "IAM role"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Image|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Image|Username"
-msgstr ""
+msgstr "Username"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Image|Uuid"
+msgstr "UUID"
+
+msgid "Import"
 msgstr ""
 
 msgid "Import Subnets"
@@ -1645,7 +1649,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime."
+msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime."
 msgstr ""
 
 msgid "Include this host within Foreman reporting"
@@ -1705,11 +1709,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "KeyPair|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "KeyPair|Secret"
-msgstr ""
+msgstr "Secret"
 
 msgid "Keys"
 msgstr ""
@@ -1760,7 +1764,7 @@ msgid "Loading Images information"
 msgstr ""
 
 msgid "Location"
-msgstr ""
+msgstr "FOO"
 
 msgid "Location configuration"
 msgstr ""
@@ -1769,7 +1773,7 @@ msgid "Location/Organization"
 msgstr ""
 
 msgid "Locations"
-msgstr ""
+msgstr "FOOS"
 
 msgid "Locations are used to manage and differentiate the physical place where a system managed via Foreman is housed."
 msgstr ""
@@ -1783,7 +1787,7 @@ msgstr ""
 msgid "Logged-in"
 msgstr ""
 
-msgid "Login &#187;"
+msgid "Login"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1796,55 +1800,55 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Default value"
-msgstr ""
+msgstr "Default value"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Description"
-msgstr ""
+msgstr "Description"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Is param"
-msgstr ""
+msgstr "Is parameter"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Key"
-msgstr ""
+msgstr "Parameter"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Key type"
-msgstr ""
+msgstr "Parameter type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Lookup values count"
-msgstr ""
+msgstr "Number of values"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Override"
-msgstr ""
+msgstr "Override"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Path"
-msgstr ""
+msgstr "Path"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Required"
-msgstr ""
+msgstr "Required"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Validator rule"
-msgstr ""
+msgstr "Validator rule"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Validator type"
-msgstr ""
+msgstr "Validator type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupValue|Match"
-msgstr ""
+msgstr "Match"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "LookupValue|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "MAC Address"
 msgstr ""
@@ -1861,13 +1865,19 @@ msgstr ""
 msgid "Manage Bookmarks"
 msgstr ""
 
+msgid "Manage Locations"
+msgstr ""
+
+msgid "Manage Organizations"
+msgstr ""
+
 msgid "Manage host"
 msgstr ""
 
 msgid "Manually Assign"
 msgstr ""
 
-msgid "Manually select and assign Hosts with No %s"
+msgid "Manually select and assign hosts with no %s"
 msgstr ""
 
 msgid "Matcher"
@@ -1888,27 +1898,27 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Config path"
-msgstr ""
+msgstr "NFS configuration path"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Image path"
-msgstr ""
+msgstr "NFS image path"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Media path"
-msgstr ""
+msgstr "NFS media path"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Os family"
-msgstr ""
+msgstr "Operating system family"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Medium|Path"
-msgstr ""
+msgstr "Path"
 
 msgid "Memory"
 msgstr ""
@@ -1922,11 +1932,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Message|Digest"
-msgstr ""
+msgstr "Digest"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Metrics"
 msgstr ""
@@ -1949,19 +1959,19 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Model|Hardware model"
-msgstr ""
+msgstr "Hardware model"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Model|Info"
-msgstr ""
+msgstr "Information"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Model|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Model|Vendor class"
-msgstr ""
+msgstr "Vendor class"
 
 msgid "Modified"
 msgstr ""
@@ -2039,8 +2049,9 @@ msgstr ""
 msgid "New Host"
 msgstr ""
 
-msgid "New Hostgroup"
-msgstr ""
+#, fuzzy
+msgid "New Host Group"
+msgstr "Host Group"
 
 msgid "New Image"
 msgstr ""
@@ -2072,10 +2083,7 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New Partition Table layout"
-msgstr ""
-
-msgid "New Partition table layout"
+msgid "New Partition Table"
 msgstr ""
 
 msgid "New Proxy"
@@ -2114,13 +2122,7 @@ msgstr ""
 msgid "New compute resource"
 msgstr ""
 
-msgid "New hostgroup"
-msgstr ""
-
 msgid "New installation medium"
-msgstr ""
-
-msgid "New partition table"
 msgstr ""
 
 msgid "New role"
@@ -2128,51 +2130,24 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Attrs"
-msgstr ""
+msgstr "Attributes"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Ip"
-msgstr ""
+msgstr "IP address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Mac"
-msgstr ""
+msgstr "MAC address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings"
 msgstr ""
 
-msgid "No Environment selected!"
-msgstr ""
-
-msgid "No History Found"
-msgstr ""
-
-msgid "No Hostgroup selected!"
-msgstr ""
-
-msgid "No Hosts selected"
-msgstr ""
-
-msgid "No Preference"
-msgstr ""
-
-msgid "No Subnets selected"
-msgstr ""
-
 msgid "No TFTP proxies defined, can't continue"
-msgstr ""
-
-msgid "No Template found"
-msgstr ""
-
-msgid "No Trend Counter Defined."
-msgstr ""
-
-msgid "No Trend Counter Found."
 msgstr ""
 
 msgid "No changes"
@@ -2181,13 +2156,25 @@ msgstr ""
 msgid "No domains"
 msgstr ""
 
+msgid "No environment selected!"
+msgstr ""
+
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
 
 msgid "No finish templates were found for this host, make sure you define at least one in your %s settings"
 msgstr ""
 
+msgid "No history found"
+msgstr ""
+
+msgid "No host group selected!"
+msgstr ""
+
 msgid "No hosts are mismatched!"
+msgstr ""
+
+msgid "No hosts selected"
 msgstr ""
 
 msgid "No hosts were found with that id or name"
@@ -2197,6 +2184,9 @@ msgid "No new subnets found"
 msgstr ""
 
 msgid "No parameters were allocated to the selected hosts, can't mass assign."
+msgstr ""
+
+msgid "No preference"
 msgstr ""
 
 msgid "No puppet activity for this host in the last %s days"
@@ -2211,7 +2201,19 @@ msgstr ""
 msgid "No subnets"
 msgstr ""
 
+msgid "No subnets selected"
+msgstr ""
+
+msgid "No template found"
+msgstr ""
+
 msgid "No templates found!"
+msgstr ""
+
+msgid "No trend counter defined."
+msgstr ""
+
+msgid "No trend counter found."
 msgstr ""
 
 msgid "No value error"
@@ -2253,15 +2255,15 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Notice|Content"
-msgstr ""
+msgstr "Content"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Notice|Global"
-msgstr ""
+msgstr "Global"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Notice|Level"
-msgstr ""
+msgstr "Level"
 
 msgid "Notification disabled"
 msgstr ""
@@ -2281,7 +2283,7 @@ msgstr ""
 msgid "Number of Hosts"
 msgstr ""
 
-msgid "Number of Values"
+msgid "Number of values"
 msgstr ""
 
 #. host's status: first character of "OK"
@@ -2354,16 +2356,14 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
+#, fuzzy
+msgid "Operating system"
+msgstr "Name"
+
 msgid "Operating system default"
 msgstr ""
 
 msgid "Operating systems"
-msgstr ""
-
-msgid "Operating<br>System"
-msgstr ""
-
-msgid "Operating<br>system"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -2372,23 +2372,23 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Operatingsystem|Major"
-msgstr ""
+msgstr "Major version"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Operatingsystem|Minor"
-msgstr ""
+msgstr "Minor version"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Operatingsystem|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Operatingsystem|Nameindicator"
-msgstr ""
+msgstr "Name indicator"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Operatingsystem|Release name"
-msgstr ""
+msgstr "Release name"
 
 msgid "Operation"
 msgstr ""
@@ -2435,17 +2435,17 @@ msgstr ""
 msgid "Other reports for this host"
 msgstr ""
 
-msgid "Out Of Sync Hosts"
+msgid "Out of sync"
 msgstr ""
 
-msgid "Out of sync"
+msgid "Out of sync Hosts"
 msgstr ""
 
 msgid "Override Value"
 msgstr ""
 
 msgid "Override a Puppetclass Parameter"
-msgstr ""
+msgstr "Override a Puppet class parameter"
 
 msgid "Override this value"
 msgstr ""
@@ -2493,23 +2493,23 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
-msgstr ""
+msgstr "Priority"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Parent"
 msgstr ""
 
-msgid "Partition Table"
+msgid "Partition Tables"
 msgstr ""
 
-msgid "Partition Tables"
+msgid "Partition table"
 msgstr ""
 
 msgid "Partition table configuration"
@@ -2563,7 +2563,10 @@ msgstr ""
 msgid "Please save the Operating System first and try again."
 msgstr ""
 
-msgid "Please select an Environment first"
+msgid "Please select an environment first"
+msgstr ""
+
+msgid "Please select an image"
 msgstr ""
 
 msgid "Please try to update your request"
@@ -2623,33 +2626,42 @@ msgstr ""
 msgid "Provisioning Support is disabled or this host is not managed"
 msgstr ""
 
+#, fuzzy
+msgid "Provisioning Template"
+msgstr "Provisioning template"
+
 msgid "Provisioning Template content changed %s"
 msgstr ""
 
 msgid "Provisioning Templates"
 msgstr ""
 
+#, fuzzy
+msgid "Provisioning template"
+msgstr "Provisioning template"
+
+#, fuzzy
+msgid "Provisioning templates"
+msgstr "Provisioning templates"
+
 msgid "Proxies"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable"
-msgstr ""
+msgstr "Partition Table"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Layout"
-msgstr ""
+msgstr "Layout"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Os family"
-msgstr ""
-
-msgid "Puppet"
-msgstr ""
+msgstr "Operating system family"
 
 msgid "Puppet CA"
 msgstr ""
@@ -2693,6 +2705,9 @@ msgstr ""
 msgid "Puppet classes and environment importer"
 msgstr ""
 
+msgid "Puppet environments"
+msgstr ""
+
 msgid "Puppet error on %s"
 msgstr ""
 
@@ -2707,11 +2722,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Puppetclass"
-msgstr ""
+msgstr "Puppet class"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Puppetclass|Name"
-msgstr ""
+msgstr "Class name"
 
 msgid "Querying instance details for %s"
 msgstr ""
@@ -2782,15 +2797,15 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
-msgstr ""
+msgstr "Metrics"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Report|Reported at"
-msgstr ""
+msgstr "Report time"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Report|Status"
-msgstr ""
+msgstr "Status"
 
 msgid "Required Parameter"
 msgstr ""
@@ -2828,15 +2843,15 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Role|Builtin"
-msgstr ""
+msgstr "Built-in"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Role|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Role|Permissions"
-msgstr ""
+msgstr "Permissions"
 
 msgid "Run Puppet"
 msgstr ""
@@ -2895,19 +2910,13 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+msgid "Select Action"
+msgstr ""
+
 msgid "Select All"
 msgstr ""
 
-msgid "Select Environment"
-msgstr ""
-
-msgid "Select Host Group"
-msgstr ""
-
 msgid "Select Hosts"
-msgstr ""
-
-msgid "Select Hosts to Assign to %s"
 msgstr ""
 
 msgid "Select Location"
@@ -2920,6 +2929,18 @@ msgid "Select a period"
 msgstr ""
 
 msgid "Select all"
+msgstr ""
+
+msgid "Select all items in this page"
+msgstr ""
+
+msgid "Select environment"
+msgstr ""
+
+msgid "Select host group"
+msgstr ""
+
+msgid "Select hosts to assign to %s"
 msgstr ""
 
 msgid "Select template"
@@ -2949,27 +2970,27 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Category"
-msgstr ""
+msgstr "Category"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Default"
-msgstr ""
+msgstr "Default"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Description"
-msgstr ""
+msgstr "Description"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Settings type"
-msgstr ""
+msgstr "Settings type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Setting|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Should Foreman automate certificate signing upon provisioning new host"
 msgstr ""
@@ -3034,7 +3055,7 @@ msgstr ""
 msgid "Size (GB)"
 msgstr ""
 
-msgid "Skip Assign Hosts and Proceed to Edit %s Settings"
+msgid "Skip assign hosts and proceed to edit %s settings"
 msgstr ""
 
 msgid "Skipped"
@@ -3064,11 +3085,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
-msgstr ""
+msgstr "URL"
 
 msgid "Some or all hosts execution failed, Please check log files for more information"
 msgstr ""
@@ -3088,11 +3109,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Source|Digest"
-msgstr ""
+msgstr "Digest"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "State"
 msgstr ""
@@ -3121,43 +3142,43 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Dns primary"
-msgstr ""
+msgstr "Primary DNS server"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Dns secondary"
-msgstr ""
+msgstr "Secondary DNS server"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
-msgstr ""
+msgstr "Start of IP range"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Gateway"
-msgstr ""
+msgstr "Gateway address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
-msgstr ""
+msgstr "Network mask"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
-msgstr ""
+msgstr "Network address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
-msgstr ""
+msgstr "Priority"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|To"
-msgstr ""
+msgstr "End of IP range"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Vlanid"
-msgstr ""
+msgstr "VLAN ID"
 
 msgid "Success"
 msgstr ""
@@ -3201,7 +3222,7 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "TaxableTaxonomy|Taxable type"
-msgstr ""
+msgstr "Taxable type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Taxonomy"
@@ -3209,11 +3230,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Taxonomy|Ignore types"
-msgstr ""
+msgstr "All objects"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Taxonomy|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Template / Hardware Profile to use"
 msgstr ""
@@ -3233,7 +3254,7 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "TemplateKind|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Templates"
 msgstr ""
@@ -3281,7 +3302,7 @@ msgid "The class of CPU supplied in this machine. This is primarily used by Spar
 msgstr ""
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
-msgstr ""
+msgstr "The class of the machine as reported by the OpenBoot PROM. This is primarily used by Solaris SPARC builds and can be left blank for other architectures. The value can be determined on Solaris via `uname -i|cut -f2 -d`."
 
 msgid "The default administrator email address"
 msgstr ""
@@ -3325,7 +3346,7 @@ msgstr ""
 msgid "The full DNS Domain name"
 msgstr ""
 
-msgid "The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration."
+msgid "The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration."
 msgstr ""
 
 msgid "The hostname where your Foreman instance is reachable"
@@ -3340,7 +3361,7 @@ msgstr ""
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
+msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
 msgstr ""
 
 msgid "The order in which values are resolved"
@@ -3355,17 +3376,13 @@ msgstr ""
 msgid "The user that is used to ssh into the instance, normally ec2-user, ubuntu, root etc"
 msgstr ""
 
-msgid "There are"
+msgid "There are two strategies when using host groups."
 msgstr ""
 
-msgid "There are two strategies when using hostgroups."
-msgstr ""
-
-msgid "There aren't any locations yet."
-msgstr ""
-
-msgid "There aren't any organizations yet."
-msgstr ""
+msgid "There is"
+msgid_plural "There are"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "There was an error creating the PXE Default file: %s"
 msgstr ""
@@ -3421,11 +3438,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Token|Expires"
-msgstr ""
+msgstr "Expires"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Token|Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Total"
 msgstr ""
@@ -3449,7 +3466,7 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "TrendCounter|Count"
-msgstr ""
+msgstr "Count"
 
 msgid "Trends"
 msgstr ""
@@ -3459,19 +3476,19 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
-msgstr ""
+msgstr "Fact name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact value"
-msgstr ""
+msgstr "Fact value"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Name"
-msgstr ""
+msgstr "Name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Trendable type"
-msgstr ""
+msgstr "Trend type"
 
 msgid "Trigger a puppetrun on a node; requires that puppet run is enabled"
 msgstr ""
@@ -3500,7 +3517,7 @@ msgstr ""
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-msgid "Unable to find templates As this Host has no Operating System"
+msgid "Unable to find templates as this host has no operating system"
 msgstr ""
 
 msgid "Unable to generate output, Check log files\\n"
@@ -3536,10 +3553,10 @@ msgstr ""
 msgid "Updated all hosts!"
 msgstr ""
 
-msgid "Updated hosts: Changed Environment"
+msgid "Updated hosts: changed environment"
 msgstr ""
 
-msgid "Updated hosts: Changed Hostgroup"
+msgid "Updated hosts: changed host group"
 msgstr ""
 
 msgid "Use Signo SSO for login"
@@ -3577,19 +3594,19 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "UserFact|Andor"
-msgstr ""
+msgstr "and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "UserFact|Criteria"
-msgstr ""
+msgstr "Criteria"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "UserFact|Operator"
-msgstr ""
+msgstr "Operator"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "UserRole|Inherited from"
-msgstr ""
+msgstr "Inherited from"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Usergroup"
@@ -3601,11 +3618,11 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "UsergroupMember|Member type"
-msgstr ""
+msgstr "Member type"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Usergroup|Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Username"
 msgstr ""
@@ -3615,63 +3632,63 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Admin"
-msgstr ""
+msgstr "Administrator"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Compute resources andor"
-msgstr ""
+msgstr "Compute resources and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Domains andor"
-msgstr ""
+msgstr "Domains and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Facts andor"
-msgstr ""
+msgstr "Facts and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Filter on owner"
-msgstr ""
+msgstr "Filter on owner"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
-msgstr ""
+msgstr "First name"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Hostgroups andor"
-msgstr ""
+msgstr "Host groups and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Last login on"
-msgstr ""
+msgstr "Last login time"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Lastname"
-msgstr ""
+msgstr "Surname"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Locations andor"
-msgstr ""
+msgstr "Locations and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Login"
-msgstr ""
+msgstr "Username"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Mail"
-msgstr ""
+msgstr "Email address"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Organizations andor"
-msgstr ""
+msgstr "Organizations and/or"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Password hash"
-msgstr ""
+msgstr "Password hash"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "User|Password salt"
-msgstr ""
+msgstr "Password salt"
 
 msgid "Using the organization system provides a way to group resources together for easy management."
 msgstr ""
@@ -3682,10 +3699,13 @@ msgstr ""
 msgid "VCenter/Server"
 msgstr ""
 
-msgid "Valid Host group and Environment Combinations"
+msgid "VM"
 msgstr ""
 
 msgid "Valid from"
+msgstr ""
+
+msgid "Valid host group and environment combinations"
 msgstr ""
 
 msgid "Validation types"
@@ -3707,9 +3727,6 @@ msgid "Version"
 msgstr ""
 
 msgid "View last report details"
-msgstr ""
-
-msgid "Virtual Machine"
 msgstr ""
 
 msgid "Virtual Machines"
@@ -3742,13 +3759,13 @@ msgstr ""
 msgid "What is a <a href=\"%s\" rel=\"external\">Smart variable</a>?"
 msgstr ""
 
-msgid "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"
-msgstr ""
-
 msgid "When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:"
 msgstr ""
 
 msgid "When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments"
+msgstr ""
+
+msgid "When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"
 msgstr ""
 
 msgid "When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see"
@@ -3826,7 +3843,7 @@ msgstr ""
 msgid "You may also find the"
 msgstr ""
 
-msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration."
+msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration."
 msgstr ""
 
 msgid "You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host."
@@ -4051,10 +4068,17 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
+msgid "items selected. Uncheck to Clear"
+msgstr ""
+
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
 msgstr[1] ""
+
+#, fuzzy
+msgid "location"
+msgstr "FOO"
 
 msgid "locations"
 msgstr ""
@@ -4086,8 +4110,9 @@ msgstr ""
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-msgid "not has %s"
-msgstr ""
+#, fuzzy
+msgid "organization"
+msgstr "Organizations and/or"
 
 msgid "organizations"
 msgstr ""
@@ -4098,7 +4123,7 @@ msgstr ""
 msgid "page"
 msgstr ""
 
-msgid "parameters require an associated domain, host or hostgroup"
+msgid "parameters require an associated domain, host or host group"
 msgstr ""
 
 msgid "plus all"

--- a/locale/es/foreman.po
+++ b/locale/es/foreman.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-23 15:23+0200\n"
+"POT-Creation-Date: 2013-05-07 18:30+0100\n"
 "PO-Revision-Date: 2013-04-03 15:06-0100\n"
 "Last-Translator: Daniel Lobato Garcia <elobatocs@gmail.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -21,6 +21,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
+msgstr ""
+
+msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
 msgid "%s Distribution"
@@ -67,13 +70,13 @@ msgid_plural "%s weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%{count} hosts with no %{taxonomy_single} assigned"
-msgstr "%{count} hosts sin ninguna %{taxonomy_single} asignada"
+#, fuzzy
+msgid "%{count} host with no %{taxonomy_single} assigned"
+msgid_plural "%{count} hosts with no %{taxonomy_single} assigned"
+msgstr[0] "%{count} hosts sin ninguna %{taxonomy_single} asignada"
+msgstr[1] "%{count} hosts sin ninguna %{taxonomy_single} asignada"
 
 msgid "%{default_value} is not one of %{validator_rule}"
-msgstr ""
-
-msgid "%{host} - %{time} ago"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
@@ -107,15 +110,15 @@ msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr ""
 
 #, fuzzy
-msgid "*Clear Hostgroup*"
-msgstr "Grupo de Hosts"
-
-#, fuzzy
 msgid "*Clear environment*"
 msgstr "Todos los Entornos"
 
 #, fuzzy
-msgid "*Inherit from hostgroup*"
+msgid "*Clear host group*"
+msgstr "Grupo de Hosts"
+
+#, fuzzy
+msgid "*Inherit from host group*"
 msgstr "Grupo de Hosts"
 
 msgid "<b>Description:</b> %{key}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}"
@@ -134,7 +137,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-msgid "A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
+msgid "A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
 msgstr ""
 
 msgid "A medium represents the source of one or more operating system's installation files, accessible via the network.\\n  It will probably be a mirror from the internet or a copy of one or more CD or DVDs."
@@ -182,9 +185,6 @@ msgstr "Seleccionar Hosts"
 msgid "Add Bookmark"
 msgstr ""
 
-msgid "Add Combination"
-msgstr ""
-
 msgid "Add Filter"
 msgstr "Añadir filtro"
 
@@ -212,6 +212,10 @@ msgstr "Añadir filtro"
 
 msgid "Add a fact filter"
 msgstr "Añadir filtro de datos"
+
+#, fuzzy
+msgid "Add combination"
+msgstr "Lugares"
 
 msgid "Add:"
 msgstr ""
@@ -250,7 +254,8 @@ msgstr "Todos los Dominios"
 msgid "All Environments"
 msgstr "Todos los Entornos"
 
-msgid "All Hostgroups"
+#, fuzzy
+msgid "All Host Groups"
 msgstr "Todos los Grupos de Hosts"
 
 msgid "All Media"
@@ -301,6 +306,9 @@ msgstr ""
 msgid "An explicit layout for the partitions of your hard drive(s). E.G."
 msgstr ""
 
+msgid "Any Context"
+msgstr ""
+
 #, fuzzy
 msgid "Any Location"
 msgstr "Lugares"
@@ -341,12 +349,6 @@ msgstr ""
 msgid "Assign All"
 msgstr "Asignar a todos"
 
-msgid "Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}"
-msgstr "Asignar a todos %{count} los hosts sin %{taxonomy_type} a %{taxonomy_name}"
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}"
-msgstr "Asignar a todos %{count} los hosts sin %{taxonomy_upcase} a %{taxonomy_name}"
-
 msgid "Assign Hosts to %s"
 msgstr "Asignar hosts a %s"
 
@@ -363,10 +365,17 @@ msgid "Assign Selected Hosts"
 msgstr "Seleccionar Hosts"
 
 #, fuzzy
+msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
+msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
+msgstr[0] "Asignar a todos %{count} los hosts sin %{taxonomy_upcase} a %{taxonomy_name}"
+msgstr[1] "Asignar a todos %{count} los hosts sin %{taxonomy_upcase} a %{taxonomy_name}"
+
+#, fuzzy
 msgid "Assign to %s"
 msgstr "Asignar hosts a %s"
 
-msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using."
+#, fuzzy
+msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using."
 msgstr "Si asignas los hosts a %{taxonomy_name} , esto actualizará %{taxonomy_name} para que incluya todos los recursos que los hosts seleccionados estan usando actualmente."
 
 #, fuzzy
@@ -639,6 +648,9 @@ msgstr "Entorno"
 msgid "Change Group"
 msgstr ""
 
+msgid "Change your avatar at gravatar.com"
+msgstr ""
+
 msgid "Changed environments and puppet classes"
 msgstr ""
 
@@ -742,17 +754,9 @@ msgstr "Recursos de Computación"
 msgid "Config Retrieval"
 msgstr "PlantillaDeConfiguración"
 
-#, fuzzy
-msgid "Config Template"
-msgstr "PlantillaDeConfiguración"
-
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
 msgid "Config template"
-msgstr "PlantillaDeConfiguración"
-
-#, fuzzy
-msgid "Config templates"
 msgstr "PlantillaDeConfiguración"
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -996,10 +1000,6 @@ msgid "Edit Bookmark"
 msgstr ""
 
 #, fuzzy
-msgid "Edit Config Template"
-msgstr "PlantillaDeConfiguración"
-
-#, fuzzy
 msgid "Edit Domain"
 msgstr "Dominio"
 
@@ -1009,10 +1009,6 @@ msgstr "Entorno"
 
 msgid "Edit Global Parameter"
 msgstr ""
-
-#, fuzzy
-msgid "Edit Host"
-msgstr "Editar %s"
 
 msgid "Edit LDAP Auth Source"
 msgstr ""
@@ -1033,8 +1029,9 @@ msgstr "Editar Propiedades"
 msgid "Edit Parameters"
 msgstr "Editar Propiedades"
 
-msgid "Edit Partition table"
-msgstr ""
+#, fuzzy
+msgid "Edit Partition Table"
+msgstr "Configuracion de lugares"
 
 msgid "Edit Properties"
 msgstr "Editar Propiedades"
@@ -1056,6 +1053,10 @@ msgstr ""
 #, fuzzy
 msgid "Edit Subnet"
 msgstr "Subred"
+
+#, fuzzy
+msgid "Edit Template"
+msgstr "PlantillaDeConfiguración"
 
 #, fuzzy
 msgid "Edit Trend %s"
@@ -1395,9 +1396,6 @@ msgstr ""
 msgid "Future content goes here!"
 msgstr ""
 
-msgid "General"
-msgstr ""
-
 msgid "General useful description, for example this kind of hardware needs a special BIOS setup"
 msgstr ""
 
@@ -1416,7 +1414,7 @@ msgstr ""
 msgid "Global variable or class Parameter, not both"
 msgstr ""
 
-msgid "Good Host Reports in the last %s"
+msgid "Good host reports in the last %s"
 msgstr ""
 
 msgid "Hardware"
@@ -1451,10 +1449,6 @@ msgstr ""
 msgid "Host Configuration Status"
 msgstr "Configuracion de lugares"
 
-#, fuzzy
-msgid "Host Group"
-msgstr "Grupos de Hosts"
-
 msgid "Host Groups"
 msgstr "Grupos de Hosts"
 
@@ -1469,6 +1463,34 @@ msgstr ""
 msgid "Host details"
 msgstr "Detalles de la discordancia"
 
+#, fuzzy
+msgid "Host group"
+msgstr "Grupo de Hosts"
+
+#, fuzzy
+msgid "Host group / Environment"
+msgstr "Entorno"
+
+#, fuzzy
+msgid "Host group and Environment"
+msgstr "Entorno"
+
+#, fuzzy
+msgid "Host group configuration"
+msgstr "Configuracion de lugares"
+
+#, fuzzy
+msgid "Host group hosts"
+msgstr "Hosts en el Grupo de Hosts"
+
+#, fuzzy
+msgid "Host group only"
+msgstr "Grupo de Hosts"
+
+#, fuzzy
+msgid "Host groups"
+msgstr "Grupo de Hosts"
+
 msgid "Host is pending for Build"
 msgstr ""
 
@@ -1477,13 +1499,6 @@ msgstr ""
 
 msgid "Host times seems to be adrift!"
 msgstr ""
-
-msgid "Host-group and Environment"
-msgstr ""
-
-#, fuzzy
-msgid "Host-group only"
-msgstr "Grupo de Hosts"
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Build"
@@ -1574,21 +1589,6 @@ msgstr ""
 msgid "Hostgroup"
 msgstr "Grupo de Hosts"
 
-#, fuzzy
-msgid "Hostgroup / Environment"
-msgstr "Entorno"
-
-#, fuzzy
-msgid "Hostgroup configuration"
-msgstr "Configuracion de lugares"
-
-msgid "Hostgroup hosts"
-msgstr "Hosts en el Grupo de Hosts"
-
-#, fuzzy
-msgid "Hostgroups"
-msgstr "Grupo de Hosts"
-
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
 msgid "Hostgroup|Ancestry"
@@ -1630,13 +1630,7 @@ msgstr "Hosts"
 msgid "Hosts Inventory"
 msgstr ""
 
-msgid "Hosts With Alerts Disabled"
-msgstr ""
-
-msgid "Hosts With No Reports"
-msgstr ""
-
-msgid "Hosts in Error State"
+msgid "Hosts in error state"
 msgstr ""
 
 msgid "Hosts that had pending changes"
@@ -1651,13 +1645,19 @@ msgstr ""
 msgid "Hosts which didn't run puppet in the last %s"
 msgstr ""
 
+msgid "Hosts with alerts disabled"
+msgstr ""
+
 msgid "Hosts with errors"
+msgstr ""
+
+msgid "Hosts with no reports"
 msgstr ""
 
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-msgid "How Templates are determined"
+msgid "How templates are determined"
 msgstr ""
 
 msgid "How values are validated"
@@ -1730,6 +1730,10 @@ msgid "Image|Uuid"
 msgstr ""
 
 #, fuzzy
+msgid "Import"
+msgstr "Todos los usuarios"
+
+#, fuzzy
 msgid "Import Subnets"
 msgstr "Subredes"
 
@@ -1764,7 +1768,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime."
+msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime."
 msgstr ""
 
 msgid "Include this host within Foreman reporting"
@@ -1907,8 +1911,8 @@ msgstr "Sesión cerrada - Hasta pronto'"
 msgid "Logged-in"
 msgstr ""
 
-msgid "Login &#187;"
-msgstr "Abrir sesión &#187;"
+msgid "Login"
+msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Lookup key"
@@ -1986,13 +1990,22 @@ msgid "Manage Bookmarks"
 msgstr ""
 
 #, fuzzy
+msgid "Manage Locations"
+msgstr "Lugares"
+
+#, fuzzy
+msgid "Manage Organizations"
+msgstr "Organizaciones"
+
+#, fuzzy
 msgid "Manage host"
 msgstr "Hosts propios"
 
 msgid "Manually Assign"
 msgstr "Asignar manualmente"
 
-msgid "Manually select and assign Hosts with No %s"
+#, fuzzy
+msgid "Manually select and assign hosts with no %s"
 msgstr "Seleccionar y asignar manualmente Hosts sin %s"
 
 #, fuzzy
@@ -2177,7 +2190,7 @@ msgid "New Host"
 msgstr "Nuevo %s"
 
 #, fuzzy
-msgid "New Hostgroup"
+msgid "New Host Group"
 msgstr "Grupo de Hosts"
 
 msgid "New Image"
@@ -2212,11 +2225,9 @@ msgstr "Organizaciones"
 msgid "New Parameter"
 msgstr ""
 
-msgid "New Partition Table layout"
-msgstr ""
-
-msgid "New Partition table layout"
-msgstr ""
+#, fuzzy
+msgid "New Partition Table"
+msgstr "Configuracion de lugares"
 
 msgid "New Proxy"
 msgstr ""
@@ -2259,14 +2270,7 @@ msgstr ""
 msgid "New compute resource"
 msgstr "Recursos de computación"
 
-#, fuzzy
-msgid "New hostgroup"
-msgstr "Grupo de Hosts"
-
 msgid "New installation medium"
-msgstr ""
-
-msgid "New partition table"
 msgstr ""
 
 #, fuzzy
@@ -2292,37 +2296,7 @@ msgstr ""
 msgid "No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings"
 msgstr ""
 
-#, fuzzy
-msgid "No Environment selected!"
-msgstr "Entornos"
-
-msgid "No History Found"
-msgstr ""
-
-#, fuzzy
-msgid "No Hostgroup selected!"
-msgstr "Hosts en el Grupo de Hosts"
-
-msgid "No Hosts selected"
-msgstr ""
-
-msgid "No Preference"
-msgstr ""
-
-msgid "No Subnets selected"
-msgstr ""
-
 msgid "No TFTP proxies defined, can't continue"
-msgstr ""
-
-#, fuzzy
-msgid "No Template found"
-msgstr "Plantill"
-
-msgid "No Trend Counter Defined."
-msgstr ""
-
-msgid "No Trend Counter Found."
 msgstr ""
 
 msgid "No changes"
@@ -2332,14 +2306,30 @@ msgstr ""
 msgid "No domains"
 msgstr "Dominios"
 
+#, fuzzy
+msgid "No environment selected!"
+msgstr "Entornos"
+
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
 
 msgid "No finish templates were found for this host, make sure you define at least one in your %s settings"
 msgstr ""
 
+#, fuzzy
+msgid "No history found"
+msgstr "Plantill"
+
+#, fuzzy
+msgid "No host group selected!"
+msgstr "Hosts en el Grupo de Hosts"
+
 msgid "No hosts are mismatched!"
 msgstr "Ningun host con discordancias!"
+
+#, fuzzy
+msgid "No hosts selected"
+msgstr "Hosts en el Grupo de Hosts"
 
 msgid "No hosts were found with that id or name"
 msgstr ""
@@ -2348,6 +2338,9 @@ msgid "No new subnets found"
 msgstr ""
 
 msgid "No parameters were allocated to the selected hosts, can't mass assign."
+msgstr ""
+
+msgid "No preference"
 msgstr ""
 
 msgid "No puppet activity for this host in the last %s days"
@@ -2364,8 +2357,23 @@ msgstr ""
 msgid "No subnets"
 msgstr "Subredes"
 
+#, fuzzy
+msgid "No subnets selected"
+msgstr "Entornos"
+
+#, fuzzy
+msgid "No template found"
+msgstr "Plantill"
+
 msgid "No templates found!"
 msgstr ""
+
+msgid "No trend counter defined."
+msgstr ""
+
+#, fuzzy
+msgid "No trend counter found."
+msgstr "Plantill"
 
 msgid "No value error"
 msgstr ""
@@ -2440,8 +2448,9 @@ msgstr ""
 msgid "Number of Hosts"
 msgstr "Nuevo %s"
 
-msgid "Number of Values"
-msgstr ""
+#, fuzzy
+msgid "Number of values"
+msgstr "Nuevo %s"
 
 #. host's status: first character of "OK"
 msgid "O"
@@ -2515,18 +2524,15 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
+#, fuzzy
+msgid "Operating system"
+msgstr "Editar Propiedades"
+
 msgid "Operating system default"
 msgstr ""
 
 msgid "Operating systems"
 msgstr ""
-
-msgid "Operating<br>System"
-msgstr ""
-
-#, fuzzy
-msgid "Operating<br>system"
-msgstr "Editar Propiedades"
 
 #. "Table name" or "Table name|Column name" for error messages
 #, fuzzy
@@ -2604,11 +2610,12 @@ msgstr ""
 msgid "Other reports for this host"
 msgstr ""
 
-msgid "Out Of Sync Hosts"
-msgstr ""
-
 msgid "Out of sync"
 msgstr ""
+
+#, fuzzy
+msgid "Out of sync Hosts"
+msgstr "Nuevo %s"
 
 msgid "Override Value"
 msgstr ""
@@ -2679,11 +2686,12 @@ msgstr "Añadir filtro"
 msgid "Parent"
 msgstr ""
 
-msgid "Partition Table"
-msgstr ""
-
 msgid "Partition Tables"
 msgstr ""
+
+#, fuzzy
+msgid "Partition table"
+msgstr "Configuracion de lugares"
 
 #, fuzzy
 msgid "Partition table configuration"
@@ -2738,7 +2746,11 @@ msgid "Please save the Operating System first and try again."
 msgstr ""
 
 #, fuzzy
-msgid "Please select an Environment first"
+msgid "Please select an environment first"
+msgstr "Todos los Entornos"
+
+#, fuzzy
+msgid "Please select an image"
 msgstr "Todos los Entornos"
 
 msgid "Please try to update your request"
@@ -2799,11 +2811,23 @@ msgstr ""
 msgid "Provisioning Support is disabled or this host is not managed"
 msgstr ""
 
+#, fuzzy
+msgid "Provisioning Template"
+msgstr "PlantillaDeConfiguración"
+
 msgid "Provisioning Template content changed %s"
 msgstr ""
 
 #, fuzzy
 msgid "Provisioning Templates"
+msgstr "PlantillaDeConfiguración"
+
+#, fuzzy
+msgid "Provisioning template"
+msgstr "PlantillaDeConfiguración"
+
+#, fuzzy
+msgid "Provisioning templates"
 msgstr "PlantillaDeConfiguración"
 
 #, fuzzy
@@ -2824,9 +2848,6 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Os family"
-msgstr ""
-
-msgid "Puppet"
 msgstr ""
 
 msgid "Puppet CA"
@@ -2873,6 +2894,10 @@ msgstr "Editar Propiedades"
 
 msgid "Puppet classes and environment importer"
 msgstr ""
+
+#, fuzzy
+msgid "Puppet environments"
+msgstr "Entornos"
 
 msgid "Puppet error on %s"
 msgstr ""
@@ -3088,22 +3113,15 @@ msgid "Select"
 msgstr "Seleccionar Hosts"
 
 #, fuzzy
+msgid "Select Action"
+msgstr "Nuevo lugar"
+
+#, fuzzy
 msgid "Select All"
-msgstr "Seleccionar Hosts"
-
-#, fuzzy
-msgid "Select Environment"
-msgstr "Todos los Entornos"
-
-#, fuzzy
-msgid "Select Host Group"
 msgstr "Seleccionar Hosts"
 
 msgid "Select Hosts"
 msgstr "Seleccionar Hosts"
-
-msgid "Select Hosts to Assign to %s"
-msgstr "Seleccionar Hosts a los que asignar a %s"
 
 #, fuzzy
 msgid "Select Location"
@@ -3119,6 +3137,21 @@ msgstr ""
 #, fuzzy
 msgid "Select all"
 msgstr "Seleccionar Hosts"
+
+msgid "Select all items in this page"
+msgstr ""
+
+#, fuzzy
+msgid "Select environment"
+msgstr "Todos los Entornos"
+
+#, fuzzy
+msgid "Select host group"
+msgstr "Seleccionar Hosts"
+
+#, fuzzy
+msgid "Select hosts to assign to %s"
+msgstr "Seleccionar Hosts a los que asignar a %s"
 
 #, fuzzy
 msgid "Select template"
@@ -3235,7 +3268,8 @@ msgstr ""
 msgid "Size (GB)"
 msgstr ""
 
-msgid "Skip Assign Hosts and Proceed to Edit %s Settings"
+#, fuzzy
+msgid "Skip assign hosts and proceed to edit %s settings"
 msgstr "Saltar asignacion a hosts y proceder a editar la configuracion de %s"
 
 msgid "Skipped"
@@ -3547,7 +3581,7 @@ msgstr ""
 msgid "The full DNS Domain name"
 msgstr ""
 
-msgid "The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration."
+msgid "The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration."
 msgstr ""
 
 msgid "The hostname where your Foreman instance is reachable"
@@ -3562,7 +3596,7 @@ msgstr ""
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
+msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
 msgstr ""
 
 msgid "The order in which values are resolved"
@@ -3577,17 +3611,13 @@ msgstr ""
 msgid "The user that is used to ssh into the instance, normally ec2-user, ubuntu, root etc"
 msgstr ""
 
-msgid "There are"
+msgid "There are two strategies when using host groups."
 msgstr ""
 
-msgid "There are two strategies when using hostgroups."
-msgstr ""
-
-msgid "There aren't any locations yet."
-msgstr ""
-
-msgid "There aren't any organizations yet."
-msgstr ""
+msgid "There is"
+msgid_plural "There are"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "There was an error creating the PXE Default file: %s"
 msgstr ""
@@ -3724,7 +3754,7 @@ msgstr ""
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-msgid "Unable to find templates As this Host has no Operating System"
+msgid "Unable to find templates as this host has no operating system"
 msgstr ""
 
 msgid "Unable to generate output, Check log files\\n"
@@ -3762,10 +3792,11 @@ msgstr ""
 msgid "Updated all hosts!"
 msgstr ""
 
-msgid "Updated hosts: Changed Environment"
-msgstr ""
+#, fuzzy
+msgid "Updated hosts: changed environment"
+msgstr "Entorno"
 
-msgid "Updated hosts: Changed Hostgroup"
+msgid "Updated hosts: changed host group"
 msgstr ""
 
 msgid "Use Signo SSO for login"
@@ -3923,10 +3954,13 @@ msgstr ""
 msgid "VCenter/Server"
 msgstr ""
 
-msgid "Valid Host group and Environment Combinations"
+msgid "VM"
 msgstr ""
 
 msgid "Valid from"
+msgstr ""
+
+msgid "Valid host group and environment combinations"
 msgstr ""
 
 msgid "Validation types"
@@ -3948,9 +3982,6 @@ msgid "Version"
 msgstr ""
 
 msgid "View last report details"
-msgstr ""
-
-msgid "Virtual Machine"
 msgstr ""
 
 msgid "Virtual Machines"
@@ -3983,13 +4014,13 @@ msgstr ""
 msgid "What is a <a href=\"%s\" rel=\"external\">Smart variable</a>?"
 msgstr ""
 
-msgid "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"
-msgstr ""
-
 msgid "When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:"
 msgstr ""
 
 msgid "When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments"
+msgstr ""
+
+msgid "When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"
 msgstr ""
 
 msgid "When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see"
@@ -4067,7 +4098,7 @@ msgstr ""
 msgid "You may also find the"
 msgstr ""
 
-msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration."
+msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration."
 msgstr ""
 
 msgid "You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host."
@@ -4296,10 +4327,17 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
+msgid "items selected. Uncheck to Clear"
+msgstr ""
+
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
 msgstr[1] ""
+
+#, fuzzy
+msgid "location"
+msgstr "Lugares"
 
 #, fuzzy
 msgid "locations"
@@ -4333,8 +4371,9 @@ msgstr ""
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-msgid "not has %s"
-msgstr "no tiene %s"
+#, fuzzy
+msgid "organization"
+msgstr "organizaciones"
 
 msgid "organizations"
 msgstr "organizaciones"
@@ -4345,7 +4384,7 @@ msgstr ""
 msgid "page"
 msgstr ""
 
-msgid "parameters require an associated domain, host or hostgroup"
+msgid "parameters require an associated domain, host or host group"
 msgstr ""
 
 msgid "plus all"
@@ -4452,6 +4491,10 @@ msgstr ""
 #~ msgstr "Contraseña"
 
 #, fuzzy
+#~ msgid "Assign all %{count} hosts with no %{taxonomy_type} to %{taxonomy_name}"
+#~ msgstr "Asignar a todos %{count} los hosts sin %{taxonomy_type} a %{taxonomy_name}"
+
+#, fuzzy
 #~ msgid "Attr Firstname"
 #~ msgstr "Nombre"
 
@@ -4463,6 +4506,18 @@ msgstr ""
 #~ msgid "Config Path"
 #~ msgstr "PlantillaDeConfiguración"
 
+#, fuzzy
+#~ msgid "Config Template"
+#~ msgstr "PlantillaDeConfiguración"
+
+#, fuzzy
+#~ msgid "Config templates"
+#~ msgstr "PlantillaDeConfiguración"
+
+#, fuzzy
+#~ msgid "Edit Host"
+#~ msgstr "Editar %s"
+
 #~ msgid "First Name"
 #~ msgstr "Nombre"
 
@@ -4470,8 +4525,19 @@ msgstr ""
 #~ msgid "Full Name"
 #~ msgstr "Nombre"
 
+#, fuzzy
+#~ msgid "Host Group"
+#~ msgstr "Grupos de Hosts"
+
+#, fuzzy
+#~ msgid "Hostgroups"
+#~ msgstr "Grupo de Hosts"
+
 #~ msgid "Last Name"
 #~ msgstr "Apellidos"
+
+#~ msgid "Login &#187;"
+#~ msgstr "Abrir sesión &#187;"
 
 #, fuzzy
 #~ msgid "Match"
@@ -4480,6 +4546,22 @@ msgstr ""
 #, fuzzy
 #~ msgid "Media Path"
 #~ msgstr "Medios"
+
+#, fuzzy
+#~ msgid "New Host group"
+#~ msgstr "Grupo de Hosts"
+
+#, fuzzy
+#~ msgid "New Hostgroup"
+#~ msgstr "Grupo de Hosts"
+
+#, fuzzy
+#~ msgid "New hostgroup"
+#~ msgstr "Grupo de Hosts"
+
+#, fuzzy
+#~ msgid "Operating<br>system"
+#~ msgstr "Editar Propiedades"
 
 #, fuzzy
 #~ msgid "Release Name"
@@ -4492,3 +4574,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Template"
 #~ msgstr "Plantill"
+
+#~ msgid "not has %s"
+#~ msgstr "no tiene %s"

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-23 15:23+0200\n"
+"POT-Creation-Date: 2013-05-07 18:30+0100\n"
 "PO-Revision-Date: 2013-03-01 15:45-0500\n"
 "Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -20,6 +20,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
+msgstr ""
+
+msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
 msgid "%s Distribution"
@@ -63,13 +66,12 @@ msgid_plural "%s weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%{count} hosts with no %{taxonomy_single} assigned"
-msgstr ""
+msgid "%{count} host with no %{taxonomy_single} assigned"
+msgid_plural "%{count} hosts with no %{taxonomy_single} assigned"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "%{default_value} is not one of %{validator_rule}"
-msgstr ""
-
-msgid "%{host} - %{time} ago"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
@@ -102,13 +104,13 @@ msgstr ""
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr ""
 
-msgid "*Clear Hostgroup*"
-msgstr ""
-
 msgid "*Clear environment*"
 msgstr ""
 
-msgid "*Inherit from hostgroup*"
+msgid "*Clear host group*"
+msgstr ""
+
+msgid "*Inherit from host group*"
 msgstr ""
 
 msgid "<b>Description:</b> %{key}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}"
@@ -127,7 +129,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-msgid "A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
+msgid "A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
 msgstr ""
 
 msgid "A medium represents the source of one or more operating system's installation files, accessible via the network.\\n  It will probably be a mirror from the internet or a copy of one or more CD or DVDs."
@@ -172,9 +174,6 @@ msgstr ""
 msgid "Add Bookmark"
 msgstr ""
 
-msgid "Add Combination"
-msgstr ""
-
 msgid "Add Filter"
 msgstr ""
 
@@ -197,6 +196,9 @@ msgid "Add Volume"
 msgstr ""
 
 msgid "Add a fact filter"
+msgstr ""
+
+msgid "Add combination"
 msgstr ""
 
 msgid "Add:"
@@ -235,7 +237,7 @@ msgstr ""
 msgid "All Environments"
 msgstr ""
 
-msgid "All Hostgroups"
+msgid "All Host Groups"
 msgstr ""
 
 msgid "All Media"
@@ -283,6 +285,9 @@ msgstr ""
 msgid "An explicit layout for the partitions of your hard drive(s). E.G."
 msgstr ""
 
+msgid "Any Context"
+msgstr ""
+
 msgid "Any Location"
 msgstr ""
 
@@ -318,12 +323,6 @@ msgstr ""
 msgid "Assign All"
 msgstr ""
 
-msgid "Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}"
-msgstr ""
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}"
-msgstr ""
-
 msgid "Assign Hosts to %s"
 msgstr ""
 
@@ -336,10 +335,15 @@ msgstr ""
 msgid "Assign Selected Hosts"
 msgstr ""
 
+msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
+msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Assign to %s"
 msgstr ""
 
-msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using."
+msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using."
 msgstr ""
 
 msgid "Association"
@@ -604,6 +608,9 @@ msgstr ""
 msgid "Change Group"
 msgstr ""
 
+msgid "Change your avatar at gravatar.com"
+msgstr ""
+
 msgid "Changed environments and puppet classes"
 msgstr ""
 
@@ -696,14 +703,8 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr ""
 
-msgid "Config Template"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Config template"
-msgstr ""
-
-msgid "Config templates"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -930,9 +931,6 @@ msgstr ""
 msgid "Edit Bookmark"
 msgstr ""
 
-msgid "Edit Config Template"
-msgstr ""
-
 msgid "Edit Domain"
 msgstr ""
 
@@ -940,9 +938,6 @@ msgid "Edit Environment"
 msgstr ""
 
 msgid "Edit Global Parameter"
-msgstr ""
-
-msgid "Edit Host"
 msgstr ""
 
 msgid "Edit LDAP Auth Source"
@@ -960,7 +955,7 @@ msgstr ""
 msgid "Edit Parameters"
 msgstr ""
 
-msgid "Edit Partition table"
+msgid "Edit Partition Table"
 msgstr ""
 
 msgid "Edit Properties"
@@ -979,6 +974,9 @@ msgid "Edit Smart Variable"
 msgstr ""
 
 msgid "Edit Subnet"
+msgstr ""
+
+msgid "Edit Template"
 msgstr ""
 
 msgid "Edit Trend %s"
@@ -1295,9 +1293,6 @@ msgstr ""
 msgid "Future content goes here!"
 msgstr ""
 
-msgid "General"
-msgstr ""
-
 msgid "General useful description, for example this kind of hardware needs a special BIOS setup"
 msgstr ""
 
@@ -1316,7 +1311,7 @@ msgstr ""
 msgid "Global variable or class Parameter, not both"
 msgstr ""
 
-msgid "Good Host Reports in the last %s"
+msgid "Good host reports in the last %s"
 msgstr ""
 
 msgid "Hardware"
@@ -1349,9 +1344,6 @@ msgstr ""
 msgid "Host Configuration Status"
 msgstr ""
 
-msgid "Host Group"
-msgstr ""
-
 msgid "Host Groups"
 msgstr ""
 
@@ -1364,6 +1356,27 @@ msgstr ""
 msgid "Host details"
 msgstr ""
 
+msgid "Host group"
+msgstr ""
+
+msgid "Host group / Environment"
+msgstr ""
+
+msgid "Host group and Environment"
+msgstr ""
+
+msgid "Host group configuration"
+msgstr ""
+
+msgid "Host group hosts"
+msgstr ""
+
+msgid "Host group only"
+msgstr ""
+
+msgid "Host groups"
+msgstr ""
+
 msgid "Host is pending for Build"
 msgstr ""
 
@@ -1371,12 +1384,6 @@ msgid "Host reported time is <em>%s</em>"
 msgstr ""
 
 msgid "Host times seems to be adrift!"
-msgstr ""
-
-msgid "Host-group and Environment"
-msgstr ""
-
-msgid "Host-group only"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1467,18 +1474,6 @@ msgstr ""
 msgid "Hostgroup"
 msgstr ""
 
-msgid "Hostgroup / Environment"
-msgstr ""
-
-msgid "Hostgroup configuration"
-msgstr ""
-
-msgid "Hostgroup hosts"
-msgstr ""
-
-msgid "Hostgroups"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Ancestry"
 msgstr ""
@@ -1513,13 +1508,7 @@ msgstr ""
 msgid "Hosts Inventory"
 msgstr ""
 
-msgid "Hosts With Alerts Disabled"
-msgstr ""
-
-msgid "Hosts With No Reports"
-msgstr ""
-
-msgid "Hosts in Error State"
+msgid "Hosts in error state"
 msgstr ""
 
 msgid "Hosts that had pending changes"
@@ -1534,13 +1523,19 @@ msgstr ""
 msgid "Hosts which didn't run puppet in the last %s"
 msgstr ""
 
+msgid "Hosts with alerts disabled"
+msgstr ""
+
 msgid "Hosts with errors"
+msgstr ""
+
+msgid "Hosts with no reports"
 msgstr ""
 
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-msgid "How Templates are determined"
+msgid "How templates are determined"
 msgstr ""
 
 msgid "How values are validated"
@@ -1611,6 +1606,9 @@ msgstr ""
 msgid "Image|Uuid"
 msgstr ""
 
+msgid "Import"
+msgstr ""
+
 msgid "Import Subnets"
 msgstr ""
 
@@ -1644,7 +1642,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime."
+msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime."
 msgstr ""
 
 msgid "Include this host within Foreman reporting"
@@ -1782,7 +1780,7 @@ msgstr ""
 msgid "Logged-in"
 msgstr ""
 
-msgid "Login &#187;"
+msgid "Login"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1860,13 +1858,19 @@ msgstr ""
 msgid "Manage Bookmarks"
 msgstr ""
 
+msgid "Manage Locations"
+msgstr ""
+
+msgid "Manage Organizations"
+msgstr ""
+
 msgid "Manage host"
 msgstr ""
 
 msgid "Manually Assign"
 msgstr ""
 
-msgid "Manually select and assign Hosts with No %s"
+msgid "Manually select and assign hosts with no %s"
 msgstr ""
 
 msgid "Matcher"
@@ -2038,7 +2042,7 @@ msgstr ""
 msgid "New Host"
 msgstr ""
 
-msgid "New Hostgroup"
+msgid "New Host Group"
 msgstr ""
 
 msgid "New Image"
@@ -2071,10 +2075,7 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New Partition Table layout"
-msgstr ""
-
-msgid "New Partition table layout"
+msgid "New Partition Table"
 msgstr ""
 
 msgid "New Proxy"
@@ -2113,13 +2114,7 @@ msgstr ""
 msgid "New compute resource"
 msgstr ""
 
-msgid "New hostgroup"
-msgstr ""
-
 msgid "New installation medium"
-msgstr ""
-
-msgid "New partition table"
 msgstr ""
 
 msgid "New role"
@@ -2144,34 +2139,7 @@ msgstr ""
 msgid "No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings"
 msgstr ""
 
-msgid "No Environment selected!"
-msgstr ""
-
-msgid "No History Found"
-msgstr ""
-
-msgid "No Hostgroup selected!"
-msgstr ""
-
-msgid "No Hosts selected"
-msgstr ""
-
-msgid "No Preference"
-msgstr ""
-
-msgid "No Subnets selected"
-msgstr ""
-
 msgid "No TFTP proxies defined, can't continue"
-msgstr ""
-
-msgid "No Template found"
-msgstr ""
-
-msgid "No Trend Counter Defined."
-msgstr ""
-
-msgid "No Trend Counter Found."
 msgstr ""
 
 msgid "No changes"
@@ -2180,13 +2148,25 @@ msgstr ""
 msgid "No domains"
 msgstr ""
 
+msgid "No environment selected!"
+msgstr ""
+
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
 
 msgid "No finish templates were found for this host, make sure you define at least one in your %s settings"
 msgstr ""
 
+msgid "No history found"
+msgstr ""
+
+msgid "No host group selected!"
+msgstr ""
+
 msgid "No hosts are mismatched!"
+msgstr ""
+
+msgid "No hosts selected"
 msgstr ""
 
 msgid "No hosts were found with that id or name"
@@ -2196,6 +2176,9 @@ msgid "No new subnets found"
 msgstr ""
 
 msgid "No parameters were allocated to the selected hosts, can't mass assign."
+msgstr ""
+
+msgid "No preference"
 msgstr ""
 
 msgid "No puppet activity for this host in the last %s days"
@@ -2210,7 +2193,19 @@ msgstr ""
 msgid "No subnets"
 msgstr ""
 
+msgid "No subnets selected"
+msgstr ""
+
+msgid "No template found"
+msgstr ""
+
 msgid "No templates found!"
+msgstr ""
+
+msgid "No trend counter defined."
+msgstr ""
+
+msgid "No trend counter found."
 msgstr ""
 
 msgid "No value error"
@@ -2280,7 +2275,7 @@ msgstr ""
 msgid "Number of Hosts"
 msgstr ""
 
-msgid "Number of Values"
+msgid "Number of values"
 msgstr ""
 
 #. host's status: first character of "OK"
@@ -2353,16 +2348,13 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
+msgid "Operating system"
+msgstr ""
+
 msgid "Operating system default"
 msgstr ""
 
 msgid "Operating systems"
-msgstr ""
-
-msgid "Operating<br>System"
-msgstr ""
-
-msgid "Operating<br>system"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -2434,10 +2426,10 @@ msgstr ""
 msgid "Other reports for this host"
 msgstr ""
 
-msgid "Out Of Sync Hosts"
+msgid "Out of sync"
 msgstr ""
 
-msgid "Out of sync"
+msgid "Out of sync Hosts"
 msgstr ""
 
 msgid "Override Value"
@@ -2505,10 +2497,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-msgid "Partition Table"
+msgid "Partition Tables"
 msgstr ""
 
-msgid "Partition Tables"
+msgid "Partition table"
 msgstr ""
 
 msgid "Partition table configuration"
@@ -2562,7 +2554,10 @@ msgstr ""
 msgid "Please save the Operating System first and try again."
 msgstr ""
 
-msgid "Please select an Environment first"
+msgid "Please select an environment first"
+msgstr ""
+
+msgid "Please select an image"
 msgstr ""
 
 msgid "Please try to update your request"
@@ -2622,10 +2617,19 @@ msgstr ""
 msgid "Provisioning Support is disabled or this host is not managed"
 msgstr ""
 
+msgid "Provisioning Template"
+msgstr ""
+
 msgid "Provisioning Template content changed %s"
 msgstr ""
 
 msgid "Provisioning Templates"
+msgstr ""
+
+msgid "Provisioning template"
+msgstr ""
+
+msgid "Provisioning templates"
 msgstr ""
 
 msgid "Proxies"
@@ -2645,9 +2649,6 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Os family"
-msgstr ""
-
-msgid "Puppet"
 msgstr ""
 
 msgid "Puppet CA"
@@ -2690,6 +2691,9 @@ msgid "Puppet classes Parameters"
 msgstr ""
 
 msgid "Puppet classes and environment importer"
+msgstr ""
+
+msgid "Puppet environments"
 msgstr ""
 
 msgid "Puppet error on %s"
@@ -2894,19 +2898,13 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+msgid "Select Action"
+msgstr ""
+
 msgid "Select All"
 msgstr ""
 
-msgid "Select Environment"
-msgstr ""
-
-msgid "Select Host Group"
-msgstr ""
-
 msgid "Select Hosts"
-msgstr ""
-
-msgid "Select Hosts to Assign to %s"
 msgstr ""
 
 msgid "Select Location"
@@ -2919,6 +2917,18 @@ msgid "Select a period"
 msgstr ""
 
 msgid "Select all"
+msgstr ""
+
+msgid "Select all items in this page"
+msgstr ""
+
+msgid "Select environment"
+msgstr ""
+
+msgid "Select host group"
+msgstr ""
+
+msgid "Select hosts to assign to %s"
 msgstr ""
 
 msgid "Select template"
@@ -3033,7 +3043,7 @@ msgstr ""
 msgid "Size (GB)"
 msgstr ""
 
-msgid "Skip Assign Hosts and Proceed to Edit %s Settings"
+msgid "Skip assign hosts and proceed to edit %s settings"
 msgstr ""
 
 msgid "Skipped"
@@ -3324,7 +3334,7 @@ msgstr ""
 msgid "The full DNS Domain name"
 msgstr ""
 
-msgid "The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration."
+msgid "The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration."
 msgstr ""
 
 msgid "The hostname where your Foreman instance is reachable"
@@ -3339,7 +3349,7 @@ msgstr ""
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
+msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
 msgstr ""
 
 msgid "The order in which values are resolved"
@@ -3354,17 +3364,13 @@ msgstr ""
 msgid "The user that is used to ssh into the instance, normally ec2-user, ubuntu, root etc"
 msgstr ""
 
-msgid "There are"
+msgid "There are two strategies when using host groups."
 msgstr ""
 
-msgid "There are two strategies when using hostgroups."
-msgstr ""
-
-msgid "There aren't any locations yet."
-msgstr ""
-
-msgid "There aren't any organizations yet."
-msgstr ""
+msgid "There is"
+msgid_plural "There are"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "There was an error creating the PXE Default file: %s"
 msgstr ""
@@ -3499,7 +3505,7 @@ msgstr ""
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-msgid "Unable to find templates As this Host has no Operating System"
+msgid "Unable to find templates as this host has no operating system"
 msgstr ""
 
 msgid "Unable to generate output, Check log files\\n"
@@ -3535,10 +3541,10 @@ msgstr ""
 msgid "Updated all hosts!"
 msgstr ""
 
-msgid "Updated hosts: Changed Environment"
+msgid "Updated hosts: changed environment"
 msgstr ""
 
-msgid "Updated hosts: Changed Hostgroup"
+msgid "Updated hosts: changed host group"
 msgstr ""
 
 msgid "Use Signo SSO for login"
@@ -3681,10 +3687,13 @@ msgstr ""
 msgid "VCenter/Server"
 msgstr ""
 
-msgid "Valid Host group and Environment Combinations"
+msgid "VM"
 msgstr ""
 
 msgid "Valid from"
+msgstr ""
+
+msgid "Valid host group and environment combinations"
 msgstr ""
 
 msgid "Validation types"
@@ -3706,9 +3715,6 @@ msgid "Version"
 msgstr ""
 
 msgid "View last report details"
-msgstr ""
-
-msgid "Virtual Machine"
 msgstr ""
 
 msgid "Virtual Machines"
@@ -3741,13 +3747,13 @@ msgstr ""
 msgid "What is a <a href=\"%s\" rel=\"external\">Smart variable</a>?"
 msgstr ""
 
-msgid "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"
-msgstr ""
-
 msgid "When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:"
 msgstr ""
 
 msgid "When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments"
+msgstr ""
+
+msgid "When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"
 msgstr ""
 
 msgid "When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see"
@@ -3825,7 +3831,7 @@ msgstr ""
 msgid "You may also find the"
 msgstr ""
 
-msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration."
+msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration."
 msgstr ""
 
 msgid "You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host."
@@ -4050,10 +4056,16 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
+msgid "items selected. Uncheck to Clear"
+msgstr ""
+
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "location"
+msgstr ""
 
 msgid "locations"
 msgstr ""
@@ -4085,7 +4097,7 @@ msgstr ""
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-msgid "not has %s"
+msgid "organization"
 msgstr ""
 
 msgid "organizations"
@@ -4097,7 +4109,7 @@ msgstr ""
 msgid "page"
 msgstr ""
 
-msgid "parameters require an associated domain, host or hostgroup"
+msgid "parameters require an associated domain, host or host group"
 msgstr ""
 
 msgid "plus all"

--- a/locale/ja/foreman.po
+++ b/locale/ja/foreman.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-23 15:23+0200\n"
+"POT-Creation-Date: 2013-05-07 18:30+0100\n"
 "PO-Revision-Date: 2013-03-01 15:45-0500\n"
 "Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -21,6 +21,9 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "%s - Press Shift-F12 to release the cursor."
+msgstr ""
+
+msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
 msgid "%s Distribution"
@@ -60,13 +63,11 @@ msgid "%s week ago"
 msgid_plural "%s weeks ago"
 msgstr[0] ""
 
-msgid "%{count} hosts with no %{taxonomy_single} assigned"
-msgstr ""
+msgid "%{count} host with no %{taxonomy_single} assigned"
+msgid_plural "%{count} hosts with no %{taxonomy_single} assigned"
+msgstr[0] ""
 
 msgid "%{default_value} is not one of %{validator_rule}"
-msgstr ""
-
-msgid "%{host} - %{time} ago"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
@@ -99,13 +100,13 @@ msgstr ""
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr ""
 
-msgid "*Clear Hostgroup*"
-msgstr ""
-
 msgid "*Clear environment*"
 msgstr ""
 
-msgid "*Inherit from hostgroup*"
+msgid "*Clear host group*"
+msgstr ""
+
+msgid "*Inherit from host group*"
 msgstr ""
 
 msgid "<b>Description:</b> %{key}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}"
@@ -124,7 +125,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-msgid "A Host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
+msgid "A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states."
 msgstr ""
 
 msgid "A medium represents the source of one or more operating system's installation files, accessible via the network.\\n  It will probably be a mirror from the internet or a copy of one or more CD or DVDs."
@@ -169,9 +170,6 @@ msgstr ""
 msgid "Add Bookmark"
 msgstr ""
 
-msgid "Add Combination"
-msgstr ""
-
 msgid "Add Filter"
 msgstr ""
 
@@ -194,6 +192,9 @@ msgid "Add Volume"
 msgstr ""
 
 msgid "Add a fact filter"
+msgstr ""
+
+msgid "Add combination"
 msgstr ""
 
 msgid "Add:"
@@ -232,8 +233,9 @@ msgstr ""
 msgid "All Environments"
 msgstr ""
 
-msgid "All Hostgroups"
-msgstr ""
+#, fuzzy
+msgid "All Host Groups"
+msgstr "ユーザー名"
 
 msgid "All Media"
 msgstr ""
@@ -280,6 +282,9 @@ msgstr ""
 msgid "An explicit layout for the partitions of your hard drive(s). E.G."
 msgstr ""
 
+msgid "Any Context"
+msgstr ""
+
 msgid "Any Location"
 msgstr ""
 
@@ -315,12 +320,6 @@ msgstr ""
 msgid "Assign All"
 msgstr ""
 
-msgid "Assign All %{count} Hosts with No %{taxonomy_type} to %{taxonomy_name}"
-msgstr ""
-
-msgid "Assign All %{count} Hosts with No %{taxonomy_upcase} to %{taxonomy_name}"
-msgstr ""
-
 msgid "Assign Hosts to %s"
 msgstr ""
 
@@ -333,10 +332,14 @@ msgstr ""
 msgid "Assign Selected Hosts"
 msgstr ""
 
+msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
+msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
+msgstr[0] ""
+
 msgid "Assign to %s"
 msgstr ""
 
-msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected Hosts are currently using."
+msgid "Assigning hosts to %{taxonomy_name} will also update %{taxonomy_name} to include all the resources that the selected hosts are currently using."
 msgstr ""
 
 msgid "Association"
@@ -602,6 +605,9 @@ msgstr ""
 msgid "Change Group"
 msgstr ""
 
+msgid "Change your avatar at gravatar.com"
+msgstr ""
+
 msgid "Changed environments and puppet classes"
 msgstr ""
 
@@ -694,14 +700,8 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr ""
 
-msgid "Config Template"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Config template"
-msgstr ""
-
-msgid "Config templates"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -928,9 +928,6 @@ msgstr ""
 msgid "Edit Bookmark"
 msgstr ""
 
-msgid "Edit Config Template"
-msgstr ""
-
 msgid "Edit Domain"
 msgstr ""
 
@@ -938,9 +935,6 @@ msgid "Edit Environment"
 msgstr ""
 
 msgid "Edit Global Parameter"
-msgstr ""
-
-msgid "Edit Host"
 msgstr ""
 
 msgid "Edit LDAP Auth Source"
@@ -958,7 +952,7 @@ msgstr ""
 msgid "Edit Parameters"
 msgstr ""
 
-msgid "Edit Partition table"
+msgid "Edit Partition Table"
 msgstr ""
 
 msgid "Edit Properties"
@@ -977,6 +971,9 @@ msgid "Edit Smart Variable"
 msgstr ""
 
 msgid "Edit Subnet"
+msgstr ""
+
+msgid "Edit Template"
 msgstr ""
 
 msgid "Edit Trend %s"
@@ -1293,9 +1290,6 @@ msgstr ""
 msgid "Future content goes here!"
 msgstr ""
 
-msgid "General"
-msgstr ""
-
 msgid "General useful description, for example this kind of hardware needs a special BIOS setup"
 msgstr ""
 
@@ -1314,7 +1308,7 @@ msgstr ""
 msgid "Global variable or class Parameter, not both"
 msgstr ""
 
-msgid "Good Host Reports in the last %s"
+msgid "Good host reports in the last %s"
 msgstr ""
 
 msgid "Hardware"
@@ -1347,11 +1341,9 @@ msgstr ""
 msgid "Host Configuration Status"
 msgstr ""
 
-msgid "Host Group"
-msgstr ""
-
+#, fuzzy
 msgid "Host Groups"
-msgstr ""
+msgstr "ユーザー名"
 
 msgid "Host Parameters"
 msgstr ""
@@ -1362,6 +1354,31 @@ msgstr ""
 msgid "Host details"
 msgstr ""
 
+#, fuzzy
+msgid "Host group"
+msgstr "ユーザー名"
+
+msgid "Host group / Environment"
+msgstr ""
+
+msgid "Host group and Environment"
+msgstr ""
+
+msgid "Host group configuration"
+msgstr ""
+
+#, fuzzy
+msgid "Host group hosts"
+msgstr "ユーザー名"
+
+#, fuzzy
+msgid "Host group only"
+msgstr "ユーザー名"
+
+#, fuzzy
+msgid "Host groups"
+msgstr "ユーザー名"
+
 msgid "Host is pending for Build"
 msgstr ""
 
@@ -1369,12 +1386,6 @@ msgid "Host reported time is <em>%s</em>"
 msgstr ""
 
 msgid "Host times seems to be adrift!"
-msgstr ""
-
-msgid "Host-group and Environment"
-msgstr ""
-
-msgid "Host-group only"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1465,18 +1476,6 @@ msgstr ""
 msgid "Hostgroup"
 msgstr ""
 
-msgid "Hostgroup / Environment"
-msgstr ""
-
-msgid "Hostgroup configuration"
-msgstr ""
-
-msgid "Hostgroup hosts"
-msgstr ""
-
-msgid "Hostgroups"
-msgstr ""
-
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Hostgroup|Ancestry"
 msgstr ""
@@ -1512,13 +1511,7 @@ msgstr ""
 msgid "Hosts Inventory"
 msgstr ""
 
-msgid "Hosts With Alerts Disabled"
-msgstr ""
-
-msgid "Hosts With No Reports"
-msgstr ""
-
-msgid "Hosts in Error State"
+msgid "Hosts in error state"
 msgstr ""
 
 msgid "Hosts that had pending changes"
@@ -1533,13 +1526,19 @@ msgstr ""
 msgid "Hosts which didn't run puppet in the last %s"
 msgstr ""
 
+msgid "Hosts with alerts disabled"
+msgstr ""
+
 msgid "Hosts with errors"
+msgstr ""
+
+msgid "Hosts with no reports"
 msgstr ""
 
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-msgid "How Templates are determined"
+msgid "How templates are determined"
 msgstr ""
 
 msgid "How values are validated"
@@ -1611,6 +1610,9 @@ msgstr "ユーザー名"
 msgid "Image|Uuid"
 msgstr ""
 
+msgid "Import"
+msgstr ""
+
 msgid "Import Subnets"
 msgstr ""
 
@@ -1644,7 +1646,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a hostgroup to further refine the behavior of the puppet runtime."
+msgid "In addition to defining which puppet classes get included when building this host type you are also able to assign variables and provisioning information to a host group to further refine the behavior of the puppet runtime."
 msgstr ""
 
 msgid "Include this host within Foreman reporting"
@@ -1782,7 +1784,7 @@ msgstr ""
 msgid "Logged-in"
 msgstr ""
 
-msgid "Login &#187;"
+msgid "Login"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -1860,13 +1862,19 @@ msgstr ""
 msgid "Manage Bookmarks"
 msgstr ""
 
+msgid "Manage Locations"
+msgstr ""
+
+msgid "Manage Organizations"
+msgstr ""
+
 msgid "Manage host"
 msgstr ""
 
 msgid "Manually Assign"
 msgstr ""
 
-msgid "Manually select and assign Hosts with No %s"
+msgid "Manually select and assign hosts with no %s"
 msgstr ""
 
 msgid "Matcher"
@@ -2038,8 +2046,9 @@ msgstr ""
 msgid "New Host"
 msgstr ""
 
-msgid "New Hostgroup"
-msgstr ""
+#, fuzzy
+msgid "New Host Group"
+msgstr "ユーザー名"
 
 msgid "New Image"
 msgstr ""
@@ -2071,10 +2080,7 @@ msgstr ""
 msgid "New Parameter"
 msgstr ""
 
-msgid "New Partition Table layout"
-msgstr ""
-
-msgid "New Partition table layout"
+msgid "New Partition Table"
 msgstr ""
 
 msgid "New Proxy"
@@ -2113,13 +2119,7 @@ msgstr ""
 msgid "New compute resource"
 msgstr ""
 
-msgid "New hostgroup"
-msgstr ""
-
 msgid "New installation medium"
-msgstr ""
-
-msgid "New partition table"
 msgstr ""
 
 msgid "New role"
@@ -2144,34 +2144,7 @@ msgstr ""
 msgid "No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings"
 msgstr ""
 
-msgid "No Environment selected!"
-msgstr ""
-
-msgid "No History Found"
-msgstr ""
-
-msgid "No Hostgroup selected!"
-msgstr ""
-
-msgid "No Hosts selected"
-msgstr ""
-
-msgid "No Preference"
-msgstr ""
-
-msgid "No Subnets selected"
-msgstr ""
-
 msgid "No TFTP proxies defined, can't continue"
-msgstr ""
-
-msgid "No Template found"
-msgstr ""
-
-msgid "No Trend Counter Defined."
-msgstr ""
-
-msgid "No Trend Counter Found."
 msgstr ""
 
 msgid "No changes"
@@ -2180,13 +2153,25 @@ msgstr ""
 msgid "No domains"
 msgstr ""
 
+msgid "No environment selected!"
+msgstr ""
+
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
 
 msgid "No finish templates were found for this host, make sure you define at least one in your %s settings"
 msgstr ""
 
+msgid "No history found"
+msgstr ""
+
+msgid "No host group selected!"
+msgstr ""
+
 msgid "No hosts are mismatched!"
+msgstr ""
+
+msgid "No hosts selected"
 msgstr ""
 
 msgid "No hosts were found with that id or name"
@@ -2196,6 +2181,9 @@ msgid "No new subnets found"
 msgstr ""
 
 msgid "No parameters were allocated to the selected hosts, can't mass assign."
+msgstr ""
+
+msgid "No preference"
 msgstr ""
 
 msgid "No puppet activity for this host in the last %s days"
@@ -2210,7 +2198,19 @@ msgstr ""
 msgid "No subnets"
 msgstr ""
 
+msgid "No subnets selected"
+msgstr ""
+
+msgid "No template found"
+msgstr ""
+
 msgid "No templates found!"
+msgstr ""
+
+msgid "No trend counter defined."
+msgstr ""
+
+msgid "No trend counter found."
 msgstr ""
 
 msgid "No value error"
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Number of Hosts"
 msgstr ""
 
-msgid "Number of Values"
+msgid "Number of values"
 msgstr ""
 
 #. host's status: first character of "OK"
@@ -2353,16 +2353,13 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
+msgid "Operating system"
+msgstr ""
+
 msgid "Operating system default"
 msgstr ""
 
 msgid "Operating systems"
-msgstr ""
-
-msgid "Operating<br>System"
-msgstr ""
-
-msgid "Operating<br>system"
 msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
@@ -2434,10 +2431,10 @@ msgstr ""
 msgid "Other reports for this host"
 msgstr ""
 
-msgid "Out Of Sync Hosts"
+msgid "Out of sync"
 msgstr ""
 
-msgid "Out of sync"
+msgid "Out of sync Hosts"
 msgstr ""
 
 msgid "Override Value"
@@ -2505,10 +2502,10 @@ msgstr ""
 msgid "Parent"
 msgstr ""
 
-msgid "Partition Table"
+msgid "Partition Tables"
 msgstr ""
 
-msgid "Partition Tables"
+msgid "Partition table"
 msgstr ""
 
 msgid "Partition table configuration"
@@ -2562,7 +2559,10 @@ msgstr ""
 msgid "Please save the Operating System first and try again."
 msgstr ""
 
-msgid "Please select an Environment first"
+msgid "Please select an environment first"
+msgstr ""
+
+msgid "Please select an image"
 msgstr ""
 
 msgid "Please try to update your request"
@@ -2622,10 +2622,19 @@ msgstr ""
 msgid "Provisioning Support is disabled or this host is not managed"
 msgstr ""
 
+msgid "Provisioning Template"
+msgstr ""
+
 msgid "Provisioning Template content changed %s"
 msgstr ""
 
 msgid "Provisioning Templates"
+msgstr ""
+
+msgid "Provisioning template"
+msgstr ""
+
+msgid "Provisioning templates"
 msgstr ""
 
 msgid "Proxies"
@@ -2645,9 +2654,6 @@ msgstr ""
 
 #. "Table name" or "Table name|Column name" for error messages
 msgid "Ptable|Os family"
-msgstr ""
-
-msgid "Puppet"
 msgstr ""
 
 msgid "Puppet CA"
@@ -2690,6 +2696,9 @@ msgid "Puppet classes Parameters"
 msgstr ""
 
 msgid "Puppet classes and environment importer"
+msgstr ""
+
+msgid "Puppet environments"
 msgstr ""
 
 msgid "Puppet error on %s"
@@ -2893,19 +2902,13 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+msgid "Select Action"
+msgstr ""
+
 msgid "Select All"
 msgstr ""
 
-msgid "Select Environment"
-msgstr ""
-
-msgid "Select Host Group"
-msgstr ""
-
 msgid "Select Hosts"
-msgstr ""
-
-msgid "Select Hosts to Assign to %s"
 msgstr ""
 
 msgid "Select Location"
@@ -2918,6 +2921,18 @@ msgid "Select a period"
 msgstr ""
 
 msgid "Select all"
+msgstr ""
+
+msgid "Select all items in this page"
+msgstr ""
+
+msgid "Select environment"
+msgstr ""
+
+msgid "Select host group"
+msgstr ""
+
+msgid "Select hosts to assign to %s"
 msgstr ""
 
 msgid "Select template"
@@ -3032,7 +3047,7 @@ msgstr ""
 msgid "Size (GB)"
 msgstr ""
 
-msgid "Skip Assign Hosts and Proceed to Edit %s Settings"
+msgid "Skip assign hosts and proceed to edit %s settings"
 msgstr ""
 
 msgid "Skipped"
@@ -3323,7 +3338,7 @@ msgstr ""
 msgid "The full DNS Domain name"
 msgstr ""
 
-msgid "The hostgroup's classes and the hostgroup's variables are included in the external node information when the puppetmaster compiles the host's configuration."
+msgid "The host group's classes and the host group's variables are included in the external node information when the puppetmaster compiles the host's configuration."
 msgstr ""
 
 msgid "The hostname where your Foreman instance is reachable"
@@ -3338,7 +3353,7 @@ msgstr ""
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
+msgid "The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"
 msgstr ""
 
 msgid "The order in which values are resolved"
@@ -3353,17 +3368,12 @@ msgstr ""
 msgid "The user that is used to ssh into the instance, normally ec2-user, ubuntu, root etc"
 msgstr ""
 
-msgid "There are"
+msgid "There are two strategies when using host groups."
 msgstr ""
 
-msgid "There are two strategies when using hostgroups."
-msgstr ""
-
-msgid "There aren't any locations yet."
-msgstr ""
-
-msgid "There aren't any organizations yet."
-msgstr ""
+msgid "There is"
+msgid_plural "There are"
+msgstr[0] ""
 
 msgid "There was an error creating the PXE Default file: %s"
 msgstr ""
@@ -3498,7 +3508,7 @@ msgstr ""
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-msgid "Unable to find templates As this Host has no Operating System"
+msgid "Unable to find templates as this host has no operating system"
 msgstr ""
 
 msgid "Unable to generate output, Check log files\\n"
@@ -3534,10 +3544,10 @@ msgstr ""
 msgid "Updated all hosts!"
 msgstr ""
 
-msgid "Updated hosts: Changed Environment"
+msgid "Updated hosts: changed environment"
 msgstr ""
 
-msgid "Updated hosts: Changed Hostgroup"
+msgid "Updated hosts: changed host group"
 msgstr ""
 
 msgid "Use Signo SSO for login"
@@ -3692,10 +3702,13 @@ msgstr ""
 msgid "VCenter/Server"
 msgstr ""
 
-msgid "Valid Host group and Environment Combinations"
+msgid "VM"
 msgstr ""
 
 msgid "Valid from"
+msgstr ""
+
+msgid "Valid host group and environment combinations"
 msgstr ""
 
 msgid "Validation types"
@@ -3717,9 +3730,6 @@ msgid "Version"
 msgstr ""
 
 msgid "View last report details"
-msgstr ""
-
-msgid "Virtual Machine"
 msgstr ""
 
 msgid "Virtual Machines"
@@ -3752,13 +3762,13 @@ msgstr ""
 msgid "What is a <a href=\"%s\" rel=\"external\">Smart variable</a>?"
 msgstr ""
 
-msgid "When Host and Hostgroup have different environments should all classes be included (regardless if they exists or not in the other environment)"
-msgstr ""
-
 msgid "When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:"
 msgstr ""
 
 msgid "When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments"
+msgstr ""
+
+msgid "When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"
 msgstr ""
 
 msgid "When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see"
@@ -3836,7 +3846,7 @@ msgstr ""
 msgid "You may also find the"
 msgstr ""
 
-msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a hostgroup called <b>host-type-ldap-server</b> and add the required classes into the hostgroup configuration."
+msgid "You may create puppet classes that represent high-level host configurations, for example, a <b>host-type-ldap-server</b> class, which includes all the required functionality from other modules or you may decide to create a host group called <b>host-type-ldap-server</b> and add the required classes into the host group configuration."
 msgstr ""
 
 msgid "You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host."
@@ -4061,9 +4071,15 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
+msgid "items selected. Uncheck to Clear"
+msgstr ""
+
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
+
+msgid "location"
+msgstr ""
 
 msgid "locations"
 msgstr ""
@@ -4095,7 +4111,7 @@ msgstr ""
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-msgid "not has %s"
+msgid "organization"
 msgstr ""
 
 msgid "organizations"
@@ -4107,7 +4123,7 @@ msgstr ""
 msgid "page"
 msgstr ""
 
-msgid "parameters require an associated domain, host or hostgroup"
+msgid "parameters require an associated domain, host or host group"
 msgstr ""
 
 msgid "plus all"

--- a/locale/taxonomies.rb
+++ b/locale/taxonomies.rb
@@ -1,0 +1,15 @@
+# Taxonomies is a generic impl used for both locations and organizations which
+# uses Rails' inflector to get variations on the controller name (singular,
+# plural etc).  This file contains the equivalent strings for i18n extraction.
+
+# Singular, lower case (taxonomy_single)
+_("location")
+_("organization")
+
+# Singular, titleized (taxonomy_title)
+_("Location")
+_("Organization")
+
+# Plural, titleized (taxonomy_upcase)
+_("Locations")
+_("Organizations")

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -328,7 +328,7 @@ class HostsControllerTest < ActionController::TestCase
   test 'multiple without hosts' do
     post :update_multiple_hostgroup, {}, set_session_user
     assert_redirected_to hosts_url
-    assert_equal "No Hosts selected", flash[:error]
+    assert_equal "No hosts selected", flash[:error]
 
     # now try to pass an invalid id
     post :update_multiple_hostgroup, {:host_ids => [-1], :host_names => ["no.such.host"]}, set_session_user


### PR DESCRIPTION
- "translated" all of the English model and column names
- one big change was renaming "Hostgroup" to "host group"
- tried to remove extraneous capital letters from sentences around the app (incomplete, but better)
- improved taxonomies i18n by extracting variations of the taxonomy/controller name
