### PR TITLE
Prevent host creation when facts are uploaded

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -396,14 +396,17 @@ class Host::Managed < Host::Base
         return raise(::Foreman::Exception.new(N_("Invalid Facts, much be a Puppet::Node::Facts or a Hash")))
     end
 
+    h = nil
     if name == certname or certname.nil?
       h = Host.find_by_name name
     else
       h = Host.find_by_certname certname
       h ||= Host.find_by_name name
     end
-    h ||= Host.new :name => name
 
+    h ||= Host.new(:name => name) if Setting[:create_new_host_when_facts_are_uploaded]
+
+    return true if h.nil?
     h.save(:validate => false) if h.new_record?
     h.importFacts(name, values)
   end

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -25,7 +25,8 @@ class Setting::Puppet < Setting
         self.set('use_uuid_for_certificates', N_("Should Foreman use random UUID's for certificate signing instead of hostnames"), false),
         self.set('update_environment_from_facts', N_("Should Foreman update a host's environment from its facts"), false),
         self.set('remove_classes_not_in_environment', N_("When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"), false),
-        self.set('host_group_matchers_inheritance', N_("Should Foreman use host group ancestors matchers to set puppet classes parameters values"), true)
+        self.set('host_group_matchers_inheritance', N_("Should Foreman use host group ancestors matchers to set puppet classes parameters values"), true),
+        self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true)
       ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
 
       true

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -174,3 +174,8 @@ attribute35:
   category: Setting::Auth
   default: "https://localhost:3002"
   description: "Where Signo runs"
+attribute36:
+  name: create_new_host_when_facts_are_uploaded
+  category: Setting::Puppet
+  default: "true"
+  description: Foreman will create the host when new facts are received

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -85,6 +85,16 @@ class HostTest < ActiveSupport::TestCase
     assert_equal value_ids, Host.find_by_name('a.server.b.domain').fact_values.map(&:id)
   end
 
+  test "host is not created when uploading facts if setting is false" do
+    Setting[:create_new_host_when_facts_are_uploaded] = false
+    assert_equal false, Setting[:create_new_host_when_facts_are_uploaded]
+    assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.yml")))
+    host = Host.find_by_name('a.server.b.domain')
+    Setting[:create_new_host_when_facts_are_uploaded] =
+        Setting.find_by_name("create_new_host_when_facts_are_uploaded").default
+    assert_nil host
+  end
+
   test "should not save if neither ptable or disk are defined when the host is managed" do
     if unattended?
       host = Host.create :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.4.4.03",


### PR DESCRIPTION
http://projects.theforeman.org/issues/1963

This commit adds a new option [0] to avoid creating new
hosts when new facts are uploaded to Foreman. The
default value is true, that meaning that the default
behaviour is preserved (hosts are created).

[0] create_new_host_when_facts_are_uploaded
