### PR TITLE
fixes #3712 - change develop versioning scheme to indicate next version

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.3-develop
+1.4-develop

--- a/foreman.spec
+++ b/foreman.spec
@@ -13,8 +13,8 @@
 %endif
 
 Name:   foreman
-Version: 1.3.9999
-Release: 7%{?dist}
+Version: 1.4.0
+Release: 0.develop%{?dist}
 Summary:Systems Management web application
 
 Group:  Applications/System
@@ -447,7 +447,6 @@ ln -sv %{_localstatedir}/log/%{name} %{buildroot}%{_datadir}/%{name}/log
 
 # Put tmp files in %{_localstatedir}/run/%{name}
 ln -sv %{_localstatedir}/run/%{name} %{buildroot}%{_datadir}/%{name}/tmp
-echo %{version} > %{buildroot}%{_datadir}/%{name}/VERSION
 
 %clean
 rm -rf %{buildroot}
@@ -547,6 +546,9 @@ if [ $1 -ge 1 ] ; then
 fi
 
 %changelog
+* Thu Nov 21 2013 Dominic Cleal <dcleal@redhat.com> - 1.4.0-0.develop
+- Bump and change versioning scheme, don't overwrite VERSION (#3712)
+
 * Tue Nov 12 2013 Sam Kottler <shk@redhat.com> - 1.3.9999-7
 - Add rubygem-unf as a requires for the compute subpackage
 


### PR DESCRIPTION
See http://projects.theforeman.org/issues/3712 for the reason behind this.

The key point here is to ensure that the version of our nightly packages indicates it's 1.4, but according to RPM's versioning is less than the first RC and any stable release.  Hopefully I've achieved that.

The nightly builds from Jenkins will continue to append a date and git SHA immediately before the %{?dist}.

Updated wiki docs:
http://projects.theforeman.org/projects/foreman/wiki/RPM_Packaging/diff?utf8=%E2%9C%93&version=37&version_from=35&commit=View+differences
http://projects.theforeman.org/projects/foreman/wiki/Release_Process/diff?utf8=%E2%9C%93&version=71&version_from=69&commit=View+differences

CC @lzap, @skottler and @jmontleon, please ACK.

Replaces #996.
