### PR TITLE
Fixes #3183 - Ensure timestamp fact is a string, not a symbol

### DIFF
--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -5,8 +5,8 @@ class FactName < ActiveRecord::Base
   has_many :users, :through => :user_facts
   has_many_hosts :through => :fact_values
 
-  scope :no_timestamp_fact, :conditions => ["fact_names.name <> ?",:_timestamp]
-  scope :timestamp_facts,   :conditions => ["fact_names.name = ?", :_timestamp]
+  scope :no_timestamp_fact, :conditions => ["fact_names.name <> ?",'_timestamp']
+  scope :timestamp_facts,   :conditions => ["fact_names.name = ?", '_timestamp']
 
   default_scope :order => 'fact_names.name'
 

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -12,10 +12,10 @@ class FactValue < ActiveRecord::Base
   scoped_search :in => :hostgroup, :on => :name, :rename => :"host.hostgroup", :complete_value => true
 
   scope :no_timestamp_facts, :include => [:fact_name],
-              :conditions => ["fact_names.name <> ?",:_timestamp]
+              :conditions => ["fact_names.name <> ?",'_timestamp']
 
   scope :timestamp_facts, :joins => [:fact_name],
-              :conditions => ["fact_names.name = ?",:_timestamp]
+              :conditions => ["fact_names.name = ?",'_timestamp']
 
   scope :my_facts, lambda {
     if User.current.admin? and Organization.current.nil? and Location.current.nil?

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -70,6 +70,12 @@ module Host
 
       # we are not importing facts for hosts in build state (e.g. waiting for a re-installation)
       raise ::Foreman::Exception.new("Host is pending for Build") if build
+
+      # Ensure timestamp is always a string
+      if facts.include?(:_timestamp)
+        timestamp = facts.delete(:_timestamp)
+        facts['_timestamp'] = timestamp unless facts['_timestamp'].present?
+      end
       time = facts[:_timestamp]
       time = time.to_time if time.is_a?(String)
 
@@ -124,7 +130,6 @@ module Host
       fact_names = FactName.maximum(:id, :group => 'name')
 
       # Create any needed new FactNames
-      facts['_timestamp'] = facts.delete(:_timestamp) if facts.include?(:_timestamp)
       facts.each do |name, value|
         next if db_facts.include?(name)
         values = value.is_a?(Array) ? value : [value]

--- a/test/unit/facts.json
+++ b/test/unit/facts.json
@@ -1,6 +1,7 @@
 {
   "name": "sinn1636.lan",
   "facts": {
+    "_timestamp": "2013-10-04 14:17:07.886377 +01:00",
     "processor3": "Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz",
     "productname": "IBM System x -[7870K4G]-",
     "kernelmajversion": "2.6",

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -119,6 +119,19 @@ class HostTest < ActiveSupport::TestCase
     assert_nil host
   end
 
+  test "should convert a timestamp symbol key to a string key" do
+    raw                = parse_json_fixture('/facts.json')
+    name               = raw['name']
+    facts              = raw['facts']
+    time               = facts.delete('_timestamp')
+    facts[:_timestamp] = time
+    assert Host.importHostAndFacts(name, facts)
+    h = Host.find_by_name('sinn1636.lan')
+    refute h.facts_hash[:_timestamp]
+    assert_equal time, h.facts_hash['_timestamp']
+  end
+
+
   test "should not save if neither ptable or disk are defined when the host is managed" do
     if unattended?
       host = Host.create :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.4.4.03",


### PR DESCRIPTION
Do we need the db:migration? I can't find a `:_timestamp` fact_name in any of my DBs...
