### PR TITLE
[DO NOT MERGE] fixes #3790 - Adding functionality to support isolate_namespace engines

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -29,8 +29,8 @@ module HomeHelper
 
   def menu_item_tag item
     content_tag(:li,
-                link_to(_(item.caption), item.link_to_path, item.html_options.merge(:id => "menu_item_#{item.name}")),
-                :class => "menu_tab_#{item.url_hash[:controller]}_#{item.url_hash[:action]}")
+                link_to(_(item.caption), item.url, item.html_options.merge(:id => "menu_item_#{item.name}")),
+                :class => "menu_tab_#{item.path_hash[:controller]}_#{item.path_hash[:action]}")
   end
 
   def org_switcher_title

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,5 +1,8 @@
 module HomeHelper
 
+  extend ActiveSupport::Concern
+  include Rails.application.routes.url_helpers
+
   def render_menu menu_name
     authorized_menu_actions(Menu::Manager.items(menu_name).children).map do |menu|
       items = authorized_menu_actions(menu.children)
@@ -26,7 +29,7 @@ module HomeHelper
 
   def menu_item_tag item
     content_tag(:li,
-                link_to(_(item.caption), item.url_hash, item.html_options.merge(:id => "menu_item_#{item.name}")),
+                link_to(_(item.caption), item.link_to_path, item.html_options.merge(:id => "menu_item_#{item.name}")),
                 :class => "menu_tab_#{item.url_hash[:controller]}_#{item.url_hash[:action]}")
   end
 

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -148,6 +148,10 @@ module Foreman #:nodoc:
       @parent = current
     end
 
+    def divider(menu, options = {})
+      Menu::Manager.map(menu).divider(options)
+    end
+
     # Removes item from the given menu
     def delete_menu_item(menu, item)
       Menu::Manager.map(menu).delete(item)

--- a/app/services/menu/divider.rb
+++ b/app/services/menu/divider.rb
@@ -2,6 +2,7 @@ module Menu
   class Divider < Node
     def initialize(name, options={})
       @caption = options[:caption]
+      @parent = options.fetch(:parent, nil)
       super name
     end
 

--- a/app/services/menu/isolated_routes.rb
+++ b/app/services/menu/isolated_routes.rb
@@ -1,0 +1,28 @@
+module Menu
+  module IsolatedRoutes
+    extend ActiveSupport::Concern
+
+      # Create route helper methods for each isolated engine similar to what is available in controllers and views loaded by ActionDispatch::Routing::RoutesProxy
+      # def katello
+      #   Katello.railtie_routes_url_helpers
+      # end
+      # ex.  link_to "Systems", katello.systems_path when called with main_app
+      #
+      Module.constants.each do |mod|
+        next unless (mod.to_s.constantize && mod.to_s.constantize.const_defined?("Engine") && mod.to_s.constantize.respond_to?(:railtie_routes_url_helpers) rescue nil)
+        if mod.to_s.constantize.const_defined?("Engine") && mod.to_s.constantize.respond_to?(:railtie_routes_url_helpers)
+          define_method(mod.to_s.constantize::Engine.engine_name) do
+              mod.to_s.constantize.railtie_routes_url_helpers
+          end
+        end
+      end
+
+      # Create main_app route helper methods similar to what is available in controllers and views loaded by ActionDispatch::Routing::RoutesProxy
+      # ex. link_to "Hosts", main_app.hosts_path when called from isolated engine
+      def main_app
+        Rails.application.routes.url_helpers
+      end
+
+  end
+end
+


### PR DESCRIPTION
DO NOT MERGE
This PR codes code from @ehelms PR #1071

The goal was to eliminate the need to pass :url_hash by the isolated engine and instead build the path based on the menu name using the named path helpers.

example:

``` ruby
      Foreman::Plugin.register :new_system do
        menu(:top_menu, :hosts, { :caption => 'List of Hosts', :parent => :monitor_menu, :first => :menu,
                  :engine_name => 'main_app' }  )
        menu(:top_menu, :systems, { :caption => 'List of Systems', :parent => :infrastructure_menu, :first => :menu,
                 :engine_name => 'katello'  } )
      end
```
