### PR TITLE
fix #2093 vmware compute resources don't support folders

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -1,7 +1,7 @@
 module FogExtensions
   module Vsphere
     class MiniServer
-      attr_reader :name, :identity, :cpus, :memory, :ready
+      attr_reader :name, :identity, :cpus, :memory, :ready, :path
       alias_method :ready?, :ready
 
       def initialize (raw, path = nil)
@@ -16,10 +16,6 @@ module FogExtensions
 
       def state
         raw.runtime.powerState
-      end
-
-      def path
-        @path
       end
 
       private

--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -4,17 +4,22 @@ module FogExtensions
       attr_reader :name, :identity, :cpus, :memory, :ready
       alias_method :ready?, :ready
 
-      def initialize raw
+      def initialize (raw, path = nil)
         @raw      = raw
         @name     = raw.name
         @identity = raw.config.instanceUuid
         @cpus     = raw.config.hardware.numCPU
         @memory   = raw.config.hardware.memoryMB * 1024 * 1024
         @ready    = raw.runtime.powerState == "poweredOn"
+        @path     = path
       end
 
       def state
         raw.runtime.powerState
+      end
+
+      def path
+        @path
       end
 
       private

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -10,21 +10,19 @@ module FogExtensions
       end
 
       def all(filters = { })
-        ret = []
-        allbyfolder(dc.vmFolder, nil).each do |entry|
-          ret.push MiniServer.new(entry[:vm], entry[:path])
+        allbyfolder(dc.vmFolder, nil).map do |entry|
+          MiniServer.new(entry[:vm], entry[:path])
         end
-        ret
       end
 
-      def allbyfolder(folder, path = nil, recursing = false)
+      def allbyfolder(folder, path = nil)
         ret = []
-        if recursing
+        unless folder == @dc.vmFolder 
           path = path.nil? ? folder.name : path + '/' + folder.name
         end
         folder.childEntity.each do |entity|
           if entity.is_a?(RbVmomi::VIM::Folder)
-            ret = ret + (allbyfolder(entity, path, true))
+            ret = ret + (allbyfolder(entity, path))
           elsif entity.is_a?(RbVmomi::VIM::VirtualMachine)
             ret.push ({ :vm => entity, :path => path })
           end

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -10,11 +10,28 @@ module FogExtensions
       end
 
       def all(filters = { })
-        dc.vmFolder.childEntity.grep(RbVmomi::VIM::VirtualMachine).map do |server|
-          MiniServer.new(server)
+        ret = []
+        allbyfolder(dc.vmFolder, nil).each do |entry|
+          ret.push MiniServer.new(entry[:vm], entry[:path])
         end
+        ret
       end
 
+      def allbyfolder(folder, path = nil, recursing = false)
+        ret = []
+        if recursing
+          path = path.nil? ? folder.name : path + '/' + folder.name
+        end
+        folder.childEntity.each do |entity|
+          if entity.is_a?(RbVmomi::VIM::Folder)
+            ret = ret + (allbyfolder(entity, path, true))
+          elsif entity.is_a?(RbVmomi::VIM::VirtualMachine)
+            ret.push ({ :vm => entity, :path => path })
+          end
+        end
+        ret
+      end
+        
       private
       attr_reader :client, :dc
     end

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -2,6 +2,7 @@
   <thead>
   <tr>
     <th><%= _('Name') -%></th>
+    <th><%= _('Folder') -%></th>
     <th><%= _('CPUs') -%></th>
     <th><%= _('Memory') -%></th>
     <th><%= _('Power') -%></th>
@@ -12,6 +13,7 @@
   <% @vms.each do |vm| -%>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
+      <td><%= vm.path %></td>
       <td><%= vm.cpus %></td>
       <td> <%= number_to_human_size vm.memory %></td>
       <td> <span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %></span> </td>


### PR DESCRIPTION
Fix issue [#2093](http://projects.theforeman.org/issues/2093)

traverse all datacenter folders and their subvolders
store vSphere folder path string in MiniServer object
add folder column to "Virtual Machines" view
