### PR TITLE
Fixes #2817 - wrong param types in lookup keys api documentation 

### DIFF
--- a/app/controllers/api/v2/lookup_keys_controller.rb
+++ b/app/controllers/api/v2/lookup_keys_controller.rb
@@ -91,10 +91,10 @@ module Api
         param :description, String
         param :validator_type, String
         param :validator_rule, String
-        param :is_param, :boolean
+        param :is_param, :bool
         param :key_type, String
-        param :override, :boolean
-        param :required, :boolean
+        param :override, :bool
+        param :required, :bool
       end
 
       def create
@@ -112,10 +112,10 @@ module Api
         param :description, String
         param :validator_type, String
         param :validator_rule, String
-        param :is_param, :boolean
+        param :is_param, :bool
         param :key_type, String
-        param :override, :boolean
-        param :required, :boolean
+        param :override, :bool
+        param :required, :bool
       end
 
       def update


### PR DESCRIPTION
There is no parameter type :boolean. :bool must be used for true/false values.
Wrong type was breaking lookup controller apidoc page.
