### PR TITLE
Use facts[:operatingsystemrelease] to determined gentoo release

### DIFF
--- a/app/models/facts_importer.rb
+++ b/app/models/facts_importer.rb
@@ -8,7 +8,7 @@ module Facts
 
     def operatingsystem
       orel    = case os_name
-                  when /(suse|sles)/i
+                  when /(suse|sles|gentoo)/i
                     facts[:operatingsystemrelease]
                   else
                     facts[:lsbdistrelease] || facts[:operatingsystemrelease]


### PR DESCRIPTION
Use of facts[:lsbdistrelease] to determine gentoo release is not relevant, use facts[:operatingsystemrelease] instead.
