### PR TITLE
fixes #3600 Replace / in bookmark name with _

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -7,7 +7,7 @@ class BookmarksController < ApplicationController
 
   def new
     @bookmark            = Bookmark.new
-    @bookmark.name       = params[:query].to_s.strip.split(/\s| = |!|~|>|</)[0]
+    @bookmark.name       = params[:query].to_s.strip.split(/\s| = |!|~|>|</)[0].sub("/", "_")
     @bookmark.controller = params[:kontroller]
   end
 


### PR DESCRIPTION
Fix for #3600.  When a user creates a bookmark name that has a "/", it breaks the bookmarks page.  The user would then have to delete the entry manually from the database.  This fixes that be replacing "/" in a bookmark name with "_".  

Not sure if you'd prefer to error out and tell the user not to use "/"'s instead.  Maybe that's the better solution.
