### PR TITLE
Fix libv8 build fail on ARM (raspberry pi)

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -4,7 +4,7 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
   gem "jquery-rails", "2.0.3"
   gem 'jquery-ui-rails'
-  gem "therubyracer", '0.11.3', :require => 'v8'
+  gem "therubyracer", '~> 0.12.0', :require => 'v8'
   gem "twitter-bootstrap-rails", '2.2.6'
   gem "spice-html5-rails"
   gem "flot-rails", '0.0.3'


### PR DESCRIPTION
therubyracer 0.11.3 depends on libv8 ~> 3.11.8.12 that does not build on ARM (tested on raspberry pi).

This PR fixes that issue by depending on therubyracer 0.12.0 that depends on libv8 ~> 3.16.14.0 that builds on ARM (providing foreman works well with therubyracer 0.12.0).
