### PR TITLE
fixes #2498 FactNames are not precreated

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -82,21 +82,17 @@ module Host
       FactValue.delete(deletions) unless deletions.empty?
 
       # Get FactNames in one call
-      fact_names = FactName.where(:name => facts.keys)
+      fact_names = FactName.maximum(:id, :group => 'name')
 
       # Create any needed new FactNames
-      facts.keys.dup.delete_if { |n| fact_names.map(&:name).include? n }.each do |needed|
-        fact_names << FactName.create(:name => needed)
-      end
-
-      # Lastly, add any new parameters.
-      fact_names.each do |fact_name|
-        next if db_facts.include?(fact_name.name)
-        value = facts[fact_name.name]
+      facts.each do |name, value|
+        next if db_facts.include?(name)
         values = value.is_a?(Array) ? value : [value]
+
         values.each do |v|
           next if v.nil?
-          fact_values.build(:value => v, :fact_name => fact_name)
+          fact_values.build(:value => v, :fact_name => fact_names.keys.include?(name) ?
+                                         fact_names[name] : FactName.create!(:name => name))
         end
       end
     end


### PR DESCRIPTION
 facts.keys.dup.delete_if { |n| fact_names.map(&:name).include? n } creates a tremendous overhead on the facts import from the puppet masters, this fix simply takes the code from the original Puppet::Rails::Host. As an example, imports have gone from ~30s to ~200ms
