### PR TITLE
Fixes #2655 - Display Host buttons on unmanaged hosts if a puppet proxy exists

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -273,4 +273,12 @@ module HostsHelper
       :os   => host.try(:operatingsystem_id) || (params[:host] && params[:host][:operatingsystem_id])
     }
   end
+
+  def show_appropriate_host_buttons(host)
+    [ link_to_if_authorized(_("Audits"), hash_for_host_audits_path(:host_id => @host), :title => _("Host audit entries") , :class => 'btn'),
+      (link_to_if_authorized(_("Facts"), hash_for_host_facts_path(:host_id => host), :title => _("Browse host facts") , :class => 'btn') if host.facts_hash.present?),
+      (link_to_if_authorized(_("Reports"), hash_for_host_reports_path(:host_id => host), :title => _("Browse host reports") , :class => 'btn') if host.reports.present?),
+      (link_to(_("YAML"), externalNodes_host_path(:name => host), :title => _("Puppet external nodes YAML dump") , :class => 'btn') if SmartProxy.puppet_proxies.present?)
+    ].compact
+  end
 end

--- a/app/views/hosts/_overview.html.erb
+++ b/app/views/hosts/_overview.html.erb
@@ -4,14 +4,9 @@
   </tr>
   <tr>
     <td>
-      <%= link_to_if_authorized(_("Audits"), hash_for_host_audits_path(:host_id => @host), :title => _("Host audit entries") , :class => 'btn') %>
-      <% if @host.try(:puppet_proxy) %>
-        <%=
-          link_to_if_authorized(_("Facts"), hash_for_host_facts_path(:host_id => @host), :title => _("Browse host facts") , :class => 'btn') +
-            link_to_if_authorized(_("Reports"), hash_for_host_reports_path(:host_id => @host), :title => _("Browse host reports") , :class => 'btn') +
-            link_to(_("YAML"), externalNodes_host_path(:name => @host), :title => _("Puppet external nodes YAML dump") , :class => 'btn')
-          %>
-      <% end %>
+      <% show_appropriate_host_buttons(@host).each do |btn| -%>
+        <%= btn %>
+      <% end -%>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
The test on SmartProxies is there to ensure we don't display the buttons on a host which was create as Managed and then later made Unmanaged, when there is no Puppetmaster present at all.
