### PR TITLE
fixes #3093 - invalid data for a subnet address or mask returns 'is invalid and is invalid'

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -159,11 +159,11 @@ class Subnet < ActiveRecord::Base
   end
 
   def ensure_ip_addr_new
-    errors.add(:network, _("is invalid")) if network.present? && (IPAddr.new(network) rescue nil).nil?
-    errors.add(:mask, _("is invalid")) if mask.present? && (IPAddr.new(mask) rescue nil).nil?
-    errors.add(:gateway, _("is invalid")) if gateway.present? && (IPAddr.new(gateway) rescue nil).nil?
-    errors.add(:dns_primary, _("is invalid")) if dns_primary.present? && (IPAddr.new(dns_primary) rescue nil).nil?
-    errors.add(:dns_secondary, _("is invalid")) if dns_secondary.present? && (IPAddr.new(dns_secondary) rescue nil).nil?
+    errors.add(:network, _("is invalid")) if network.present? && (IPAddr.new(network) rescue nil).nil? && !errors.keys.include?(:network)
+    errors.add(:mask, _("is invalid")) if mask.present? && (IPAddr.new(mask) rescue nil).nil? && !errors.keys.include?(:mask)
+    errors.add(:gateway, _("is invalid")) if gateway.present? && (IPAddr.new(gateway) rescue nil).nil? && !errors.keys.include?(:gateway)
+    errors.add(:dns_primary, _("is invalid")) if dns_primary.present? && (IPAddr.new(dns_primary) rescue nil).nil? && !errors.keys.include?(:dns_primary)
+    errors.add(:dns_secondary, _("is invalid")) if dns_secondary.present? && (IPAddr.new(dns_secondary) rescue nil).nil? && !errors.keys.include?(:dns_secondary)
   end
 
 end

--- a/test/unit/subnet_test.rb
+++ b/test/unit/subnet_test.rb
@@ -228,6 +228,7 @@ class SubnetTest < ActiveSupport::TestCase
     # missing number
     s.network = "100.101.102"
     refute s.valid?
+    assert_equal "is invalid", s.errors[:network].first
   end
 
 end


### PR DESCRIPTION
Only have one "is invalid" returned for each key, not two
