### PR TITLE
Removing rr gem, fixes #3597

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -5,7 +5,6 @@ group :test do
     gem 'spork-minitest'
   end
   gem 'single_test'
-  gem 'rr'
   gem 'minitest', '~> 4.7'
   gem 'minitest-spec-rails'
   gem 'minitest-spec-rails-tu-shim', :platforms => :ruby_18

--- a/foreman.spec
+++ b/foreman.spec
@@ -14,7 +14,7 @@
 
 Name:   foreman
 Version: 1.3.9999
-Release: 4%{?dist}
+Release: 5%{?dist}
 Summary:Systems Management web application
 
 Group:  Applications/System
@@ -324,7 +324,6 @@ Meta Package to install requirements for devel support
 Summary: Foreman test support
 Group:  Applications/System
 Requires: %{?scl_prefix}rubygem(mocha)
-Requires: %{?scl_prefix}rubygem(rr)
 Requires: %{?scl_prefix}rubygem(rake)
 Requires: %{?scl_prefix}rubygem(maruku)
 Requires: %{?scl_prefix}rubygem(single_test)
@@ -532,6 +531,9 @@ if [ $1 -ge 1 ] ; then
 fi
 
 %changelog
+* Wed Nov 6 2013 David Davis <daviddavis@redhat.com> - 1.3.9999-5
+- Removing rr gem, fixes #3597
+
 * Fri Oct 25 2013 Martin Bacovsky <mbacovsk@redhat.com> - 1.3.9999-4
 - foreman-cli metapackage installs hammer
 

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -9,9 +9,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should run puppet for specific host" do
     User.current=nil
-    any_instance_of(ProxyAPI::Puppet) do |klass|
-      stub(klass).run { true }
-    end
+    ProxyAPI::Puppet.any_instance.stubs(:run).returns(true)
     get :puppetrun, { :id => hosts(:one).to_param }
     assert_response :success
   end

--- a/test/lib/proxy_api/dhcp_test.rb
+++ b/test/lib/proxy_api/dhcp_test.rb
@@ -22,39 +22,42 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
   end
 
   test "unused_ip should get an IP using only the network address" do
-    mock(subnet = Object.new).network { '192.168.0.0' }
-    mock(from = Object.new).present? { false }
-    mock(subnet).from { from }
+    subnet_mock = mock('subnet')
+    subnet_mock.expects(:network).returns('192.168.0.0')
+    subnet_mock.expects(:from).returns(nil)
 
     @dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet))
+    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
   end
 
   test "unused_ip should get an IP using the network, from and to addresses" do
-    mock(subnet = Object.new).network { '192.168.0.0' }
-    mock(from = Object.new).present? { true }
-    mock(from).to_s { '192.168.0.50' }
-    mock(to = Object.new).present? { true }
-    mock(to).to_s { '192.168.0.150' }
-    mock(subnet).from.returns(from).at_least(1)
-    mock(subnet).to.returns(to).at_least(1)
+    from_mock = mock('from')
+    from_mock.expects(:to_s).returns('192.168.0.50')
+    from_mock.expects(:present?).returns(true)
+    to_mock = mock('to')
+    to_mock.expects(:to_s).returns('192.168.0.150')
+    to_mock.expects(:present?).returns(true)
+    subnet_mock = mock('subnet')
+    subnet_mock.expects(:network).at_least_once.returns('192.168.0.0')
+    subnet_mock.expects(:from).at_least_once.returns(from_mock)
+    subnet_mock.expects(:to).at_least_once.returns(to_mock)
 
     @dhcp.expects(:get).with() do |path|
       # Params built with a hash, so order can change
-      path.include? '192.168.0.0/unused_ip?' and
-        path.include? 'from=192.168.0.50' and
-        path.include? 'to=192.168.0.150'
+      path.include?('192.168.0.0/unused_ip?') &&
+        path.include?('from=192.168.0.50') &&
+        path.include?('to=192.168.0.150')
     end.returns(fake_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet))
+    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
   end
 
   test "unused_ip should get an IP using the network and MAC address" do
-    mock(subnet = Object.new).network { '192.168.0.0' }
-    mock(from = Object.new).present? { false }
-    mock(subnet).from { from }
+    subnet_mock = mock()
+    subnet_mock.expects(:network).returns('192.168.0.0')
+    subnet_mock.expects(:from).returns(nil)
 
     @dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet, '00:11:22:33:44:55'))
+    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock, '00:11:22:33:44:55'))
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,10 +53,6 @@ Spork.prefork do
       Rails.logger
     end
 
-    class MiniTest::Unit::TestCase
-      include RR::Adapters::MiniTest
-    end
-
     def set_session_user
       SETTINGS[:login] ? {:user => User.admin.id, :expires_at => 5.minutes.from_now} : {}
     end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -34,7 +34,7 @@ class ApacheTest < ActiveSupport::TestCase
   def get_controller(api_request)
     controller = Struct.new(:request, :session).new(Struct.new(:env).new({ 'REMOTE_USER' => 'ares' }))
     controller.session = {}
-    stub(controller).api_request? { api_request }
+    controller.stubs(:api_request?).returns(api_request)
     controller
   end
 end

--- a/test/unit/sso/basic_test.rb
+++ b/test/unit/sso/basic_test.rb
@@ -25,8 +25,8 @@ class BasicTest < ActiveSupport::TestCase
 
   def get_basic_controller(api_request)
     controller = Struct.new(:request).new(Struct.new(:authorization).new('Basic'))
-    stub(controller).api_request? { api_request }
-    stub(controller).authenticate_with_http_basic { Struct.new(:login).new('testuser') }
+    controller.stubs(:api_request?).returns(api_request)
+    controller.stubs(:authenticate_with_http_basic).returns(Struct.new(:login).new('testuser'))
     controller
   end
 end

--- a/test/unit/sso/oauth_test.rb
+++ b/test/unit/sso/oauth_test.rb
@@ -28,8 +28,8 @@ class OauthTest < ActiveSupport::TestCase
 
   def get_controller(api_request)
     controller = Struct.new(:request).new(Struct.new(:authorization).new('OAuth'))
-    stub(controller).headers { { 'foreman_user' => 'testuser' } }
-    stub(controller).api_request? { api_request }
+    controller.stubs(:headers).returns({'foreman_user' => 'testuser'})
+    controller.stubs(:api_request?).returns(api_request)
     controller
   end
 

--- a/test/unit/sso/signo_basic_test.rb
+++ b/test/unit/sso/signo_basic_test.rb
@@ -41,7 +41,7 @@ class SignoBasicTest < ActiveSupport::TestCase
 
   def get_basic_controller(api_request)
     controller = Struct.new(:request).new(Struct.new(:authorization).new('Basic'))
-    stub(controller).api_request? { api_request }
+    controller.stubs(:api_request?).returns(api_request)
     controller
   end
 end

--- a/test/unit/sso/signo_test.rb
+++ b/test/unit/sso/signo_test.rb
@@ -7,13 +7,13 @@ class SignoTest < ActiveSupport::TestCase
 
   def test_openid_request_authenticated?
     controller = get_controller
-    stub(controller.request).env { { Rack::OpenID::RESPONSE => {} } }
+    controller.request.stubs(:env).returns({ Rack::OpenID::RESPONSE => {} })
     signo = get_signo_method(controller)
 
-    stub(signo).parse_open_id { false }
+    signo.stubs(:parse_open_id).returns(false)
     assert !signo.authenticated?
 
-    stub(signo).parse_open_id { true }
+    signo.stubs(:parse_open_id).returns(true)
     assert signo.authenticated?
     assert_equal signo.session[:sso_method], 'SSO::Signo'
   end
@@ -21,8 +21,8 @@ class SignoTest < ActiveSupport::TestCase
   def test_parse_open_id_success
     signo    = get_signo_method
     response = Object.new
-    stub(response).status { :success }
-    stub(response).identity_url { 'https://localhost/user/ares' }
+    response.stubs(:status).returns(:success)
+    response.stubs(:identity_url).returns('https://localhost/user/ares')
     assert signo.send(:parse_open_id, response)
     assert_equal signo.user, 'ares'
   end
@@ -30,29 +30,28 @@ class SignoTest < ActiveSupport::TestCase
   def test_parse_open_id_fail
     signo    = get_signo_method
     response = Object.new
-    stub(response).status { :fail }
+    response.stubs(:status).returns(:fail)
     assert !signo.send(:parse_open_id, response)
   end
 
   def test_authenticate_without_cookie
     controller = get_controller
-    stub(controller.request).params { { } }
-    stub(controller.request).url { 'https://localhost/foreman?a=b&c=d' }
-    signo = get_signo_method(controller)
+    controller.request.stubs(:params).returns({})
+    controller.request.stubs(:url).returns('https://localhost/foreman?a=b&c=d')
     url   = Setting['signo_url'] + "?return_url=#{URI.escape('https://localhost/foreman?a=b&c=d')}"
     Setting['signo_sso'] = true
     controller.send(:extend, Foreman::Controller::Authentication)
-    stub(controller).api_request? { false }
-    stub(controller.request).authorization {}
-    stub(controller.request).fullpath {}
+    controller.stubs(:api_request?).returns(false)
+    controller.request.stubs(:authorization).returns({})
+    controller.request.stubs(:fullpath).returns({})
     controller.expects(:redirect_to).with(url).once
     controller.authenticate
   end
 
   def test_authenticate_with_cookie
     controller = get_controller
-    stub(controller.request).cookies { { 'username' => 'ares' } }
-    stub(controller).render { 'correct render' }
+    controller.stubs(:render).returns('correct render')
+    controller.request.stubs(:cookies).returns({'username' => 'ares'})
     signo    = get_signo_method(controller)
     response = signo.authenticate!
 
@@ -63,9 +62,9 @@ class SignoTest < ActiveSupport::TestCase
 
   def test_authenticate_with_username
     controller = get_controller
-    stub(controller.request).cookies { { } }
-    stub(controller.request).params { { :username => 'ares' } }
-    stub(controller).render { 'correct render' }
+    controller.request.stubs(:cookies).returns({})
+    controller.request.stubs(:params).returns({:username => 'ares'})
+    controller.stubs(:render).returns('correct render')
     signo    = get_signo_method(controller)
     response = signo.authenticate!
 
@@ -85,16 +84,16 @@ class SignoTest < ActiveSupport::TestCase
     # we must create and save hash object reference otherwise we'll create new empty hash
     # with every method call, hence Hash.new lines
     req = Hash.new
-    stub(request).env { req }
+    request.stubs(:env).returns(req)
     cookies = Hash.new
-    stub(request).cookies { cookies }
-    stub(request).url { 'https://localhost/wherever/am?i=whoever&am=i' }
+    request.stubs(:cookies).returns(cookies)
+    request.stubs(:url).returns('https://localhost/wherever/am?i=whoever&am=i')
     headers = Hash.new
-    stub(controller).headers { headers }
-    stub(controller).request { request }
+    controller.stubs(:headers).returns(headers)
+    controller.stubs(:request).returns(request)
     session = Hash.new
-    stub(controller).session { session }
-    stub(controller).root_url { 'https://localhost/foreman?a=b&c=d' }
+    controller.stubs(:session).returns(session)
+    controller.stubs(:root_url).returns('https://localhost/foreman?a=b&c=d')
 
     controller
   end


### PR DESCRIPTION
This was needed for Katello which uses mocks from mocha (as rr also has a `mock()` method). However, this is also makes the stubbing and mocking more consistent in the Foreman tests as there were test files alternated their usage of rr stubbing and the mocha stubbing. Now the tests use mocha only.
