### PR TITLE
Fixes #2586 - Revert "Refs #2002 - Fog quick hack"

### DIFF
--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -23,11 +23,6 @@ begin
   require 'fog/libvirt'
   require 'fog/libvirt/models/compute/server'
   Fog::Compute::Libvirt::Server.send(:include, FogExtensions::Libvirt::Server)
-  # temporary fix for id attribute until next fog release (probably 1.11.2)
-  require 'fog/libvirt/models/compute/nic'
-  unless Fog::Compute::Libvirt::Nic.instance_methods.include?(:id)
-    Fog::Compute::Libvirt::Nic.attribute(:id)
-  end
 
   require 'fog/ovirt'
   require 'fog/ovirt/models/compute/server'


### PR DESCRIPTION
This reverts commit d37be454fa99c808acf7a89507ee6fd714f139de.
The original commit is not needed becase fog was upgraded.
