### PR TITLE
fixes #2862 - removing oauth key from the log file

### DIFF
--- a/app/services/api/authorization.rb
+++ b/app/services/api/authorization.rb
@@ -56,7 +56,7 @@ module Api
 
       unless (incoming_key = OAuth::RequestProxy.proxy(controller.request).oauth_consumer_key) ==
           Setting['oauth_consumer_key']
-        Rails.logger.warn "oauth_consumer_key should be '#{Setting['oauth_consumer_key']}' but was '#{incoming_key}'"
+        Rails.logger.warn "OAuth consumer key is invalid"
         return nil
       end
 


### PR DESCRIPTION
This is more secure. Same situation with "password is invalid" vs "either
username or password is invalid".
