### PR TITLE
audit-ui - adjusting audit table to match other tables

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -17,7 +17,8 @@ module AuditExtensions
     scoped_search :on => :action, :complete_value => { :create => 'create', :update => 'update', :delete => 'destroy' }
     scoped_search :on => :auditable_type, :complete_value => { :host => 'Host', :parameter => 'Parameter', :architecture => 'Architecture',
                                                                :puppetclass => 'Puppetclass', :os => 'Operatingsystem', :hostgroup => 'Hostgroup',
-                                                               :template => "ConfigTemplate" }, :rename => :type
+                                                               :template => "ConfigTemplate", :organization => 'Organization', :user => 'User',
+                                                               :ptable => "Ptable" }, :rename => :type
 
     scoped_search :in => :search_parameters, :on => :name, :complete_value => true, :rename => :parameter, :only_explicit => true
     scoped_search :in => :search_templates, :on => :name, :complete_value => true, :rename => :template, :only_explicit => true

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,6 +1,38 @@
 <% title _("Audits") %>
 
-<%= render :partial => 'list', :locals =>{:audits => @audits}%>
+<table class="table table-bordered table-striped table-condensed table-two-pane">
+  <tr>
+    <th><%= sort :type, :as => s_("Audit|Type") %></th>
+    <th><%= sort :action, :as => s_("Audit|Action") %></th>
+    <th><%= sort :username, :as => s_("Audit|User") %></th>
+    <th><%= sort :time, :as => s_("Audit|Time") %></th>
+    <th><%= s_("Audit|Details") %></th>
+  </tr>
+  <% for audit in @audits %>
+    <tr>
+      <td><%= link_to(audited_icon(audit), audit_path(audit)) %></td>
+      <td>
+        <%= audit_action_name audit%> <%=link_to(audit_title(audit), audit_path(audit)) %>
+      </td>
+      <td>
+        <% if audit_login? audit %>
+          <%= audit_user(audit)%> <%= link_to(_("Logged-in"), audit_path(audit))  %>
+        <% else %>
+          <%= audit_user(audit) %> <%= audit_remote_address audit %>
+        <% end %>
+      </td>
+      <td><%=h audit_time(audit) %></td>
+      <td>
+        <ul>
+          <% details(audit).each do |item| %>
+            <% next if item.nil? or item.to_s.empty? %>
+            <li><%= item %></li>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
+  <% end %>
+</table>
 
 <%= page_entries_info @audits %>
 <%= will_paginate @audits %>


### PR DESCRIPTION
![audits](https://f.cloud.github.com/assets/338096/1558624/dbe4f982-4f9d-11e3-94fa-0ab78d8f5194.png)

Restructured index table to match other pages. Suggestions on column titles and content welcome.

Also added missing types to audit extensions so they could be searched on.
