### PR TITLE
bumping up the minimum required version of gettext-i18n-rails gem to 0.10.0

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -122,19 +122,13 @@ module LayoutHelper
     help_block  = content_tag(:span, options.delete(:help_block), :class => "help-block")
     content_tag :div, :class => "control-group #{fluid ? "row-fluid" : ""} #{error.empty? ? "" : 'error'}" do
       label   = options.delete(:label)
-
-      label ||= ((clazz = gettext_key(f.object.class)).respond_to?(:gettext_translation_for_attribute_name) &&
+      label ||= ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
                   s_(clazz.gettext_translation_for_attribute_name attr)) if f
-
       label_tag(attr, label, :class=>"control-label").html_safe +
         content_tag(:div, :class => "controls") do
           yield.html_safe + help_inline.html_safe + help_block.html_safe
         end.html_safe
     end
-  end
-
-  def gettext_key(aclass)
-    aclass.respond_to?(:base_class) ? aclass.base_class : aclass
   end
 
   def help_inline(inline, error)

--- a/bundler.d/i18n.rb
+++ b/bundler.d/i18n.rb
@@ -1,6 +1,6 @@
 group :i18n do
   gem 'fast_gettext', '>=0.4.8'
-  gem 'gettext_i18n_rails'
+  gem 'gettext_i18n_rails', '>= 0.10.0'
   gem 'gettext_i18n_rails_js', '>= 0.0.8'
   gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 end

--- a/foreman.spec
+++ b/foreman.spec
@@ -67,7 +67,7 @@ Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.0.16
 Requires: %{?scl_prefix}rubygem(bundler_ext)
 Requires: %{?scl_prefix}rubygem(thin)
 Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.4.8
-Requires: %{?scl_prefix}rubygem(gettext_i18n_rails)
+Requires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 0.10.0
 Requires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 Requires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 Requires: %{?scl_prefix}rubygem(therubyracer)
@@ -81,7 +81,7 @@ BuildRequires: %{?scl_prefix}rubygem(bundler_ext)
 BuildRequires: %{?scl_prefix}rubygem(coffee-rails) => 3.2.1
 BuildRequires: %{?scl_prefix}rubygem(gettext) >= 1.9.3
 BuildRequires: %{?scl_prefix}rubygem(fast_gettext)
-BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails)
+BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails) >= 0.10.0
 BuildRequires: %{?scl_prefix}rubygem(gettext_i18n_rails_js) >= 0.0.8
 BuildRequires: %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 BuildRequires: %{?scl_prefix}rubygem(jquery-rails)


### PR DESCRIPTION
And removing a workaround for handling of STI classes from app/helpers/layout_helper.rb --
  gettext_i18n_rails handles those natively starting from 0.10.0
