### PR TITLE
(#3481) Don't have to set a hostname for each interface, but it must be unique if it is set

### DIFF
--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -6,7 +6,8 @@ module Nic
 
     attr_accessible :name, :subnet_id, :subnet, :domain_id, :domain
 
-    validates :name, :uniqueness => {:scope => :domain_id}
+    # Don't have to set a hostname for each interface, but it must be unique if it is set.
+    validates :name, :uniqueness => {:scope => :domain_id}, :allow_nil => true, :allow_blank => true
 
     belongs_to :subnet
     belongs_to :domain


### PR DESCRIPTION
This changes the validation for the name attribute on a NIC to allow nil and empty values without violating the uniqueness constraint.
