### PR TITLE
fixes #3566 - exposes orchestration tasks via the API(v2).

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -46,6 +46,10 @@ module Api
 
     protected
 
+    def not_found
+      render_error 'not_found', :status => :not_found and return false
+    end
+
     def process_resource_error(options = { })
       resource = options[:resource] || get_resource
 
@@ -128,7 +132,7 @@ module Api
       if resource
         return instance_variable_set(:"@#{resource_name}", resource)
       else
-        render_error 'not_found', :status => :not_found and return false
+        not_found
       end
     end
 
@@ -181,7 +185,7 @@ module Api
     def find_required_nested_object
       find_nested_object
       return @nested_obj if @nested_obj
-      render_error 'not_found', :status => :not_found and return false
+      not_found
     end
 
     def find_optional_nested_object

--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -45,6 +45,7 @@ module Api
         param :enabled, :bool
         param :provision_method, String
         param :managed, :bool
+        param :report_progress_id, String, :desc => 'UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks'
         param :capabilities, String
         param :compute_attributes, Hash do
         end

--- a/app/controllers/api/v2/tasks_controller.rb
+++ b/app/controllers/api/v2/tasks_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V2
+    class TasksController < BaseController
+      before_filter :find_tasks
+
+      api :GET, '/orchestration/:id/tasks/', 'List all tasks for a given orchestration event'
+
+      def index
+        # @tasks is already in JSON format
+        render :text => @tasks
+      end
+
+      private
+
+      def find_tasks
+        return not_found unless Foreman.is_uuid?((id = params[:id]))
+        @tasks = Rails.cache.fetch(id)
+        not_found if @tasks.blank?
+      end
+
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,16 +1,11 @@
 class TasksController < ApplicationController
   skip_before_filter :session_expiry, :update_activity_time, :set_taxonomy, :only => [:show]
+  before_filter :ajax_request
 
   def show
-    id = params[:id]
-    queue = Rails.cache.fetch(id)
-    respond_to do |format|
-      format.html {
-        @tasks = queue.nil? ? [] : JSON(queue)
-        return render :partial => 'list' if ajax?
-      }
-      format.json { render :json => queue }
-    end
+    id     = params[:id]
+    queue  = Rails.cache.fetch(id)
+    @tasks = queue.nil? ? [] : JSON(queue)
+    render :partial => 'list'
   end
-
 end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -245,7 +245,8 @@ Foreman::AccessControl.map do |map|
                                     :subnets => subnets_ajax_actions,
                                      :"api/v1/hosts" => [:create],
                                      :"api/v2/hosts" => [:create],
-                                     :"api/v2/interfaces" => [:create]
+                                     :"api/v2/interfaces" => [:create],
+                                     :"api/v2/tasks" => [:index]
                                   }
     map.permission :edit_hosts,    {:hosts => [:edit, :update, :multiple_actions, :reset_multiple, :submit_multiple_enable,
                                       :select_multiple_hostgroup, :select_multiple_environment, :submit_multiple_disable,
@@ -267,7 +268,8 @@ Foreman::AccessControl.map do |map|
                                     :"api/v2/interfaces" => [:destroy]
                                   }
     map.permission :build_hosts,   {:hosts => [:setBuild, :cancelBuild, :multiple_build, :submit_multiple_build],
-                                    :tasks => tasks_ajax_actions}
+                                    :tasks => tasks_ajax_actions,
+                                    :"api/v2/tasks" => [:index] }
     map.permission :power_hosts,   {:hosts          => [:power],
                                     :"api/v2/hosts" => [:power] }
     map.permission :console_hosts, {:hosts => [:console] }

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -264,6 +264,7 @@ Foreman::Application.routes.draw do
 
         end
       end
+      get 'orchestration/(:id)/tasks', to: 'tasks#index'
     end
 
     match '*other', :to => 'v1/home#route_error', :constraints => ApiConstraints.new(:version => 2)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -264,7 +264,7 @@ Foreman::Application.routes.draw do
 
         end
       end
-      get 'orchestration/(:id)/tasks', to: 'tasks#index'
+      get 'orchestration/(:id)/tasks', :to => 'tasks#index'
     end
 
     match '*other', :to => 'v1/home#route_error', :constraints => ApiConstraints.new(:version => 2)

--- a/test/functional/api/v2/tasks_controller_test.rb
+++ b/test/functional/api/v2/tasks_controller_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Api::V2::TasksControllerTest < ActionController::TestCase
+
+  test 'should not get index without an id' do
+    get :index, { :id => nil }
+    assert_response :not_found
+
+    get :index, { :id => '' }
+    assert_response :not_found
+
+    get :index, { :id => "Random-#{Foreman.uuid}" }
+    assert_response :not_found
+  end
+
+  test 'should get index' do
+    uuid = Foreman.uuid
+
+    queue = Orchestration::Queue.new
+    queue.create(:name => 'create something', :priority => 10, :action => [Object.new, :to_s])
+    Rails.cache.write(uuid, queue.to_json)
+
+    get :index, { :id => uuid }
+    tasks = ActiveSupport::JSON.decode(@response.body)
+    assert_response :success
+    assert_equal 1, tasks.size
+    task = tasks.first
+    assert_equal 'create something', task['name']
+    assert_equal 'pending', task['status']
+    assert_equal 10, task['priority']
+    assert Time.now - Time.parse(task['timestamp']) < 5.seconds
+  end
+
+end


### PR DESCRIPTION
this patch create a new route:

/api/orchestration/id/tasks
