### PR TITLE
fixes #2685 incorrect and inefficient regexp checking madium name format

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -13,7 +13,7 @@ class Medium < ActiveRecord::Base
   validates_uniqueness_of :name
   validates_uniqueness_of :path
   validates_presence_of :name, :path
-  validates_format_of :name, :with => /\A(\S+\s?)+\Z/, :message => N_("can't be blank or contain trailing white spaces.")
+  validates_format_of :name, :with => /\A(\S+\s)*\S+\Z/, :message => N_("can't be blank or contain trailing white spaces.")
   validates_format_of :path, :with => /^(http|https|ftp|nfs):\/\//,
     :message => _("Only URLs with schema http://, https://, ftp:// or nfs:// are allowed (e.g. nfs://server/vol/dir)")
 

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -17,6 +17,12 @@ class MediumTest < ActiveSupport::TestCase
     assert !medium.name.strip.squeeze(" ").empty?
     assert !medium.save
 
+    medium.name = "Archlinux mirror      thing", :path => "http://www.google.com"
+    assert !medium.save
+
+    medium.name = "Archlinux mirror thing ", :path => "http://www.google.com"
+    assert !medium.save
+
     medium.name.strip!.squeeze!(" ")
     assert medium.save!
   end


### PR DESCRIPTION
It takes eternity to compute something like this:

"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  b" =~ /\A(\S+\s?)+\Z

Also "this is wrong " was not matched
