### PR TITLE
helper script to show dependencies nicely

### DIFF
--- a/lib/tasks/bundler.rake
+++ b/lib/tasks/bundler.rake
@@ -1,0 +1,21 @@
+desc "Show dependencies in nicely-formatted output"
+namespace :bundler do
+  task :deps => :environment do
+    groups = {}
+    Bundler.definition.dependencies.each do |dep|
+      dep.groups.each do |group|
+        groups[group] = [] if groups[group].nil?
+        groups[group] << "#{dep.name} #{dep.requirements_list.inspect}"
+      end
+    end
+
+    groups.sort.map do |group, deps|
+      puts "Group #{group}"
+      deps.sort.each do |dep|
+        puts " #{dep}"
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Maybe it worths merging, if not, just close. Example output:

```
Group assets
 coffee-rails ["~> 3.2.1"]
 flot-rails ["= 0.0.3"]
 gettext [">= 1.9.3"]
 gettext_i18n_rails_js [">= 0.0.8"]
 jquery-rails ["= 2.0.3"]
 jquery-ui-rails [">= 0"]
 quiet_assets [">= 0"]
 sass-rails ["~> 3.2.3"]
 spice-html5-rails [">= 0"]
 therubyracer ["= 0.11.3"]
 twitter-bootstrap-rails ["= 2.2.6"]
 uglifier [">= 1.0.3"]
Group console
 awesome_print [">= 0"]
 hirb-unicode [">= 0"]
 wirb [">= 0"]
Group default
 ancestry ["~> 1.3"]
 apipie-rails ["~> 0.0.22"]
 audited-activerecord ["= 3.0.0"]
 debugger [">= 0"]
 json [">= 0"]
 net-ldap [">= 0"]
 oauth [">= 0"]
 puppet [">= 0"]
 rabl [">= 0.7.5"]
 rails ["= 3.2.13"]
 rest-client [">= 0"]
 ruby_parser ["~> 3.0.0"]
 safemode ["~> 1.2"]
 scoped_search [">= 2.5"]
 uuidtools [">= 0"]
 will_paginate ["~> 3.0.2"]
Group development
 gettext [">= 1.9.3"]
 maruku [">= 0"]
 pry [">= 0"]
 term-ansicolor [">= 0"]
Group fog
 fog [">= 1.10"]
Group i18n
 fast_gettext [">= 0.4.8"]
 gettext_i18n_rails [">= 0.10.0"]
 gettext_i18n_rails_js [">= 0.0.8"]
 i18n_data [">= 0.2.6"]
Group libvirt
 ruby-libvirt [">= 0"]
Group mysql
 mysql [">= 0"]
Group mysql2
 mysql2 ["> 0.3.0"]
Group openid
 rack-openid [">= 0"]
Group ovirt
 rbovirt [">= 0.0.20"]
Group postgresql
 pg [">= 0"]
Group sqlite
 sqlite3 [">= 0"]
Group test
 capybara ["~> 2.0.0"]
 ci_reporter [">= 1.6.3"]
 database_cleaner [">= 0"]
 launchy [">= 0"]
 minitest ["~> 4.7"]
 minitest-spec-rails [">= 0"]
 minitest-spec-rails-tu-shim [">= 0"]
 mocha [">= 0"]
 rr [">= 0"]
 simplecov [">= 0"]
 single_test [">= 0"]
 spork [">= 0"]
 spork-minitest [">= 0"]
Group vmware
 rbvmomi [">= 0"]

```
