### PR TITLE
fixes #3794 - don't validate IP address that's later provided by a CR

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -558,12 +558,13 @@ class Host::Managed < Host::Base
   def require_ip_validation?
     # if it's not managed there's nowhere to specify an IP anyway
     return false unless managed?
-    ip_for_compute = (compute? && compute_resource.provided_attributes.keys.include?(:ip))
+    # if the CR will provide an IP, then don't validate yet
+    return false if compute? && compute_resource.provided_attributes.keys.include?(:ip)
     ip_for_dns     = (subnet.present? && subnet.dns_id.present?) || (domain.present? && domain.dns_id.present?)
     ip_for_dhcp    = subnet.present? && subnet.dhcp_id.present?
     ip_for_token   = Setting[:token_duration] == 0 && !capabilities.include?(:image)
     # Any of these conditions will require an IP, so chain with OR
-    ip_for_compute or ip_for_dns or ip_for_dhcp or ip_for_token
+    ip_for_dns or ip_for_dhcp or ip_for_token
   end
 
   # if certname does not exist, use hostname instead

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -932,7 +932,7 @@ class HostTest < ActiveSupport::TestCase
     refute h.require_ip_validation?
   end
 
-  test "CR's without IP attribute don't require an IP" do
+  test "CRs without IP attribute don't require an IP" do
     Setting[:token_duration] = 30 #enable tokens so that we only test the CR
     h=Host.new :managed => true,
       :compute_resource => compute_resources(:one),
@@ -940,12 +940,13 @@ class HostTest < ActiveSupport::TestCase
     refute h.require_ip_validation?
   end
 
-  test "CR's with IP attribute do require an IP" do
+  test "CRs with IP attribute and a DNS-enabled domain do not require an IP" do
     Setting[:token_duration] = 30 #enable tokens so that we only test the CR
     h=Host.new :managed => true,
       :compute_resource => compute_resources(:openstack),
-      :compute_attributes => {:fake => "data"}
-    assert h.require_ip_validation?
+      :compute_attributes => {:fake => "data"},
+      :domain => domains(:mydomain)
+    refute h.require_ip_validation?
   end
 
   test "hosts with a DNS-enabled Domain do require an IP" do


### PR DESCRIPTION
@GregSutcliffe should fix what you were seeing last week
