### PR TITLE
Don't use a hidden value of certname if use_uuid_for_certificates has been toggled on/off

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -234,7 +234,10 @@ class Host::Managed < Host::Base
     # If the user has changed use_uuid_for_certificates to false,
     # then null out the certname. This means we may revoke the hostname
     # or UUID but will only set autosign for the hostname.
-    self.certname = nil if !Setting[:use_uuid_for_certificates] && Foreman.is_uuid?(certname)
+    if !Setting[:use_uuid_for_certificates] && Foreman.is_uuid?(certname)
+      logger.info "Removing UUID certificate value #{certname} for host #{name}"
+      self.certname = nil
+    end
 
     setAutosign
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -222,9 +222,21 @@ class Host::Managed < Host::Base
   # Called after a host is given their provisioning template
   # Returns : Boolean status of the operation
   def handle_ca
+    # If there's no puppetca, tell the caller that everything is ok
     return true unless Setting[:manage_puppetca]
     return true unless puppetca?
-    respond_to?(:initialize_puppetca,true) && initialize_puppetca && delCertificate && setAutosign
+
+    # From here out, we expect things to work and return true
+    return false unless respond_to?(:initialize_puppetca, true)
+    return false unless initialize_puppetca
+    return false unless delCertificate
+
+    # If the user has changed use_uuid_for_certificates to false,
+    # then null out the certname. This means we may revoke the hostname
+    # or UUID but will only set autosign for the hostname.
+    self.certname = nil if !Setting[:use_uuid_for_certificates] && Foreman.is_uuid?(certname)
+
+    setAutosign
   end
 
   # returns the host correct disk layout, custom or common

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -3,4 +3,11 @@ module Foreman
   def self.uuid
     UUIDTools::UUID.random_create.to_s
   end
+
+  UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
+                           "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
+  # does this look like a UUID?
+  def self.is_uuid?(str)
+    !!(str =~ UUID_REGEXP)
+  end
 end


### PR DESCRIPTION
Expected:
- Enable use_uuid_for_certificates
- Create a host
- Host has a UUID now
- Set host to Build, pull the host's template, watch the certname UUID value be added to the Puppet Autosign file.
- ... realize that uuid certificates aren't right for your organization ...
- Disable use_uuid_for_certificates
- Set host to Build, pull the host's template, watch the _certname hostname value_ be added to the autosign file.

Actual:
- Set host to Build, pull the host's template, watch the _certname UUID value_ be added to the Puppet Autosign file.
- Watch as your Puppet run fails to get a certificate because the client has submitted a certificate request using its hostname now.

Patch fixes this by checking for state of the use_uuid_for_certificates setting in the certname model method.
