### PR TITLE
fixes #3133 - fix security group filtering when no groups need filtering

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -104,6 +104,6 @@ module ComputeResourcesVmsHelper
   end
 
   def security_groups_for_vpc(security_groups, vpc_id)
-    security_groups.map{ |sg| [sg.name, sg.group_id] if sg.vpc_id == vpc_id}.compact!
+    security_groups.map{ |sg| [sg.name, sg.group_id] if sg.vpc_id == vpc_id}.compact
   end
 end


### PR DESCRIPTION
"[compact!] returns nil if no changes were made, otherwise returns the array"
http://www.ruby-doc.org/core-2.0.0/Array.html#method-i-compact-21

Hence if there are no VPC groups (vpc_id are all nil), the security_groups array is unfiltered, and the method returned nil rather than all the non-VPC security groups.
