### PR TITLE
fixes #2486 - ensure facts import is idempotent when values are unchanged

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -58,10 +58,10 @@ module Host
 
       deletions = []
       fact_values.includes(:fact_name).each do |value|
-        deletions << value['id'] and next unless facts.include?(value['name'])
+        deletions << value['id'] and next unless facts.include?(value.name)
         # Now store them for later testing.
-        db_facts[value['name']] ||= []
-        db_facts[value['name']] << value
+        db_facts[value.name] ||= []
+        db_facts[value.name] << value
       end
 
       # Now get rid of any parameters whose value list is different.
@@ -69,9 +69,11 @@ module Host
       # a single value, but in the most common case (a single value has changed)
       # this makes sense.
       db_facts.each do |name, value_hashes|
-        values = value_hashes.collect { |v| v['value'] }
+        db_values = value_hashes.collect { |v| v['value'] }
+        value = facts[name]
+        values = value.is_a?(Array) ? value : [value.to_s]
 
-        unless values == facts[name]
+        unless db_values == values
           value_hashes.each { |v| deletions << v['id'] }
         end
       end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -70,6 +70,13 @@ class HostTest < ActiveSupport::TestCase
     assert Host.find_by_name('a.server.b.domain')
   end
 
+  test "should import facts idempotently" do
+    assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.yml")))
+    value_ids = Host.find_by_name('a.server.b.domain').fact_values.map(&:id)
+    assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.yml")))
+    assert_equal value_ids, Host.find_by_name('a.server.b.domain').fact_values.map(&:id)
+  end
+
   test "should not save if neither ptable or disk are defined when the host is managed" do
     if unattended?
       host = Host.create :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.4.4.03",


### PR DESCRIPTION
three fixes:
- calling ['name'] wasn't returning the associated name, needed to do .name
- we compared ["value"] from the DB against "value" from the hash
- we compared "1234" from the DB against 1234 integers from the hash (e.g. uptime)
