### PR TITLE
fixes #3277 - Filtering host from within the organization table fails with organization names containing blanks

### DIFF
--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -20,7 +20,7 @@
   <% @taxonomies.each do |taxonomy| %>
     <tr class="<%= cycle("even", "odd") %>">
       <td><%= link_to taxonomy.to_label, edit_taxonomy_path(taxonomy) %></td>
-      <td><%= link_to @counter[taxonomy.id] || 0, hosts_path(:search => "#{controller_name.singularize} = #{taxonomy}") %></td>
+      <td><%= link_to @counter[taxonomy.id] || 0, hosts_path(:search => "#{controller_name.singularize} = \"#{taxonomy}\"") %></td>
       <td>
         <%= action_buttons(
           display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),


### PR DESCRIPTION
Added quotes to the search string so that organization names with blanks with are handled correct.
