### PR TITLE
Fixes #2758 - Set key_type when importing parameter defaults

### DIFF
--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -207,6 +207,7 @@ class PuppetClassImporter
       key = db_class.class_params.find_by_key param_name
       if key.override == false
         key.default_value = value
+        key.key_type = nil
         key.save!
       end
     end


### PR DESCRIPTION
Previously, when importing a class that had a default parameter previously overridden, the types could be different, which caused the error "Validation failed: Default value is invalid" when you try to perform an import.
