### PR TITLE
Bug #3280 - Authenticate returns true for API requests when login:false

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -35,6 +35,7 @@ module Foreman::Controller::Authentication
       # We assume we always have a user logged in, if authentication is disabled, the user is the built-in admin account.
       User.current = User.admin
       session[:user] = User.current.id unless api_request?
+      true
     end
   end
 

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -21,4 +21,24 @@ class Api::TestableControllerTest < ActionController::TestCase
     end
   end
 
+  context "API authentication" do
+    setup do
+      User.current = nil
+      SETTINGS[:login] = false
+    end
+
+    teardown do
+      SETTINGS[:login] = true
+    end
+
+    it "does not need an username and password when Settings[:login]=false" do
+      get :index
+      assert_response :success
+    end
+
+    it "does not set session data for API requests" do
+      get :index
+      assert_not session[:user]
+    end
+  end
 end


### PR DESCRIPTION
Unauthenticated API requests should go through when login:false. As of now they don't because the last line in our 'authenticate' method returns nil for API requests. Therefore, only the web UI works.

http://projects.theforeman.org/issues/3280
