### PR TITLE
foreman supplies user, fog expects username

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -67,7 +67,7 @@ module Foreman::Model
       args[:image_name]  = args[:image_id]
 
       username = images.where(:uuid => args[:image_name]).first.try(:username)
-      ssh      = { :user => username, :public_key => key_pair.public }
+      ssh      = { :username => username, :public_key => key_pair.public }
       super(args.merge(ssh))
     rescue Exception => e
       logger.debug "Unhandled GCE error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")


### PR DESCRIPTION
^ Does what it says on the tin. This was the last thing I had to change (besides setting private_ip instead of public_ip) to get foreman to work on gce.
