### PR TITLE
fixes #2838 - taxonomies controller - fix in params and finder

### DIFF
--- a/app/controllers/api/v2/locations_controller.rb
+++ b/app/controllers/api/v2/locations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class LocationsController < V2::BaseController
 
-      apipie_concern_subst(:a_resource => "a location", :resource => "locations")
+      apipie_concern_subst(:a_resource => "a location", :resource => "location")
       include Api::V2::TaxonomiesController
 
     end

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -19,9 +19,13 @@ module Api::V2::TaxonomiesController
   end
 
   api :GET, '/:resource_id', 'List all :resource_id'
+  param :search, String, :desc => "filter results"
+  param :order, String, :desc => "sort results"
+  param :page, String, :desc => "paginate results"
+  param :per_page, String, :desc => "number of entries per request"
   def index
     if @nested_obj
-      #@taxonomies = @domain.locations.paginate(paginate_options)
+      #@taxonomies = @domain.locations.search_for(*search_options).paginate(paginate_options)
       @taxonomies = @nested_obj.send(taxonomies_plural).search_for(*search_options).paginate(paginate_options)
     else
       @taxonomies = taxonomy_class.search_for(*search_options).paginate(paginate_options)
@@ -81,12 +85,7 @@ module Api::V2::TaxonomiesController
   end
 
   def taxonomy_id
-    case controller_name
-      when 'organizations'
-        :organization_id
-      when 'locations'
-        :location_id
-    end
+    "#{taxonomy_single}_id".to_sym
   end
 
   def taxonomy_single
@@ -102,12 +101,7 @@ module Api::V2::TaxonomiesController
   end
 
   def find_taxonomy
-    case controller_name
-      when 'organizations'
-        @taxonomy = @organization = Organization.find(params[:id])
-      when 'locations'
-        @taxonomy = @location = Location.find(params[:id])
-    end
+    @taxonomy = find_resource
   end
 
 end

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -3,5 +3,6 @@ attributes :id, :name,
             :organization_ids, :hostgroup_ids,
             :environment_ids, :domain_ids, :medium_ids,
             :subnet_ids, :compute_resource_ids,
-            :smart_proxy_ids, :user_ids, :config_template_ids
+            :smart_proxy_ids, :user_ids, :config_template_ids,
+            :created_at, :updated_at
 attribute :ignore_types => :select_all_types


### PR DESCRIPTION
- added mising apipie params for search & pagination
- simplified resource finder
- now finds also by name
- show response has timestamps
- fix resource names in apipie docs
