### PR TITLE
fixes #3241 - default password is now MD5

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -11,7 +11,7 @@ class Setting::Provisioning < Setting
 
     self.transaction do
       [
-        self.set('root_pass', N_("Default encrypted root password on provisioned hosts (default is 123123)"), "xybxa6JUkz63w"),
+        self.set('root_pass', N_("Default encrypted root password on provisioned hosts (default is 123123)"), "$1$default$hCkak1kaJPQILNmYbUXhD0"),
         self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true),
         self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert),
         self.set('ssl_ca_file', N_( "SSL CA file that Foreman will use to communicate with its proxies"), ssl_ca_file),


### PR DESCRIPTION
I am changing the default password to "$1$default$hCkak1kaJPQILNmYbUXhD0".
Can you plese test this on various systems (Debian, Ubuntu, Fedora, Suse)?
The only thing to do is to provision a system with default root password set
to this and try to log in.

I don't know why the current default password (plain crypt with "xy" salt)
does not work with Anaconda in RHEL6.

We can implement auto-encryption of user-inserted password for this entry,
but I am not going to do this in this PR as I would like to get RHEL working
in 1.3 final release. Please do comment and test.
