### PR TITLE
Fix #3626: add unf to the bundler configuration for proper encoding for fog

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,3 +1,4 @@
 group :fog do
  gem 'fog', '>= 1.15'
+ gem 'unf'
 end


### PR DESCRIPTION
I'm working on building packages into nightly for this, so hold off on merging.

Adding the `unf` gem to the Gemfile fixes a warning: `[fog][WARNING] Unable to load the 'unf' gem. Your AWS strings may not be properly encoded`.
