### PR TITLE
fixes #3737 - added PXEGrub specific PXE localboot template

### DIFF
--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -78,7 +78,11 @@ module Orchestration::TFTP
     if build?
       pxe_render configTemplate({:kind => os.template_kind}).template
     else
-      pxe_render ConfigTemplate.find_by_name("PXE Localboot Default").template
+      if os.template_kind == "PXEGrub"
+        pxe_render ConfigTemplate.find_by_name("PXEGrub Localboot Default").template
+      else
+        pxe_render ConfigTemplate.find_by_name("PXE Localboot Default").template
+      end
     end
   rescue => e
     failure _("Failed to generate %{template_kind} template: %{e}") % { :template_kind => os.template_kind, :e => e }

--- a/app/views/unattended/pxegrub_local.erb
+++ b/app/views/unattended/pxegrub_local.erb
@@ -1,0 +1,7 @@
+<%# This template has special name (do not change it) and it is used for booting already provisioned hosts. %>
+
+default=0
+timeout=1
+title Chainload into bootloader on first disk
+root (hd0,0)
+chainloader +1

--- a/db/migrate/20131122150434_add_pxegrub_localboot_template.rb
+++ b/db/migrate/20131122150434_add_pxegrub_localboot_template.rb
@@ -1,0 +1,15 @@
+class AddPxegrubLocalbootTemplate < ActiveRecord::Migration
+  class ConfigTemplate < ActiveRecord::Base
+    has_and_belongs_to_many :operatingsystems
+  end
+  def self.up
+    ConfigTemplate.create(
+      :name                => "PXEGrub Localboot Default",
+      :template_kind_id    => TemplateKind.find_by_name("PXEGrub").id,
+      :operatingsystem_ids => [],
+      :template            => File.read("#{Rails.root}/app/views/unattended/pxegrub_local.erb"))
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This change allows to use pxegrub for bootstrapping and later, localbooting machines. Added 'localboot' type template for PXEGrub, which will be selected if bootstrapped node used PXEGrub type template.
