### PR TITLE
Avoid inheriting from Puppet::Resource

### DIFF
--- a/lib/proxy_api/bmc.rb
+++ b/lib/proxy_api/bmc.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class BMC < Resource
+  class BMC < ProxyAPI::Resource
 
     def initialize args
       @target = args[:host_ip] || '127.0.0.1'

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class DHCP < Resource
+  class DHCP < ProxyAPI::Resource
     def initialize args
       @url  = args[:url] + "/dhcp"
       super args

--- a/lib/proxy_api/dns.rb
+++ b/lib/proxy_api/dns.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class DNS < Resource
+  class DNS < ProxyAPI::Resource
     def initialize args
       @url  = args[:url] + "/dns"
       super args

--- a/lib/proxy_api/features.rb
+++ b/lib/proxy_api/features.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class Features < Resource
+  class Features < ProxyAPI::Resource
     def initialize args
       @url  = args[:url] + "/features"
       super args

--- a/lib/proxy_api/puppet.rb
+++ b/lib/proxy_api/puppet.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class Puppet < Resource
+  class Puppet < ProxyAPI::Resource
     def initialize args
       @url  = args[:url] + "/puppet"
       super args

--- a/lib/proxy_api/puppetca.rb
+++ b/lib/proxy_api/puppetca.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class Puppetca < Resource
+  class Puppetca < ProxyAPI::Resource
     def initialize args
       @url  = args[:url] + "/puppet/ca"
       super args

--- a/lib/proxy_api/tftp.rb
+++ b/lib/proxy_api/tftp.rb
@@ -1,5 +1,5 @@
 module ProxyAPI
-  class TFTP < Resource
+  class TFTP < ProxyAPI::Resource
     def initialize args
       @url     = args[:url] + "/tftp"
       @variant = args[:variant]


### PR DESCRIPTION
Basically rails autoloading will load Puppet::Resource on your load path, and therefore all these classes will inherit from Puppet::Resource instead of ProxyAPI::Resource, making the ProxyAPI likely to be broken.
