### PR TITLE
Fixes #2406 - add recent report summary to dashboard latest events box

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -32,4 +32,31 @@ module DashboardHelper
     link_to name, hosts_path(:search => search),:class=>"dashboard-links"
   end
 
+  def latest_events
+    # 7 reports + header fits the events box nicely...
+    summary = Report.my_reports.interesting.search_for('reported > "7 days ago"').limit(7)
+  end
+
+  def translated_header(shortname, longname)
+    "<th><span class='small' title='' data-original-title='#{longname}'>#{shortname}</span></th>"
+  end
+
+  def latest_headers
+    string =  "<th>#{_("Host")}</th>"
+    # TRANSLATORS: initial character of Applied
+    string += translated_header(_('A'),_('Applied'))
+    # TRANSLATORS: initial character of Restarted
+    string += translated_header(_('R'),_('Restarted'))
+    # TRANSLATORS: initial character of Failed
+    string += translated_header(_('F'),_('Failed'))
+    # TRANSLATORS: Failed initial characters of Restarts
+    string += translated_header(_('FR'),_('Failed Restarts'))
+    # TRANSLATORS: initial character of Skipped
+    string += translated_header(_('S'),_('Skipped'))
+    # TRANSLATORS: initial character of Pending
+    string += translated_header(_('P'),_('Pending'))
+
+    string.html_safe
+  end
+
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -14,7 +14,27 @@
   <div class="row-fluid">
     <div class="span5 stats-well">
       <h4 style="text-align: center;"><%= _("Latest Events") %></h4>
-      <%= _('Future content goes here!') %>
+      <% events = latest_events %>
+      <% if events.empty? -%>
+        <p style="text-align: center;"><%= _("No interesting reports received in the last week") %></p>
+      <% else -%>
+        <table class="table table-bordered table-striped ellipsis">
+          <tr>
+            <%= latest_headers %>
+          </tr>
+          <% events.each do |report| -%>
+            <tr>
+              <td><%= link_to h(trunc(report.host, 14)), host_reports_path(report.host) %></td>
+              <td><%= report_event_column(report.applied, "label-info") %></td>
+              <td><%= report_event_column(report.restarted, "label-info") %></td>
+              <td><%= report_event_column(report.failed, "label-important") %></td>
+              <td><%= report_event_column(report.failed_restarts, "label-warning") %></td>
+              <td><%= report_event_column(report.skipped, "label-info") %></td>
+              <td><%= report_event_column(report.pending, "label-info") %></td>
+            </tr>
+          <% end -%>
+        </table>
+      <% end -%>
     </div>
     <div class="span7 stats-well">
       <h4 style="text-align: center;"><%= n_("Run distribution in the last %s minute", "Run distribution in the last %s minutes", Setting[:puppet_interval]) % Setting[:puppet_interval] %></h4>


### PR DESCRIPTION
Needs some DRYing as it's basically cut-n-paste from the Reports view, but at least something gets displayed :)
