### PR TITLE
fixes #3855 - pin ruby-libvirt to 0.4 for Ruby 1.8 workaround

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,3 +1,3 @@
 group :libvirt do
-  gem "ruby-libvirt", :require => 'libvirt'
+  gem "ruby-libvirt", '< 0.5.0', :require => 'libvirt'
 end

--- a/foreman.spec
+++ b/foreman.spec
@@ -145,7 +145,7 @@ for Yum.
 %package libvirt
 Summary: Foreman libvirt support
 Group:  Applications/System
-Requires: %{?scl_prefix}rubygem(ruby-libvirt)
+Requires: %{?scl_prefix}rubygem(ruby-libvirt) < 0.5.0
 Requires: %{name} = %{version}-%{release}
 Requires: foreman-compute = %{version}-%{release}
 Obsoletes: foreman-virt < 1.0.0


### PR DESCRIPTION
This is temporary due to https://www.redhat.com/archives/libvir-list/2013-December/msg00593.html, I intend to revert the commit once Chris has released 0.5.1.  But for now, it's causing problems in Jenkins.

Please let Jenkins run through and make sure Ruby 1.8 passes.
