### PR TITLE
fixes #3107 - sort hostgroups alphabetically

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -28,7 +28,11 @@ class Hostgroup < ActiveRecord::Base
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here
-  default_scope lambda { with_taxonomy_scope }
+  default_scope lambda {
+    with_taxonomy_scope do
+      order("hostgroups.label")
+    end
+  }
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :label, :complete_value => :true

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -4,7 +4,7 @@
 
 <table class="table table-bordered table-striped">
   <tr>
-    <th><%= s_('Hostgroup|Name') %></th>
+    <th><%= sort :label, :as => _('Hostgroup|Name') %></th>
     <th></th>
   </tr>
   <% Hostgroup.sort_by_ancestry(@hostgroups).each do |hostgroup| %>


### PR DESCRIPTION
Makes hostgroup name a sortable column.
