### PR TITLE
fix #3134 vSphere UI host create/edit requires some fixes

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -58,8 +58,8 @@ module Foreman::Model
 
     def nictypes
       {
-        "E1000" => "VirtualE1000",
-        "VMXNET 3" => "VirtualVmxnet3" 
+        "VirtualE1000" => "E1000",
+        "VirtualVmxnet3" => "VMXNET 3" 
       }
     end      
 
@@ -94,14 +94,15 @@ module Foreman::Model
     end
 
     def create_vm args = { }
+      dc_networks = networks
       args["interfaces_attributes"].each do |key, interface|
         # Convert interface type to RbVmomi class
-        unless nictypes.has_value? interface["type"]
+        unless nictypes.has_key? interface["type"]
           raise "Unknown NIC type: #{interface["type"]}"
         end
         interface["type"] = ("RbVmomi::VIM::" + interface["type"]).constantize
         # Convert network id into name
-        net = networks.find { |n| n.id == interface["network"] }
+        net = dc_networks.find { |n| n.id == interface["network"] }
         raise "Unknown Network ID: #{interface["network"]}" if net.nil?
         interface["network"] = net.name
       end

--- a/app/views/compute_resources_vms/form/_vmware.html.erb
+++ b/app/views/compute_resources_vms/form/_vmware.html.erb
@@ -1,4 +1,4 @@
-<% new = f.object && f.object.new? -%>
+<% new = @host ? @host.created_at.nil? : true -%>
 <%= text_f f, :name, :disabled => !new if controller_name != "hosts" %>
 <%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :class => "input-mini", :disabled => !new %>
 <%= text_f f, :memory_mb, :class => "span2", :disabled => !new, :label => _("Memory (MB)") %>
@@ -10,12 +10,14 @@
 <div class="children_fields">
   <%= new_child_fields_template(f, :interfaces, {
       :object  => compute_resource.new_interface,
-      :partial => 'compute_resources_vms/form/vmware/network', :form_builder_attrs => { :compute_resource => compute_resource } }) %>
+      :partial => 'compute_resources_vms/form/vmware/network', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
   <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do -%>
     <%= f.fields_for :interfaces do |i| %>
-      <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource %>
+      <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource, :new => new %>
     <% end -%>
-    <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
+    <% if new %>
+      <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
+    <% end %>
   <% end -%>
 </div>
 
@@ -23,12 +25,14 @@
 <div class="children_fields">
   <%= new_child_fields_template(f, :volumes, {
       :object  => compute_resource.new_volume,
-      :partial => 'compute_resources_vms/form/vmware/volume', :form_builder_attrs => { :compute_resource => compute_resource } }) %>
+      :partial => 'compute_resources_vms/form/vmware/volume', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
   <%= field_set_tag _("Storage"), :id => "storage_volumes", :title => _('Storage') do -%>
     <%= f.fields_for :volumes do |i| %>
-      <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource %>
+      <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource, :new => new %>
     <% end -%>
-    <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+    <% if new %>
+      <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+    <% end %>
   <% end -%>
 </div>
 

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,6 +1,6 @@
 <div class="fields">
   <% if (networks = compute_resource.networks).any? -%>
-    <%= select_f f, :type, compute_resource.nictypes, :last, :first, { },
+    <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
                      :class       => "span2",
                      :label       => _('NIC type'),
                      :disabled    => !new

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,12 +1,15 @@
 <div class="fields">
   <% if (networks = compute_resource.networks).any? -%>
-    <%= selectable_f f, :type, compute_resource.nictypes.keys, { },
+    <%= select_f f, :type, compute_resource.nictypes, :last, :first, { },
                      :class       => "span2",
-                     :label       => _('NIC type')
+                     :label       => _('NIC type'),
+                     :disabled    => !new
     %>
-    <%= selectable_f f, :network, networks, { },
+    <%= select_f f, :network, networks, :id, :name, { },
                      :class       => "span2",
                      :label       => _('Network'),
-                     :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) %>
+                     :disabled    => !new,
+                     :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) 
+    %>
   <% end -%>
 </div>

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -1,13 +1,14 @@
 <div class="fields">
-  <%= selectable_f f, :datastore, compute_resource.datastores, { }, :class => "span2", :label => _("Data Store") %>
-  <%= text_f f, :name, :class => "input-mini", :label => "Name" %>
+  <%= selectable_f f, :datastore, compute_resource.datastores, { }, :class => "span2", :label => _("Data Store"), :disabled => !new %>
+  <%= text_f f, :name, :class => "input-mini", :label => "Name", :disabled => !new %>
   <%= text_f f, :size_gb,
              :class       => "input-mini",
-             :label       => _("Size (GB)") %>
+             :label => _("Size (GB)"),
+             :disabled => !new %>
   <%= checkbox_f f, :thin, {
-             :checked => true,
              :label => _("Thin provision"),
-             :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-important' }) },
+             :disabled => !new,
+             :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-important', :disabled => !new })},
              true,
              false %>
 </div>


### PR DESCRIPTION
fix issue [#3134](http://projects.theforeman.org/issues/3134)

Host create/edit mode:
- Editing of existing VMs is not yet supported, networks and storage should by grayed out by now
- The new network interface type selection does not detect already configured values
- The thick/thin provisioning checkbox should not always be on
- If cloning a VM, the Virtual Machine options should be identical as source VM and editable (not grayed out)
