### PR TITLE
Bug #2231: Hostgroup deletion follows :restrict orphan policy

### DIFF
--- a/app/controllers/api/v1/hostgroups_controller.rb
+++ b/app/controllers/api/v1/hostgroups_controller.rb
@@ -64,7 +64,11 @@ module Api
       param :id, :identifier, :required => true
 
       def destroy
-        process_response @hostgroup.destroy
+        if @hostgroup.has_children?
+          render :json => {'message'=> _("Cannot delete group %{current} because it has nested groups.") % { :current => @hostgroup.label } }, :status => :conflict
+        else
+          process_response @hostgroup.destroy
+        end
       end
 
     end

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -68,7 +68,11 @@ module Api
       param :id, :identifier, :required => true
 
       def destroy
-        process_response @hostgroup.destroy
+        if @hostgroup.has_children?
+          render :json => {'message'=> _("Cannot delete group %{current} because it has nested groups.") % { :current => @hostgroup.label } }, :status => :conflict
+        else
+          process_response @hostgroup.destroy
+        end
       end
 
     end

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -83,10 +83,15 @@ class HostgroupsController < ApplicationController
   end
 
   def destroy
-    if @hostgroup.destroy
-      process_success
-    else
-      load_vars_for_ajax
+    begin
+      if @hostgroup.destroy
+        process_success
+      else
+        load_vars_for_ajax
+        process_error
+      end
+    rescue Ancestry::AncestryException
+      flash[:error] = _("Cannot delete group %{current} because it has nested groups.") % { :current => @hostgroup.label }
       process_error
     end
   end

--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -6,7 +6,7 @@ module HostgroupsHelper
     msg = [_("Are you sure?")]
     if group.has_children?
       msg << _("This group has nested groups!") + "\n"
-      msg << _("Deleting this group will unlink its nested groups and any associated puppet classes and / or parameters")
+      msg << _("Please delete all nested groups before deleting it.")
     end
     msg.join("\n")
   end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -1,5 +1,5 @@
 class Hostgroup < ActiveRecord::Base
-  has_ancestry :orphan_strategy => :rootify
+  has_ancestry :orphan_strategy => :restrict
   include Authorization
   include Taxonomix
   include HostCommon

--- a/test/functional/api/v1/hostgroups_controller_test.rb
+++ b/test/functional/api/v1/hostgroups_controller_test.rb
@@ -38,6 +38,14 @@ class Api::V1::HostgroupsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "blocks API deletion of hosts with children" do
+    assert hostgroups(:parent).has_children?
+    assert_no_difference('Hostgroup.count') do
+      delete :destroy, { :id => hostgroups(:parent).to_param }
+    end
+    assert_response :conflict
+  end
+
   test "should create nested hostgroup with a parent" do
     assert_difference('Hostgroup.count') do
       post :create, { :hostgroup => valid_attrs.merge(:parent_id => hostgroups(:common).id) }

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -38,6 +38,14 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "blocks API deletion of hosts with children" do
+    assert hostgroups(:parent).has_children?
+    assert_no_difference('Hostgroup.count') do
+      delete :destroy, { :id => hostgroups(:parent).to_param }
+    end
+    assert_response :conflict
+  end
+
   test "should create nested hostgroup with a parent" do
     assert_difference('Hostgroup.count') do
       post :create, { :hostgroup => valid_attrs.merge(:parent_id => hostgroups(:common).id) }


### PR DESCRIPTION
Given a hostgroup hierarchy like:

/base
/base/test01
/base/test01/test02
/base/test01/test03

Currently, if /base/test01 is deleted, it leads to a clunky configuration

/base
/test02
/test03

In addition to that, it might lead to having several hostgroups with the same name:

/base
/test/base

If test is deleted, we would end up with

/base
/base

This change restricts hostgroup deletion only to hostgroups who have no children so that the problems above can be avoided.

http://projects.theforeman.org/issues/2231
