### PR TITLE
Feature #3882 Use ruby-libvirt's latest version.

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,3 +1,3 @@
 group :libvirt do
-  gem "ruby-libvirt", '< 0.5.0', :require => 'libvirt'
+  gem "ruby-libvirt", :require => 'libvirt'
 end


### PR DESCRIPTION
0.5.1 is out and it compiles against 1.8.7 and 1.9.3p327 perfectly, so I'm getting rid of the temporary fix here.

https://www.redhat.com/archives/libvir-list/2013-December/msg00846.html
- http://projects.theforeman.org/issues/3882
