### PR TITLE
fixes #3728 - add architecture button in os forms

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -366,3 +366,32 @@ $(this).removeClass('hidden').removeClass('hide')
 return originalShowMethod.apply( this, arguments );
 }
 })();
+
+
+function appendMultiselectOption(selectElem, optionName, value, name) {
+
+  if (selectElem.is('select')) {
+    // multiselect widget
+    var option = $('<option>', {
+      value: value,
+      text: name
+    });
+    selectElem.append(option);
+    selectElem.multiSelect('refresh');
+
+  } else {
+    // list of inputs
+    var input = $('<input>', {
+      type: 'checkbox',
+      value: value,
+      name: optionName+'[]',
+    })
+
+    var label =  $('<label>');
+    label.append(input);
+    label.append(' '+name);
+
+    var li = $('<li>').append(label);
+    selectElem.append(li);
+  }
+}

--- a/app/assets/javascripts/os_edit.js
+++ b/app/assets/javascripts/os_edit.js
@@ -1,0 +1,37 @@
+$(document).on('ContentLoad', function() {
+  $('#operatingsystem_architecture_ids').parent().append($('#add_architecture_btn'));
+  $('#add_architecture_btn').show();
+});
+
+$(document).on('click','#add_architecture .submit', function() {
+  var arch_form = $('#add_architecture form');
+  $.ajax({
+    type:'POST',
+    url: arch_form.attr('action'),
+    data: arch_form.serialize(),
+    context: this,
+    success: function(response) {
+      // append newly created architecture to the multiselect
+      appendMultiselectOption(
+        $('#operatingsystem_architecture_ids'),
+        'operatingsystem[architecture_ids]',
+        response.architecture.id,
+        response.architecture.name
+      );
+
+      // and hide the modal window
+      $('#add_architecture').modal('hide');
+      $.jnotify(_("Architecture created") , {type: 'success'});
+    },
+    error: function(response) {
+      // parse errors and display them in a notification
+      response = $.parseJSON(response.responseText);
+      $.jnotify(response.errors.join("<br>"), {type: 'error'});
+    }
+  });
+});
+
+$(document).on('click','#add_architecture_btn', function() {
+  $('#add_architecture').modal();
+  return false;
+});

--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -45,6 +45,15 @@ class OperatingsystemsController < ApplicationController
     end
   end
 
+  def add_architecture
+    @architecture = Architecture.new(params[:architecture])
+    if @architecture.save
+      render :json => @architecture
+    else
+      render :json => {:errors => @architecture.errors.full_messages}, :status => 500
+    end
+  end
+
   private
   def find_os
     @operatingsystem = Operatingsystem.find(params[:id])

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -9,6 +9,7 @@ Foreman::AccessControl.map do |map|
                    :"api/v2/architectures" => [:index, :show]
     map.permission :create_architectures,
                    :architectures => [:new, :create],
+                   :operatingsystems => [:add_architecture],
                    :"api/v1/architectures" => [:new, :create],
                    :"api/v2/architectures" => [:new, :create]
     map.permission :edit_architectures,

--- a/app/views/common/_edit_habtm.html.erb
+++ b/app/views/common/_edit_habtm.html.erb
@@ -4,7 +4,8 @@
   <% association = associations.first %>
   <%= link_to_function(icon_text("check", _("Select All")),
                        "toggleCheckboxesBySelector(\"[id$='#{ActiveModel::Naming.singular(association)}_ids_']\")" ) %>
-  <ul class="inputs-list">
+  <% element_id = "#{prefix || klass.class.model_name.tableize.singularize}_#{ActiveModel::Naming.singular(association)}_ids" %>
+  <ul class="inputs-list" id="<%= element_id %>">
     <% selected_ids = klass.send(ActiveModel::Naming.plural(association)).select("#{association.class.table_name}.id").map(&:id) %>
     <% associations.sort{|a,b| a.to_s <=> b.to_s}.each do |association| %>
       <li>

--- a/app/views/operatingsystems/_add_architecture_modal.html.erb
+++ b/app/views/operatingsystems/_add_architecture_modal.html.erb
@@ -1,0 +1,20 @@
+<div id="add_architecture" class="modal hide">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h3 class="modal-title"><%= _("Add Architecture") %></h>
+      </div>
+      <div class="modal-body">
+        <%= form_for Architecture.new, :url => '/foreman/operatingsystems/architectures', :html => { :class => 'form-horizontal' } do |f| %>
+          <%= text_f f, :name %>
+          <%= multiple_checkboxes(f, :operatingsystems, Architecture.new, Operatingsystem, :label => _("Operating Systems")) %>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <a class="cancel btn btn-default" data-dismiss="modal"><%= _("Cancel") %></a>
+        <a class="submit btn btn-primary"><%= _("Submit") %></a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -1,3 +1,4 @@
+<%= javascript 'os_edit' %>
 <%= form_for @operatingsystem do |f| %>
   <%= base_errors_for @operatingsystem %>
   <ul class="nav nav-tabs" data-tabs="tabs">
@@ -26,6 +27,8 @@
       </div>
 
       <%= multiple_checkboxes f, :architectures, @operatingsystem, Architecture, :label => _("Architectures") %>
+      <%= link_to(_("+ Add Architecture"), hash_for_new_architecture_path, :class => "btn btn-success hidden", :id => "add_architecture_btn", :target => "_blank") %>
+
     </div>
 
     <% if SETTINGS[:unattended] %>
@@ -45,3 +48,5 @@
 
   <%= submit_or_cancel f %>
 <% end %>
+
+<%= render "add_architecture_modal" %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -1,3 +1,4 @@
+<%= javascript 'os_edit' %>
 <% title _("Operating systems") %>
 <% title_actions display_link_if_authorized(_("New Operating system"), hash_for_new_operatingsystem_path) %>
 
@@ -20,3 +21,5 @@
 
 <%= page_entries_info @operatingsystems %>
 <%= will_paginate @operatingsystems %>
+
+<%= render "add_architecture_modal" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Foreman::Application.routes.draw do
       end
       collection do
         get 'auto_complete_search'
+        post 'architectures', :action => :add_architecture
       end
     end
     resources :media, :except => [:show] do

--- a/test/functional/operatingsystems_controller_test.rb
+++ b/test/functional/operatingsystems_controller_test.rb
@@ -28,6 +28,26 @@ class OperatingsystemsControllerTest < ActionController::TestCase
     assert_template 'edit'
   end
 
+  def test_add_architecture_succeeds
+    post :add_architecture, {:architecture => {:name => 'xxx'}}, set_session_user
+    assert_response :success
+  end
+
+  def test_add_architecture_returns_name
+    post :add_architecture, {:architecture => {:name => 'xxx'}}, set_session_user
+    assert JSON.parse(response.body)['architecture']['name'] == 'xxx'
+  end
+
+  def test_add_invalid_architecture_fails
+    post :add_architecture, {}, set_session_user
+    assert_response 500
+  end
+
+  def test_add_existing_architecture_returns_errors
+    post :add_architecture, {:architecture => {:name => 'x86_64'}}, set_session_user
+    assert JSON.parse(response.body)['errors'] == ["Name has already been taken"]
+  end
+
   def test_update_invalid
     Operatingsystem.any_instance.stubs(:valid?).returns(false)
     Redhat.any_instance.stubs(:valid?).returns(false)


### PR DESCRIPTION
Extends operating system's forms with "+ Add Architecture" button that
opens a form for adding architectures in a modal window. The inserted
architectures are appended to the architecture multiselect.
