### PR TITLE
[GCE] image_id alias image_name

### DIFF
--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -10,6 +10,10 @@ module FogExtensions
       def flavors
         service.flavors
       end
+      
+      def image_id
+        image_name
+      end
 
     end
   end

--- a/app/views/compute_resources_vms/form/_gce.html.erb
+++ b/app/views/compute_resources_vms/form/_gce.html.erb
@@ -4,7 +4,7 @@
    images = possible_images(compute_resource, arch, os)
 %>
 <div id='image_selection'>
-  <%= select_f f, :image_name, images, :uuid, :name,
+  <%= select_f f, :image_id, images, :uuid, :name,
                { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
                { :disabled => images.empty? } %>
 </div>

--- a/app/views/compute_resources_vms/form/_gce.html.erb
+++ b/app/views/compute_resources_vms/form/_gce.html.erb
@@ -4,7 +4,7 @@
    images = possible_images(compute_resource, arch, os)
 %>
 <div id='image_selection'>
-  <%= select_f f, :image_id, images, :uuid, :name,
+  <%= select_f f, :image_name, images, :uuid, :name,
                { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
                { :disabled => images.empty? } %>
 </div>


### PR DESCRIPTION
GCE compute resources fail to list out available images in the compute_resource_vms gce form partial because it expects an image_id (like in aws). Fog's gce module uses image_name instead!

I'm tagging icco@ruby-fog to line up the google module with aws but this will prevent headaches in the mean time (or if he rejects the PR's)
