### PR TITLE
[Obsolete by https://github.com/theforeman/foreman/pull/967] Improve the REMOTE_USER (for example mod_auth_kerb) support

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -49,6 +49,10 @@ module Foreman::Controller::Authentication
     authenticate
   end
 
+  def optional_login
+    authenticate or redirect_to login_users_path
+  end
+
   def is_admin?
     return true unless SETTINGS[:login]
     return true if User.current && User.current.admin?

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -26,6 +26,7 @@ module Foreman::Controller::Authentication
           session[:original_uri] = request.fullpath
           @available_sso ||= SSO::Base.new(self)
 
+          return if @available_sso.login_url == request.fullpath
           (redirect_to @available_sso.login_url and return) unless @available_sso.has_rendered
         end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   before_filter :find_user, :only => [:edit, :update, :destroy]
   skip_before_filter :require_mail, :only => [:edit, :update, :logout]
-  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogin]
+  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogin, :extlogout]
   before_filter :optional_login, :only => [:extlogin]
   after_filter       :update_activity_time, :only => :login
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,8 @@ class UsersController < ApplicationController
 
   before_filter :find_user, :only => [:edit, :update, :destroy]
   skip_before_filter :require_mail, :only => [:edit, :update, :logout]
-  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout]
+  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogin]
+  before_filter :optional_login, :only => [:extlogin]
   after_filter       :update_activity_time, :only => :login
 
   attr_accessor :editing_self

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,6 +97,14 @@ class UsersController < ApplicationController
       end
     end
   end
+
+  def extlogin
+    if session[:user]
+       user = User.find_by_id(session[:user])
+       login_user(user)
+    end
+  end
+
   # Called from the logout link
   # Clears the rails session and redirects to the login action
   def logout

--- a/app/models/auth_sources/auth_source_external.rb
+++ b/app/models/auth_sources/auth_source_external.rb
@@ -1,0 +1,11 @@
+class AuthSourceExternal < AuthSource
+
+  def authenticate(login, password)
+    raise NotImplementedError, "#{__class__} does not support authenticate"
+  end
+
+  def auth_method_name
+    "EXTERNAL"
+  end
+  alias_method :to_label, :auth_method_name
+end

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -19,7 +19,8 @@ class Setting::Auth < Setting
         self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY'),
         self.set('signo_sso', N_('Use Signo SSO for login'), false),
         self.set('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo"),
-        self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), 'https://example.com/logout')
+        self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), 'https://example.com/logout'),
+        self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'), '-'),
       ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
     end
 

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -27,7 +27,7 @@ module SSO
     end
 
     def logout_url
-      "#{Setting['login_delegation_logout_url']}"
+      controller.extlogout_users_path
     end
 
     def expiration_url

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -18,6 +18,10 @@ module SSO
       true
     end
 
+    def login_url
+      controller.extlogin_users_path
+    end
+
     def logout_url
       "#{Setting['login_delegation_logout_url']}"
     end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -18,6 +18,7 @@ module SSO
     # authenticate the user without using password.
     def authenticated?
       self.user = request.env[CAS_USERNAME]
+      return false unless self.user and User.find_or_create_external_user(self.user, Setting['authorize_login_delegation_auth_source_user_autocreate'])
       store
       true
     end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -10,6 +10,10 @@ module SSO
       true
     end
 
+    def support_expiration?
+      true
+    end
+
     # If REMOTE_USER is provided by the web server then
     # authenticate the user without using password.
     def authenticated?
@@ -24,6 +28,10 @@ module SSO
 
     def logout_url
       "#{Setting['login_delegation_logout_url']}"
+    end
+
+    def expiration_url
+      controller.extlogin_users_path
     end
 
     def store

--- a/app/views/users/extlogout.html.erb
+++ b/app/views/users/extlogout.html.erb
@@ -3,6 +3,6 @@
     <%= image_tag("foreman_white.png", :class=>"login-logo") %>
   </div>
   <div class="section">
-    <a href="/users/extlogin">Please log in again.</a>
+    <%= link_to(_("Please log in again."), extlogin_users_path) %>
   </div>
 </div>

--- a/app/views/users/extlogout.html.erb
+++ b/app/views/users/extlogout.html.erb
@@ -1,0 +1,8 @@
+<div id="login" class="login-container">
+  <div class="aside">
+    <%= image_tag("foreman_white.png", :class=>"login-logo") %>
+  </div>
+  <div class="section">
+    <a href="/users/extlogin">Please log in again.</a>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Foreman::Application.routes.draw do
         post 'login'
         get 'logout'
         get 'extlogin'
+        get 'extlogout'
         get 'auth_source_selected'
         get 'auto_complete_search'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Foreman::Application.routes.draw do
         get 'login'
         post 'login'
         get 'logout'
+        get 'extlogin'
         get 'auth_source_selected'
         get 'auto_complete_search'
       end

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -12,7 +12,7 @@ require 'foreman/access_permissions'
 # an appropriate permission so views using those requests function.
 class AccessPermissionsTest < ActiveSupport::TestCase
   MAY_SKIP_REQUIRE_LOGIN = [
-    "users/login", "users/logout", "home/status", "notices/destroy", "unattended/",
+    "users/login", "users/logout", "users/extlogout", "home/status", "notices/destroy", "unattended/",
 
     # puppetmaster interfaces
     "fact_values/create", "reports/create",


### PR DESCRIPTION
This series of patches makes it possible to set up a protected "logon" location in Apache via

  &lt;Location /users/extlogin>
  ...
  &lt;/Location>

and configure mod_auth_\* authentication modules for that location. It was tested with mod_auth_kerb.

The possibilities and issues with the existing REMOTE_USER support are listed at http://projects.theforeman.org/projects/foreman/wiki/Foreman_and_mod_auth_kerb, together with explanations introduced by this pull request.
