### PR TITLE
Fixes #2502 - session expiration updates

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -112,7 +112,7 @@ class UsersController < ApplicationController
   # Clears the rails session and redirects to the login action
   def logout
     TopbarSweeper.expire_cache(self)
-
+    sso_logout_path = get_sso_method.try(:logout_url)
     session[:user] = @user = User.current = nil
     if flash[:notice] or flash[:error]
       flash.keep
@@ -120,7 +120,7 @@ class UsersController < ApplicationController
       session.clear
       notice _("Logged out - See you soon")
     end
-    redirect_to login_users_path
+    redirect_to sso_logout_path || login_users_path
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,10 +293,6 @@ module ApplicationHelper
     "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}?d=mm&s=30"
   end
 
-  def sign_out_url
-    (session[:logout_path] || '') + URI.escape(logout_users_url)
-  end
-
   private
   def edit_inline(object, property, options={})
     name       = "#{type}[#{property}]"

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -2,7 +2,7 @@
   <li class="dropdown">
     <%= user_header %>
     <ul class="dropdown-menu pull-right">
-      <li><%= link_to(_("Sign Out"), sign_out_url) %></li>
+      <li><%= link_to(_("Sign Out"), logout_users_url) %></li>
       <li><%= link_to(_("My account"), edit_user_path(User.current) )%></li>
     </ul>
   </li>

--- a/lib/sso/base.rb
+++ b/lib/sso/base.rb
@@ -12,10 +12,13 @@ module SSO
       false
     end
 
-    def support_logout?
+    # don't forget to implement expiration_url method if your SSO method changes this to true
+    def support_expiration?
       false
     end
 
+    # if your SSO method supports logout page, you should store it into a session[:logout_url]
+    # during this method execution
     def authenticated?
       raise NotImplemented, 'authenticated? not implemented for this authentication method'
     end

--- a/lib/sso/signo.rb
+++ b/lib/sso/signo.rb
@@ -2,7 +2,7 @@ module SSO
   class Signo < Base
     attr_reader :env, :headers
     delegate :env, :to => :request
-    delegate :headers, :to => :controller
+    delegate :headers, :session, :root_url, :to => :controller
 
     def available?
       Setting['signo_sso'] && defined?(Rack::OpenID) && !controller.api_request?
@@ -15,17 +15,14 @@ module SSO
       !@failed
     end
 
-    def support_logout?
+    def support_expiration?
       true
-    end
-
-    def logout_path
-      "#{Setting['signo_url']}/logout?return_url="
     end
 
     def authenticated?
       if (response = env[Rack::OpenID::RESPONSE])
-        parse_open_id(response)
+        store if (result = parse_open_id(response))
+        result
       else
         false
       end
@@ -39,11 +36,27 @@ module SSO
         controller.render :text => '', :status => 401
       else
         # we have no cookie yet so we plain redirect to OpenID provider to login
-        controller.redirect_to "#{Setting['signo_url']}?return_url=#{URI.escape(request.url)}"
+        controller.redirect_to login_url
       end
     end
 
+    def login_url
+      "#{Setting['signo_url']}?return_url=#{URI.escape(request.url)}"
+    end
+
+    def logout_url
+      "#{Setting['signo_url']}/logout?return_url=#{URI.escape(root_url)}"
+    end
+
+    def expiration_url
+      "#{login_url}&notice=expired"
+    end
+
     private
+
+    def store
+      session[:sso_method] = self.class.to_s
+    end
 
     def parse_open_id(response)
       case response.status

--- a/test/unit/sso/signo_test.rb
+++ b/test/unit/sso/signo_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class SignoTest < ActiveSupport::TestCase
-  def test_logout_path_can_be_appended
-    assert_equal get_signo_method.logout_path.last, '='
-  end
-
   def test_casual_request_authenticated?
     assert !get_signo_method.authenticated?
   end
@@ -19,6 +15,7 @@ class SignoTest < ActiveSupport::TestCase
 
     stub(signo).parse_open_id { true }
     assert signo.authenticated?
+    assert_equal signo.session[:sso_method], 'SSO::Signo'
   end
 
   def test_parse_open_id_success
@@ -72,9 +69,13 @@ class SignoTest < ActiveSupport::TestCase
     stub(request).env { req }
     cookies = Hash.new
     stub(request).cookies { cookies }
+    stub(request).url { 'https://localhost/wherever/am?i=whoever&am=i' }
     headers = Hash.new
     stub(controller).headers { headers }
     stub(controller).request { request }
+    session = Hash.new
+    stub(controller).session { session }
+    stub(controller).root_url { 'https://localhost/foreman?a=b&c=d' }
 
     controller
   end


### PR DESCRIPTION
Signo now allows to transparently prolong user session which got
expired. Also when you now logout from Foreman you will end up in Signo
login form. This brings some code clean up and test changes and small
SSO method API change.

THIS PR MUST BE MERGED AT THE SAME TIME AS:
- https://github.com/Katello/signo/pull/2
- https://github.com/Katello/katello/pull/2310

Please let me know before you merge this.
