### PR TITLE
Fix Gravatar URL for email addresses with uppercases

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -307,7 +307,7 @@ module ApplicationHelper
 
   def gravatar_url(email, default_image)
     return default_image if email.blank?
-    "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}?d=mm&s=30"
+    "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=mm&s=30"
   end
 
   private


### PR DESCRIPTION
As per:

http://en.gravatar.com/site/implement/hash/

you should downcase the email address before hashing it.

cheers,
gav
