### PR TITLE
fixes #2650 - adding minitest dependency for console

### DIFF
--- a/bundler.d/console.rb
+++ b/bundler.d/console.rb
@@ -2,4 +2,7 @@ group :console do
   gem 'wirb'
   gem 'hirb-unicode'
   gem 'awesome_print', :require => 'ap'
+
+  # minitest - workaround until Rails 4.0 (#2650)
+  gem 'minitest'
 end

--- a/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
+++ b/extras/packaging/rpm/rel-eng/comps/comps-foreman-rhel6.xml
@@ -99,6 +99,7 @@
       <packagereq type="default">ruby193-rubygem-mail</packagereq>
       <packagereq type="default">ruby193-rubygem-maruku</packagereq>
       <packagereq type="default">ruby193-rubygem-mime-types</packagereq>
+      <packagereq type="default">ruby193-rubygem-minitest</packagereq>
       <packagereq type="default">ruby193-rubygem-mocha</packagereq>
       <packagereq type="default">ruby193-rubygem-multi_json</packagereq>
       <packagereq type="default">ruby193-rubygem-mysql2</packagereq>

--- a/foreman.spec
+++ b/foreman.spec
@@ -224,6 +224,8 @@ Group:  Applications/System
 Requires: %{?scl_prefix}rubygem(awesome_print)
 Requires: %{?scl_prefix}rubygem(hirb-unicode)
 Requires: %{?scl_prefix}rubygem(wirb)
+# minitest - workaround until Rails 4.0 (#2650)
+Requires: %{?scl_prefix}rubygem(minitest)
 Requires: %{name} = %{version}-%{release}
 
 %description console


### PR DESCRIPTION
Temporary workaround, commented.

Did not comment the one in comps as we will likely need minitest once we
review our foreman-spec requires.
