### PR TITLE
fixes #3769 - added foreman-rake and debug man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ locale/*/*.pox
 locale/*/LC_MESSAGES
 coverage/
 tags
+_build

--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -1,0 +1,45 @@
+require 'rake/clean'
+
+BUILDDIR = File.expand_path(ENV['BUILDDIR'] || '_build')
+PREFIX = ENV['PREFIX'] || '/usr/local'
+BINDIR = ENV['BINDIR'] || "#{PREFIX}/bin"
+LIBDIR = ENV['LIBDIR'] || "#{PREFIX}/lib"
+SBINDIR = ENV['SBINDIR'] || "#{PREFIX}/sbin"
+INCLUDEDIR = ENV['INCLUDEDIR'] || "#{PREFIX}/include"
+SYSCONFDIR = ENV['SYSCONFDIR'] || "#{PREFIX}/etc"
+LOCALSTATEDIR = ENV['LOCALSTATEDIR'] || "#{PREFIX}/var"
+SHAREDSTAREDIR = ENV['SHAREDSTAREDIR'] || "#{LOCALSTATEDIR}/lib"
+DATAROOTDIR = DATADIR = ENV['DATAROOTDIR'] || "#{PREFIX}/share"
+MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
+
+file BUILDDIR do
+  mkdir BUILDDIR
+end
+
+file "#{BUILDDIR}/foreman-rake.8.gz" => "man/foreman-rake.8.asciidoc" do |t|
+  sh "a2x -d manpage -f manpage -D #{BUILDDIR}/ #{t.prerequisites[0]}"
+  sh "gzip -f9 #{BUILDDIR}/foreman-rake.8"
+end
+
+file "#{BUILDDIR}/foreman-debug.8.gz" => "man/foreman-debug.8.asciidoc" do |t|
+  sh "a2x -d manpage -f manpage -D #{BUILDDIR}/ #{t.prerequisites[0]}"
+  sh "gzip -f9 #{BUILDDIR}/foreman-debug.8"
+end
+
+task :build => [
+  BUILDDIR,
+  "#{BUILDDIR}/foreman-rake.8.gz",
+  "#{BUILDDIR}/foreman-debug.8.gz",
+]
+
+task :install => :build do |t|
+  mkdir_p "#{MANDIR}/man8"
+  cp "#{BUILDDIR}/foreman-rake.8.gz", "#{MANDIR}/man8/"
+  cp "#{BUILDDIR}/foreman-debug.8.gz", "#{MANDIR}/man8/"
+end
+
+task :default => :build
+
+CLEAN.include [
+  '_build',
+]

--- a/foreman.spec
+++ b/foreman.spec
@@ -113,6 +113,8 @@ BuildRequires: %{?scl_prefix}rubygem(foreigner) >= 1.4.2
 BuildRequires: %{?scl_prefix}rubygem(rails3_before_render)
 BuildRequires: %{?scl_prefix}facter
 BuildRequires: gettext
+BuildRequires: asciidoc
+BuildRequires: %{?scl_prefix}rubygem(rake)
 
 %package cli
 Summary: Foreman CLI
@@ -133,7 +135,8 @@ Group:  	Applications/System
 
 %description release
 Foreman repository contains open source and other distributable software for
-Fedora. This package contains the repository configuration for Yum.
+distributions in RPM format. This package contains the repository configuration
+for Yum.
 
 %files release
 %config(noreplace) %{_sysconfdir}/yum.repos.d/*
@@ -365,6 +368,13 @@ plugins required for Foreman to work.
 %setup -q
 
 %build
+#build man pages
+%{scl_rake} -f Rakefile.dist build \
+  PREFIX=%{_prefix} \
+  SBINDIR=%{_sbindir} \
+  SYSCONFDIR=%{_sysconfdir} \
+  --trace
+
 #replace shebangs and binaries in scripts for SCL
 %if %{?scl:1}%{!?scl:0}
   # shebangs
@@ -396,6 +406,15 @@ rm config/database.yml config/settings.yaml
 
 %install
 rm -rf %{buildroot}
+
+#install man pages
+%{scl_rake} -f Rakefile.dist install \
+  PREFIX=%{buildroot}%{_prefix} \
+  SBINDIR=%{buildroot}%{_sbindir} \
+  SYSCONFDIR=%{buildroot}%{_sysconfdir} \
+  --trace
+%{scl_rake} -f Rakefile.dist clean
+
 install -d -m0755 %{buildroot}%{_datadir}/%{name}
 install -d -m0755 %{buildroot}%{_sysconfdir}/%{name}
 install -d -m0755 %{buildroot}%{_localstatedir}/lib/%{name}
@@ -467,6 +486,7 @@ rm -rf %{buildroot}
 %{_initrddir}/%{name}
 %{_sbindir}/%{name}-debug
 %{_sbindir}/%{name}-rake
+%{_mandir}/man8
 %config(noreplace) %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}

--- a/man/foreman-debug.8.asciidoc
+++ b/man/foreman-debug.8.asciidoc
@@ -1,0 +1,62 @@
+foreman\-debug(8)
+=================
+:man source:  foreman-debug
+:man manual:  Foreman Manual
+
+NAME
+----
+foreman-debug - Foreman configuration and log collector
+
+SYNOPSIS
+--------
+foreman-debug [OPTIONS]
+
+foreman-debug -d /output/dir -a -m 9000 -v
+
+foreman-debug -h
+
+DESCRIPTION
+-----------
+
+Collects configuration and log data for Foreman, Smart Proxies, backend
+services and system information while removing security information like
+passwords, tokens and keys.
+
+This program can be used on Foreman instances, Smart Proxy instances or
+backend services separately.
+
+SENDING INFORMATION
+-------------------
+
+Use the *foreman-debug* tool to generate a tarball with your configuration and
+recent logs and send it to developers for further investigation. Note that
+passwords and tokens are filtered out, but the tarball still can contain
+*sensitive information*. For this reason it is recommended to send directly to
+the developers, and not publicly on the mailing list for production instances.
+
+OPTIONS
+-------
+
+The following options are available:
+
+  -d DIR  Directory to place the tarball in (default /tmp/foreman-XYZ)
+  -g      Skip generic info (CPU, memory, firewall etc.)
+  -a      Do not generate a tarball from the resulting directory
+  -m NUM  Maximum lines to keep for each file (default 5000)
+  -j PRG  Filter with provided program when creating a tarball
+  -p      Additionally print all passwords which are being filtered
+  -q      Quiet mode
+  -v      Verbose mode
+  -h      Shows this message
+
+
+SEE ALSO
+--------
+
+*foreman-rake*(8)
+
+GETTING HELP
+------------
+
+For support, please see http://theforeman.org/support.html, the
+foreman-users@googlegroups.com mailing list or #theforeman on on Freenode.

--- a/man/foreman-rake.8.asciidoc
+++ b/man/foreman-rake.8.asciidoc
@@ -1,0 +1,54 @@
+foreman\-rake(8)
+================
+:man source:  foreman-rake
+:man manual:  Foreman Manual
+
+NAME
+----
+foreman-rake - Foreman command for the Ruby rake tool
+
+SYNOPSIS
+--------
+foreman-rake [OPTIONS]
+
+foreman-rake -T
+
+foreman-rake db:migrate
+
+foreman-rake db:migrate --trace
+
+foreman-rake --help
+
+DESCRIPTION
+-----------
+
+The foreman-rake is an utility which is a simple wrapper around the Ruby rake
+command. Normally, it calls rake command, but on environments with Software
+Collections, it also enables the appropriate collection.
+
+Additionally, it does the following:
+
+- changes to foreman system account
+- changes working directory to foreman user's home directory
+- sets RAILS_ENV to production
+- executes rake command with or without SCL
+
+OPTIONS
+-------
+
+Please refer to the rake documentation to find out supported options:
+
+    foreman-rake -T
+
+    foreman-rake --help
+
+SEE ALSO
+--------
+
+*scl*(8), *foreman-debug*(8)
+
+GETTING HELP
+------------
+
+For support, please see http://theforeman.org/support.html, the
+foreman-users@googlegroups.com mailing list or #theforeman on on Freenode.


### PR DESCRIPTION
This patch introduces new file Rakefile.dist which is then used in the SPEC
file to generate man pages. My plan is to refactor everything that make sense
from SPEC file into this new Rakefile.

The reason why separate Rakefile is because we do not want to boot whole Rails
stack during build.

This is much more flexible and gives us possibility to do things like:
- distribute project tarballs with assets precompiled and vendorized gems
- less patches in Debian packages
- be more close to the traditional software delivery in the open-source
  industry

Additionally, it fixes "Fedora" use in the description.
