### PR TITLE
[REFACTOR] fixes #3205 Extracts report importing logic

### DIFF
--- a/app/models/concerns/report_common.rb
+++ b/app/models/concerns/report_common.rb
@@ -42,12 +42,8 @@ module ReportCommon
   #when no metric type is specific returns hash with all values
   #passing a METRIC member will return its value
   def status(type = nil)
-    raise(N_("invalid type %s") % type) if type and not METRIC.include?(type)
-    h = {}
-    (type.is_a?(String) ? [type] : METRIC).each do |m|
-      h[m] = (read_attribute(self.class.report_status) || 0) >> (BIT_NUM*METRIC.index(m)) & MAX
-    end
-    type.nil? ? h : h[type]
+    @calc ||= ReportStatusCalculator.new(:bit_field => read_attribute(self.class.report_status))
+    @calc.status(type)
   end
 
 end

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -1,0 +1,107 @@
+class ReportImporter
+  delegate :logger, :to => :Rails
+  attr_reader :report
+
+  def self.import(raw, proxy_id = nil)
+    importer = new(raw, proxy_id)
+    importer.import
+    importer.report
+  end
+
+  def initialize(raw, proxy_id = nil)
+    raise ::Foreman::Exception.new(_('Invalid report')) unless raw.is_a?(Hash)
+    @raw      = raw
+    @proxy_id = proxy_id
+  end
+
+  def import
+    start_time = Time.now
+    logger.info "processing report for #{name}"
+    logger.debug { "Report: #{raw.inspect}" }
+
+    if host.new_record? && !Setting[:create_new_host_when_report_is_uploaded]
+      logger.info("skipping report for #{name} as its an unknown host and create_new_host_when_report_is_uploaded setting is disabled")
+      return Report.new
+    end
+
+    # convert report status to bit field
+    st                   = ReportStatusCalculator.new(:counters => raw['status']).calculate
+
+    # we update our host record, so we won't need to lookup the report information just to display the host list / info
+    host.last_report     = time if host.last_report.nil? or host.last_report.utc < time
+    # we save the report bit status value in our host too.
+    host.puppet_status   = st
+
+    # if proxy authentication is enabled and we have no puppet proxy set, use it.
+    host.puppet_proxy_id ||= proxy_id
+
+    # we save the host without validation for two reasons:
+    # 1. It might be auto imported, therefore might not be valid (e.g. missing partition table etc)
+    # 2. We want this to be fast and light on the db.
+    # at this point, the report is important, not the host
+    host.save(:validate => false)
+
+    # and save our report
+    @report = Report.new(:host => host, :reported_at => time, :status => st, :metrics => raw['metrics'])
+    return report unless report.save
+    # Store all Puppet message logs
+    import_log_messages
+    # Check for errors
+    inspect_report
+    logger.info("Imported report for #{name} in #{(Time.now - start_time).round(2)} seconds")
+  end
+
+  private
+  attr_reader :raw, :proxy_id
+
+  def name
+    @name ||= raw['host']
+  end
+
+  def host
+    @host ||= Host::Base.find_by_certname(name) ||
+      Host::Base.find_by_name(name) ||
+      Host::Managed.new(:name => name)
+  end
+
+  def time
+    @time ||= Time.parse(raw['reported_at']).utc
+  end
+
+  def logs
+    raw['logs'] || []
+  end
+
+  def import_log_messages
+    logs.each do |log|
+      # Parse the API format
+      level = log['log']['level']
+      msg   = log['log']['messages']['message']
+      src   = log['log']['sources']['source']
+
+      message = Message.find_or_create msg
+      source  = Source.find_or_create src
+
+      # Symbols get turned into strings via the JSON API, so convert back here if it matches
+      # and expected log level. Log objects can't be created without one, so raise if not
+      raise(::Foreman::Exception.new(N_("Invalid log level: %s", level))) unless Report::LOG_LEVELS.include?(level)
+
+      Log.create(:message_id => message.id, :source_id => source.id, :report => report, :level => level.to_sym)
+    end
+  end
+
+  def inspect_report
+    if report.error?
+      # found a report with errors
+      # notify via email IF enabled is set to true
+      logger.warn "#{name} is disabled - skipping." and return if host.disabled?
+
+      logger.debug 'error detected, checking if we need to send an email alert'
+      HostMailer.error_state(report).deliver if Setting[:failed_report_email_notification]
+      # add here more actions - e.g. snmp alert etc
+    end
+  rescue => e
+    logger.warn "failed to send failure email notification: #{e}"
+    logger.debug e.backtrace
+  end
+end

--- a/app/services/report_status_calculator.rb
+++ b/app/services/report_status_calculator.rb
@@ -1,0 +1,37 @@
+class ReportStatusCalculator
+
+  # converts a counters hash into a bit field
+  # expects a metrics_to_hash kind of counters
+  # see the report_processor for the implementation
+  def initialize(options = {})
+    @counters   = options[:counters]  || {}
+    @raw_status = options[:bit_field] || 0
+  end
+
+  def calculate
+    @raw_status = 0
+    counters.each do |type, value|
+      value = value.to_i                         # JSON does everything as strings
+      value = Report::MAX if value > Report::MAX # we store up to 2^BIT_NUM -1 values as we want to use only BIT_NUM bits.
+      @raw_status |= value << (Report::BIT_NUM * Report::METRIC.index(type))
+    end
+    raw_status
+  end
+
+  #returns metrics
+  #when no metric type is specific returns hash with all values
+  #passing a METRIC member will return its value
+  def status(type = nil)
+    calculate if raw_status == 0
+    raise(Foreman::Exception(N_("invalid type %s") % type)) if type && !Report::METRIC.include?(type)
+    counters = Hash.new(0)
+    (type.is_a?(String) ? [type] : Report::METRIC).each do |m|
+      counters[m] = (raw_status || 0) >> (Report::BIT_NUM * Report::METRIC.index(m)) & Report::MAX
+    end
+    type.nil? ? counters : counters[type]
+  end
+
+  private
+  attr_reader :raw_status, :counters
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,11 @@ Spork.prefork do
     def disable_orchestration
       ActiveSupport::TestCase.disable_orchestration
     end
+
+    def read_json_fixture(file)
+      json = File.expand_path(File.join('..', 'fixtures', file), __FILE__)
+      JSON.parse(File.read(json))
+    end
   end
 
   # Transactional fixtures do not work with Selenium tests, because Capybara

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class ReportImporterTest < ActiveSupport::TestCase
+
+  def setup
+    User.current = User.admin
+  end
+
+  def teardown
+    User.current = nil
+  end
+
+  test 'json_fixture_loader' do
+    assert_kind_of Hash, read_json_fixture('report-empty.json')
+  end
+
+  test 'it should import reports with no metrics' do
+    r = ReportImporter.import(read_json_fixture('report-empty.json'))
+    assert r
+    assert_equal({}, r.metrics)
+  end
+
+  test 'it should import reports where logs is nil' do
+    r = Report.import read_json_fixture('report-no-logs.json')
+    assert_empty r.logs
+  end
+
+  test 'when notification is set to true, if report has an error, a mail to admin should be sent' do
+    setup_for_email_reporting
+    Setting[:failed_report_email_notification] = true
+    assert_difference 'ActionMailer::Base.deliveries.size' do
+      ReportImporter.import read_json_fixture('report-errors.json')
+    end
+  end
+
+  test 'when notification is set to false, if the report has an error, no mail should be sent' do
+    setup_for_email_reporting
+    Setting[:failed_report_email_notification] = false
+    assert_no_difference 'ActionMailer::Base.deliveries.size' do
+      ReportImporter.import read_json_fixture('report-errors.json')
+    end
+  end
+
+  test 'if report has no error, no mail should be sent' do
+    setup_for_email_reporting
+    assert_no_difference 'ActionMailer::Base.deliveries.size' do
+      ReportImporter.import read_json_fixture('report-applied.json')
+    end
+  end
+
+  private
+
+  def setup_for_email_reporting
+    # Email recipient
+    Setting[:administrator] = 'admin@example.com'
+    Setting[:failed_report_email_notification] = true
+  end
+
+end

--- a/test/unit/report_status_calculator_test.rb
+++ b/test/unit/report_status_calculator_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+class ReportStatusCalculatorTest < ActiveSupport::TestCase
+
+  test 'it should not change host report status when we have skipped reports but there are no log entries' do
+    r = ReportStatusCalculator.new(:counters => {'applied' => 0, 'restarted' => 0, 'failed' => 0, 'failed_restarts' => 0, 'skipped' => 1, 'pending' => 0})
+    assert_equal 0, r.status['failed']
+  end
+
+  test 'it should save metrics as bits in status integer' do
+    r = ReportStatusCalculator.new(:counters => {'applied' => 92, 'restarted' => 300, 'failed' => 4, 'failed_restarts' => 12, 'skipped' => 3, 'pending' => 4})
+    assert_equal Report::MAX, r.status['applied']
+    assert_equal Report::MAX, r.status['restarted']
+    assert_equal 4, r.status['failed']
+    assert_equal 12, r.status['failed_restarts']
+    assert_equal 3, r.status['skipped']
+    assert_equal 4, r.status['pending']
+  end
+end

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -3,23 +3,7 @@ require 'test_helper'
 class ReportTest < ActiveSupport::TestCase
   def setup
     User.current = User.admin
-    @r=Report.import read_json_fixture("/../fixtures/report-skipped.json")
-  end
-
-  test "it should not change host report status when we have skipped reports but there are no log entries" do
-    @r.status={"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 1, "pending" => 0}
-    assert_equal @r.failed, 0
-  end
-
-  test "it should save metrics as bits in status integer" do
-    @r.status={"applied" => 92, "restarted" => 300, "failed" => 4, "failed_restarts" => 12, "skipped" => 3, "pending" => 4}
-    @r.save
-    assert_equal @r.applied, Report::MAX
-    assert_equal @r.restarted, Report::MAX
-    assert_equal @r.failed, 4
-    assert_equal @r.failed_restarts, 12
-    assert_equal @r.skipped, 3
-    assert_equal @r.pending, 4
+    @r=Report.import read_json_fixture("report-skipped.json")
   end
 
   test "it should true on error? if there were errors" do
@@ -120,49 +104,6 @@ class ReportTest < ActiveSupport::TestCase
     record.status = {}
     assert !record.save
     assert record.valid?
-  end
-
-  test "it should import reports with no metrics" do
-    r=Report.import read_json_fixture("/../fixtures/report-empty.json")
-    assert r
-  end
-
-  test "it should import reports where logs is nil" do
-    r=Report.import read_json_fixture("/../fixtures/report-no-logs.json")
-    assert r
-  end
-
-  test "when notification is set to true, if report has an error, a mail to admin should be sent" do
-    setup_for_email_reporting
-    Setting[:failed_report_email_notification] = true
-    assert_difference 'ActionMailer::Base.deliveries.size' do
-      Report.import read_json_fixture("/../fixtures/report-errors.json")
-    end
-  end
-
-  test "when notification is set to false, if the report has an error, no mail should be sent" do
-    setup_for_email_reporting
-    Setting[:failed_report_email_notification] = false
-    assert_no_difference 'ActionMailer::Base.deliveries.size' do
-      Report.import read_json_fixture("/../fixtures/report-errors.json")
-    end
-  end
-
-  test "if report has no error, no mail should be sent" do
-    setup_for_email_reporting
-    assert_no_difference 'ActionMailer::Base.deliveries.size' do
-      Report.import read_json_fixture("/../fixtures/report-applied.json")
-    end
-  end
-
-  def setup_for_email_reporting
-    # Email recepient
-    Setting[:administrator] = "admin@example.com"
-    Setting[:failed_report_email_notification] = true
-  end
-
-  def read_json_fixture(file)
-    JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + file)))
   end
 
 end


### PR DESCRIPTION
This patch extracts all report importing logic into seperate importer class.
long term this could allow:
1. aliases methods for async operations
2. different types of reports imports (based on reporting type).
