### PR TITLE
fixes #2374 - added allocation option to libvirt VM

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -621,3 +621,29 @@ function disable_vm_form_fields() {
   });
   $("a.disable-unsupported").remove();
 }
+
+function capacity_edit(element) {
+  var buttons = $(element).closest('.fields').find('button[name=allocation_radio_btn].btn.active');
+  if (buttons.size() > 0 && $(buttons[0]).text() == 'Full') {
+    var allocation = $(element).closest('.fields').find('[id$=allocation]')[0];
+    allocation.value = element.value;
+  }
+  return false;
+}
+
+function allocation_switcher(element, action) {
+  var allocation = $(element).closest('.fields').find('[id$=allocation]')[0];
+  if (action == 'None') {
+    $(allocation).attr('readonly', 'readonly');
+    allocation.value = '0G';
+  } else if (action == 'Size') {
+    $(allocation).removeAttr('readonly');
+    allocation.value = '';
+    $(allocation).focus();
+  } else if (action == 'Full') {
+    $(allocation).attr('readonly', 'readonly');
+    var capacity = $(element).closest('.fields').find('[id$=capacity]')[0];
+    allocation.value = capacity.value;
+  }
+  return false;
+}

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -285,4 +285,20 @@ module HostsHelper
       (link_to(_("YAML"), externalNodes_host_path(:name => host), :title => _("Puppet external nodes YAML dump") , :class => 'btn') if SmartProxy.puppet_proxies.any?)
     ].compact
   end
+
+  def allocation_text_f f
+    active = 'Size'
+    active = 'None' if f.object.allocation.to_i == 0
+    active = 'Full' if f.object.allocation == f.object.capacity
+    text_f f, :allocation, :class => "input-mini", :label => _("Allocation (GB)"),
+    :readonly => (active == 'Size') ? false : true,
+    :help_inline => (content_tag(:span, :class => 'btn-group', :'data-toggle' => 'buttons-radio') do
+      [N_('None'), N_('Size'), N_('Full')].collect do |label|
+        content_tag :button, _(label), :type => 'button', :href => '#',
+          :name => 'allocation_radio_btn',
+          :class => (label == active) ? 'btn active' : 'btn',
+          :onclick => "allocation_switcher(this, '#{label}');"
+      end.join(' ').html_safe
+    end)
+  end
 end

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -62,7 +62,7 @@ module Foreman::Model
     end
 
     def new_volume attr={ }
-      client.volumes.new attr
+      client.volumes.new(attrs.merge(:allocation => '0G'))
     end
 
     def storage_pools
@@ -167,8 +167,8 @@ module Foreman::Model
         vols = []
         (volumes = args[:volumes]).each do |vol|
           vol.name       = "#{args[:prefix]}-disk#{volumes.index(vol)+1}"
-          vol.allocation = "0G"
           vol.capacity = "#{vol.capacity}G" unless vol.capacity.to_s.end_with?('G')
+          vol.allocation = "#{vol.allocation}G" unless vol.allocation.to_s.end_with?('G')
           vol.save
           vols << vol
         end

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -1,6 +1,7 @@
 <div class="fields">
   <%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :class => "span2", :label => _("Storage pool") %>
-  <%= text_f f, :capacity, :class => "input-mini", :label => _("Size (GB)") %>
-  <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "span2", :label => _("Type"),
+  <%= text_f f, :capacity, :class => "input-mini", :label => _("Size (GB)"), :onchange => 'capacity_edit(this)' %>
+  <%= allocation_text_f f %>
+    <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "span2", :label => _("Type"),
                    :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-important disable-unsupported' }) %>
 </div>


### PR DESCRIPTION
This patch adds allocation field for libvirt. It is "freeform", therefore users
are able to edit it, but I am providing three buttons (in a button group):
- None - Sets allocation to 0G (this is default)
- Size - Allocation field is writable and user can give any value
- Full - Sets allocation to full size of the volume

When form is being edited, Size button is toggled so user can make edits. If
allocation is set to 0, then None button is toggled automatically. Also if
allocation is set to Full and user edits size of the volume, the value gets
copied to allocation automatically.

This fixes bug 2374 - basically it's a nice workaround for problems with LVM
allocating. When using LVM, always set allocate to Full and you will be fine.
Unfortunately we are not able to detect this via fog - it does not provide us
enough details AFAIK.
