### PR TITLE
Fixes #2780 - Enhance puppet classes assignment

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -150,15 +150,17 @@ function add_puppet_class(item){
   var id = $(item).attr('data-class-id');
   var type = $(item).attr('data-type');
   $(item).tooltip('hide');
-  var content = $(item).parent().clone();
+  var content = $(item).closest('li').clone();
   content.attr('id', 'selected_puppetclass_'+ id);
   content.append("<input id='" + type +"_puppetclass_ids_' name='" + type +"[puppetclass_ids][]' type='hidden' value=" +id+ ">");
   content.children('span').tooltip();
 
   var link = content.children('a');
-  link.attr('onclick', 'remove_puppet_class(this)');
-  link.attr('data-original-title', _('Click to undo adding this class'));
-  link.removeClass('icon-plus-sign').addClass('icon-remove-sign').tooltip();
+  var links = content.find('a');
+  links.attr('onclick', 'remove_puppet_class(this)');
+  links.attr('data-original-title', _('Click to undo adding this class'));
+  links.tooltip();
+  link.removeClass('icon-plus-sign').addClass('icon-remove-sign');
 
   $('#selected_classes').append(content);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -115,10 +115,12 @@ div.flash.notice {
   margin-left: 10px;
   margin-bottom: 0px;
 }
-.puppetclass a, .puppetclass li a, .selected_puppetclass a, .selected_puppetclass li a {
-  color: #333;
-  float: right;
-  margin-right: 10px;
+.puppetclass, .puppetclass li, .selected_puppetclass, .selected_puppetclass li {
+  a { color: #333; }
+  a.icon-remove-sign, a.icon-plus-sign {
+    float: right;
+    margin-right: 10px;
+  }
 }
 
 #title_action {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,25 +41,40 @@ module ApplicationHelper
 
   def link_to_remove_puppetclass klass, host
     options = klass.name.size > 28 ? {:'data-original-title'=>klass.name, :rel=>'twipsy'} : {}
-    content_tag(:span, truncate(klass.name, :length => 28), options).html_safe +
-    link_to_function("","remove_puppet_class(this)", :'data-class-id'=>klass.id,
-                     :'data-original-title'=>_("Click to remove %s") % klass, :rel=>'twipsy',
-                     :'data-url' => parameters_puppetclass_path( :id => klass.id),
-                     :'data-host-id' => host.id,
+    functions_options = { :klass => klass, :host => host, :css_class => ''}
+    text = remove_link_to_function(truncate(klass.name, :length => 28), functions_options)
+    content_tag(:span, text, options).html_safe +
+        remove_link_to_function('', functions_options.merge(:css_class => 'icon-remove-sign'))
+
+  end
+
+  def remove_link_to_function(text, options)
+    link_to_function(text,"remove_puppet_class(this)", :'data-class-id'=>options[:klass].id,
+                     :'data-original-title'=>_("Click to remove %s") % options[:klass], :rel=>'twipsy',
+                     :'data-url' => parameters_puppetclass_path( :id => options[:klass].id),
+                     :'data-host-id' => options[:host].id,
                      :'data-animation' => "",
-                     :class=>"icon-remove-sign")
+                     :class=>options[:css_class])
   end
 
   def link_to_add_puppetclass klass, host, type
     options = klass.name.size > 28 ? {:'data-original-title'=>klass.name, :rel=>'twipsy'} : {}
-    content_tag(:span, truncate(klass.name, :length => 28), options).html_safe +
-    link_to_function("", "add_puppet_class(this)",
-                       :'data-class-id' => klass.id, 'data-type' => type,
-                       :'data-url' => parameters_puppetclass_path( :id => klass.id),
-                       :'data-host-id' => host.try(:id),
-                       :'data-original-title' => _("Click to add %s") % klass, :rel => 'twipsy',
-                       :'data-animation' => "",
-                       :class => "icon-plus-sign")
+    function_options = { :klass => klass, :host => host, :type => type }
+    text             = add_link_to_function(truncate(klass.name, :length => 28), function_options)
+
+    content_tag(:span, text, options).html_safe +
+        add_link_to_function('', function_options.merge(:css_class => 'icon-plus-sign'))
+
+  end
+
+  def add_link_to_function(text, options)
+    link_to_function(text, "add_puppet_class(this)",
+                     :'data-class-id'       => options[:klass].id, 'data-type' => options[:type],
+                     :'data-url'            => parameters_puppetclass_path(:id => options[:klass].id),
+                     :'data-host-id'        => options[:host].try(:id),
+                     :'data-original-title' => _("Click to add %s") % options[:klass], :rel => 'twipsy',
+                     :'data-animation'      => "",
+                     :class                 => options[:css_class])
   end
 
   def add_html_classes options, classes


### PR DESCRIPTION
Allows you to assign/unassign puppet classes to a host/hostgroup by
clicking on it's name. You can still use the small icon on particular
line.
