### PR TITLE
Fixes 3790: Adding functionality to support isolate_namespace engines.

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -25,8 +25,9 @@ module HomeHelper
   end
 
   def menu_item_tag item
+    path = item.path || item.url_hash
     content_tag(:li,
-                link_to(_(item.caption), item.url_hash, item.html_options.merge(:id => "menu_item_#{item.name}")),
+                link_to(_(item.caption), path, item.html_options.merge(:id => "menu_item_#{item.name}")),
                 :class => "menu_tab_#{item.url_hash[:controller]}_#{item.url_hash[:action]}")
   end
 

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -148,6 +148,10 @@ module Foreman #:nodoc:
       @parent = current
     end
 
+    def divider(menu, options = {})
+      Menu::Manager.map(menu).divider(options)
+    end
+
     # Removes item from the given menu
     def delete_menu_item(menu, item)
       Menu::Manager.map(menu).delete(item)

--- a/app/services/menu/divider.rb
+++ b/app/services/menu/divider.rb
@@ -2,6 +2,7 @@ module Menu
   class Divider < Node
     def initialize(name, options={})
       @caption = options[:caption]
+      @parent = options.fetch(:parent, nil)
       super name
     end
 

--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -1,7 +1,9 @@
 module Menu
   class Item < Node
     include Rails.application.routes.url_helpers
-    attr_reader :name, :condition, :parent, :child_menus, :last, :html_options
+    include AbstractController::Railties::RoutesHelpers
+
+    attr_reader :name, :condition, :parent, :child_menus, :last, :html_options, :path
 
     def initialize(name, options)
       raise ArgumentError, "Invalid option :if for menu item '#{name}'" if options[:if] && !options[:if].respond_to?(:call)
@@ -10,6 +12,7 @@ module Menu
       raise ArgumentError, "Invalid option :children for menu item '#{name}'" if options[:children] && !options[:children].respond_to?(:call)
       @name = name
       @url_hash = options[:url_hash]
+      @path = @url_hash.nil? ? nil : options[:url_hash][:path]
       @condition = options[:if]
       @caption = options[:caption]
       @html_options = options[:html] || {}

--- a/app/services/menu/manager.rb
+++ b/app/services/menu/manager.rb
@@ -30,7 +30,7 @@ module Menu
 
       def items(menu_name)
         # force menu reload in development when auto loading modified files
-        @items || Menu::Loader.load
+        @items || {}
         @items[menu_name.to_sym] || Node.new(:root)
       end
     end

--- a/test/unit/menu_item_test.rb
+++ b/test/unit/menu_item_test.rb
@@ -82,4 +82,10 @@ class MenuItemTest < ActiveSupport::TestCase
     assert_equal get_menu_item(:test_menu, :child_menu), parent_item.children[0]
     assert_equal get_menu_item(:test_menu, :child2_menu), parent_item.children[1]
   end
+
+  def test_allow_setting_path
+    item = Menu::Item.new(:test_menu, :url_hash => {:path => 'test_path'})
+
+    assert_equal item.path, 'test_path'
+  end
 end


### PR DESCRIPTION
When engines are defined with isolate_namespace, their routes and
route resolutions are not directly available to the parent application.
Thus, this adds the ability to specify a path directly by the plugin
for a given menu item. Further, since isolated engines may include
entire menus of their own and wish to separate the items, a divider
function is added.
