### PR TITLE
fixes #2548 - add non-SCL dependencies to comps for publishing

### DIFF
--- a/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
+++ b/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
@@ -145,6 +145,9 @@
       <packagereq type="default">ruby193-rubygem-wirb</packagereq>
       <packagereq type="default">ruby193-rubygems</packagereq>
       <packagereq type="default">ruby193-v8</packagereq>
+
+      <packagereq type="default">rubygem-highline</packagereq>
+      <packagereq type="default">rubygem-rkerberos</packagereq>
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
cc @mbacovsky for review

rubygem-highline is a dependency of foreman-installer.
