### PR TITLE
fix #3136 host cloning should auto-suggest a new IP address

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -72,8 +72,6 @@ class HostsController < ApplicationController
   def clone
     @clone_host = @host
     new = @host.dup
-    new.name = nil
-    new.ip = nil
     load_vars_for_ajax
     flash[:warning] = _("The marked fields will need reviewing")
     new.valid?

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -72,6 +72,9 @@ class HostsController < ApplicationController
   def clone
     @clone_host = @host
     new = @host.dup
+    new.name = nil
+    new.mac = nil
+    new.ip = nil
     load_vars_for_ajax
     flash[:warning] = _("The marked fields will need reviewing")
     new.valid?

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -70,7 +70,10 @@ class HostsController < ApplicationController
 
   # Clone the host
   def clone
+    @clone_host = @host
     new = @host.dup
+    new.name = nil
+    new.ip = nil
     load_vars_for_ajax
     flash[:warning] = _("The marked fields will need reviewing")
     new.valid?

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -182,5 +182,12 @@ module Host
         comparison_object.id == id
     end
 
+    def dup
+      new = super
+      new.name = nil
+      new.ip = nil
+      new
+    end
+
   end
 end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -182,13 +182,5 @@ module Host
         comparison_object.id == id
     end
 
-    def dup
-      new = super
-      new.name = nil
-      new.mac = nil
-      new.ip = nil
-      new
-    end
-
   end
 end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -185,6 +185,7 @@ module Host
     def dup
       new = super
       new.name = nil
+      new.mac = nil
       new.ip = nil
       new
     end

--- a/app/views/hosts/new.html.erb
+++ b/app/views/hosts/new.html.erb
@@ -1,3 +1,5 @@
-<% title(_("%s Host") % params[:action].capitalize) %>
+<% t = _("%s Host") % params[:action].capitalize
+   t = t + ' ' + @clone_host.name if @clone_host && @clone_host.name
+   title(t)  %>
 
 <%= render :partial => 'form' %>

--- a/app/views/hosts/new.html.erb
+++ b/app/views/hosts/new.html.erb
@@ -1,5 +1,7 @@
-<% t = _("%s Host") % params[:action].capitalize
-   t = t + ' ' + @clone_host.name if @clone_host && @clone_host.name
-   title(t)  %>
+<% unless (@clone_host && @clone_host.name)
+     title(_("%s Host") % params[:action].capitalize)
+   else
+     title(_("Clone Host %s") % @clone_host.name)
+   end  %>
 
 <%= render :partial => 'form' %>


### PR DESCRIPTION
Fix issue [#3136](http://projects.theforeman.org/issues/3136)
In the clone host form, the ip should be auto-suggested and mac and name blanked out
If we are cloning a host, the name of the original host should be in the page title
This might be a nice-to-have in 1.3, too
