### PR TITLE
fixes #2808 - pin nokogiri to 1.5.x for Ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ if RUBY_VERSION =~ /^1\.8/
   # Older version of safemode for Ruby 1.8, as the latest causes regexp overflows (#2100)
   gem 'safemode', '~> 1.0.1'
   gem 'ruby_parser', '>= 2.3.1', '< 3.0'
+
+  # Used in fog, rbovirt etc.  1.6.0 breaks Ruby 1.8 compatibility.
+  gem 'nokogiri', '~> 1.5.0'
 else
   # Newer version of safemode contains fixes for Ruby 1.9
   gem 'safemode', '~> 1.2'


### PR DESCRIPTION
PR tests are down at the moment as test_develop is broken, they won't run this.
