### PR TITLE
If we cannot find a BMC proxy for the hosts subnet, report an error

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -26,7 +26,6 @@ module Nic
     def proxy
       # try to find a bmc proxy in the same subnet as our bmc device
       proxy   = SmartProxy.bmc_proxies.joins(:subnets).where(['dhcp_id = ? or tftp_id = ?', subnet_id, subnet_id]).first if subnet_id
-      proxy ||= SmartProxy.bmc_proxies.first
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?
       ProxyAPI::BMC.new({ :host_ip  => ip,
                           :url      => proxy.url,


### PR DESCRIPTION
Instead of using a random proxy that might not work.

Before

```
500 Internal Server Error
```

Expected (with this change)

```
Failure: ERF51-1518: Unable to find a proxy with BMC feature
```

See also https://github.com/theforeman/foreman/commit/40df7dfbf#commitcomment-4543636

I'll open a Redmine for this soon!
