### PR TITLE
Bug #3515 - API handles not found objects with 404

### DIFF
--- a/app/controllers/api/v1/home_controller.rb
+++ b/app/controllers/api/v1/home_controller.rb
@@ -18,7 +18,6 @@ module Api
       def route_error
         render_error 'route_error', :status => :not_found
       end
-
     end
   end
 end

--- a/app/controllers/api/v2/home_controller.rb
+++ b/app/controllers/api/v2/home_controller.rb
@@ -20,7 +20,6 @@ module Api
       def route_error
         render_error 'route_error', :status => :not_found
       end
-
     end
   end
 end

--- a/app/controllers/api/v2/host_classes_controller.rb
+++ b/app/controllers/api/v2/host_classes_controller.rb
@@ -41,7 +41,7 @@ module Api
         else
           @host ||= Host::Managed.find_by_name(params[:host_id])
           return @host_id = @host.id if @host
-          render_error 'not_found', :status => :not_found and return false
+          not_found
         end
       end
 

--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -77,8 +77,7 @@ module Api
 
       def return_if_override_mismatch
         if (@override_values && @override_value && !@override_values.find_by_id(@override_value.id)) || (@override_values && !@override_value) || !@override_values
-          msg = "Override value not found by id '#{params[:id]}'"
-          render :json => {:message => msg}, :status => :not_found and return false
+          not_found "Override value not found by id '#{params[:id]}'"
         end
       end
 

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -121,7 +121,7 @@ module Api
         @parameter   = @parameters.find_by_id(params[:id].to_i) if params[:id].to_i > 0
         @parameter ||= @parameters.find_by_name(params[:id])
         return @parameter if @parameter
-        render_error 'not_found', :status => :not_found and return false
+        not_found
       end
 
     end

--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -36,9 +36,7 @@ module Api
 
       def find_parent_config_template
         @config_template = ConfigTemplate.find(params[:config_template_id])
-        unless @config_template
-          render_error 'not_found', :status => :not_found and return false
-        end
+        not_found unless @config_template
         @config_template
       end
     end

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -82,8 +82,7 @@ module Api::ImportPuppetclassesCommonController
     @smart_proxy   = SmartProxy.find_by_id(id.to_i) if id.to_i > 0
     @smart_proxy ||= SmartProxy.find_by_name(id)
     unless @smart_proxy && SmartProxy.puppet_proxies.pluck("smart_proxies.id").include?(@smart_proxy.id)
-      msg = 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
-      render :json => {:message => msg}, :status => :not_found and return false
+      not_found 'We did not find a foreman proxy that can provide the information, ensure that this proxy has the puppet feature turned on.'
     end
     @smart_proxy
   end

--- a/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
+++ b/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
@@ -137,8 +137,7 @@ module Api::V2::LookupKeysCommonController
              else
                params.keys.include?('smart_class_parameter_id') ? params['smart_variable_id'] : params['id']
              end
-        msg = "#{obj} not found by id '#{id}'"
-        render :json => {:message => msg}, :status => :not_found and return false
+        not_found "#{obj} not found by id '#{id}'"
       end
     end
 

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -71,7 +71,7 @@ Foreman::Application.routes.draw do
       match '/', :to => 'home#index'
       match 'status', :to => 'home#status', :as => "status"
     end
-
+    match '*other', :to => 'v1/home#route_error', :constraints => ApiConstraints.new(:version => 1)
   end
 
 end

--- a/test/functional/api/v1/reports_controller_test.rb
+++ b/test/functional/api/v1/reports_controller_test.rb
@@ -60,7 +60,7 @@ class Api::V1::ReportsControllerTest < ActionController::TestCase
 
   test "should give error if no last report for given host" do
     get :last, {:host_id => hosts(:two).to_param }
-    assert_response 500
+    assert_response :not_found
   end
 
 end

--- a/test/functional/api/v1/subnets_controller_test.rb
+++ b/test/functional/api/v1/subnets_controller_test.rb
@@ -27,6 +27,11 @@ class Api::V1::SubnetsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "does not create subnet with non-existent domain" do
+    post :create, { :subnet => valid_attrs.merge( :domain_ids => [1, 2] ) }
+    assert_response :not_found
+  end
+
   test "should update subnet" do
     put :update, { :id => subnets(:one).to_param, :subnet => { } }
     assert_response :success

--- a/test/functional/api/v2/reports_controller_test.rb
+++ b/test/functional/api/v2/reports_controller_test.rb
@@ -175,7 +175,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
 
   test "should give error if no last report for given host" do
     get :last, {:host_id => hosts(:two).to_param }
-    assert_response 500
+    assert_response :not_found
   end
 
 end

--- a/test/functional/api/v2/subnets_controller_test.rb
+++ b/test/functional/api/v2/subnets_controller_test.rb
@@ -4,13 +4,12 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
 
   valid_attrs = { :name => 'QA2', :network => '10.35.2.27', :mask => '255.255.255.0' }
 
-  def test_index
+  test "index content is a JSON array" do
     get :index
     subnets = ActiveSupport::JSON.decode(@response.body)
     assert subnets['results'].is_a?(Array)
     assert_response :success
     assert !subnets.empty?
-
   end
 
   test "should show individual record" do
@@ -25,6 +24,11 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
       post :create, { :subnet => valid_attrs }
     end
     assert_response :success
+  end
+
+  test "does not create subnet with non-existent domain" do
+    post :create, { :subnet => valid_attrs.merge( :domain_ids => [1, 2] ) }
+    assert_response :not_found
   end
 
   test "should update subnet" do
@@ -46,7 +50,7 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
-  def test_destroy_json
+  test "delete destroys subnet not in use" do
     subnet = Subnet.first
     subnet.hosts.clear
     subnet.interfaces.clear


### PR DESCRIPTION
This PR makes the API return sensible 404s (it used to return 500) when it cannot found something needed.

Two examples, with curl and hammer:

```
curl localhost:3000/api/subnets/232
HTTP/1.1 404 Not Found
{"message":"Resource subnet not found by id '232'"}
```

```
hammer --output base subnet create --name "allparams" --network "251.10.10.11" --mask "255.255.255.0" --gateway "251.10.10.255" --dns-primary "251.10.11.255" --dns-secondary "251.10.12.255" --from "251.10.10.10" --to "251.10.10.12" --vlanid "2" --domain-ids "1"

Could not create the subnet:
  404 Resource Not Found
```

In the latter example, Foreman fails to find a domain with id '1'. However hammer does not show the full content of the response, which is `{"message":"Resource domain not found by id '1'"}`

http://projects.theforeman.org/issues/3515
