### PR TITLE
fixes #3020 - API v2 - option to specify version in URL as well as in header

### DIFF
--- a/app/services/api_constraints.rb
+++ b/app/services/api_constraints.rb
@@ -5,11 +5,12 @@ class ApiConstraints
   end
 
   def matches?(req)
-    req.accept =~ /version=([\d\.]+)/
-    if (version = $1) # version is specified in header
-      version == @version.to_s # are the versions same
-    else
-      @default # version is not specified, match if it's default version of api
-    end
+    route_match       = req.fullpath.match(%r{/api/v(\d+)}) if req.fullpath
+    header_match      = req.accept.match(%r{version=(\d+)}) if req.accept
+
+    return (@version.to_s == route_match[1]) if route_match
+    return (@version.to_s == header_match[1]) if header_match
+    # if version is not specified in route or header, then it returns true only if :default => true in routes file v1.rb or v2.rb
+    @default
   end
 end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -2,7 +2,7 @@
 Foreman::Application.routes.draw do
 
   namespace :api, :defaults => {:format => 'json'} do
-    scope :module => :v1, :constraints => ApiConstraints.new(:version => 1, :default => true) do
+    scope "(:apiv)", :module => :v1, :defaults => {:apiv => 'v1'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 1, :default => true) do
 
       resources :architectures, :except => [:new, :edit]
       resources :audits, :only => [:index, :show]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -4,7 +4,7 @@ Foreman::Application.routes.draw do
   namespace :api, :defaults => {:format => 'json'} do
 
     # new v2 routes that point to v2
-    scope :module => :v2, :constraints => ApiConstraints.new(:version => 2) do
+    scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2) do
 
       resources :architectures, :except => [:new, :edit]
 

--- a/test/integration/api_routing_test.rb
+++ b/test/integration/api_routing_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class RoutingTest < ActionDispatch::IntegrationTest
+
+  test "should go to v1 controller for /v1/ passed in URL" do
+    assert_recognizes({:controller => "api/v1/domains", :action => "index", :apiv => "v1", :format => "json"}, "/api/v1/domains")
+  end
+
+  test "should go to v2 controller for /v2 passed in URL" do
+    assert_recognizes({:controller => "api/v2/domains", :action => "index", :apiv => "v2", :format => "json"}, "/api/v2/domains")
+  end
+
+end


### PR DESCRIPTION
If specified in both, then current in URL 'wins' over header.

Order of priority
1. URL - /v1/ or /v2/
2. header - version=2
3. default - if neither URL or header is specified.
