### PR TITLE
fixes 2764: settings defined in seetings.yaml file are now read-only

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -310,6 +310,20 @@ module ApplicationHelper
     "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=mm&s=30"
   end
 
+  def readonly_field(object, property, options={})
+    name       = "#{type}[#{property}]"
+    helper     = options[:helper]
+    value      = helper.nil? ? object.send(property) : self.send(helper, object)
+    klass      = options[:type]
+    title      = options[:title]
+
+    opts = { :title => title, :class => klass.to_s, :name => name, :value => value}
+
+    content_tag_for :span, object, opts do
+      h(value)
+    end
+  end
+
   private
   def edit_inline(object, property, options={})
     name       = "#{type}[#{property}]"
@@ -324,7 +338,6 @@ module ApplicationHelper
     content_tag_for :span, object, opts do
       h(value)
     end
-
   end
 
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,6 +1,12 @@
 module SettingsHelper
 
   def value setting
+    if setting.readonly?
+      return readonly_field(
+          setting, :value,
+          {:title => _("This setting is defined in the configuration file 'settings.yaml' and is read-only."), :helper => :show_value})
+    end
+
     case setting.settings_type
     when "boolean"
       edit_select(setting, :value, {:select_values => {:true => "true", :false => "false"}.to_json } )

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -7,23 +7,19 @@ class Setting::Auth < Setting
 
     fqdn = Facter.fqdn
     self.transaction do
-      [
-        self.set('oauth_active', N_("Should foreman use OAuth for authorization in API"), false),
-        self.set('oauth_consumer_key', N_("OAuth consumer key"), 'katello'),
-        self.set('oauth_consumer_secret', N_("OAuth consumer secret"), 'shhhh'),
-        self.set('oauth_map_users', N_("Should foreman map users by username in request-header"), true),
-        self.set('restrict_registered_puppetmasters', N_('Only known Smart Proxies with the Puppet feature can access fact/report importers and ENC output'), true),
-        self.set('require_ssl_puppetmasters', N_('Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)'), true),
-        self.set('trusted_puppetmaster_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), []),
-        self.set('ssl_client_dn_env', N_('Environment variable containing the subject DN from a client SSL certificate'), 'SSL_CLIENT_S_DN'),
-        self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY'),
-        self.set('signo_sso', N_('Use Signo SSO for login'), false),
-        self.set('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo")
-      ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
+        Setting::Auth.init_on_startup!('oauth_active', N_("Should foreman use OAuth for authorization in API"), false)
+        Setting::Auth.init_on_startup!('oauth_consumer_key', N_("OAuth consumer key"), 'katello')
+        Setting::Auth.init_on_startup!('oauth_consumer_secret', N_("OAuth consumer secret"), 'shhhh')
+        Setting::Auth.init_on_startup!('oauth_map_users', N_("Should foreman map users by username in request-header"), true)
+        Setting::Auth.init_on_startup!('restrict_registered_puppetmasters', N_('Only known Smart Proxies with the Puppet feature can access fact/report importers and ENC output'), true)
+        Setting::Auth.init_on_startup!('require_ssl_puppetmasters', N_('Client SSL certificates are used to identify Smart Proxies accessing fact/report importers and ENC output over HTTPS (:require_ssl should also be enabled)'), true)
+        Setting::Auth.init_on_startup!('trusted_puppetmaster_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [])
+        Setting::Auth.init_on_startup!('ssl_client_dn_env', N_('Environment variable containing the subject DN from a client SSL certificate'), 'SSL_CLIENT_S_DN')
+        Setting::Auth.init_on_startup!('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY')
+        Setting::Auth.init_on_startup!('signo_sso', N_('Use Signo SSO for login'), false)
+        Setting::Auth.init_on_startup!('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo")
     end
-
     true
-
   end
 
 end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -7,21 +7,17 @@ class Setting::General < Setting
 
     self.transaction do
       domain = Facter.domain
-      [
-        self.set('administrator', N_("The default administrator email address"), "root@#{domain}"),
-        self.set('foreman_url', N_(  "The hostname where your Foreman instance is reachable"), "foreman.#{domain}"),
-        self.set('email_reply_address', N_("The email reply address for emails that Foreman is sending"), "Foreman-noreply@#{domain}"),
-        self.set('entries_per_page', N_("The amount of records shown per page in Foreman"), 20),
-        self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"),false),
-        self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"),false),
-        self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"),60),
-        self.set('max_trend', N_("Max days for Trends graphs"),30),
-        self.set('use_gravatar', N_("Should Foreman use gravatar to display user icons"),true)
-      ].each { |s| self.create! s.update(:category => "Setting::General")}
+      Setting::General.init_on_startup!('administrator', N_("The default administrator email address"), "root@#{domain}")
+      Setting::General.init_on_startup!('foreman_url', N_(  "The hostname where your Foreman instance is reachable"), "foreman.#{domain}")
+      Setting::General.init_on_startup!('email_reply_address', N_("The email reply address for emails that Foreman is sending"), "Foreman-noreply@#{domain}")
+      Setting::General.init_on_startup!('entries_per_page', N_("The amount of records shown per page in Foreman"), 20)
+      Setting::General.init_on_startup!('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"),false)
+      Setting::General.init_on_startup!('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"),false)
+      Setting::General.init_on_startup!('idle_timeout', N_("Log out idle users after a certain number of minutes"),60)
+      Setting::General.init_on_startup!('max_trend', N_("Max days for Trends graphs"),30)
+      Setting::General.init_on_startup!('use_gravatar', N_("Should Foreman use gravatar to display user icons"),true)
     end
-
     true
-
   end
 
 end

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -7,24 +7,19 @@ class Setting::Provisioning < Setting
 
     ppsettings = PuppetSetting.new.get :hostcert, :localcacert, :hostprivkey, :storeconfigs
     self.transaction do
-      [
-        self.set('root_pass', N_("Default encrypted root password on provisioned hosts (default is 123123)"), "xybxa6JUkz63w"),
-        self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true),
-        self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ppsettings[:hostcert]),
-        self.set('ssl_ca_file', N_( "SSL CA file that Foreman will use to communicate with its proxies"), ppsettings[:localcacert]),
-        self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ppsettings[:hostprivkey]),
-        self.set('manage_puppetca', N_("Should Foreman automate certificate signing upon provisioning new host"), true),
-        self.set('ignore_puppet_facts_for_provisioning', N_("Does not update ipaddress and MAC values from Puppet facts"), false),
-        self.set('query_local_nameservers', N_("Should Foreman query the locally configured name server or the SOA/NS authorities"), false),
-        self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1"),
-        self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0),
-        self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0"),
-        self.set('update_ip_from_built_request', N_("Should we use the originating IP of the built request to update the host's IP?"), false)
-      ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
+      Setting::Provisioning.init_on_startup!('root_pass', N_("Default encrypted root password on provisioned hosts (default is 123123)"), "xybxa6JUkz63w")
+      Setting::Provisioning.init_on_startup!('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true)
+      Setting::Provisioning.init_on_startup!('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ppsettings[:hostcert])
+      Setting::Provisioning.init_on_startup!('ssl_ca_file', N_( "SSL CA file that Foreman will use to communicate with its proxies"), ppsettings[:localcacert])
+      Setting::Provisioning.init_on_startup!('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ppsettings[:hostprivkey])
+      Setting::Provisioning.init_on_startup!('manage_puppetca', N_("Should Foreman automate certificate signing upon provisioning new host"), true)
+      Setting::Provisioning.init_on_startup!('ignore_puppet_facts_for_provisioning', N_("Does not update ipaddress and MAC values from Puppet facts"), false)
+      Setting::Provisioning.init_on_startup!('query_local_nameservers', N_("Should Foreman query the locally configured name server or the SOA/NS authorities"), false)
+      Setting::Provisioning.init_on_startup!('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1")
+      Setting::Provisioning.init_on_startup!('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0)
+      Setting::Provisioning.init_on_startup!('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0")
+      Setting::Provisioning.init_on_startup!('update_ip_from_built_request', N_("Should we use the originating IP of the built request to update the host's IP?"), false)
     end
-
     true
-
   end
-
 end

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -9,30 +9,24 @@ class Setting::Puppet < Setting
     param_enc = Gem::Version.new(Facter.puppetversion.split('-').first) >= Gem::Version.new('2.6.5')
     ppsettings = PuppetSetting.new.get :storeconfigs
     self.transaction do
-      [
-        self.set('puppet_interval', N_("Puppet interval in minutes"), 30 ),
-        self.set('default_puppet_environment', N_("The Puppet environment Foreman will default to in case it can't auto detect it"), "production"),
-        self.set('modulepath',N_("The Puppet default module path in case Foreman can't auto detect it"), "/etc/puppet/modules"),
-        self.set('document_root', N_("Document root where puppetdoc files should be created"), "#{Rails.root}/public/puppet/rdoc"),
-        self.set('puppetrun', N_("Enables Puppetrun support"), false),
-        self.set('puppet_server', N_("Default Puppet server hostname"), "puppet"),
-        self.set('failed_report_email_notification', N_("Enable Email alerts per each failed Puppet report"), false),
-        self.set('using_storeconfigs', N_("Foreman is sharing its database with Puppet Store configs"), ppsettings[:storeconfigs] == 'true'),
-        self.set('Default_variables_Lookup_Path', N_("The Default path in which Foreman resolves host specific variables"), ["fqdn", "hostgroup", "os", "domain"]),
-        self.set('Enable_Smart_Variables_in_ENC', N_("Should the smart variables be exposed via the ENC yaml output?"), true),
-        self.set('Parametrized_Classes_in_ENC', N_("Should Foreman use the new format (2.6.5+) to answer Puppet in its ENC yaml output?"), param_enc),
-        self.set('enc_environment', N_("Should Foreman provide puppet environment in ENC yaml output? (this avoids the mismatch error between puppet.conf and ENC environment)"), true),
-        self.set('use_uuid_for_certificates', N_("Should Foreman use random UUID's for certificate signing instead of hostnames"), false),
-        self.set('update_environment_from_facts', N_("Should Foreman update a host's environment from its facts"), false),
-        self.set('remove_classes_not_in_environment', N_("When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"), false),
-        self.set('host_group_matchers_inheritance', N_("Should Foreman use host group ancestors matchers to set puppet classes parameters values"), true),
-        self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true)
-      ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
-
+      Setting::Puppet.init_on_startup!('puppet_interval', N_("Puppet interval in minutes"), 30 )
+      Setting::Puppet.init_on_startup!('default_puppet_environment', N_("The Puppet environment Foreman will default to in case it can't auto detect it"), "production")
+      Setting::Puppet.init_on_startup!('modulepath',N_("The Puppet default module path in case Foreman can't auto detect it"), "/etc/puppet/modules")
+      Setting::Puppet.init_on_startup!('document_root', N_("Document root where puppetdoc files should be created"), "#{Rails.root}/public/puppet/rdoc")
+      Setting::Puppet.init_on_startup!('puppetrun', N_("Enables Puppetrun support"), false)
+      Setting::Puppet.init_on_startup!('puppet_server', N_("Default Puppet server hostname"), "puppet")
+      Setting::Puppet.init_on_startup!('failed_report_email_notification', N_("Enable Email alerts per each failed Puppet report"), false)
+      Setting::Puppet.init_on_startup!('using_storeconfigs', N_("Foreman is sharing its database with Puppet Store configs"), ppsettings[:storeconfigs] == 'true')
+      Setting::Puppet.init_on_startup!('Default_variables_Lookup_Path', N_("The Default path in which Foreman resolves host specific variables"), ["fqdn", "hostgroup", "os", "domain"])
+      Setting::Puppet.init_on_startup!('Enable_Smart_Variables_in_ENC', N_("Should the smart variables be exposed via the ENC yaml output?"), true)
+      Setting::Puppet.init_on_startup!('Parametrized_Classes_in_ENC', N_("Should Foreman use the new format (2.6.5+) to answer Puppet in its ENC yaml output?"), param_enc)
+      Setting::Puppet.init_on_startup!('enc_environment', N_("Should Foreman provide puppet environment in ENC yaml output? (this avoids the mismatch error between puppet.conf and ENC environment)"), true)
+      Setting::Puppet.init_on_startup!('use_uuid_for_certificates', N_("Should Foreman use random UUID's for certificate signing instead of hostnames"), false)
+      Setting::Puppet.init_on_startup!('update_environment_from_facts', N_("Should Foreman update a host's environment from its facts"), false)
+      Setting::Puppet.init_on_startup!('remove_classes_not_in_environment', N_("When host and host group have different environments should all classes be included (regardless if they exists or not in the other environment)"), false)
+      Setting::Puppet.init_on_startup!('host_group_matchers_inheritance', N_("Should Foreman use host group ancestors matchers to set puppet classes parameters values"), true)
+      Setting::Puppet.init_on_startup!('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true)
       true
-
     end
-
   end
-
 end


### PR DESCRIPTION
I'm not entirely sure what to do about the current behaviour for settings defined in the configuration file -- they are used to set default values. 
- Should this behaviour be preserved? I think it's awkward.
- If we want to use the configuration file to set default values, should those be updated when configuration file changes? I think so, as this would be less confusing than current semantic (default value can only be set once).
