### PR TITLE
Fixes #3208 - print warnings for old enc/report routes

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
 
-      before_filter :find_resource, :except => :facts
-      add_puppetmaster_filters :facts
+      before_filter :find_resource, :except => [:facts, :enc_deprecation_msg]
+      add_puppetmaster_filters [:facts, :enc_deprecation_msg]
 
       api :GET, "/hosts/:id/puppetrun", "Force a puppet run on the agent."
 
@@ -51,6 +51,13 @@ module Api
         process_response state
       rescue ::Foreman::Exception => e
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
+      end
+
+      def enc_deprecation_msg
+        msg  = "/fact_values/create is deprecated, update your ENC to POST facts to /api/hosts/facts\n"
+        msg += '  See the Foreman 1.3 release notes for a new example ENC script'
+        logger.error "DEPRECATION: #{msg}."
+        render :json => {:message => msg}, :status => 400
       end
 
       private

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
 
-      add_puppetmaster_filters :create
+      add_puppetmaster_filters [:create, :report_deprecation_msg]
 
       api :POST, "/reports/", "Create a report."
       param :report, Hash, :required => true do
@@ -20,6 +20,13 @@ module Api
         process_response @report.valid?
       rescue ::Foreman::Exception => e
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
+      end
+
+      def report_deprecation_msg
+        msg  = "/reports/create is deprecated, update your report processor to POST to /api/reports\n"
+        msg += '  See the Foreman 1.3 release notes for a new example report processor'
+        logger.error "DEPRECATION: #{msg}."
+        render :json => {:message => msg}, :status => 400
       end
 
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ require 'api_constraints'
 Foreman::Application.routes.draw do
   #ENC requests goes here
   match "node/:name" => 'hosts#externalNodes', :constraints => { :name => /[^\.][\w\.-]+/ }
+  # To be removed for 1.4
+  match 'reports/create',     :to => 'api/v2/reports#report_deprecation_msg', :via => 'post'
+  match 'fact_values/create', :to => 'api/v2/hosts#enc_deprecation_msg',      :via => 'post'
 
   resources :reports, :only => [:index, :show, :destroy] do
     collection do

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -23,6 +23,9 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     # No controller action actually exists, shouldn't be permitted either
     "audits/create", "audits/destroy", "audits/edit", "audits/new", "audits/update",
 
+    # Deprecated routes
+    "api/v2/hosts/enc_deprecation_msg", "api/v2/reports/report_deprecation_msg",
+
     # Apipie
     "apipie/apipies/index"
 


### PR DESCRIPTION
We should revert this once 1.3 is out...
