### PR TITLE
Bug #3920: Prevent 500 ScopedSearch errors on the API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,7 +19,8 @@ module Api
       render_error 'standard_error', :status => 500, :locals => { :exception => error }
     }
 
-    rescue_from Apipie::ParamError, :with => lambda { |error|
+    rescue_from ScopedSearch::QueryNotSupported,
+                Apipie::ParamError, :with => lambda { |error|
       logger.info "#{error.message} (#{error.class})"
       render_error 'param_error', :status => :bad_request, :locals => { :exception => error }
     }

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -5,9 +5,6 @@ class AuditsController < ApplicationController
 
   def index
     Audit.unscoped { @audits = Audit.search_for(params[:search], :order => params[:order]).paginate :page => params[:page] }
-  rescue => e
-    error e.to_s
-    @audits = Audit.search_for('', :order => params[:order]).paginate :page => params[:page]
   end
 
   def show

--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -5,13 +5,7 @@ class ComputeResourcesController < ApplicationController
   before_filter :find_by_id, :only => [:show, :edit, :update, :destroy, :ping, :associate] + AJAX_REQUESTS
 
   def index
-    begin
-      values = ComputeResource.my_compute_resources.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      values = ComputeResource.my_compute_resources.search_for ""
-    end
-    @compute_resources = values.paginate :page => params[:page]
+    @compute_resources = ComputeResource.my_compute_resources.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
   end
 
   def new

--- a/app/controllers/config_templates_controller.rb
+++ b/app/controllers/config_templates_controller.rb
@@ -7,13 +7,7 @@ class ConfigTemplatesController < ApplicationController
   before_filter :handle_template_upload, :only => [:create, :update]
 
   def index
-    begin
-      values = ConfigTemplate.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      values = ConfigTemplate.search_for ""
-    end
-    @config_templates = values.paginate(:page => params[:page]).includes(:template_kind, :template_combinations => [:hostgroup, :environment])
+    @config_templates = ConfigTemplate.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page]).includes(:template_kind, :template_combinations => [:hostgroup, :environment])
   end
 
   def new

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -4,7 +4,7 @@ class DomainsController < ApplicationController
 
   def index
     @domains = Domain.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
-    @counter = Host.group(:domain_id).where(:domain_id => @domains.pluck(:id)).count
+    @host_counter = Host.group(:domain_id).where(:domain_id => @domains.pluck(:id)).count
   end
 
   def new

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -6,7 +6,7 @@ class EnvironmentsController < ApplicationController
 
   def index
     @environments = Environment.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
-    @counter      = Host.group(:environment_id).where(:environment_id => @environments.pluck(:id)).count
+    @host_counter = Host.group(:environment_id).where(:environment_id => @environments.pluck(:id)).count
   end
 
   def new

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -5,14 +5,7 @@ class HostgroupsController < ApplicationController
   before_filter :find_hostgroup, :only => [:edit, :update, :destroy, :clone]
 
   def index
-    begin
-      my_groups = User.current.admin? ? Hostgroup : Hostgroup.my_groups
-      values = my_groups.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      values = my_groups.search_for ""
-    end
-    @hostgroups = values.paginate :page => params[:page]
+    @hostgroups = Hostgroup.my_groups.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
   end
 
   def new

--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -4,13 +4,7 @@ class LookupKeysController < ApplicationController
   before_filter :setup_search_options, :only => :index
 
   def index
-    begin
-      values = LookupKey.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      values = LookupKey.search_for ""
-    end
-    @lookup_keys = values.includes(:puppetclass).paginate(:page => params[:page])
+    @lookup_keys = LookupKey.search_for(params[:search], :order => params[:order]).includes(:puppetclass).paginate(:page => params[:page])
   end
 
   def edit

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -3,7 +3,7 @@ class ModelsController < ApplicationController
 
   def index
     @models  = Model.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
-    @counter = Host.group(:model_id).where(:model_id => @models.pluck(:id)).count
+    @host_counter = Host.group(:model_id).where(:model_id => @models.pluck(:id)).count
   end
 
   def new

--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -4,7 +4,7 @@ class OperatingsystemsController < ApplicationController
 
   def index
     @operatingsystems = Operatingsystem.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
-    @counter = Host.group(:operatingsystem_id).where(:operatingsystem_id => @operatingsystems.pluck(:id)).count
+    @host_counter     = Host.group(:operatingsystem_id).where(:operatingsystem_id => @operatingsystems.pluck(:id)).count
   end
 
   def new

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -7,13 +7,7 @@ class PuppetclassesController < ApplicationController
   before_filter :store_redirect_to_url, :only => :edit
 
   def index
-    begin
-      values = Puppetclass.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      values = Puppetclass.search_for ""
-    end
-    @puppetclasses = values.paginate(:page => params[:page])
+    @puppetclasses = Puppetclass.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
     @host_counter = Host.group(:puppetclass_id).joins(:puppetclasses).where(:puppetclasses => {:id => @puppetclasses.collect(&:id)}).count
     @keys_counter = Puppetclass.joins(:class_params).select('distinct environment_classes.lookup_key_id').group(:name).count
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,9 +5,6 @@ class ReportsController < ApplicationController
 
   def index
     @reports = Report.my_reports.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page]).includes(:host)
-  rescue => e
-    error e.to_s
-    @reports = Report.my_reports.search_for("").paginate :page => params[:page]
   end
 
   def show

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,7 @@
 class SettingsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   before_filter :require_admin
+
   #This can happen in development when removing a plugin
   rescue_from ActiveRecord::SubclassNotFound do |e|
     type = (e.to_s =~ /\'(Setting::.*)\'\./) ? $1 : 'STI-Type'

--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -1,5 +1,6 @@
 class SmartProxiesController < ApplicationController
   before_filter :find_by_id, :only => [:edit, :update, :destroy, :ping, :refresh]
+
   def index
     @proxies = SmartProxy.includes(:features).paginate :page => params[:page]
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,13 +9,7 @@ class UsersController < ApplicationController
   after_filter       :update_activity_time, :only => :login
 
   def index
-    begin
-      users = User.search_for(params[:search], :order => params[:order])
-    rescue => e
-      error e.to_s
-      users = User.search_for('', :order => params[:order])
-    end
-    @users = users.includes(:auth_source).paginate(:page => params[:page])
+    @users = User.search_for(params[:search], :order => params[:order]).includes(:auth_source).paginate(:page => params[:page])
   end
 
   def new

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -11,7 +11,7 @@
   <% for domain in @domains %>
     <tr>
       <td><%= link_to_if_authorized h(domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain)%></td>
-      <td><%= link_to @counter[domain.id] || 0, hosts_path(:search => "domain = #{domain}") %>
+      <td><%= link_to @host_counter[domain.id] || 0, hosts_path(:search => "domain = #{domain}") %>
       <td><%= display_delete_if_authorized hash_for_domain_path(:id => domain), :confirm => _("Delete %s?") % domain.name %></td>
     </tr>
   <% end %>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -14,7 +14,7 @@
       <td>
         <%= link_to_if_authorized environment.name, hash_for_edit_environment_path(:id => environment.name) %>
       </td>
-      <td><%= link_to @counter[environment.id] || 0, hosts_path(:search => "environment = #{environment}") %>
+      <td><%= link_to @host_counter[environment.id] || 0, hosts_path(:search => "environment = #{environment}") %>
       <td>
         <%= action_buttons(link_to(_('Classes'), puppetclasses_path(:search => "environment = #{environment}")),
                            display_delete_if_authorized(hash_for_environment_path(:id => environment.name), :confirm => "Delete #{environment.name}?")) %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -15,7 +15,7 @@
       <td><%=link_to_if_authorized h(model.name), hash_for_edit_model_path(:id => model)%></td>
       <td><%=h(model.vendor_class)%></td>
       <td><%=h(model.hardware_model)%></td>
-      <td class="ra"><%= link_to @counter[model.id] || 0, hosts_path(:search => "model = \"#{model}\"") %></td>
+      <td class="ra"><%= link_to @host_counter[model.id] || 0, hosts_path(:search => "model = \"#{model}\"") %></td>
       <td class="ra">
         <%= display_delete_if_authorized hash_for_model_path(:id => model), :confirm => _("Delete %s?") % model.name %>
       </td>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -10,7 +10,7 @@
   <% for operatingsystem in @operatingsystems %>
     <tr>
       <td><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem.id)) %></td>
-      <td class="ra"><%= link_to @counter[operatingsystem.id] || 0, hosts_path(:search => "os = #{operatingsystem.name}") %></td>
+      <td class="ra"><%= link_to @host_counter[operatingsystem.id] || 0, hosts_path(:search => "os = #{operatingsystem.name}") %></td>
       <td class="ra">
         <%= display_delete_if_authorized hash_for_operatingsystem_path(:id => operatingsystem), :confirm => _("Delete %s?") % operatingsystem.fullname %>
       </td>

--- a/test/functional/api/v1/models_controller_test.rb
+++ b/test/functional/api/v1/models_controller_test.rb
@@ -40,4 +40,8 @@ class Api::V1::ModelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "invalid searches are handled gracefully" do
+    get :index, { :search => 'notarightterm = wrong' }
+    assert_response :bad_request
+  end
 end

--- a/test/functional/api/v2/models_controller_test.rb
+++ b/test/functional/api/v2/models_controller_test.rb
@@ -40,4 +40,8 @@ class Api::V2::ModelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "invalid searches are handled gracefully" do
+    get :index, { :search => 'notarightterm = wrong' }
+    assert_response :bad_request
+  end
 end

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -131,6 +131,24 @@ class ComputeResourcesControllerTest < ActionController::TestCase
     assert_redirected_to compute_resources_path
   end
 
+  context 'search' do
+    setup { setup_user 'view' }
+
+    test 'valid fields' do
+      get :index, { :search => 'name = openstack' }, set_session_user
+      assert_response :success
+      assert flash.empty?
+    end
+
+    test 'invalid fields' do
+      @request.env['HTTP_REFERER'] = "http://test.host#{compute_resources_path}"
+      get :index, { :search => 'wrongwrong = centos' }, set_session_user
+      assert_response :redirect
+      assert_redirected_to :back
+      assert_match /not recognized for searching/, flash[:error]
+    end
+  end
+
   def set_session_user
     User.current = users(:admin) unless User.current
     SETTINGS[:login] ? {:user => User.current.id, :expires_at => 5.minutes.from_now} : {}

--- a/test/functional/operatingsystems_controller_test.rb
+++ b/test/functional/operatingsystems_controller_test.rb
@@ -1,70 +1,92 @@
 require 'test_helper'
-
 class OperatingsystemsControllerTest < ActionController::TestCase
-  def test_index
-    get :index, {}, set_session_user
-    assert_template 'index'
-  end
-
-  def test_new
-    get :new, {}, set_session_user
-    assert_template 'new'
-  end
-
-  def test_create_invalid
-    Operatingsystem.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
-    assert_template 'new'
-  end
-
-  def test_create_valid
-    Operatingsystem.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
-    assert_redirected_to operatingsystems_url
-  end
-
-  def test_edit
-    get :edit, {:id => Operatingsystem.first}, set_session_user
-    assert_template 'edit'
-  end
-
-  def test_update_invalid
-    Operatingsystem.any_instance.stubs(:valid?).returns(false)
-    Redhat.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Operatingsystem.first}, set_session_user
-    assert_template 'edit'
-  end
-
-  def test_update_valid
-    Operatingsystem.any_instance.stubs(:valid?).returns(true)
-    Redhat.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Operatingsystem.first}, set_session_user
-    assert_redirected_to operatingsystems_url
-  end
-
-  def test_destroy
-    operatingsystem = Operatingsystem.first
-    operatingsystem.hosts.delete_all
-    operatingsystem.hostgroups.delete_all
-    delete :destroy, {:id => operatingsystem}, set_session_user
-    assert_redirected_to operatingsystems_url
-    assert !Operatingsystem.exists?(operatingsystem.id)
-  end
 
   def setup_user
     @request.session[:user] = users(:one).id
     users(:one).roles       = [Role.find_by_name('Anonymous'), Role.find_by_name('Viewer')]
   end
 
-  test 'user with viewer rights should fail to edit an operating system' do
-    setup_user
-    get :edit, {:id => Operatingsystem.first.id}, set_session_user.merge(:user => users(:one).id)
-    assert_equal @response.status, 403
+  context 'template rendering' do
+    test 'index' do
+      get :index, {}, set_session_user
+      assert_template 'index'
+    end
+
+    test 'new' do
+      get :new, {}, set_session_user
+      assert_template 'new'
+    end
+
+    test 'create invalid' do
+      Operatingsystem.any_instance.stubs(:valid?).returns(false)
+      post :create, {}, set_session_user
+      assert_template 'new'
+    end
+
+    test 'edit' do
+      get :edit, {:id => Operatingsystem.first}, set_session_user
+      assert_template 'edit'
+    end
+
+    test 'update invalid' do
+      Operatingsystem.any_instance.stubs(:valid?).returns(false)
+      Redhat.any_instance.stubs(:valid?).returns(false)
+      put :update, {:id => Operatingsystem.first}, set_session_user
+      assert_template 'edit'
+    end
   end
 
-  test 'user with viewer rights should succeed in viewing operatingsystems' do
-    setup_user
-    get :index, {}, set_session_user.merge(:user => users(:one).id)
-    assert_response :success
+  context 'redirects' do
+    test 'create valid' do
+      Operatingsystem.any_instance.stubs(:valid?).returns(true)
+      post :create, {}, set_session_user
+      assert_redirected_to operatingsystems_url
+    end
+
+    test 'update valid' do
+      Operatingsystem.any_instance.stubs(:valid?).returns(true)
+      Redhat.any_instance.stubs(:valid?).returns(true)
+      put :update, {:id => Operatingsystem.first}, set_session_user
+      assert_redirected_to operatingsystems_url
+    end
+
+    test 'destroy' do
+      operatingsystem = Operatingsystem.first
+      operatingsystem.hosts.delete_all
+      operatingsystem.hostgroups.delete_all
+      delete :destroy, {:id => operatingsystem}, set_session_user
+      assert_redirected_to operatingsystems_url
+      assert !Operatingsystem.exists?(operatingsystem.id)
+    end
+  end
+
+  context 'permission access' do
+    test 'user with viewer rights should fail to edit an operating system' do
+      setup_user
+      get :edit, {:id => Operatingsystem.first.id}, set_session_user.merge(:user => users(:one).id)
+      assert_equal @response.status, 403
+    end
+
+    test 'user with viewer rights should succeed in viewing operatingsystems' do
+      setup_user
+      get :index, {}, set_session_user.merge(:user => users(:one).id)
+      assert_response :success
+    end
+  end
+
+  context 'search' do
+    test 'valid fields' do
+      get :index, { :search => 'name = centos' }, set_session_user
+      assert_response :success
+      assert flash.empty?
+    end
+
+    test 'invalid fields' do
+      @request.env['HTTP_REFERER'] = "http://test.host#{operatingsystems_path}"
+      get :index, { :search => 'wrongwrong = centos' }, set_session_user
+      assert_response :redirect
+      assert_redirected_to :back
+      assert_match /not recognized for searching/, flash[:error]
+    end
   end
 end


### PR DESCRIPTION
This PR applies a filter on every controller, around the index action.

It's functionality is basically to avoid 500 errors caused by broken
ScopedSearch queries, for instance "wrongfield = dlkas". 

Tests just check that the appropriate template is rendered for the API, and in the UI case it checks the flash message and an appropriate redirection.

Without this PR, wrongly formed queries will result on 500 errors from the API and the UI side. Some of the controllers already implemented a fix for this, so this functionality was extracted and applied across all controllers.

Here's a list of the controllers where this is fixed (all of them except 2):

```
          500: settings - fixed
                  models   - fixed
                  images   - fixed
                  architectures - fixed
                  media - fixed
                  roles - fixed
                  ptables - fixed
                  operatingsystems - fixed
                  environments - fixed
                  domains - fixed
                  common_parameters - fixed
                  subnets - fixed

          200:  compute_resources - fixed
                  reports - fixed 
                  users - fixed
                  lookup_values - fixed
                  hostgroups - fixed
                  config_templates - fixed
                  puppetclasses - fixed
                  lookup_keys - fixed
                  audits - fixed

                  fact_values
                  hosts
                  are hard to fix because of post processing after search. Error handling is done in the controller itself, not on application_controller.


          n/a:   statistics
                  dashboard
                  facts
                  about
                  compute_resources_vms
```

http://projects.theforeman.org/issues/3920
