### PR TITLE
fixes #2851 - refresh puppet classes on environment change

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -59,7 +59,7 @@
             :help_inline => :indicator } %>
 
         <%= select_f f, :environment_id, Environment.all, :id, :to_label, { :include_blank => true },
-            {:onchange => 'hostgroup_or_environment_changed(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
+            {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
             :'data-host-id' => @host.id, :help_inline => :indicator} %>
         <%= puppet_master_fields f %>
       </div>


### PR DESCRIPTION
@abenari, please review.  I think it was accidentally changed in 89b9ecb0, or maybe you were going to redesign hostgroup/env changes on the form?
