### PR TITLE
support apt proxy configuration in default preseed

### DIFF
--- a/app/views/unattended/preseed.erb
+++ b/app/views/unattended/preseed.erb
@@ -24,7 +24,7 @@ d-i hw-detect/load_firmware boolean true
 d-i mirror/country string manual
 d-i mirror/http/hostname string <%= @preseed_server %>
 d-i mirror/http/directory string <%= @preseed_path %>
-d-i mirror/http/proxy string
+d-i mirror/http/proxy string <%= @host.parameters['preseed-proxy'] ? @host.parameters['preseed-proxy'] : '' %>
 d-i mirror/codename string <%= @host.operatingsystem.release_name %>
 d-i mirror/suite string <%= @host.operatingsystem.release_name %>
 d-i mirror/udeb/suite string <%= @host.operatingsystem.release_name %>


### PR DESCRIPTION
since our lab machine is in our office and we try to be nice to our
fellow officemates, we have an apt-cacher-server running in the lab.
this patch allows for that to be configured on a host parameter basis
(our lab is just a hostgroup, and we have the parameter set there)

transparent for anyone not using it
