### PR TITLE
fix #2093 vmware compute resources don't support folders

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -1,20 +1,21 @@
 module FogExtensions
   module Vsphere
     class MiniServer
-      attr_reader :name, :identity, :cpus, :memory, :ready
-      alias_method :ready?, :ready
+      attr_reader :name, :identity, :cpus, :memory, :state, :path
 
-      def initialize raw
+      def initialize (raw, path = nil, uuid = nil)
+        hardware  = raw.config.hardware
         @raw      = raw
         @name     = raw.name
-        @identity = raw.config.instanceUuid
-        @cpus     = raw.config.hardware.numCPU
-        @memory   = raw.config.hardware.memoryMB * 1024 * 1024
-        @ready    = raw.runtime.powerState == "poweredOn"
+        @identity = uuid
+        @cpus     = hardware.numCPU
+        @memory   = hardware.memoryMB * 1024 * 1024
+        @state    = raw.runtime.powerState
+        @path     = path
       end
 
-      def state
-        raw.runtime.powerState
+      def ready?
+        @state == "poweredOn"
       end
 
       private

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -24,7 +24,8 @@ module FogExtensions
           if entity.is_a?(RbVmomi::VIM::Folder)
             ret = ret + (allvmsbyfolder(entity, path))
           elsif entity.is_a?(RbVmomi::VIM::VirtualMachine)
-            if (entity.config.template != true && uuid = entity.config.instanceUuid)
+            config = entity.config
+            if (config.template != true && uuid = config.instanceUuid)
               ret.push ({ :vm => entity, :path => path, :uuid => uuid})
             end
           end

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -24,7 +24,7 @@ module FogExtensions
           if entity.is_a?(RbVmomi::VIM::Folder)
             ret = ret + (allvmsbyfolder(entity, path))
           elsif entity.is_a?(RbVmomi::VIM::VirtualMachine)
-            if (uuid = entity.config.instanceUuid)
+            if (entity.config.template != true && uuid = entity.config.instanceUuid)
               ret.push ({ :vm => entity, :path => path, :uuid => uuid})
             end
           end

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -2,6 +2,7 @@
   <thead>
   <tr>
     <th><%= _('Name') -%></th>
+    <th><%= _('Folder') -%></th>
     <th><%= _('CPUs') -%></th>
     <th><%= _('Memory') -%></th>
     <th><%= _('Power') -%></th>
@@ -12,9 +13,10 @@
   <% @vms.each do |vm| -%>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
+      <td><%= vm.path %></td>
       <td><%= vm.cpus %></td>
-      <td> <%= number_to_human_size vm.memory %></td>
-      <td> <span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %></span> </td>
+      <td><%= number_to_human_size vm.memory %></td> 
+      <td><span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %></span> </td>
       <td>
         <%= action_buttons(vm_power_action(vm),
                            show_console_action(vm.ready?, display_link_if_authorized("Console", hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity))),


### PR DESCRIPTION
do not include VMs without a valid instanceUuid
read state information only once
add folder column to "Virtual Machhines" view
