### PR TITLE
fixes #1966 - improved UI errors for proxy

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -62,9 +62,6 @@ module Orchestration
 
   private
 
-  def proxy_error e
-    e.respond_to?(:message)  ? e.message : e
-  end
   # Handles the actual queue
   # takes care for running the tasks in order
   # if any of them fail, it rollbacks all completed tasks
@@ -96,9 +93,6 @@ module Orchestration
       rescue Net::LeaseConflict => e
         task.status = "failed"
         failure _("DHCP has a lease at %s") % e, e.backtrace
-      rescue RestClient::Exception => e
-        task.status = "failed"
-        failure _("%{task} task failed with the following error: %{e}") % { :task => task.name, :e => proxy_error(e) }, e.backtrace
       rescue => e
         task.status = "failed"
         failure _("%{task} task failed with the following error: %{e}") % { :task => task.name, :e => e }, e.backtrace

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -44,7 +44,8 @@ module Orchestration::DHCP
     # if that failed, trying to guess out tftp next server based on the smart proxy hostname
     bs ||= URI.parse(subnet.tftp.url).host
     # now convert it into an ip address (see http://theforeman.org/issues/show/1381)
-    return to_ip_address(bs) if bs.present?
+    ip = to_ip_address(bs) if bs.present?
+    return ip unless ip.nil?
 
     failure _("Unable to determine the host's boot server. The DHCP smart proxy failed to provide this information and this subnet is not provided with TFTP services.")
   rescue => e

--- a/app/models/concerns/orchestration/puppetca.rb
+++ b/app/models/concerns/orchestration/puppetca.rb
@@ -21,8 +21,6 @@ module Orchestration::Puppetca
   def delCertificate
     logger.info "Remove puppet certificate for #{name}"
     puppetca.del_certificate certname
-  rescue => e
-    failure _("Failed to remove %{name}'s puppet certificate: %{e}") % { :name => name, :e => proxy_error(e) }
   end
 
   # Empty method for rollbacks - maybe in the future we would support creating the certificates directly
@@ -32,16 +30,12 @@ module Orchestration::Puppetca
   def setAutosign
     logger.info "Adding autosign entry for #{name}"
     puppetca.set_autosign certname
-  rescue => e
-    failure _("Failed to add %{name} to autosign file: %{e}") % { :name => name, :e => proxy_error(e) }
   end
 
   # Removes the host's name from the autosign.conf file
   def delAutosign
     logger.info "Delete the autosign entry for #{name}"
     puppetca.del_autosign certname
-  rescue => e
-    failure _("Failed to remove %{self} from the autosign file: %{e}") % { :self => self, :e => proxy_error(e) }
   end
 
   private

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -24,8 +24,6 @@ module Orchestration::TFTP
   def setTFTP
     logger.info "Add the TFTP configuration for #{name}"
     tftp.set mac, :pxeconfig => generate_pxe_template
-  rescue => e
-    failure _("Failed to set TFTP: %s") % proxy_error(e)
   end
 
   # Removes the host from the forward and reverse TFTP zones
@@ -33,8 +31,6 @@ module Orchestration::TFTP
   def delTFTP
     logger.info "Delete the TFTP configuration for #{name}"
     tftp.delete mac
-  rescue => e
-    failure _("Failed to delete TFTP: %s") % proxy_error(e)
   end
 
   def setTFTPBootFiles
@@ -47,8 +43,6 @@ module Orchestration::TFTP
     end
     failure _("Failed to fetch boot files") unless valid
     valid
-  rescue => e
-    failure _("Failed to fetch boot files: %s") % proxy_error(e)
   end
 
   #empty method for rollbacks

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -818,9 +818,15 @@ class Host::Managed < Host::Base
   # otherwise, use normal systems dns settings to resolv
   def to_ip_address name_or_ip
     return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
-    return dns_ptr_record.dns_lookup(name_or_ip).ip if dns_ptr_record
+    if dns_ptr_record
+      lookup = dns_ptr_record.dns_lookup(name_or_ip)
+      return lookup.ip unless lookup.nil?
+    end
     # fall back to normal dns resolution
     domain.resolver.getaddress(name_or_ip).to_s
+  rescue => e
+    logger.warn "Unable to find IP address for '#{name_or_ip}': #{e}"
+    raise ::Foreman::Exception.new(N_("Unable to find IP address for '%{name_or_ip}': %{e}") % {:name => name_or_ip, :e => e})
   end
 
   def set_default_user

--- a/app/services/foreman/wrapped_exception.rb
+++ b/app/services/foreman/wrapped_exception.rb
@@ -1,22 +1,24 @@
 module Foreman
 
   class WrappedException < ::Foreman::Exception
-    def initialize exception, message, *params
+    def initialize wrapped_exception, message, *params
       super(message, *params)
-      @exception = exception
+      @wrapped_exception = wrapped_exception
     end
 
     def wrapped_exception
-      @exception
+      @wrapped_exception
     end
 
     def message
-      if @exception.nil?
+      if @wrapped_exception.nil?
         wrapped = ""
+        super
       else
-        wrapped = " (#{@exception.class.name} - #{@exception.message})"
+        cls = @wrapped_exception.class.name
+        msg = @wrapped_exception.message.try(:truncate, 90)
+        super + " ([#{cls}]: #{msg})"
       end
-      "#{code}: #{@message}#{wrapped}"
     end
   end
 

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -6,10 +6,10 @@ module Foreman
       @params = params
     end
 
-    # Error code is made up first 8 characters of base64 (RFC 4648) encoded MD5
-    # sum of concatenated classname and message
     def self.calculate_error_code classname, message
-      class_hash = Zlib::crc32(classname) % 100
+      return 'ERF00-0000' if classname.nil? or message.nil?
+      basename = classname.split(':').last
+      class_hash = Zlib::crc32(basename) % 100
       msg_hash = Zlib::crc32(message) % 10000
       sprintf "ERF%02d-%04d", class_hash, msg_hash
     end
@@ -28,12 +28,15 @@ module Foreman
       if Kernel.respond_to? :_
         translated_msg = _(@message) % @params
       else
-        translated_msg = @message
+        # use plain ruby interpolation
+        translated_msg = @message % @params
       end
-      "#{code}: #{translated_msg}"
+      "#{code} [#{self.class.name}]: #{translated_msg}"
     end
 
-    alias :to_s :message
+    def to_s
+      message
+    end
   end
 
   class FingerprintException < Exception

--- a/lib/foreman/gettext/debug.rb
+++ b/lib/foreman/gettext/debug.rb
@@ -3,39 +3,42 @@ require 'fast_gettext'
 # include this module to see translations in the UI
 module Foreman::Gettext::Debug
 
+  DL = "\u00BB".encode("UTF-8") rescue '>'
+  DR = "\u00AB".encode("UTF-8") rescue '<'
+
   # slightly modified copy of fast_gettext D_* method
   def _(key)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.d_(domain, key) {nil}
-      return "X#{result}X" unless result.nil?
+      return DL + result + DR unless result.nil?
     end
-    'X' + key + 'X'
+    DL + key + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def n_(*keys)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.dn_(domain, *keys) {nil}
-      return "X#{result}X" unless result.nil?
+      return DL + result + DR unless result.nil?
     end
-    'X' + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last + 'X'
+    DL + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def s_(key, separator=nil)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) {nil}
-      return "X#{result}X" unless result.nil?
+      return DL + result + DR unless result.nil?
     end
-    'X' + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last + 'X'
+    DL + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def ns_(*keys)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.dns_(domain, *keys) {nil}
-      return "X#{result}X" unless result.nil?
+      return DL + result + DR unless result.nil?
     end
-    'X' + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last + 'X'
+    DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last + DR
   end
 end

--- a/lib/foreman/gettext/support.rb
+++ b/lib/foreman/gettext/support.rb
@@ -26,7 +26,7 @@ module Foreman::Gettext::Support
       else
         FastGettext.default_available_locales = Dir.glob(locale_search_path).collect {|f| locale_search_re.match(f)[1] }
       end
-    rescue Exception => e
+    rescue => e
       Rails.logger.warn "Unable to set available locales for domain #{locale_domain}: #{e}"
       FastGettext.default_available_locales = ['en']
     end

--- a/lib/proxy_api/bmc.rb
+++ b/lib/proxy_api/bmc.rb
@@ -11,11 +11,15 @@ module ProxyAPI
     # gets a list of supported providers
     def providers
       parse get("providers")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get BMC providers"))
     end
 
     # gets a list of supported providers installed on the proxy
     def providers_installed
       parse get("providers/installed")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get installed BMC providers"))
     end
 
     # Perform a boot operation on the bmc device
@@ -32,6 +36,10 @@ module ProxyAPI
       else
         raise NoMethodError
       end
+    rescue NoMethodError => e
+      raise e
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to perform boot BMC operation"))
     end
 
     # Perform a power operation on the bmc device
@@ -50,6 +58,10 @@ module ProxyAPI
       else
         raise NoMethodError
       end
+    rescue NoMethodError => e
+      raise e
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to perform power BMC operation"))
     end
 
     # perform an identify operation on the bmc device
@@ -64,7 +76,10 @@ module ProxyAPI
       else
         raise NoMethodError
       end
-
+    rescue NoMethodError => e
+      raise e
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to perform identify BMC operation"))
     end
 
     # perform a lan get operation on the bmc device
@@ -77,6 +92,10 @@ module ProxyAPI
       else
         raise NoMethodError
       end
+    rescue NoMethodError => e
+      raise e
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to perform lan BMC operation"))
     end
 
     private

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -10,10 +10,14 @@ module ProxyAPI
     # Example [{"network":"192.168.11.0","netmask":"255.255.255.0"},{"network":"192.168.122.0","netmask":"255.255.255.0"}]
     def subnets
       parse get
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve DHCP subnets"))
     end
 
     def subnet subnet
       parse get(subnet)
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve DHCP subnet"))
     end
 
     def unused_ip subnet, mac = nil
@@ -27,6 +31,8 @@ module ProxyAPI
         params = ""
       end
       parse get("#{subnet.network}/unused_ip#{params}")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve unused IP"))
     end
 
     # Retrieves a DHCP entry
@@ -43,6 +49,8 @@ module ProxyAPI
       end
     rescue RestClient::ResourceNotFound
       nil
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve DHCP entry for %s"), mac)
     end
 
     # Sets a DHCP entry
@@ -54,6 +62,8 @@ module ProxyAPI
       raise "Must define a subnet" if subnet.empty?
       raise "Must provide arguments" unless args.is_a?(Hash)
       parse(post(args, subnet.to_s))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to set DHCP entry"))
     end
 
     # Deletes a DHCP entry
@@ -65,6 +75,8 @@ module ProxyAPI
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway
       return true
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete DHCP entry for %s"), mac)
     end
   end
 end

--- a/lib/proxy_api/dns.rb
+++ b/lib/proxy_api/dns.rb
@@ -11,6 +11,8 @@ module ProxyAPI
     # Returns  : Boolean status
     def set args
       parse post(args, "")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to set DNS entry"))
     end
 
     # Deletes a DNS entry
@@ -21,6 +23,8 @@ module ProxyAPI
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway
       return true
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete DNS entry"))
     end
   end
 end

--- a/lib/proxy_api/features.rb
+++ b/lib/proxy_api/features.rb
@@ -7,6 +7,8 @@ module ProxyAPI
 
     def features
       parse get
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to detect features"))
     end
   end
 end

--- a/lib/proxy_api/proxy_exception.rb
+++ b/lib/proxy_api/proxy_exception.rb
@@ -1,0 +1,17 @@
+module ProxyAPI
+
+  class ProxyException < ::Foreman::WrappedException
+
+    attr_reader :url
+
+    def initialize url, exception, message, *params
+      super(exception, message, *params)
+      @url = url
+    end
+
+    def message
+      super + ' ' + _('for proxy') + ' ' + url
+    end
+  end
+
+end

--- a/lib/proxy_api/puppet.rb
+++ b/lib/proxy_api/puppet.rb
@@ -7,10 +7,14 @@ module ProxyAPI
 
     def environments
       parse(get "environments")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get environments from Puppet"))
     end
 
     def environment env
       parse(get "environments/#{env}")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get environment from Puppet"))
     end
 
     def classes env
@@ -19,10 +23,14 @@ module ProxyAPI
       Hash[pcs.map { |k| [k.keys.first, Foreman::ImporterPuppetclass.new(k.values.first)] }]
     rescue RestClient::ResourceNotFound
       []
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get classes from Puppet for %s"), env)
     end
 
     def run hosts
       parse(post({:nodes => hosts}, "run"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to execute Puppet run"))
     end
   end
 end

--- a/lib/proxy_api/puppetca.rb
+++ b/lib/proxy_api/puppetca.rb
@@ -7,10 +7,14 @@ module ProxyAPI
 
     def autosign
       parse(get "autosign")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get PuppetCA autosign"))
     end
 
     def set_autosign certname
       parse(post("", "autosign/#{certname}"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to set PuppetCA autosign for %s"), certname)
     end
 
     def del_autosign certname
@@ -18,10 +22,14 @@ module ProxyAPI
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway
       true
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete PuppetCA autosign for %s"), certname)
     end
 
     def sign_certificate certname
       parse(post("", certname))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to sign PuppetCA certificate for %s"), certname)
     end
 
     def del_certificate certname
@@ -29,10 +37,14 @@ module ProxyAPI
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway
       true
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete PuppetCA certificate for %s"), certname)
     end
 
     def all
       parse(get)
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to get PuppetCA certificates"))
     end
   end
 end

--- a/lib/proxy_api/tftp.rb
+++ b/lib/proxy_api/tftp.rb
@@ -13,6 +13,8 @@ module ProxyAPI
     # Returns  : Boolean status
     def set mac, args
       parse(post(args, "#{@variant}/#{mac}"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to set TFTP boot entry for %s"), mac)
     end
 
     # Deletes a TFTP boot entry
@@ -20,6 +22,8 @@ module ProxyAPI
     # Returns : Boolean status
     def delete mac
       parse(super("#{@variant}/#{mac}"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete TFTP boot entry for %s"), mac)
     end
 
     # Requests that the proxy download the bootfile from the media's source
@@ -29,6 +33,8 @@ module ProxyAPI
     # Returns    : Boolean status
     def fetch_boot_file args
       parse(post(args, "fetch_boot_file"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to fetch TFTP boot file"))
     end
 
     # returns the TFTP boot server for this proxy
@@ -39,6 +45,8 @@ module ProxyAPI
       false
     rescue RestClient::ResourceNotFound
       nil
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to detect TFTP boot server"))
     end
 
     # Create a default pxe menu
@@ -47,6 +55,8 @@ module ProxyAPI
     # Returns    : Boolean status
     def create_default args
       parse(post(args, "create_default"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to create default TFTP boot menu"))
     end
 
   end

--- a/lib/tasks/exception.rake
+++ b/lib/tasks/exception.rake
@@ -6,11 +6,12 @@ namespace :exception do
   task :codes => :environment do
     wiki = defined? ENV['WIKI']
     exceptions = [
-      ::Foreman::Exception,
-      ::Foreman::WrappedException,
+      'Foreman::Exception',
+      'WrappedException',
+      'ProxyException',
     ]
     result = {}
-    regexp = /raise.*:?:?(#{exceptions.join('|')})(\.new)?\(?N_\(?(["'])([^\3]+?)\3\)?\)?/
+    regexp = /raise.*(#{exceptions.join('|')})(\.new)?.*N_\(?(["'])([^\3]+?)\3\)?\)?/
     Dir['app/**/*rb', 'lib/**/*rb'].each do |path|
       File.open(path) do |f|
         f.grep( /#{regexp}/ ) do |line|
@@ -22,7 +23,7 @@ namespace :exception do
 
     result.keys.sort.each do |k|
       v = result[k]
-      puts "#{k} #{v}"
+      puts " * [[#{k}]] - #{v}"
     end
   end
 

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -302,7 +302,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     facts    = fact_json['facts']
     post :facts, {:name => hostname, :facts => facts, :type => "Host::Invalid"}, set_session_user
     assert_response :unprocessable_entity
-    assert_equal JSON.parse(response.body)['message'], 'ERF51-2640: A problem occurred when detecting host type: uninitialized constant Host::Invalid'
+    assert JSON.parse(response.body)['message'] =~ /ERF42-2640/
   end
 
   test "when the imported host failed to save, :unprocessable_entity is returned" do


### PR DESCRIPTION
Improved error reporting on all generic proxy errors plus improved TFTP IP
address determination code (was throwing undefined method `ip' for
nil:NilClass).
