### PR TITLE
fixes 3177: a 'G' suffix is automatically appended to libvirt volume capacity value if none was specified

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -107,7 +107,7 @@ module Foreman::Model
 
     def console uuid
       vm = find_vm_by_uuid(uuid)
-      raise "VM is not running!" unless vm.ready?
+      raise Foreman::Exception.new(N_("VM is not running!")) unless vm.ready?
       password = random_password
       # Listen address cannot be updated while the guest is running
       # When we update the display password, we pass the existing listen address
@@ -116,7 +116,7 @@ module Foreman::Model
     rescue ::Libvirt::Error => e
       if e.message =~ /cannot change listen address/
         logger.warn e
-        raise "Unable to change VM display listen address, make sure the display is not attached to localhost only"
+        Foreman::Exception.new(N_("Unable to change VM display listen address, make sure the display is not attached to localhost only"))
       else
         raise e
       end
@@ -162,19 +162,28 @@ module Foreman::Model
     end
 
     def create_volumes args
-      vols = []
-      (volumes = args[:volumes]).each do |vol|
-        vol.name       = "#{args[:prefix]}-disk#{volumes.index(vol)+1}"
-        vol.allocation = "0G"
-        vol.save
-        vols << vol
+      args[:volumes].each {|vol| validate_volume_capacity(vol)}
+      begin
+        vols = []
+        (volumes = args[:volumes]).each do |vol|
+          vol.name       = "#{args[:prefix]}-disk#{volumes.index(vol)+1}"
+          vol.allocation = "0G"
+          vol.capacity = "#{vol.capacity}G" unless vol.capacity.to_s.end_with?('G')
+          vol.save
+          vols << vol
+        end
+        vols
+      rescue => e
+        logger.debug "Failure detected #{e}: removing already created volumes" if vols.any?
+        vols.each { |vol| vol.destroy }
+        raise e
       end
-      vols
-    rescue => e
-      logger.debug "Failure detected #{e}: removing already created volumes" if vols.any?
-      vols.each { |vol| vol.destroy }
-      raise e
     end
 
+    def validate_volume_capacity(vol)
+      if vol.capacity.to_s.empty? or /^\d+G?$/.match(vol.capacity.to_s).nil?
+        raise Foreman::Exception.new(N_("Please specify volume size. You may optionally use suffix 'G' to specify volume size in Gigabytes."))
+      end
+    end
   end
 end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -150,5 +150,4 @@ module Orchestration::Compute
       failure(_("Selected image does not belong to %s") % compute_resource) and return false
     end
   end
-
 end

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -126,4 +126,28 @@ class ComputeResourceTest < ActiveSupport::TestCase
     cr.display_type='SPICE'
     assert_equal 'spice', cr.send(:vm_instance_defaults)['display']['type']
   end
+
+  test "libvirt: 'G' suffix should be appended to libvirt volume capacity if none was specified" do
+    volume = OpenStruct.new(:capacity => 10)
+    volume.stubs(:save!).returns(true)
+
+    result = Foreman::Model::Libvirt.new.send(:create_volumes, {:prefix => 'test', :volumes => [volume]})
+
+    assert_equal "10G", result[0].capacity
+  end
+
+  test "libvirt: no exceptions should be raised if a 'G' suffix was specified for volume capacity" do
+    volume = OpenStruct.new(:capacity => "10G")
+    volume.stubs(:save!).returns(true)
+
+    assert_nothing_raised { Foreman::Model::Libvirt.new.send(:create_volumes, {:prefix => 'test', :volumes => [volume]}) }
+  end
+
+  test "libvirt: an exception should be raised if a suffix other than 'G' was used in volume capacity value" do
+    volume = OpenStruct.new(:capacity => "10K")
+
+    assert_raise(Foreman::Exception) do
+      Foreman::Model::Libvirt.new.send(:create_volumes, {:prefix => 'test', :volumes => [volume]})
+    end
+  end
 end


### PR DESCRIPTION
I think the UI to volume capacity could be improved. libvirt internally stores volume sizes in bytes, but allows to specify the size in a variety of units. We could switch to follow the same convention. 

It's a bit confusing atm, as libvirt expects a suffix to be present, but we only support one -- "G".  
