### PR TITLE
Fix link to reports search for failed hosts

### DIFF
--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -43,7 +43,7 @@
         <td style="border:1px solid #FF9933;border-collapse:collapse;padding:4px;background-color:#FFFFFF;">
       <% end %>
       <% if v > 0 %>
-        <%= link_to v, reports_path(:search=>"#{host} and #{m} > 0", :host => @url, :only_path => false) %>
+        <%= link_to v, reports_path(:search=>"host = #{host} and #{m} > 0", :host => @url, :only_path => false) %>
       <% else %>
         <%= v %>
       <% end %>


### PR DESCRIPTION
Should produce a link like http://foreman.example.com/reports?search=host+%3D+foo.example.com+and+failed+%3E+0 instead of the current http://foreman.example.com/reports?search=foo.example.com+and+failed+%3E+0
