### PR TITLE
Fixes 2513 - orgs created in katello do not appear in org filtering

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,8 @@ module Api
 
     before_filter :set_default_response_format, :authorize, :add_version_header
 
+    cache_sweeper :topbar_sweeper
+
     respond_to :json
 
     after_filter do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   before_filter :authorize
 
 
-  cache_sweeper :topbar_sweeper, :unless => :api_request?
+  cache_sweeper :topbar_sweeper
 
   def welcome
     @searchbar = true

--- a/app/controllers/topbar_sweeper.rb
+++ b/app/controllers/topbar_sweeper.rb
@@ -17,8 +17,16 @@ class TopbarSweeper < ActionController::Caching::Sweeper
     expire_cache_for(record)
   end
 
+  def self.fragment_name
+    "tabs_and_title_records-#{User.current.id}"
+  end
+
+  def self.expire_cache(controller)
+    controller.expire_fragment(TopbarSweeper.fragment_name) if User.current
+  end
+
   private
   def expire_cache_for(record)
-    expire_fragment("tabs_and_title_records-#{User.current.id}") if User.current
+    expire_fragment(TopbarSweeper.fragment_name) if User.current
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,8 +73,6 @@ class UsersController < ApplicationController
     else
       process_error
     end
-    # make sure users cache are expired (assuming some permissions changed etc)
-    expire_fragment("tabs_and_title_records-#{@user.id}")
     User.current.editing_self = false if editing_self
 
     # Remove locale from the session when set to "Browser Locale" and editing self
@@ -113,7 +111,8 @@ class UsersController < ApplicationController
   # Called from the logout link
   # Clears the rails session and redirects to the login action
   def logout
-    expire_fragment("tabs_and_title_records-#{User.current.id}") if User.current
+    TopbarSweeper.expire_cache(self)
+
     session[:user] = @user = User.current = nil
     if flash[:notice] or flash[:error]
       flash.keep

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -11,7 +11,7 @@
 <div id='current_tab' data-controller='<%=controller_name.gsub(/_.*/,"s")%>' data-settings='<%= class_for_setting_page %>'> </div>
 
 <% if User.current -%>
-  <% cache("tabs_and_title_records-#{User.current.id}") do %>
+  <% cache(TopbarSweeper.fragment_name) do %>
     <div class="nav-collapse collapse nav1">
       <ul class="nav" id="menu">
       <%= render "home/org_switcher" %>

--- a/lib/foreman/controller/taxonomies_controller.rb
+++ b/lib/foreman/controller/taxonomies_controller.rb
@@ -91,7 +91,7 @@ module Foreman::Controller::TaxonomiesController
     taxonomy_class.current = @taxonomy
     session[taxonomy_id] = @taxonomy ? @taxonomy.id : nil
 
-    expire_fragment("tabs_and_title_records-#{User.current.id}")
+    TopbarSweeper.expire_cache(self)
     redirect_back_or_to root_url
   end
 
@@ -99,7 +99,7 @@ module Foreman::Controller::TaxonomiesController
     taxonomy_class.current = nil
     session[taxonomy_id] = nil
 
-    expire_fragment("tabs_and_title_records-#{User.current.id}")
+    TopbarSweeper.expire_cache(self)
     redirect_back_or_to root_url
   end
 


### PR DESCRIPTION
- topbar cache sweeper turned on for api controllers
- a bit of refactoring to get rid of repetitive expire_fragment
