### PR TITLE
fixes #1770 - Refactored rdeckfacts definition to use facts_hash

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -520,7 +520,7 @@ class Host::Managed < Host::Base
   def rundeck
     rdecktags = puppetclasses_names.map{|k| "class=#{k}"}
     unless self.params["rundeckfacts"].empty?
-      rdecktags += self.params["rundeckfacts"].split(",").map{|rdf| "#{rdf}=#{fact(rdf)[0].value}"}
+      rdecktags += self.params["rundeckfacts"].gsub(/\s+/, '').split(',').map { |rdf| "#{rdf}=" + (facts_hash[rdf] || "undefined") }
     end
     { name => { "description" => comment, "hostname" => name, "nodename" => name,
       "osArch" => arch.name, "osFamily" => os.family, "osName" => os.name,

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -838,6 +838,23 @@ class HostsControllerTest < ActionController::TestCase
     assert_equal new_password, @host.interfaces.bmc.first.password
   end
 
+  test "index returns YAML output for rundeck" do
+    get :index, {:format => 'yaml', :rundeck => true}, set_session_user
+    hosts = YAML.load(@response.body)
+    assert !hosts.empty?
+    host = Host.first
+    assert_equal host.os.name, hosts[host.name]["osName"]  # rundeck-specific field
+  end
+
+  test "show returns YAML output for rundeck" do
+    host = Host.first
+    get :show, {:id => host.to_param, :format => 'yaml', :rundeck => true}, set_session_user
+    yaml = YAML.load(@response.body)
+    assert_kind_of Hash, yaml[host.name]
+    assert_equal host.name, yaml[host.name]["hostname"]
+    assert_equal host.os.name, yaml[host.name]["osName"]  # rundeck-specific field
+  end
+
   private
   def initialize_host
     User.current = users(:admin)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -706,4 +706,25 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "#rundeck returns hash" do
+    h = hosts(:one)
+    rundeck = h.rundeck
+    assert_kind_of Hash, rundeck
+    assert_equal ['my5name.mydomain.net'], rundeck.keys
+    assert_kind_of Hash, rundeck[h.name]
+    assert_equal 'my5name.mydomain.net', rundeck[h.name]['hostname']
+    assert_equal ['class=base'], rundeck[h.name]['tags']
+  end
+
+  test "#rundeck returns extra facts as tags" do
+    h = hosts(:one)
+    h.params['rundeckfacts'] = "kernelversion, ipaddress\n"
+    h.save!
+
+    rundeck = h.rundeck
+    assert rundeck[h.name]['tags'].include?('class=base'), 'puppet class missing'
+    assert rundeck[h.name]['tags'].include?('kernelversion=2.6.9'), 'kernelversion fact missing'
+    assert rundeck[h.name]['tags'].include?('ipaddress=10.0.19.33'), 'ipaddress fact missing'
+  end
+
 end


### PR DESCRIPTION
Replaces GH-752 with tests.
