### PR TITLE
fixes #2633 - enable generate_token rake task to run from elsewhere

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -4,7 +4,7 @@ namespace :security do
   desc 'Generate new security token'
   task :generate_token do
     include Foreman::Util
-    File.open("config/initializers/local_secret_token.rb", "w") do |fd|
+    File.open(Rails.root.join('config', 'initializers', 'local_secret_token.rb'), "w") do |fd|
       fd.write("# Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.


### PR DESCRIPTION
scratch build: https://koji.katello.org/koji/taskinfo?taskID=39097

<pre>
[root@rhel6b ~]# rpm -ivh "http://koji.katello.org/koji/getfile?taskID=39097&name=foreman-1.2.9999-4.el6.noarch.rpm" "http://koji.katello.org/koji/getfile?taskID=39097&name=foreman-sqlite-1.2.9999-4.el6.noarch.rpm"
Retrieving http://koji.katello.org/koji/getfile?taskID=39097&name=foreman-1.2.9999-4.el6.noarch.rpm
Retrieving http://koji.katello.org/koji/getfile?taskID=39097&name=foreman-sqlite-1.2.9999-4.el6.noarch.rpm
Preparing...                ########################################### [100%]
   1:foreman                ########################################### [ 50%]
   2:foreman-sqlite         ########################################### [100%]
[root@rhel6b ~]# ll ~foreman/config/initializers/local_secret_token.rb
-rw-r-----. 1 root foreman 570 Jun 10 17:04 /usr/share/foreman/config/initializers/local_secret_token.rb
</pre>
