### PR TITLE
Fixes #2867: use the future relative tense for the orchestration process during provisioning

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -29,11 +29,11 @@ module Orchestration::Compute
   end
 
   def queue_compute_create
-    queue.create(:name   => _("Settings up compute instance %s") % self, :priority => 1,
+    queue.create(:name   => _("Set up compute instance %s") % self, :priority => 1,
                  :action => [self, :setCompute])
-    queue.create(:name   => _("Acquiring IP address for %s") % self, :priority => 2,
+    queue.create(:name   => _("Acquire IP address for %s") % self, :priority => 2,
                  :action => [self, :setComputeIP]) if compute_resource.provided_attributes.keys.include?(:ip)
-    queue.create(:name   => _("Querying instance details for %s") % self, :priority => 3,
+    queue.create(:name   => _("Query instance details for %s") % self, :priority => 3,
                  :action => [self, :setComputeDetails])
     queue.create(:name   => _("Power up compute instance %s") % self, :priority => 1000,
                  :action => [self, :setComputePowerUp]) if compute_attributes[:start] == '1'
@@ -41,7 +41,7 @@ module Orchestration::Compute
 
   def queue_compute_update
     return unless compute_update_required?
-    logger.debug("Detected a change is required for Compute resource")
+    logger.debug("Detected a change is required for compute resource")
     queue.create(:name   => _("Compute resource update for %s") % old, :priority => 7,
                  :action => [self, :setComputeUpdate])
   end

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -19,13 +19,13 @@ module Orchestration::SSHProvision
   # I guess this is not going to happen on create as we might not have an ip address yet.
   def queue_ssh_provision_create
 
-    post_queue.create(:name   => _("Preparing Post installation script for %s") % self, :priority => 2000,
+    post_queue.create(:name   => _("Prepare post installation script for %s") % self, :priority => 2000,
                  :action => [self, :setSSHProvisionScript])
-    post_queue.create(:name   => _("Waiting for %s to come online") % self, :priority => 2001,
+    post_queue.create(:name   => _("Wait for %s to come online") % self, :priority => 2001,
                  :action => [self, :setSSHWaitForResponse])
-    post_queue.create(:name   => _("Enable Certificate generation for %s") % self, :priority => 2002,
+    post_queue.create(:name   => _("Enable certificate generation for %s") % self, :priority => 2002,
                  :action => [self, :setSSHCert])
-    post_queue.create(:name   => _("Configuring instance %s via SSH") % self, :priority => 2003,
+    post_queue.create(:name   => _("Configure instance %s via SSH") % self, :priority => 2003,
                  :action => [self, :setSSHProvision])
   end
 


### PR DESCRIPTION
This is a total nitpick, but since I stare at it every time I provision a machine I figured I should fix it :+1: 
