### PR TITLE
fixes #2516 - dbmigrate changes for SCL

### DIFF
--- a/extras/dbmigrate
+++ b/extras/dbmigrate
@@ -1,10 +1,17 @@
 #!/bin/sh
 USERNAME=$(/usr/bin/id -un)
 WANTED_USER=${1:-'foreman'}
+RAKE_CMD=/usr/bin/rake
+BUNDLER_CMD=""
+
+die() {
+  echo $*; exit 1
+}
 
 if [ $USERNAME = $WANTED_USER ]; then
-  cd && bundle exec /usr/bin/rake db:migrate RAILS_ENV=production
+  cd || die "Cannot change to home directory"
+  [ -f Gemfile ] && BUNDLER_CMD="bundle exec"
+  $BUNDLER_CMD $RAKE_CMD db:migrate RAILS_ENV=production
 else
-  echo "$0 has to be run as user ${WANTED_USER}!"
-  exit 1
+  die "$0 has to be run as user ${WANTED_USER}!"
 fi

--- a/foreman.spec
+++ b/foreman.spec
@@ -338,14 +338,17 @@ plugins required for Foreman to work.
 %setup -q
 
 %build
-#replace shebangs for SCL
+#replace shebangs and binaries in scripts for SCL
 %if %{?scl:1}%{!?scl:0}
-    for f in extras/query/ssh_using_foreman extras/rdoc/rdoc_prepare_script.rb extras/cli/foremancli \
-		script/rails script/performance/profiler script/performance/benchmarker script/foreman-config ; do
-	    sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' $f
-    done
-    sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' %{confdir}/foreman.init
-    sed -ri '1,$s|THIN=/usr/bin/thin|THIN="run_in_scl"|' %{confdir}/foreman.init
+  # shebangs
+  for f in extras/query/ssh_using_foreman extras/rdoc/rdoc_prepare_script.rb extras/cli/foremancli \
+  script/rails script/performance/profiler script/performance/benchmarker script/foreman-config ; do
+    sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' $f
+  done
+  sed -ri '1,$sX/usr/bin/rubyX%{scl_ruby}X' %{confdir}/foreman.init
+  sed -ri '1,$s|THIN=/usr/bin/thin|THIN="run_in_scl"|' %{confdir}/foreman.init
+  # script content
+  sed -ri 'sX/usr/bin/rakeX%{scl_rake}X' extras/dbmigrate
 %endif
 
 mv Gemfile Gemfile.in


### PR DESCRIPTION
The dbmigrate script now use SCL (when enabled).

A scratch build is here: http://koji.katello.org/koji/taskinfo?taskID=36266
