### PR TITLE
fixes foreman version format

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.3-develop
+1.4.develop


### PR DESCRIPTION
Fixed Foreman version to reflect the fact that develop branch is where we develop version 1.4 and replaced the '-' sign with '.' to be consistent with gem versions.

See gem version spec:
http://rubygems.rubyforge.org/rubygems-update/Gem/Version.html
