### PR TITLE
fixes #3491 - API v2 rabl templates base, main, show for each controller

### DIFF
--- a/app/views/api/v2/architectures/base.json.rabl
+++ b/app/views/api/v2/architectures/base.json.rabl
@@ -1,0 +1,3 @@
+object @architecture
+
+attributes :name, :id

--- a/app/views/api/v2/architectures/index.json.rabl
+++ b/app/views/api/v2/architectures/index.json.rabl
@@ -1,3 +1,3 @@
 collection @architectures
 
-extends "api/v2/architectures/show"
+extends "api/v2/architectures/main"

--- a/app/views/api/v2/architectures/main.json.rabl
+++ b/app/views/api/v2/architectures/main.json.rabl
@@ -1,0 +1,5 @@
+object @architecture
+
+extends "api/v2/architectures/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/architectures/show.json.rabl
+++ b/app/views/api/v2/architectures/show.json.rabl
@@ -1,3 +1,3 @@
 object @architecture
 
-attributes :name, :id, :created_at, :operatingsystem_ids, :updated_at
+extends "api/v2/architectures/main"

--- a/app/views/api/v2/audits/base.json.rabl
+++ b/app/views/api/v2/audits/base.json.rabl
@@ -1,0 +1,3 @@
+object @audit
+
+attributes :id, :auditable_id, :auditable_name, :auditable_type, :action, :audited_changes

--- a/app/views/api/v2/audits/index.json.rabl
+++ b/app/views/api/v2/audits/index.json.rabl
@@ -1,3 +1,3 @@
 collection @audits
 
-extends "api/v2/audits/show"
+extends "api/v2/audits/main"

--- a/app/views/api/v2/audits/main.json.rabl
+++ b/app/views/api/v2/audits/main.json.rabl
@@ -1,0 +1,6 @@
+object @audit
+
+extends "api/v2/audits/base"
+
+attributes :user_id, :user_type, :user_name, :version, :comment, :associated_id, :associated_type,
+           :remote_address, :associated_name, :created_at, :updated_at

--- a/app/views/api/v2/audits/show.json.rabl
+++ b/app/views/api/v2/audits/show.json.rabl
@@ -1,5 +1,3 @@
 object @audit
 
 attributes :id, :auditable_id, :auditable_type, :user_id, :user_type, :user_name, :action, :audited_changes, :version, :comment, :associated_id, :associated_type, :created_at, :remote_address, :auditable_name, :associated_name, :updated_at
-
-

--- a/app/views/api/v2/audits/show.json.rabl
+++ b/app/views/api/v2/audits/show.json.rabl
@@ -1,3 +1,3 @@
 object @audit
 
-attributes :id, :auditable_id, :auditable_type, :user_id, :user_type, :user_name, :action, :audited_changes, :version, :comment, :associated_id, :associated_type, :created_at, :remote_address, :auditable_name, :associated_name, :updated_at
+extends "api/v2/audits/main"

--- a/app/views/api/v2/auth_source_ldaps/base.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/base.json.rabl
@@ -1,0 +1,3 @@
+object @auth_source_ldap
+
+attributes :id, :type, :name

--- a/app/views/api/v2/auth_source_ldaps/index.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/index.json.rabl
@@ -1,3 +1,3 @@
 collection @auth_source_ldaps
 
-extends "api/v2/auth_source_ldaps/show"
+extends "api/v2/auth_source_ldaps/main"

--- a/app/views/api/v2/auth_source_ldaps/main.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/main.json.rabl
@@ -1,0 +1,5 @@
+object @auth_source_ldap
+
+extends "api/v2/auth_source_ldaps/base"
+
+attributes :port, :account, :base_dn, :ldap_filter, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :onthefly_register, :tls, :created_at, :updated_at

--- a/app/views/api/v2/auth_source_ldaps/show.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/show.json.rabl
@@ -1,3 +1,3 @@
 object @auth_source_ldap
 
-attributes :id, :type, :name, :host, :port, :account, :base_dn, :ldap_filter, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :onthefly_register, :tls, :created_at, :updated_at
+extends "api/v2/auth_source_ldaps/main"

--- a/app/views/api/v2/common_parameters/base.json.rabl
+++ b/app/views/api/v2/common_parameters/base.json.rabl
@@ -1,0 +1,3 @@
+object @common_parameter
+
+attributes :id, :name, :value

--- a/app/views/api/v2/common_parameters/index.json.rabl
+++ b/app/views/api/v2/common_parameters/index.json.rabl
@@ -1,3 +1,3 @@
 collection @common_parameters
 
-extends "api/v2/common_parameters/show"
+extends "api/v2/common_parameters/main"

--- a/app/views/api/v2/common_parameters/main.json.rabl
+++ b/app/views/api/v2/common_parameters/main.json.rabl
@@ -1,0 +1,5 @@
+object @common_parameter
+
+extends "api/v2/common_parameters/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/common_parameters/show.json.rabl
+++ b/app/views/api/v2/common_parameters/show.json.rabl
@@ -1,3 +1,3 @@
 object @common_parameter
 
-attributes :id, :name, :value
+extends "api/v2/common_parameters/main"

--- a/app/views/api/v2/compute_resources/base.json.rabl
+++ b/app/views/api/v2/compute_resources/base.json.rabl
@@ -1,0 +1,4 @@
+object @compute_resource
+
+attributes :id, :name
+attribute :provider_friendly_name => 'provider'

--- a/app/views/api/v2/compute_resources/index.json.rabl
+++ b/app/views/api/v2/compute_resources/index.json.rabl
@@ -1,3 +1,3 @@
 collection @compute_resources
 
-extends "api/v2/compute_resources/show"
+extends "api/v2/compute_resources/main"

--- a/app/views/api/v2/compute_resources/main.json.rabl
+++ b/app/views/api/v2/compute_resources/main.json.rabl
@@ -1,0 +1,9 @@
+object @compute_resource
+
+extends "api/v2/compute_resources/base"
+
+attributes :description, :url, :created_at, :updated_at
+
+node do |r|
+  partial("api/v2/compute_resources/#{r.provider.downcase}.json", :object => r)
+end

--- a/app/views/api/v2/compute_resources/show.json.rabl
+++ b/app/views/api/v2/compute_resources/show.json.rabl
@@ -1,8 +1,3 @@
 object @compute_resource
 
-attributes :id, :name, :description, :url, :created_at, :updated_at
-attribute :provider_friendly_name => 'provider'
-
-node do |r|
-  partial("api/v2/compute_resources/#{r.provider.downcase}.json", :object => r)
-end
+extends "api/v2/compute_resources/main"

--- a/app/views/api/v2/config_templates/base.json.rabl
+++ b/app/views/api/v2/config_templates/base.json.rabl
@@ -1,0 +1,3 @@
+object @config_template
+
+attributes :id, :name

--- a/app/views/api/v2/config_templates/index.json.rabl
+++ b/app/views/api/v2/config_templates/index.json.rabl
@@ -1,3 +1,3 @@
 collection @config_templates
 
-extends "api/v2/config_templates/show"
+extends "api/v2/config_templates/main"

--- a/app/views/api/v2/config_templates/main.json.rabl
+++ b/app/views/api/v2/config_templates/main.json.rabl
@@ -2,4 +2,4 @@ object @config_template
 
 extends "api/v2/config_templates/base"
 
-attributes :template, :snippet, :audit_comment, :template_kind_id, :template_kind_name, :created_at, :updated_at
+attributes :snippet, :audit_comment, :template_kind_id, :template_kind_name, :created_at, :updated_at

--- a/app/views/api/v2/config_templates/main.json.rabl
+++ b/app/views/api/v2/config_templates/main.json.rabl
@@ -1,0 +1,5 @@
+object @config_template
+
+extends "api/v2/config_templates/base"
+
+attributes :template, :snippet, :audit_comment, :template_kind_id, :template_kind_name, :created_at, :updated_at

--- a/app/views/api/v2/config_templates/show.json.rabl
+++ b/app/views/api/v2/config_templates/show.json.rabl
@@ -2,8 +2,10 @@ object @config_template
 
 extends "api/v2/config_templates/main"
 
+attributes :template
+
 child :template_combinations, :object_root => false do
-  extends "api/v2/template_combinations/show"
+  extends "api/v2/template_combinations/base"
 end
 
 child :operatingsystems, :object_root => false do

--- a/app/views/api/v2/config_templates/show.json.rabl
+++ b/app/views/api/v2/config_templates/show.json.rabl
@@ -1,11 +1,11 @@
 object @config_template
 
-attributes :id, :name, :template, :snippet, :audit_comment, :template_kind_id, :template_kind_name
+extends "api/v2/config_templates/main"
 
 child :template_combinations, :object_root => false do
   extends "api/v2/template_combinations/show"
 end
 
 child :operatingsystems, :object_root => false do
-  attributes :id, :name
+  extends "api/v2/operatingsystems/base"
 end

--- a/app/views/api/v2/domains/base.json.rabl
+++ b/app/views/api/v2/domains/base.json.rabl
@@ -1,0 +1,3 @@
+object @domain
+
+attributes :id, :name

--- a/app/views/api/v2/domains/index.json.rabl
+++ b/app/views/api/v2/domains/index.json.rabl
@@ -1,3 +1,3 @@
 collection @domains
 
-extends "api/v2/domains/show"
+extends "api/v2/domains/main"

--- a/app/views/api/v2/domains/main.json.rabl
+++ b/app/views/api/v2/domains/main.json.rabl
@@ -1,0 +1,5 @@
+object @domain
+
+extends "api/v2/domains/base"
+
+attributes :fullname, :dns_id, :created_at, :updated_at

--- a/app/views/api/v2/domains/show.json.rabl
+++ b/app/views/api/v2/domains/show.json.rabl
@@ -1,2 +1,3 @@
 object @domain
-attributes :id, :name, :fullname, :dns_id, :created_at, :updated_at
+
+extends "api/v2/domains/main"

--- a/app/views/api/v2/environments/base.json.rabl
+++ b/app/views/api/v2/environments/base.json.rabl
@@ -1,0 +1,3 @@
+object @environment
+
+attributes :name, :id

--- a/app/views/api/v2/environments/index.json.rabl
+++ b/app/views/api/v2/environments/index.json.rabl
@@ -1,3 +1,3 @@
 collection @environments
 
-extends "api/v2/environments/show"
+extends "api/v2/environments/main"

--- a/app/views/api/v2/environments/main.json.rabl
+++ b/app/views/api/v2/environments/main.json.rabl
@@ -1,0 +1,5 @@
+object @environment
+
+extends "api/v2/environments/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/environments/show.json.rabl
+++ b/app/views/api/v2/environments/show.json.rabl
@@ -1,5 +1,3 @@
 object @environment
 
-attributes :name, :id, :created_at, :updated_at
-
-
+extends "api/v2/environments/main"

--- a/app/views/api/v2/hostgroups/base.json.rabl
+++ b/app/views/api/v2/hostgroups/base.json.rabl
@@ -1,0 +1,3 @@
+object @hostgroup
+
+attributes :id, :name, :label

--- a/app/views/api/v2/hostgroups/index.json.rabl
+++ b/app/views/api/v2/hostgroups/index.json.rabl
@@ -1,3 +1,3 @@
 collection @hostgroups
 
-extends "api/v2/hostgroups/show"
+extends "api/v2/hostgroups/main"

--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -1,0 +1,5 @@
+object @hostgroup
+
+extends "api/v2/hostgroups/base"
+
+attributes :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name, :domain_id, :domain_name, :environment_id, :environment_name, :ancestry, :parameters, :puppetclass_ids

--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -1,3 +1,3 @@
 object @hostgroup
 
-attributes :name, :id, :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name, :domain_id, :domain_name, :environment_id, :environment_name, :ancestry, :label, :parameters, :puppetclass_ids
+extends "api/v2/hostgroups/main"

--- a/app/views/api/v2/hosts/base.json.rabl
+++ b/app/views/api/v2/hosts/base.json.rabl
@@ -1,0 +1,3 @@
+object @host
+
+attributes :name, :id

--- a/app/views/api/v2/hosts/index.json.rabl
+++ b/app/views/api/v2/hosts/index.json.rabl
@@ -1,3 +1,3 @@
 collection @hosts
 
-attributes :name, :id, :hostgroup_id, :hostgroup_name, :operatingsystem_id, :operatingsystem_name
+extends "api/v2/hosts/main"

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -2,13 +2,13 @@ object @host
 
 extends "api/v2/hosts/base"
 
-attributes :ip, :environment_id, :environment_name, :last_report, :updated_at, :created_at, :mac,
+attributes :ip, :environment_id, :environment_name, :last_report, :mac,
            :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
            :subnet_id, :subnet_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
            :comment, :disk, :installed_at, :model_id, :model_name, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
            :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
            :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
-           :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status, :root_pass
+           :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status
 
 if SETTINGS[:organizations_enabled]
   attributes :organization_id, :organization_name

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -1,0 +1,19 @@
+object @host
+
+extends "api/v2/hosts/base"
+
+attributes :ip, :environment_id, :environment_name, :last_report, :updated_at, :created_at, :mac,
+           :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
+           :subnet_id, :subnet_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
+           :comment, :disk, :installed_at, :model_id, :model_name, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
+           :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
+           :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
+           :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status, :root_pass
+
+if SETTINGS[:organizations_enabled]
+  attributes :organization_id, :organization_name
+end
+
+if SETTINGS[:locations_enabled]
+  attributes :location_id, :location_name
+end

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -1,9 +1,9 @@
-object @host
+  object @host
 
 extends "api/v2/hosts/main"
 
 child :host_parameters, :object_root => false do
-  attributes :id, :name, :value, :priority, :is_property, :created_at, :updated_at
+  extends "api/v2/parameters/base"
 end
 
 node do |host|

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -1,20 +1,6 @@
 object @host
 
-attributes :name, :id, :ip, :environment_id, :environment_name, :last_report, :updated_at, :created_at, :mac,
-           :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
-           :subnet_id, :subnet_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
-           :comment, :disk, :installed_at, :model_id, :model_name, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
-           :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
-           :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
-           :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status, :root_pass
-
-if SETTINGS[:organizations_enabled]
-  attributes :organization_id, :organization_name
-end
-
-if SETTINGS[:locations_enabled]
-  attributes :location_id, :location_name
-end
+extends "api/v2/hosts/main"
 
 child :host_parameters, :object_root => false do
   attributes :id, :name, :value, :priority, :is_property, :created_at, :updated_at

--- a/app/views/api/v2/images/base.json.rabl
+++ b/app/views/api/v2/images/base.json.rabl
@@ -1,0 +1,3 @@
+object @image
+
+attributes :id, :name

--- a/app/views/api/v2/images/index.json.rabl
+++ b/app/views/api/v2/images/index.json.rabl
@@ -1,3 +1,3 @@
 collection @images
 
-extends "api/v2/images/show"
+extends "api/v2/images/main"

--- a/app/views/api/v2/images/main.json.rabl
+++ b/app/views/api/v2/images/main.json.rabl
@@ -1,0 +1,7 @@
+object @image
+
+extends "api/v2/images/base"
+
+attributes :operatingsystem_id, :operatingsystem_name, :compute_resource_id, :compute_resource_name, :architecture_id, :architecture_name, :uuid, :username, :created_at, :updated_at
+attribute :iam_role, :if => lambda { |img| img.compute_resource.kind_of? Foreman::Model::EC2 }
+

--- a/app/views/api/v2/images/show.json.rabl
+++ b/app/views/api/v2/images/show.json.rabl
@@ -1,4 +1,3 @@
 object @image
 
-attributes :id, :operatingsystem_id, :operatingsystem_name, :compute_resource_id, :compute_resource_name, :architecture_id, :architecture_name, :uuid, :username, :name, :created_at, :updated_at
-attribute :iam_role, :if => lambda { |img| img.compute_resource.kind_of? Foreman::Model::EC2 }
+extends "api/v2/images/main"

--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,3 +1,3 @@
 object @interface
 
-attributes :id, :name, :type
+attributes :id, :name, :type, :ip, :mac

--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,0 +1,3 @@
+object @interface
+
+attributes :id, :name, :type

--- a/app/views/api/v2/interfaces/create.json.rabl
+++ b/app/views/api/v2/interfaces/create.json.rabl
@@ -1,3 +1,3 @@
-object @interface => :interface
+object @interface
 
 extends "api/v2/interfaces/show"

--- a/app/views/api/v2/interfaces/index.json.rabl
+++ b/app/views/api/v2/interfaces/index.json.rabl
@@ -1,3 +1,3 @@
 collection @interfaces
 
-extends "api/v2/interfaces/show"
+extends "api/v2/interfaces/main"

--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -1,0 +1,5 @@
+object @interface
+
+extends "api/v2/interfaces/base"
+
+attributes :ip, :mac, :username, :password, :provider, :subnet_id, :subnet_name, :domain_id, :domain_name, :created_at, :updated_at

--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -2,4 +2,4 @@ object @interface
 
 extends "api/v2/interfaces/base"
 
-attributes :ip, :mac, :username, :password, :provider, :subnet_id, :subnet_name, :domain_id, :domain_name, :created_at, :updated_at
+attributes :username, :password, :provider, :subnet_id, :subnet_name, :domain_id, :domain_name, :created_at, :updated_at

--- a/app/views/api/v2/interfaces/show.json.rabl
+++ b/app/views/api/v2/interfaces/show.json.rabl
@@ -1,3 +1,3 @@
-object @interface => :interface
+object @interface
 
-attributes :id, :ip, :mac, :name, :type, :username, :password, :provider, :subnet_id, :subnet_name, :domain_id, :domain_name,:created_at, :updated_at
+extends "api/v2/interfaces/main"

--- a/app/views/api/v2/interfaces/update.json.rabl
+++ b/app/views/api/v2/interfaces/update.json.rabl
@@ -1,3 +1,3 @@
-object @interface => :interface
+object @interface
 
 extends "api/v2/interfaces/show"

--- a/app/views/api/v2/media/base.json.rabl
+++ b/app/views/api/v2/media/base.json.rabl
@@ -1,0 +1,3 @@
+object @medium
+
+attributes :id, :name

--- a/app/views/api/v2/media/index.json.rabl
+++ b/app/views/api/v2/media/index.json.rabl
@@ -1,3 +1,3 @@
 collection @media
 
-extends "api/v2/media/show"
+extends "api/v2/media/main"

--- a/app/views/api/v2/media/main.json.rabl
+++ b/app/views/api/v2/media/main.json.rabl
@@ -1,0 +1,11 @@
+object @medium
+
+extends "api/v2/media/base"
+
+attributes :path, :os_family, :created_at, :updated_at, :operatingsystem_ids
+
+node do |medium|
+  if medium.os_family == 'Solaris'
+    attributes :media_path, :config_path, :image_path
+  end
+end

--- a/app/views/api/v2/media/main.json.rabl
+++ b/app/views/api/v2/media/main.json.rabl
@@ -2,7 +2,7 @@ object @medium
 
 extends "api/v2/media/base"
 
-attributes :path, :os_family, :created_at, :updated_at, :operatingsystem_ids
+attributes :path, :os_family, :created_at, :updated_at
 
 node do |medium|
   if medium.os_family == 'Solaris'

--- a/app/views/api/v2/media/show.json.rabl
+++ b/app/views/api/v2/media/show.json.rabl
@@ -1,9 +1,3 @@
 object @medium
 
-attributes :id, :name, :path, :os_family, :created_at, :updated_at, :operatingsystem_ids
-
-node do |medium|
-  if medium.os_family == 'Solaris'
-    attributes :media_path, :config_path, :image_path
-  end
-end
+extends "api/v2/media/main"

--- a/app/views/api/v2/media/show.json.rabl
+++ b/app/views/api/v2/media/show.json.rabl
@@ -1,3 +1,7 @@
 object @medium
 
 extends "api/v2/media/main"
+
+child :operatingsystems, :object_root => false do
+  extends "api/v2/operatingsystems/base"
+end

--- a/app/views/api/v2/models/base.json.rabl
+++ b/app/views/api/v2/models/base.json.rabl
@@ -1,0 +1,3 @@
+object @model
+
+attributes :id, :name

--- a/app/views/api/v2/models/index.rabl
+++ b/app/views/api/v2/models/index.rabl
@@ -1,4 +1,4 @@
 collection @models
 
-extends "api/v2/models/show"
+extends "api/v2/models/main"
 

--- a/app/views/api/v2/models/main.json.rabl
+++ b/app/views/api/v2/models/main.json.rabl
@@ -1,0 +1,5 @@
+object @model
+
+extends "api/v2/models/base"
+
+attributes :info, :created_at, :updated_at, :vendor_class, :hardware_model

--- a/app/views/api/v2/models/show.rabl
+++ b/app/views/api/v2/models/show.rabl
@@ -1,3 +1,3 @@
 object @model
 
-attributes :id, :name, :info, :created_at, :updated_at, :vendor_class, :hardware_model
+extends "api/v2/models/main"

--- a/app/views/api/v2/operatingsystems/base.json.rabl
+++ b/app/views/api/v2/operatingsystems/base.json.rabl
@@ -1,3 +1,3 @@
 object @operatingsystem
 
-attributes :id, :name
+attributes :id, :name, :fullname

--- a/app/views/api/v2/operatingsystems/base.json.rabl
+++ b/app/views/api/v2/operatingsystems/base.json.rabl
@@ -1,0 +1,3 @@
+object @operatingsystem
+
+attributes :id, :name

--- a/app/views/api/v2/operatingsystems/index.json.rabl
+++ b/app/views/api/v2/operatingsystems/index.json.rabl
@@ -1,3 +1,3 @@
 collection @operatingsystems
 
-extends "api/v2/operatingsystems/show"
+extends "api/v2/operatingsystems/main"

--- a/app/views/api/v2/operatingsystems/main.json.rabl
+++ b/app/views/api/v2/operatingsystems/main.json.rabl
@@ -1,0 +1,4 @@
+object @operatingsystem
+
+extends "api/v2/operatingsystems/base"
+attributes :major, :minor, :family, :release_name, :created_at, :updated_at

--- a/app/views/api/v2/operatingsystems/show.json.rabl
+++ b/app/views/api/v2/operatingsystems/show.json.rabl
@@ -3,19 +3,19 @@ object @operatingsystem
 extends "api/v2/operatingsystems/main"
 
 child :media, :object_root => false do
-  attributes :id, :name
+  extends "api/v2/media/base"
 end
 
 child :architectures, :object_root => false do
-  attributes :id, :name
+  extends "api/v2/architectures/base"
 end
 
 child :ptables, :object_root => false do
-  attributes :id, :name
+  extends "api/v2/ptables/base"
 end
 
 child :config_templates, :object_root => false do
-  attributes :name, :id
+  extends "api/v2/config_templates/base"
 end
 
 child :os_default_templates, :object_root => false do

--- a/app/views/api/v2/operatingsystems/show.json.rabl
+++ b/app/views/api/v2/operatingsystems/show.json.rabl
@@ -1,5 +1,6 @@
 object @operatingsystem
-attributes :id, :name, :major, :minor, :family, :release_name
+
+extends "api/v2/operatingsystems/main"
 
 child :media, :object_root => false do
   attributes :id, :name

--- a/app/views/api/v2/override_values/base.json.rabl
+++ b/app/views/api/v2/override_values/base.json.rabl
@@ -1,0 +1,3 @@
+object @override_value
+
+attributes :id, :match, :value

--- a/app/views/api/v2/override_values/create.json.rabl
+++ b/app/views/api/v2/override_values/create.json.rabl
@@ -1,3 +1,3 @@
 object @override_value
 
-extends "api/v2/override_values/show"
+extends "api/v2/override_values/base"

--- a/app/views/api/v2/override_values/create.json.rabl
+++ b/app/views/api/v2/override_values/create.json.rabl
@@ -1,3 +1,3 @@
 object @override_value
 
-extends "api/v2/override_values/base"
+extends "api/v2/override_values/show"

--- a/app/views/api/v2/override_values/index.json.rabl
+++ b/app/views/api/v2/override_values/index.json.rabl
@@ -1,3 +1,3 @@
 collection @override_values
 
-extends "api/v2/override_values/show"
+extends "api/v2/override_values/main"

--- a/app/views/api/v2/override_values/main.json.rabl
+++ b/app/views/api/v2/override_values/main.json.rabl
@@ -1,0 +1,5 @@
+object @override_value
+
+extends "api/v2/override_values/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/override_values/show.json.rabl
+++ b/app/views/api/v2/override_values/show.json.rabl
@@ -1,3 +1,3 @@
-object @override_value => :override_value
+object @override_value
 
-attributes :id, :match, :value
+extends "api/v2/override_values/main"

--- a/app/views/api/v2/parameters/base.json.rabl
+++ b/app/views/api/v2/parameters/base.json.rabl
@@ -1,0 +1,3 @@
+object @parameter
+
+attributes :id, :name, :value

--- a/app/views/api/v2/parameters/create.json.rabl
+++ b/app/views/api/v2/parameters/create.json.rabl
@@ -1,3 +1,3 @@
-object @parameter => :parameter
+object @parameter
 
 extends "api/v2/parameters/show"

--- a/app/views/api/v2/parameters/index.json.rabl
+++ b/app/views/api/v2/parameters/index.json.rabl
@@ -1,3 +1,3 @@
 collection @parameters
 
-extends "api/v2/parameters/show"
+extends "api/v2/parameters/main"

--- a/app/views/api/v2/parameters/main.json.rabl
+++ b/app/views/api/v2/parameters/main.json.rabl
@@ -2,4 +2,4 @@ object @parameter
 
 extends "api/v2/parameters/base"
 
-attributes :created_at, :updated_at
+attributes :priority, :is_property, :created_at, :updated_at

--- a/app/views/api/v2/parameters/main.json.rabl
+++ b/app/views/api/v2/parameters/main.json.rabl
@@ -1,0 +1,5 @@
+object @parameter
+
+extends "api/v2/parameters/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/parameters/show.json.rabl
+++ b/app/views/api/v2/parameters/show.json.rabl
@@ -1,3 +1,3 @@
 object @parameter
 
-attributes :id, :name, :value
+extends "api/v2/parameters/main"

--- a/app/views/api/v2/parameters/show.json.rabl
+++ b/app/views/api/v2/parameters/show.json.rabl
@@ -1,3 +1,3 @@
-object @parameter => :parameter
+object @parameter
 
 attributes :id, :name, :value

--- a/app/views/api/v2/parameters/update.json.rabl
+++ b/app/views/api/v2/parameters/update.json.rabl
@@ -1,3 +1,3 @@
-object @parameter => :parameter
+object @parameter
 
 extends "api/v2/parameters/show"

--- a/app/views/api/v2/ptables/base.json.rabl
+++ b/app/views/api/v2/ptables/base.json.rabl
@@ -1,0 +1,3 @@
+object @ptable
+
+attributes :name, :id

--- a/app/views/api/v2/ptables/index.json.rabl
+++ b/app/views/api/v2/ptables/index.json.rabl
@@ -1,3 +1,3 @@
 collection @ptables
 
-extends "api/v2/ptables/show"
+extends "api/v2/ptables/main"

--- a/app/views/api/v2/ptables/main.json.rabl
+++ b/app/views/api/v2/ptables/main.json.rabl
@@ -2,4 +2,4 @@ object @ptable
 
 extends "api/v2/ptables/base"
 
-attributes :layout, :os_family, :created_at, :updated_at
+attributes :os_family, :created_at, :updated_at

--- a/app/views/api/v2/ptables/main.json.rabl
+++ b/app/views/api/v2/ptables/main.json.rabl
@@ -1,0 +1,5 @@
+object @ptable
+
+extends "api/v2/ptables/base"
+
+attributes :layout, :os_family, :created_at, :updated_at

--- a/app/views/api/v2/ptables/show.json.rabl
+++ b/app/views/api/v2/ptables/show.json.rabl
@@ -1,3 +1,3 @@
 object @ptable
 
-attributes :name, :id, :layout, :os_family, :created_at, :updated_at
+extends "api/v2/ptables/main"

--- a/app/views/api/v2/ptables/show.json.rabl
+++ b/app/views/api/v2/ptables/show.json.rabl
@@ -1,3 +1,5 @@
 object @ptable
 
 extends "api/v2/ptables/main"
+
+attributes :layout

--- a/app/views/api/v2/puppetclasses/main.json.rabl
+++ b/app/views/api/v2/puppetclasses/main.json.rabl
@@ -1,0 +1,5 @@
+object @puppetclass
+
+extends "api/v2/puppetclasses/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/puppetclasses/show.json.rabl
+++ b/app/views/api/v2/puppetclasses/show.json.rabl
@@ -1,6 +1,6 @@
 object @puppetclass
 
-attributes :id, :name, :created_at, :updated_at
+extends "api/v2/puppetclasses/main"
 
 child :environments, :object_root => false do
   attributes :id, :name

--- a/app/views/api/v2/puppetclasses/show.json.rabl
+++ b/app/views/api/v2/puppetclasses/show.json.rabl
@@ -3,11 +3,11 @@ object @puppetclass
 extends "api/v2/puppetclasses/main"
 
 child :environments, :object_root => false do
-  attributes :id, :name
+  extends "api/v2/environments/base"
 end
 
 child :hostgroups, :object_root => false do
-  attributes :id, :label
+  extends "api/v2/hostgroups/base"
 end
 
 node do |puppetclass|

--- a/app/views/api/v2/reports/base.json.rabl
+++ b/app/views/api/v2/reports/base.json.rabl
@@ -1,3 +1,3 @@
 object @report
 
-attributes :id, :reported_at, :status
+attributes :id, :host_id, :host_name, :reported_at, :status

--- a/app/views/api/v2/reports/base.json.rabl
+++ b/app/views/api/v2/reports/base.json.rabl
@@ -1,0 +1,3 @@
+object @report
+
+attributes :id, :reported_at, :status

--- a/app/views/api/v2/reports/index.json.rabl
+++ b/app/views/api/v2/reports/index.json.rabl
@@ -1,3 +1,3 @@
 collection @reports
 
-extends "api/v2/reports/show"
+extends "api/v2/reports/main"

--- a/app/views/api/v2/reports/main.json.rabl
+++ b/app/views/api/v2/reports/main.json.rabl
@@ -1,0 +1,19 @@
+object @report
+
+extends "api/v2/reports/base"
+
+attributes :metrics, :created_at, :updated_at
+
+child :logs, :object_root => false do
+  child :source, :object_root => false do
+    attribute :value => :source
+  end
+  child :message, :object_root => false do
+    attribute :value => :message
+  end
+  attribute :level
+end
+
+node :summary do |report|
+  report.summaryStatus
+end

--- a/app/views/api/v2/reports/main.json.rabl
+++ b/app/views/api/v2/reports/main.json.rabl
@@ -3,17 +3,3 @@ object @report
 extends "api/v2/reports/base"
 
 attributes :metrics, :created_at, :updated_at
-
-child :logs, :object_root => false do
-  child :source, :object_root => false do
-    attribute :value => :source
-  end
-  child :message, :object_root => false do
-    attribute :value => :message
-  end
-  attribute :level
-end
-
-node :summary do |report|
-  report.summaryStatus
-end

--- a/app/views/api/v2/reports/show.json.rabl
+++ b/app/views/api/v2/reports/show.json.rabl
@@ -1,6 +1,6 @@
 object @report
 
-attributes :id, :reported_at, :status, :metrics
+extends "api/v2/reports/main"
 
 child :logs, :object_root => false do
   child :source, :object_root => false do
@@ -13,5 +13,5 @@ child :logs, :object_root => false do
 end
 
 node :summary do |report|
-	report.summaryStatus
+  report.summaryStatus
 end

--- a/app/views/api/v2/roles/base.json.rabl
+++ b/app/views/api/v2/roles/base.json.rabl
@@ -1,0 +1,3 @@
+object @role
+
+attributes :name, :id

--- a/app/views/api/v2/roles/index.json.rabl
+++ b/app/views/api/v2/roles/index.json.rabl
@@ -1,3 +1,3 @@
 collection @roles
 
-extends "api/v2/roles/show"
+extends "api/v2/roles/main"

--- a/app/views/api/v2/roles/main.json.rabl
+++ b/app/views/api/v2/roles/main.json.rabl
@@ -1,0 +1,5 @@
+object @role
+
+extends "api/v2/roles/base"
+
+attributes :builtin, :permissions, :created_at, :updated_at

--- a/app/views/api/v2/roles/show.json.rabl
+++ b/app/views/api/v2/roles/show.json.rabl
@@ -1,3 +1,3 @@
 object @role
 
-attributes :name, :id, :builtin, :permissions
+extends "api/v2/roles/main"

--- a/app/views/api/v2/settings/base.json.rabl
+++ b/app/views/api/v2/settings/base.json.rabl
@@ -1,0 +1,3 @@
+object @setting
+
+attributes :id, :name

--- a/app/views/api/v2/settings/index.json.rabl
+++ b/app/views/api/v2/settings/index.json.rabl
@@ -1,3 +1,3 @@
 collection @settings
 
-extends "api/v2/settings/show"
+extends "api/v2/settings/main"

--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -1,0 +1,5 @@
+object @setting
+
+extends "api/v2/settings/base"
+
+attributes :value, :description, :category, :settings_type, :default, :created_at, :updated_at

--- a/app/views/api/v2/settings/show.json.rabl
+++ b/app/views/api/v2/settings/show.json.rabl
@@ -1,3 +1,3 @@
 object @setting
 
-attributes :id, :name, :value, :description, :category, :settings_type, :default, :created_at, :updated_at
+extends "api/v2/settings/main"

--- a/app/views/api/v2/smart_class_parameters/base.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/base.json.rabl
@@ -1,4 +1,4 @@
-object @smart_class_parameter => :smart_class_parameter
+object @smart_class_parameter
 
 attribute :parameter
 attributes :id

--- a/app/views/api/v2/smart_class_parameters/create.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/create.json.rabl
@@ -1,3 +1,3 @@
-object @smart_class_parameter => :smart_class_parameter
+object @smart_class_parameter
 
-extends "api/v2/smart_class_parameters/show"
+extends "api/v2/smart_class_parameters/base"

--- a/app/views/api/v2/smart_class_parameters/create.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/create.json.rabl
@@ -1,3 +1,3 @@
 object @smart_class_parameter
 
-extends "api/v2/smart_class_parameters/base"
+extends "api/v2/smart_class_parameters/show"

--- a/app/views/api/v2/smart_class_parameters/destroy.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/destroy.json.rabl
@@ -1,5 +1,3 @@
-object @smart_class_parameter => :smart_class_parameter
+object @smart_class_parameter
 
 extends "api/v2/smart_class_parameters/base"
-attributes :description, :override, :parameter_type, :default_value, :required, :validator_type, :validator_rule,
-           :override_value_order, :override_values_count, :created_at, :updated_at

--- a/app/views/api/v2/smart_class_parameters/destroy.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/destroy.json.rabl
@@ -1,3 +1,3 @@
 object @smart_class_parameter
 
-extends "api/v2/smart_class_parameters/base"
+extends "api/v2/smart_class_parameters/show"

--- a/app/views/api/v2/smart_class_parameters/index.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/index.json.rabl
@@ -1,3 +1,3 @@
 collection @smart_class_parameters
 
-extends "api/v2/smart_class_parameters/show"
+extends "api/v2/smart_class_parameters/main"

--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -1,0 +1,6 @@
+object @smart_class_parameter
+
+extends "api/v2/smart_class_parameters/base"
+
+attributes :description, :override, :parameter_type, :default_value, :required, :validator_type, :validator_rule,
+           :override_value_order, :override_values_count, :created_at, :updated_at

--- a/app/views/api/v2/smart_class_parameters/show.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/show.json.rabl
@@ -1,8 +1,6 @@
-object @smart_class_parameter => :smart_class_parameter
+object @smart_class_parameter
 
-extends "api/v2/smart_class_parameters/base"
-attributes :description, :override, :parameter_type, :default_value, :required, :validator_type, :validator_rule,
-           :override_value_order, :override_values_count, :created_at, :updated_at
+extends "api/v2/smart_class_parameters/main"
 
 unless params[:puppetclass_id].present?
   node do |smart_class_parameter|
@@ -17,5 +15,5 @@ unless params[:environment_id].present?
 end
 
 node do |smart_class_parameter|
-  { :override_values => partial("api/v2/override_values/show", :object => smart_class_parameter.lookup_values) }
+  { :override_values => partial("api/v2/override_values/base", :object => smart_class_parameter.lookup_values) }
 end

--- a/app/views/api/v2/smart_proxies/base.json.rabl
+++ b/app/views/api/v2/smart_proxies/base.json.rabl
@@ -1,3 +1,3 @@
 object @smart_proxy
 
-attributes :name, :id
+attributes :name, :id, :url

--- a/app/views/api/v2/smart_proxies/base.json.rabl
+++ b/app/views/api/v2/smart_proxies/base.json.rabl
@@ -1,0 +1,3 @@
+object @smart_proxy
+
+attributes :name, :id

--- a/app/views/api/v2/smart_proxies/index.json.rabl
+++ b/app/views/api/v2/smart_proxies/index.json.rabl
@@ -1,3 +1,3 @@
 collection @smart_proxies
 
-attributes :name, :id, :url, :created_at, :updated_at
+extends "api/v2/smart_proxies/main"

--- a/app/views/api/v2/smart_proxies/main.json.rabl
+++ b/app/views/api/v2/smart_proxies/main.json.rabl
@@ -2,4 +2,8 @@ object @smart_proxy
 
 extends "api/v2/smart_proxies/base"
 
-attributes :url, :created_at, :updated_at
+attributes :created_at, :updated_at
+
+child :features, :object_root => false do
+  attributes :name, :id, :url
+end

--- a/app/views/api/v2/smart_proxies/main.json.rabl
+++ b/app/views/api/v2/smart_proxies/main.json.rabl
@@ -1,0 +1,5 @@
+object @smart_proxy
+
+extends "api/v2/smart_proxies/base"
+
+attributes :url, :created_at, :updated_at

--- a/app/views/api/v2/smart_proxies/show.json.rabl
+++ b/app/views/api/v2/smart_proxies/show.json.rabl
@@ -1,6 +1,6 @@
 object @smart_proxy
 
-attributes :name, :id, :url, :created_at, :updated_at
+extends "api/v2/smart_proxies/main"
 
 child :features, :object_root => false do
 	attributes :name, :id, :url

--- a/app/views/api/v2/smart_proxies/show.json.rabl
+++ b/app/views/api/v2/smart_proxies/show.json.rabl
@@ -1,9 +1,3 @@
 object @smart_proxy
 
 extends "api/v2/smart_proxies/main"
-
-child :features, :object_root => false do
-	attributes :name, :id, :url
-end
-
-

--- a/app/views/api/v2/smart_variables/base.json.rabl
+++ b/app/views/api/v2/smart_variables/base.json.rabl
@@ -1,4 +1,4 @@
-object @smart_variable => :smart_variable
+object @smart_variable
 
 attribute :variable
 attributes :id

--- a/app/views/api/v2/smart_variables/create.json.rabl
+++ b/app/views/api/v2/smart_variables/create.json.rabl
@@ -1,3 +1,3 @@
 object @smart_variable
 
-extends "api/v2/smart_variables/base"
+extends "api/v2/smart_variables/show"

--- a/app/views/api/v2/smart_variables/create.json.rabl
+++ b/app/views/api/v2/smart_variables/create.json.rabl
@@ -1,3 +1,3 @@
-object @smart_variable => :smart_variable
+object @smart_variable
 
-extends "api/v2/smart_variables/show"
+extends "api/v2/smart_variables/base"

--- a/app/views/api/v2/smart_variables/destroy.json.rabl
+++ b/app/views/api/v2/smart_variables/destroy.json.rabl
@@ -1,3 +1,3 @@
 object @smart_variable
 
-extends "api/v2/smart_variables/base"
+extends "api/v2/smart_variables/show"

--- a/app/views/api/v2/smart_variables/destroy.json.rabl
+++ b/app/views/api/v2/smart_variables/destroy.json.rabl
@@ -1,5 +1,3 @@
-object @smart_variable => :smart_variable
+object @smart_variable
 
 extends "api/v2/smart_variables/base"
-attributes :description, :parameter_type, :default_value, :validator_type, :validator_rule, :override_value_order, :override_values_count,
-           :puppetclass_id, :puppetclass_name, :created_at, :updated_at

--- a/app/views/api/v2/smart_variables/index.json.rabl
+++ b/app/views/api/v2/smart_variables/index.json.rabl
@@ -1,3 +1,3 @@
 collection @smart_variables
 
-extends "api/v2/smart_variables/show"
+extends "api/v2/smart_variables/main"

--- a/app/views/api/v2/smart_variables/main.json.rabl
+++ b/app/views/api/v2/smart_variables/main.json.rabl
@@ -1,0 +1,6 @@
+object @smart_variable
+
+extends "api/v2/smart_variables/base"
+
+attributes :description, :parameter_type, :default_value, :validator_type, :validator_rule, :override_value_order, :override_values_count,
+           :puppetclass_id, :puppetclass_name, :created_at, :updated_at

--- a/app/views/api/v2/smart_variables/show.json.rabl
+++ b/app/views/api/v2/smart_variables/show.json.rabl
@@ -1,10 +1,8 @@
-object @smart_variable => :smart_variable
+object @smart_variable
 
-extends "api/v2/smart_variables/base"
-attributes :description, :parameter_type, :default_value, :validator_type, :validator_rule, :override_value_order, :override_values_count,
-           :puppetclass_id, :puppetclass_name, :created_at, :updated_at
+extends "api/v2/smart_variables/main"
 
 node do |smart_variable|
-  { :override_values => partial("api/v2/override_values/show", :object => smart_variable.lookup_values) }
+  { :override_values => partial("api/v2/override_values/base", :object => smart_variable.lookup_values) }
 end
 

--- a/app/views/api/v2/subnets/base.json.rabl
+++ b/app/views/api/v2/subnets/base.json.rabl
@@ -1,0 +1,3 @@
+object @subnet
+
+attributes :id, :name

--- a/app/views/api/v2/subnets/index.json.rabl
+++ b/app/views/api/v2/subnets/index.json.rabl
@@ -1,5 +1,3 @@
 collection @subnets
 
-attributes :id, :name, :network, :mask, :priority, :vlanid,
-  :gateway, :dns_primary, :dns_secondary, :from, :to, :domain_ids,
-  :dns_id, :dhcp_id, :tftp_id
+extends "api/v2/subnets/main"

--- a/app/views/api/v2/subnets/main.json.rabl
+++ b/app/views/api/v2/subnets/main.json.rabl
@@ -1,0 +1,7 @@
+object @subnet
+
+extends "api/v2/subnets/base"
+
+attributes :network, :mask, :priority, :vlanid,
+  :gateway, :dns_primary, :dns_secondary, :from, :to, :domain_ids,
+  :dns_id, :dhcp_id, :tftp_id, :cidr

--- a/app/views/api/v2/subnets/show.json.rabl
+++ b/app/views/api/v2/subnets/show.json.rabl
@@ -3,13 +3,13 @@ object @subnet
 extends "api/v2/subnets/main"
 
 child :dhcp => :dhcp do
-  attributes :id, :name, :url
+  extends "api/v2/smart_proxies/base"
 end
 
 child :tftp => :tftp do
-  attributes :id, :name, :url
+  extends "api/v2/smart_proxies/base"
 end
 
 child :dns => :dns do
-  attributes :id, :name, :url
+  extends "api/v2/smart_proxies/base"
 end

--- a/app/views/api/v2/subnets/show.json.rabl
+++ b/app/views/api/v2/subnets/show.json.rabl
@@ -1,8 +1,6 @@
 object @subnet
 
-attributes :id, :name, :network, :mask, :priority, :vlanid,
-  :gateway, :dns_primary, :dns_secondary, :from, :to, :domain_ids,
-  :dns_id, :dhcp_id, :tftp_id, :cidr
+extends "api/v2/subnets/main"
 
 child :dhcp => :dhcp do
   attributes :id, :name, :url

--- a/app/views/api/v2/taxonomies/base.json.rabl
+++ b/app/views/api/v2/taxonomies/base.json.rabl
@@ -1,0 +1,3 @@
+object @taxonomy
+
+attributes :id, :name

--- a/app/views/api/v2/taxonomies/index.json.rabl
+++ b/app/views/api/v2/taxonomies/index.json.rabl
@@ -1,3 +1,3 @@
 collection @taxonomies
 
-attributes :id, :name
+extends "api/v2/taxonomies/main"

--- a/app/views/api/v2/taxonomies/main.json.rabl
+++ b/app/views/api/v2/taxonomies/main.json.rabl
@@ -1,0 +1,5 @@
+object @taxonomy
+
+extends "api/v2/taxonomies/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -1,8 +1,11 @@
 object @taxonomy
-attributes :id, :name,
-            :organization_ids, :hostgroup_ids,
+
+extends "api/v2/taxonomies/main"
+
+attributes  :organization_ids, :hostgroup_ids,
             :environment_ids, :domain_ids, :medium_ids,
             :subnet_ids, :compute_resource_ids,
             :smart_proxy_ids, :user_ids, :config_template_ids,
             :created_at, :updated_at
+
 attribute :ignore_types => :select_all_types

--- a/app/views/api/v2/template_combinations/base.json.rabl
+++ b/app/views/api/v2/template_combinations/base.json.rabl
@@ -1,0 +1,3 @@
+object @template_combination
+
+attributes :id, :config_template_id, :config_template_name, :hostgroup_id, :hostgroup_name, :environment_id, :environment_name

--- a/app/views/api/v2/template_combinations/index.json.rabl
+++ b/app/views/api/v2/template_combinations/index.json.rabl
@@ -1,3 +1,3 @@
 collection @template_combinations
 
-extends "api/v2/template_combinations/show"
+extends "api/v2/template_combinations/main"

--- a/app/views/api/v2/template_combinations/main.json.rabl
+++ b/app/views/api/v2/template_combinations/main.json.rabl
@@ -1,0 +1,5 @@
+object @template_combination
+
+extends "api/v2/template_combinations/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/template_combinations/show.json.rabl
+++ b/app/views/api/v2/template_combinations/show.json.rabl
@@ -1,3 +1,3 @@
 object @template_combination
 
-attributes :id, :config_template_id, :config_template_name, :hostgroup_id, :hostgroup_name, :environment_id, :environment_name
+extends "api/v2/template_combinations/main"

--- a/app/views/api/v2/template_kinds/base.json.rabl
+++ b/app/views/api/v2/template_kinds/base.json.rabl
@@ -1,0 +1,3 @@
+object @template_kind
+
+attributes :name, :id

--- a/app/views/api/v2/template_kinds/index.json.rabl
+++ b/app/views/api/v2/template_kinds/index.json.rabl
@@ -1,3 +1,3 @@
 collection @template_kinds
 
-extends "api/v2/template_kinds/show"
+extends "api/v2/template_kinds/main"

--- a/app/views/api/v2/template_kinds/main.json.rabl
+++ b/app/views/api/v2/template_kinds/main.json.rabl
@@ -1,0 +1,5 @@
+object @template_kind
+
+extends "api/v2/template_kinds/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/template_kinds/show.json.rabl
+++ b/app/views/api/v2/template_kinds/show.json.rabl
@@ -1,3 +1,3 @@
 object @template_kind
 
-attributes :name, :id
+extends "api/v2/template_kinds/main"

--- a/app/views/api/v2/usergroups/base.json.rabl
+++ b/app/views/api/v2/usergroups/base.json.rabl
@@ -1,0 +1,3 @@
+object @usergroup
+
+attributes :name, :id, :created_at, :updated_at

--- a/app/views/api/v2/usergroups/index.json.rabl
+++ b/app/views/api/v2/usergroups/index.json.rabl
@@ -1,3 +1,3 @@
 collection @usergroups
 
-extends "api/v2/usergroups/show"
+extends "api/v2/usergroups/main"

--- a/app/views/api/v2/usergroups/main.json.rabl
+++ b/app/views/api/v2/usergroups/main.json.rabl
@@ -1,0 +1,5 @@
+object @usergroup
+
+extends "api/v2/usergroups/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/usergroups/show.json.rabl
+++ b/app/views/api/v2/usergroups/show.json.rabl
@@ -1,3 +1,3 @@
 object @usergroup
 
-attributes :name, :id, :created_at, :updated_at
+extends "api/v2/usergroups/main"

--- a/app/views/api/v2/users/base.json.rabl
+++ b/app/views/api/v2/users/base.json.rabl
@@ -1,0 +1,3 @@
+object @user
+
+attributes :id, :login

--- a/app/views/api/v2/users/index.json.rabl
+++ b/app/views/api/v2/users/index.json.rabl
@@ -1,5 +1,3 @@
 collection @users
 
-attributes :id, :login, :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :last_login_on,
-           :domains_andor, :hostgroups_andor, :facts_andor, :filter_on_owner, :compute_resources_andor,
-           :created_at, :updated_at
+extends "api/v2/users/main"

--- a/app/views/api/v2/users/main.json.rabl
+++ b/app/views/api/v2/users/main.json.rabl
@@ -2,4 +2,4 @@ object @user
 
 extends "api/v2/users/base"
 
-attributes :created_at, :updated_at
+attributes :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :last_login_on, :created_at, :updated_at

--- a/app/views/api/v2/users/main.json.rabl
+++ b/app/views/api/v2/users/main.json.rabl
@@ -1,0 +1,5 @@
+object @user
+
+extends "api/v2/users/base"
+
+attributes :created_at, :updated_at

--- a/app/views/api/v2/users/show.json.rabl
+++ b/app/views/api/v2/users/show.json.rabl
@@ -1,8 +1,6 @@
 object @user
 
-attributes :id, :login, :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :last_login_on,
-           :domains_andor, :hostgroups_andor, :facts_andor, :filter_on_owner, :compute_resources_andor,
-           :created_at, :updated_at
+extends "api/v2/users/main"
 
 child :auth_source do
   extends "api/v2/auth_source_ldaps/show"

--- a/app/views/api/v2/users/show.json.rabl
+++ b/app/views/api/v2/users/show.json.rabl
@@ -3,9 +3,9 @@ object @user
 extends "api/v2/users/main"
 
 child :auth_source do
-  extends "api/v2/auth_source_ldaps/show"
+  extends "api/v2/auth_source_ldaps/base"
 end
 
 child :roles, :object_root => false do
-  extends "api/v2/roles/show"
+  extends "api/v2/roles/base"
 end

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -117,7 +117,7 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     response = ActiveSupport::JSON.decode(@response.body)
     assert response.kind_of?(Hash)
     assert response['results'].kind_of?(Array)
-    assert_equal ['id', 'name'], response['results'][0].keys.sort
+    assert_equal ['created_at', 'id', 'name', 'updated_at'], response['results'][0].keys.sort
   end
 
   test "object name on show defaults to object class name" do


### PR DESCRIPTION
base.json.rabl - usually contains `:id, :name` and possibly another important attribute

main.json.rabl - extends 'base' and adds attributes, but no :child nodes
                         - index.json.rabl extends the 'main' template

show.json.rabl - extends 'main' and adds :child nodes
                          - currently, 'show' may not have anything different other than extending 'main', but this will probably change in PR 
                            fixes #3492 to add nested routes and relationships in responses.
