### PR TITLE
Update apipie-rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "ancestry", "~> 2.0"
 gem 'scoped_search', '>= 2.5'
 gem 'net-ldap'
 gem 'uuidtools'
-gem "apipie-rails", "~> 0.0.23"
+gem "apipie-rails", "~> 0.0.24"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oauth'
 gem 'foreigner', '~> 1.4.2'


### PR DESCRIPTION
The 0.0.24 version includes a fix for DOS vulnerability. Neither the Foreman
nor Katello are affected because they use Apipie cache in the production
environment.

However, when talking about the dynamic documentation for foreman plugins,
there might be a need to turn off the cache (although, I would still prefer to
regenerate the cache after a new plugin is added than generating the docs on
demand, as we do in development.)

I just wanted to make sure we don't forget about this.
