### PR TITLE
#2871 Params search works with nested hostgroups

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -114,7 +114,7 @@ module Hostext
             when 'OsParameter'
               conditions << "hosts.operatingsystem_id = #{param.reference_id}"
             when 'GroupParameter'
-              conditions << "hosts.hostgroup_id = #{param.reference_id}"
+              conditions << "hosts.hostgroup_id IN (#{param.hostgroup.subtree_ids.join(', ')})"
             when 'HostParameter'
               conditions << "hosts.id = #{param.reference_id}"
           end

--- a/test/fixtures/hostgroups.yml
+++ b/test/fixtures/hostgroups.yml
@@ -26,3 +26,13 @@ db:
   medium: one
   puppet_proxy: puppetmaster
   label: db
+
+parent:
+  name: Parent
+  label: Parent
+  id: 1
+
+inherited:
+  name: inherited
+  label: Parent/inherited
+  ancestry: 1

--- a/test/fixtures/parameters.yml
+++ b/test/fixtures/parameters.yml
@@ -28,3 +28,4 @@ os:
   value: os1
   type: OsParameter
   operatingsystem: redhat
+

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -765,4 +765,20 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "can search hosts by params" do
+    parameter = parameters(:host)
+    hosts = Host.search_for("params.host1 = host1")
+    assert_equal hosts.count, 1
+    assert_equal hosts.first.params['host1'], 'host1'
+  end
+
+  test "can search hosts by inherited params from a hostgroup" do
+    host = hosts(:one)
+    host.update_attribute(:hostgroup, hostgroups(:inherited))
+    GroupParameter.create( { :name => 'foo', :value => 'bar', :hostgroup => host.hostgroup.parent } )
+    hosts = Host.search_for("params.foo = bar")
+    assert_equal hosts.count, 1
+    assert_equal hosts.first.params['foo'], 'bar'
+  end
+
 end


### PR DESCRIPTION
This tiny tiny PR allows you to search (UI or API) on parameters that are inherited from hostgroups. 

For instance, imagine a host 'foo.cern.ch', and a hostgroup 'bar/baz'. If hostgroup 'bar' defines a parameter 'firewall = on', 'foo.cern.ch' will inherit it. Nonetheless, if you use the search bar, and search for 'params.firewall = true', it will not show 'foo.cern.ch' unless you move it to '/bar/' instead of '/bar/baz'
