### PR TITLE
Fixes #2519 - Protect locale changes from validation failure so that password validation can be run 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ActiveRecord::Base
                    :allow_blank => true
   validates :mail, :presence => true, :on => :update
 
-  validates :locale, :format => { :with => /^\w{2}([_-]\w{2})?$/ }, :allow_blank => true
+  validates :locale, :format => { :with => /^\w{2}([_-]\w{2})?$/ }, :allow_blank => true, :if => Proc.new { |user| user.respond_to?(:locale) }
   before_validation :normalize_locale
 
   validates_uniqueness_of :login, :message => N_("already exists")
@@ -224,7 +224,9 @@ class User < ActiveRecord::Base
   end
 
   def normalize_locale
-    self.locale = nil if locale.empty?
+    if self.respond_to?(:locale)
+      self.locale = nil if locale.empty?
+    end
   end
 
   def normalize_mail

--- a/db/migrate/20100628123400_add_internal_auth.rb
+++ b/db/migrate/20100628123400_add_internal_auth.rb
@@ -12,7 +12,7 @@ class AddInternalAuth < ActiveRecord::Migration
     src.update_attribute :name, "Internal"
     user.auth_source_id = src.id
     user.password="changeme"
-    if user.without_auditing { user.save(:validate => false) }
+    if user.save_without_auditing
       say "****************************************************************************************"
       say "The newly created internal account named admin has been allocated a password of 'changeme'"
       say "Set this to something else in the settings/users page"


### PR DESCRIPTION
Debugged this a little, and tracked down the cause. The problem is here: https://github.com/theforeman/foreman/commit/e2c2abfea496c581f0b9d66e3074caf0f9604f75#L9R15

Because the validation is now skipped, the :prepare_password filter is also skipped. Sadly we can't just re-enable validations as it breaks looking for the non-existant locale column.

This patch reverts and re-enables the validations, but then checks if the locale column has been created yet when running the locale validations. This protects the admin user creation migration from bombing out.
