### PR TITLE
Change case of Setting to SETTING

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -142,7 +142,7 @@ src ||= AuthSourceInternal.create :name => "Internal"
 # Users
 unless User.find_by_login("admin").present?
   User.without_auditing do
-    user = User.new(:login => "admin", :firstname => "Admin", :lastname => "User", :mail => Setting[:administrator])
+    user = User.new(:login => "admin", :firstname => "Admin", :lastname => "User", :mail => SETTINGS[:administrator])
     user.admin = true
     user.auth_source = src
     user.password = "changeme"


### PR DESCRIPTION
The administrator setting wasn't being used to set the current user's
email when seeding.  Instead, the current user's email was being set to
nil.
