### PR TITLE
fixes #3212 - disabled constraint checks for mysql database

### DIFF
--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -79,14 +79,6 @@ namespace :db do
         self.inheritance_column = :_type_disabled
       end
 
-      # turn off Foreign Key checks for development db in case of a postgresql db
-      ActiveRecord::Base.establish_connection(:development)
-      if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
-        ActiveRecord::Migration.execute "SET CONSTRAINTS ALL DEFERRED;"
-      elsif ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-        ActiveRecord::Migration.execute "SET FOREIGN_KEY_CHECKS=0;"
-      end 
-
       ActiveRecord::Base.establish_connection(:production)
       skip_tables = ["schema_info", "schema_migrations"]
       (ActiveRecord::Base.connection.tables - skip_tables).each do |table_name|

--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -79,6 +79,14 @@ namespace :db do
         self.inheritance_column = :_type_disabled
       end
 
+      # turn off Foreign Key checks for development db in case of a postgresql db
+      ActiveRecord::Base.establish_connection(:development)
+      if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+        ActiveRecord::Migration.execute "SET CONSTRAINTS ALL DEFERRED;"
+      elsif ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+        ActiveRecord::Migration.execute "SET FOREIGN_KEY_CHECKS=0;"
+      end 
+
       ActiveRecord::Base.establish_connection(:production)
       skip_tables = ["schema_info", "schema_migrations"]
       (ActiveRecord::Base.connection.tables - skip_tables).each do |table_name|
@@ -92,6 +100,8 @@ namespace :db do
         # turn off Foreign Key checks for development db - this is per session
         if DevelopmentModelClass.connection.adapter_name.downcase.starts_with? 'mysql'
           DevelopmentModelClass.connection.execute("SET FOREIGN_KEY_CHECKS=0;")
+        elsif DevelopmentModelClass.connection.adapter_name == 'PostgreSQL'
+          DevelopmentModelClass.connection.execute "SET CONSTRAINTS ALL DEFERRED;"
         end
         DevelopmentModelClass.set_table_name(table_name)
         DevelopmentModelClass.reset_column_information

--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -89,6 +89,10 @@ namespace :db do
         ProductionModelClass.reset_column_information
 
         DevelopmentModelClass.establish_connection(:development)
+        # turn off Foreign Key checks for development db - this is per session
+        if DevelopmentModelClass.connection.adapter_name.downcase.starts_with? 'mysql'
+          DevelopmentModelClass.connection.execute("SET FOREIGN_KEY_CHECKS=0;")
+        end
         DevelopmentModelClass.set_table_name(table_name)
         DevelopmentModelClass.reset_column_information
         DevelopmentModelClass.record_timestamps = false


### PR DESCRIPTION
This is a fix for a problem I was facing when I tried to move from sqlite to mysql and that should have been fixed by https://github.com/theforeman/foreman/pull/934. I removed to postgresql stuff, as I'm not able to verify this. In the long term it might be a good thing solve the foreign key issues by migrating them in the correct order.
