### PR TITLE
fixes #2747 - scoped search lambda takes one argument

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -98,7 +98,7 @@ class Host::Managed < Host::Base
 
   scope :alerts_enabled, {:conditions => ["enabled = ?", true] }
 
-  scope :completer_scope, lambda { my_hosts }
+  scope :completer_scope, lambda { |opts| my_hosts }
 
   scope :run_distribution, lambda { |fromtime,totime|
     if fromtime.nil? or totime.nil?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -4,7 +4,7 @@ class Location < Taxonomy
   has_and_belongs_to_many :organizations
   has_many_hosts :dependent => :nullify
 
-  scope :completer_scope, lambda { my_locations }
+  scope :completer_scope, lambda { |opts| my_locations }
 
   scope :my_locations, lambda {
         user = User.current

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,7 +4,7 @@ class Organization < Taxonomy
   has_and_belongs_to_many :locations
   has_many_hosts :dependent => :nullify
 
-  scope :completer_scope, lambda { my_organizations }
+  scope :completer_scope, lambda { |opts| my_organizations }
 
   scope :my_organizations, lambda {
       user = User.current

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -697,4 +697,13 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "can auto-complete searches by host name" do
+    as_admin do
+      completions = Host::Managed.complete_for("name =")
+      Host::Managed.all.each do |h|
+        assert completions.include?("name = #{h.name}"), "completion missing: #{h}"
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Due to https://github.com/wvanbergen/scoped_search/commit/b8c6b1c1933ddb28ee753d9f9904b08450f5883b this argument appears mandatory for completer_scope.  cc @abenari for review.
