### PR TITLE
Use __method__ instead of static method names in SSO

### DIFF
--- a/lib/sso/base.rb
+++ b/lib/sso/base.rb
@@ -20,11 +20,11 @@ module SSO
     # if your SSO method supports logout page, you should store it into a session[:logout_url]
     # during this method execution
     def authenticated?
-      raise NotImplemented, 'authenticated? not implemented for this authentication method'
+      raise NotImplemented, "#{__method__} not implemented for this authentication method"
     end
 
     def authenticate!
-      raise NotImplemented, 'authenticate! not implemented for this authentication method'
+      raise NotImplemented, "#{__method__} not implemented for this authentication method"
     end
   end
 end


### PR DESCRIPTION
This is a simple change to use `__method__` instead of static names of methods. I just changed one of the method names to test something and the message didn't change. This PR is just a quick fix to prevent that from happening in the future.
