### PR TITLE
fixes #3091 - strip leading and trailing whitespace before_save on names of all objects

### DIFF
--- a/app/models/concerns/strip_whitespace.rb
+++ b/app/models/concerns/strip_whitespace.rb
@@ -1,0 +1,20 @@
+module StripWhitespace
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :strip_spaces
+  end
+
+  def strip_spaces
+    self.changes.each do |column, values|
+      # return string if RuntimeError: can't modify frozen String
+      self.send(column).strip! if (values.last.kind_of?(String) && !skip_strip_attrs.include?(column)) rescue send(column)
+    end
+  end
+
+  # default empty array - overwrite in each model for specific string fields that should not be .strip!
+  def skip_strip_attrs
+    []
+  end
+
+end

--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -134,6 +134,10 @@ class ConfigTemplate < ActiveRecord::Base
     return [200, _("PXE Default file has been deployed to all Smart Proxies")]
   end
 
+  def skip_strip_attrs
+    ['template']
+  end
+
   private
 
   # check if our template is a snippet, and remove its associations just in case they were selected.

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -3,6 +3,7 @@ class Hostgroup < ActiveRecord::Base
   include Authorization
   include Taxonomix
   include HostCommon
+
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many :hostgroup_classes, :dependent => :destroy
   has_many :puppetclasses, :through => :hostgroup_classes

--- a/app/models/key_pair.rb
+++ b/app/models/key_pair.rb
@@ -2,4 +2,9 @@ class KeyPair < ActiveRecord::Base
   belongs_to :compute_resource
   validates_presence_of :name, :secret, :compute_resource_id
   validates_uniqueness_of :compute_resource_id
+
+  def skip_strip_attrs
+    ['secret']
+  end
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,4 +12,8 @@ class Message < ActiveRecord::Base
     Message.where(:digest => digest).first || Message.create(:value => val, :digest => digest)
   end
 
+  def skip_strip_attrs
+    ['value']
+  end
+
 end

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -18,4 +18,8 @@ class Ptable < ActiveRecord::Base
   scoped_search :on => :layout, :complete_value => false
   scoped_search :on => :os_family, :rename => "family", :complete_value => :true
 
+  def skip_strip_attrs
+    ['layout']
+  end
+
 end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -152,7 +152,6 @@ class Subnet < ActiveRecord::Base
   end
 
   def cleanup_ip(address)
-    address = address.strip
     address.gsub!(/\.\.+/, ".")
     address.gsub!(/2555+/, "255")
     address

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -1,4 +1,5 @@
 class ActiveRecord::Base
   extend Host::Hostmix
   include HasManyCommon
+  include StripWhitespace
 end

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -17,10 +17,10 @@ class ArchitectureTest < ActiveSupport::TestCase
 
   test "name should not contain white spaces" do
     architecture = Architecture.new :name => " i38  6 "
-    assert !architecture.name.strip.squeeze(" ").tr(' ', '').empty?
+    assert !architecture.name.squeeze(" ").tr(' ', '').empty?
     assert !architecture.save
 
-    architecture.name.strip!.squeeze!(" ").tr!(' ', '')
+    architecture.name.squeeze!(" ").tr!(' ', '')
     assert architecture.save
   end
 

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -12,10 +12,10 @@ class HostgroupTest < ActiveSupport::TestCase
 
   test "name can't contain trailing white spaces" do
     host_group = Hostgroup.new :name => " all    hosts in the     world    "
-    assert !host_group.name.strip.squeeze(" ").empty?
+    assert !host_group.name.squeeze(" ").empty?
     assert !host_group.save
 
-    host_group.name.strip!.squeeze!(" ")
+    host_group.name.squeeze!(" ")
     assert host_group.save
   end
 

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -14,16 +14,13 @@ class MediumTest < ActiveSupport::TestCase
 
   test "name can't contain white spaces" do
     medium = Medium.new :name => "   Archlinux mirror   thing   ", :path => "http://www.google.com"
-    assert !medium.name.strip.squeeze(" ").empty?
+    assert !medium.name.squeeze(" ").empty?
     assert !medium.save
 
     medium.name = "Archlinux mirror      thing"
     assert !medium.save
 
-    medium.name = "Archlinux mirror thing "
-    assert !medium.save
-
-    medium.name.strip!.squeeze!(" ")
+    medium.name.squeeze!(" ")
     assert medium.save!
   end
 

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -17,10 +17,10 @@ class OperatingsystemTest < ActiveSupport::TestCase
 
   test "name shouldn't contain white spaces" do
     operating_system = Operatingsystem.new :name => " U bun     tu ", :major => "9"
-    assert !operating_system.name.strip.squeeze(" ").tr(' ', '').empty?
+    assert !operating_system.name.squeeze(" ").tr(' ', '').empty?
     assert !operating_system.save
 
-    operating_system.name.strip!.squeeze!(" ").tr!(' ', '')
+    operating_system.name.squeeze!(" ").tr!(' ', '')
     assert !operating_system.name.include?(' ')
     assert operating_system.save
   end

--- a/test/unit/ptable_test.rb
+++ b/test/unit/ptable_test.rb
@@ -13,10 +13,10 @@ class PtableTest < ActiveSupport::TestCase
 
   test "name can't contain trailing white spaces" do
     partition_table = Ptable.new :name => "   Archlinux        default  ", :layout => "any layout"
-    assert !partition_table.name.strip.squeeze(" ").empty?
+    assert !partition_table.name.squeeze(" ").empty?
     assert !partition_table.save
 
-    partition_table.name.strip!.squeeze!(" ")
+    partition_table.name.squeeze!(" ")
     assert partition_table.save
   end
 

--- a/test/unit/puppetclass_test.rb
+++ b/test/unit/puppetclass_test.rb
@@ -12,10 +12,10 @@ class PuppetclassTest < ActiveSupport::TestCase
 
   test "name can't contain trailing white spaces" do
     puppet_class = Puppetclass.new :name => "   test     class   "
-    assert !puppet_class.name.strip.squeeze(" ").empty?
+    assert !puppet_class.name.squeeze(" ").empty?
     assert !puppet_class.save
 
-    puppet_class.name.strip!.squeeze!(" ")
+    puppet_class.name.squeeze!(" ")
     assert puppet_class.save
   end
 

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -56,14 +56,14 @@ class RoleTest < ActiveSupport::TestCase
     role.wont_be :valid?
   end
 
-  it "should not allow a leading space on name" do
+  it "should strip leading space on name" do
     role = Role.new(:name => " a role name")
-    role.wont_be :valid?
+    role.must_be :valid?
   end
 
-  it "should not allow a trailing space on name" do
+  it "should strip a trailing space on name" do
     role = Role.new(:name => "a role name ")
-    role.wont_be :valid?
+    role.must_be :valid?
   end
 
   def test_add_permission

--- a/test/unit/subnet_test.rb
+++ b/test/unit/subnet_test.rb
@@ -231,4 +231,11 @@ class SubnetTest < ActiveSupport::TestCase
     assert_equal "is invalid", s.errors[:network].first
   end
 
+  # test module StripWhitespace which strips leading and trailing whitespace on :name field
+  test "should strip whitespace on name" do
+    s = Subnet.new(:name => '    ABC Network     ', :network => "10.10.20.1", :mask => "255.255.255.0")
+    assert s.save!
+    assert_equal "ABC Network", s.name
+  end
+
 end


### PR DESCRIPTION
Replaces PR #884 and strips whitespace on on string attributes, not just :name
This PR also takes care of a feature request to strip whitespace on :mac address. 
