### PR TITLE
Accept MAC address as a paramater to obtain the gPXE configuration

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -135,6 +135,8 @@ class UnattendedController < ApplicationController
         logger.info "unknown RHN_PROVISIONING header #{e}"
         mac_list = []
       end
+    else
+      mac_list << params['mac'] if params['mac']
     end
     # we try to match first based on the MAC, falling back to the IP
     Host.where(mac_list.empty? ? { :ip => ip } : ["lower(mac) IN (?)", mac_list]).first

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -91,6 +91,14 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should render gpxe for a host when providing MAC address" do
+    Host::Managed.any_instance.stubs(:build).returns(true)
+    get :gPXE, {:mac => hosts(:myfullhost).mac}, set_session_user
+    assert assigns(:initrd)
+    assert assigns(:kernel)
+    assert_response :success
+  end
+
   test "should accept built notifications" do
     @request.env["REMOTE_ADDR"] = hosts(:ubuntu).ip
     get :built


### PR DESCRIPTION
I attempted a brown-field install, so I already have a PXE server in my lab which serves PXELinux, gPXE and iPXE (both PXElinux and gPXE chain-load to iPXE since it is the most flexible).  This server is used frequently by our team for OS installations and to test our product.  My challenge was to allow continued use of the existing PXE server and also bring in Foreman.  I am already running a Windows DHCP server and haven't attempted installing the smart-proxy to handle DHCP yet.  Since I can't have two PXE servers on the network, I decided to create a default entry in my iPXE menu which chain loads the Foreman gPXE URL.  The only problem is that Foreman doesn't have any way to tie the incoming request to a Host in it's database.  This PR allows you to append the mac as a param to identify the host similar to the way that the spoof param is used for the IP.

iPXE entry looks something like:

```
:foreman
chain http://foreman.example.com/unattended/gPXE?mac=${net0/mac}
```

To Foreman, the requested URL looks something like:
`http://foreman.example.com/unattended/gPXE?mac=00:11:22:33:44:55`
