### PR TITLE
IPs and tokens update

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -20,7 +20,7 @@ class Setting::Provisioning < Setting
         self.set('ignore_puppet_facts_for_provisioning', N_("Does not update ipaddress and MAC values from Puppet facts"), false),
         self.set('query_local_nameservers', N_("Should Foreman query the locally configured name server or the SOA/NS authorities"), false),
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1"),
-        self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 0),
+        self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 60),
         self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0"),
         self.set('update_ip_from_built_request', N_("Should we use the originating IP of the built request to update the host's IP?"), false),
         self.set('use_shortname_for_vms', N_("Should Foreman use the short hostname instead of the FQDN for creating new virtual machines"), false)

--- a/app/views/hosts/_unattended.html.erb
+++ b/app/views/hosts/_unattended.html.erb
@@ -20,7 +20,8 @@
         <span id="subnet_select">
           <%= render 'common/domain', :item => @host %>
         </span>
-        <%= text_f f, :ip, :help_inline => _("IP Address for this host, if DHCP Smart proxy is enabled, this should be auto suggested to you") , :autocomplete => 'off'%>
+        <%= text_f f, :ip, :autocomplete => 'off',
+          :help_inline => popover("?", _("The IP address will be auto-suggested if you have a DHCP-enabled Smart Proxy on the Subnet selected above.<br/><br/>The IP address can be left blank if:<br/><ul><li>Provisioning Tokens are being used</li><li>The Subnet does not use DNS</li><li>The Subnet does not use DHCP</li><li>The Domain does not use DNS</li></ul>"), :title => _("The IP Address for this host")).html_safe %>
         <%= f.fields_for :interfaces do |interfaces| %>
           <%= render 'hosts/interfaces', :f => interfaces  %>
         <% end %>

--- a/test/fixtures/subnets.yml
+++ b/test/fixtures/subnets.yml
@@ -24,3 +24,10 @@ three:
    dhcp: one
    tftp: two
    vlanid: 43
+
+four:
+   name: four
+   network: 3.3.5.0
+   mask: 255.255.255.0
+   tftp: two
+   vlanid: 44


### PR DESCRIPTION
#3182
#3196

We might want some kind of AJAX on the IP field to display when it is/isn't required. Otherwise the user may get confused. Conditions are:
- When it's on a DNS or DHCP enabled Subnet
- When it's on a DNS enable Domain
- When Tokens are disabled
- Not when it's an image-based Compute VM
