### PR TITLE
fixes #3239 - pxelinux spoofing on postgres now works

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -2,9 +2,9 @@ class UnattendedController < ApplicationController
   layout false
 
   # Methods which return configuration files for syslinux(pxe), pxegrub or g/ipxe
-  PXE_CONFIG_URLS = [:pxe_kickstart_config, :pxe_debian_config, :pxemenu] + TemplateKind.where("name LIKE ?","pxelinux").map(&:name)
-  PXEGRUB_CONFIG_URLS = [:pxe_jumpstart_config] + TemplateKind.where("name LIKE ?", "pxegrub").map(&:name)
-  GPXE_CONFIG_URLS = [:gpxe_kickstart_config] + TemplateKind.where("name LIKE ?", "gpxe").map(&:name)
+  PXE_CONFIG_URLS = [:pxe_kickstart_config, :pxe_debian_config, :pxemenu] + TemplateKind.where("name LIKE ?","PXELinux").map(&:name)
+  PXEGRUB_CONFIG_URLS = [:pxe_jumpstart_config] + TemplateKind.where("name LIKE ?", "PXEGrub").map(&:name)
+  GPXE_CONFIG_URLS = [:gpxe_kickstart_config] + TemplateKind.where("name LIKE ?", "gPXE").map(&:name)
   CONFIG_URLS = PXE_CONFIG_URLS + GPXE_CONFIG_URLS + PXEGRUB_CONFIG_URLS
   # Methods which return valid provision instructions, used by the OS
   PROVISION_URLS = [:kickstart, :preseed, :jumpstart ] + TemplateKind.where("name LIKE ?", "provision").map(&:name)

--- a/test/fixtures/config_templates.yml
+++ b/test/fixtures/config_templates.yml
@@ -45,3 +45,16 @@ pxe_local_default:
    template: DEFAULT menu~PROMPT 0~MENU TITLE PXE Menu~TIMEOUT 200~TOTALTIMEOUT 6000~ONTIMEOUT local~~LABEL local~MENU LABEL (local)~MENU DEFAULT~LOCALBOOT 0
    template_kind: pxelinux
    operatingsystems: centos5_3, redhat
+
+gpxe:
+   name: gPXE Dummy Menu
+   template: "FOO"
+   template_kind: gpxe
+   operatingsystems: centos5_3
+
+pxegrub:
+   name: PXEGrub Dummy Menu
+   template: "FOO"
+   template_kind: pxegrub
+   operatingsystems: centos5_3
+

--- a/test/fixtures/os_default_templates.yml
+++ b/test/fixtures/os_default_templates.yml
@@ -19,3 +19,14 @@ four:
   config_template: pxekickstart
   template_kind: PXELinux
   operatingsystem: centos5_3
+
+five:
+  config_template: pxegrub
+  template_kind: pxegrub
+  operatingsystem: centos5_3
+
+six:
+  config_template: gpxe
+  template_kind: gpxe
+  operatingsystem: centos5_3
+

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -12,3 +12,6 @@ script:
 
 finish:
   name: finish
+
+pxegrub:
+  name: PXEGrub

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -70,6 +70,27 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should render spoof pxelinux for a host" do
+    get :PXELinux, {:spoof => hosts(:myfullhost).ip}, set_session_user
+    assert assigns(:initrd)
+    assert assigns(:kernel)
+    assert_response :success
+  end
+
+  test "should render spoof pxegrub for a host" do
+    get :PXEGrub, {:spoof => hosts(:myfullhost).ip}, set_session_user
+    assert assigns(:initrd)
+    assert assigns(:kernel)
+    assert_response :success
+  end
+
+  test "should render spoof gpxe for a host" do
+    get :gPXE, {:spoof => hosts(:myfullhost).ip}, set_session_user
+    assert assigns(:initrd)
+    assert assigns(:kernel)
+    assert_response :success
+  end
+
   test "should accept built notifications" do
     @request.env["REMOTE_ADDR"] = hosts(:ubuntu).ip
     get :built


### PR DESCRIPTION
This was working on sqlite3 of course, but not on SQL engines where LIKE is
case sensitive. Nice bug indeed.
