### PR TITLE
[WIP] Fixes #3653: Always set the vsphere guest_id

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -202,6 +202,7 @@ module Foreman::Model
     def vm_instance_defaults
       super.merge(
         :memory_mb  => 768,
+        :guest_id   => "otherGuest",
         :interfaces => [new_interface],
         :volumes    => [new_volume],
         :datacenter => datacenter


### PR DESCRIPTION
Recent versions of fog require the guest ID to be set.

The proper fix would be to present the user with a selection of all 
servertypes as the datacenter provides them.
