### PR TITLE
Fix #3116 NIC type selection for vSphere

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -1,10 +1,10 @@
 require 'fog_extensions/vsphere/mini_servers'
 require 'foreman/exception'
+require 'rbvmomi'
 
 module Foreman::Model
   class Vmware < ComputeResource
 
-    NETWORK_INTERFACE_TYPES = %w(VirtualE1000)
     validates_presence_of :user, :password, :server, :datacenter
     before_create :update_public_key
 
@@ -56,6 +56,13 @@ module Foreman::Model
       dc.networks.all(:accessible => true)
     end
 
+    def nictypes
+      {
+        "E1000" => RbVmomi::VIM::VirtualE1000,
+        "VMXNET 3" => RbVmomi::VIM::VirtualVmxnet3 
+      }
+    end      
+
     def datastores
       dc.datastores.all(:accessible => true)
     end
@@ -87,8 +94,15 @@ module Foreman::Model
     end
 
     def create_vm args = { }
-      vm = new_vm(args)
+      # Convert interface type to RbVmomi class
+      args["interfaces_attributes"].each do |key, interface|
+        unless nictypes.has_key?(interface["type"])
+          raise "Unknown NIC type: #{interface["type"]}"
+        end
+        interface["type"] = nictypes[interface["type"]]
+      end
 
+      vm = new_vm(args)
       vm.save
     rescue Fog::Errors::Error => e
       logger.debug e.backtrace

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,8 +1,12 @@
 <div class="fields">
   <% if (networks = compute_resource.networks).any? -%>
+    <%= selectable_f f, :type, compute_resource.nictypes.keys, { },
+                     :class       => "span2",
+                     :label       => _('NIC type')
+    %>
     <%= selectable_f f, :network, networks, { },
                      :class       => "span2",
-                     :label       => "Network",
+                     :label       => _('Network'),
                      :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) %>
   <% end -%>
 </div>


### PR DESCRIPTION
Provide solution issue [#3116](http://projects.theforeman.org/issues/3116)
Add NIC selection for vSphere and two initial types: E1000 and VMXNET 3

For the future the selection can be optimized to vSphere allowed network interface types, but it is quite complicated to query the API for this result (and not supported by fog at all).

Reviewed by: Dominic Cleal
