### PR TITLE
fixes #3661 - mis-redirection from /hosts/fqdn/edit to /hosts

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -111,6 +111,6 @@
     </div>
 
     <%= f.hidden_field :overwrite? %>
-    <%= submit_or_cancel f, @host.overwrite? %>
+    <%= submit_or_cancel f, @host.overwrite?, :cancel_path => @host %>
   <% end %>
 <% end %>

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -28,4 +28,16 @@ class HostTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Delete", :href => "/hosts/my5name.mydomain.net")
   end
 
+  test "edit page" do
+    disable_orchestration  # Avoid DNS errors  
+    visit hosts_path
+    click_link "my5name.mydomain.net"
+    first(:link, "Edit").click 
+    assert page.has_link?("Cancel", :href => "/hosts/my5name.mydomain.net")
+    fill_in "host_name", :with => "my5rename.mydomain.net"
+    assert_submit_button("/hosts/my5rename.mydomain.net")
+    visit hosts_path
+    assert page.has_link?("my5rename.mydomain.net")
+  end
+
 end


### PR DESCRIPTION
Fixing a minor annoyance.
