### PR TITLE
fixes #3973 - foreman-debug can now upload tarballs

### DIFF
--- a/foreman.spec
+++ b/foreman.spec
@@ -38,7 +38,7 @@ Requires: %{?scl_prefix}ruby(abi) = 1.9.1
 Requires: %{scl_ruby}
 Requires: %{?scl_prefix}rubygems
 Requires: %{?scl_prefix}facter
-Requires: wget
+Requires: wget rsync
 Requires: /etc/cron.d
 Requires(pre):  shadow-utils
 Requires(post): chkconfig

--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -268,3 +268,19 @@ else
   qprintf "%s: %s\n\n" "A debug directory has been created" "$DIR"
 fi
 
+echo "You may want to upload the tarball to our public server via rsync. There is a"
+echo "write only directory (readable only by Foreman core developers) for that. Note"
+echo "the rsync transmission is UNENCRYPTED:"
+echo -e "\nrsync $TARBALL rsync://theforeman.org/debug-incoming\n"
+
+# offer upload if the shell is interactive
+if tty -s; then
+  if type -p rsync >/dev/null; then
+    read -p "Do you want to do this now? [y/N] " -n 1 -r; echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "Uploading..."
+      rsync $TARBALL rsync://theforeman.org/debug-incoming
+      echo "The tarball has been uploaded, please contact us on mailing list or IRC."
+    fi
+  fi
+fi


### PR DESCRIPTION
I will send an e-mail with instructions how to pick tarballs up. Only us can do
that of course.
