### PR TITLE
Fix #2540: Error listing VM's on Rackspace CR's

### DIFF
--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -3,7 +3,7 @@ class ComputeResourcesVmsController < ApplicationController
   before_filter :find_vm, :only => [:show, :power, :console]
 
   def index
-    @vms = @compute_resource.vms.all(params[:filters] || {})
+    @vms = @compute_resource.type == 'Foreman::Model::Rackspace' ? @compute_resource.vms.all : @compute_resource.vms.all(params[:filters] || {})
     respond_to do |format|
       format.html
       format.json { render :json => @vms }

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -94,7 +94,14 @@ module Foreman::Model
     private
 
     def client
-      @client = Fog::Compute.new(:provider => "Rackspace", :version => 'v2', :rackspace_api_key => password, :rackspace_username => user, :rackspace_auth_url => url, :rackspace_endpoint => endpoint)
+      @client = Fog::Compute.new(
+        :provider => "Rackspace",
+        :version => 'v2',
+        :rackspace_api_key => password,
+        :rackspace_username => user,
+        :rackspace_auth_url => url,
+        :rackspace_compute_url => endpoint
+      )
       return @client
     end
 

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :class => "input-xlarge", :help_block => _("e.g. https://identity.api.rackspacecloud.com") %>
+<%= text_f f, :url, :class => "input-xlarge", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0") %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :label => _("API Key") %>
 <% flavors = f.object.flavors rescue [] -%>


### PR DESCRIPTION
This PR fixes the issue with listing VM's, but it also:
- Moves from the deprecated `:rackspace_endpoint` to `:rackspace_compute_url`
- Suggests for users to choose the v2 API (which is what we require)

I'm happy to move those two things into separate PR's, but since they are related to this fix I figured they should at least get reviewed along with it.
