### PR TITLE
Fixes #2272 - added Capybara integration tests, but without javascripts tests

### DIFF
--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -1,7 +1,11 @@
 begin
   require "ci/reporter/rake/minitest"
   namespace :jenkins do
-    task :unit => ["jenkins:setup:minitest", 'rake:test']
+    task :unit => ["jenkins:setup:minitest", 'rake:test:units', 'rake:test:lib', 'rake:test:functionals']
+    task :integration => ["jenkins:setup:minitest", 'rake:test:integration']
+    task :lib => ["jenkins:setup:minitest", 'rake:test:lib']
+    task :functionals => ["jenkins:setup:minitest", 'rake:test:functionals']
+    task :units => ["jenkins:setup:minitest", 'rake:test:units']
 
     namespace :setup do
       task :pre_ci do

--- a/test/fixtures/auth_sources.yml
+++ b/test/fixtures/auth_sources.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 one:
-  name: ldap
+  name: ldap-server
   host: ldap
   port: 123
-  account: 
-  account_password: 
+  account:
+  account_password:
   base_dn: dn=x,dn=y
   ldap_filter:
   attr_login: uid

--- a/test/fixtures/compute_resources.yml
+++ b/test/fixtures/compute_resources.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 one:
-  name: MyString
+  name: bigcompute
   description: MyString
   url: qemu://stam/system
   user: MyString
@@ -36,3 +36,12 @@ openstack:
   password: 1234567
   uuid: yourcompute
   type: Foreman::Model::Openstack
+
+ec2:
+  name: amazon123
+  description: yourcompute
+  url: eu-west-1
+  user: MyString
+  password: MyString
+  uuid: 234234234324
+  type: Foreman::Model::EC2

--- a/test/fixtures/trends.yml
+++ b/test/fixtures/trends.yml
@@ -1,9 +1,11 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 one:
-  trendable_type: MyString
+  trendable_type: Operatingsystem
   trendable_id: 1
+  type: "ForemanTrend"
 
 two:
-  trendable_type: MyString
+  trendable_type: Model
   trendable_id: 1
+  type: "ForemanTrend"

--- a/test/fixtures/usergroups.yml
+++ b/test/fixtures/usergroups.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
 
 one:
-  name: MyString
+  name: Admins
 
 two:
-  name: MyString2
+  name: Engineers

--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class AboutTest < ActionDispatch::IntegrationTest
+
+  test "about page" do
+    visit about_index_path
+    assert_index_page(about_index_path,"About", nil, false, false)
+    assert page.has_selector?('h4', :text => "System Status"), "System Status was expected in the <h4> tag, but was not found"
+    assert page.has_selector?('h4', :text => "Support"), "Support was expected in the <h4> tag, but was not found"
+    assert page.has_selector?('h4', :text => "System Information"), "System Information was expected in the <h4> tag, but was not found"
+    assert page.has_link?("Smart Proxies", :href => "#smart_proxies")
+    assert page.has_link?("Compute Resources", :href => "#compute_resources")
+    assert page.has_link?("Foreman Users", :href => "http://groups.google.com/group/foreman-users")
+    assert page.has_link?("Foreman Developers", :href => "http://groups.google.com/group/foreman-dev")
+    assert page.has_link?("issue tracker", :href => "http://projects.theforeman.org/projects/foreman/issues")
+    assert page.has_link?("Wiki", :href => "http://theforeman.org/wiki/foreman")
+    assert page.has_link?("Ohad Levy", :href => "mailto:ohadlevy@gmail.com")
+    assert page.has_content?("Version")
+  end
+
+end

--- a/test/integration/architecture_test.rb
+++ b/test/integration/architecture_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ArchitectureTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(architectures_path,"Architectures","New Architecture")
+  end
+
+  test "create new page" do
+    assert_new_button(architectures_path,"New Architecture",new_architecture_path)
+    fill_in "architecture_name", :with => "i386"
+    assert_submit_button(architectures_path)
+    assert page.has_link? 'i386'
+  end
+
+  test "edit page" do
+    visit architectures_path
+    click_link "x86_64"
+    fill_in "architecture_name", :with => "z128"
+    assert_submit_button(architectures_path)
+    assert page.has_link? 'z128'
+  end
+
+end

--- a/test/integration/audit_test.rb
+++ b/test/integration/audit_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class AuditTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(audits_path,"Audits",nil,true)
+  end
+
+  test "audit content" do
+    visit audits_path
+    assert has_content?("updated Host"), "expected 'updated Host' but it doesn't exist"
+  end
+
+end

--- a/test/integration/auth_source_ldap_test.rb
+++ b/test/integration/auth_source_ldap_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class AuthSourceLdapTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(auth_source_ldaps_path,"LDAP Authentication","New LDAP Source",false,false)
+  end
+
+  test "create new page" do
+    assert_new_button(auth_source_ldaps_path,"New LDAP Source",new_auth_source_ldap_path)
+    fill_in "auth_source_ldap_name", :with => "corporate-ldap"
+    fill_in "auth_source_ldap_host", :with => "10.0.0.77"
+    fill_in "auth_source_ldap_port", :with => "5555"
+    fill_in "auth_source_ldap_account", :with => "superadmin"
+    fill_in "auth_source_ldap_account_password", :with => "secretsecret"
+    fill_in "auth_source_ldap_base_dn", :with => "dn=x,dn=y"
+    fill_in "auth_source_ldap_attr_login", :with => "johndoe"
+    fill_in "auth_source_ldap_attr_firstname", :with => "John"
+    fill_in "auth_source_ldap_attr_lastname", :with => "Doe"
+    fill_in "auth_source_ldap_attr_mail", :with => "john@example.com"
+    assert_submit_button(auth_source_ldaps_path)
+    assert page.has_link? "corporate-ldap"
+    assert page.has_content? "10.0.0.77"
+  end
+
+  test "edit auth_source_ldaps_path" do
+    visit auth_source_ldaps_path
+    click_link "ldap-server"
+    fill_in "auth_source_ldap_name", :with => "testing-ldap"
+    fill_in "auth_source_ldap_host", :with => "10.1.2.34"
+    assert_submit_button(auth_source_ldaps_path)
+    assert page.has_link? "testing-ldap"
+    assert page.has_content? '10.1.2.34'
+  end
+
+end

--- a/test/integration/bookmark_test.rb
+++ b/test/integration/bookmark_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class BookmarkTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(bookmarks_path,"Manage Bookmarks",false,false,true)
+  end
+
+  test "edit path" do
+    visit bookmarks_path
+    within("table") do
+      click_link("foo")
+    end
+    fill_in "bookmark_name", :with => "recent"
+    fill_in "bookmark_query", :with => "last_report > 60 minutes ago"
+    assert_submit_button(bookmarks_path)
+    assert page.has_link? "recent"
+    assert page.has_content? 'last_report > 60 minutes ago'
+  end
+
+end

--- a/test/integration/common_parameter_test.rb
+++ b/test/integration/common_parameter_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class CommonParameterTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(common_parameters_path,"Global Parameters","New Parameter")
+  end
+
+  test "create new page" do
+    assert_new_button(common_parameters_path,"New Parameter",new_common_parameter_path)
+    fill_in "common_parameter_name", :with => "ssh_debug_key"
+    fill_in "common_parameter_value", :with => "ssh-rsa AAAAB3NzaC1yc2E"
+    assert_submit_button(common_parameters_path)
+    assert page.has_link? 'ssh_debug_key'
+    assert page.has_content? 'ssh-rsa AAAAB3NzaC1yc2E'
+  end
+
+  test "edit page" do
+    visit common_parameters_path
+    click_link "test"
+    fill_in "common_parameter_value", :with => "mynewvalue"
+    assert_submit_button(common_parameters_path)
+    assert page.has_content? 'mynewvalue'
+  end
+
+end

--- a/test/integration/compute_resource_test.rb
+++ b/test/integration/compute_resource_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ComputeResourceTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(compute_resources_path,"Listing compute resources","New Compute Resource")
+  end
+
+  test "edit compute resource" do
+    visit compute_resources_path
+    click_link "mycompute"
+    click_link "Edit"
+    fill_in "compute_resource_name", :with => "mycompute_old"
+    assert_submit_button(compute_resources_path)
+    assert page.has_link? 'mycompute_old'
+  end
+
+end

--- a/test/integration/config_template_test.rb
+++ b/test/integration/config_template_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ConfigTemplateTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(config_templates_path,"Provisioning Templates","New Template")
+  end
+
+end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class DashboardTest < ActionDispatch::IntegrationTest
+
+  def assert_dashboard_link(text)
+    visit dashboard_path
+    assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
+    click_link(text)
+    assert_equal hosts_path, current_path, "new path #{hosts_path} was expected but it was #{current_path}"
+    assert_not_nil find_field('search').value
+  end
+
+  test "dashboard page" do
+    assert_index_page(dashboard_path,"Overview",false,true,false)
+    assert page.has_content? 'Generated at'
+  end
+
+  test "dashboard link hosts that had performed modifications" do
+    assert_dashboard_link 'Hosts that had performed modifications without error'
+  end
+
+  test "dashboard link hosts in error state" do
+    assert_dashboard_link 'Hosts in error state'
+  end
+
+  test "dashboard link good host reports" do
+    assert_dashboard_link 'Good host reports in the last 35 minutes'
+  end
+
+  test "dashboard link hosts that had pending changes" do
+    assert_dashboard_link 'Hosts that had pending changes'
+  end
+
+  test "dashboard link out of sync hosts" do
+    assert_dashboard_link 'Out of sync Hosts'
+  end
+
+  test "dashboard link hosts with no reports" do
+    assert_dashboard_link 'Hosts with no reports'
+  end
+
+  test "dashboard link hosts with alerts disabled" do
+    assert_dashboard_link 'Hosts with alerts disabled'
+  end
+
+end

--- a/test/integration/domain_test.rb
+++ b/test/integration/domain_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class DomainTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(domains_path,"Domains","New Domain")
+  end
+
+  test "create new page" do
+    assert_new_button(domains_path,"New Domain",new_domain_path)
+    fill_in "domain_name", :with => "ynet.tlv.com"
+    assert_submit_button(domains_path)
+    assert page.has_link? 'ynet.tlv.com'
+  end
+
+  test "edit page" do
+    visit domains_path
+    click_link "mydomain.net"
+    fill_in "domain_name", :with => "my.updated.domain.org"
+    assert_submit_button(domains_path)
+    assert page.has_link? 'my.updated.domain.org'
+  end
+
+end

--- a/test/integration/environment_test.rb
+++ b/test/integration/environment_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class EnvironmentTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(environments_path,"Environments","New Environment")
+  end
+
+  test "create new page" do
+    assert_new_button(environments_path,"New Environment",new_environment_path)
+    fill_in "environment_name", :with => "golive"
+    assert_submit_button(environments_path)
+    assert page.has_link? 'golive'
+  end
+
+  test "edit page" do
+    visit environments_path
+    click_link "production"
+    fill_in "environment_name", :with => "production222"
+    assert_submit_button(environments_path)
+    assert page.has_link? 'production222'
+  end
+
+end

--- a/test/integration/fact_value_test.rb
+++ b/test/integration/fact_value_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class FactValueTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(fact_values_path,"Fact Values",nil,true)
+  end
+
+  test "host fact links" do
+    visit fact_values_path
+    within(:xpath, "//tr[contains(.,'kernelversion')]") do
+      click_link("my5name.mydomain.net")
+    end
+    assert_equal 'host = my5name.mydomain.net', find_field('search').value
+  end
+
+  test "fact_name fact links" do
+    visit fact_values_path
+    within(:xpath, "//tr[contains(.,'ipaddress')]") do
+      #first("ipaddress").click  #click_link returns ambigous
+      first(:xpath, "//td[2]/a[2]").click
+    end
+    assert_equal 'name = ipaddress', find_field('search').value
+  end
+
+  test "value fact links" do
+    visit fact_values_path
+    click_link("2.6.9")
+    assert_equal 'facts.kernelversion = "2.6.9"', find_field('search').value
+  end
+
+end

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class HostTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(hosts_path,"Hosts","New Host")
+  end
+
+  test "create new page" do
+    assert_new_button(hosts_path,"New Host",new_host_path)
+    assert page.has_link?("Host", :href => "#primary")
+    assert page.has_link?("Network", :href => "#network")
+    assert page.has_link?("Operating System", :href => "#os")
+    assert page.has_link?("Parameters", :href => "#params")
+    assert page.has_link?("Additional Information", :href => "#info")
+  end
+
+  test "show page" do
+    visit hosts_path
+    click_link "my5name.mydomain.net"
+    assert page.has_selector?('h1', :text => "my5name.mydomain.net"), "my5name.mydomain.net <h1> tag, but was not found"
+    assert page.has_link?("Properties", :href => "#properties")
+    assert page.has_link?("Metrics", :href => "#metrics")
+    assert page.has_link?("Templates", :href => "#template")
+    assert page.has_link?("Edit", :href => "/hosts/my5name.mydomain.net/edit")
+    assert page.has_link?("Build", :href => "/hosts/my5name.mydomain.net/setBuild")
+    assert page.has_link?("Run puppet", :href => "/hosts/my5name.mydomain.net/puppetrun")
+    assert page.has_link?("Delete", :href => "/hosts/my5name.mydomain.net")
+  end
+
+end

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class HostgroupTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(hostgroups_path,"Host Groups","New Host Group")
+  end
+
+  test "create new page" do
+    assert_new_button(hostgroups_path,"New Host Group",new_hostgroup_path)
+    fill_in "hostgroup_name", :with => "staging"
+    select "production", :from => "hostgroup_environment_id"
+    assert_submit_button(hostgroups_path)
+    assert page.has_link? 'staging'
+  end
+
+  test "edit page" do
+    visit hostgroups_path
+    click_link "Common"
+    fill_in "hostgroup_name", :with => "Common Old"
+    assert_submit_button(hostgroups_path)
+    assert page.has_link? 'Common Old'
+  end
+
+end

--- a/test/integration/location_test.rb
+++ b/test/integration/location_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class LocationTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(locations_path,"Locations","New Location")
+  end
+
+  # context - has nil hosts
+  test "index page has notice if nil hosts" do
+    Host.update_all(:location_id => nil)
+    visit locations_path
+    assert has_selector?("div.alert", :text => "with no location assigned")
+  end
+
+  # context - does not nil hosts
+  test "index page does not show notice if all hosts" do
+    Host.update_all(:location_id => Location.first.id)
+    visit locations_path
+    assert has_no_selector?("div.alert", :text => "with no location assigned")
+  end
+
+  # context - creating when all hosts are assigned
+  test "create new page when all hosts are assigned a location" do
+    Host.update_all(:location_id => Location.first.id)
+    assert has_no_selector?("div.alert", :text => "with no location assigned")
+    assert_new_button(locations_path,"New Location",new_location_path)
+    fill_in "location_name", :with => "Raleigh"
+    assert_submit_button(locations_path)
+    assert page.has_link? "Raleigh"
+  end
+
+  # content - click Assign All
+  test "create new page when some hosts are not assigned a location and click Assign All" do
+    assert_new_button(locations_path,"New Location",new_location_path)
+    fill_in "location_name", :with => "Raleigh"
+    click_button "Submit"
+    assert_equal step2_location_path(Location.order(:id).last), current_path, "redirect path #{step2_location_path(Location.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Assign All"
+    assert_equal locations_path, current_path, "redirect path #{locations_path} was expected but it was #{current_path}"
+    assert page.has_link? "Raleigh"
+  end
+
+  # content - click Manually Assign
+  test "create new page when some hosts are not assigned a location and click Manually Assign" do
+    assert_new_button(locations_path,"New Location",new_location_path)
+    fill_in "location_name", :with => "Raleigh"
+    click_button "Submit"
+    assert_equal step2_location_path(Location.order(:id).last), current_path, "redirect path #{step2_location_path(Location.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Manually Assign"
+    assert_equal assign_hosts_location_path(Location.order(:id).last), current_path, "redirect path #{assign_hosts_location_path(Location.order(:id).last)} was expected but it was #{current_path}"
+    assert_submit_button(locations_path, "Assign to Location")
+    assert page.has_link? "Raleigh"
+  end
+
+  # click Proceed to Edit
+  test "create new page when some hosts are and assigned a location and click Proceed to Edit" do
+    assert_new_button(locations_path,"New Location",new_location_path)
+    fill_in "location_name", :with => "Raleigh"
+    click_button "Submit"
+    assert_equal step2_location_path(Location.order(:id).last), current_path, "redirect path #{step2_location_path(Location.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Proceed to Edit"
+    assert_equal edit_location_path(Location.order(:id).last), current_path, "redirect path #{edit_location_path(Location.order(:id).last)} was expected but it was #{current_path}"
+    assert page.has_selector?('h1', :text => "Edit"), "Edit was expected in the <h1> tag, but was not found"
+  end
+
+  # PENDING
+  # test "mismatches report" do
+  # end
+end

--- a/test/integration/lookup_key_test.rb
+++ b/test/integration/lookup_key_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class LookupKeyTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(lookup_keys_path,"Smart variables",false)
+  end
+
+  test "edit page" do
+    visit lookup_keys_path
+    within(:xpath, "//table") do
+      click_link "cluster"
+    end
+    fill_in "lookup_key_key", :with => "webport"
+    select "base", :from => "lookup_key_puppetclass_id"
+    fill_in "lookup_key_default_value", :with => "8080"
+    assert_submit_button(lookup_keys_path)
+    assert page.has_link? 'webport'
+  end
+
+end

--- a/test/integration/media_test.rb
+++ b/test/integration/media_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class MediaTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(media_path,"Media","New Medium")
+  end
+
+  test "create new page" do
+    assert_new_button(media_path,"New Medium",new_medium_path)
+    fill_in "medium_name", :with => "Fedora Mirror 123"
+    fill_in "medium_path", :with => "http://download.eng.tlv.redhat.com/pub/fedora123/linux/releases/$major/Fedora/$arch/os"
+    select "Redhat", :from => "medium_os_family"
+    assert_submit_button(media_path)
+    assert page.has_link? 'Fedora Mirror 123'
+  end
+
+  test "edit page" do
+    visit media_path
+    click_link "Ubuntu Mirror"
+    fill_in "medium_name", :with => "Ubuntu Mirror 123"
+    select "Debian", :from => "medium_os_family"
+    assert_submit_button(media_path)
+    assert page.has_link? 'Ubuntu Mirror 123'
+  end
+
+end

--- a/test/integration/model_test.rb
+++ b/test/integration/model_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ModelTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(models_path,"Hardware Models","New Model")
+  end
+
+  test "create new page" do
+    assert_new_button(models_path,"New Model",new_model_path)
+    fill_in "model_name", :with => "IBM 123"
+    fill_in "model_hardware_model", :with => "IBMabcde"
+    fill_in "model_vendor_class", :with => "ABCDE"
+    fill_in "model_info", :with => "description text"
+    assert_submit_button(models_path)
+    assert page.has_link? "IBM 123"
+  end
+
+  test "edit page" do
+    visit models_path
+    click_link "KVM"
+    fill_in "model_name", :with => "RHEV 123"
+    assert_submit_button(models_path)
+    assert page.has_link? 'RHEV 123'
+  end
+
+end

--- a/test/integration/operatingsystem_test.rb
+++ b/test/integration/operatingsystem_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class OperatingsystemTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(operatingsystems_path,"Operating systems","New Operating system")
+  end
+
+  test "create new page" do
+    assert_new_button(operatingsystems_path,"New Operating system",new_operatingsystem_path)
+    fill_in "operatingsystem_name", :with => "Archy"
+    fill_in "operatingsystem_major", :with => "9"
+    fill_in "operatingsystem_minor", :with => "2"
+    select "Archlinux", :from => "operatingsystem_family"
+    check "x86_64"
+    assert_submit_button(operatingsystems_path)
+    assert page.has_link? "Archy 9.2"
+  end
+
+  test "edit page" do
+    visit operatingsystems_path
+    click_link "centos 5.3"
+    fill_in "operatingsystem_major", :with => "6"
+    assert_submit_button(operatingsystems_path)
+    assert page.has_link? 'centos 6.3'
+  end
+
+  # PENDING
+  # test "add parameters" do
+  # end
+
+  # PENDING
+  # test "add templates" do
+  # end
+
+end

--- a/test/integration/organization_test.rb
+++ b/test/integration/organization_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+class OrganizationTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(organizations_path,"Organizations","New Organization")
+  end
+
+  # context - has nil hosts
+  test "index page has notice if nil hosts" do
+    Host.update_all(:organization_id => nil)
+    visit organizations_path
+    assert has_selector?("div.alert", :text => "with no organization assigned")
+  end
+
+  # context - does not nil hosts
+  test "index page does not show notice if all hosts" do
+    Host.update_all(:organization_id => Organization.first.id)
+    visit locations_path
+    assert has_no_selector?("div.alert", :text => "with no organization assigned")
+  end
+
+  # context - creating when all hosts are assigned
+  test "create new page when all hosts are assigned a organization" do
+    Host.update_all(:organization_id => Organization.first.id)
+    assert !has_selector?("div.alert", :text => "with no organization assigned")
+    assert_new_button(organizations_path,"New Organization",new_organization_path)
+    fill_in "organization_name", :with => "Finance"
+    assert_submit_button(organizations_path)
+    assert page.has_link? "Finance"
+  end
+
+  # content - click Assign All
+  test "create new page when some hosts are NOT assigned a organization - click Assign All" do
+    assert_new_button(organizations_path,"New Organization",new_organization_path)
+    fill_in "organization_name", :with => "Finance"
+    click_button "Submit"
+    assert_equal step2_organization_path(Organization.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Assign All"
+    assert_equal organizations_path, current_path, "redirect path #{organizations_path} was expected but it was #{current_path}"
+    assert page.has_link? "Finance"
+  end
+
+  # content - click Manually Assign
+  test "create new page when some hosts are NOT assigned a organization - click Manually Assign" do
+    assert_new_button(organizations_path,"New Organization",new_organization_path)
+    fill_in "organization_name", :with => "Finance"
+    click_button "Submit"
+    assert_equal step2_organization_path(Organization.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Manually Assign"
+    assert_equal assign_hosts_organization_path(Organization.order(:id).last), current_path, "redirect path #{assign_hosts_organization_path(Organization.order(:id).last)} was expected but it was #{current_path}"
+    assert_submit_button(organizations_path, "Assign to Organization")
+    assert page.has_link? "Finance"
+  end
+
+  # click Proceed to Edit
+  test "create new page when some hosts are NOT assigned a organization - click Proceed to Edit" do
+    assert_new_button(organizations_path,"New Organization",new_organization_path)
+    fill_in "organization_name", :with => "Finance"
+    click_button "Submit"
+    assert_equal step2_organization_path(Organization.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.order(:id).last)} was expected but it was #{current_path}"
+    click_link "Proceed to Edit"
+    assert_equal edit_organization_path(Organization.order(:id).last), current_path, "redirect path #{edit_organization_path(Organization.order(:id).last)} was expected but it was #{current_path}"
+    assert page.has_selector?('h1', :text => "Edit"), "Edit was expected in the <h1> tag, but was not found"
+  end
+
+  # PENDING
+  # test "mismatches report" do
+  # end
+
+end

--- a/test/integration/ptable_test.rb
+++ b/test/integration/ptable_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class PtableTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(ptables_path,"Partition Tables","New Partition Table")
+  end
+
+  test "create new page" do
+    assert_new_button(ptables_path,"New Partition Table",new_ptable_path)
+    fill_in "ptable_name", :with => "ubuntu 123 layout"
+    fill_in "ptable_layout", :with => "d-i partman-auto/disk string"
+    select "Debian", :from => "ptable_os_family"
+    assert_submit_button(ptables_path)
+    assert page.has_link? "ubuntu 123 layout"
+  end
+
+  test "edit page" do
+    visit ptables_path
+    click_link "ubuntu default"
+    fill_in "ptable_name", :with => "debian default"
+    fill_in "ptable_layout", :with => "d-i partman-auto/disk string /dev/sda\nd-i"
+    assert_submit_button(ptables_path)
+    assert page.has_link? 'debian default'
+  end
+
+end

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class PuppetclassTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(puppetclasses_path,"Puppet classes","New Puppet class")
+  end
+
+  test "create new page" do
+    assert_new_button(puppetclasses_path,"New Puppet class",new_puppetclass_path)
+    fill_in "puppetclass_name", :with => "sublime"
+    assert_submit_button(puppetclasses_path)
+    assert page.has_link? "sublime"
+  end
+
+  test "edit page" do
+    visit puppetclasses_path
+    click_link "vim"
+    fill_in "puppetclass_name", :with => "vim_renamed"
+    assert_submit_button(puppetclasses_path)
+    assert page.has_link? 'vim_renamed'
+  end
+
+  # PENDING
+  # test "smart variables" do
+  # end
+
+  # PENDING
+  # test "smart class parameters" do
+  # end
+
+end

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ReportTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    visit reports_path
+    assert find_button('Search').visible?, "Search button is not visible"
+  end
+
+  test "reports for host" do
+    visit reports_path
+    click_link("my5name.mydomain.net")
+    assert_equal 'host = my5name.mydomain.net', find_field('search').value
+  end
+
+  test "show specific report" do
+    visit reports_path
+    click_link("7 days ago")
+    assert page.has_selector?('h1', :text => "my5name.mydomain.net"), "'my5name.mydomain.net' was expected in the <h1> tag, but was not found"
+  end
+
+end

--- a/test/integration/role_test.rb
+++ b/test/integration/role_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class RoleTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(roles_path,"Roles","New role")
+  end
+
+  test "create new page" do
+    assert_new_button(roles_path,"New role",new_role_path)
+    fill_in "role_name", :with => "Big Boss"
+    assert_submit_button(roles_path)
+    assert page.has_link? "Big Boss"
+  end
+
+  test "edit page" do
+    visit roles_path
+    click_link "Manager"
+    fill_in "role_name", :with => "Vice President"
+    assert_submit_button(roles_path)
+    assert page.has_link? 'Vice President'
+  end
+
+  # PENDING
+  # permission report
+end

--- a/test/integration/setting_test.rb
+++ b/test/integration/setting_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class SettingTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(settings_path,"Settings",false,true,false)
+    assert page.has_link?("General", :href => "#General")
+    assert page.has_link?("Puppet", :href => "#Puppet")
+    assert page.has_link?("Provisioning", :href => "#Provisioning")
+    assert page.has_link?("Auth", :href => "#Auth")
+  end
+
+end

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class SmartProxyTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(smart_proxies_path,"Proxies","New Proxy",false)
+  end
+
+  test "create new page" do
+    assert_new_button(smart_proxies_path,"New Proxy",new_smart_proxy_path)
+    fill_in "smart_proxy_name", :with => "DNS Worldwide"
+    fill_in "smart_proxy_url", :with => "http://dns.example.com"
+    assert_submit_button(smart_proxies_path)
+    assert page.has_link? "DNS Worldwide"
+    assert page.has_content? "http://dns.example.com"
+  end
+
+  test "edit page" do
+    visit smart_proxies_path
+    click_link "DHCP Proxy"
+    fill_in "smart_proxy_name", :with => "DHCP Secure"
+    fill_in "smart_proxy_url", :with => "https://secure.net:8443"
+    assert_submit_button(smart_proxies_path)
+    assert page.has_link? 'DHCP Secure'
+    assert page.has_content? "https://secure.net:8443"
+  end
+
+end

--- a/test/integration/statistic_test.rb
+++ b/test/integration/statistic_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class StatisticTest < ActionDispatch::IntegrationTest
+
+  test "statistics page" do
+    visit statistics_path
+    assert page.has_selector?('h4', :text => "OS Distribution")
+    assert page.has_selector?('h4', :text => "Architecture Distribution")
+    assert page.has_selector?('h4', :text => "Environments Distribution")
+    assert page.has_selector?('h4', :text => "Number of CPUs")
+    assert page.has_selector?('h4', :text => "Hardware")
+    assert page.has_selector?('h4', :text => "Class Distribution")
+    assert page.has_selector?('h4', :text => "Average memory usage")
+    assert page.has_selector?('h4', :text => "Average swap usage")
+    assert page.has_selector?('h4', :text => "Total memory usage")
+  end
+
+end

--- a/test/integration/subnet_test.rb
+++ b/test/integration/subnet_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SubnetTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(subnets_path,"Subnets","New Subnet")
+  end
+
+  test "create new page" do
+    assert_new_button(subnets_path,"New Subnet",new_subnet_path)
+    fill_in "subnet_name", :with => "home-office"
+    fill_in "subnet_network", :with => "10.0.0.77"
+    fill_in "subnet_mask", :with => "255.255.255.0"
+    assert_submit_button(subnets_path)
+    assert page.has_link? "home-office"
+  end
+
+  test "edit page" do
+    visit subnets_path
+    click_link "one"
+    fill_in "subnet_name", :with => "one-secure"
+    fill_in "subnet_network", :with => "10.1.1.177"
+    assert_submit_button(subnets_path)
+    assert page.has_link? 'one-secure'
+  end
+
+end

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+class TopBarTest < ActionDispatch::IntegrationTest
+
+  test "top bar links" do
+    visit root_path
+    within("div.logo-bar") do
+      assert page.has_link?("Foreman", :href => "/")
+    end
+    within("div.navbar-inner") do
+      assert page.has_link?("Dashboard", :href => "/dashboard")
+      assert page.has_link?("Hosts", :href => "/hosts")
+      assert page.has_link?("Reports", :href => "/reports?search=eventful+%3D+true")
+      assert page.has_link?("Facts", :href => "/fact_values")
+      assert page.has_link?("Audits", :href => "/audits")
+      assert page.has_link?("Statistics", :href => "/statistics")
+      assert page.has_link?("Trends", :href => "/trends")
+    end
+  end
+
+  test "Dashboard link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Dashboard")
+    end
+    assert page.has_selector?('h1', :text => "Overview")
+  end
+
+  test "Hosts link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Hosts")
+    end
+    assert page.has_selector?('h1', :text => "Hosts")
+  end
+
+  test "Facts link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Facts")
+    end
+    assert page.has_selector?('h1', :text => "Fact Values")
+  end
+
+  test "Audits link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Audits")
+    end
+    assert page.has_selector?('h1', :text => "Audits")
+  end
+
+  test "Statistics link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Statistics")
+    end
+    assert page.has_selector?('h4', :text => "OS Distribution")
+  end
+
+  test "Trends link" do
+    visit root_path
+    within("div.navbar-inner") do
+      click_link("Trends")
+    end
+    assert page.has_selector?('h1', :text => "Trends")
+  end
+
+  #PENDING - click on Menu Bar js
+
+end

--- a/test/integration/trend_test.rb
+++ b/test/integration/trend_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class TrendTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    visit trends_path
+    assert page.has_selector?('h1', :text => "Trends"), "Trends was expected in the <h1> tag, but was not found"
+    assert find_link("Add Trend Counter").visible?, "Add Trend Counter is not visible"
+  end
+
+  #PENDING
+  # test "create new page" do
+  #   assert_new_button(trends_path,"Add Trend Counter",new_trend_path)
+  #   fill_in "trend_name", :with => "architecture"
+  #   assert_submit_button(trends_path)
+  #   assert page.has_link? "architecture"
+  # end
+
+  #PENDING - SHOW trend
+
+end

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class UserTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(users_path,"Users","New User")
+  end
+
+  test "edit page" do
+    visit users_path
+    click_link "one"
+    fill_in "user_login", :with => "user12345"
+    assert_submit_button(users_path)
+    assert page.has_link? 'user12345'
+  end
+
+end

--- a/test/integration/usergroup_test.rb
+++ b/test/integration/usergroup_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class UsergroupTest < ActionDispatch::IntegrationTest
+
+  test "index page" do
+    assert_index_page(usergroups_path,"User Groups","New User group",false)
+  end
+
+  test "create new page" do
+    assert_new_button(usergroups_path,"New User group",new_usergroup_path)
+    fill_in "usergroup_name", :with => "bosses"
+    assert_submit_button(usergroups_path)
+    assert page.has_link? "bosses"
+  end
+
+  test "edit page" do
+    visit usergroups_path
+    click_link "Admins"
+    fill_in "usergroup_name", :with => "SuperAdmins"
+    assert_submit_button(usergroups_path)
+    assert page.has_link? 'SuperAdmins'
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,6 @@ Spork.prefork do
     # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
     # Note: You'll currently still have to declare fixtures explicitly in integration tests
     # -- they do not yet inherit this setting
-
     fixtures :all
     set_fixture_class({ :hosts => Host::Base })
     set_fixture_class :nics => Nic::BMC
@@ -124,6 +123,55 @@ Spork.prefork do
 
     # Stop ActiveRecord from wrapping tests in transactions
     self.use_transactional_fixtures = false
+
+    def assert_index_page(index_path,title_text,new_link_text = nil,has_search = true,has_pagination = true)
+      visit index_path
+      assert page.has_selector?('h1', :text => title_text), "#{title_text} was expected in the <h1> tag, but was not found"
+      (assert find_link(new_link_text).visible?, "#{new_link_text} is not visible") if new_link_text
+      (assert find_button('Search').visible?, "Search button is not visible") if has_search
+      (assert has_content?("Displaying"), "Pagination 'Display ...' does not appear") if has_pagination
+    end
+
+    def assert_new_button(index_path,new_link_text,new_path)
+      visit index_path
+      click_link new_link_text
+      assert_equal new_path, current_path, "new path #{new_path} was expected but it was #{current_path}"
+    end
+
+    def assert_submit_button(redirect_path,button_text = "Submit")
+      click_button button_text
+      assert_equal redirect_path, current_path, "redirect path #{redirect_path} was expected but it was #{current_path}"
+    end
+
+    def assert_delete_row(index_path, link_text, delete_text = "Delete", dropdown = false)
+      visit index_path
+      within(:xpath, "//tr[contains(.,'#{link_text}')]") do
+        find("i.caret").click if dropdown
+        click_link(delete_text)
+      end
+      popup = page.driver.browser.switch_to.alert
+      popup.accept
+      assert page.has_no_link?(link_text), "link '#{link_text}' was expected NOT to be on the page, but it was found."
+      assert page.has_content?('Successfully destroyed'), "flash message 'Successfully destroyed' was expected but it was not found on the page"
+    end
+
+    def assert_cannot_delete_row(index_path, link_text, delete_text = "Delete", dropdown = false, flash_message = true)
+      visit index_path
+      within(:xpath, "//tr[contains(.,'#{link_text}')]") do
+        find("i.caret").click if dropdown
+        click_link(delete_text)
+      end
+      popup = page.driver.browser.switch_to.alert
+      popup.accept
+      assert page.has_link?(link_text), "link '#{link_text}' was expected but it was not found on the page."
+      assert page.has_content?("is used by"), "flash message 'is used by' was expected but it was not found on the page."
+    end
+
+    def fix_mismatches
+      Location.all_import_missing_ids
+      Organization.all_import_missing_ids
+    end
+
   end
 
   class ActionView::TestCase


### PR DESCRIPTION
Need to select the appropriate javascript driver before merging js integration tests 
