### PR TITLE
RPM packaging fixes

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -4,7 +4,7 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
   gem "jquery-rails", "2.0.3"
   gem 'jquery-ui-rails'
-  gem "therubyracer", '0.11.3'
+  gem "therubyracer", '0.11.3', :require => 'v8'
   gem "twitter-bootstrap-rails"
   gem "spice-html5-rails"
   gem "flot-rails", '0.0.3'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,5 +2,7 @@ require 'rubygems'
 require 'yaml'
 require File.expand_path('../../config/settings', __FILE__)
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+unless File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+  require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+end

--- a/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
+++ b/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
@@ -68,10 +68,13 @@
       <packagereq type="default">ruby193-rubygem-execjs</packagereq>
       <packagereq type="default">ruby193-rubygem-fast_gettext</packagereq>
       <packagereq type="default">ruby193-rubygem-ffi</packagereq>
+      <packagereq type="default">ruby193-rubygem-flot-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-fog</packagereq>
       <packagereq type="default">ruby193-rubygem-foremancli</packagereq>
       <packagereq type="default">ruby193-rubygem-formatador</packagereq>
+      <packagereq type="default">ruby193-rubygem-gettext</packagereq>
       <packagereq type="default">ruby193-rubygem-gettext_i18n_rails</packagereq>
+      <packagereq type="default">ruby193-rubygem-gettext_i18n_rails_js</packagereq>
       <packagereq type="default">ruby193-rubygem-hike</packagereq>
       <packagereq type="default">ruby193-rubygem-hirb-unicode</packagereq>
       <packagereq type="default">ruby193-rubygem-hirb</packagereq>
@@ -82,6 +85,7 @@
       <packagereq type="default">ruby193-rubygem-jquery-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-jquery-ui-rails</packagereq>
       <packagereq type="default">ruby193-rubygem-json</packagereq>
+      <packagereq type="default">ruby193-rubygem-levenshtein</packagereq>
       <packagereq type="default">ruby193-rubygem-mail</packagereq>
       <packagereq type="default">ruby193-rubygem-mime-types</packagereq>
       <packagereq type="default">ruby193-rubygem-multi_json</packagereq>
@@ -94,6 +98,7 @@
       <packagereq type="default">ruby193-rubygem-oauth</packagereq>
       <packagereq type="default">ruby193-rubygem-pg</packagereq>
       <packagereq type="default">ruby193-rubygem-polyglot</packagereq>
+      <packagereq type="default">ruby193-rubygem-po_to_json</packagereq>
       <packagereq type="default">ruby193-rubygem-quiet_assets</packagereq>
       <packagereq type="default">ruby193-rubygem-rabl</packagereq>
       <packagereq type="default">ruby193-rubygem-rack-cache</packagereq>

--- a/extras/packaging/rpm/sources/foreman.init
+++ b/extras/packaging/rpm/sources/foreman.init
@@ -17,11 +17,12 @@ function run_in_scl() {
 }
 
 prog=foreman
-THIN=run_in_scl
+THIN=/usr/bin/thin
 RETVAL=0
 FOREMAN_PORT=${FOREMAN_PORT:-3000}
 FOREMAN_USER=${FOREMAN_USER:-foreman}
 FOREMAN_HOME=${FOREMAN_HOME:-/usr/share/foreman}
+export HOME=$FOREMAN_HOME
 FOREMAN_ENV=${FOREMAN_ENV:-production}
 FOREMAN_USE_PASSENGER=${FOREMAN_USE_PASSENGER:-0}
 FOREMAN_USE_THIN=${FOREMAN_USE_THIN:-0}
@@ -47,7 +48,7 @@ start() {
             --rackup "${FOREMAN_HOME}/config.ru"
     else
         cd ${FOREMAN_HOME}
-        daemon --user ${FOREMAN_USER} /usr/bin/ruby193-ruby ${FOREMAN_HOME}/script/rails s -p ${FOREMAN_PORT} -e ${FOREMAN_ENV} -d ${FOREMAN_EXTRA_ARGS} > /dev/null
+        daemon --user ${FOREMAN_USER} /usr/bin/ruby ${FOREMAN_HOME}/script/rails s -p ${FOREMAN_PORT} -e ${FOREMAN_ENV} -d ${FOREMAN_EXTRA_ARGS} > /dev/null
     fi
     RETVAL=$?
     if [ $RETVAL = 0 ]

--- a/foreman.spec
+++ b/foreman.spec
@@ -63,15 +63,15 @@ Requires: %{?scl_prefix}rubygem(oauth)
 Requires: %{?scl_prefix}rubygem(rabl) >= 0.7.5
 Requires: %{?scl_prefix}rubygem(rake) >= 0.8.3
 Requires: %{?scl_prefix}rubygem(ruby_parser) >= 3.0.0
-Requires: %{?scl_prefix}rubygem(ruby_parser) < 3.1.0
 Requires: %{?scl_prefix}rubygem(audited-activerecord) >= 3.0.0
-Requires: %{?scl_prefix}rubygem(apipie-rails) = 0.0.16
+Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.0.16
 Requires: %{?scl_prefix}rubygem(bundler_ext)
 Requires: %{?scl_prefix}rubygem(thin)
 Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.4.8
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails)
+Requires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 Requires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
-Requires: %{?scl_prefix}rubygem(therubyracer) =  0.11.3
+Requires: %{?scl_prefix}rubygem(therubyracer)
 Requires: %{?scl_prefix}rubygem(jquery-ui-rails)
 Requires: %{?scl_prefix}rubygem(twitter-bootstrap-rails)
 BuildRequires: %{?scl_prefix}rubygem(ancestry) < 1.4.0
@@ -80,8 +80,11 @@ BuildRequires: %{?scl_prefix}rubygem(apipie-rails) >= 0.0.16
 BuildRequires: %{?scl_prefix}rubygem(audited-activerecord) >= 3.0.0
 BuildRequires: %{?scl_prefix}rubygem(bundler_ext)
 BuildRequires: %{?scl_prefix}rubygem(coffee-rails) => 3.2.1
+BuildRequires: %{?scl_prefix}rubygem(gettext) >= 1.9.3
 BuildRequires: %{?scl_prefix}rubygem(fast_gettext)
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails)
+BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
+BuildRequires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 BuildRequires: %{?scl_prefix}rubygem(jquery-rails)
 BuildRequires: %{?scl_prefix}rubygem(jquery-ui-rails)
 BuildRequires: %{?scl_prefix}rubygem(less-rails)
@@ -103,7 +106,7 @@ BuildRequires: %{?scl_prefix}rubygem(will_paginate) >= 3.0.2
 BuildRequires: %{?scl_prefix}rubygem(rails)
 BuildRequires: %{?scl_prefix}rubygem(quiet_assets)
 BuildRequires: %{?scl_prefix}rubygem(spice-html5-rails)
-BuildRequires: %{?scl_prefix}rubygem(flot-rails)
+BuildRequires: %{?scl_prefix}rubygem(flot-rails) = 0.0.3
 BuildRequires: %{?scl_prefix}facter
 BuildRequires: %{?scl_prefix}puppet >= 0.24.4
 BuildRequires: puppet
@@ -202,6 +205,8 @@ Requires: %{?scl_prefix}rubygem(therubyracer)
 Requires: %{?scl_prefix}rubygem(twitter-bootstrap-rails)
 Requires: %{?scl_prefix}rubygem(uglifier)
 Requires: %{?scl_prefix}rubygem(flot-rails) = 0.0.3
+Requires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
+Requires: %{?scl_prefix}rubygem(gettext) >= 1.9.3
 
 %description assets
 Meta package to install asset pipeline support.
@@ -339,8 +344,8 @@ plugins required for Foreman to work.
 		script/rails script/performance/profiler script/performance/benchmarker script/foreman-config ; do
 	    sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' $f
     done
-    sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' foreman.init
-    sed -ri '1,$s|THIN=/usr/bin/thin|THIN="run_in_scl"|' foreman.init
+    sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' %{confdir}/foreman.init
+    sed -ri '1,$s|THIN=/usr/bin/thin|THIN="run_in_scl"|' %{confdir}/foreman.init
 %endif
 
 mv Gemfile Gemfile.in
@@ -348,10 +353,11 @@ mv Gemfile Gemfile.in
 # upstream bug https://github.com/wvanbergen/scoped_search/issues/53
 sed -i "s/gem 'scoped_search'/gem 'sprockets'\n&/" Gemfile.in
 cp config/database.yml.example config/database.yml
+cp config/settings.yaml.example config/settings.yaml
 export BUNDLER_EXT_NOSTRICT=1
 export BUNDLER_EXT_GROUPS="default assets"
 %{scl_rake} assets:precompile:all RAILS_ENV=production --trace
-rm config/database.yml
+rm config/database.yml config/settings.yaml
 
 %install
 rm -rf %{buildroot}
@@ -424,7 +430,7 @@ rm -rf %{buildroot}
 %attr(-,%{name},%{name}) %{_localstatedir}/run/%{name}
 %attr(-,%{name},root) %{_datadir}/%{name}/config.ru
 %attr(-,%{name},root) %{_datadir}/%{name}/config/environment.rb
-%ghost %{_datadir}/%{name}/config/initializers/local_secret_token.rb
+%ghost %attr(0640,root,%{name}) %{_datadir}/%{name}/config/initializers/local_secret_token.rb
 
 %pre
 # Add the "foreman" user and group


### PR DESCRIPTION
- fix therubyracer require name
- when Foreman launched twice within same PID, ENV['BUNDLE_GEMFILE'] is already
  set, causing bundler to load instead of bundler_ext
- revert SCL additions to init.d script, spec file handles them
- fix init script path
- export HOME in init script as Puppet requires it
- add gettext_i18n_rails_js dependency, minor dependency fixes to compile
  assets and match RPM versions
- create settings.yaml to precompile assets
- specify required attributes for local_secret_token.rb
- comps updates

@skottler, would you mind looking at this?  This was the set of changes required to build this: http://koji.katello.org/koji/taskinfo?taskID=36039 complete with assets precompilation.

(I meant to put the entire description in the PR, not the commit, feel free to remove it.)
