### PR TITLE
(Fixes #3064) Links to hostgroups are consistent

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -194,7 +194,7 @@ module HostsHelper
       [_("Puppet Environment"), (link_to(host.environment, hosts_path(:search => "environment = #{host.environment}")) if host.environment)],
       [_("Host Architecture"), (link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}")) if host.arch)],
       [_("Operating System"), (link_to(host.os, hosts_path(:search => "os = #{host.os.name}")) if host.os)],
-      [_("Host group"), (link_to(host.hostgroup, hosts_path(:search => "hostgroup = #{host.hostgroup}")) if host.hostgroup)],
+      [_("Host group"), (link_to(host.hostgroup, hosts_path(:search => "hostgroup_fullname = #{host.hostgroup}")) if host.hostgroup)],
     ]
     fields += [[_("Location"), (link_to(host.location.name, hosts_path(:search => "location = #{host.location}")) if host.location)]] if SETTINGS[:locations_enabled]
     fields += [[_("Organization"), (link_to(host.organization.name, hosts_path(:search => "organization = #{host.organization}")) if host.organization)]] if SETTINGS[:organizations_enabled]

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -20,7 +20,7 @@
       <td class="hidden-phone"><%= (icon(host.os, :size => "18x18") + trunc(" #{host.os}",14)).html_safe if host.os %></td>
       <td class="hidden-phone"><%= trunc(host.try(:environment), 14) %></td>
       <td class="hidden-tablet hidden-phone ellipsis"><%= model_name host %></td>
-      <td class="hidden-tablet hidden-phone ellipsis"><%= hostgroup_name host.hostgroup, 26 %></td>
+      <td class="hidden-tablet hidden-phone ellipsis"><%= hostgroup_name(host.hostgroup, 26) if host.hostgroup %></td>
       <td class="hidden-tablet hidden-phone"><%= last_report_column(host) %></td>
       <td>
         <%= action_buttons(


### PR DESCRIPTION
In the host list view, the hostgroup link points to the edit view. However, in the host detail, it points to "search=hostgroup+%3D+aisusie%2Fdevel%2Fbackend" which is wrong too.
It'd be nice if both pointed to search=hostgroup_fullname=HOSTGROUP.

credits to https://its.cern.ch/jira/browse/AI-2624

When the user is in the hosts list view, it's confusing that when you click on a hostgroup it does not simply search for all hosts in that hostgroup, but instead it leads you to the edit page.

http://projects.theforeman.org/issues/3064
