### PR TITLE
fixes #3338 - grey out VM form when editing is not supported

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -483,6 +483,7 @@ function onHostEditLoad(){
    });
   $('#image_selection').appendTo($('#image_provisioning'));
   $('#params-tab').on('shown', function(){mark_params_override()});
+  if ($('#supports_update') && !$('#supports_update').data('supports-update')) disable_vm_form_fields();
 }
 
 $(document).on('submit',"[data-submit='progress_bar']", function() {
@@ -611,4 +612,12 @@ function interface_type_selected(element) {
     bmc_fields.addClass("hide");
   }
 
+}
+
+function disable_vm_form_fields() {
+  $("#update_not_supported").show();
+  $("[id^=host_compute_attributes]").each(function () {
+    $(this).attr("disabled", "disabled");
+  });
+  $("a.disable-unsupported").remove();
 }

--- a/app/views/compute_resources_vms/form/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/form/_libvirt.html.erb
@@ -12,7 +12,7 @@
     <%= f.fields_for :nics do |i| %>
       <%= render 'compute_resources_vms/form/libvirt/network', :f => i, :compute_resource => compute_resource %>
     <% end %>
-    <%= add_child_link '+ ' + _("Add Interface"), :nics, { :class => "info", :title => _('add new network interface') } %>
+    <%= add_child_link '+ ' + _("Add Interface"), :nics, { :class => "info disable-unsupported", :title => _('add new network interface') } %>
   <% end %>
 </div>
 
@@ -25,7 +25,7 @@
     <%= f.fields_for :volumes do |i| %>
       <%= render 'compute_resources_vms/form/libvirt/volume', :f => i, :compute_resource => compute_resource %>
     <% end %>
-    <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+    <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info disable-unsupported", :title => _('add new storage volume') } %>
   <% end %>
 </div>
 <!--TODO # Move to a helper-->

--- a/app/views/compute_resources_vms/form/_vmware.html.erb
+++ b/app/views/compute_resources_vms/form/_vmware.html.erb
@@ -16,7 +16,7 @@
       <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource, :new => new %>
     <% end %>
     <% if new %>
-      <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
+      <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info disable-unsupported", :title => _('add new network interface') } %>
     <% end %>
   <% end %>
 </div>
@@ -31,7 +31,7 @@
       <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource, :new => new %>
     <% end %>
     <% if new %>
-      <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+      <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info disable-unsupported", :title => _('add new storage volume') } %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -5,7 +5,7 @@
   <%= selectable_f f, :type, libvirt_networks(compute_resource), {},
                    { :label    => _('Network Type'), :help_inline =>
                        remove_child_link('X', f, { :method => :'_delete', :title => _('remove network interface'),
-                                                   :class  => 'label label-important' }),
+                                                   :class  => 'label label-important disable-unsupported' }),
                      :onchange => 'libvirt_network_selected(this)' } %>
   <div id='nat' class='<%= 'hide' if f.object.type != 'network' %>'>
     <%= selectable_f f, :network, nat.map(&:name),

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -2,5 +2,5 @@
   <%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :class => "span2", :label => _("Storage Pool") %>
   <%= text_f f, :capacity, :class => "input-mini", :label => _("Size (GB)") %>
   <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "span2", :label => _("Type"),
-                   :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' }) %>
+                   :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important disable-unsupported' }) %>
 </div>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,15 +1,13 @@
 <div class="fields">
   <% if (networks = compute_resource.networks).any? %>
     <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
-                     :class       => "span2",
-                     :label       => _('NIC type'),
-                     :disabled    => !new
+                     :class       => "span2 disable-unsupported",
+                     :label       => _('NIC type')
     %>
     <%= select_f f, :network, networks, :id, :name, { },
-                     :class       => "span2",
+                     :class       => "span2 disable-unsupported",
                      :label       => _('Network'),
-                     :disabled    => !new,
-                     :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important' })
+                     :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important disable-unsupported' })
     %>
   <% end %>
 </div>

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -1,14 +1,13 @@
 <div class="fields">
-  <%= selectable_f f, :datastore, compute_resource.datastores, { }, :class => "span2", :label => _("Data Store"), :disabled => !new %>
-  <%= text_f f, :name, :class => "input-mini", :label => "Name", :disabled => !new %>
+  <%= selectable_f f, :datastore, compute_resource.datastores, { }, :class => "span2 disable-unsupported", :label => _("Data Store") %>
+  <%= text_f f, :name, :class => "input-mini disable-unsupported", :label => "Name" %>
   <%= text_f f, :size_gb,
-             :class       => "input-mini",
-             :label => _("Size (GB)"),
-             :disabled => !new %>
+             :class       => "input-mini disable-unsupported",
+             :label => _("Size (GB)") %>
   <%= checkbox_f f, :thin, {
              :label => _("Thin provision"),
-             :disabled => !new,
-             :help_inline => !new ? nil : remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-important', :disabled => !new })},
+             :class => 'disable-unsupported',
+             :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-important disable-unsupported' })},
              true,
              false %>
 </div>

--- a/app/views/hosts/_compute.html.erb
+++ b/app/views/hosts/_compute.html.erb
@@ -1,5 +1,6 @@
 <%= fields_for "#{type}[compute_attributes]", @host ? @host.compute_object : compute_resource.new_vm do |compute| %>
   <% if compute.object %>
+    <div id='update_not_supported' class='alert hide'><%= _("VM editing is not implemented for this provider") %></div>
     <%= render :partial => "compute_resources_vms/form/#{compute_resource.provider.downcase}",
                :locals => { :f => compute, :compute_resource => compute_resource}.merge(args_for_compute_resource_partial(@host)) %>
   <% else %>
@@ -14,4 +15,5 @@
     </div>
   <% end%>
   <%= hidden_field_tag 'capabilities', compute_resource.capabilities %>
+  <%= content_tag(:div,'', :id => :'supports_update', :data=>{:'supports-update'=> compute_resource.supports_update? || (@host && @host.new_record?)}) %>
 <% end if compute_resource %>


### PR DESCRIPTION
I went for JavaScript solution because it allows us a generic solution.
ComputeResources already have supports_update? methods and it is easy to
determine this in one place rather than editing all the fields and all
possible places. This will prevent errors when implementing new CRs.
