### PR TITLE
Refactor #3144 - Remove user_id and inherited_from

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -23,10 +23,4 @@ class UserRole < ActiveRecord::Base
   validates_presence_of :user
 
   validates_uniqueness_of :user_id, :scope => :role_id, :message => "has this role already"
-
-  def inherited?
-    !inherited_from.nil?
-  end
-
-  private
 end

--- a/db/migrate/20130924145800_remove_unused_role_fields.rb
+++ b/db/migrate/20130924145800_remove_unused_role_fields.rb
@@ -1,0 +1,11 @@
+class RemoveUnusedRoleFields < ActiveRecord::Migration
+  def up
+    remove_column :users, :role_id
+    remove_column :user_roles, :inherited_from
+  end
+
+  def down
+    add_column :users, :role_id, :integer
+    add_column :user_roles, :inherited_from, :integer
+  end
+end


### PR DESCRIPTION
Fields user_id in model User and inherited_from in model UserRole are
absolutely superfluous as they are not being used anywhere and result in
unnecessary lines of code and clutter in the database, which contains
NULL values in all cases.
