### PR TITLE
Fixes #3753: Adds a check to see if the incoming controller is from an

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -325,9 +325,9 @@ class ApplicationController < ActionController::Base
 
     if User.current && User.current.admin?
       if SETTINGS[:locations_enabled] && Location.unconfigured?
-        redirect_to locations_path, :notice => _("You must create at least one location before continuing.")
+        redirect_to main_app.locations_path, :notice => _("You must create at least one location before continuing.")
       elsif SETTINGS[:organizations_enabled] && Organization.unconfigured?
-        redirect_to organizations_path, :notice => _("You must create at least one organization before continuing.")
+        redirect_to main_app.organizations_path, :notice => _("You must create at least one organization before continuing.")
       end
     end
   end

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -33,11 +33,11 @@ module SSO
 
     def authenticate!
       self.has_rendered = true
-      controller.redirect_to controller.extlogin_users_path
+      controller.redirect_to controller.main_app.extlogin_users_path
     end
 
     def login_url
-      controller.extlogin_users_path
+      controller.main_app.extlogin_users_path
     end
 
     def logout_url
@@ -45,7 +45,7 @@ module SSO
     end
 
     def expiration_url
-      controller.extlogin_users_path
+      controller.main_app.extlogin_users_path
     end
 
     private

--- a/app/services/sso/base.rb
+++ b/app/services/sso/base.rb
@@ -18,7 +18,7 @@ module SSO
 
     # Override this value on SSO objects to redirect your users to a custom auth path
     def login_url
-      controller.login_users_path
+      controller.main_app.login_users_path
     end
 
     # don't forget to implement expiration_url method if your SSO method changes this to true
@@ -35,5 +35,6 @@ module SSO
     def authenticate!
       raise NotImplementedError, "#{__method__} not implemented for this authentication method"
     end
+
   end
 end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -69,10 +69,12 @@ class ApacheTest < ActiveSupport::TestCase
   end
 
   def get_controller(api_request)
+    main_app = stub
+    controller.stubs(:extlogin_users_path).returns('/extlogin')
     controller = Struct.new(:request, :session, :extlogin_users_path).new(Struct.new(:env, :fullpath).new({ SSO::Apache::CAS_USERNAME => 'ares' }))
     controller.session = {}
-    controller.extlogin_users_path = '/extlogin'
     controller.stubs(:api_request?).returns(api_request)
+    controller.stubs(:main_app).returns(main_app)
     controller
   end
 end


### PR DESCRIPTION
isolated namespace plugin controller to determine the login_users_path.

When a plugin is defined using isolate_namespace, the parent routes
are not available when in the context of an entity from the plugin. The routes
of the parent application must instead be accessed through the 'main_app'
entity made available to the plugin. This adds a check to see if the
main_app object is available as an indicator that an isolate_namespace
plugin is making the request to check authentication and be redirected
to the login page.
