### PR TITLE
fixes #2579 - explicitly list field name, workaround rails #5990

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -91,7 +91,7 @@ class Hostgroup < ActiveRecord::Base
   end
 
   def puppetclass_ids
-    classes.reorder('').pluck(:id)
+    classes.reorder('').pluck('puppetclasses.id')
   end
 
   def inherited_lookup_value key


### PR DESCRIPTION
You'll need 3.2.8 to replicate this issue.
