### PR TITLE
fixes #2741 - remove dash from -%> to %>

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -7,8 +7,8 @@
       <div class="stats-well">
         <h4><%=_("System Status")%></h4>
         <ul class="nav nav-tabs" data-tabs="tabs">
-          <li class="active"><a href="#smart_proxies" data-toggle="tab"><%= _('Smart Proxies') -%></a></li>
-          <li><a href="#compute_resources" data-toggle="tab"><%= _('Compute Resources') -%></a></li>
+          <li class="active"><a href="#smart_proxies" data-toggle="tab"><%= _('Smart Proxies') %></a></li>
+          <li><a href="#compute_resources" data-toggle="tab"><%= _('Compute Resources') %></a></li>
         </ul>
         <div class="tab-content">
           <div class="tab-pane active" id="smart_proxies">

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -9,14 +9,14 @@
 
 <div class="tabbable">
   <ul class="nav nav-tabs">
-    <% if tmplt -%>
-      <li class="active"><a href="#tab0" data-toggle="tab"><%= _('Template Diff') -%></a></li>
-    <% end -%>
-    <li class='<%= "active" unless tmplt %>' ><a href="#tab1" data-toggle="tab"><%= _('Details') -%></a></li>
-    <li><a href="#tab2" data-toggle="tab"><%= _('History') -%></a></li>
+    <% if tmplt %>
+      <li class="active"><a href="#tab0" data-toggle="tab"><%= _('Template Diff') %></a></li>
+    <% end %>
+    <li class='<%= "active" unless tmplt %>' ><a href="#tab1" data-toggle="tab"><%= _('Details') %></a></li>
+    <li><a href="#tab2" data-toggle="tab"><%= _('History') %></a></li>
   </ul>
   <div class="tab-content">
-    <% if tmplt -%>
+    <% if tmplt %>
     <div class="tab-pane active" id="tab0">
        <%= render 'config_templates/diff', :templates => @audit.audited_changes["template"], :file_name => audit_title(@audit) %>
     </div>
@@ -24,28 +24,28 @@
     <div class='tab-pane <%= "active" unless tmplt%>' id="tab1">
       <table class="table table-bordered table-striped">
         <tr>
-          <th><%= _('Item') -%></th>
+          <th><%= _('Item') %></th>
           <% if @audit.action == 'update' %>
-            <th><%= _('Old') -%></th>
-            <th><%= _('New') -%></th>
+            <th><%= _('Old') %></th>
+            <th><%= _('New') %></th>
           <% else %>
-            <th><%= _('Value') -%></th>
+            <th><%= _('Value') %></th>
           <% end  %>
         </tr>
-        <% @audit.audited_changes.each do |name,change| -%>
-            <% next if change.nil? or change.to_s.empty? -%>
-            <% next if name == "template" -%>
+        <% @audit.audited_changes.each do |name,change| %>
+            <% next if change.nil? or change.to_s.empty? %>
+            <% next if name == "template" %>
             <tr>
               <td><%= name.humanize %></td>
               <% if change.is_a?(Array) %>
-                  <% change.each do |v| -%>
+                  <% change.each do |v| %>
                       <td><%= id_to_label(name,v) %></td>
-                  <% end -%>
-              <% else -%>
+                  <% end %>
+              <% else %>
                   <td><%= id_to_label(name,change) %></td>
-              <% end -%>
+              <% end %>
             </tr>
-        <% end -%>
+        <% end %>
       </table>
     </div>
     <div class="tab-pane" id="tab2">

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -18,7 +18,7 @@
     <%= text_f f, :attr_firstname, :help_inline => _("e.g. givenName") %>
     <%= text_f f, :attr_lastname, :help_inline => _("e.g. sn") %>
     <%= text_f f, :attr_mail, :help_inline => _("e.g. mail") %>
-  <% end -%>
+  <% end %>
 
   <%= submit_or_cancel f %>
 <% end %>

--- a/app/views/autosign/_form.html.erb
+++ b/app/views/autosign/_form.html.erb
@@ -6,4 +6,4 @@
     </div>
   </div>
   <%= submit_tag _('Save'), :class => "btn btn-success" %>
-<% end -%>
+<% end %>

--- a/app/views/autosign/index.html.erb
+++ b/app/views/autosign/index.html.erb
@@ -8,14 +8,14 @@
     <th><%= _("Name") %></th>
     <th></th>
   </tr>
-  <% @autosign.each do |cert| -%>
+  <% @autosign.each do |cert| %>
       <tr>
         <td><%= h cert%> </td>
         <td>
           <%= action_buttons(display_delete_if_authorized hash_for_smart_proxy_autosign_path(:smart_proxy_id => @proxy, :id => cert), :class => 'delete')%>
         </td>
       </tr>
-  <% end -%>
+  <% end %>
 </table>
 <%= page_entries_info @autosign %>
 <%= will_paginate @autosign %>

--- a/app/views/bookmarks/_list.html.erb
+++ b/app/views/bookmarks/_list.html.erb
@@ -1,7 +1,7 @@
-<% if bookmarks.any? -%>
+<% if bookmarks.any? %>
 <ul class='dropdown-menu'>
-  <% bookmarks.each do |bookmark| -%>
+  <% bookmarks.each do |bookmark| %>
       <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
-  <% end -%>
+  <% end %>
 </ul>
-<% end -%>
+<% end %>

--- a/app/views/common/_domain.html.erb
+++ b/app/views/common/_domain.html.erb
@@ -4,4 +4,4 @@
     { :disabled => domain_subnets.empty?, :'data-url' => SETTINGS[:unattended] ? freeip_subnets_path : '',
       :label => _("Subnet"), :help_inline => :indicator, :onchange => 'subnet_selected(this);'}
   %>
-<% end -%>
+<% end %>

--- a/app/views/common/_domain_subnet.html.erb
+++ b/app/views/common/_domain_subnet.html.erb
@@ -6,4 +6,4 @@
   <span id="subnet_select">
     <%= render 'common/domain', :item => item %>
   </span>
-<% end  -%>
+<% end  %>

--- a/app/views/common/_edit_habtm.html.erb
+++ b/app/views/common/_edit_habtm.html.erb
@@ -1,12 +1,12 @@
 <ul class="inputs-list">
-  <% if associations.empty? -%>
+  <% if associations.empty? %>
     <strong><%= _("None Found") %></strong>
-  <% else -%>
+  <% else %>
     <% association = associations.first %>
     <%= link_to_function(icon_text("check", ""), "toggleCheckboxesBySelector(\"[id$='#{ActiveModel::Naming.singular(association)}_ids_']\")",
                                          :title => _("Select all")) %>
     <% selected_ids = klass.send(ActiveModel::Naming.plural(association)).select("#{association.class.table_name}.id").map(&:id) %>
-    <% associations.sort{|a,b| a.to_s <=> b.to_s}.each do |association| -%>
+    <% associations.sort{|a,b| a.to_s <=> b.to_s}.each do |association| %>
       <li>
       <%= content_tag_for :label, association do %>
         <% check_box_name = "#{prefix || klass.class.model_name.tableize.singularize}[#{ActiveModel::Naming.singular(association)}_ids][]" %>
@@ -14,8 +14,8 @@
                           :disabled => options[:disabled].present? && options[:disabled].include?(association.id)) %>
         <%= contract association %>
         <%= hidden_field_tag check_box_name %>
-      <% end -%>
+      <% end %>
       </li>
-    <% end -%>
-  <% end -%>
+    <% end %>
+  <% end %>
 </ul>

--- a/app/views/common/_notice.html.erb
+++ b/app/views/common/_notice.html.erb
@@ -1,16 +1,16 @@
 <div id="notice" style="clear:both;">
   <%= field_set_tag _("Notifications") do %>
     <table width="100%">
-      <% for notice in  @notices-%>
+      <% for notice in  @notices%>
         <tr>
-          <td style="width:1%"><img src="images/<%= notice.level -%>.png"></td>
+          <td style="width:1%"><img src="images/<%= notice.level %>.png"></td>
           <td>
-            <%= truncate notice.content, 100 -%>
+            <%= truncate notice.content, 100 %>
           </td>
           <td align="right" style="width:1%">
-            <% link_to notice, :method => :delete do -%>
+            <% link_to notice, :method => :delete do %>
               <img src="images/close_hl.png">
-            <% end -%>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -1,5 +1,5 @@
-<% title _("Changed environments") -%>
-<%= form_tag send("obsolete_and_new_#{controller_name}_path") do -%>
+<% title _("Changed environments") %>
+<%= form_tag send("obsolete_and_new_#{controller_name}_path") do %>
   <h4><%= _("Select the changes you want to realize in Foreman") %></h4>
   <h6>
   <%= _("Toggle") %>:
@@ -21,9 +21,9 @@
                              :title => _("Check/Uncheck all")) %>
       </th>
       <th><%= _("Environment") %></th><th><%= _("Operation") %></th><th><%= _("Puppet Modules") %></th>
-      <% for kind in ["new", "obsolete", "updated"] -%>
-        <% unless (envs = @changed[kind]).empty? -%>
-          <% for env in envs.keys.sort -%>
+      <% for kind in ["new", "obsolete", "updated"] %>
+        <% unless (envs = @changed[kind]).empty? %>
+          <% for env in envs.keys.sort %>
           <tr>
             <td>
               <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind} env_select_boxes_env_#{env}" %>
@@ -32,20 +32,20 @@
               <%= link_to_function("#{env}", "toggleCheckboxesBySelector('.env_select_boxes_env_#{env}')", :title => _("Check/Uncheck all %s changes") % env) %>
             </td>
             <td>
-              <%= {"new" => _("Add:"), "obsolete" => _("Remove:"), "updated" => _("Update:")}[kind] -%>
+              <%= {"new" => _("Add:"), "obsolete" => _("Remove:"), "updated" => _("Update:")}[kind] %>
             </td>
             <td>
-              <% pcs = @changed[kind][env] -%>
+              <% pcs = @changed[kind][env] %>
               <%= class_update_text pcs, env %>
             </td>
           </tr>
-        <% end -%>
-      <% end -%>
-    <% end -%>
+        <% end %>
+      <% end %>
+    <% end %>
     </tr>
   </table>
   <div>
     <%= link_to _("Cancel"), send("#{controller_name}_path"), :class => "btn" %>
     <%= submit_tag _("Update"), :class => "btn btn-primary" %>
   </div>
-<% end -%>
+<% end %>

--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -11,16 +11,16 @@
       </button>
       <ul class="dropdown-menu pull-right">
         <% bookmarks = Bookmark.my_bookmarks.controller(controller_name) %>
-        <% bookmarks.each do |bookmark| -%>
+        <% bookmarks.each do |bookmark| %>
             <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
-        <% end -%>
+        <% end %>
         <li class="divider"></li>
         <li><%= link_to_function _('Bookmark this search'), "$('#bookmarks-modal').modal();",
                                  {:id => "bookmark", :"data-url"=> new_bookmark_path(:kontroller => controller_name)}%></li>
       </ul>
     </div>
     </div>
-<% end -%>
+<% end %>
 
 <div id="bookmarks-modal" class="modal hide fade">
   <div class="modal-header">

--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -7,4 +7,4 @@
       :help_inline => :indicator,
       :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected')}
   %>
-<% end -%>
+<% end %>

--- a/app/views/common/os_selection/_image_details.html.erb
+++ b/app/views/common/os_selection/_image_details.html.erb
@@ -4,4 +4,4 @@
                    :onchange => 'use_image_selected(this)', :'data-url'=> method_path('use_image_selected'), :'data-type' => controller_name %>
     <%= text_f f, :image_file, :disabled => !item.use_image, :class => "span6" %>
   </span>
-<% end -%>
+<% end %>

--- a/app/views/common/os_selection/_initial.html.erb
+++ b/app/views/common/os_selection/_initial.html.erb
@@ -12,4 +12,4 @@
     </span>
 
   </span>
-<% end -%>
+<% end %>

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -10,7 +10,7 @@
     {:id => type + "_ptable_id", :name => type + "[ptable_id]", :label => _("Partition table"), :disabled => os_ptable.empty?}
   %>
 
-  <% if @operatingsystem and @operatingsystem.supports_image -%>
+  <% if @operatingsystem and @operatingsystem.supports_image %>
     <%= render "common/os_selection/image_details", {:item => item} %>
-  <% end -%>
-<% end -%>
+  <% end %>
+<% end %>

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -4,11 +4,11 @@
     <th class='span3'><%= _("Scope") %></th>
     <th class='span2'><%= _("Name") %></th>
     <th class='span7'><%= _("Value") %></th>
-    <th><%= _('Actions') -%></th>
+    <th><%= _('Actions') %></th>
   </tr>
   </thead>
   <tbody>
-  <% inherited_parameters.keys.sort.each do |name| -%>
+  <% inherited_parameters.keys.sort.each do |name| %>
       <tr>
         <%= "<td class='span2' rowspan='#{inherited_parameters.size}'>#{_('Global')}</td>".html_safe if name == inherited_parameters.first[0]%>
         <td class='span2'><%= content_tag :span, name, :id=>"name_#{name}", :class => "span2" %></td>
@@ -17,7 +17,7 @@
         <%= link_to_function(_("override"), "override_param(this)", :title => _("Override this value"),
                              :'data-tag' => 'override', :class =>"btn" ) if authorized_via_my_scope("host_editing", "create_params") %>
       </tr>
-  <% end -%>
+  <% end %>
   </tbody>
 </table>
 

--- a/app/views/common_parameters/_parameters.html.erb
+++ b/app/views/common_parameters/_parameters.html.erb
@@ -1,6 +1,6 @@
 <div id="parameters">
-  <%= f.fields_for type do |builder| -%>
+  <%= f.fields_for type do |builder| %>
     <%= render "common_parameters/parameter", :f => builder %>
-  <% end -%>
+  <% end %>
   <%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields('+ ' + _("Add Parameter"), f, type, "common_parameters/parameter") : "" %>
 </div>

--- a/app/views/common_parameters/_puppetclasses_parameters.html.erb
+++ b/app/views/common_parameters/_puppetclasses_parameters.html.erb
@@ -1,7 +1,7 @@
 <div id="puppetclasses_parameters">
-  <%= f.fields_for :lookup_values do |builder| -%>
+  <%= f.fields_for :lookup_values do |builder| %>
     <%= render "common_parameters/puppetclass_parameter", :f => builder %>
-  <% end -%>
-  <%# Hidden button to add an override, used from javascript only -%>
+  <% end %>
+  <%# Hidden button to add an override, used from javascript only %>
   <%= authorized_via_my_scope('host_editing', 'create_params') ? link_to_add_fields('+ ' + _('Override a Puppetclass Parameter'), f, :lookup_values, 'common_parameters/puppetclass_parameter', :class => 'hide') : '' %>
 </div>

--- a/app/views/common_parameters/_show_parameter.html.erb
+++ b/app/views/common_parameters/_show_parameter.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <% parameter.each do |p| -%>
+  <% parameter.each do |p| %>
     <li><%= "#{p.name} #{p.value}" %></li>
-  <% end -%>
+  <% end %>
 </ul>

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -6,9 +6,9 @@
                   :help_inline => _("Set a randomly generated password on the display connection") %>
 
 <% hypervisor = f.object.hypervisor.uuid rescue nil%>
-<% if hypervisor -%>
+<% if hypervisor %>
   <%= f.hidden_field :uuid, :value => hypervisor %>
-<% end -%>
+<% end %>
 <%= link_to_function _("Test Connection"), "testConnection(this)", :class => "btn + #{hypervisor.nil? ? "" : "btn-success"}", :'data-url' => test_connection_compute_resources_path %>
 
 <%= image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide') %>

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -1,7 +1,7 @@
 <%= text_f f, :url, :class => "input-xlarge", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0") %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :label => _("API Key") %>
-<% flavors = f.object.flavors rescue [] -%>
+<% flavors = f.object.flavors rescue [] %>
 <%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region'),
                  :help_inline => link_to_function(_("Test Connection"), "testConnection(this)",
                  :class => "btn + #{flavors.empty? ? "" : "btn-success"}",

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -7,9 +7,9 @@
 <ul class="nav nav-tabs" data-tabs="tabs">
   <li class="active"><a href="#primary" data-toggle="tab"><%= _("Compute Resource") %></a></li>
   <li><a href="#vms" data-toggle="tab"><%= _("Virtual Machines") %></a></li>
-  <% if @compute_resource.capabilities.include?(:image) -%>
+  <% if @compute_resource.capabilities.include?(:image) %>
     <li><a href="#images" data-toggle="tab"><%= _("Images") %></a></li>
-  <% end -%>
+  <% end %>
 </ul>
 
 <div class="tab-content">
@@ -41,7 +41,7 @@
       <%= _('Loading virtual machines information ...') %>
     </p>
   </div>
-  <% if @compute_resource.capabilities.include?(:image) -%>
+  <% if @compute_resource.capabilities.include?(:image) %>
     <div id="images" class="tab-pane">
       <%= title_actions(display_link_if_authorized(_("New Image"), hash_for_new_compute_resource_image_path(:compute_resource_id => @compute_resource.id), :class => "btn btn-success")) %>
       <div id="images_list" data-url=<%= compute_resource_images_path(@compute_resource) %>>
@@ -51,7 +51,7 @@
         </p>
       </div>
     </div>
-  <% end -%>
+  <% end %>
 
 </div>
 

--- a/app/views/compute_resources_vms/form/_ec2.html.erb
+++ b/app/views/compute_resources_vms/form/_ec2.html.erb
@@ -2,18 +2,18 @@
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)
--%>
+%>
 
 <div id='image_selection'><%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')}, {:disabled => images.empty? } %></div>
 
 <%= selectable_f f, :availability_zone, compute_resource.zones, {:include_blank => _("No preference")} %>
 
 <div id='subnet_selection'>
-<% if compute_resource.subnets.any? -%>
+<% if compute_resource.subnets.any? %>
   <%= select_f f, :subnet_id, compute_resource.subnets, :subnet_id, :cidr_block,
                 {:include_blank => _("EC2")},
                 {:label => _("Subnet"), :onchange => "ec2_vpcSelected(this);"} %>
-<% end -%>
+<% end %>
 
 <%
   vpc_id = compute_object_vpc_id(f)

--- a/app/views/compute_resources_vms/form/_gce.html.erb
+++ b/app/views/compute_resources_vms/form/_gce.html.erb
@@ -2,7 +2,7 @@
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)
--%>
+%>
 <div id='image_selection'>
   <%= select_f f, :image_id, images, :uuid, :name,
                { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },

--- a/app/views/compute_resources_vms/form/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/form/_libvirt.html.erb
@@ -1,4 +1,4 @@
-<% new = f.object && f.object.new? -%>
+<% new = f.object && f.object.new? %>
 <%= text_f f, :name, :disabled => !new if controller_name != "hosts" %>
 <%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :class => "input-mini",:disabled => !new %>
 <%= selectable_f f, :memory, memory_options(compute_resource.max_memory), { }, :class => "span2", :disabled => !new %>
@@ -8,12 +8,12 @@
   <%= new_child_fields_template(f, :nics, {
       :object  => compute_resource.new_nic,
       :partial => 'compute_resources_vms/form/libvirt/network', :form_builder_attrs => { :compute_resource => compute_resource } }) %>
-  <%= field_set_tag "Network interfaces", :id => "network_interfaces", :title => _('Networks') do -%>
+  <%= field_set_tag "Network interfaces", :id => "network_interfaces", :title => _('Networks') do %>
     <%= f.fields_for :nics do |i| %>
       <%= render 'compute_resources_vms/form/libvirt/network', :f => i, :compute_resource => compute_resource %>
-    <% end -%>
+    <% end %>
     <%= add_child_link '+ ' + _("Add Interface"), :nics, { :class => "info", :title => _('add new network interface') } %>
-  <% end -%>
+  <% end %>
 </div>
 
 <!--Storage-->
@@ -21,12 +21,12 @@
   <%= new_child_fields_template(f, :volumes, {
       :object  => compute_resource.new_volume,
       :partial => 'compute_resources_vms/form/libvirt/volume', :form_builder_attrs => { :compute_resource => compute_resource } }) %>
-  <%= field_set_tag "Storage", :id => "storage_volumes", :title => _('Storage') do -%>
+  <%= field_set_tag "Storage", :id => "storage_volumes", :title => _('Storage') do %>
     <%= f.fields_for :volumes do |i| %>
       <%= render 'compute_resources_vms/form/libvirt/volume', :f => i, :compute_resource => compute_resource %>
-    <% end -%>
+    <% end %>
     <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
-  <% end -%>
+  <% end %>
 </div>
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>

--- a/app/views/compute_resources_vms/form/_openstack.html.erb
+++ b/app/views/compute_resources_vms/form/_openstack.html.erb
@@ -1,10 +1,10 @@
-<% new = f.object && f.object.id.blank? -%>
+<% new = f.object && f.object.id.blank? %>
 <%= text_f f, :name, :disabled => !new if controller_name != "hosts" %>
 <%= select_f f, :flavor_ref, compute_resource.flavors, :id, :name, {}, :label => _('Flavor') %>
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)
--%>
+%>
 <div id='image_selection'>
   <%= select_f f, :image_ref, images, :uuid, :name,
                { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },

--- a/app/views/compute_resources_vms/form/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/form/_ovirt.html.erb
@@ -21,22 +21,22 @@
     <%= new_child_fields_template(f, :interfaces, {
         :object  => compute_resource.new_interface,
         :partial => 'compute_resources_vms/form/ovirt/network', :form_builder_attrs => { :clusters => clusters, :compute_resource => compute_resource } }) %>
-    <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do -%>
+    <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do %>
       <%= f.fields_for :interfaces do |i| %>
         <%= render 'compute_resources_vms/form/ovirt/network', :f => i, :clusters => clusters, :compute_resource => compute_resource %>
-      <% end -%>
+      <% end %>
       <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
-    <% end -%>
+    <% end %>
 
     <%= new_child_fields_template(f, :volumes, {
             :object  => compute_resource.new_volume,
             :partial => 'compute_resources_vms/form/ovirt/volume', :form_builder_attrs => { :clusters => clusters, :compute_resource => compute_resource } }) %>
-    <%= field_set_tag _("Volumes"), :id => "volumes", :title => _('Volumes') do -%>
+    <%= field_set_tag _("Volumes"), :id => "volumes", :title => _('Volumes') do %>
         <%= f.fields_for :volumes do |i| %>
             <%= render 'compute_resources_vms/form/ovirt/volume', :f => i, :compute_resource => compute_resource %>
-        <% end -%>
+        <% end %>
         <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new volume') } %>
-    <% end -%>
+    <% end %>
   </div>
 </div>
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>

--- a/app/views/compute_resources_vms/form/_rackspace.html.erb
+++ b/app/views/compute_resources_vms/form/_rackspace.html.erb
@@ -2,6 +2,6 @@
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)
--%>
+%>
 
 <div id='image_selection'><%= select_f f, :image_id, images, :uuid, :name, { :include_blank => (images.empty? || images.size == 1) ? false : _('Please Select an Image') }, { :disabled => images.empty? } %></div>

--- a/app/views/compute_resources_vms/form/_vmware.html.erb
+++ b/app/views/compute_resources_vms/form/_vmware.html.erb
@@ -1,4 +1,4 @@
-<% new = @host ? @host.created_at.nil? : true -%>
+<% new = @host ? @host.created_at.nil? : true %>
 <%= text_f f, :name, :disabled => !new if controller_name != "hosts" %>
 <%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :class => "input-mini", :disabled => !new %>
 <%= text_f f, :memory_mb, :class => "span2", :disabled => !new, :label => _("Memory (MB)") %>
@@ -11,14 +11,14 @@
   <%= new_child_fields_template(f, :interfaces, {
       :object  => compute_resource.new_interface,
       :partial => 'compute_resources_vms/form/vmware/network', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
-  <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do -%>
+  <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do %>
     <%= f.fields_for :interfaces do |i| %>
       <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource, :new => new %>
-    <% end -%>
+    <% end %>
     <% if new %>
       <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
     <% end %>
-  <% end -%>
+  <% end %>
 </div>
 
 <!--Storage-->
@@ -26,14 +26,14 @@
   <%= new_child_fields_template(f, :volumes, {
       :object  => compute_resource.new_volume,
       :partial => 'compute_resources_vms/form/vmware/volume', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
-  <%= field_set_tag _("Storage"), :id => "storage_volumes", :title => _('Storage') do -%>
+  <%= field_set_tag _("Storage"), :id => "storage_volumes", :title => _('Storage') do %>
     <%= f.fields_for :volumes do |i| %>
       <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource, :new => new %>
-    <% end -%>
+    <% end %>
     <% if new %>
       <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
     <% end %>
-  <% end -%>
+  <% end %>
 </div>
 
 <!--TODO # Move to a helper-->

--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -1,6 +1,6 @@
 <div class="fields">
-  <% nat    = compute_resource.networks -%>
-  <% bridge = compute_resource.interfaces -%>
+  <% nat    = compute_resource.networks %>
+  <% bridge = compute_resource.interfaces %>
 
   <%= selectable_f f, :type, libvirt_networks(compute_resource), {},
                    { :label    => _('Network Type'), :help_inline =>
@@ -14,13 +14,13 @@
   </div>
 
   <div id='bridge' class='<%= 'hide' if f.object.type != 'bridge' %>'>
-    <% if bridge.any? -%>
+    <% if bridge.any? %>
       <%= selectable_f f, :bridge, bridge.map(&:name),
                        { :include_blank => bridge.any? ? false : _("No bridges") },
                        { :class => "span2", :label => _("Network"), :disabled => f.object.type != 'bridge' } %>
-    <% else -%>
-      <%= text_f f, :bridge, :class => "span2", :label => _("Network"), :help_block => _("your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)") -%>
-    <% end -%>
+    <% else %>
+      <%= text_f f, :bridge, :class => "span2", :label => _("Network"), :help_block => _("your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)") %>
+    <% end %>
   </div>
   <%= selectable_f f, :model, %w(virtio rtl8139 ne2k_pci pcnet e1000), {},
                    { :label => _('NIC type'), :class => 'span2' } %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -1,5 +1,5 @@
 <div class="fields">
-  <% if f.object._delete != '1' -%>
+  <% if f.object._delete != '1' %>
     <% disabled = (f.object.persisted? == "true" || f.object.persisted? == true) %>
     <%= text_f f, :name, :disabled => disabled, :class => "span2" %>
     <%= f.hidden_field :name if disabled %>
@@ -9,5 +9,5 @@
                  { }, :disabled => disabled, :class => "span2",
                  :help_inline   => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) %>
     <%= f.hidden_field :network if disabled %>
-  <% end -%>
+  <% end %>
 </div>

--- a/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
@@ -1,6 +1,6 @@
 <div class="fields">
   <div class="control-group">
-  <% if f.object._delete != '1' -%>
+  <% if f.object._delete != '1' %>
     <% disabled = !f.object.id.blank? %>
     <%= text_f f,:size_gb, :label => _('Size (GB)'), :disabled => disabled, :class => "span2" %>
     <%= f.hidden_field :size_gb if disabled %>
@@ -13,6 +13,6 @@
         radio_button_f f, :bootable, {:disabled => disabled, :value=>'true', :checked => (f.object.bootable == 'true'), :onclick => 'bootable_radio(this)',
         :text => _('Only one volume can be Bootable')}
     end %>
-  <% end -%>
+  <% end %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,5 +1,5 @@
 <div class="fields">
-  <% if (networks = compute_resource.networks).any? -%>
+  <% if (networks = compute_resource.networks).any? %>
     <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
                      :class       => "span2",
                      :label       => _('NIC type'),
@@ -9,7 +9,7 @@
                      :class       => "span2",
                      :label       => _('Network'),
                      :disabled    => !new,
-                     :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) 
+                     :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' })
     %>
-  <% end -%>
+  <% end %>
 </div>

--- a/app/views/compute_resources_vms/index/_ec2.html.erb
+++ b/app/views/compute_resources_vms/index/_ec2.html.erb
@@ -1,14 +1,14 @@
 <table class="table table-bordered" data-table="inline">
   <thead>
     <tr>
-      <th><%= _('Name') -%></th>
-      <th><%= _('DNS') -%></th>
-      <th><%= _('Type') -%></th>
-      <th><%= _('State') -%></th>
+      <th><%= _('Name') %></th>
+      <th><%= _('DNS') %></th>
+      <th><%= _('Type') %></th>
+      <th><%= _('State') %></th>
       <th></th>
     </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
       <td><%= vm.dns %></td>
@@ -21,5 +21,5 @@
         %>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_gce.html.erb
+++ b/app/views/compute_resources_vms/index/_gce.html.erb
@@ -1,13 +1,13 @@
 <table class="table table-bordered" data-table="inline">
   <thead>
   <tr>
-    <th><%= _('Name') -%></th>
-    <th><%= _('Type') -%></th>
-    <th><%= _('State') -%></th>
+    <th><%= _('Name') %></th>
+    <th><%= _('Type') %></th>
+    <th><%= _('State') %></th>
     <th></th>
   </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
       <td><%= vm.pretty_machine_type %></td>
@@ -16,5 +16,5 @@
         <%= action_buttons(vm_power_action(vm), display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity))) %>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/index/_libvirt.html.erb
@@ -1,14 +1,14 @@
 <table class="table table-bordered" data-table='inline'>
   <thead>
     <tr>
-      <th><%= _('Name') -%></th>
-      <th><%= _('CPUs') -%></th>
-      <th><%= _('Memory') -%></th>
-      <th><%= _('Power') -%></th>
+      <th><%= _('Name') %></th>
+      <th><%= _('CPUs') %></th>
+      <th><%= _('Memory') %></th>
+      <th><%= _('Power') %></th>
       <th></th>
     </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.uuid) %></td>
       <td><%= vm.cpus %></td>
@@ -19,5 +19,5 @@
             display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.uuid))) %>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_openstack.html.erb
+++ b/app/views/compute_resources_vms/index/_openstack.html.erb
@@ -1,14 +1,14 @@
 <table class="table table-bordered" data-table='inline'>
   <thead>
     <tr>
-      <th><%= _('Name') -%></th>
-      <th><%= _('Type') -%></th>
-      <th><%= _('Tenant') -%></th>
-      <th><%= _('State') -%></th>
+      <th><%= _('Name') %></th>
+      <th><%= _('Type') %></th>
+      <th><%= _('Tenant') %></th>
+      <th><%= _('State') %></th>
       <th></th>
     </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
       <td><%= vm.flavor_with_object %></td>
@@ -18,5 +18,5 @@
         <%= action_buttons(*available_actions(vm)) %>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/index/_ovirt.html.erb
@@ -1,14 +1,14 @@
 <table class="table table-bordered" data-table='inline'>
   <thead>
     <tr>
-      <th><%= _('Name') -%></th>
-      <th><%= _('CPUs') -%></th>
-      <th><%= _('Memory') -%></th>
-      <th><%= _('Power') -%></th>
+      <th><%= _('Name') %></th>
+      <th><%= _('CPUs') %></th>
+      <th><%= _('Memory') %></th>
+      <th><%= _('Power') %></th>
       <th></th>
     </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
       <td><%= vm.cores %></td>
@@ -20,5 +20,5 @@
       </td>
 
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_rackspace.html.erb
+++ b/app/views/compute_resources_vms/index/_rackspace.html.erb
@@ -1,13 +1,13 @@
 <table class="table table-bordered" data-table='inline'>
   <thead>
     <tr>
-      <th><%= _('Name') -%></th>
-      <th><%= _('Type') -%></th>
-      <th><%= _('State') -%></th>
+      <th><%= _('Name') %></th>
+      <th><%= _('Type') %></th>
+      <th><%= _('State') %></th>
       <th></th>
     </tr>
   </thead>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= vm.name %></td>
       <td><%= vm.flavor.name %></td>
@@ -18,5 +18,5 @@
                 display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.id))) %>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -1,15 +1,15 @@
 <table class="table table-bordered" data-table='inline'>
   <thead>
   <tr>
-    <th><%= _('Name') -%></th>
-    <th><%= _('CPUs') -%></th>
-    <th><%= _('Memory') -%></th>
-    <th><%= _('Power') -%></th>
+    <th><%= _('Name') %></th>
+    <th><%= _('CPUs') %></th>
+    <th><%= _('Memory') %></th>
+    <th><%= _('Power') %></th>
     <th></th>
   </tr>
   </thead>
   <tbody>
-  <% @vms.each do |vm| -%>
+  <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
       <td><%= vm.cpus %></td>
@@ -22,6 +22,6 @@
       </td>
 
     </tr>
-  <% end -%>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/compute_resources_vms/show/_gce.html.erb
+++ b/app/views/compute_resources_vms/show/_gce.html.erb
@@ -20,11 +20,11 @@
       <td>Private IP</td>
       <td><%= @vm.private_ip_address %></td>
     </tr>
-    <% if @vm.public_ip_address.present? -%>
+    <% if @vm.public_ip_address.present? %>
       <tr>
         <td>Public IP</td>
         <td><%= @vm.public_ip_address %></td>
       </tr>
-    <% end -%>
+    <% end %>
   </table>
 </div>

--- a/app/views/compute_resources_vms/show/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/show/_libvirt.html.erb
@@ -2,51 +2,51 @@
 
 <div class='span12'>
   <table class="table table-bordered table-striped">
-    <tr><th colspan="2"><%= _('Properties') -%></th></tr>
+    <tr><th colspan="2"><%= _('Properties') %></th></tr>
     <tr>
-      <td><%= _('Name') -%></td>
+      <td><%= _('Name') %></td>
       <td><%= @vm.name %></td>
     </tr>
 
     <tr>
-      <td><%= _('Machine Type') -%></td>
+      <td><%= _('Machine Type') %></td>
       <td><%= @vm.domain_type %> / <%= @vm.arch %></td>
     </tr>
 
     <tr>
-      <td><%= _('VCPU(s)') -%></td>
+      <td><%= _('VCPU(s)') %></td>
       <td><%= @vm.cpus %></td>
     </tr>
 
     <tr>
-      <td><%= _('UUID') -%></td>
+      <td><%= _('UUID') %></td>
       <td><%= @vm.uuid %></td>
     </tr>
     <tr>
-      <td><%= _('Memory') -%></td>
+      <td><%= _('Memory') %></td>
       <td><%= number_to_human_size @vm.max_memory_size*1024 %> <%= "(" + _("Allocated") + ": #{number_to_human_size @vm.memory_size*1024})" %></td>
     </tr>
 
     <tr>
-      <td><%= _('Display') -%></td>
+      <td><%= _('Display') %></td>
       <td><%= @vm.display[:type] %> (<%= @vm.display[:port] %>)</td>
     </tr>
-    <% @vm.nics.each do |nic| -%>
+    <% @vm.nics.each do |nic| %>
         <tr>
-          <td><%= _('NIC') -%></td>
+          <td><%= _('NIC') %></td>
           <td><%= "#{nic.bridge} - #{nic.mac} (#{nic.model})" %></td>
         </tr>
-    <% end -%>
+    <% end %>
 
-    <% @vm.volumes.each do |vol| -%>
+    <% @vm.volumes.each do |vol| %>
         <tr>
-          <td><%= _('Disk') -%></td>
+          <td><%= _('Disk') %></td>
           <td><%= _("using %{allocation} GB out of %{capacity} GB (%{pool_name} storage pool - %{path})") % { :allocation => vol.allocation, :capacity => vol.capacity, :pool_name => vol.pool_name, :path => vol.path } %></td>
         </tr>
-    <% end -%>
+    <% end %>
 
     <tr>
-      <td><%= _('Running on') -%></td>
+      <td><%= _('Running on') %></td>
       <td><%= link_to @compute_resource, compute_resource_path(@compute_resource) %></td>
     </tr>
   </table>

--- a/app/views/compute_resources_vms/show/_openstack.html.erb
+++ b/app/views/compute_resources_vms/show/_openstack.html.erb
@@ -9,7 +9,7 @@
         <td><%= address["pool"] %> network</td>
         <td><%= address["ip"] %> (floating), <%= address["fixed_ip"] %> (fixed ip) </td>
       </tr>
-    <% end -%>
+    <% end %>
     <%= prop :state %>
     <%= prop :created_at %>
     <%= prop :tenant %>

--- a/app/views/compute_resources_vms/show/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/show/_ovirt.html.erb
@@ -1,46 +1,46 @@
 <% title @vm.name %>
 <div class='span12'>
   <table class="table table-bordered table-striped">
-    <tr><th colspan="2"><%= _('Properties') -%></th></tr>
+    <tr><th colspan="2"><%= _('Properties') %></th></tr>
     <tr>
-      <td><%= _('Name') -%></td>
+      <td><%= _('Name') %></td>
       <td><%= @vm.name %></td>
     </tr>
 
     <tr>
-      <td><%= _('VCPU(s)') -%></td>
+      <td><%= _('VCPU(s)') %></td>
       <td><%= @vm.cores %></td>
     </tr>
 
     <tr>
-      <td><%= _('UUID') -%></td>
+      <td><%= _('UUID') %></td>
       <td><%= @vm.identity %></td>
     </tr>
     <tr>
-      <td><%= _('Memory') -%></td>
+      <td><%= _('Memory') %></td>
       <td><%= number_to_human_size @vm.memory %> </td>
     </tr>
 
     <tr>
-      <td><%= _('Display') -%></td>
+      <td><%= _('Display') %></td>
       <td><%= @vm.display[:type] %> (<%= @vm.display[:port] %>)</td>
     </tr>
-    <% @vm.interfaces.each do |nic| -%>
+    <% @vm.interfaces.each do |nic| %>
         <tr>
-          <td><%= _('NIC') -%></td>
+          <td><%= _('NIC') %></td>
           <td><%= "#{nic.name} - #{nic.mac}" %></td>
         </tr>
-    <% end -%>
+    <% end %>
 
-    <% @vm.volumes.each do |vol| -%>
+    <% @vm.volumes.each do |vol| %>
         <tr>
-          <td><%= _('Disk') -%></td>
+          <td><%= _('Disk') %></td>
           <td><%= _("using %s") % number_to_human_size(vol.size) %></td>
         </tr>
-    <% end -%>
+    <% end %>
 
     <tr>
-      <td><%= _('Running on') -%></td>
+      <td><%= _('Running on') %></td>
       <td><%= link_to @compute_resource, compute_resource_path(@compute_resource) %></td>
     </tr>
   </table>

--- a/app/views/config_templates/_combinations.html.erb
+++ b/app/views/config_templates/_combinations.html.erb
@@ -1,6 +1,6 @@
-<%= field_set_tag _("Valid host group and environment combinations"), :id => "template_combination" do -%>
-  <%= f.fields_for :template_combinations do |builder| -%>
+<%= field_set_tag _("Valid host group and environment combinations"), :id => "template_combination" do %>
+  <%= f.fields_for :template_combinations do |builder| %>
     <%= render 'combination', :f => builder %>
-  <% end -%>
+  <% end %>
   <p><%= link_to_add_fields('+ ' + _("Add combination"), f, :template_combinations, "combination") %></p>
-<% end -%>
+<% end %>

--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -55,8 +55,8 @@
                       <%= link_to icon_text("eye-open", _("Show Diff")), audit_path(audit) %>
                     </div>
                   </div>
-              <% end -%>
-          <% else -%>
+              <% end %>
+          <% else %>
               <%= alert :header => _('No history found'), :text => _('Save something and try again') %>
           <% end %>
         </div>

--- a/app/views/config_templates/index.html.erb
+++ b/app/views/config_templates/index.html.erb
@@ -22,7 +22,7 @@
       <td><%= config_template.try(:template_kind) %></td>
       <td><%= checked_icon config_template.snippet %></td>
       <td><%= display_delete_if_authorized hash_for_config_template_path(:id => config_template.to_param),
-                                           :confirm => _("Delete %s?") % config_template -%> </td>
+                                           :confirm => _("Delete %s?") % config_template %> </td>
     </tr>
   <% end %>
 </table>

--- a/app/views/dashboard/_status_table.html.erb
+++ b/app/views/dashboard/_status_table.html.erb
@@ -1,4 +1,4 @@
-<h4 class="header"><%= _('Host Configuration Status') -%></h4>
+<h4 class="header"><%= _('Host Configuration Status') %></h4>
 <ul>
     <%= searchable_links _('Hosts that had performed modifications without error'),
                          "last_report > \"#{Setting[:puppet_interval] + 5} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,14 +15,14 @@
     <div class="span5 stats-well">
       <h4 style="text-align: center;"><%= _("Latest Events") %></h4>
       <% events = latest_events %>
-      <% if events.empty? -%>
+      <% if events.empty? %>
         <p class="ca"><%= _("No interesting reports received in the last week") %></p>
-      <% else -%>
+      <% else %>
         <table class="table table-striped ellipsis">
           <tr>
             <%= latest_headers %>
           </tr>
-          <% events.each do |report| -%>
+          <% events.each do |report| %>
             <tr>
               <td><%= link_to h(trunc(report.host, 14)), host_reports_path(report.host) %></td>
               <td><%= report_event_column(report.applied, "label-info") %></td>
@@ -32,9 +32,9 @@
               <td><%= report_event_column(report.skipped, "label-info") %></td>
               <td><%= report_event_column(report.pending, "label-info") %></td>
             </tr>
-          <% end -%>
+          <% end %>
         </table>
-      <% end -%>
+      <% end %>
     </div>
     <div class="span7 stats-well">
       <h4 style="text-align: center;"><%= n_("Run distribution in the last %s minute", "Run distribution in the last %s minutes", Setting[:puppet_interval]) % Setting[:puppet_interval] %></h4>

--- a/app/views/dashboard/welcome.html.erb
+++ b/app/views/dashboard/welcome.html.erb
@@ -3,22 +3,22 @@
   <p>
     <%= _('Before you can use Foreman for the first time there are a few tasks that must be performed.') %>
 
-    <%= _('You must decide how you wish to use the software, and update the primary settings file <b>config/settings.yaml</b> and the').html_safe -%>
+    <%= _('You must decide how you wish to use the software, and update the primary settings file <b>config/settings.yaml</b> and the').html_safe %>
     <%= link_to _("settings"), settings_path %>
     <%= _('to indicate your selections.') %>
   </p>
 
-  <h2><%= _('Operating Mode') -%></h2>
+  <h2><%= _('Operating Mode') %></h2>
 
   <p>
     <%= _('You may operate Foreman in basic mode, in which it acts as a reporting and external node classifier or you may also turn on unattended mode operation in which Foreman creates and manages the configuration files necessary to completely configure a new host.') %>
 
     <%= _('When operating in unattended mode Foreman will require more information, so expect more questions, but it will be able to automate host installations for redhat, debian, suse and solaris operating systems (and their clones), see') %>
-    <a href=http://theforeman.org/projects/foreman/wiki/Unattended_installations rel="external"><%= _('here') -%></a>
+    <a href=http://theforeman.org/projects/foreman/wiki/Unattended_installations rel="external"><%= _('here') %></a>
     <%= _('for more details.') %>
   </p>
 
-  <h2><%= _('Create a Smart Proxy') -%></h2>
+  <h2><%= _('Create a Smart Proxy') %></h2>
 
   <p>
     <%= _("If you're planning to do anything more than just handle reports, you'll be in need of a smart proxy - either on this machine or elsewhere on your network.") %>
@@ -26,14 +26,14 @@
     <a href=http://theforeman.org/projects/foreman/wiki/Smart-Proxy_Installation rel="external"><%= _('Smart-Proxy Installation') %></a>.
 
     <p>
-      <span class="label label-important"><%= _('Important') -%></span>
+      <span class="label label-important"><%= _('Important') %></span>
       <%= _('Once installed you should head over to') %>
       <a href=smart_proxies><%= _('Smart Proxies') %></a>
       <%= _('to point Foreman at it.') %>
     </p>
   </p>
 
-  <h2><%= _('User Authentication') -%></h2>
+  <h2><%= _('User Authentication') %></h2>
 
   <p>
     <%= _('Foreman, by default, operates in anonymous mode where all operations are performed without reference to the user who is performing the task.') %>
@@ -44,7 +44,7 @@
       <%= _('Additionally, you may restrict user permissions based on many criteria, make sure you check the roles settings tab.') %>
     </p>
 
-    <% if SETTINGS[:login] -%>
+    <% if SETTINGS[:login] %>
       <ul>
         <li>
           <%= _('For internal Users, simply create a new user at the') %>
@@ -62,17 +62,17 @@
           <%= _('page') %>
         </li>
       </ul>
-    <% else -%>
-      <p><span class="label label-info"><%= _('Notice') -%></span>
+    <% else %>
+      <p><span class="label label-info"><%= _('Notice') %></span>
       <%= _('You would need to enable login in your settings.yml file first and restart foreman') %>
       </p>
-      <p><span class="label label-important"><%= _('Important') -%></span>
+      <p><span class="label label-important"><%= _('Important') %></span>
       <%= _('The default username and password are <b>admin</b> and <b>changeme</b>').html_safe %>
       </p>
-    <% end -%>
+    <% end %>
   </p>
 
-  <h2><%= _('Import your data') -%></h2>
+  <h2><%= _('Import your data') %></h2>
 
   <p>
     <%= _('Foreman comes with some importers to ease the burden of entering loads of data about your current installation.') %>
@@ -80,24 +80,24 @@
     <ul>
       <li>
         <%= _('Inventory browser') %>
-        - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_Facts rel="external"><%= _('Importing Puppet Facts') -%></a>
+        - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_Facts rel="external"><%= _('Importing Puppet Facts') %></a>
       </li>
       <li>
         <%= _('Puppet External Nodes') %>
-        - <a href=http://theforeman.org/projects/foreman/wiki/External_Nodes rel="external"><%= _('Importing Puppet classes and environments') -%></a>
+        - <a href=http://theforeman.org/projects/foreman/wiki/External_Nodes rel="external"><%= _('Importing Puppet classes and environments') %></a>
       </li>
       <li>
         <%= _('Reporting') %>
-        - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_Reports rel="external"><%= _('Puppet Reports integration') -%></a>
+        - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_Reports rel="external"><%= _('Puppet Reports integration') %></a>
       </li>
     </ul>
   </p>
 
-  <h2><%= _('Additional steps') -%></h2>
+  <h2><%= _('Additional steps') %></h2>
 
   <p>
     <%= _('You may optionally wish to generate the online documentation for your puppet classes') %>
-    - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_class_browser rel="external"><%= _('puppet class browser') -%></a>.
+    - <a href=http://theforeman.org/projects/foreman/wiki/Puppet_class_browser rel="external"><%= _('puppet class browser') %></a>.
   </p>
 
   <p>
@@ -106,12 +106,12 @@
 
   <p>
     <%= _('You may also find the') %>
-    <a href=http://theforeman.org/projects/foreman/wiki/Howtos rel="external"><%= _('Howtos') -%></a>
+    <a href=http://theforeman.org/projects/foreman/wiki/Howtos rel="external"><%= _('Howtos') %></a>
     <%= _('useful.') %>
   </p>
 
   <p>
-    <span class="label label-info"><%= _('Notice') -%></span>
+    <span class="label label-info"><%= _('Notice') %></span>
     <%= _('This page will self destruct once data comes in.') %>
   </p>
 

--- a/app/views/environments/_form.html.erb
+++ b/app/views/environments/_form.html.erb
@@ -2,12 +2,12 @@
   <%= base_errors_for @environment %>
   <% if show_taxonomy_tabs? %>
     <ul class="nav nav-tabs" data-tabs="tabs">
-      <li class="active"><a href="#primary" data-toggle="tab"><%= _('Primary') -%></a></li>
+      <li class="active"><a href="#primary" data-toggle="tab"><%= _('Primary') %></a></li>
       <% if show_location_tab? %>
-        <li><a href="#locations" data-toggle="tab"><%= _('Locations') -%></a></li>
+        <li><a href="#locations" data-toggle="tab"><%= _('Locations') %></a></li>
       <% end %>
       <% if show_organization_tab? %>
-        <li><a href="#organizations" data-toggle="tab"><%= _('Organizations') -%></a></li>
+        <li><a href="#organizations" data-toggle="tab"><%= _('Organizations') %></a></li>
       <% end %>
     </ul>
 

--- a/app/views/environments/welcome.html.erb
+++ b/app/views/environments/welcome.html.erb
@@ -2,13 +2,13 @@
 <% title _("Environment configuration") %>
 <div id="welcome">
   <p>
-  <%= _('If you are planning to use Foreman as an external node classifier you should provide information about one or more environments.') -%>
-  <%= _('This information is commonly imported from a pre-existing puppet configuration by the use of the') -%>
+  <%= _('If you are planning to use Foreman as an external node classifier you should provide information about one or more environments.') %>
+  <%= _('This information is commonly imported from a pre-existing puppet configuration by the use of the') %>
   <a href=http://theforeman.org/projects/foreman/wiki/External_Nodes rel="external"><%= _('Puppet classes and environment importer') %></a>
   </p>
 
   <p>
-  <%= _('Environments may be manually created and only require the name of the environment to be declared.') -%>
+  <%= _('Environments may be manually created and only require the name of the environment to be declared.') %>
   </p>
 
 </div>

--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -2,20 +2,20 @@
 
 <table class="table table-bordered table-striped ellipsis">
   <tr>
-    <% unless params[:host_id] -%>
+    <% unless params[:host_id] %>
       <th><%= sort :host, :as => _("Host") %></th>
     <% end %>
     <th><%= sort :name, :as => _("Name")  %></th>
     <th><%= sort :value, :as => s_("FactValue|Value") %></th>
-    <th><%= _('Reported at') -%></th>
+    <th><%= _('Reported at') %></th>
   </tr>
   <% for fact_value in @fact_values %>
     <tr>
-      <% unless params[:host_id] -%>
+      <% unless params[:host_id] %>
         <td>
-          <% if fact_value.host -%>
+          <% if fact_value.host %>
             <%= link_to(fact_value.host, host_facts_path(:host_id => fact_value.host), :title => _("Show host facts")) %>
-          <% else -%>
+          <% else %>
             <%= _('N/A') %>
           <% end %>
         </td>

--- a/app/views/home/_settings.html.erb
+++ b/app/views/home/_settings.html.erb
@@ -2,21 +2,21 @@
 <% choices = setting_options %>
 <%= link_to (_("More") + content_tag(:span,'', :class=>"caret")).html_safe, "#", :class => "dropdown-toggle", :'data-toggle'=>"dropdown" unless choices.empty?%>
   <ul class="dropdown-menu">
-    <% choices.each do |item|-%>
+    <% choices.each do |item|%>
        <% if item[0] == :divider  %>
          <%= content_tag(:li, "", :class=>"divider") %>
        <% elsif item[0] == :group %>
          <%= content_tag :li, :class=>"dropdown-submenu" do %>
            <%= link_to(item[1],"#",:class=>"dropdown-toggle", :"data-toggle"=>"dropdown") %>
            <%=  content_tag :ul, :class=>"dropdown-menu" do%>
-             <% item[2].each do |sub_item|-%>
+             <% item[2].each do |sub_item|%>
                <%= content_tag(:li, link_to(sub_item[0], {:controller => "/#{sub_item[1]}", :action => :index})) %>
              <% end %>
            <% end %>
          <% end %>
        <% else %>
          <%= content_tag(:li, link_to(item[0], {:controller => "/#{item[1]}", :action => :index})) %>
-       <% end -%>
-    <% end -%>
+       <% end %>
+    <% end %>
   </ul>
 </li>

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -10,7 +10,7 @@
 <!-- menu -->
 <div id='current_tab' data-controller='<%=controller_name.gsub(/_.*/,"s")%>' data-settings='<%= class_for_setting_page %>'> </div>
 
-<% if User.current -%>
+<% if User.current %>
   <% cache(TopbarSweeper.fragment_name) do %>
     <div class="nav-collapse collapse nav1">
       <ul class="nav" id="menu">
@@ -26,8 +26,8 @@
   </div>
   <div class="nav-collapse collapse nav2">
     <ul class="nav pull-right" id="menu2">
-      <%= render "home/settings" -%>
+      <%= render "home/settings" %>
     </ul>
   </div>
-  <% end -%>
-<% end -%>
+  <% end %>
+<% end %>

--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -17,16 +17,16 @@
     text-align:center;
     background-color: #FF9933;">Environment
   </th>
-  <% list.first.last[:metrics].keys.each do |header| -%>
+  <% list.first.last[:metrics].keys.each do |header| %>
     <th style="border: 1px solid #FF9933;
       border-collapse: collapse;
       padding: 4px;
       text-align:center;
       background-color: #FF9933;"><%= header %>
     </th>
-  <% end -%>
+  <% end %>
 </tr>
-<% list.each do |host,params| -%>
+<% list.each do |host,params| %>
   <tr>
     <% host_object = Host.find_by_name(host) %>
     <%= render 'link_to_host', :host => host %>
@@ -36,18 +36,18 @@
     <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
       <%= host_object.environment %>
     </td>
-    <% params[:metrics].each do |m,v| -%>
-      <% if m =~ /failed|failed_restart/ and v > 0 -%>
+    <% params[:metrics].each do |m,v| %>
+      <% if m =~ /failed|failed_restart/ and v > 0 %>
         <td style="color:red;font-weight:bold;border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
-      <% else -%>
+      <% else %>
         <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
-      <% end -%>
-      <% if v > 0 -%>
+      <% end %>
+      <% if v > 0 %>
         <%= link_to v, reports_path(:search=>"#{host} and #{m} > 0", :host => @url, :only_path => false) %>
-      <% else -%>
+      <% else %>
         <%= v %>
-      <% end -%>
+      <% end %>
     </td>
-    <% end -%>
+    <% end %>
   </tr>
-<% end -%>
+<% end %>

--- a/app/views/host_mailer/_list.html.erb
+++ b/app/views/host_mailer/_list.html.erb
@@ -1,5 +1,5 @@
 <h2 style='font-family: Arial,"Times new roman"; font-size: 90%;'><%= title %></h2>
-<% if list.size > 0 -%>
+<% if list.size > 0 %>
   <table style='border: 1px solid #FF9933;
     border-collapse:collapse;
     padding: 5px;
@@ -8,6 +8,6 @@
     <%= render :partial => "#{state}_hosts", :locals => {:list => list } %>
   </table>
   <p style='font-family: Arial,"Times new roman"; font-size: 90%;'>Total of <%= pluralize(list.size, 'host') %></p>
-<% else -%>
+<% else %>
   <b>None!</b>
-<% end -%>
+<% end %>

--- a/app/views/host_mailer/_nonactive_hosts.html.erb
+++ b/app/views/host_mailer/_nonactive_hosts.html.erb
@@ -5,7 +5,7 @@
     padding: 4px;
     background-color: #FF0000;">Hostname
   </th>
-  <th style="border: 1px solid #FF9933; 
+  <th style="border: 1px solid #FF9933;
     border-collapse: collapse;
     padding: 4px;
     text-align:center;
@@ -16,7 +16,7 @@
     padding: 4px;
     text-align:center;
     background-color: #FF0000;">Environment
-  </th> 
+  </th>
 
   <th style="border: 1px solid #FF9933;
     border-collapse: collapse;
@@ -25,25 +25,25 @@
     background-color: #FF0000;">Last Report
   </th>
 </tr>
-<% list.each do |host| -%>
+<% list.each do |host| %>
   <tr>
     <%= render 'link_to_host', :host => host %>
     <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
-      <%= host.hostgroup %> 
+      <%= host.hostgroup %>
     </td>
     <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
       <%= host.environment %>
     </td>
-    <% if host.last_report -%>
+    <% if host.last_report %>
       <td style="border: 1px solid #FF9933;
         border-collapse: collapse;
         padding: 4px;
         background-color: #FFFFFF;"><%= time_ago_in_words(host.last_report) %></td>
-    <% else -%>
+    <% else %>
       <td style="border: 1px solid #FF9933;
         border-collapse: collapse;
         padding: 4px;
         background-color: #FFFFFF;">Unknown</td>
-    <% end -%>
+    <% end %>
   </tr>
-<% end -%>
+<% end %>

--- a/app/views/host_mailer/failed_runs.html.erb
+++ b/app/views/host_mailer/failed_runs.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<%# this view contains style as some email clients ignore css files -%>
+<%# this view contains style as some email clients ignore css files %>
 <html>
   <head>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
@@ -7,9 +7,9 @@
   </head>
   <body style="background-color: #ffffff;">
     <h1 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Summary from <%= distance_of_time_in_words (Time.now - @timerange) %> ago to now</h1>
-    <% unless @filter.empty? -%>
-      <h2 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Filtering resulted based on <%= @filter.join(" and ") -%></h2>
-    <% end -%>
+    <% unless @filter.empty? %>
+      <h2 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Filtering resulted based on <%= @filter.join(" and ") %></h2>
+    <% end %>
     <%= render :partial => 'list', :locals => {:state => 'active', :title => "Hosts with interesting values (changed, failures etc)", :list => @hosts} %>
     <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => "Hosts which are currently not running puppet", :list => @out_of_sync } %>
     <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => "Hosts which Foreman reporting is disabled", :list => @disabled } %>

--- a/app/views/host_mailer/summary.html.erb
+++ b/app/views/host_mailer/summary.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<%# this view contains style as some email clients ignore css files -%>
+<%# this view contains style as some email clients ignore css files %>
 <html>
   <head>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
@@ -7,9 +7,9 @@
   </head>
   <body style="background-color: #ffffff;">
     <h1 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Summary from <%= distance_of_time_in_words (Time.now - @timerange) %> ago to now</h1>
-    <% unless @filter.empty? -%>
-      <h2 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Filtering resulted based on <%= @filter.join(" and ") -%></h2>
-    <% end -%>
+    <% unless @filter.empty? %>
+      <h2 style='font-family: Arial,"Times new roman"; font-size: 90%;'>Filtering resulted based on <%= @filter.join(" and ") %></h2>
+    <% end %>
     <%= render :partial => 'list', :locals => {:state => 'active', :title => "Hosts with interesting values (changed, failures etc)", :list => @hosts} %>
     <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => "Hosts which are currently not running puppet", :list => @out_of_sync } %>
     <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => "Hosts which Foreman reporting is disabled", :list => @disabled } %>

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -3,18 +3,18 @@
   <%= base_errors_for @hostgroup %>
 
   <ul class="nav nav-tabs" data-tabs="tabs">
-    <li class="active"><a href="#primary" data-toggle="tab"><%= _('Hostgroup') -%></a></li>
-    <li><a href="#puppet_klasses" data-toggle="tab"><%= _('Puppet Classes') -%></a></li>
-    <% if SETTINGS[:unattended] -%>
-      <li><a href="#network" data-toggle="tab"><%= _('Network') -%></a></li>
-      <li><a href="#os" data-toggle="tab"><%= _('Operating System') -%></a></li>
-    <% end -%>
-    <li><a href="#params" id='params-tab' data-toggle="tab"><%= _('Parameters') -%></a></li>
+    <li class="active"><a href="#primary" data-toggle="tab"><%= _('Hostgroup') %></a></li>
+    <li><a href="#puppet_klasses" data-toggle="tab"><%= _('Puppet Classes') %></a></li>
+    <% if SETTINGS[:unattended] %>
+      <li><a href="#network" data-toggle="tab"><%= _('Network') %></a></li>
+      <li><a href="#os" data-toggle="tab"><%= _('Operating System') %></a></li>
+    <% end %>
+    <li><a href="#params" id='params-tab' data-toggle="tab"><%= _('Parameters') %></a></li>
     <% if show_location_tab? %>
-      <li><a href="#locations" data-toggle="tab"><%= _('Locations') -%></a></li>
+      <li><a href="#locations" data-toggle="tab"><%= _('Locations') %></a></li>
     <% end %>
     <% if show_organization_tab? %>
-      <li><a href="#organizations" data-toggle="tab"><%= _('Organizations') -%></a></li>
+      <li><a href="#organizations" data-toggle="tab"><%= _('Organizations') %></a></li>
     <% end %>
   </ul>
 
@@ -32,11 +32,11 @@
     </div>
 
     <div class="tab-pane" id="puppet_klasses">
-      <% if @environment or @hostgroup.environment -%>
+      <% if @environment or @hostgroup.environment %>
         <%= render 'puppetclasses/class_selection', :obj => @hostgroup %>
-      <% else -%>
-        <p class="alert alert-message"><%= _('Please select an environment first') -%></p>
-      <% end -%>
+      <% else %>
+        <p class="alert alert-message"><%= _('Please select an environment first') %></p>
+      <% end %>
     </div>
 
     <div class="tab-pane" id="network">
@@ -49,10 +49,10 @@
     </div>
 
     <div class="tab-pane" id="params">
-      <h6><%= _('Puppet classes parameters') -%></h6>
+      <h6><%= _('Puppet classes parameters') %></h6>
       <p/>
       <%= render "puppetclasses/classes_parameters", { :obj => @hostgroup } %>
-      <h6><%= _('Host group parameters') -%></h6>
+      <h6><%= _('Host group parameters') %></h6>
       <p/>
       <%= render "common_parameters/puppetclasses_parameters", :f => f %>
       <p/>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -4,7 +4,7 @@
 
 <table class="table table-bordered table-striped">
   <tr>
-    <th><%= s_('Hostgroup|Name') -%></th>
+    <th><%= s_('Hostgroup|Name') %></th>
     <th></th>
   </tr>
   <% Hostgroup.sort_by_ancestry(@hostgroups).each do |hostgroup| %>

--- a/app/views/hosts/_conflicts.html.erb
+++ b/app/views/hosts/_conflicts.html.erb
@@ -13,11 +13,11 @@
     </p>
 
     <div class="alert alert-message alert-block base">
-      <% conflict_objects(@host.errors).each do |obj| -%>
-        <% @host.errors[obj].each do |e| -%>
+      <% conflict_objects(@host.errors).each do |obj| %>
+        <% @host.errors[obj].each do |e| %>
           <li><%= e %></li>
-        <% end -%>
-      <% end -%>
+        <% end %>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -8,19 +8,19 @@
     <%= base_errors_for @host %>
 
     <ul class="nav nav-tabs" data-tabs="tabs">
-      <li class="active"><a href="#primary" data-toggle="tab"><%= _('Host') -%></a></li>
-      <% if SmartProxy.puppet_proxies.count > 0 -%>
-        <li><a href="#puppet_klasses" data-toggle="tab"><%= _('Puppet Classes') -%></a></li>
-      <% end -%>
-      <% if SETTINGS[:unattended] and @host.managed -%>
-        <li><a href="#network" data-toggle="tab"><%= _('Network') -%></a></li>
-        <li><a href="#os" data-toggle="tab"><%= _('Operating System') -%></a></li>
-        <% if authorized_for("Compute::Resources::Vms", :create) -%>
-          <li id="compute_resource_tab" <%= display? !(@host.compute_resource_id  || params[:host] && params[:host][:compute_resource_id].present?)%>><a href="#compute_resource" data-toggle="tab"><%= _('Virtual Machine') -%></a></li>
-        <% end -%>
-      <% end -%>
-      <li><a href="#params" id='params-tab' data-url='<%= current_parameters_hosts_path %>' data-url2='<%= puppetclass_parameters_hosts_path %>' data-toggle="tab"><%= _('Parameters') -%></a></li>
-      <li><a href="#info" data-toggle="tab"><%= _('Additional Information') -%></a></li>
+      <li class="active"><a href="#primary" data-toggle="tab"><%= _('Host') %></a></li>
+      <% if SmartProxy.puppet_proxies.count > 0 %>
+        <li><a href="#puppet_klasses" data-toggle="tab"><%= _('Puppet Classes') %></a></li>
+      <% end %>
+      <% if SETTINGS[:unattended] and @host.managed %>
+        <li><a href="#network" data-toggle="tab"><%= _('Network') %></a></li>
+        <li><a href="#os" data-toggle="tab"><%= _('Operating System') %></a></li>
+        <% if authorized_for("Compute::Resources::Vms", :create) %>
+          <li id="compute_resource_tab" <%= display? !(@host.compute_resource_id  || params[:host] && params[:host][:compute_resource_id].present?)%>><a href="#compute_resource" data-toggle="tab"><%= _('Virtual Machine') %></a></li>
+        <% end %>
+      <% end %>
+      <li><a href="#params" id='params-tab' data-url='<%= current_parameters_hosts_path %>' data-url2='<%= puppetclass_parameters_hosts_path %>' data-toggle="tab"><%= _('Parameters') %></a></li>
+      <li><a href="#info" data-toggle="tab"><%= _('Additional Information') %></a></li>
     </ul>
 
     <div class="tab-content">
@@ -65,27 +65,27 @@
       </div>
 
       <div class="tab-pane" id="puppet_klasses">
-        <% if @environment or @hostgroup -%>
+        <% if @environment or @hostgroup %>
           <%= render 'puppetclasses/class_selection', :obj => @host %>
-        <% else -%>
+        <% else %>
           <p class="alert alert-message"><%= _('Please select an environment first') %></p>
-        <% end -%>
+        <% end %>
       </div>
 
       <%= f.hidden_field :managed %>
       <%= f.hidden_field :progress_report_id, :data=>{:url=>task_path(@host.progress_report_id)} %>
       <%= f.hidden_field :type, :value => @host.type if @host.type_changed? %>
 
-      <%= render('hosts/unattended', :f => f) if SETTINGS[:unattended] and @host.managed -%>
+      <%= render('hosts/unattended', :f => f) if SETTINGS[:unattended] and @host.managed %>
 
       <div class="tab-pane"  id="params">
-        <h6><%= _('Puppet classes Parameters') -%></h6>
+        <h6><%= _('Puppet classes Parameters') %></h6>
         <p></p>
         <%= render "puppetclasses/classes_parameters", { :obj => @host } %>
-        <h6><%= _('Included Parameters via inheritance') -%></h6>
+        <h6><%= _('Included Parameters via inheritance') %></h6>
         <p></p>
         <%= render "common_parameters/inherited_parameters", { :inherited_parameters => @host.host_inherited_params(true) } %>
-        <h6><%= _('Host Parameters') -%></h6>
+        <h6><%= _('Host Parameters') %></h6>
         <p></p>
         <%= render "common_parameters/puppetclasses_parameters", :f => f %>
         <p></p>
@@ -93,12 +93,12 @@
       </div>
 
       <div class="tab-pane"  id="info">
-        <% if SETTINGS[:login] -%>
+        <% if SETTINGS[:login] %>
           <%= selectable_f f, :is_owned_by, option_groups_from_collection_for_select(
             [User, Usergroup], :all, :table_name, :id_and_type, :select_title,
             @host.is_owned_by), { :include_blank => _("select an owner") }, { :label => _("Owned By") }
           %>
-        <% end -%>
+        <% end %>
         <%= checkbox_f f, :enabled,
           :help_inline => _("Include this host within Foreman reporting")
         %>

--- a/app/views/hosts/_interfaces.html.erb
+++ b/app/views/hosts/_interfaces.html.erb
@@ -1,6 +1,6 @@
 <div class="fields">
   <%= field_set_tag _("Interface").html_safe + " #{remove_child_link('x', f, { :rel => 'twipsy', "data-title" => _('remove network interface'), :'data-placement' => 'left',
-                                                             :class => 'fr badge badge-important'})}".html_safe, :id => "interface" do -%>
+                                                             :class => 'fr badge badge-important'})}".html_safe, :id => "interface" do %>
     <%= selectable_f f, :type, [[_("Interface"), Nic::Managed],[_("BMC"), Nic::BMC]], {}, :class => 'interface_type', :disabled => !f.object.new_record? %>
     <%= text_f f, :mac %>
     <%= text_f f, :name, :help_inline => _("DNS name") %>
@@ -16,7 +16,7 @@
                    :class => 'interface_subnet', :'data-url' => freeip_subnets_path } %>
     <%= text_f f, :ip  %>
 
-    <%# hack to get BMC attributes show up without AJAX -%>
+    <%# hack to get BMC attributes show up without AJAX %>
     <%= content_tag :span, :id => 'bmc_fields', :class => f.object.is_a?(Nic::BMC) ? '' : 'hide' do %>
       <%= text_f f, :username, ifs_bmc_opts(f.object) %>
       <%= password_f f, :password, ifs_bmc_opts(f.object) %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -11,10 +11,10 @@
     <th class="hidden-tablet hidden-phone"><%= sort :last_report, :as => _('Last report') %></th>
     <th></th>
   </tr>
-  <% hosts.each do |host| -%>
+  <% hosts.each do |host| %>
     <tr>
       <td class="ca">
-        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' -%>
+        <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' %>
       </td>
       <td class='ellipsis'><%= name_column(host) %> </td>
       <td class="hidden-phone"><%= (icon(host.os, :size => "18x18") + trunc(" #{host.os}",14)).html_safe if host.os %></td>
@@ -29,7 +29,7 @@
                     display_delete_if_authorized(hash_for_host_path(:id => host), :confirm => _("Delete %s?") % host.name, :action => :destroy))%>
       </td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>
 <div id="confirmation-modal" class="modal hide fade">
   <div class="modal-header">

--- a/app/views/hosts/_metrics.html.erb
+++ b/app/views/hosts/_metrics.html.erb
@@ -3,11 +3,11 @@
     <th><%= _('Report Status') %></th>
     <th></th>
   </tr>
-    <% report_summary.each do |name, value| -%>
+    <% report_summary.each do |name, value| %>
     <tr>
       <td> <%= name %> </td>
-      <% style = (name =~ /failed|failed_restart/ and value > 0) ? "label label-important" : ""-%>
+      <% style = (name =~ /failed|failed_restart/ and value > 0) ? "label label-important" : ""%>
       <td><p class="<%= style %>"> <%= value %> </p></td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -14,9 +14,9 @@
   end %>
 </div>
 <div id='network_provisioning' <%= display? image_provisioning  %> >
-  <% if @host.new_record? or @host.type_changed? -%>
+  <% if @host.new_record? or @host.type_changed? %>
       <%= checkbox_f f, :build, :checked => true, :help_inline => _("Enable this host for provisioning") %>
-  <% end -%>
+  <% end %>
   <span id="media_select">
     <%= render 'common/os_selection/operatingsystem', :item => @host %>
   </span>

--- a/app/views/hosts/_overview.html.erb
+++ b/app/views/hosts/_overview.html.erb
@@ -4,9 +4,9 @@
   </tr>
   <tr>
     <td>
-      <% show_appropriate_host_buttons(@host).each do |btn| -%>
+      <% show_appropriate_host_buttons(@host).each do |btn| %>
         <%= btn %>
-      <% end -%>
+      <% end %>
     </td>
   </tr>
 </table>
@@ -15,10 +15,10 @@
     <th><%= _('Properties') %></th>
     <th></th>
   </tr>
-  <% overview_fields(host).each do |name, value| -%>
+  <% overview_fields(host).each do |name, value| %>
     <tr>
       <td><%= name %></td>
       <td><%= value %></td>
     </tr>
-  <% end -%>
+  <% end %>
 </table>

--- a/app/views/hosts/_provisioning.html.erb
+++ b/app/views/hosts/_provisioning.html.erb
@@ -1,9 +1,9 @@
 <div class="alert alert-success">
   <a class="close" href="#" data-dismiss="alert">&times;</a>
-<% templates.sort{|t,x| t.template_kind <=> x.template_kind}.each do |tmplt| -%>
+<% templates.sort{|t,x| t.template_kind <=> x.template_kind}.each do |tmplt| %>
   <div class="control-group">
     <div class="control-label"> <%= _("%s Template") % tmplt.template_kind %> </div>
     <div class="controls"> <%= link_to_if_authorized h(tmplt), hash_for_edit_config_template_path(:id => tmplt.to_param), :rel=>"external" %></div>
   </div>
-<% end -%>
+<% end %>
 </div>

--- a/app/views/hosts/_selected_hosts.html.erb
+++ b/app/views/hosts/_selected_hosts.html.erb
@@ -12,7 +12,7 @@
         </tr>
       </thead>
       <tbody>
-        <% hosts.each do |host| -%>
+        <% hosts.each do |host| %>
           <tr>
             <td><%=h host %> </td>
             <td><%=h host.try(:hostgroup) %></td>
@@ -24,7 +24,7 @@
             <td><%=h host.try(:organization) %></td>
             <% end %>
           </tr>
-        <% end -%>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/hosts/_unattended.html.erb
+++ b/app/views/hosts/_unattended.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="tab-pane"  id="network">
-  <%= field_set_tag _("Primary Interface"), :id => "primary_interface" do -%>
+  <%= field_set_tag _("Primary Interface"), :id => "primary_interface" do %>
     <div id="mac_address" <%= display? @host.compute_resource_id %> >
       <%= text_f f, :mac, :help_inline => _("MAC address for this host"), :autocomplete => 'off' %>
     </div>

--- a/app/views/hosts/console/log.html.erb
+++ b/app/views/hosts/console/log.html.erb
@@ -3,12 +3,12 @@
   <%= title_actions(link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn')) if @host %>
   <% title "#{@console[:name]}" %>
 </div>
-<% if @host && (@host.installed_at.nil? or (@console['timestamp'] - @host.installed_at < 5.minutes)) -%>
+<% if @host && (@host.installed_at.nil? or (@console['timestamp'] - @host.installed_at < 5.minutes)) %>
   <div class='alert'>
     <a class="close" href="#" data-dismiss="alert">&times;</a>
     Console output may be out of date
   </div>
-<% end -%>
+<% end %>
 <pre class="pre-scrollable">
   <code>
     <%= @console['output'] %>

--- a/app/views/hosts/console/spice.html.erb
+++ b/app/views/hosts/console/spice.html.erb
@@ -12,7 +12,7 @@
 
 <%= content_tag(:div, :id =>'spice-area', :data => spice_data_attributes(@console)) do %>
   <div class="console-status">
-    <div id="spice-status" class="span7 label" data-host="<%= @console[:name] -%>"><%= _("Connecting (unencrypted) to: %s") % @console[:name] %></div>
+    <div id="spice-status" class="span7 label" data-host="<%= @console[:name] %>"><%= _("Connecting (unencrypted) to: %s") % @console[:name] %></div>
   </div>
   <div id="spice-screen" class="console-screen"> </div>
 <% end %>

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -1,7 +1,7 @@
 <% title(_("Edit %s") % @host) %>
-<% if SETTINGS[:unattended] -%>
+<% if SETTINGS[:unattended] %>
   <% title_actions display_link_if_authorized((@host.managed? ? _("Unmanage host") : _("Manage host")),
     hash_for_toggle_manage_host_path(:id => @host.name), {:method => :put}) %>
-<% end -%>
+<% end %>
 
 <%= render :partial => 'hosts/form' %>

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,4 +1,4 @@
-<% if authorized? -%>
-  <% title_actions multiple_actions_select, (link_to_if_authorized _("New Host"), hash_for_new_host_path) -%>
-<% end -%>
+<% if authorized? %>
+  <% title_actions multiple_actions_select, (link_to_if_authorized _("New Host"), hash_for_new_host_path) %>
+<% end %>
 <%= render 'list', :hosts => @hosts, :header => @title || _("Hosts")  %>

--- a/app/views/hosts/multiple_build.html.erb
+++ b/app/views/hosts/multiple_build.html.erb
@@ -1,6 +1,6 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_build_hosts_path({:host_ids => params[:host_ids]}) do -%>
+<%= form_tag submit_multiple_build_hosts_path({:host_ids => params[:host_ids]}) do %>
   <span class="label label-info"><%= _('Provision') %></span>
   <%= _('these hosts for a build operation on next boot') %>
 <% end %>

--- a/app/views/hosts/multiple_destroy.html.erb
+++ b/app/views/hosts/multiple_destroy.html.erb
@@ -1,6 +1,6 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_destroy_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do -%>
+<%= form_tag submit_multiple_destroy_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do %>
   <span class="label label-warning"><%= _('Warning') %></span>
   <%= _('This might take a while, as all hosts, facts and reports will be destroyed as well') %>
 <% end %>

--- a/app/views/hosts/multiple_disable.html.erb
+++ b/app/views/hosts/multiple_disable.html.erb
@@ -1,6 +1,6 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_disable_hosts_path({:host_ids => params[:host_ids]}) do -%>
+<%= form_tag submit_multiple_disable_hosts_path({:host_ids => params[:host_ids]}) do %>
   <%# submit_tag _("Disable alerts for selected hosts") %>
   <small><%= _('Disable alerts for selected hosts') %></small>
 <% end %>

--- a/app/views/hosts/multiple_enable.html.erb
+++ b/app/views/hosts/multiple_enable.html.erb
@@ -1,6 +1,6 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_enable_hosts_path({:host_ids => params[:host_ids]}) do -%>
+<%= form_tag submit_multiple_enable_hosts_path({:host_ids => params[:host_ids]}) do %>
   <%# submit_tag _("Enable alerts for selected hosts") %>
     <small><%= _('Enable alerts for selected hosts') %></small>
 <% end %>

--- a/app/views/hosts/multiple_parameters.html.erb
+++ b/app/views/hosts/multiple_parameters.html.erb
@@ -1,9 +1,9 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<% if @parameters.empty? -%>
+<% if @parameters.empty? %>
   <%= _('Sorry, these hosts do not have parameters assigned to them, you must add them first.') %>
   <p><%= link_to _("Back to host list"), hosts_path %></p>
-<% else -%>
+<% else %>
   <%= form_tag update_multiple_parameters_hosts_path({:host_ids => params[:host_ids]}) do %>
     <% for param in @parameters %>
       <%= text_field :name, param.name, :class => "input-xxlarge", :placeholder => param.name %>

--- a/app/views/hosts/multiple_puppetrun.html.erb
+++ b/app/views/hosts/multiple_puppetrun.html.erb
@@ -1,5 +1,5 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag update_multiple_puppetrun_hosts_path({:host_ids => params[:host_ids]}) do -%>
+<%= form_tag update_multiple_puppetrun_hosts_path({:host_ids => params[:host_ids]}) do %>
   <small><%= _('Run Puppet on the following hosts') %></small>
 <% end %>

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -25,14 +25,14 @@
         <%= render :partial => "hosts/overview", :locals => { :host => @host } %>
       </div>
       <div class="tab-pane" id="metrics">
-        <% if @report_summary.size == 0 -%>
+        <% if @report_summary.size == 0 %>
             <p><%= _('No puppet activity for this host in the last %s days') % @range %></p>
-        <% else -%>
+        <% else %>
             <%= render :partial => "hosts/metrics", :locals => { :report_summary => @report_summary[@host.name][:metrics] } %>
-        <% end -%>
+        <% end %>
       </div>
       <div class="tab-pane" id="template">
-        <%= show_templates -%>
+        <%= show_templates %>
       </div>
       <div class="tab-pane" id="vm">
         <%  if @vm %>

--- a/app/views/hosts/update_multiple_parameters.html.erb
+++ b/app/views/hosts/update_multiple_parameters.html.erb
@@ -1,18 +1,18 @@
 <h3><%= _('The following hosts were updated') %></h3>
 <ul>
-  <% for host in @hosts -%>
+  <% for host in @hosts %>
     <li>
     <%= link_to h(host.name), host_path(host) %>
-    <% unless @skipped_parameters[host.name].empty? -%>
+    <% unless @skipped_parameters[host.name].empty? %>
       <br/>
       <%= _('The following parameters were skipped as they did not exists on this host:') %>
       <ul>
         <% for parm in @skipped_parameters[host.name] %>
           <li><%= h parm %></li>
-        <% end -%>
+        <% end %>
       </ul>
-    <% end -%>
+    <% end %>
     </li>
-  <% end -%>
+  <% end %>
 </ul>
 <%= link_to _("Back to host list"), hosts_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale -%>">
+<html lang="<%= I18n.locale %>">
   <head>
     <title> <%= h(yield(:title) || "Foreman") %></title>
     <%= stylesheet_link_tag 'application' %>
@@ -35,16 +35,16 @@
         </div>
       <% end %>
       <div id="main">
-        <%= content_tag('div', flash[:error],   :class => 'flash hide error')   if flash[:error] -%>
-        <%= content_tag('div', flash[:warning], :class => 'flash hide warning') if flash[:warning] -%>
-        <%= content_tag('div', flash[:notice],  :class => 'flash hide notice')  if flash[:notice] -%>
-        <%= render 'common/notice' unless @notices.empty? -%>
+        <%= content_tag('div', flash[:error],   :class => 'flash hide error')   if flash[:error] %>
+        <%= content_tag('div', flash[:warning], :class => 'flash hide warning') if flash[:warning] %>
+        <%= content_tag('div', flash[:notice],  :class => 'flash hide notice')  if flash[:notice] %>
+        <%= render 'common/notice' unless @notices.empty? %>
         <div id="content" class="container">
-          <% unless @page_header.blank? -%>
+          <% unless @page_header.blank? %>
             <div class="row control-group">
               <h1 class="span8"><%=h @page_header %></h1>
             </div>
-          <% end -%>
+          <% end %>
           <div class="row">
             <div class="title_filter <%= searchable? ? "span6" : "span4" %>">
               <%= render "common/searchbar" if searchable? %>
@@ -55,7 +55,7 @@
             </div>
           </div>
 
-          <%= yield -%>
+          <%= yield %>
         </div>
       </div>
     </div>

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -1,6 +1,6 @@
 
 <div id='<%= (f.object.key || 'new_lookup_keys').to_s.gsub(' ','_')%>' class='tab-pane fields' >
-  <% is_param = f.object.is_param -%>
+  <% is_param = f.object.is_param %>
 
   <%= text_f(f, :environment_classes, :value => f.object.environment_classes.map(&:environment).to_sentence,:class=>'span4', :label=> _('Puppet Environments'), :disabled=>true) if is_param%>
 

--- a/app/views/lookup_keys/index.html.erb
+++ b/app/views/lookup_keys/index.html.erb
@@ -4,7 +4,7 @@
   <tr>
     <th><%= sort :key, :as => _("Variable") %></th>
     <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-    <th><%= _('Number of values') -%></th>
+    <th><%= _('Number of values') %></th>
     <th></th>
   </tr>
 

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -5,4 +5,4 @@
   <%= text_f f, :vendor_class, :help_block => _("The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,") %>
   <%= textarea_f f, :info, :class => "input-xxlarge", :help_block => _("General useful description, for example this kind of hardware needs a special BIOS setup") %>
   <%= submit_or_cancel f %>
-<% end -%>
+<% end %>

--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -3,9 +3,9 @@
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("Operating System") %></a></li>
     <li><a href="#params" data-toggle="tab" id="params-tab"><%= _("Parameters") %></a></li>
-    <% if SETTINGS[:unattended] -%>
+    <% if SETTINGS[:unattended] %>
       <li><a href="#templates" data-toggle="tab"><%= _("Templates") %></a></li>
-    <% end -%>
+    <% end %>
   </ul>
 
   <div class="tab-content">
@@ -27,7 +27,7 @@
       <%= multiple_checkboxes f, :media, @operatingsystem,   os_habtm_family(Medium, f.object), :label => _("Installation media") %>
     </div>
 
-    <%= render('template_defaults', :f => f) if SETTINGS[:unattended] -%>
+    <%= render('template_defaults', :f => f) if SETTINGS[:unattended] %>
 
     <div class="tab-pane" id="params">
       <%= render "common_parameters/parameters", { :f => f, :type => :os_parameters } %>

--- a/app/views/operatingsystems/_template_defaults.html.erb
+++ b/app/views/operatingsystems/_template_defaults.html.erb
@@ -1,19 +1,19 @@
 <div class="tab-pane" id="templates">
-  <% if @operatingsystem.new_record? -%>
+  <% if @operatingsystem.new_record? %>
     <div class="alert alert-message alert-block alert-warning">
       <p><strong><%= _("Notice") %></strong> <%= _("It is not possible to assign provisioning templates at this stage") %></p>
       <p><%= _("Please save the Operating System first and try again.") %></p>
     </div>
-  <% else -%>
-    <% if ConfigTemplate.joins(:operatingsystems).where(:operatingsystems => { :id => @operatingsystem.id }).empty? -%>
+  <% else %>
+    <% if ConfigTemplate.joins(:operatingsystems).where(:operatingsystems => { :id => @operatingsystem.id }).empty? %>
       <div class="alert alert-message alert-warning">
         <a class="close" href="#" data-dismiss="alert">&times;</a>
         <p><strong><%= _("No templates found!") %></strong> <%= (_("you probably need to configure your %s first.") % link_to("templates", config_templates_path)).html_safe %></p>
       </div>
-    <% end -%>
+    <% end %>
 
-    <%= f.fields_for :os_default_templates do |builder| -%>
+    <%= f.fields_for :os_default_templates do |builder| %>
       <%= render 'templates', :f => builder %>
-    <% end -%>
-  <% end -%>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/puppetca/index.html.erb
+++ b/app/views/puppetca/index.html.erb
@@ -11,7 +11,7 @@
     <th><%= _("Fingerprint") %></th>
     <th></th>
   </tr>
-  <% @certificates.each do |cert| -%>
+  <% @certificates.each do |cert| %>
       <tr>
         <td><%= cert.name %> </td>
         <td><%= _(cert.state) %></td>
@@ -29,7 +29,7 @@
           %>
         </td>
       </tr>
-  <% end -%>
+  <% end %>
 </table>
 
 <%= page_entries_info @certificates  %>

--- a/app/views/puppetclasses/_class_parameters.html.erb
+++ b/app/views/puppetclasses/_class_parameters.html.erb
@@ -1,6 +1,6 @@
 <% lookup_keys = overridable_lookup_keys(puppetclass, obj) %>
 <% value_hash  = Classification::ClassParam.new(:host=>obj).inherited_values if obj.class.model_name == "Host" %>
-<% lookup_keys.each_with_index do |key,i| -%>
+<% lookup_keys.each_with_index do |key,i| %>
     <tr id="puppetclass_<%= puppetclass.id %>_params[<%= key.id %>]">
       <%= content_tag :td, (i == 0 ? {:rowspan => lookup_keys.size} : {:class => 'hide'}) do
         # In order to use the class .hide-first-col, we must have an extra, invisible cell.
@@ -14,4 +14,4 @@
                                :'data-tag' => 'override', :class =>"btn") if authorized_via_my_scope("host_editing", "create_params") %>
       </td>
     </tr>
-<% end -%>
+<% end %>

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -1,34 +1,34 @@
 <div class="row">
-  <% if obj.errors[:puppetclasses].any? -%>
+  <% if obj.errors[:puppetclasses].any? %>
     <div class="alert alert-message alert-block alert-error base in fade">
       <a class='close' href='#' data-dismiss="alert">×</a>
       <%= obj.errors[:puppetclasses].map {|e| "<li>#{e}</li>"}.to_s.html_safe %>
     </div>
-  <% end -%>
+  <% end %>
   <div class="span3 classes">
-    <h3><%= _('Included Classes') -%></h3>
-    <%# hidden field to ensure that classes gets removed if none are defined -%>
+    <h3><%= _('Included Classes') %></h3>
+    <%# hidden field to ensure that classes gets removed if none are defined %>
     <%= hidden_field_tag obj.class.model_name.downcase + "[puppetclass_ids][]" %>
     <ul id="selected_classes">
-      <% if authorized_for(:host_editing, :edit_classes) -%>
+      <% if authorized_for(:host_editing, :edit_classes) %>
         <%= render :partial => "puppetclasses/selectedClasses",
           :collection => obj.puppetclasses ,:as => :klass,
           :locals => { :type => obj.class.model_name.downcase, :host => obj } %>
-      <% else -%>
+      <% else %>
         <% obj.puppetclasses.each do |klass| %>
           <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy" style='color:black;'><%= h klass.name %></li>
-        <% end -%>
-      <% end -%>
+        <% end %>
+      <% end %>
     </ul>
     <ul>
       <% parent_classes(obj).each do |klass| %>
         <li data-original-title="<%= _('included already from host group') %>" rel="twipsy" style='color:black;'><%= h klass.name %></li>
-      <% end -%>
+      <% end %>
     </ul>
   </div>
 
   <div class="span8">
-    <h3><%= _('Available Classes') -%></h3>
+    <h3><%= _('Available Classes') %></h3>
     <div class='control-group'>
       <input placeholder="<%= _('Filter classes') %>" class="search-query" onkeyup="filter_puppet_classes(this);" type='text'>
     </div>

--- a/app/views/puppetclasses/_classes.html.erb
+++ b/app/views/puppetclasses/_classes.html.erb
@@ -1,23 +1,23 @@
-<% Puppetclass.classes2hash(puppetclasses).sort.in_groups(2,nil) do |group| -%>
+<% Puppetclass.classes2hash(puppetclasses).sort.in_groups(2,nil) do |group| %>
   <div class="span4 classes">
-    <% group.each do |list| -%>
+    <% group.each do |list| %>
       <% next if list.nil? %>
       <ul class="puppetclass_group">
         <li><%= link_to_function image_tag("bullet_toggle_plus.png") + " " + list.first, "$('#pc_#{list.first}').fadeToggle('slow')" %>
           <ul id="pc_<%= list.first %>" style="display: none;">
-            <% for klass in list.last.sort -%>
-              <% unless authorized_for(:host_editing, :edit_classes) -%>
+            <% for klass in list.last.sort %>
+              <% unless authorized_for(:host_editing, :edit_classes) %>
                 <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy"><%= h klass.name %></li>
-              <% else -%>
+              <% else %>
                 <% style = selected_puppet_classes.include?(klass) ? "hide" : "" %>
                 <%= content_tag_for :li, klass, :class=> style do %>
                   <%= link_to_add_puppetclass(klass, @host, type) %>
-                <% end -%>
-              <% end -%>
-            <% end -%>
+                <% end %>
+              <% end %>
+            <% end %>
           </ul>
         </li>
       </ul>
-    <% end -%>
+    <% end %>
   </div>
-<% end -%>
+<% end %>

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -3,9 +3,9 @@
 <%= form_for @puppetclass, :html => {:class=>"well"}, :url => (@puppetclass.new_record? ? puppetclasses_path : puppetclass_path(:id => @puppetclass.id)) do |f| %>
   <%= base_errors_for @puppetclass %>
   <ul class="nav nav-tabs" data-tabs="tabs">
-    <li class="active"><a href="#primary" data-toggle="tab"><%= _('Puppet Class') -%></a></li>
-    <li><a href="#smart_class_param" data-toggle="tab"><%= _('Smart Class Parameter') -%></a></li>
-    <li><a href="#smart_vars" data-toggle="tab"><%= _('Smart Variables') -%></a></li>
+    <li class="active"><a href="#primary" data-toggle="tab"><%= _('Puppet Class') %></a></li>
+    <li><a href="#smart_class_param" data-toggle="tab"><%= _('Smart Class Parameter') %></a></li>
+    <li><a href="#smart_vars" data-toggle="tab"><%= _('Smart Variables') %></a></li>
   </ul>
 
   <div class="tab-content">
@@ -17,19 +17,19 @@
     </div>
 
     <div class="tab-pane lookup-keys-container" id="smart_class_param">
-      <% if @puppetclass.class_params.empty? -%>
+      <% if @puppetclass.class_params.empty? %>
           <div class="alert alert-message alert-success">
             <a class="close" href="#" data-dismiss="alert">&times;</a>
             <p><strong>
               <%= _('This Puppet class has no parameters in its signature.') %>
             </strong><br><%= _('To update the class signature, go to the Puppet Classes page and select "Import".') %></p>
           </div>
-      <% else -%>
+      <% else %>
         <div class="undo-smart-vars alert alert-message hide">
           <%= _('Undo remove') %>
         </div>
           <div class="control-group">
-            <label class="control-label"><%= _('Filter Parameters') -%></label>
+            <label class="control-label"><%= _('Filter Parameters') %></label>
             <div class="controls">
               <input placeholder="Filter By Name" onkeyup="filterByClassParam(this);" type='text' class="fl">
               <div class="input-prepend">
@@ -41,11 +41,11 @@
           </div>
           <div class="tabbable tabs-left row">
             <ul class="nav nav-tabs smart-var-tabs span3" data-tabs="pills">
-              <% @puppetclass.class_params.all(:include => :environments).each do |key| -%>
+              <% @puppetclass.class_params.all(:include => :environments).each do |key| %>
                   <li data-used-environments=<%= key.environments.map(&:to_s).to_json %> >
                     <a data-toggle="tab" id="pill_<%= key.to_s.gsub(' ','_') %>" href="#<%= key.to_s.gsub(' ','_') %>" ><%= icon_text((key.override ? "flag": ""), key.to_s.gsub('_',' ')) %><span class="delete fr">&times;</span></a>
                   </li>
-              <% end -%>
+              <% end %>
             </ul>
 
             <div class="tab-content span7 smart-var-content">
@@ -54,25 +54,25 @@
               <% end %>
             </div>
           </div>
-      <% end -%>
+      <% end %>
     </div>
     <div class="tab-pane lookup-keys-container" id="smart_vars">
-      <% if @puppetclass.lookup_keys.empty? -%>
+      <% if @puppetclass.lookup_keys.empty? %>
           <div class="alert alert-message alert-warning">
             <a class="close" href="#" data-dismiss="alert">&times;</a>
-            <p><strong><%= _('Help!') -%></strong>
+            <p><strong><%= _('Help!') %></strong>
             <%= (_('What is a <a href="%s" rel="external">Smart variable</a>?') % 'http://theforeman.org/projects/foreman/wiki/Smart_Variables').html_safe %>
             </p>
           </div>
-      <% end -%>
+      <% end %>
       <div class="undo-smart-vars alert alert-message hide">
         <%= _('Undo remove') %>
       </div>
       <div class="tabbable tabs-left">
         <ul class="nav nav-tabs smart-var-tabs span2" data-tabs="pills">
-          <% @puppetclass.lookup_keys.each do |key| -%>
+          <% @puppetclass.lookup_keys.each do |key| %>
               <li><a data-toggle="tab" id="pill_<%= key.to_s.gsub(' ','_') %>" href="#<%= key.to_s.gsub(' ','_') %>"><%= key %><span class="delete fr">&times;</span></a></li>
-          <% end -%>
+          <% end %>
           <li><%= link_to_function '+ ' + _("Add Variable"), "add_child_node(this);" ,:class=>"btn btn-success",:style=>":hover{}", :"data-association" => :lookup_keys %></li>
         </ul>
 

--- a/app/views/puppetclasses/_selectedClasses.html.erb
+++ b/app/views/puppetclasses/_selectedClasses.html.erb
@@ -1,4 +1,4 @@
 <%= content_tag_for :li, klass, :selected, :class => cycle('even', 'odd') do %>
   <%= link_to_remove_puppetclass(klass, host) %>
   <%= hidden_field_tag "#{type}[puppetclass_ids][]", klass.id %>
-<% end -%>
+<% end %>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -6,16 +6,16 @@
   <tr>
     <th><%= sort :name, :as => s_("Puppetclass|Name") %></th>
     <th><%= sort :environment, :as => _("Environments and documentation") %></th>
-    <th><%= _('Host group') -%></th>
-    <th><%= _('Hosts') -%></th>
-    <th><%= _('Keys') -%></th>
+    <th><%= _('Host group') %></th>
+    <th><%= _('Hosts') %></th>
+    <th><%= _('Keys') %></th>
     <th></th>
   </tr>
   <% for puppetclass in @puppetclasses %>
     <tr>
       <td><%=link_to_if_authorized h(puppetclass.name), hash_for_edit_puppetclass_path(:id => puppetclass) %></td>
       <td>
-        <% puppetclass.environments.uniq.each do |environment| -%>
+        <% puppetclass.environments.uniq.each do |environment| %>
           <%= link_to_function environment, 'show_rdoc(this)', :'data-url' => rdoc_classes_path(environment, puppetclass.name) %>
         <% end %>
       </td>

--- a/app/views/reports/_list.html.erb
+++ b/app/views/reports/_list.html.erb
@@ -1,8 +1,8 @@
 <table class="table table-bordered table-striped ellipsis">
   <tr>
-    <% unless params[:host_id] -%>
+    <% unless params[:host_id] %>
       <th><%= sort :host %></th>
-    <% end -%>
+    <% end %>
     <th><%= sort :reported, :as => _("Last report") %></th>
     <th class="small"><%= sort :applied, :as => _("Applied") %></th>
     <th class="small"><%= sort :restarted, :as => _("Restarted") %></th>
@@ -14,9 +14,9 @@
   </tr>
   <% for report in @reports %>
     <tr>
-      <% unless params[:host_id] -%>
+      <% unless params[:host_id] %>
         <td><%= link_to h(report.host), host_reports_path(report.host) %></td>
-      <% end -%>
+      <% end %>
       <td><%= reported_at_column(report) %></td>
       <td><%= report_event_column(report.applied, "label-info") %></td>
       <td><%= report_event_column(report.restarted, "label-info") %></td>

--- a/app/views/reports/_metrics.html.erb
+++ b/app/views/reports/_metrics.html.erb
@@ -2,18 +2,18 @@
 <% metrics.delete_if{ |k,v| v < 0.001 } %>
 <div class="row-fluid">
   <div class="stats-well span4">
-    <h4 class="ca" ><%= _('Report Metrics') -%></h4>
+    <h4 class="ca" ><%= _('Report Metrics') %></h4>
     <div style="margin-top:50px;padding-bottom: 40px;">
     <%= flot_pie_chart("metrics" ,_("Report Metrics"), metrics, :class => "statistics-pie small")%>
     </div>
   </div>
   <div class="stats-well span4">
-    <h4 class="ca" ><%= _('Report Status') -%></h4>
+    <h4 class="ca" ><%= _('Report Status') %></h4>
     <%= flot_bar_chart("status" ,"", _("Number of Events"), status, :class => "statistics-bar")%>
   </div>
   <div class="span4">
     <table class='table table-bordered table-striped' style="height: 398px;">
-      <% metrics.sort.each do |title, value|-%>
+      <% metrics.sort.each do |title, value|%>
         <tr>
           <td> <%= title %> </td>
           <td> <%= metric value %> </td>

--- a/app/views/reports/_output.html.erb
+++ b/app/views/reports/_output.html.erb
@@ -2,12 +2,12 @@
   <tr>
     <th><%= _("Level") %></th><th><%= _("Resource") %></th><th><%= _("message") %></th>
   </tr>
-  <% logs.each do |log| -%>
+  <% logs.each do |log| %>
       <tr>
         <td><span <%= report_tag log.level %>><%= h log.level %></span></td>
         <td><%= h log.source %></td>
         <td><%= h log.message %></td>
       </tr>
-  <% end -%>
+  <% end %>
   <tr id='ntsh' <%= "style='display: none;'".html_safe if logs.size > 0%>><td colspan="3"> <%= _("Nothing to show") %> </td></tr>
 </table>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -2,7 +2,7 @@
 <% title "#{@report.host}"%>
 
 <p class='ra'> <%= _("Reported at %s ") % @report.reported_at.getlocal %> </p>
-<% if @offset > 10 -%>
+<% if @offset > 10 %>
   <div class="alert alert-message alert-block alert-error">
     <a class="close" href="#" data-dismiss="alert">&times;</a>
     <h3><%= _("Host times seems to be adrift!") %></h3>
@@ -10,12 +10,12 @@
     <%= (_("Foreman report creation time is <em>%s</em>") % @report.created_at).html_safe %> <br/>
     <%= (_("Which is an offset of <b>%s</b>") % distance_of_time_in_words(@report.reported_at, @report.created_at, true)).html_safe %>
   </div>
-<% end -%>
+<% end %>
 
 <% content_for(:search_bar) {logs_show} %>
 
 <%= render 'output', :logs => @report.logs%>
-<%= render 'metrics', :status => @report.status, :metrics => @report.metrics["time"] if @report.metrics["time"] -%>
+<%= render 'metrics', :status => @report.status, :metrics => @report.metrics["time"] if @report.metrics["time"] %>
 
 <%= title_actions link_to(_('Back'), :back),
   display_delete_if_authorized(hash_for_report_path(:id => @report), :class=> "btn btn-danger"),

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -17,12 +17,12 @@
               <%= check_box_tag 'role[permissions][]', permission.name, (@role.permissions.include? permission.name), :class => "role_checkbox" %>
               <%= permission.name %>
               <%= hidden_field_tag 'role[permissions][]' %>
-            <% end -%>
+            <% end %>
             </li>
           <% end %>
         </ul>
       </div>
     </div>
-  <% end -%>
+  <% end %>
   <%= submit_or_cancel f %>
-<% end -%>
+<% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,5 +1,5 @@
 <div id="statistics" class="grid">
-<% charts.each do |ch| -%>
+<% charts.each do |ch| %>
   <%= content_tag(:div, ch, :class=>"stats-well") %>
-<% end -%>
+<% end %>
 </div>

--- a/app/views/subnets/import.html.erb
+++ b/app/views/subnets/import.html.erb
@@ -2,10 +2,10 @@
 
 <h2><%= _("The following subnets have been found") %></h2>
 
-<%= form_for "subnets[]", :url => create_multiple_subnets_path do |f| -%>
+<%= form_for "subnets[]", :url => create_multiple_subnets_path do |f| %>
   <% display_all = !minimal?(@subnets) %>
   <div class="accordion" id='accordion1'>
-  <% @subnets.each do |subnet| -%>
+  <% @subnets.each do |subnet| %>
     <% id = 'subnet_fields_'+subnet.to_s.gsub('/','_').gsub('.','_') %>
     <div class="accordion-group">
       <div class="accordion-heading" >
@@ -14,13 +14,13 @@
       </div>
       <div id="<%= id %>" class="accordion-body collapse <%= 'in' if display_all %>" >
         <div class="accordion-inner">
-          <%= fields_for "subnets[]", subnet do |s| -%>
+          <%= fields_for "subnets[]", subnet do |s| %>
               <%= render 'fields', :f => s %>
-          <% end -%>
+          <% end %>
         </div>
       </div>
     </div>
-  <% end -%>
+  <% end %>
   </div>
   <%= submit_or_cancel f %>
-<% end -%>
+<% end %>

--- a/app/views/taxonomies/_form.html.erb
+++ b/app/views/taxonomies/_form.html.erb
@@ -11,7 +11,7 @@
         <li><a href="#media" data-toggle="tab"><%= _("Media") %></a></li>
         <li><a href="#template" data-toggle="tab"><%= _("Templates") %></a></li>
         <li><a href="#domains" data-toggle="tab"><%= _("Domains") %></a></li>
-      <% end -%>
+      <% end %>
       <li><a href="#environments" data-toggle="tab"><%= _("Environments") %></a></li>
       <li><a href="#hostgroups" data-toggle="tab"><%= _("Host Groups") %></a></li>
       <% if (taxonomy.is_a?(Organization) && SETTINGS[:locations_enabled]) %>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -18,7 +18,7 @@
   </tr>
 
   <% @taxonomies.each do |taxonomy| %>
-    <tr class="<%= cycle("even", "odd") -%>">
+    <tr class="<%= cycle("even", "odd") %>">
       <td><%= link_to taxonomy.to_label, edit_taxonomy_path(taxonomy) %></td>
       <td><%= link_to @counter[taxonomy.id] || 0, hosts_path(:search => "#{controller_name.singularize} = #{taxonomy}") %></td>
       <td>

--- a/app/views/taxonomies/mismatches.html.erb
+++ b/app/views/taxonomies/mismatches.html.erb
@@ -12,7 +12,7 @@
     </tr>
     <% @mismatches.each do |mismatch| %>
       <% if !mismatch.empty? %>
-      <tr class="<%= cycle("even", "odd") -%>">
+      <tr class="<%= cycle("even", "odd") %>">
         <% if mismatch.first[:taxonomy_type] == "Location" %>
         <td><%= link_to mismatch.first[:taxonomy_name], edit_location_path(mismatch.first[:taxonomy_id]) %>
             <%= "(#{mismatch.first[:taxonomy_type]})" %>

--- a/app/views/trends/_hosts.html.erb
+++ b/app/views/trends/_hosts.html.erb
@@ -1,7 +1,7 @@
 <% @trend.find_hosts.in_groups(4, false) do |group| %>
   <div class="span3">
     <td>
-      <% group.each do |host| -%>
+      <% group.each do |host| %>
         <ul class="base">
           <li>
             <%= link_to(host, host_path(:id => host), :title => _("Show Host")) %>
@@ -10,4 +10,4 @@
       <% end %>
     </td>
   </div>
-<% end -%>
+<% end %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Trends") %>
 
 <% title_actions display_link_if_authorized(_("Add Trend Counter"), hash_for_new_trend_path) %>
-<% if @trends.empty? -%>
+<% if @trends.empty? %>
   <div class="alert alert-message alert-info">
     <a class="close" href="#" data-dismiss="alert">&times;</a>
 

--- a/app/views/users/_filters.html.erb
+++ b/app/views/users/_filters.html.erb
@@ -5,7 +5,7 @@
       <%= contracted_host_list @user %>
       <%= expanded_host_list @user %>
     </div>
-    <% end -%>
+    <% end %>
 
     <%= field_set_tag _("Domain hosts") do %>
         <%= f.select :domains_andor, [[_("in domain"), "and"], [_("plus all"), "or"]], {}, :class => "input-small" %>
@@ -32,12 +32,12 @@
       <div class="control-group">
         <%= f.select :facts_andor, [[_("must match"), "and"], [_("plus all"), "or"]], {} ,:class => "input-small" %>
         <div class="offset1">
-          <%= f.fields_for :user_facts do |builder| -%>
+          <%= f.fields_for :user_facts do |builder| %>
               <%= render "user_fact", :f => builder %>
-          <% end -%>
-          <% if authorized_for(params[:controller], params[:action]) -%>
+          <% end %>
+          <% if authorized_for(params[:controller], params[:action]) %>
               <p><%= link_to_add_fields('+ ' + _("Add Filter"), f, :user_facts, "user_fact", :title => _("Add a fact filter")) %></p>
-          <% end -%>
+          <% end %>
         </div>
       </div>
   <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -11,7 +11,7 @@
       <% if show_organization_tab? %>
         <li><a href="#organizations" data-toggle="tab"><%= _("Organizations") %></a></li>
       <% end %>
-    <% end -%>
+    <% end %>
   </ul>
 
   <div class="tab-content">
@@ -30,13 +30,13 @@
         <%= password_f f, :password, :label => _("Password") %>
         <%= password_f f, :password_confirmation, :label => _("Verify") %>
       </div>
-      <% unless @editing_self -%>
+      <% unless @editing_self %>
         <%= checkbox_f f, :admin if User.current.can_change_admin_flag? %>
         <%= multiple_checkboxes f, :roles, @user, Role.givable.for_current_user, {:label => _('Roles')} %>
       <% end %>
     </div>
 
-    <% unless @editing_self -%>
+    <% unless @editing_self %>
       <div class="tab-pane" id="filters">
         <%= render("filters", :f => f) %>
       </div>
@@ -56,4 +56,4 @@
     <% end %>
   </div>
   <%= submit_or_cancel f %>
-<% end -%>
+<% end %>

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -6,27 +6,27 @@ class RendererTest < ActiveSupport::TestCase
 
   test "should evaluate template variables under safemode" do
     Setting.expects(:[]).with(:safemode_render).returns(true)
-    tmpl = render_safe('<%= @foo -%>', [], { :foo => 'bar' })
+    tmpl = render_safe('<%= @foo %>', [], { :foo => 'bar' })
     assert_equal 'bar', tmpl
   end
 
   test "should evaluate template variables without safemode" do
     Setting.expects(:[]).with(:safemode_render).returns(false)
-    tmpl = render_safe('<%= @foo -%>', [], { :foo => 'bar' })
+    tmpl = render_safe('<%= @foo %>', [], { :foo => 'bar' })
     assert_equal 'bar', tmpl
   end
 
   test "should evaluate renderer methods under safemode" do
     Setting.expects(:[]).with(:safemode_render).returns(true)
     self.expects(:foreman_url).returns('bar')
-    tmpl = render_safe('<%= foreman_url -%>', [:foreman_url])
+    tmpl = render_safe('<%= foreman_url %>', [:foreman_url])
     assert_equal 'bar', tmpl
   end
 
   test "should evaluate renderer methods without safemode" do
     Setting.expects(:[]).with(:safemode_render).returns(false)
     self.expects(:foreman_url).returns('bar')
-    tmpl = render_safe('<%= foreman_url -%>')
+    tmpl = render_safe('<%= foreman_url %>')
     assert_equal 'bar', tmpl
   end
 end


### PR DESCRIPTION
I'm pretty sure that -%> is a Rails 2.x syntax.  Here's what the current docs say.
http://api.rubyonrails.org/classes/ActionView/Base.html

<%- and -%> suppress leading and trailing whitespace, including the trailing newline, and can be used interchangeably with <% and %>.
