### PR TITLE
Refs #969 - Foreman-side changes for serving templates from the proxy

### DIFF
--- a/db/migrate/20130625113217_add_templates_to_features.rb
+++ b/db/migrate/20130625113217_add_templates_to_features.rb
@@ -1,0 +1,9 @@
+class AddTemplatesToFeatures < ActiveRecord::Migration
+  def self.up
+    Feature.create(:name => 'Templates')
+  end
+
+  def self.down
+    Feature.find_by_name('Templates').destroy
+  end
+end

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -18,8 +18,25 @@ module Foreman
       # Get basic stuff
       config   = URI.parse(Setting[:unattended_url])
       protocol = config.scheme || 'http'
-      host     = config.host || request.host
       port     = config.port || request.port
+      host     = config.host || request.host
+
+      # Only proxy templates if both the proxy and the host support it
+      proxy = @host.subnet.tftp
+      if proxy.features.map(&:name).include?('Templates') and !@host.token.nil?
+        url = begin
+                "http://" + ProxyAPI::Template.new(:url => proxy.url).template_url
+              rescue
+                proxy.url
+              end
+        uri      = URI.parse(url)
+        host     = uri.host
+        port     = uri.port
+        protocol = 'http'
+      end
+
+      # No need to specify port for http connections
+      port = nil if port == 80
 
       url_for :only_path => false, :controller => "/unattended", :action => action,
               :protocol  => protocol, :host => host, :port => port,

--- a/lib/proxy_api/template.rb
+++ b/lib/proxy_api/template.rb
@@ -1,0 +1,19 @@
+module ProxyAPI
+  class Template < ProxyAPI::Resource
+    def initialize args
+      @url     = args[:url] + "/unattended"
+      super args
+    end
+
+    # returns the Template URL for this proxy
+    def template_url
+      if (response = parse(get("templateServer"))) and response["templateServer"].present?
+        return response["templateServer"]
+      end
+      false
+    rescue RestClient::ResourceNotFound
+      nil
+    end
+
+  end
+end

--- a/test/fixtures/features.yml
+++ b/test/fixtures/features.yml
@@ -24,3 +24,6 @@ bmc:
 
 chefproxy:
   name: Chef Proxy
+
+templates:
+  name: Templates

--- a/test/fixtures/hosts.yml
+++ b/test/fixtures/hosts.yml
@@ -264,3 +264,19 @@ noip:
   subnet: one
   puppet_proxy: puppetmaster
   compute_resource: one
+
+templater:
+  type: Host::Managed
+  name: temp-45.yourdomain.net
+  ip: 203.0.113.111
+  mac: ac:bb:cc:dd:ee:de
+  environment: production
+  architecture: x86_64
+  operatingsystem: ubuntu1010
+  build: true
+  ptable: ubuntu
+  domain: yourdomain
+  medium: ubuntu
+  subnet: template
+  puppet_proxy: puppetmaster
+  compute_resource: one

--- a/test/fixtures/smart_proxies.yml
+++ b/test/fixtures/smart_proxies.yml
@@ -26,3 +26,8 @@ bmc:
   name: BMC proxy
   url: http://else.where:45673
   features: bmc
+
+template:
+  name: TFTP Template Proxy
+  url: http://somewhere.again
+  features: tftp, templates

--- a/test/fixtures/subnets.yml
+++ b/test/fixtures/subnets.yml
@@ -31,3 +31,12 @@ four:
    mask: 255.255.255.0
    tftp: two
    vlanid: 44
+
+template:
+   name: template
+   # RFC 5737 - 203.0.113.0/24 (TEST-NET-3)
+   network: 203.0.113.0
+   mask: 255.255.255.0
+   dhcp: one
+   tftp: template
+   vlanid: 45

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -663,7 +663,7 @@ class HostsControllerTest < ActionController::TestCase
   test "update multiple location imports taxable_taxonomies rows if succeeds on optimistic import" do
     @request.env['HTTP_REFERER'] = hosts_path
     location = taxonomies(:location1)
-    assert_difference "location.taxable_taxonomies.count", 7 do
+    assert_difference "location.taxable_taxonomies.count", 16 do
       post :update_multiple_location, {
                                          :location => {:id => location.id, :optimistic_import => "yes"},
                                          :host_ids => Host.all.map(&:id)
@@ -728,7 +728,7 @@ class HostsControllerTest < ActionController::TestCase
   test "update multiple organization imports taxable_taxonomies rows if succeeds on optimistic import" do
     @request.env['HTTP_REFERER'] = hosts_path
     organization = taxonomies(:organization1)
-    assert_difference "organization.taxable_taxonomies.count", 9 do
+    assert_difference "organization.taxable_taxonomies.count", 16 do
       post :update_multiple_organization, {
                                          :organization => {:id => organization.id, :optimistic_import => "yes"},
                                          :host_ids => Host.all.map(&:id)

--- a/test/functional/locations_controller_test.rb
+++ b/test/functional/locations_controller_test.rb
@@ -96,7 +96,7 @@ class LocationsControllerTest < ActionController::TestCase
   end
   test "should assign all hosts with no location to selected location and add taxable_taxonomies" do
     location = taxonomies(:location1)
-    assert_difference "location.taxable_taxonomies.count", 7 do
+    assert_difference "location.taxable_taxonomies.count", 16 do
       post :assign_all_hosts, {:id => location.id}, set_session_user
     end
   end

--- a/test/functional/organizations_controller_test.rb
+++ b/test/functional/organizations_controller_test.rb
@@ -94,7 +94,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
   test "should assign all hosts with no organization to selected organization and add taxable_taxonomies" do
     organization = taxonomies(:organization1)
-    assert_difference "organization.taxable_taxonomies.count", 9 do
+    assert_difference "organization.taxable_taxonomies.count", 16 do
       post :assign_all_hosts, {:id => organization.id}, set_session_user
     end
   end

--- a/test/lib/proxy_api/template_test.rb
+++ b/test/lib/proxy_api/template_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ProxyApiTemplateTest < ActiveSupport::TestCase
+  def setup
+    @url = "http://localhost:8443"
+    @template = ProxyAPI::Template.new({:url => @url})
+  end
+
+  def fake_response(data)
+    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+    net_http_resp.add_field 'Set-Cookie', 'Monster'
+    RestClient::Response.create(JSON(data), net_http_resp, nil)
+  end
+
+  test "constructor should complete" do
+    assert_not_nil(@template)
+  end
+
+  test "base url should equal /unattended" do
+    expected = "#{@url}/unattended"
+    assert_equal(expected, @template.url)
+  end
+
+  test "should get template server url" do
+    @template.expects(:get).with('templateServer').returns(fake_response({'templateServer'=>'mytemplateserver'}))
+    assert_equal('mytemplateserver', @template.template_url)
+  end
+
+end


### PR DESCRIPTION
Needs the proxy-side PR to function.

The unattended template tests got slightly restructured to make more sense, sorry for the noise in that file.
