### PR TITLE
fixes #2622 - error messages with HTML properly escaped

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -162,7 +162,7 @@ module LayoutHelper
   def base_errors_for obj
     unless obj.errors[:base].blank?
       content_tag(:div, :class => "alert alert-message alert-block alert-error base in fade") do
-        ("<a class='close' href='#' data-dismiss='alert'>&times;</a><h4>" + _("Unable to save") + "</h4> " + obj.errors[:base].map {|e| "<li>#{e}</li>"}.join).html_safe
+        ("<a class='close' href='#' data-dismiss='alert'>&times;</a><h4>" + _("Unable to save") + "</h4> " + obj.errors[:base].map {|e| "<li>".html_safe + e + "</li>".html_safe}.join).html_safe
       end
     end
   end


### PR DESCRIPTION
String interpolation does not work with safe/unsafe strings in Rails 3.2.
