### PR TITLE
fixes #2975 added setting for using the shortname instead of FQDN for new VMs

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -54,7 +54,7 @@ module Orchestration::Compute
 
   def setCompute
     logger.info "Adding Compute instance for #{name}"
-    self.vm = compute_resource.create_vm compute_attributes.merge(:name => name)
+    self.vm = compute_resource.create_vm compute_attributes.merge(:name => SETTINGS[:use_shortname_for_vms] ? shortname : name)
   rescue => e
     failure _("Failed to create a compute %{compute_resource} instance %{name}: %{message}\n ") % { :compute_resource => compute_resource, :name => name, :message => e.message }, e.backtrace
   end

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -22,7 +22,8 @@ class Setting::Provisioning < Setting
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1"),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0),
         self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0"),
-        self.set('update_ip_from_built_request', N_("Should we use the originating IP of the built request to update the host's IP?"), false)
+        self.set('update_ip_from_built_request', N_("Should we use the originating IP of the built request to update the host's IP?"), false),
+        self.set('use_shortname_for_vms', N_("Should Foreman use the short hostname instead of the FQDN for creating new virtual machines"), false)
       ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
     end
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -200,3 +200,8 @@ attribute40:
   category: Setting::Puppet
   default: "true"
   description: "Should Foreman parse ERB to return dynamic parameters?"
+attribute41:
+  name: use_shortname_for_vms
+  category: Setting::Provisioning
+  default: "false"
+  description: "Should Foreman use the short hostname instead of the FQDN for creating new virtual machines"


### PR DESCRIPTION
Hello!

I made a setting for using the shortname when creating new machines. Unfortunately our test vsphere cluster is currently down so I cannot test it. 

If someone tries to provision a hostname twice the error from the virtualization should be passed on, on which Foreman refuses the creation. I therefore haven't implemented any error handling (hope I'm right :) ).

Cheers
Hannes
