### PR TITLE
Fallback to assets pipeline if a precompiled asset is missed in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,8 +50,10 @@ Foreman::Application.configure do
   # Compress JavaScripts and CSS
   config.assets.compress = true
 
-  # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
+  # Fallback to assets pipeline if a precompiled asset is missed:
+  # that's the case when an engine with it's own assets is added to
+  # Foreman later in production. Especially for images.
+  config.assets.compile = true
 
   # Generate digests for assets URLs
   config.assets.digest = true


### PR DESCRIPTION
That's the case when an engine with it's own assets is added to Foreman later
in production. Especially for images.
