### PR TITLE
fixes #3790 - Added support for isolated engine to foreman menu.

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -26,7 +26,7 @@ module HomeHelper
 
   def menu_item_tag item
     content_tag(:li,
-                link_to(_(item.caption), item.url_hash, item.html_options.merge(:id => "menu_item_#{item.name}")),
+                link_to(_(item.caption), item.url, item.html_options.merge(:id => "menu_item_#{item.name}")),
                 :class => "menu_tab_#{item.url_hash[:controller]}_#{item.url_hash[:action]}")
   end
 

--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -1,10 +1,10 @@
 module Menu
   class Item < Node
-    include Rails.application.routes.url_helpers
     attr_reader :name, :condition, :parent, :child_menus, :last, :html_options
 
     def initialize(name, options)
       raise ArgumentError, "Invalid option :if for menu item '#{name}'" if options[:if] && !options[:if].respond_to?(:call)
+      raise ArgumentError, "Invalid option :engine for menu item '#{name}'" if options[:engine] && !options[:engine].respond_to?(:routes)
       raise ArgumentError, "Invalid option :html for menu item '#{name}'" if options[:html] && !options[:html].is_a?(Hash)
       raise ArgumentError, "Cannot set the :parent to be the same as this item" if options[:parent] == name.to_sym
       raise ArgumentError, "Invalid option :children for menu item '#{name}'" if options[:children] && !options[:children].respond_to?(:call)
@@ -16,11 +16,16 @@ module Menu
       @parent = options[:parent]
       @child_menus = options[:children]
       @last = options[:last] || false
+      @context =  options[:engine] || Rails.application
       super @name.to_sym
     end
 
+    def url
+      @context.routes.url_for(url_hash.merge(:only_path=>true))
+    end
+
     def url_hash
-      @url_hash ||= send("hash_for_#{name}_path")
+      @url_hash ||= @context.routes.url_helpers.send("hash_for_#{name}_path")
       @url_hash.inject({}) do |h,(key,value)|
         h[key] = (value.respond_to?(:call) ? value.call : value)
         h

--- a/app/views/home/_location_dropdown.html.erb
+++ b/app/views/home/_location_dropdown.html.erb
@@ -4,14 +4,14 @@
   <%= location_dropdown location_count %>
   <ul class="dropdown-menu">
     <% if User.current.admin? %>
-      <li><%= link_to(_('Any Location'), clear_locations_path) %></li>
+      <li><%= link_to(_('Any Location'), main_app.clear_locations_path) %></li>
       <%= content_tag(:li, "", :class=>"divider") %>
     <% end %>
     <% Location.my_locations.each do |location| %>
-      <li><%= link_to(location.name, select_location_path(location)) %></li>
+      <li><%= link_to(location.name, main_app.select_location_path(location)) %></li>
     <% end %>
   </ul>
 </li>
 <% if User.current.allowed_to?(:create_locations) %>
-  <li><%= link_to _("Manage Locations"), locations_path, :class=> "manage-menu" %></li>
+  <li><%= link_to _("Manage Locations"), main_app.locations_path, :class=> "manage-menu" %></li>
 <% end %>

--- a/app/views/home/_organization_dropdown.html.erb
+++ b/app/views/home/_organization_dropdown.html.erb
@@ -4,14 +4,14 @@
   <%= organization_dropdown orgs_count %>
   <ul class="dropdown-menu">
     <% if User.current.admin? %>
-      <li><%= link_to(_('Any Organization'), clear_organizations_path) %></li>
+      <li><%= link_to(_('Any Organization'), main_app.clear_organizations_path) %></li>
       <%= content_tag(:li, "", :class => "divider") %>
     <% end %>
     <% Organization.my_organizations.each do |organization| %>
-      <li><%= link_to(organization.name, select_organization_path(organization)) %></li>
+      <li><%= link_to(organization.name, main_app.select_organization_path(organization)) %></li>
     <% end %>
   </ul>
 </li>
 <% if User.current.allowed_to?(:create_organizations) %>
-  <li><%= link_to _("Manage Organizations"), organizations_path, :class => "manage-menu" %></li>
+  <li><%= link_to _("Manage Organizations"), main_app.organizations_path, :class => "manage-menu" %></li>
 <% end %>


### PR DESCRIPTION
Isolated engines needs to run the route helpers in the plugin context. Since the menu is common to the plugins and the main app, menu items urls needs to be computed at the correct context.
This patch add option to the 'menu' method.
An isolated engine needs to declare

``` ruby
 :engine => MyPlugin::Engine
```

for each menu item.
I was experimenting with declaring an engine is isolated instead of repeating the declaration for each menu item but favored the proposed solution because it lets an isolated plugin writer to interact with foremans controllers too.

This pull request replaces PR #1075  
