### PR TITLE
fix #3123 vSphere VM info misses MAC address and displays memory in byte...

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -16,7 +16,7 @@ module ComputeResourcesVmsHelper
         when nil
             _("N/A")
         else
-          value.to_s
+          method == :memory ? number_to_human_size(value) : value.to_s
         end
       end
       result

--- a/app/views/compute_resources_vms/show/_vmware.html.erb
+++ b/app/views/compute_resources_vms/show/_vmware.html.erb
@@ -7,6 +7,7 @@
     <%= prop :cluster %>
     <%= prop :memory %>
     <%= prop :ipaddress %>
+    <%= prop :mac %>
     <%= prop :cpus %>
     <%= prop :hypervisor %>
     <%= prop :connection_state %>


### PR DESCRIPTION
Fix for issue [#3123](http://projects.theforeman.org/issues/3123).
Add MAC address to vSphere VM information.
Make output from prop ":memory" method human readable.
