### PR TITLE
fixes #2951 - Host API documentation lacks compute_resource_id

### DIFF
--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -22,23 +22,32 @@ module Api
       api :POST, "/hosts/", "Create a host."
       param :host, Hash, :required => true do
         param :name, String, :required => true
-        param :environment_id, String, :required => true
+        param :environment_id, String
         param :ip, String, :desc => "not required if using a subnet with dhcp proxy"
         param :mac, String, :desc => "not required if its a virtual machine"
-        param :architecture_id, :number, :required => true
-        param :domain_id, :number, :required => true
-        param :puppet_proxy_id, :number, :required => true
-        param :operatingsystem_id, String, :required => true
+        param :architecture_id, :number
+        param :domain_id, :number
+        param :puppet_proxy_id, :number
+        param :puppet_class_ids, Array
+        param :operatingsystem_id, String
         param :medium_id, :number
         param :ptable_id, :number
         param :subnet_id, :number
+        param :compute_resource_id, :number
         param :sp_subnet_id, :number
-        param :model_id_id, :number
+        param :model_id, :number
         param :hostgroup_id, :number
         param :owner_id, :number
         param :puppet_ca_proxy_id, :number
         param :image_id, :number
         param :host_parameters_attributes, Array
+        param :build, :bool
+        param :enabled, :bool
+        param :provision_method, String
+        param :managed, :bool
+        param :capabilities, String
+        param :compute_attributes, Hash do
+        end
       end
 
       def create
@@ -59,16 +68,25 @@ module Api
         param :domain_id, :number
         param :puppet_proxy_id, :number
         param :operatingsystem_id, String
+        param :puppet_class_ids, Array
         param :medium_id, :number
         param :ptable_id, :number
         param :subnet_id, :number
+        param :compute_resource_id, :number
         param :sp_subnet_id, :number
-        param :model_id_id, :number
+        param :model_id, :number
         param :hostgroup_id, :number
         param :owner_id, :number
         param :puppet_ca_proxy_id, :number
         param :image_id, :number
         param :host_parameters_attributes, Array
+        param :build, :bool
+        param :enabled, :bool
+        param :provision_method, String
+        param :managed, :bool
+        param :capabilities, String
+        param :compute_attributes, Hash do
+        end
       end
 
       def update

--- a/app/views/api/v1/hosts/show.json.rabl
+++ b/app/views/api/v1/hosts/show.json.rabl
@@ -5,7 +5,7 @@ attributes :name, :id, :ip, :environment_id, :last_report, :updated_at, :created
            :environment_id, :subnet_id, :sp_subnet_id, :ptable_id, :medium_id, :build,
            :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_type,
            :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id,
-           :puppet_proxy_id, :certname, :image_id,
+           :puppet_proxy_id, :certname, :image_id, :created_at, :updated_at,
            :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status, :root_pass
 
 if SETTINGS[:organizations_enabled]

--- a/test/functional/api/v1/hosts_controller_test.rb
+++ b/test/functional/api/v1/hosts_controller_test.rb
@@ -3,14 +3,15 @@ require 'test_helper'
 class Api::V1::HostsControllerTest < ActionController::TestCase
 
   def valid_attrs
-    { :name               => 'testhost11',
-      :environment_id     => environments(:production).id,
-      :domain_id          => domains(:mydomain).id,
-      :ip                 => '10.0.0.20',
-      :mac                => '52:53:00:1e:85:93',
-      :architecture_id    => Architecture.find_by_name('x86_64').id,
-      :operatingsystem_id => Operatingsystem.find_by_name('Redhat').id,
-      :puppet_proxy_id    => smart_proxies(:one).id
+    { :name                => 'testhost11',
+      :environment_id      => environments(:production).id,
+      :domain_id           => domains(:mydomain).id,
+      :ip                  => '10.0.0.20',
+      :mac                 => '52:53:00:1e:85:93',
+      :architecture_id     => Architecture.find_by_name('x86_64').id,
+      :operatingsystem_id  => Operatingsystem.find_by_name('Redhat').id,
+      :puppet_proxy_id     => smart_proxies(:one).id,
+      :compute_resource_id => compute_resources(:one).id
     }
   end
 


### PR DESCRIPTION
- added timestamps to show
- added all missing params (I was able to figure out) to create/update 
