### PR TITLE
Fixes #2721 - Allow use of spice for libvirt via existing Setting

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -36,10 +36,12 @@ module ComputeResourcesVmsHelper
     options.merge!(
       :address     => console[:address],
       :secure_port => console[:secure_port],
-      :ca_cert     => URI.escape(console[:ca_cert]),
       :subject     => console[:subject],
       :title       => _("%s - Press Shift-F12 to release the cursor.") % console[:name]
     ) if supports_spice_xpi?
+    options.merge!(
+      :ca_cert     => URI.escape(console[:ca_cert])
+    ) if console[:ca_cert].present?
     options
   end
 

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -180,6 +180,16 @@ class ComputeResource < ActiveRecord::Base
     []
   end
 
+  def set_console_password?
+    self.attrs[:setpw] == 1 || self.attrs[:setpw].nil?
+  end
+
+  def set_console_password=(setpw)
+    self.attrs[:setpw] = setpw.to_i
+  rescue
+    # passed something non-integer, don't set it
+  end
+
   protected
 
   def client
@@ -191,6 +201,7 @@ class ComputeResource < ActiveRecord::Base
   end
 
   def random_password
+    return nil unless set_console_password?
     n = 8
     chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
     (0...n).map { chars[rand(chars.length)].chr }.join

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -3,6 +3,15 @@ module Foreman::Model
 
     validates_format_of :url, :with => URI.regexp
 
+    # Some getters/setters for the attrs Hash
+    def display_type
+      self.attrs[:display].present? ? self.attrs[:display] : 'vnc'
+    end
+
+    def display_type=(display)
+      self.attrs[:display] = display
+    end
+
     def provided_attributes
       super.merge({:mac => :mac})
     end
@@ -102,7 +111,7 @@ module Foreman::Model
       password = random_password
       # Listen address cannot be updated while the guest is running
       # When we update the display password, we pass the existing listen address
-      vm.update_display(:password => password, :listen => vm.display[:listen])
+      vm.update_display(:password => password, :listen => vm.display[:listen], :type => vm.display[:type])
       WsProxy.start(:host => hypervisor.hostname, :host_port => vm.display[:port], :password => password).merge(:type =>  vm.display[:type].downcase, :name=> vm.name)
     rescue ::Libvirt::Error => e
       if e.message =~ /cannot change listen address/
@@ -139,7 +148,12 @@ module Foreman::Model
         :boot_order => %w[network hd],
         :nics       => [new_nic],
         :volumes    => [new_volume],
-        :display    => { :type => 'vnc', :listen => Setting[:libvirt_default_console_address], :password => random_password, :port => '-1' }
+        :display    => {
+                         :type => display_type.downcase,
+                         :listen => Setting[:libvirt_default_console_address],
+                         :password => random_password,
+                         :port => '-1'
+                       }
       )
     end
 

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,5 +1,10 @@
 <%= text_f f, :url, :class => "input-xlarge", :help_block => _("e.g. qemu://host.example.com/system") %>
 
+<%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display type") %>
+<%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
+                  :label => _("Console passwords"),
+                  :help_inline => _("Set a randomly generated password on the display connection") %>
+
 <% hypervisor = f.object.hypervisor.uuid rescue nil%>
 <% if hypervisor -%>
   <%= f.hidden_field :uuid, :value => hypervisor %>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -7,4 +7,7 @@
                  :class => "btn + #{datacenters.empty? ? "" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :class=>"input-xxlarge" %>
+<%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
+                  :label => _("Console passwords"),
+                  :help_inline => _("Set a randomly generated password on the display connection") %>
 <%= f.hidden_field(:pubkey_hash) if f.object.uuid.present? %>

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -32,6 +32,8 @@
         <td><%= _("URL") %></td>
         <td><%= @compute_resource.url %></td>
       </tr>
+      <% # optional extra display elements based on type %>
+      <%= render "compute_resources/show/#{@compute_resource.provider.downcase}" %>
     </table>
   </div>
   <div id="vms" class="tab-pane" data-url=<%= compute_resource_vms_path(@compute_resource) %>>

--- a/app/views/compute_resources/show/_ec2.html.erb
+++ b/app/views/compute_resources/show/_ec2.html.erb
@@ -1,0 +1,1 @@
+<%# placeholder for future content %>

--- a/app/views/compute_resources/show/_libvirt.html.erb
+++ b/app/views/compute_resources/show/_libvirt.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td><%= _("Display type") %></td>
+  <td><%= @compute_resource.display_type %></td>
+</tr>
+<tr>
+  <td><%= _("Console passwords") %></td>
+  <td><%= @compute_resource.set_console_password? ? _("Enabled") : _("Disabled") %></td>
+</tr>

--- a/app/views/compute_resources/show/_openstack.html.erb
+++ b/app/views/compute_resources/show/_openstack.html.erb
@@ -1,0 +1,1 @@
+<%# placeholder for future content %>

--- a/app/views/compute_resources/show/_ovirt.html.erb
+++ b/app/views/compute_resources/show/_ovirt.html.erb
@@ -1,0 +1,1 @@
+<%# placeholder for future content %>

--- a/app/views/compute_resources/show/_rackspace.html.erb
+++ b/app/views/compute_resources/show/_rackspace.html.erb
@@ -1,0 +1,1 @@
+<%# placeholder for future content %>

--- a/app/views/compute_resources/show/_vmware.html.erb
+++ b/app/views/compute_resources/show/_vmware.html.erb
@@ -1,0 +1,4 @@
+<tr>
+  <td><%= _("Console passwords") %></td>
+  <td><%= @compute_resource.set_console_password? ? _("True") : _("False") %></td>
+</tr>

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -85,4 +85,24 @@ class ComputeResourceTest < ActiveSupport::TestCase
     record.name = "renamed"
     assert !record.save
   end
+
+  test "random_password should return nil when set_console_password is false" do
+    cr=compute_resources(:mycompute)
+    cr.set_console_password=0
+    assert_nil cr.send(:random_password) # Can't call protected methods directly
+  end
+
+  test "random_password should return a string when set_console_password is true" do
+    cr=compute_resources(:mycompute)
+    cr.set_console_password=1
+    assert_match /^[[:alnum:]]+$/, cr.send(:random_password) # Can't call protected methods directly
+  end
+
+  test "libvirt vm_instance_defaults should contain the stored display type" do
+    cr=compute_resources(:mycompute)
+    cr.display_type='VNC'
+    assert_equal 'vnc', cr.send(:vm_instance_defaults)['display']['type']
+    cr.display_type='SPICE'
+    assert_equal 'spice', cr.send(:vm_instance_defaults)['display']['type']
+  end
 end


### PR DESCRIPTION
I appreciate this is a slight regression as the Spice variant of `display` has `:listen => '0'` in it, but I wanted to open discussions before going to the effort of adding a whole new Setting. Opinions please?
