### PR TITLE
fixes #3140 - API to allow importing of puppet classes

### DIFF
--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class EnvironmentsController < V1::BaseController
+
+      include Api::ImportPuppetclassesCommonController
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/environments/", "List all environments."

--- a/app/controllers/api/v1/smart_proxies_controller.rb
+++ b/app/controllers/api/v1/smart_proxies_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class SmartProxiesController < V1::BaseController
+
+      include Api::ImportPuppetclassesCommonController
       before_filter :find_resource, :only => %w{show update destroy refresh}
       before_filter :check_feature_type, :only => :index
 

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -1,0 +1,91 @@
+module Api::ImportPuppetclassesCommonController
+  extend ActiveSupport::Concern
+
+  included do
+    before_filter :find_required_puppet_proxy, :only => [:import_puppetclasses]
+    before_filter :find_optional_environment, :only => [:import_puppetclasses]
+  end
+
+  extend Apipie::DSL::Concern
+
+  api :GET, "/smart_proxies/:id/import_puppetclasses", "Import puppetclasses from puppet proxy."
+  api :GET, "/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses", "Import puppetclasses from puppet proxy for particular environment."
+  api :GET, "/environments/:environment_id/smart_proxies/:id/import_puppetclasses", "Import puppetclasses from puppet proxy for particular environment."
+  param :smart_proxy_id, :identifier, :required => true
+  param :environment_id, :identifier, :required => false
+  param :dryrun, String, :required => false
+
+  def import_puppetclasses
+    render(:json => {:message => "No changes to your environments detected"}) and return unless changed_environments
+
+    # DRYRUN - /import_puppetclasses?dryrun - do not run PuppetClassImporter
+    rabl_template = @environment ? 'show' : 'index'
+    render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout") and return if params.keys.include?('dryrun')
+
+    # RUN PuppetClassImporter
+    if (errors = ::PuppetClassImporter.new.obsolete_and_new(@changed)).empty?
+      render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
+    else
+      render :json => {:message => "Failed to update the environments and puppetclasses from the on-disk puppet installation #{errors.join(", ")}"}
+    end
+  end
+
+  def changed_environments
+    begin
+      opts      =  { :url => @smart_proxy.url }
+      @importer = PuppetClassImporter.new(opts)
+      @changed  = @importer.changes
+
+      if @environment
+        # only return :keys equal to @environment in @changed hash
+        ["new", "obsolete", "updated"].each do |kind|
+          @changed[kind].slice!(@environment.name) unless @changed[kind].empty?
+        end
+      end
+
+    rescue => e
+      if e.message =~ /puppet feature/i
+      msg = 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
+      render :json => {:message => msg}, :status => :not_found and return false
+      end
+    end
+
+    # PuppetClassImporter expects [kind][env] to be in json format
+    ["new", "obsolete", "updated"].each do |kind|
+      unless (envs = @changed[kind]).empty?
+        envs.keys.sort.each do |env|
+          @changed[kind][env] = @changed[kind][env].to_json
+        end
+      end
+    end
+
+    # @environments is used in import_puppletclasses/index.json.rabl
+    environments_new = @changed["new"].size > 0 ? @changed["new"].keys : []
+    environments_obsolete = @changed["obsolete"].size > 0 ? @changed["obsolete"].keys : []
+    environments_updated = @changed["updated"].size > 0 ? @changed["updated"].keys : []
+    environment_names = (environments_new + environments_obsolete + environments_updated).uniq.sort
+    @environments = environment_names.map do |name|
+      OpenStruct.new(:name => name)
+    end
+    @environments.any?
+  end
+
+  def find_required_puppet_proxy
+    id = params.keys.include?('smart_proxy_id') ? params['smart_proxy_id'] : params['id']
+    @smart_proxy   = SmartProxy.find_by_id(id.to_i) if id.to_i > 0
+    @smart_proxy ||= SmartProxy.find_by_name(id)
+    unless @smart_proxy && SmartProxy.puppet_proxies.pluck(:id).include?(@smart_proxy.id)
+      msg = 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
+      render :json => {:message => msg}, :status => :not_found and return false
+    end
+    @smart_proxy
+  end
+
+  def find_optional_environment
+    id = params.keys.include?('environment_id') ? params['environment_id'] : params['id']
+    @environment   = Environment.find_by_id(id.to_i) if id.to_i > 0
+    @environment ||= Environment.find_by_name(id)
+    @environment
+  end
+
+end

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -3,6 +3,7 @@ module Api::ImportPuppetclassesCommonController
 
   included do
     before_filter :find_required_puppet_proxy, :only => [:import_puppetclasses]
+    before_filter :get_environment_id, :only => [:import_puppetclasses]
     before_filter :find_optional_environment, :only => [:import_puppetclasses]
   end
 
@@ -13,20 +14,20 @@ module Api::ImportPuppetclassesCommonController
   api :GET, "/environments/:environment_id/smart_proxies/:id/import_puppetclasses", "Import puppetclasses from puppet proxy for particular environment."
   param :smart_proxy_id, :identifier, :required => true
   param :environment_id, :identifier, :required => false
-  param :dryrun, String, :required => false
+  param :dryrun, :bool, :required => false
 
   def import_puppetclasses
-    render(:json => {:message => "No changes to your environments detected"}) and return unless changed_environments
+    return unless changed_environments
 
     # DRYRUN - /import_puppetclasses?dryrun - do not run PuppetClassImporter
     rabl_template = @environment ? 'show' : 'index'
-    render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout") and return if params.keys.include?('dryrun')
+    render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout") and return if (params.keys.include?('dryrun') && params['dryrun'] != 'false')
 
     # RUN PuppetClassImporter
     if (errors = ::PuppetClassImporter.new.obsolete_and_new(@changed)).empty?
       render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
     else
-      render :json => {:message => "Failed to update the environments and puppetclasses from the on-disk puppet installation #{errors.join(", ")}"}
+      render :json => {:message => "Failed to update the environments and puppetclasses from the on-disk puppet installation #{errors.join(", ")}"}, :status => 500
     end
   end
 
@@ -36,7 +37,8 @@ module Api::ImportPuppetclassesCommonController
       @importer = PuppetClassImporter.new(opts)
       @changed  = @importer.changes
 
-      if @environment
+      # check if environemnt id passed in URL is name of NEW environment in puppetmaster that doesn't exist in db
+      if @environment || (@changed['new'].keys.include?(@env_id) && (@environment ||= OpenStruct.new(:name => @env_id)))
         # only return :keys equal to @environment in @changed hash
         ["new", "obsolete", "updated"].each do |kind|
           @changed[kind].slice!(@environment.name) unless @changed[kind].empty?
@@ -45,9 +47,11 @@ module Api::ImportPuppetclassesCommonController
 
     rescue => e
       if e.message =~ /puppet feature/i
-      msg = 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
-      render :json => {:message => msg}, :status => :not_found and return false
+        msg = 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
+      else
+        msg = e.message
       end
+      render :json => {:message => msg}, :status => 500 and return false
     end
 
     # PuppetClassImporter expects [kind][env] to be in json format
@@ -60,13 +64,12 @@ module Api::ImportPuppetclassesCommonController
     end
 
     # @environments is used in import_puppletclasses/index.json.rabl
-    environments_new = @changed["new"].size > 0 ? @changed["new"].keys : []
-    environments_obsolete = @changed["obsolete"].size > 0 ? @changed["obsolete"].keys : []
-    environments_updated = @changed["updated"].size > 0 ? @changed["updated"].keys : []
-    environment_names = (environments_new + environments_obsolete + environments_updated).uniq.sort
+    environment_names = (@changed["new"].keys + @changed["obsolete"].keys + @changed["updated"].keys).uniq.sort
     @environments = environment_names.map do |name|
-      OpenStruct.new(:name => name)
-    end
+                      OpenStruct.new(:name => name)
+                    end
+
+    render :json => {:message => "No changes to your environments detected"} and return false unless @environments.any?
     @environments.any?
   end
 
@@ -81,10 +84,18 @@ module Api::ImportPuppetclassesCommonController
     @smart_proxy
   end
 
+  def get_environment_id
+    @env_id = if params.keys.include?('environment_id')
+                params['environment_id']
+              elsif controller_name == 'environments' && params['id'].present?
+                params['id']
+              end
+    @env_id
+  end
+
   def find_optional_environment
-    id = params.keys.include?('environment_id') ? params['environment_id'] : params['id']
-    @environment   = Environment.find_by_id(id.to_i) if id.to_i > 0
-    @environment ||= Environment.find_by_name(id)
+    @environment   = Environment.find_by_id(@env_id.to_i) if @env_id.to_i > 0
+    @environment ||= Environment.find_by_name(@env_id)
     @environment
   end
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -138,7 +138,13 @@ Foreman::AccessControl.map do |map|
                                            :"api/v1/environments" => [:destroy],
                                            :"api/v2/environments" => [:destroy]
     }
-    map.permission :import_environments,  {:environments => [:import_environments, :obsolete_and_new]}
+    map.permission :import_environments,  {:environments => [:import_environments, :obsolete_and_new],
+                                           :"api/v1/environments" => [:import_puppetclasses],
+                                           :"api/v2/environments" => [:import_puppetclasses],
+                                           :"api/v1/smart_proxies" => [:import_puppetclasses],
+                                           :"api/v2/smart_proxies" => [:import_puppetclasses]
+                                            }
+
   end
 
   map.security_block :external_variables do |map|
@@ -427,7 +433,12 @@ Foreman::AccessControl.map do |map|
                                           :"api/v1/puppetclasses" => [:destroy],
                                           :"api/v2/puppetclasses" => [:destroy]
                                         }
-    map.permission :import_puppetclasses,  {:puppetclasses => [:import_environments, :obsolete_and_new]}
+    map.permission :import_puppetclasses,  {:puppetclasses => [:import_environments, :obsolete_and_new],
+                                           :"api/v1/environments" => [:import_puppetclasses],
+                                           :"api/v2/environments" => [:import_puppetclasses],
+                                           :"api/v1/smart_proxies" => [:import_puppetclasses],
+                                           :"api/v2/smart_proxies" => [:import_puppetclasses]
+                                            }
   end
 
   map.security_block :smart_proxies do |map|

--- a/app/views/api/layouts/import_puppetclasses_layout.json.erb
+++ b/app/views/api/layouts/import_puppetclasses_layout.json.erb
@@ -1,0 +1,9 @@
+{
+  "message": <%= 'Successfully updated environment and puppetclasses from the on-disk puppet installation'.to_json.html_safe %>,
+  <% unless @environment %>
+  "environments_with_new_puppetclasses": <%= @changed["new"].size.to_json.html_safe %>,
+  "environments_updated_puppetclasses": <%= @changed["updated"].size.to_json.html_safe %>,
+  "environments_obsolete": <%= @changed["obsolete"].size.to_json.html_safe %>,
+  <% end %>
+  "results": <%= yield %>
+}

--- a/app/views/api/v1/import_puppetclasses/index.json.rabl
+++ b/app/views/api/v1/import_puppetclasses/index.json.rabl
@@ -1,0 +1,3 @@
+collection @environments, :root => false, :object_root => false
+
+extends "api/v1/import_puppetclasses/show"

--- a/app/views/api/v1/import_puppetclasses/show.json.rabl
+++ b/app/views/api/v1/import_puppetclasses/show.json.rabl
@@ -1,4 +1,4 @@
-object @environment
+object @environment => nil
 
 attributes :name
 
@@ -23,5 +23,5 @@ node(:obsolete_puppetclasses, :if => lambda { |environment| @changed['obsolete']
 end
 
 node(:removed_environment, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
-  environment.name.to_json
+  environment.name
 end

--- a/app/views/api/v1/import_puppetclasses/show.json.rabl
+++ b/app/views/api/v1/import_puppetclasses/show.json.rabl
@@ -1,0 +1,27 @@
+object @environment
+
+attributes :name
+
+node(:actions) do |environment|
+ actions = []
+ actions << 'new' if @changed['new'][environment.name].present?
+ actions << 'updated' if @changed['updated'][environment.name].present?
+ actions << 'obsolete' if @changed['obsolete'][environment.name].present?
+ actions.as_json
+end
+
+node(:new_puppetclasses, :if => lambda { |environment| @changed['new'][environment.name].present? }) do |environment|
+  JSON.parse(@changed['new'][environment.name]).keys
+end
+
+node(:updated_puppetclasses, :if => lambda { |environment| @changed['updated'][environment.name].present? }) do |environment|
+  JSON.parse(@changed['updated'][environment.name]).keys
+end
+
+node(:obsolete_puppetclasses, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && !@changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+  JSON.parse(@changed['obsolete'][environment.name])
+end
+
+node(:removed_environment, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+  environment.name.to_json
+end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -33,7 +33,11 @@ Foreman::Application.routes.draw do
       end
       resources :dashboard, :only => [:index]
       resources :statistics, :only => [:index]
-      resources :environments, :except => [:new, :edit]
+      resources :environments, :except => [:new, :edit] do
+        resources :smart_proxies, :only => [] do
+          post :import_puppetclasses, :on => :member
+        end
+      end
       resources :fact_values, :only => [:index]
       resources :hostgroups, :except => [:new, :edit]
       resources :lookup_keys, :except => [:new, :edit]
@@ -53,6 +57,10 @@ Foreman::Application.routes.draw do
       resources :settings, :only => [:index, :show, :update]
       resources :smart_proxies, :except => [:new, :edit] do
         put :refresh, :on => :member
+        post :import_puppetclasses, :on => :member
+        resources :environments, :only => [] do
+          post :import_puppetclasses, :on => :member
+        end
       end
       resources :subnets, :except => [:new, :edit]
       resources :usergroups, :except => [:new, :edit]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -28,7 +28,11 @@ Foreman::Application.routes.draw do
       end
       resources :dashboard, :only => [:index]
       resources :statistics, :only => [:index]
-      resources :environments, :except => [:new, :edit]
+      resources :environments, :except => [:new, :edit] do
+        resources :smart_proxies, :only => [] do
+          post :import_puppetclasses, :on => :member
+        end
+      end
       resources :fact_values, :only => [:index]
       resources :hostgroups, :except => [:new, :edit]
       resources :lookup_keys, :except => [:new, :edit]
@@ -47,6 +51,10 @@ Foreman::Application.routes.draw do
       resources :settings, :only => [:index, :show, :update]
       resources :smart_proxies, :except => [:new, :edit] do
         put :refresh, :on => :member
+        post :import_puppetclasses, :on => :member
+        resources :environments, :only => [] do
+          post :import_puppetclasses, :on => :member
+        end
       end
       resources :subnets, :except => [:new, :edit]
       resources :usergroups, :except => [:new, :edit]

--- a/test/functional/api/v1/smart_proxies_controller_test.rb
+++ b/test/functional/api/v1/smart_proxies_controller_test.rb
@@ -191,4 +191,18 @@ class Api::V1::SmartProxiesControllerTest < ActionController::TestCase
     assert_equal 'Successfully updated environment and puppetclasses from the on-disk puppet installation', response['message']
   end
 
+  test "should import new environment that does not exist in db" do
+    setup_import_classes
+    as_admin do
+      env_name = 'env1'
+      assert Environment.find_by_name(env_name).destroy
+      assert_difference('Environment.count', 1) do
+        post :import_puppetclasses, {:id => smart_proxies(:puppetmaster).id, :environment_id => env_name}, set_session_user
+      end
+      assert_response :success
+      response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal env_name, response['results']['name']
+    end
+  end
+
 end


### PR DESCRIPTION
works for v1 and v2

API URL examples

api/smart_proxies/7/import_puppetclasses
api/smart_proxies/7/import_puppetclasses?dryrun

api/smart_proxies/7/environments/15/import_puppetclasses
api/smart_proxies/7/environments/15/import_puppetclasses?dryrun

api/environments/15/smart_proxies/7/import_puppetclasses
api/environments/15/smart_proxies/7/import_puppetclasses?dryrun
