### PR TITLE
Fix #2839 - Authentication issues with cloud-init

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -98,6 +98,10 @@ class Foreman::Provision::SSH
         logger.debug "Host timed out for #{address}, retrying"
         sleep(2)
         retry
+      rescue Net::SSH::AuthenticationFailed
+        logger.debug "Auth failed for #{username} at #{address}.. retrying"
+        sleep(2)
+        retry
       rescue Timeout::Error
         retry
       rescue => e


### PR DESCRIPTION
Fixes authentication issue with openstack cloud-init. Foreman attempts to ssh before the user is created and causes a rollback.
