### PR TITLE
Fixes #2389 - Authentication failure with cloud-init

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -98,6 +98,10 @@ class Foreman::Provision::SSH
         logger.debug "Host timed out for #{address}, retrying"
         sleep(2)
         retry
+      rescue Net::SSH::AuthenticationFailed
+        logger.debug "Auth failed for #{address}.. retrying"
+        sleep(2)
+        retry
       rescue Timeout::Error
         retry
       rescue => e


### PR DESCRIPTION
Added an extra rescue catch to ssh.rb to catch an authentication failure. This seems to happen when cloud-init is ran and foreman attempts to ssh to the box before the user is created.
