### PR TITLE
[REFACTOR] fixes #2967 - refactored Fact Importer

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -29,6 +29,8 @@ class FactValue < ActiveRecord::Base
   scope :required_fields, lambda { includes(:host, :fact_name) }
   scope :facts_counter, lambda {|value, name_id| where(:value => value, :fact_name_id => name_id) }
 
+  validates :fact_name_id, :uniqueness => { :scope => :host_id }
+
   # Todo: find a way to filter which values are logged,
   # this generates too much useless data
   #

--- a/app/services/facts_parser.rb
+++ b/app/services/facts_parser.rb
@@ -1,5 +1,5 @@
 module Facts
-  class Importer
+  class Parser
     attr_reader :facts
 
     def initialize facts

--- a/app/services/puppet_fact_importer.rb
+++ b/app/services/puppet_fact_importer.rb
@@ -1,0 +1,73 @@
+class PuppetFactImporter
+  delegate :logger, :to => :Rails
+  attr_reader :counters
+
+  def initialize(host, facts = {})
+    @host = host
+    @facts = normalize(facts)
+    @counters = {}
+  end
+
+  # expect a facts hash
+  def import!
+
+    delete_removed_facts
+    add_new_facts
+    update_facts
+
+    logger.info("Import facts for '#{host}' completed. Added: #{counters[:added]}, Updated: #{counters[:updated]}, Deleted #{counters[:deleted]} facts")
+  end
+
+  private
+  attr_reader :host, :facts
+
+  def delete_removed_facts
+    deleted_counter = FactValue.delete_all([
+                                             'fact_name_id IN (SELECT ID FROM fact_names WHERE name NOT IN (?)) AND host_id=?',
+                                             facts.keys, host.id
+                                           ])
+    @db_facts       = nil
+    @counters[:deleted] = deleted_counter
+    logger.debug("Merging facts for '#{host}': deleted #{deleted_counter} facts")
+  end
+
+  def add_new_facts
+    fact_names      = FactName.maximum(:id, :group => 'name')
+    facts_to_create = facts.keys - db_facts.keys
+    # if the host does not exists yet, we don't have an host_id to use the fact_values table.
+    method = host.new_record? ? :build : :create!
+    facts_to_create.each do |name|
+      host.fact_values.send(method,:value        => facts[name],
+                            :fact_name_id => fact_names[name] || FactName.create!(:name => name).id)
+    end
+
+    @counters[:added] = facts_to_create.size
+    logger.debug("Merging facts for '#{host}': added #{@counters[:added]} facts")
+  end
+
+  def update_facts
+    facts_to_update = []
+    db_facts.each { |name, fv| facts_to_update << [facts[name], fv] if fv.value != facts[name] }
+
+    @counters[:updated] = facts_to_update.size
+    return logger.debug("No facts update required for #{host}") if facts_to_update.empty?
+
+    logger.debug("Merging facts for '#{host}': updated #{@counters[:updated]} facts")
+
+    facts_to_update.each do |new_value, fv|
+      fv.update_attribute(:value, new_value)
+    end
+  end
+
+  def normalize(facts)
+    facts.keep_if { |k, v| v.present? && v.is_a?(String) }
+  end
+
+  def db_facts
+    @db_facts ||= host.fact_values.includes(:fact_name).index_by(&:name)
+  end
+
+  def current_facts_counter
+    FactValue.where(:host_id => host).count
+  end
+end

--- a/app/services/puppet_fact_importer.rb
+++ b/app/services/puppet_fact_importer.rb
@@ -3,8 +3,8 @@ class PuppetFactImporter
   attr_reader :counters
 
   def initialize(host, facts = {})
-    @host = host
-    @facts = normalize(facts)
+    @host     = host
+    @facts    = normalize(facts)
     @counters = {}
   end
 
@@ -21,11 +21,11 @@ class PuppetFactImporter
   attr_reader :host, :facts
 
   def delete_removed_facts
-    deleted_counter = FactValue.delete_all([
-                                             'fact_name_id IN (SELECT id FROM fact_names WHERE name NOT IN (?)) AND host_id=?',
-                                             facts.keys, host.id
-                                           ])
-    @db_facts       = nil
+    deleted_counter     = FactValue.delete_all([
+                                                 'fact_name_id IN (SELECT id FROM fact_names WHERE name NOT IN (?)) AND host_id=?',
+                                                 facts.keys, host.id
+                                               ])
+    @db_facts           = nil
     @counters[:deleted] = deleted_counter
     logger.debug("Merging facts for '#{host}': deleted #{deleted_counter} facts")
   end
@@ -34,10 +34,10 @@ class PuppetFactImporter
     fact_names      = FactName.maximum(:id, :group => 'name')
     facts_to_create = facts.keys - db_facts.keys
     # if the host does not exists yet, we don't have an host_id to use the fact_values table.
-    method = host.new_record? ? :build : :create!
+    method          = host.new_record? ? :build : :create!
     facts_to_create.each do |name|
-      host.fact_values.send(method,:value        => facts[name],
-                            :fact_name_id => fact_names[name] || FactName.create!(:name => name).id)
+      host.fact_values.send(method, :value => facts[name],
+                            :fact_name_id  => fact_names[name] || FactName.create!(:name => name).id)
     end
 
     @counters[:added] = facts_to_create.size

--- a/app/services/puppet_fact_importer.rb
+++ b/app/services/puppet_fact_importer.rb
@@ -10,7 +10,6 @@ class PuppetFactImporter
 
   # expect a facts hash
   def import!
-
     delete_removed_facts
     add_new_facts
     update_facts
@@ -23,7 +22,7 @@ class PuppetFactImporter
 
   def delete_removed_facts
     deleted_counter = FactValue.delete_all([
-                                             'fact_name_id IN (SELECT ID FROM fact_names WHERE name NOT IN (?)) AND host_id=?',
+                                             'fact_name_id IN (SELECT id FROM fact_names WHERE name NOT IN (?)) AND host_id=?',
                                              facts.keys, host.id
                                            ])
     @db_facts       = nil
@@ -67,7 +66,4 @@ class PuppetFactImporter
     @db_facts ||= host.fact_values.includes(:fact_name).index_by(&:name)
   end
 
-  def current_facts_counter
-    FactValue.where(:host_id => host).count
-  end
 end

--- a/db/migrate/20130523131455_add_unique_constraints_to_fact_values.rb
+++ b/db/migrate/20130523131455_add_unique_constraints_to_fact_values.rb
@@ -1,0 +1,9 @@
+class AddUniqueConstraintsToFactValues < ActiveRecord::Migration
+  def up
+    add_index(:fact_values, [:fact_name_id, :host_id], :unique => true)
+  end
+
+  def down
+    remove_index(:fact_values, [:fact_name_id, :host_id])
+  end
+end

--- a/test/unit/fact_value_test.rb
+++ b/test/unit/fact_value_test.rb
@@ -7,10 +7,6 @@ class FactValueTest < ActiveSupport::TestCase
     @fact_value = FactValue.create(:value => "some value", :host => @host, :fact_name => @fact_name)
   end
 
-#  test "should return the memory average" do
-#    p FactValue.mem_average("my_facting_name")
-#  end
-
   test "should return the count of each fact" do
     h = [{:label=>"some value", :data=>1}]
     assert_equal h, FactValue.count_each("my_facting_name")
@@ -20,6 +16,10 @@ class FactValueTest < ActiveSupport::TestCase
     other_fact_value = FactValue.create(:value => "some value", :host => @other_host, :fact_name => @fact_name)
     h = [{:label=>"some value", :data=>2}]
     assert_equal h, FactValue.count_each("my_facting_name")
+  end
+
+  test "should fail validation when the host already has a fact with the same name" do
+    assert !FactValue.new(:value => "some value", :host => @host, :fact_name => @fact_name).valid?
   end
 end
 

--- a/test/unit/facts_parser_test.rb
+++ b/test/unit/facts_parser_test.rb
@@ -1,10 +1,10 @@
 require "test_helper"
 
-class FactsImporterTest < ActiveSupport::TestCase
+class FactsParserTest < ActiveSupport::TestCase
   attr_reader :importer
 
   def setup
-    @importer = Facts::Importer.new facts
+    @importer = Facts::Parser.new facts
     User.current = User.admin
   end
 
@@ -19,7 +19,7 @@ class FactsImporterTest < ActiveSupport::TestCase
   end
 
   test "should raise on an invalid os" do
-    @importer = Facts::Importer.new({})
+    @importer = Facts::Parser.new({})
     assert_raise ::Foreman::Exception do
       importer.operatingsystem
     end
@@ -41,14 +41,14 @@ class FactsImporterTest < ActiveSupport::TestCase
   end
 
   test "should make non-numeric os version strings into numeric" do
-    @importer = Facts::Importer.new({'operatingsystem'=>'AnyOS','operatingsystemrelease'=>'1&2.3y4'})
+    @importer = Facts::Parser.new({'operatingsystem'=>'AnyOS','operatingsystemrelease'=>'1&2.3y4'})
     data = importer.operatingsystem
     assert_equal '12', data.major
     assert_equal '34', data.minor
   end
 
   test "should allow OS version minor component to be nil" do
-    @importer = Facts::Importer.new({'operatingsystem'=>'AnyOS','operatingsystemrelease'=>'6'})
+    @importer = Facts::Parser.new({'operatingsystem'=>'AnyOS','operatingsystemrelease'=>'6'})
     data = importer.operatingsystem
     assert_equal "AnyOS 6", data.to_s
     assert_equal '6', data.major
@@ -56,12 +56,12 @@ class FactsImporterTest < ActiveSupport::TestCase
   end
 
   test "release_name should be nil when lsbdistcodename isn't set on Debian" do
-    @importer = Facts::Importer.new(debian_facts.delete_if { |k,v| k == "lsbdistcodename" })
+    @importer = Facts::Parser.new(debian_facts.delete_if { |k,v| k == "lsbdistcodename" })
     assert_equal nil, @importer.operatingsystem.release_name
   end
 
   test "should set os.release_name to the lsbdistcodename fact on Debian" do
-    @importer = Facts::Importer.new(debian_facts)
+    @importer = Facts::Parser.new(debian_facts)
     assert_equal 'wheezy', @importer.operatingsystem.release_name
   end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -534,10 +534,11 @@ class HostTest < ActiveSupport::TestCase
     h = hosts(:one)
     f = fact_names(:kernelversion)
     as_admin do
-      FactValue.create!(:value => "superbox", :host_id => h.id, :fact_name_id => f.id)
+      fact_value = FactValue.where(:fact_name_id => f.id).first
+      fact_value.update_attributes!(:value => "superbox")
     end
     assert_difference('Model.count') do
-    facts = JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.json")))
+      facts = JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + "/facts.json")))
       h.populateFieldsFromFacts facts['facts']
     end
   end
@@ -881,10 +882,7 @@ class HostTest < ActiveSupport::TestCase
     assert_equal hosts.first.params['foo'], 'bar'
   end
 
-  private
-
   def parse_json_fixture(relative_path)
     return JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + relative_path)))
   end
-
 end

--- a/test/unit/puppet_fact_importer_test.rb
+++ b/test/unit/puppet_fact_importer_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class PuppetFactImporterTest < ActiveSupport::TestCase
+  attr_reader :host, :importer
+  setup do
+    disable_orchestration
+    User.current = User.admin
+    @host        = hosts(:one)
+  end
+
+  test 'importer adds new facts' do
+    assert_equal '2.6.9', value('kernelversion')
+    assert_equal '10.0.19.33', value('ipaddress')
+    import 'foo' => 'bar', 'kernelversion' => '2.6.9', 'ipaddress' => '10.0.19.33'
+    assert_equal 'bar', value('foo')
+    assert_equal '2.6.9', value('kernelversion')
+    assert_equal 0, importer.counters[:deleted]
+    assert_equal 0, importer.counters[:updated]
+    assert_equal 1, importer.counters[:added]
+  end
+
+  test 'importer removes deleted facts' do
+    import 'ipaddress' => '10.0.19.33'
+    assert_nil value('kernelversion')
+
+    assert_equal 1, importer.counters[:deleted]
+    assert_equal 0, importer.counters[:updated]
+    assert_equal 0, importer.counters[:added]
+  end
+
+  test 'importer updates fact values' do
+    assert_equal '2.6.9', value('kernelversion')
+    assert_equal '10.0.19.33', value('ipaddress')
+    import 'kernelversion' => '3.8.11', 'ipaddress' => '10.0.19.33'
+    assert_equal '3.8.11', value('kernelversion')
+
+    assert_equal 0, importer.counters[:deleted]
+    assert_equal 1, importer.counters[:updated]
+    assert_equal 0, importer.counters[:added]
+  end
+
+  test "importer shouldn't set nil values" do
+    assert_equal '2.6.9', value('kernelversion')
+    assert_equal '10.0.19.33', value('ipaddress')
+    import('kernelversion' => nil, 'ipaddress' => '10.0.19.33')
+    assert_nil value('kernelversion')
+    assert_equal '10.0.19.33', value('ipaddress')
+
+    assert_equal 1, importer.counters[:deleted]
+    assert_equal 0, importer.counters[:updated]
+    assert_equal 0, importer.counters[:added]
+  end
+
+  test "importer adds, removes and deletes facts" do
+    assert_equal '2.6.9', value('kernelversion')
+    assert_equal '10.0.19.33', value('ipaddress')
+    import('kernelversion' => nil, 'ipaddress' => '10.0.19.5', 'uptime' => '1 picosecond')
+    assert_nil value('kernelversion')
+    assert_equal '10.0.19.5', value('ipaddress')
+    assert_equal '1 picosecond', value('uptime')
+
+    assert_equal 1, importer.counters[:deleted]
+    assert_equal 1, importer.counters[:updated]
+    assert_equal 1, importer.counters[:added]
+
+  end
+
+  def import(facts)
+    @importer = PuppetFactImporter.new(@host, facts)
+    importer.import!
+  end
+
+  def value fact
+    FactValue.joins(:fact_name).where(:host_id => @host.id, :fact_names => {:name => fact }).first.try(:value)
+  end
+end

--- a/test/unit/puppet_fact_importer_test.rb
+++ b/test/unit/puppet_fact_importer_test.rb
@@ -71,6 +71,6 @@ class PuppetFactImporterTest < ActiveSupport::TestCase
   end
 
   def value fact
-    FactValue.joins(:fact_name).where(:host_id => @host.id, :fact_names => {:name => fact }).first.try(:value)
+    FactValue.joins(:fact_name).where(:host_id => @host.id, :fact_names => { :name => fact }).first.try(:value)
   end
 end


### PR DESCRIPTION
Based on Dmitri Dolguikh dmitri@appliedlogic.ca original patch.
- renamed original fact_importer class to fact_parser class
- moved fact handling logic to its own fact_importer class
- fact importer now assumes single-value facts
- added a uniqueness constraint on fact_values table on fact_name_id and host_id
- added tests

replaces PR https://github.com/theforeman/foreman/pull/646
