### PR TITLE
fixes #3693 - API v2 - accept GET json format of object in PUT/POST requests to add/remove has_many associations

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -82,6 +82,11 @@ module Api
         end
       end
 
+      # overwrite Api::BaseController
+      def resource_class
+        LookupValue
+      end
+
     end
   end
 end

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -57,6 +57,11 @@ module Api
         render 'api/v2/smart_class_parameters/destroy'
       end
 
+      # overwrite Api::BaseController
+      def resource_class
+        LookupKey
+      end
+
     end
   end
 end

--- a/app/controllers/api/v2/smart_variables_controller.rb
+++ b/app/controllers/api/v2/smart_variables_controller.rb
@@ -69,6 +69,11 @@ module Api
         render 'api/v2/smart_variables/destroy'
       end
 
+      # overwrite Api::BaseController
+      def resource_class
+        LookupKey
+      end
+
     end
   end
 end

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -68,6 +68,8 @@ class LookupKey < ActiveRecord::Base
   alias_attribute :variable_type, :key_type
   alias_attribute :override_value_order, :path
   alias_attribute :override_values_count, :lookup_values_count
+  alias_attribute :override_values, :lookup_values
+  alias_attribute :override_value_ids, :lookup_value_ids
 
   # to prevent errors caused by find_resource from override_values controller
   def self.find_by_name(str)

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -18,6 +18,11 @@ class Puppetclass < ActiveRecord::Base
   validates :name, :uniqueness => true, :presence => true, :format => {:with => /\A(\S+\s?)+\Z/, :message => N_("can't be blank or contain white spaces.") }
   audited :allow_mass_assignment => true
 
+  alias_attribute :smart_variables, :lookup_keys
+  alias_attribute :smart_variable_ids, :lookup_key_ids
+  alias_attribute :smart_class_parameters, :class_params
+  alias_attribute :smart_class_parameter_ids, :class_param_ids
+
   default_scope lambda { order('puppetclasses.name') }
 
   scoped_search :on => :name, :complete_value => :true

--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -52,4 +52,26 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should update associated architectures by ids" do
+    os = operatingsystems(:redhat)
+    puts
+    assert_difference('os.architectures.count') do
+      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { },
+                     :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ]
+                   }
+    end
+    assert_response :success
+  end
+
+  test "should update associated architectures by name" do
+    os = operatingsystems(:redhat)
+    puts
+    assert_difference('os.architectures.count') do
+      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { },
+                     :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ]
+                   }
+    end
+    assert_response :success
+  end
+
 end


### PR DESCRIPTION
Currently we have to use _ids= methods to add/remove relationships.

```
{
  "id": 42,
  "name": "CentOS",
  "architecture_ids": [1,2]
}
```

This is what we want 

```
{
  "id": 42,
  "name": "CentOS",
  "architectures": [ 
        {
        "id": 1,
        "name": "i386" 
         }, 
        {
         "id": 2,
         "name": "x86_64" 
         }
     ]
}
```

This DOES NOT update the associated objects (architectures).  It's only for adding/removing relationships

If "id" is NOT present and "name" is, then it can add/remove relationships by name

```
{
  "id": 42,
  "name": "CentOS",
  "architectures": [ 
        {
        "name": "i386" 
         }, 
        {
         "name": "x86_64" 
         }
     ]
}
```
