### PR TITLE
Improve the REMOTE_USER (for example mod_auth_kerb) support

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -64,7 +64,12 @@ module Foreman::Controller::Authentication
       elsif available_sso.support_login?
         available_sso.authenticate!
       else
-        logger.warn("SSO failed, falling back to login form")
+        logger.warn("SSO failed")
+        if available_sso.support_fallback? && !available_sso.has_rendered
+          logger.warn("falling back to login form")
+          available_sso.has_rendered = true
+          redirect_to login_users_path
+        end
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   before_filter :find_user, :only => [:edit, :update, :destroy]
   skip_before_filter :require_mail, :only => [:edit, :update, :logout]
-  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout]
+  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogout]
   after_filter       :update_activity_time, :only => :login
 
   attr_accessor :editing_self

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,6 +97,14 @@ class UsersController < ApplicationController
       end
     end
   end
+
+  def extlogin
+    if session[:user]
+      user = User.find_by_id(session[:user])
+      login_user(user)
+    end
+  end
+
   # Called from the logout link
   # Clears the rails session and redirects to the login action
   def logout

--- a/app/models/auth_sources/auth_source_external.rb
+++ b/app/models/auth_sources/auth_source_external.rb
@@ -1,0 +1,11 @@
+class AuthSourceExternal < AuthSource
+
+  def authenticate(login, password)
+    raise NotImplementedError, "#{__class__} does not support authenticate"
+  end
+
+  def auth_method_name
+    "EXTERNAL"
+  end
+  alias_method :to_label, :auth_method_name
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,7 +4,7 @@ class Setting < ActiveRecord::Base
   TYPES= %w{ integer boolean hash array string }
   FROZEN_ATTRS = %w{ name category }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend }
-  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url }
+  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate }
 
   attr_accessible :name, :value, :description, :category, :settings_type, :default
   # audit the changes to this model

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,7 +4,7 @@ class Setting < ActiveRecord::Base
   TYPES= %w{ integer boolean hash array string }
   FROZEN_ATTRS = %w{ name category }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend }
-  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts }
+  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url }
 
   attr_accessible :name, :value, :description, :category, :settings_type, :default
   # audit the changes to this model

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -19,7 +19,7 @@ class Setting::Auth < Setting
         self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY'),
         self.set('signo_sso', N_('Use Signo SSO for login'), false),
         self.set('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo"),
-        self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), 'https://example.com/logout')
+        self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), nil),
       ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
     end
 

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -20,6 +20,7 @@ class Setting::Auth < Setting
         self.set('signo_sso', N_('Use Signo SSO for login'), false),
         self.set('signo_url', N_('Signo SSO url'), "https://#{fqdn}/signo"),
         self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), nil),
+        self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'), nil),
       ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,7 +138,7 @@ class User < ActiveRecord::Base
   def self.find_or_create_external_user(login, auth_source_name)
     if (user = unscoped.find_by_login(login))
       return true
-    elsif not auth_source_name
+    elsif auth_source_name.nil?
       return false
     else
       User.as :admin do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,6 +135,21 @@ class User < ActiveRecord::Base
     user
   end
 
+  def self.find_or_create_external_user(login, auth_source_name)
+    if (user = unscoped.find_by_login(login))
+      return true
+    elsif not auth_source_name
+      return false
+    else
+      User.as :admin do
+        options = { :name => auth_source_name }
+        auth_source = AuthSource.where(options).first || AuthSourceExternal.create!(options)
+        User.create!(:login => login, :auth_source => auth_source)
+      end
+      return true
+    end
+  end
+
   def matching_password?(pass)
     self.password_hash == encrypt_password(pass)
   end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -22,6 +22,7 @@ module SSO
     # authenticate the user without using password.
     def authenticated?
       return false unless (self.user = request.env[CAS_USERNAME])
+      return false unless User.find_or_create_external_user(self.user, Setting['authorize_login_delegation_auth_source_user_autocreate'])
       store
       true
     end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -48,6 +48,8 @@ module SSO
       controller.extlogin_users_path
     end
 
+    private
+
     def store
       session[:sso_method] = self.class.to_s
     end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -40,7 +40,7 @@ module SSO
     end
 
     def logout_url
-      "#{Setting['login_delegation_logout_url']}"
+      Setting['login_delegation_logout_url'] || controller.extlogout_users_path
     end
 
     def expiration_url

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -10,16 +10,41 @@ module SSO
       true
     end
 
+    def support_expiration?
+      true
+    end
+
+    def support_fallback?
+      true
+    end
+
     # If REMOTE_USER is provided by the web server then
     # authenticate the user without using password.
     def authenticated?
-      self.user = request.env[CAS_USERNAME]
+      return false unless (self.user = request.env[CAS_USERNAME])
       store
       true
     end
 
+    def support_login?
+      request.fullpath != self.login_url
+    end
+
+    def authenticate!
+      self.has_rendered = true
+      controller.redirect_to controller.extlogin_users_path
+    end
+
+    def login_url
+      controller.extlogin_users_path
+    end
+
     def logout_url
       "#{Setting['login_delegation_logout_url']}"
+    end
+
+    def expiration_url
+      controller.extlogin_users_path
     end
 
     def store

--- a/app/services/sso/base.rb
+++ b/app/services/sso/base.rb
@@ -12,6 +12,10 @@ module SSO
       false
     end
 
+    def support_fallback?
+      false
+    end
+
     # Override this value on SSO objects to redirect your users to a custom auth path
     def login_url
       controller.login_users_path

--- a/app/views/users/extlogout.html.erb
+++ b/app/views/users/extlogout.html.erb
@@ -1,0 +1,11 @@
+<%  content_for(:title, _("Logout")) %>
+<div id="login" class="login-container">
+  <div class="aside">
+    <%= image_tag("foreman_white.png", :class=>"login-logo") %>
+  </div>
+  <div class="section">
+    <div id="login-form">
+      <%= link_to(_("Please log in again."), extlogin_users_path) %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Foreman::Application.routes.draw do
         post 'login'
         get 'logout'
         get 'extlogin'
+        get 'extlogout'
         get 'auth_source_selected'
         get 'auto_complete_search'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Foreman::Application.routes.draw do
         get 'login'
         post 'login'
         get 'logout'
+        get 'extlogin'
         get 'auth_source_selected'
         get 'auto_complete_search'
       end

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -12,7 +12,7 @@ require 'foreman/access_permissions'
 # an appropriate permission so views using those requests function.
 class AccessPermissionsTest < ActiveSupport::TestCase
   MAY_SKIP_REQUIRE_LOGIN = [
-    "users/login", "users/logout", "home/status", "notices/destroy", "unattended/",
+    "users/login", "users/logout", "users/extlogin", "users/extlogout", "home/status", "notices/destroy", "unattended/",
 
     # puppetmaster interfaces
     "fact_values/create", "reports/create",

--- a/test/unit/auth_source_external.rb
+++ b/test/unit/auth_source_external.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AuthSourceExternalTest < ActiveSupport::TestCase
+  test_to_label do
+    source = AuthSourceExternal.new
+    assert_equal source.auth_method_name, source.to_label
+  end
+
+end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class ApacheTest < ActiveSupport::TestCase
+  def setup
+    Setting::Auth.load_defaults
+  end
+
   def test_user_is_set_when_authenticated
+    Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache'
     apache = get_apache_method
     assert apache.authenticated?
     assert_equal apache.user, 'ares'
@@ -27,13 +32,46 @@ class ApacheTest < ActiveSupport::TestCase
     assert !apache.available?
   end
 
+
+  def test_authenticated?
+    Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache'
+    apache = get_apache_method
+    apache.controller.request.env[SSO::Apache::CAS_USERNAME] = nil
+
+    assert !apache.authenticated?
+    apache.controller.request.env[SSO::Apache::CAS_USERNAME] = 'ares'
+    assert apache.authenticated?
+  end
+
+  def test_authenticate!
+    apache = get_apache_method
+    controller = apache.controller
+    stub(controller).redirect_to { 'correct redirect' }
+
+    response = apache.authenticate!
+    assert apache.has_rendered
+    assert_equal response, 'correct redirect'
+  end
+
+  def test_support_login
+    apache = get_apache_method
+    controller = apache.controller
+    controller.request.fullpath = '/something'
+
+    assert apache.support_login?
+
+    controller.request.fullpath = '/extlogin'
+    assert !apache.support_login?
+  end
+
   def get_apache_method(api_request = false)
     SSO::Apache.new(get_controller(api_request))
   end
 
   def get_controller(api_request)
-    controller = Struct.new(:request, :session).new(Struct.new(:env).new({ 'REMOTE_USER' => 'ares' }))
+    controller = Struct.new(:request, :session, :extlogin_users_path).new(Struct.new(:env, :fullpath).new({ SSO::Apache::CAS_USERNAME => 'ares' }))
     controller.session = {}
+    controller.extlogin_users_path = '/extlogin'
     stub(controller).api_request? { api_request }
     controller
   end


### PR DESCRIPTION
This series of patches addresses http://projects.theforeman.org/issues/3312, making it possible to set up a protected "logon" location in Apache via

```
<Location /users/extlogin>
...
</Location>
```

and configure mod_auth_\* authentication modules for that location. It was tested with mod_auth_kerb.

The possibilities and issues with the existing REMOTE_USER support are listed at http://projects.theforeman.org/projects/foreman/wiki/Foreman_and_mod_auth_kerb, together with explanations introduced by this pull request.

This is a refactoring of https://github.com/theforeman/foreman/pull/958, addressing all comments in that pull request.
