### PR TITLE
fixes #2599 - Uncheck environment import checkboxes

### DIFF
--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -31,10 +31,10 @@
             <% for env in envs.keys.sort -%>
               <tr>
                 <td>
-                  <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind}" %>
+                  <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind} env_select_boxes_env_#{env}" %>
                 </td>
                 <td>
-                  <%= env -%>
+                  <%= link_to_function("#{env}", "toggleCheckboxesBySelector('.env_select_boxes_env_#{env}')", :title => _("Check/Uncheck all %s changes") % env) %>
                 </td>
                 <td>
                   <%= {"new" => _("Add:"), "obsolete" => _("Remove:"), "updated" => _("Update:")}[kind] -%>

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -4,10 +4,8 @@
     <legend><%= _("Select the changes you want to realize in Foreman") %> </legend>
     <table class="table table-striped">
       <tr>
-        <th class="ca">
-          <%= _("Toggle") %>
-        </th>
-        <th class="ca" colspan="3">
+        <th class="ca" colspan="4">
+          <%= _("Toggle") %>: 
           <%= link_to_function("#{image_tag('toggle_check.png')} #{_("New")}".html_safe,
                                "toggleCheckboxesBySelector('.env_select_boxes_new')", 
                                :title => _("Check/Uncheck new")) %> |
@@ -21,9 +19,9 @@
       </tr>
       <tr>
       <th class="ca">
-          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("All")}".html_safe,
-                               "toggleCheckboxesBySelector('.env_select_boxes')", 
-                               :title => _("Check/Uncheck all")) %>
+        <%= link_to_function("#{image_tag('toggle_check.png')} #{_("All")}".html_safe,
+                             "toggleCheckboxesBySelector('.env_select_boxes')", 
+                             :title => _("Check/Uncheck all")) %>
       </th>
       <th><%= _("Environment") %></th><th><%= _("Operation") %></th><th><%= _("Puppet Modules") %></th>
         <% for kind in ["new", "obsolete", "updated"] -%>

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -8,9 +8,6 @@
           <%= _("Toggle") %>
         </th>
         <th class="ca" colspan="3">
-          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("All")}".html_safe,
-                               "toggleCheckboxesBySelector('.env_select_boxes')", 
-                               :title => _("Check/Uncheck all")) %> |
           <%= link_to_function("#{image_tag('toggle_check.png')} #{_("New")}".html_safe,
                                "toggleCheckboxesBySelector('.env_select_boxes_new')", 
                                :title => _("Check/Uncheck new")) %> |
@@ -24,6 +21,9 @@
       </tr>
       <tr>
       <th class="ca">
+          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("All")}".html_safe,
+                               "toggleCheckboxesBySelector('.env_select_boxes')", 
+                               :title => _("Check/Uncheck all")) %>
       </th>
       <th><%= _("Environment") %></th><th><%= _("Operation") %></th><th><%= _("Puppet Modules") %></th>
         <% for kind in ["new", "obsolete", "updated"] -%>

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -1,15 +1,39 @@
 <% title _("Changed environments and puppet classes") -%>
 <%= form_tag eval("obsolete_and_new_#{controller_name}_path") do -%>
   <fieldset>
-    <legend><%= _("Accept these environment changes found in puppet?") %> </legend>
-      <table class="table table-striped">
-        <th><%= _("Environment") %></th><th><%= _("Operation") %></th><th><%= _("Puppet Modules") %></th>
+    <legend><%= _("Select the changes you want to realize in Foreman") %> </legend>
+    <table class="table table-striped">
+      <tr>
+        <th class="ca">
+          <%= _("Toggle") %>
+        </th>
+        <th class="ca" colspan="3">
+          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("All")}".html_safe,
+                               "toggleCheckboxesBySelector('.env_select_boxes')", 
+                               :title => _("Check/Uncheck all")) %> |
+          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("New")}".html_safe,
+                               "toggleCheckboxesBySelector('.env_select_boxes_new')", 
+                               :title => _("Check/Uncheck new")) %> |
+          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("Updated")}".html_safe,
+                                "toggleCheckboxesBySelector('.env_select_boxes_updated')", 
+                               :title => _("Check/Uncheck updated")) %> |
+          <%= link_to_function("#{image_tag('toggle_check.png')} #{_("Obsolete")}".html_safe,
+                               "toggleCheckboxesBySelector('.env_select_boxes_obsolete')", 
+                               :title => _("Check/Uncheck obsolete")) %>
+        </th>
+      </tr>
+      <tr>
+      <th class="ca">
+      </th>
+      <th><%= _("Environment") %></th><th><%= _("Operation") %></th><th><%= _("Puppet Modules") %></th>
         <% for kind in ["new", "obsolete", "updated"] -%>
           <% unless (envs = @changed[kind]).empty? -%>
             <% for env in envs.keys.sort -%>
               <tr>
                 <td>
-                  <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, true %>
+                  <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind}" %>
+                </td>
+                <td>
                   <%= env -%>
                 </td>
                 <td>

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -10,7 +10,7 @@
           <th>
             <%= content_tag(role.builtin? ? 'em' : 'span', h(role.name)) %>
             <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('input.role-#{role.id}')",
-                                 :title => _("Check all/Uncheck all"))
+                                 :title => _("Check/Uncheck all"))
             %>
           </th>
         <% end %>
@@ -31,7 +31,7 @@
           <tr class="<%= cycle('odd', 'even') %> permission-<%= permission.name %>">
             <td>
               <%= link_to_function(image_tag('toggle_check.png'), "toggleCheckboxesBySelector('.permission-#{permission.name} input')",
-                                   :title => _("Check all/Uncheck all"))
+                                   :title => _("Check/Uncheck all"))
               %>
               <%= permission.name.to_s.humanize %>
             </td>


### PR DESCRIPTION
Uncheck all boxes on the environment import confirmation form per default. Add a "select all" checkbox on top.
