### PR TITLE
Feature #3088 Allow user to select thick and thin provision for vSphere volumes

### DIFF
--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -3,6 +3,11 @@
   <%= text_f f, :name, :class => "input-mini", :label => "Name" %>
   <%= text_f f, :size_gb,
              :class       => "input-mini",
-             :label       => _("Size (GB)"),
-             :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) %>
+             :label       => _("Size (GB)") %>
+  <%= checkbox_f f, :thin, {
+             :checked => true,
+             :label => _("Thin Provision"),
+             :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-important' }) },
+             true,
+             false %>
 </div>

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -3769,6 +3769,9 @@ msgstr ""
 msgid "These two options are personal decisions and are up to you (where the main difference would be the parameter/variables settings)."
 msgstr ""
 
+msgid "Thin Provision"
+msgstr ""
+
 msgid "This Puppet class has no parameters in its signature."
 msgstr ""
 


### PR DESCRIPTION
Fog does create thin provisioned volumes by default but supports this functionality. This easily implemented checkbox enables the user to choose betwen thick and thin provision. Compatible with Foreman 1.2
