### PR TITLE
fixes #1830 - auto assign puppet proxy if its not defined upon facts/reports event

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -47,7 +47,7 @@ module Api
       param :type, String,     :desc => "optional: the STI type of host to create"
 
       def facts
-        @host, state = detect_host_type.importHostAndFacts params[:name],params[:facts],params[:certname]
+        @host, state = detect_host_type.importHostAndFacts params[:name], params[:facts], params[:certname], detected_proxy.try(:id)
         process_response state
       rescue ::Foreman::Exception => e
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def create
-        @report = Report.import(params[:report])
+        @report = Report.import(params[:report], detected_proxy.try(:id))
         process_response @report.errors.empty?
       rescue ::Foreman::Exception => e
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -57,14 +57,14 @@ module Foreman::Controller::SmartProxyAuth
     end
     return false unless request_hosts
 
-    hosts = proxies.map { |p| URI.parse(p.url).host }.push(*Setting[:trusted_puppetmaster_hosts])
-    logger.debug("Verifying request from #{request_hosts} against #{hosts.inspect}")
-
-    unless host = hosts.detect { |p| request_hosts.include? p }
+    hosts = Hash[proxies.map { |p| [URI.parse(p.url).host, p] }]
+    allowed_hosts = hosts.keys.push(*Setting[:trusted_puppetmaster_hosts])
+    logger.debug { ("Verifying request from #{request_hosts} against #{allowed_hosts.inspect}") }
+    unless host = allowed_hosts.detect { |p| request_hosts.include? p }
       logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_puppetmaster_hosts"
       return false
     end
-    @detected_proxy = proxies[hosts.index(host)] if host
+    @detected_proxy = hosts[host] if host
     true
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -353,7 +353,7 @@ class Host::Managed < Host::Base
   end
 
   # JSON is auto-parsed by the API, so these should be in the right format
-  def self.importHostAndFacts hostname, facts, certname = nil
+  def self.importHostAndFacts hostname, facts, certname = nil, proxy_id = nil
     raise(::Foreman::Exception.new("Invalid Facts, must be a Hash")) unless facts.is_a?(Hash)
     raise(::Foreman::Exception.new("Invalid Hostname, must be a String")) unless hostname.is_a?(String)
 
@@ -368,6 +368,10 @@ class Host::Managed < Host::Base
     return Host.new, true if h.nil?
     # if we were given a certname but found the Host by hostname we should update the certname
     h.certname = certname if certname.present?
+
+    # if proxy authentication is enabled and we have no puppet proxy set, use it.
+    h.puppet_proxy_id ||= proxy_id
+
     h.save(:validate => false) if h.new_record?
     state = h.importFacts(facts)
     return h, state

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -75,7 +75,7 @@ class Report < ActiveRecord::Base
   end
 
   #imports a report hash into database
-  def self.import(report)
+  def self.import(report, proxy_id = nil)
     raise ::Foreman::Exception.new("Invalid report") unless report.is_a?(Hash)
     logger.info "processing report for #{report['host']}"
 
@@ -100,6 +100,9 @@ class Report < ActiveRecord::Base
 
     # we save the raw bit status value in our host too.
     host.puppet_status = st
+
+    # if proxy authentication is enabled and we have no puppet proxy set, use it.
+    host.puppet_proxy_id ||= proxy_id
 
     # we save the host without validation for two reasons:
     # 1. It might be auto imported, therefore might not be valid (e.g. missing partition table etc)

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -50,6 +50,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     hostname = fact_json['name']
     facts    = fact_json['facts']
     post :facts, {:name => hostname, :facts => facts}
+    assert_nil @controller.detected_proxy
     assert_response :success
   end
 
@@ -58,10 +59,13 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     Setting[:restrict_registered_puppetmasters] = true
     Setting[:require_ssl_puppetmasters] = false
 
-    Resolv.any_instance.stubs(:getnames).returns(['else.where'])
+    proxy = smart_proxies(:puppetmaster)
+    host   = URI.parse(proxy.url).host
+    Resolv.any_instance.stubs(:getnames).returns([host])
     hostname = fact_json['name']
     facts    = fact_json['facts']
     post :facts, {:name => hostname, :facts => facts}
+    assert_equal proxy, @controller.detected_proxy
     assert_response :success
   end
 

--- a/test/functional/api/v2/reports_controller_test.rb
+++ b/test/functional/api/v2/reports_controller_test.rb
@@ -35,6 +35,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
 
     Resolv.any_instance.stubs(:getnames).returns(['else.where'])
     post :create, {:report => create_a_puppet_transaction_report }
+    assert_nil @controller.detected_proxy
     assert_response :success
   end
 
@@ -42,8 +43,11 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
     Setting[:restrict_registered_puppetmasters] = true
     Setting[:require_ssl_puppetmasters] = false
 
-    Resolv.any_instance.stubs(:getnames).returns(['else.where'])
+    proxy = smart_proxies(:puppetmaster)
+    host   = URI.parse(proxy.url).host
+    Resolv.any_instance.stubs(:getnames).returns([host])
     post :create, {:report => create_a_puppet_transaction_report }
+    assert_equal proxy, @controller.detected_proxy
     assert_response :success
   end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -892,6 +892,25 @@ class HostTest < ActiveSupport::TestCase
     assert_equal hosts.first.params['foo'], 'bar'
   end
 
+  test "should update puppet_proxy_id to the id of the validated proxy" do
+    sp  = SmartProxy.create!(:name => "Puppetmaster Proxy 2", :url => "http://another.one:4567") do |p|
+      p.features = [features(:puppet)]
+    end
+    raw = parse_json_fixture('/facts_with_caps.json')
+    Host.importHostAndFacts(raw['name'], raw['facts'], nil, sp.id)
+    assert_equal sp.id, Host.find_by_name('sinn1636.lan').puppet_proxy_id
+  end
+
+  test "shouldn't update puppet_proxy_id if it has been set" do
+    Host.new(:name => 'sinn1636.lan', :puppet_proxy_id => smart_proxies(:puppetmaster).id).save(:validate => false)
+    sp  = SmartProxy.create!(:name => "Puppetmaster Proxy 2", :url => "http://another.one:4567") do |p|
+      p.features = [features(:puppet)]
+    end
+    raw = parse_json_fixture('/facts_with_certname.json')
+    assert Host.importHostAndFacts(raw['name'], raw['facts'], nil, sp.id)
+    assert_equal smart_proxies(:puppetmaster).id, Host.find_by_name('sinn1636.lan').puppet_proxy_id
+  end
+
   def parse_json_fixture(relative_path)
     return JSON.parse(File.read(File.expand_path(File.dirname(__FILE__) + relative_path)))
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -893,9 +893,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "should update puppet_proxy_id to the id of the validated proxy" do
-    sp  = SmartProxy.create!(:name => "Puppetmaster Proxy 2", :url => "http://another.one:4567") do |p|
-      p.features = [features(:puppet)]
-    end
+    sp = smart_proxies(:puppetmaster)
     raw = parse_json_fixture('/facts_with_caps.json')
     Host.importHostAndFacts(raw['name'], raw['facts'], nil, sp.id)
     assert_equal sp.id, Host.find_by_name('sinn1636.lan').puppet_proxy_id
@@ -903,9 +901,7 @@ class HostTest < ActiveSupport::TestCase
 
   test "shouldn't update puppet_proxy_id if it has been set" do
     Host.new(:name => 'sinn1636.lan', :puppet_proxy_id => smart_proxies(:puppetmaster).id).save(:validate => false)
-    sp  = SmartProxy.create!(:name => "Puppetmaster Proxy 2", :url => "http://another.one:4567") do |p|
-      p.features = [features(:puppet)]
-    end
+    sp = smart_proxies(:puppetmaster)
     raw = parse_json_fixture('/facts_with_certname.json')
     assert Host.importHostAndFacts(raw['name'], raw['facts'], nil, sp.id)
     assert_equal smart_proxies(:puppetmaster).id, Host.find_by_name('sinn1636.lan').puppet_proxy_id


### PR DESCRIPTION
an alternative to #940, also cover reports.
