### PR TITLE
fixes #3889 - don't reload nested lookup keys during render, so validation errors aren't lost

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -102,7 +102,8 @@ class PuppetclassesController < ApplicationController
 
   def find_by_name
     not_found and return if params[:id].blank?
-    @puppetclass = (params[:id] =~ /\A\d+\Z/) ? Puppetclass.find(params[:id]) : Puppetclass.find_by_name(params[:id])
+    pc = Puppetclass.includes(:class_params => [:environment_classes, :environments, :lookup_values])
+    @puppetclass = (params[:id] =~ /\A\d+\Z/) ? pc.find(params[:id]) : pc.find_by_name(params[:id])
     not_found and return unless @puppetclass
   end
 end

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -49,7 +49,7 @@
             </ul>
 
             <div class="tab-content span7 smart-var-content">
-              <%= f.fields_for :class_params, f.object.class_params.includes(:environment_classes, :environments, :lookup_values) do |lookup_keys_form| %>
+              <%= f.fields_for :class_params do |lookup_keys_form| %>
                   <%= render 'lookup_keys/fields', :f => lookup_keys_form  %>
               <% end %>
             </div>


### PR DESCRIPTION
Having the .includes in the view was causing a reload of the objects from the DB to eagerly fetch the extra environment/lookup_values, but we now ensure they're populated when loading the top-level PuppetClass.  This ensures that the same LookupKey object we tried updating (and perhaps added errors to) is displayed, so validation errors get shown.
