### PR TITLE
fixes #3902 - [Openstack] allow selection of internal networks

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -49,8 +49,16 @@ module Foreman::Model
       client.addresses.get_address_pools.map { |p| p["name"] }
     end
 
+    def internal_networks
+      return {} if network_client.nil?
+      network_client.networks.all.select { |net| !net.router_external }
+    end
+
     def create_vm(args = {})
       network = args.delete(:network)
+      # fix internal network format for fog.
+      args[:nics].delete_if(&:blank?)
+      args[:nics].map! {|nic| { 'net_id' => nic } }
       vm      = super(args)
       if network.present?
         address = allocate_address(network)
@@ -102,10 +110,20 @@ module Foreman::Model
 
     def client
       @client ||= ::Fog::Compute.new(:provider           => :openstack,
-                                     :openstack_api_key  => password  ,
-                                     :openstack_username => user      ,
-                                     :openstack_auth_url => url       ,
+                                     :openstack_api_key  => password,
+                                     :openstack_username => user,
+                                     :openstack_auth_url => url,
                                      :openstack_tenant   => tenant)
+    end
+
+    def network_client
+      @network_client ||= ::Fog::Network.new(:provider           => :openstack,
+                                             :openstack_api_key  => password,
+                                             :openstack_username => user,
+                                             :openstack_auth_url => url,
+                                             :openstack_tenant   => tenant)
+    rescue
+      @network_client = nil
     end
 
     def setup_key_pair

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -5,6 +5,7 @@ module FogExtensions
 
       included do
         alias_method_chain :security_groups, :no_id
+        attr_reader :nics
         attr_writer :security_group, :network # floating IP
       end
 

--- a/app/views/compute_resources_vms/form/_openstack.html.erb
+++ b/app/views/compute_resources_vms/form/_openstack.html.erb
@@ -12,6 +12,8 @@
 </div>
 <%= select_f f, :tenant_id, compute_resource.tenants, :id, :name, {}, :label => _('Tenant') %>
 
-<%= select_f f, :security_group, compute_resource.security_groups, :name, :name, { :include_blank => _("None") }, :label => _("Security group")  %>
-<%= selectable_f f, :network, compute_resource.address_pools, { :include_blank => _("None") }, { :label => _("Floating IP network") } %>
+<%= select_f f, :security_groups, compute_resource.security_groups, :name, :name, {}, :label => _("Security group")  %>
+<%= select_f f, :nics, compute_resource.internal_networks, :id, :name,
+             {}, { :label => _('Internal network'), :multiple => true } %>
+<%= selectable_f f, :network, compute_resource.address_pools, { :prompt => "None" }, { :label => _("Floating IP network") } %>
 


### PR DESCRIPTION
This patch allows the user to select the internal network when deploying
a new instance in openstack.

In Grizlly, this was done automaticilly, with a nasty side effect, that
all internal networks would get assigned (didnt see that as i had only
one internal network when i was testing), starting in Havana, this is no
longer possible, and the vm creation is rejected.

as a bonus, we now retain the floating ip selection if the form had an
error.
