### PR TITLE
Remote addr can support several load balancers

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -16,7 +16,7 @@ class Setting::Provisioning < Setting
         self.set('manage_puppetca', N_("Should Foreman automate certificate signing upon provisioning new host"), true),
         self.set('ignore_puppet_facts_for_provisioning', N_("Does not update ipaddress and MAC values from Puppet facts"), false),
         self.set('query_local_nameservers', N_("Should Foreman query the locally configured name server or the SOA/NS authorities"), false),
-        self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote loadbalancer, the ip should be set here"), "127.0.0.1"),
+        self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the ip should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1) "), "127.0.0.1"),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0),
         self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0")
       ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}


### PR DESCRIPTION
Shortly after two load balancers were set up for our foreman installation, we noticed sometimes calls to /unattended/built were failing. This was due to this line of code in UnattendedController,

``` ruby
    if request.env['HTTP_X_FORWARDED_FOR'].present? and (ip =~ Regexp.new(Setting[:remote_addr]))
      ip = request.env['HTTP_X_FORWARDED_FOR']
    end
```

Since I thought :remote_addr was just an IP, this IP was set to one of the balancers. Of course in a system with several load balancers, some calls would fail. :remote_addr could be an array that contains several ips, but I believe that since it's a string used as a regexp, we can exploit this fact to support several load balancers. It works.
