### PR TITLE
Fixes #2501 - Allow my_hosts scope to include all subclasses of Host::Base

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -172,5 +172,12 @@ module Host
       name
     end
 
+    def ==(comparison_object)
+      super ||
+        comparison_object.is_a?(Host::Base) &&
+        id.present? &&
+        comparison_object.id == id
+    end
+
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -482,7 +482,7 @@ class Host::Managed < Host::Base
     current = User.current
     if (operation == "edit") or operation == "destroy"
       if current.allowed_to?("#{operation}_hosts".to_sym)
-        return true if Host.my_hosts.include? self
+        return true if Host::Base.my_hosts.include? self
       end
     else # create
       if current.allowed_to?(:create_hosts)


### PR DESCRIPTION
This change is because on save, the object in the DB is a Host::Discovered, but in memory it's a Host::Managed, meaning that `my_hosts.include? self` will never return true (as `==` in AR checks the model first)
