### PR TITLE
fixes #3095 - for new trend, disable input of trend_name if not FactTrend

### DIFF
--- a/app/assets/javascripts/trends.js
+++ b/app/assets/javascripts/trends.js
@@ -7,4 +7,9 @@ function trendTypeSelected(item){
   var is_fact = ($(item).val() == "FactName");
   var edit_mode = $(item).attr('disabled');
   $("[id$='trend_trendable_id']").attr('disabled', (is_fact && !edit_mode) ? null : 'disabled');
+  $("[id$='trend_name']").attr('disabled', (is_fact && !edit_mode) ? null : 'disabled');
+  if (!is_fact || !edit_mode) {
+    $("[id$='trend_trendable_id']").val('');
+    $("[id$='trend_name']").val('');
+  }
 }


### PR DESCRIPTION
The Trend Name is only used for FactTrends. For ForemanTrends (Model, Operating System, Compute Resource, etc), the name is not used in the list of Trends or Trend show page, so it should be disabled upon trend creation.
