### PR TITLE
add selectable network device model for libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -58,6 +58,7 @@ module Foreman::Model
     end
 
     def new_nic attr={ }
+      attr = { :model => 'virtio' }.merge(attr)
       client.nics.new attr
     end
 

--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -22,4 +22,6 @@
       <%= text_f f, :bridge, :class => "span2", :label => _("Network"), :help_block => _("your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)") -%>
     <% end -%>
   </div>
+  <%= selectable_f f, :model, ['ne2k_pci','i82551','i82557b','i82559er','rtl8139','e1000','pcnet','virtio'], {},
+                   { :label => _('NIC Model'), :class => 'span2' } %>
 </div>


### PR DESCRIPTION
defaults to 'virtio'

I needed this in my own setup because virtio was being buggy and would
crash my apt mirror VM. switching to e1000 fixed.

I don't particularly care for the device models being hardcoded. I would
of course prefer that it be queried from the libvirt itself, but I don't
see a way to do that.

So, the list I compiled is the list from my personal system. Maybe this
should be a Setting somewhere?

The list was generated via the commands fonud here:
http://libvirt.org/formatdomain.html#elementsNICSModel

I ran it on an ubuntu 13.04 Craring) machine
