### PR TITLE
fix space before parenthesis warning

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -205,7 +205,7 @@ class HostsController < ApplicationController
   end
 
   def power
-    return invalid_request unless PowerManager::SUPPORTED_ACTIONS.include? (params[:power_action])
+    return invalid_request unless PowerManager::SUPPORTED_ACTIONS.include?(params[:power_action])
     @host.power.send(params[:power_action].to_sym)
     process_success :success_redirect => :back, :success_msg => _("%{host} is now %{state}") % { :host => @host, :state => _(@host.power.state) }
   rescue => e


### PR DESCRIPTION
This is the most trivial pull request ever, but I was getting this warning in my apache passenger logs on startup:

```
hosts_controller.rb:210: warning: don't put space before argument parentheses
```

removed the space and now no complaints.  I'm running ruby 1.8.7 on CentOS 6.4, puppet 3.1.1.
