### PR TITLE
fixes #3827 - ldap avatar support

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -247,7 +247,7 @@ select{padding: initial;}
 .form-group.condensed.error textarea{border-color: #b94a48;}
 .form-group.condensed.warning textarea{border-color: #c09853;}
 
-.gravatar{
+.avatar{
   width: 30px;
   height: 30px;
   -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -332,10 +332,18 @@ module ApplicationHelper
     end
   end
 
-  def gravatar_image_tag(email, html_options = {})
-    default_image = path_to_image("user.jpg")
-    html_options.merge!(:onerror=>"this.src='#{default_image}'")
-    image_url = Setting["use_gravatar"] ? gravatar_url(email, default_image) : default_image
+  def avatar_image_tag(user, html_options = {})
+    if user.avatar_hash.nil?
+      default_image = path_to_image("user.jpg")
+      if Setting["use_gravatar"]
+        image_url = gravatar_url(user.mail, default_image)
+        html_options.merge!(:onerror=>"this.src='#{default_image}'", :alt => _('Change your avatar at gravatar.com'))
+      else
+        image_url = default_image
+      end
+    else
+      image_url = path_to_image("avatars/#{user.avatar_hash}.jpg")
+    end
     return image_tag(image_url, html_options)
   end
 

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -44,7 +44,7 @@ module HomeHelper
   end
 
   def user_header
-    summary = gravatar_image_tag(User.current.mail, :class=>'gravatar small', :alt=>_('Change your avatar at gravatar.com')) +
+    summary = avatar_image_tag(User.current, :class=>'avatar small') +
               "#{User.current.to_label} " + content_tag(:span, "", :class=>'caret')
     link_to(summary.html_safe, "#", :class => "dropdown-toggle", :'data-toggle'=>"dropdown", :id => "account_menu")
   end

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -28,6 +28,7 @@
       <%= text_f f, :attr_firstname, :help_inline => _("e.g. givenName") %>
       <%= text_f f, :attr_lastname, :help_inline => _("e.g. sn") %>
       <%= text_f f, :attr_mail, :help_inline => _("e.g. mail") %>
+      <%= text_f f, :attr_photo, :label => _("Photo attribute"), :help_inline => _("e.g. jpegPhoto") %>
     </div>
   </div>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,7 +15,7 @@
   </tr>
   <% for user in @users %>
     <tr>
-      <td><%= gravatar_image_tag user.mail, :class => "gravatar" %> <%=link_to_if_authorized h(user.login), hash_for_edit_user_path(:id => user.id).merge(:auth_object => user, :authorizer => authorizer) %></td>
+      <td><%= avatar_image_tag user, :class => "avatar" %> <%=link_to_if_authorized h(user.login), hash_for_edit_user_path(:id => user.id).merge(:auth_object => user, :authorizer => authorizer) %></td>
       <td><%=h user.firstname %></td>
       <td><%=h user.lastname %></td>
       <td><%=h user.mail %></td>

--- a/db/migrate/20131212125626_add_ldap_avatar_support.rb
+++ b/db/migrate/20131212125626_add_ldap_avatar_support.rb
@@ -1,0 +1,11 @@
+class AddLdapAvatarSupport < ActiveRecord::Migration
+  def change
+    add_column :auth_sources, :attr_photo, :string
+    add_column :users, :avatar_hash, :string, :limit => 128
+  end
+
+  def down
+   remove_column :users, :avatar_hash
+   remove_column :auth_sources, :attr_photo
+  end
+end


### PR DESCRIPTION
I know this is one of the most inconsequential things ever.  It pulls the jpegPhoto attribute from LDAP as a user avatar.

~~Currently store it in the DB... (terrible, I know).  My avatar was absolutely tiny at only 4kb.  I could write to public/avatars/<hash>.jpg too, that's probably more sensible?~~

Avatars are written to /public/avatars/[hash of image].jpg.  Changes are captured if the data in LDAP changes -- I delete the old avatar and add the new one.

This capturing of LDAP changes has the added benefit of also capturing if the other attributes are changed (first name, last name, mail, etc) for a user.
