### PR TITLE
fixes #1431 - use boardproductname as fallback

### DIFF
--- a/app/services/facts_parser.rb
+++ b/app/services/facts_parser.rb
@@ -66,7 +66,7 @@ module Facts
     end
 
     def model
-      name = facts[:productname] || facts[:model]
+      name = facts[:productname] || facts[:model] || facts[:boardproductname]
       # if its a virtual machine and we didn't get a model name, try using that instead.
       name ||= facts[:is_virtual] == "true" ? facts[:virtual] : nil
       Model.find_or_create_by_name(name.strip) unless name.blank?


### PR DESCRIPTION
if productname or model fact don't exist.

Personally, I would like "(board)manufacturer + (board)productname/model" better for the "Model" field in general, but it's probably not a good idea to change that now.
