### PR TITLE
ref #3510 - ensure rescue statement works

### DIFF
--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -32,7 +32,8 @@ module Menu
         :controller => url_hash[:controller].to_s.gsub(/::/, "_").underscore,
         :action => url_hash[:action]
       })
-    rescue false
+    rescue
+      false
     end
 
   end


### PR DESCRIPTION
the rescue statement is a method rescue statement, and does not accept
arguments normally (exculding the exception class).
