### PR TITLE
Return unsorted facts to improve /fact_values performance

### DIFF
--- a/app/controllers/fact_values_controller.rb
+++ b/app/controllers/fact_values_controller.rb
@@ -5,7 +5,7 @@ class FactValuesController < ApplicationController
 
   def index
     begin
-      values = FactValue.my_facts.no_timestamp_facts.search_for(params[:search],:order => params[:order])
+      values = FactValue.my_facts.no_timestamp_facts.search_for(params[:search],:order => params[:order]).reorder('')
     rescue => e
       error e.to_s
       values = FactValue.no_timestamp_facts.search_for ""


### PR DESCRIPTION
With around 150k facts and 7k hosts clicking the fact tab in the foreman GUI takes around 4-6 seconds.

https://gist.github.com/xorpaul/7232272

@ohadlevy suggested this patch to cut the time for the first SQL query down to a few milliseconds.

If this shouldn't be the default, maybe a config parameter or a smart switch (if the number of facts is above $THRESHOLD) should be possible.
