### PR TITLE
Fixes #3516: resource names (domains) are now being parametrized when used to construct urls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,13 +119,13 @@ class ApplicationController < ActionController::Base
   # example:
   # @host = Host.find_by_name params[:id]
   def find_by_name
-    not_found and return if (id = params[:id]).blank?
+    not_found and return if params[:id].blank?
 
     name = controller_name.singularize
     model = model_of_controller
     # determine if we are searching for a numerical id or plain name
-    cond = "find_by_" + ((id =~ /^\d+$/ && (id=id.to_i)) ? "id" : "name")
-    not_found and return unless instance_variable_set("@#{name}", model.send(cond, id))
+    cond = "find" + (params[:id] =~ /\A\d+(-.+)?\Z/ ? "" : "_by_name")
+    not_found and return unless instance_variable_set("@#{name}", model.send(cond, params[:id]))
   end
 
   def notice notice

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -100,5 +100,9 @@ class PuppetclassesController < ApplicationController
     session[:redirect_to_url] = nil
   end
 
-
+  def find_by_name
+    not_found and return if params[:id].blank?
+    @puppetclass = (params[:id] =~ /\A\d+\Z/) ? Puppetclass.find(params[:id]) : Puppetclass.find_by_name(params[:id])
+    not_found and return unless @puppetclass
+  end
 end

--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -13,7 +13,7 @@ class Architecture < ActiveRecord::Base
   scoped_search :on => :name, :complete_value => :true
 
   def to_param
-    name
+    "#{id}-#{name.parameterize}"
   end
 
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -28,7 +28,6 @@ class Bookmark < ActiveRecord::Base
   end
 
   def to_param
-    name
+    "#{id}-#{name.parameterize}"
   end
-
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -36,7 +36,7 @@ class Domain < ActiveRecord::Base
   end
 
   def to_param
-    name
+    "#{id}-#{name.parameterize}"
   end
 
   def enforce_permissions operation

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -83,7 +83,7 @@ class LookupKey < ActiveRecord::Base
   end
 
   def to_param
-    "#{id}-#{key}"
+    "#{id}-#{key.parameterize}"
   end
 
   def to_s

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <% for architecture in @architectures %>
     <tr>
-      <td class='span3'><%= link_to_if_authorized(h(architecture.name), hash_for_edit_architecture_path(:id => architecture.name)) %></td>
+      <td class='span3'><%= link_to_if_authorized(h(architecture.name), hash_for_edit_architecture_path(:id => architecture)) %></td>
       <td><%=h architecture.operatingsystems.to_sentence %></td>
       <td align="right">
         <%= display_delete_if_authorized hash_for_architecture_path(:id => architecture.name), :confirm => "Delete #{architecture.name}?" %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -11,7 +11,7 @@
   </tr>
   <% for bookmark in @bookmarks %>
     <tr>
-      <td><%= link_to_if_authorized(h(bookmark.name), hash_for_edit_bookmark_path(:id => bookmark.name)) %></td>
+      <td><%= link_to_if_authorized(h(bookmark.name), hash_for_edit_bookmark_path(:id => bookmark)) %></td>
       <td><%=h bookmark.query %></td>
       <td><%=h bookmark.controller %></td>
       <td><%=h bookmark.public %></td>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <% for domain in @domains %>
     <tr>
-      <td><%= link_to_if_authorized h(domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain.name)%></td>
+      <td><%= link_to_if_authorized h(domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain)%></td>
       <td><%= link_to @counter[domain.id] || 0, hosts_path(:search => "domain = #{domain}") %>
       <td><%= display_delete_if_authorized hash_for_domain_path(:id => domain), :confirm => _("Delete %s?") % domain.name %></td>
     </tr>


### PR DESCRIPTION
This works, but I think a better approach would be to construct resource urls using constant (as in non-editable) ids (such as a db primary key). At the moment a url that uses resource name in it stored outside of Foreman will become invalid when the user modifies the name. 
