### PR TITLE
fixes #3005 - restrict gettext to Ruby 1.8 compatible version

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -10,5 +10,5 @@ group :assets do
   gem "flot-rails", '0.0.3'
   gem "quiet_assets"
   gem 'gettext_i18n_rails_js', '>= 0.0.8'
-  gem 'gettext', '>= 1.9.3', :require => false
+  gem 'gettext', '~> 2.0', :require => false
 end

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -5,5 +5,5 @@ group :development do
 #  gem 'rack-mini-profiler'
 
   # for generating i18n files
-  gem 'gettext', '>= 1.9.3', :require => false
+  gem 'gettext', '~> 2.0', :require => false
 end


### PR DESCRIPTION
Tests aren't going to run for this as test_develop's broken.
