### PR TITLE
fixes #2986 - remove #show method from controllers and routes.rb when not used

### DIFF
--- a/app/controllers/architectures_controller.rb
+++ b/app/controllers/architectures_controller.rb
@@ -1,6 +1,6 @@
 class ArchitecturesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_by_name, :only => %w{show edit update destroy}
+  before_filter :find_by_name, :only => %w{edit update destroy}
 
   def index
     @architectures = Architecture.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :include => :operatingsystems)
@@ -8,9 +8,6 @@ class ArchitecturesController < ApplicationController
 
   def new
     @architecture = Architecture.new
-  end
-
-  def show
   end
 
   def create

--- a/app/controllers/auth_source_ldaps_controller.rb
+++ b/app/controllers/auth_source_ldaps_controller.rb
@@ -3,10 +3,6 @@ class AuthSourceLdapsController < ApplicationController
     @auth_source_ldaps = AuthSourceLdap.all
   end
 
-  def show
-    @auth_source_ldap = AuthSourceLdap.find(params[:id])
-  end
-
   def new
     @auth_source_ldap = AuthSourceLdap.new
   end

--- a/app/controllers/config_templates_controller.rb
+++ b/app/controllers/config_templates_controller.rb
@@ -2,7 +2,7 @@ class ConfigTemplatesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Renderer
 
-  before_filter :find_by_id, :only => [:show, :edit, :update, :destroy]
+  before_filter :find_by_id, :only => [:edit, :update, :destroy]
   before_filter :load_history, :only => :edit
   before_filter :handle_template_upload, :only => [:create, :update]
 
@@ -18,10 +18,6 @@ class ConfigTemplatesController < ApplicationController
 
   def new
     @config_template = ConfigTemplate.new
-  end
-
-  def show
-    return not_found
   end
 
   def create

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,6 +1,6 @@
 class DomainsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_by_name, :only => %w{show edit update destroy}
+  before_filter :find_by_name, :only => %w{edit update destroy}
 
   def index
     @domains = Domain.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
@@ -10,9 +10,6 @@ class DomainsController < ApplicationController
   def new
     @domain = Domain.new
     @domain.domain_parameters.build
-  end
-
-  def show
   end
 
   def create

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -2,14 +2,11 @@ class EnvironmentsController < ApplicationController
   include Foreman::Controller::Environments
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_by_name, :only => %w{show edit update destroy}
+  before_filter :find_by_name, :only => %w{edit update destroy}
 
   def index
     @environments = Environment.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
     @counter      = Host.count(:group => :environment_id, :conditions => {:environment_id => @environments.all})
-  end
-
-  def show
   end
 
   def new

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -2,7 +2,7 @@ class HostgroupsController < ApplicationController
   include Foreman::Controller::HostDetails
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_hostgroup, :only => [:show, :edit, :update, :destroy, :clone]
+  before_filter :find_hostgroup, :only => [:edit, :update, :destroy, :clone]
 
   def index
     begin
@@ -49,11 +49,6 @@ class HostgroupsController < ApplicationController
     @hostgroup = new
     notice _("The following fields would need reviewing")
     render :action => :new
-  end
-
-  def show
-    auth  = User.current.admin? ? true : Hostgroup.my_groups.include?(@hostgroup)
-    not_found and return unless auth
   end
 
   def create

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -10,9 +10,6 @@ class ImagesController < ApplicationController
     @image = Image.new
   end
 
-  def show
-  end
-
   def create
     @image = Image.new(params[:image])
     if @image.save

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,6 @@
 class MediaController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_medium, :only => %w{show edit update destroy}
+  before_filter :find_medium, :only => %w{edit update destroy}
 
   def index
     @media = Medium.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :include => [:operatingsystems])

--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -1,6 +1,6 @@
 class OperatingsystemsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_os, :only => %w{show edit update destroy bootfiles}
+  before_filter :find_os, :only => %w{edit update destroy bootfiles}
 
   def index
     @operatingsystems = Operatingsystem.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/ptables_controller.rb
+++ b/app/controllers/ptables_controller.rb
@@ -1,6 +1,6 @@
 class PtablesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_ptable, :only => %w{show edit update destroy}
+  before_filter :find_ptable, :only => %w{edit update destroy}
 
   def index
     @ptables = Ptable.search_for(params[:search], :order => params[:order]).paginate :page => params[:page], :include => [:operatingsystems]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,13 +76,12 @@ Foreman::Application.routes.draw do
         resources :audits        ,:only => :index
         resources :facts         ,:only => :index, :controller => :fact_values
         resources :puppetclasses ,:only => :index
-        resources :lookup_keys   ,:only => :show
       end
     end
 
 
     resources :bookmarks, :except => [:show]
-    resources :lookup_keys, :except => [:new, :create] do
+    resources :lookup_keys, :except => [:show, :new, :create] do
       resources :lookup_values, :only => [:index, :create, :update, :destroy]
       collection do
         get 'auto_complete_search'
@@ -102,12 +101,12 @@ Foreman::Application.routes.draw do
       get 'auto_complete_search'
     end
   end
-  resources :common_parameters do
+  resources :common_parameters, :except => [:show] do
     collection do
       get 'auto_complete_search'
     end
   end
-  resources :environments do
+  resources :environments, :except => [:show] do
     collection do
       get 'import_environments'
       post 'obsolete_and_new'
@@ -120,7 +119,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :hostgroups do
+  resources :hostgroups, :except => [:show] do
     member do
       get 'nest'
       get 'clone'
@@ -137,7 +136,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :puppetclasses do
+  resources :puppetclasses, :except => [:show] do
     collection do
       get 'import_environments'
       post 'obsolete_and_new'
@@ -177,7 +176,7 @@ Foreman::Application.routes.draw do
   end
 
   if SETTINGS[:login]
-    resources :usergroups
+    resources :usergroups, :except => [:show]
     resources :users, :except => [:show] do
       collection do
         get 'login'
@@ -187,7 +186,7 @@ Foreman::Application.routes.draw do
         get 'auto_complete_search'
       end
     end
-    resources :roles do
+    resources :roles, :except => [:show] do
       collection do
         get 'report'
         post 'report'
@@ -195,11 +194,11 @@ Foreman::Application.routes.draw do
       end
     end
 
-    resources :auth_source_ldaps
+    resources :auth_source_ldaps, :except => [:show]
   end
 
   if SETTINGS[:unattended]
-    resources :config_templates do
+    resources :config_templates, :except => [:show] do
       collection do
         get 'auto_complete_search'
         get 'build_pxe_default'
@@ -207,14 +206,14 @@ Foreman::Application.routes.draw do
       end
     end
     constraints(:id => /[^\/]+/) do
-      resources :domains do
+      resources :domains, :except => [:show] do
         collection do
           get 'auto_complete_search'
         end
       end
     end
 
-    resources :operatingsystems do
+    resources :operatingsystems, :except => [:show] do
       member do
         get 'bootfiles'
       end
@@ -222,25 +221,25 @@ Foreman::Application.routes.draw do
         get 'auto_complete_search'
       end
     end
-    resources :media do
+    resources :media, :except => [:show] do
       collection do
         get 'auto_complete_search'
       end
     end
 
-    resources :models do
+    resources :models, :except => [:show] do
       collection do
         get 'auto_complete_search'
       end
     end
 
-    resources :architectures do
+    resources :architectures, :except => [:show] do
       collection do
         get 'auto_complete_search'
       end
     end
 
-    resources :ptables do
+    resources :ptables, :except => [:show] do
       collection do
         get 'auto_complete_search'
       end
@@ -269,7 +268,7 @@ Foreman::Application.routes.draw do
           get 'provider_selected'
           put  'test_connection'
         end
-        resources :images
+        resources :images, :except => [:show]
       end
     end
 


### PR DESCRIPTION
Merge for 1.4.  This breaks api deprecation message for several show actions is it causes ActionController::RoutingError
