### PR TITLE
Adding Facter gem to bundler config

### DIFF
--- a/bundler.d/facter.rb
+++ b/bundler.d/facter.rb
@@ -1,0 +1,3 @@
+group :facter do
+  gem 'facter'
+end


### PR DESCRIPTION
## This prevents the following error:

```
RAILS_ENV=production bundle exec rake db:migrate
rake aborted!
cannot load such file -- facter
/usr/src/foreman/lib/tasks/reset_permissions.rake:1:in `<top (required)>'
/usr/src/foreman/Rakefile:7:in `<top (required)>'
(See full trace by running task with --trace)
```
