### PR TITLE
fix issue where host hasn't correctly set fqdn

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -345,25 +345,17 @@ class Host::Managed < Host::Base
     case facts
       when Puppet::Node::Facts
         certname = facts.name
-        if facts.values.has_key?("fqdn")
-            name     = facts.values["fqdn"].downcase
-        else
-            # Fall back to certname if host fqdn isn't set correctly
-            name     = certname.downcase
-        end
-        values   = facts.values
+        name = facts.values["fqdn"].try(:downcase)
+        name ||= certname.downcase
+        values = facts.values
       when Hash
         certname = facts["clientcert"] || facts["certname"]
-        if facts.values.has_key?("fqdn")
-            name     = facts.values["fqdn"].downcase
-        else
-            # Fall back to certname if host fqdn isn't set correctly
-            name     = certname.downcase
-        end
-        values   = facts
-        return raise(::Foreman::Exception.new(N_("invalid facts hash"))) unless name and values
+        name = facts["fqdn"].try(:downcase)
+        name ||= certname.downcase
+        values = facts
+        raise(::Foreman::Exception.new(N_("invalid facts hash"))) unless name and values
       else
-        return raise(::Foreman::Exception.new(N_("Invalid Facts, much be a Puppet::Node::Facts or a Hash")))
+        raise(::Foreman::Exception.new(N_("Invalid Facts, much be a Puppet::Node::Facts or a Hash")))
     end
 
     h = nil

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -345,11 +345,21 @@ class Host::Managed < Host::Base
     case facts
       when Puppet::Node::Facts
         certname = facts.name
-        name     = facts.values["fqdn"].downcase
+        if facts.values.has_key?("fqdn")
+            name     = facts.values["fqdn"].downcase
+        else
+            # Fall back to certname if host fqdn isn't set correctly
+            name     = certname.downcase
+        end
         values   = facts.values
       when Hash
         certname = facts["clientcert"] || facts["certname"]
-        name     = facts["fqdn"].downcase
+        if facts.values.has_key?("fqdn")
+            name     = facts.values["fqdn"].downcase
+        else
+            # Fall back to certname if host fqdn isn't set correctly
+            name     = certname.downcase
+        end
         values   = facts
         return raise(::Foreman::Exception.new(N_("invalid facts hash"))) unless name and values
       else

--- a/test/unit/facts_with_no_fqdn.yml
+++ b/test/unit/facts_with_no_fqdn.yml
@@ -1,0 +1,89 @@
+--- !ruby/object:Puppet::Node::Facts
+expiration: 2009-08-20 21:07:46.053586 +08:00
+name: siNN1636.lan
+values:
+  processor3: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  productname: "IBM System x -[7870K4G]-"
+  kernelmajversion: "2.6"
+  kernelversion: 2.6.32
+  macaddress_vnet0: FE:54:00:1E:45:13
+  macaddress_br181: E4:1F:13:CC:36:58
+  macaddress_usb0: E6:1F:13:D0:43:A3
+  macaddress_vnet1: FE:54:00:45:E5:3E
+  rubysitedir: /usr/lib/ruby/site_ruby/1.8
+  macaddress_br182: E4:1F:13:CC:36:58
+  processor4: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  macaddress_vnet2: FE:54:00:93:F5:56
+  macaddress_br183: E4:1F:13:CC:36:58
+  ps: ps -ef
+  processor5: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  macaddress_vnet10: FE:54:00:7D:F8:24
+  uniqueid: 230a021b
+  macaddress_vnet3: FE:54:00:05:49:DE
+  lsbdistcodename: Santiago
+  hardwareisa: x86_64
+  lsbdistrelease: "6.2"
+  processor6: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  serialnumber: abcdefg
+  processor7: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  macaddress_vnet4: FE:54:00:62:53:67
+  hostname: h02B
+  osfamily: RedHat
+  gateway_if: br180
+  lsbrelease: ":core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch"
+  kernelrelease: 2.6.32-131.12.1.el6.x86_64
+  kernel: Linux
+  facterversion: 1.6.2
+  uptime_seconds: 13651752
+  macaddress_vnet5: FE:54:00:01:B9:9C
+  interfaces: "br180,br181,br182,br183,eth0,eth0_181,eth0_182,eth0_183,eth1,lo,usb0,vnet0,vnet1,vnet2,vnet3,vnet4,vnet5,vnet7,vnet10"
+  macaddress_vnet7: FE:54:00:D8:F9:38
+  netmask_br180: 255.255.255.192
+  macaddress_eth0: E4:1F:13:CC:36:58
+  is_virtual: "false"
+  macaddress: E4:1F:13:CC:36:58
+  sshdsakey: AAAAB3NzaC1kc3MAAACBAIbK60jlhYKSd4Nx6LCQPMUZcq/P1lTY3sQVrwpmfbF7d4JOGed2RWSoTBAzP3/Tjwlf+8DZ3Jd8a6Yhd6WuBzinE+owym8LXo2gDTvelhnzOVrTytM8hAi8uFEiBTGbnN1zka2y7qCPVxEu+kV20qC3mPODGxpV6y/4KOZ5Y4SHAAAAFQCyjeF+Jy9CDhiD2tfnmtMGAn1xzQAAAIBwtnUhhkB0r3ivPdQZgVy6qha8AJQG94I9FU9FnGJJEjkkfqlgNrj9SxV6Cg9EcrntnAKxZxk7PQhgvDesx69Lap9PAx3Ffb5Pl47cd7ilOXv2RJGKuxZQHNdKUF2445POwNjxSuhEkIB3/zpFXBB/zPMRfqUtlXJEwP9m6z9UFgAAAIAQDBpmcGChFP7i8T2RdMZo3hSMnU4y5lpEGhmwfbODoLSAX37wWQwUmwRP8byTEqFL0+5bp3hRbt/67EoD1O6n39/We19g/UqHkbUdZQqLqFjJfyzqfepq4HXtIIT8GbqW+FGJkH9x2fY5gtQrn9nVdmPDTwERFS98qU9glufbIw==
+  uptime: 158 days
+  manufacturer: IBM
+  macaddress_eth1: E4:1F:13:CC:36:5A
+  timezone: GMT
+  ipaddress_br180: 10.35.27.2
+  puppetversion: 2.6.12
+  path: /root/.gem/bin:/root/.gem/ruby/1.8/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/sbin:/usr/sbin:/root/scripts
+  hardwaremodel: x86_64
+  macaddress_eth0_181: E4:1F:13:CC:36:58
+  netmask_lo: 255.0.0.0
+  uptime_days: 158
+  virtual: physical
+  operatingsystemrelease: "6.2"
+  processorcount: "8"
+  sshrsakey: AAAAB3NzaC1xcEabbAABIwAAAQEAwXfnuA0+6C6G152kzCbSZvTyUBrMwc0PGnmZgFpC3x4SkcMgRmtayPNqmY1vyYwyka1lNUoyU9u3TXOUkd7WrodoNYBbDQXWCAVpUci5099zUuZ8RVLcokKwNmQO0d1URgSLt2TtuLiUDB7JU2mHkoOuW9n7ODq+UzYsd2wf+/TQrvgsuyi25MROH2Z3WfMO+fmsj77h34gkuaavwB4e6lNRynjZLuEc4POFvDEW6kGCYm1g/8kRwUlB/Z1Cu0egxtxnTjILFFwfYFQu2Ksig020q1gLX3o4YL9X/YZz+JQuAOLGpK3F0owQUL7Ie3vokDsVmz2AweuLDFeh54i2Bw==
+  macaddress_eth0_182: E4:1F:13:CC:36:58
+  memorysize: 15.57 GB
+  ipaddress: 10.35.27.2
+  rubyversion: 1.8.7
+  macaddress_eth0_183: E4:1F:13:CC:36:58
+  physicalprocessorcount: 1
+  network_lo: 127.0.0.0
+  gateway: 10.35.27.62
+  lsbdistid: RedHatEnterpriseServer
+  network_br180: 10.35.27.0
+  lsbdistdescription: Red Hat Enterprise Linux Server release 6.2 (Santiago)
+  swapsize: 17.70 GB
+  processor0: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  processor1: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  macaddress_br180: E4:1F:13:CC:36:58
+  selinux: "false"
+  architecture: x86_64
+  uptime_hours: 3792
+  memoryfree: 6.87 GB
+  augeasversion: 0.9.0
+  operatingsystem: RedHat
+  ipaddress_lo: 127.0.0.1
+  processor2: Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz
+  type: Main Server Chassis
+  id: root
+  vlans: "181,182,183"
+  lsbmajdistrelease: "6"
+  swapfree: 16.72 GB
+  netmask: 255.255.255.192

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -78,6 +78,11 @@ class HostTest < ActiveSupport::TestCase
     assert Host.find_by_name('a.server.b.domain')
   end
 
+  test "should return downcased certname should no fqdn facts exist from yaml of a new host" do
+    assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts_with_no_fqdn.yml")))
+    assert Host.find_by_name('a.server.b.domain')
+  end
+
   test "should import facts idempotently" do
     assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.yml")))
     value_ids = Host.find_by_name('a.server.b.domain').fact_values.map(&:id)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -78,9 +78,9 @@ class HostTest < ActiveSupport::TestCase
     assert Host.find_by_name('a.server.b.domain')
   end
 
-  test "should return downcased certname should no fqdn facts exist from yaml of a new host" do
+  test "should return downcased certname when fqdn fact doesn't exist" do
     assert Host.importHostAndFacts(File.read(File.expand_path(File.dirname(__FILE__) + "/facts_with_no_fqdn.yml")))
-    assert Host.find_by_name('a.server.b.domain')
+    assert Host.find_by_name('sinn1636.lan')
   end
 
   test "should import facts idempotently" do


### PR DESCRIPTION
When submitting facts to the foreman API, if the facts yaml
doesn't have a FQDN, the lowercasing of the FQDN will fail
