### PR TITLE
fixes #2343 - override default settings with custom values

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -12,7 +12,7 @@ class SettingsController < ApplicationController
 
   def update
     @setting = Setting.find(params[:id])
-    if @setting.update_attributes(params[:setting])
+    if @setting.parse_string_value(params[:setting][:value]) && @setting.save
       process_success
     else
       process_error

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -137,8 +137,6 @@ class Setting < ActiveRecord::Base
     return true
   end
 
-  private
-
   def self.create opts
     if (s = Setting.find_by_name(opts[:name].to_s)).nil?
       super opts
@@ -147,6 +145,17 @@ class Setting < ActiveRecord::Base
       s
     end
   end
+
+  def self.create! opts
+    if (s = Setting.find_by_name(opts[:name].to_s)).nil?
+      super opts
+    else
+      s.update_attribute(:default, opts[:default])
+      s
+    end
+  end
+
+  private
 
   def self.cache
     Rails.cache

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -67,8 +67,8 @@ class Setting < ActiveRecord::Base
     end
   end
 
-  def value= val
-    v = (val.nil? or val == default) ?  nil : val.to_yaml
+  def value=(v)
+    v = v.to_yaml unless v.nil?
     self.class.cache.delete(name.to_s)
     write_attribute :value, v
   end
@@ -80,7 +80,8 @@ class Setting < ActiveRecord::Base
   alias_method :value_before_type_cast, :value
 
   def default
-    YAML.load(read_attribute(:default))
+    d = read_attribute(:default)
+    d.nil? ? nil : YAML.load(d)
   end
 
   def default=(v)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -85,7 +85,6 @@ class Setting < ActiveRecord::Base
   def default=(v)
     write_attribute :default, v.to_yaml
   end
-
   alias_method :default_before_type_cast, :default
 
 
@@ -124,14 +123,15 @@ class Setting < ActiveRecord::Base
         return false
       end
 
-    when "string"
+    when "string", nil
+      #string is taken as default setting type for parsing
       self.value = val.to_s.strip
 
     when "hash"
-      raise NotImplementedError, "parsing hash from string is not supported"
+      raise Foreman::Exception, "parsing hash from string is not supported"
 
     else
-      raise Foreman::Exception, "no settings type set"
+      raise Foreman::Exception.new(N_("parsing settings type '%s' from string is not defined"), settings_type)
 
     end
     return true

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,7 +1,7 @@
 class Setting < ActiveRecord::Base
   self.inheritance_column = 'category'
 
-  TYPES= %w{ integer boolean hash array }
+  TYPES= %w{ integer boolean hash array string }
   FROZEN_ATTRS = %w{ name default description category }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend }
   BLANK_ATTRS = %w{ trusted_puppetmaster_hosts }
@@ -11,17 +11,18 @@ class Setting < ActiveRecord::Base
   audited :only => [:value], :on => [:update], :allow_mass_assignment => true
 
   validates_presence_of :name, :description
+  validates_uniqueness_of :name
   validates_presence_of :default, :unless => Proc.new {|s| s.settings_type == "boolean" || BLANK_ATTRS.include?(s.name) }
   validates_inclusion_of :default, :in => [true,false], :if => Proc.new {|s| s.settings_type == "boolean"}
-  validates_uniqueness_of :name
   validates_numericality_of :value, :if => Proc.new {|s| s.settings_type == "integer"}
   validates_numericality_of :value, :if => Proc.new {|s| NONZERO_ATTRS.include?(s.name) }, :greater_than => 0
   validates_inclusion_of :value, :in => [true,false], :if => Proc.new {|s| s.settings_type == "boolean"}
   validates_presence_of :value, :if => Proc.new {|s| s.settings_type == "array" && !BLANK_ATTRS.include?(s.name) }
   validates_inclusion_of :settings_type, :in => TYPES, :allow_nil => true, :allow_blank => true
-  before_validation :fix_types
-  before_validation :save_as_settings_type
-  validate :validate_attributes
+  before_validation :set_setting_type_from_value
+  before_save :clear_value_when_default
+  before_save :clear_cache
+  validate :validate_frozen_attributes
   default_scope order(:name)
 
   # The DB may contain settings from disabled plugins - filter them out here
@@ -34,14 +35,13 @@ class Setting < ActiveRecord::Base
 
   def self.[](name)
     name = name.to_s
-
-    cache_value = Rails.cache.read(name)
+    cache_value = Setting.cache.read(name)
     if cache_value.nil?
       value = where(:name => name).first.try(:value)
-      cache.write(name, value)
+      Setting.cache.write(name, value)
       return value
     else
-      cache_value
+      return cache_value
     end
   end
 
@@ -49,7 +49,6 @@ class Setting < ActiveRecord::Base
     name   = name.to_s
     record = find_or_create_by_name name
     record.value = value
-    cache.delete(name)
     record.save!
   end
 
@@ -61,7 +60,7 @@ class Setting < ActiveRecord::Base
     #setter method
     if method_name =~ /=$/
       self[method_name.chomp("=")] = args.first
-      #getter
+    #getter
     else
       self[method_name]
     end
@@ -69,7 +68,6 @@ class Setting < ActiveRecord::Base
 
   def value=(v)
     v = v.to_yaml unless v.nil?
-    self.class.cache.delete(name.to_s)
     write_attribute :value, v
   end
 
@@ -90,13 +88,75 @@ class Setting < ActiveRecord::Base
 
   alias_method :default_before_type_cast, :default
 
+
+  def parse_string_value val
+
+    case settings_type
+    when "boolean"
+      val = val.downcase
+      if val == "true"
+        self.value = true
+      elsif val == "false"
+        self.value = false
+      else
+        invalid_value_error _("must be boolean")
+        return false
+      end
+
+    when "integer"
+      if val =~ /\d+/
+        self.value = val.to_i
+      else
+        invalid_value_error _("must be integer")
+        return false
+      end
+
+    when "array"
+      if val =~ /^\[.*\]$/
+        begin
+          self.value = YAML.load(val.gsub(/(\,)(\S)/, "\\1 \\2"))
+        rescue => e
+          invalid_value_error e.to_s
+          return false
+        end
+      else
+        invalid_value_error _("must be an array")
+        return false
+      end
+
+    when "string"
+      self.value = val.to_s.strip
+
+    when "hash"
+      raise NotImplementedError, "parsing hash from string is not supported"
+
+    else
+      raise Foreman::Exception, "no settings type set"
+
+    end
+    return true
+  end
+
   private
+
+  def self.create opts
+    if (s = Setting.find_by_name(opts[:name].to_s)).nil?
+      super opts
+    else
+      s.update_attribute(:default, opts[:default])
+      s
+    end
+  end
 
   def self.cache
     Rails.cache
   end
 
-  def save_as_settings_type
+  def invalid_value_error error
+    errors.add(:value, _("invalid value: %s") % error)
+  end
+
+  def set_setting_type_from_value
     return true unless settings_type.nil?
     t = default.class.to_s.downcase
     if TYPES.include?(t)
@@ -107,31 +167,7 @@ class Setting < ActiveRecord::Base
     end
   end
 
-  def fix_types
-    return true if read_attribute(:value).nil?
-    case settings_type
-    when "boolean"
-      self.value = true  if value == "true"
-      self.value = false if value == "false"
-    when "integer"
-      self.value = value.to_i if value =~ /\d+/
-    when "array"
-      if value =~ /^\s*\[.*\]\s*$/
-        begin
-          self.value = YAML.load(value.gsub(/(\,)(\S)/, "\\1 \\2"))
-        rescue => e
-          errors.add(:value, _("invalid value: %s") % e)
-          return false
-        end
-      else
-        errors.add(:value, _("must be an array"))
-        return false
-      end
-    end
-    true
-  end
-
-  def validate_attributes
+  def validate_frozen_attributes
     return true if new_record?
     changed_attributes.each do |c,old|
       # Allow settings_type to change at first (from nil) since it gets populated during validation
@@ -141,6 +177,18 @@ class Setting < ActiveRecord::Base
       end
     end
     true
+  end
+
+  def clear_value_when_default
+    if read_attribute(:value) == read_attribute(:default)
+      write_attribute(:value, nil)
+    end
+  end
+
+  def clear_cache
+    # ensures we don't have cache left overs in settings
+    Rails.logger.debug "removing #{name.to_s} from cache"
+    Setting.cache.delete(name.to_s)
   end
 
   # Methods for loading default settings
@@ -155,18 +203,6 @@ class Setting < ActiveRecord::Base
   def self.set name, description, default, value = nil
     value ||= SETTINGS[name.to_sym]
     {:name => name, :value => value, :description => description, :default => default}
-  end
-
-  def self.create opts
-    # ensures we don't have cache left overs in settings
-    Rails.logger.debug "removing #{opts[:name]} from cache"
-    Rails.cache.delete(opts[:name].to_s)
-
-    if (s = Setting.find_by_name(opts[:name].to_s)).nil?
-      Setting.create!(opts)
-    else
-      s.update_attribute(:default, opts[:default]) unless s.default == opts[:default]
-    end
   end
 
   def self.model_name

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -19,7 +19,7 @@ class Setting::Auth < Setting
         self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY'),
         self.set('signo_sso', N_('Use Signo SSO for login'), false),
         self.set('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo")
-      ].compact.each { |s| self.create s.update(:category => "Setting::Auth")}
+      ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
     end
 
     true

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -17,7 +17,7 @@ class Setting::General < Setting
         self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"),60),
         self.set('max_trend', N_("Max days for Trends graphs"),30),
         self.set('use_gravatar', N_("Should Foreman use gravatar to display user icons"),true)
-      ].each { |s| self.create s.update(:category => "Setting::General")}
+      ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 
     true

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -19,7 +19,7 @@ class Setting::Provisioning < Setting
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote loadbalancer, the ip should be set here"), "127.0.0.1"),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0),
         self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0")
-      ].each { |s| self.create s.update(:category => "Setting::Provisioning")}
+      ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
     end
 
     true

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -26,7 +26,7 @@ class Setting::Puppet < Setting
         self.set('update_environment_from_facts', N_("Should Foreman update a host's environment from its facts"), false),
         self.set('remove_classes_not_in_environment', N_("When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"), false),
         self.set('host_group_matchers_inheritance', N_("Should Foreman use host group ancestors matchers to set puppet classes parameters values"), true)
-      ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
+      ].compact.each { |s| self.create! s.update(:category => "Setting::Puppet")}
 
       true
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -1,5 +1,6 @@
 attributes1:
   name: administrator
+  settings_type: string
   category: Setting::General
   default: root@some.host.fqdn
   description: The Default administrator email address

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -8,13 +8,13 @@ class SettingsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Setting::General.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Setting::General.first, :format => "json"}, set_session_user
+    put :update, {:id => Setting::General.first, :format => "json", :setting => {}}, set_session_user
     assert_response :unprocessable_entity
   end
 
   def test_update_valid
     Setting::General.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Setting::General.first}, set_session_user
+    put :update, {:id => Setting::General.first, :setting => {}}, set_session_user
     assert_redirected_to settings_url
   end
 

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -75,6 +75,27 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal 3, setting.default
   end
 
+  def test_second_time_create_exclamation_persists_only_default_value
+    setting = Setting.create!(:name => "foo", :value => 8, :default => 2, :description => "test foo")
+    assert_equal 8, setting.value
+    assert_equal 2, setting.default
+
+    setting = Setting.create!(:name => "foo", :value => 9, :default => 3, :description => "test foo")
+    assert_equal 8, setting.value
+    assert_equal 3, setting.default
+  end
+
+  def test_create_with_missing_attrs_does_not_persist
+    setting = Setting.create(:name => "foo")
+    assert_equal false, setting.persisted?
+  end
+
+  def test_create_exclamation_with_missing_attrs_raises_exception
+    assert_raises(ActiveRecord::RecordInvalid) do
+      setting = Setting.create!(:name => "foo")
+    end
+  end
+
   def test_set_method_prepares_attrs_for_creation
     options = Setting.set "test_attr", "some_description", "default_value", "my_value"
     assert_equal "test_attr", options[:name]

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -237,13 +237,25 @@ class SettingTest < ActiveSupport::TestCase
 
   test "parse hash attribute raises exception without settings_type" do
     setting = Setting.new(:name => "foo", :default => "default", :settings_type => "hash")
-    assert_raises(NotImplementedError) do
+    assert_raises(Foreman::Exception) do
       setting.parse_string_value("some_value")
     end
   end
 
-  test "parse attribute raises exception without settings_type" do
+  test "parse attribute without settings_type defaults to string" do
     setting = Setting.new(:name => "foo", :default => "default")
+    setting.parse_string_value(12345)
+    setting.save
+    assert_equal "string", setting.settings_type
+    assert_equal "12345", setting.value
+  end
+
+  test "parse attribute raises exception for undefined types" do
+    class CustomSetting < Setting
+      TYPES << "custom_type"
+    end
+
+    setting = CustomSetting.new(:name => "foo", :default => "default", :settings_type => "custom_type")
     assert_raises(Foreman::Exception) do
       setting.parse_string_value("some_value")
     end


### PR DESCRIPTION
- added check for nil before attribute 'default' is loaded from yaml
- removed logic that tried to set 'value' attr to nil when it was equal to 'default';
  it didn't behave predictably as 'default' can be assigned after 'value'
