### PR TITLE
added ldap_filter to ldap auth sources to filter login lookups

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -21,9 +21,10 @@ class AuthSourceLdap < AuthSource
   validates_presence_of :host, :port
   validates_presence_of :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :if => Proc.new { |auth| auth.onthefly_register? }
   validates_length_of :name, :host, :account_password, :maximum => 60, :allow_nil => true
-  validates_length_of :account, :base_dn, :maximum => 255, :allow_nil => true
+  validates_length_of :account, :base_dn, :ldap_filter, :maximum => 255, :allow_nil => true
   validates_length_of :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :maximum => 30, :allow_nil => true
   validates_numericality_of :port, :only_integer => true
+  validate :validate_ldap_filter, :unless => Proc.new { |auth| auth.ldap_filter.blank? }
 
   before_validation :strip_ldap_attributes
   after_initialize :set_defaults
@@ -123,12 +124,19 @@ class AuthSourceLdap < AuthSource
     end]
   end
 
+  def validate_ldap_filter
+    Net::LDAP::Filter.construct(ldap_filter)
+  rescue Net::LDAP::LdapError => text
+    errors.add(:base, _("invalid LDAP filter syntax"))
+  end
+
   def search_for_user_entries(login, password)
     user          = effective_user(login)
     pass          = use_user_login_for_auth? ? password : account_password
     ldap_con      = initialize_ldap_con(user, pass)
     login_filter  = Net::LDAP::Filter.eq(attr_login, login)
     object_filter = Net::LDAP::Filter.eq("objectClass", "*")
+    object_filter = object_filter & Net::LDAP::Filter.construct(ldap_filter) unless ldap_filter.blank?
 
     # search for a match for our authenticating user.
     entries       = ldap_con.search(:base       => base_dn,

--- a/app/views/api/v1/auth_source_ldaps/show.json.rabl
+++ b/app/views/api/v1/auth_source_ldaps/show.json.rabl
@@ -1,3 +1,3 @@
 object @auth_source_ldap
 
-attributes :id, :type, :name, :host, :port, :account, :base_dn, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :onthefly_register, :tls, :created_at, :updated_at
+attributes :id, :type, :name, :host, :port, :account, :base_dn, :ldap_filter, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :onthefly_register, :tls, :created_at, :updated_at

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -10,7 +10,8 @@
   <%= text_f f, :account, :help_inline =>_("Use this account to authenticate, <i>optional</i>").html_safe %>
   <%= password_f f, :account_password, :help_inline => _("Use this account to authenticate, <i>optional</i>").html_safe %>
   <%= text_f f, :base_dn, :label => "basedn", :class => "input-xxlarge" %>
-  <%= checkbox_f f, :onthefly_register,
+  <%= text_f f, :ldap_filter, :help_inline => _("Custom LDAP Search Filter, <i>optional</i>").html_safe, :class => "input-xxlarge" %>
+    <%= checkbox_f f, :onthefly_register,
     :help_inline => _("LDAP users will have their Foreman account automatically created the first time they log into Foreman") %>
   <%= field_set_tag(_("LDAP Attributes mapping")) do %>
     <%= text_f f, :attr_login, :help_inline => _("e.g. uid") %>

--- a/db/migrate/20130814132531_add_ldap_filter_to_auth_sources.rb
+++ b/db/migrate/20130814132531_add_ldap_filter_to_auth_sources.rb
@@ -1,0 +1,5 @@
+class AddLdapFilterToAuthSources < ActiveRecord::Migration
+  def change
+    add_column :auth_sources, :ldap_filter, :string, :limit => 255, :null => true
+  end
+end

--- a/test/fixtures/auth_sources.yml
+++ b/test/fixtures/auth_sources.yml
@@ -7,6 +7,7 @@ one:
   account: 
   account_password: 
   base_dn: dn=x,dn=y
+  ldap_filter:
   attr_login: uid
   attr_firstname: givenName
   attr_lastname: sn

--- a/test/unit/auth_source_ldap_test.rb
+++ b/test/unit/auth_source_ldap_test.rb
@@ -77,6 +77,12 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     assert !@auth_source_ldap.save
   end
 
+  test "the ldap_filter should not exceed the 255 characters" do
+    set_all_required_attributes
+    assigns_a_string_of_length_greater_than(255, :ldap_filter=)
+    assert !@auth_source_ldap.save
+  end
+
   test "the attr_login should not exceed the 30 characters" do
     missing(:attr_login=)
     assigns_a_string_of_length_greater_than(30, :attr_login=)
@@ -108,6 +114,25 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
 
     @auth_source_ldap.port = 123
     assert @auth_source_ldap.save
+  end
+
+  test "invalid ldap_filter fails validation" do
+    @auth_source_ldap.ldap_filter = "("
+    assert !@auth_source_ldap.valid?
+  end
+
+  test "valid ldap_filter passes validation" do
+    missing(:ldap_filter)
+    assert @auth_source_ldap.valid?
+
+    @auth_source_ldap.ldap_filter = ""
+    assert @auth_source_ldap.valid?
+
+    @auth_source_ldap.ldap_filter = "   "
+    assert @auth_source_ldap.valid?
+
+    @auth_source_ldap.ldap_filter = "key=value"
+    assert @auth_source_ldap.valid?
   end
 
   test "should strip the ldap attributes before validate" do


### PR DESCRIPTION
implements http://projects.theforeman.org/issues/863

You can now use filters like:

(&(memberOf=CN=ForemanUsers,OU=Groups,DC=some,DC=domain)(memberOf=CN=AdminUsers,OU=Groups,DC=some,DC=domain)) 

or simply memberOf=CN=ForemanUsers,OU=Groups,DC=some,DC=domain

Maybe an input valitdation using validates in combination with Net::LDAP::Filter.construct might me useful, too.
