### PR TITLE
fixes #2933 - Installation media API misses some features

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -44,6 +44,7 @@ Available families:
         param :name, String, :required => true, :desc => "Name of media"
         param :path, String, :required => true, :desc => PATH_INFO
         param :os_family, String, :require => false, :desc => OS_FAMILY_INFO
+        param :operatingsystem_ids, Array, :require => false
       end
 
       def create
@@ -56,6 +57,7 @@ Available families:
         param :name, String, :desc => "Name of media"
         param :path, String, :desc => PATH_INFO
         param :os_family, String, :allow_nil => true, :desc => OS_FAMILY_INFO
+        param :operatingsystem_ids, Array, :require => false
       end
       api :PUT, "/media/:id/", "Update a medium."
 

--- a/app/views/api/v1/media/show.json.rabl
+++ b/app/views/api/v1/media/show.json.rabl
@@ -1,6 +1,6 @@
 object @medium
 
-attributes :id, :name, :path
+attributes :id, :name, :path, :os_family, :created_at, :updated_at, :operatingsystem_ids
 
 node do |medium|
   if medium.os_family == 'Solaris'


### PR DESCRIPTION
- added missing fields to show rabl
- apipie params for os ids
