### PR TITLE
Add missing gem facter to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "apipie-rails", "~> 0.0.23"
 gem 'rabl', '>= 0.7.5'
 gem 'oauth'
 gem 'foreigner', '~> 1.4.2'
+gem 'facter'
 
 if RUBY_VERSION =~ /^1\.8/
   # Older version of safemode for Ruby 1.8, as the latest causes regexp overflows (#2100)


### PR DESCRIPTION
When I try to build from sources it complains about missing gem facter.
This patch fixes this
