### PR TITLE
Working table joins to display host count for puppet classes

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -14,7 +14,7 @@ class PuppetclassesController < ApplicationController
       values = Puppetclass.search_for ""
     end
     @puppetclasses = values.paginate(:page => params[:page])
-    @host_counter = Host.group(:puppetclass_id).joins(:puppetclasses).where(:puppetclasses => {:id => @puppetclasses.pluck(:id)}).count
+    @host_counter = Host.count(:group => :puppetclass_id, :joins => "INNER JOIN environment_classes ON environment_classes.environment_id = hosts.environment_id INNER JOIN puppetclasses ON puppetclasses.id = environment_classes.puppetclass_id", :conditions => {:puppetclasses => {:id => @puppetclasses.all}})
     @keys_counter = Puppetclass.joins(:class_params).select('distinct environment_classes.lookup_key_id').group(:name).count
   end
 


### PR DESCRIPTION
Instead of just showing 0 hosts for each puppet class, this displays the number of hosts that are in the puppet environment that includes that puppet class.
