### PR TITLE
Using __ instead of _ to avoid conflict with underscore.js, fixes #3984.

### DIFF
--- a/app/assets/javascripts/about.js
+++ b/app/assets/javascripts/about.js
@@ -6,7 +6,7 @@ $(function() {
       type: 'post',
       url:  url,
       success: function(response) {
-        item.text(_(response.status));
+        item.text(__(response.status));
         item.attr('title',response.message);
         if(response.status == "OK"){
           item.addClass('label label-success')

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -170,7 +170,7 @@ function template_info(div, url) {
   $(div).load(url + "?operatingsystem_id=" + os_id + "&hostgroup_id=" + hostgroup_id + "&environment_id=" + env_id+"&provisioning="+build,
               function(response, status, xhr) {
                 if (status == "error") {
-                  $(div).html("<div class='alert alert-warning'><a class='close' data-dismiss='alert'>&times;</a><p>" + _('Sorry but no templates were configured.') + "</p></div>");
+                  $(div).html("<div class='alert alert-warning'><a class='close' data-dismiss='alert'>&times;</a><p>" + __('Sorry but no templates were configured.') + "</p></div>");
                 }
               });
 }
@@ -184,7 +184,7 @@ $(function() {
     var query = encodeURI($("#search").val());
     var url = $("#bookmark").attr('data-url');
     $("#bookmarks-modal .modal-body").empty();
-    $("#bookmarks-modal .modal-body").append("<span id='loading'>" + _('Loading ...') + "</span>");
+    $("#bookmarks-modal .modal-body").append("<span id='loading'>" + __('Loading ...') + "</span>");
     $("#bookmarks-modal .modal-body").load(url + '&query=' + query + ' form',
                                            function(response, status, xhr) {
                                              $("#loading").hide();
@@ -317,7 +317,7 @@ $(function() {
     var url = $(this).attr('data-ajax-url');
     $(this).load(url, function(response, status, xhr) {
       if (status == "error") {
-        $(this).closest(".tab-content").find("#spinner").html(_('Failed to fetch: ') + xhr.status + " " + xhr.statusText);
+        $(this).closest(".tab-content").find("#spinner").html(__('Failed to fetch: ') + xhr.status + " " + xhr.statusText);
       }
     });
   });

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -151,7 +151,7 @@ function chart_legend_options(item){
         noColumns:4,
         container:"#legendContainer",
         labelFormatter: function(label, series) {
-          return '<a rel="twipsy" data-original-title="' + _('Details') + '" href="' + series.href + '">' + label + '</a>';
+          return '<a rel="twipsy" data-original-title="' + __('Details') + '" href="' + series.href + '">' + label + '</a>';
         }
       }
     case "hide":
@@ -175,7 +175,7 @@ function flot_zoom(target, options, ranges) {
         yaxis: { min: ranges.yaxis.from, max: ranges.yaxis.to }
       }));
   if(target.parents('.stats-well').find('.reset-zoom').size() == 0){
-    target.parents('.stats-well').prepend("<a class='reset-zoom btn btn-sm'>" + _('Reset zoom') + "</a>");
+    target.parents('.stats-well').prepend("<a class='reset-zoom btn btn-sm'>" + __('Reset zoom') + "</a>");
   }
 }
 
@@ -236,8 +236,8 @@ function get_pie_chart(div, url) {
   if($("#"+div).length == 0)
   {
     $('body').append('<div id="' + div + '" class="modal fade"><div class="modal-dialog"><div class="modal-content"></div></div></div>');
-    $("#"+div+" .modal-content").append('<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button><h4 class="modal-title">' + _('Fact Chart') + '</h4></div>')
-        .append('<div id="' + div + '-body" class="fact_chart modal-body">' + _('Loading') + ' ...</div>')
+    $("#"+div+" .modal-content").append('<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button><h4 class="modal-title">' + __('Fact Chart') + '</h4></div>')
+        .append('<div id="' + div + '-body" class="fact_chart modal-body">' + __('Loading') + ' ...</div>')
         .append('<div class="modal-footer"></div>')
 
     $("#"+div).modal('show');

--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -4,7 +4,7 @@ $(function() {
     var url = $(this).attr('data-url');
     $(this).load(url + ' table', function(response, status, xhr) {
       if (status == "error") {
-        $(this).closest(".tab-content").find("#spinner").html(Jed.sprintf(_("There was an error listing VMs: %(status)s %(statusText)s"), {status: xhr.status, statusText: xhr.statusText}));
+        $(this).closest(".tab-content").find("#spinner").html(Jed.sprintf(__("There was an error listing VMs: %(status)s %(statusText)s"), {status: xhr.status, statusText: xhr.statusText}));
       }
       $('.dropdown-toggle').dropdown();
       $(document.body).trigger('ContentLoad');

--- a/app/assets/javascripts/config_template.js
+++ b/app/assets/javascripts/config_template.js
@@ -56,7 +56,7 @@ function set_keybinding(){
 function upload_file(evt){
   if(window.File && window.FileList && window.FileReader)
   {
-    if (!confirm(_("You are about to override the editor content, are you sure?"))) {
+    if (!confirm(__("You are about to override the editor content, are you sure?"))) {
       $('.template_file').val('');
       return;
     }
@@ -168,7 +168,7 @@ function set_diff_mode(item){
   var patch = JsDiff.createPatch(item.attr('data-file-name'), $('#old').text(), $('#new').text());
   patch = patch.replace(/^(.*\n){0,4}/,'');
   if (patch.length == 0)
-    patch = _("No changes")
+    patch = __("No changes")
 
   $(session).off('change');
   session.setValue(patch);
@@ -187,7 +187,7 @@ function IE_diff_mode(item){
 }
 
 function revert_template(item){
-  if (!confirm(_("You are about to override the editor content with a previous version, are you sure?"))) return;
+  if (!confirm(__("You are about to override the editor content with a previous version, are you sure?"))) return;
 
   var version = $(item).attr('data-version');
   var url = $(item).attr('data-url');
@@ -204,7 +204,7 @@ function revert_template(item){
         set_edit_mode($('.template_text'));
       }
       var time = $(item).closest('div.row').find('h6 span').attr('data-original-title');
-      $('#config_template_audit_comment').text(Jed.sprintf(_("Revert to revision from: %s"), time))
+      $('#config_template_audit_comment').text(Jed.sprintf(__("Revert to revision from: %s"), time))
     }
   })
 }

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -19,7 +19,7 @@ function computeResourceSelected(item){
     $("#compute_profile").show();
     $('#vm_details').empty();
     var data = $('form').serialize().replace('method=put', 'method=post');
-    $('#compute_resource').html(spinner_placeholder(_('Loading virtual machine information ...')));
+    $('#compute_resource').html(spinner_placeholder(__('Loading virtual machine information ...')));
     $('#compute_resource_tab a').removeClass('tab-error');
     $(item).indicator_show();
     var url = $(item).attr('data-url');
@@ -29,7 +29,7 @@ function computeResourceSelected(item){
       data: data,
       complete: function(){$(item).indicator_hide()},
       error: function(jqXHR, status, error){
-        $('#compute_resource').html(Jed.sprintf(_("Error loading virtual machine information: %s"), error));
+        $('#compute_resource').html(Jed.sprintf(__("Error loading virtual machine information: %s"), error));
         $('#compute_resource_tab a').addClass('tab-error');
       },
       success: function(result){
@@ -163,7 +163,7 @@ function add_puppet_class(item){
   var link = content.children('a');
   var links = content.find('a');
   links.attr('onclick', 'remove_puppet_class(this)');
-  links.attr('data-original-title', _('Click to undo adding this class'));
+  links.attr('data-original-title', __('Click to undo adding this class'));
   links.tooltip();
   link.removeClass('glyphicon-plus-sign').addClass('glyphicon-minus-sign');
 
@@ -201,7 +201,7 @@ function load_puppet_class_parameters(item) {
 
   if (url == undefined) return; // no parameters
   var placeholder = $('<tr id="puppetclass_'+id+'_params_loading">'+
-      '<td colspan="5">' + spinner_placeholder(_('Loading parameters...')) + '</td></tr>');
+      '<td colspan="5">' + spinner_placeholder(__('Loading parameters...')) + '</td></tr>');
   $('#inherited_puppetclasses_parameters').append(placeholder);
   $.ajax({
     url: url,
@@ -463,7 +463,7 @@ function reload_puppetclass_params(){
 function load_with_placeholder(target, url, data){
   if(url==undefined) return;
   var placeholder = $('<tr id="' + target + '_loading" >'+
-            '<td colspan="4">'+ spinner_placeholder(_('Loading parameters...')) + '</td></tr>');
+            '<td colspan="4">'+ spinner_placeholder(__('Loading parameters...')) + '</td></tr>');
         $('#' + target + ' tbody').replaceWith(placeholder);
         $.ajax({
           type:'post',
@@ -521,7 +521,7 @@ function interface_domain_selected(element) {
 
   subnet_options.attr('disabled', true);
   if (domain_id == '') {
-    subnet_options.append($("<option />").val(null).text(_('No subnets')));
+    subnet_options.append($("<option />").val(null).text(__('No subnets')));
     return false;
   }
 
@@ -539,7 +539,7 @@ function interface_domain_selected(element) {
     dataType:'json',
     success:function (result) {
       if (result.length > 1)
-        subnet_options.append($("<option />").val(null).text(_('Please select')));
+        subnet_options.append($("<option />").val(null).text(__('Please select')));
 
       $.each(result, function () {
         subnet_options.append($("<option />").val(this.subnet.id).text(this.subnet.name + ' (' + this.subnet.to_label + ')'));
@@ -549,7 +549,7 @@ function interface_domain_selected(element) {
         subnet_options.change();
       }
       else {
-        subnet_options.append($("<option />").text(_('No subnets')));
+        subnet_options.append($("<option />").text(__('No subnets')));
         subnet_options.attr('disabled', true);
       }
       $(element).indicator_hide();

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -5,10 +5,7 @@ $(function() {
   // Add normal gettext aliases with gettext_i18n_rails_js to enable extraction
   // when SETTINGS[:mark_translated] is enabled, wrap all strings
   if (typeof(I18N_MARK) != 'undefined' && I18N_MARK) {
-    window._ = function() { return 'X' + i18n.gettext.apply(i18n, arguments) + 'X' };
-    window.n_ = function() { return 'X' + i18n.ngettext.apply(i18n, arguments) + 'X' };
-  } else {
-    window._ = window.__;
-    window.n_ = window.n__;
+    window.__ = function() { return 'X' + i18n.gettext.apply(i18n, arguments) + 'X' };
+    window.n__ = function() { return 'X' + i18n.ngettext.apply(i18n, arguments) + 'X' };
   }
 });

--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -83,7 +83,7 @@ function add_child_node(item) {
     var field   = '';
     if (assoc == 'lookup_keys') {
       $('#smart_vars .smart-var-tabs .active, #smart_vars .smart-var-content .active').removeClass('active');
-      var pill = "<li class='active'><a data-toggle='pill' href='#new_" + new_id + "' id='pill_new_" + new_id + "'>" + _('new') + "<span class='badge close pull-right'>&times;</span></a></li>"
+      var pill = "<li class='active'><a data-toggle='pill' href='#new_" + new_id + "' id='pill_new_" + new_id + "'>" + __('new') + "<span class='badge close pull-right'>&times;</span></a></li>"
       $('#smart_vars .smart-var-tabs').prepend(pill);
       field = $('#smart_vars .smart-var-content').prepend($(content).addClass('active'));
       $('#smart_vars .smart-var-tabs li.active a').show('highlight', 500);

--- a/app/assets/javascripts/reports.js
+++ b/app/assets/javascripts/reports.js
@@ -2,7 +2,7 @@ $(function() {
   var source = $('td:contains("---")');
 
   source.contents().wrap("<div class='origin'></div>");
-  source.prepend("<a href='#' onclick='show_diff(this)' >" + _('View Diff') + "</a>");
+  source.prepend("<a href='#' onclick='show_diff(this)' >" + __('View Diff') + "</a>");
   $('.origin').hide();
 
 });

--- a/app/assets/javascripts/settings.js
+++ b/app/assets/javascripts/settings.js
@@ -2,8 +2,8 @@ $(document).ready(function() {
   var common_settings = {
     method      : 'PUT',
     indicator   : spinner_placeholder(),
-    tooltip     : _('Click to edit..'),
-    placeholder : _('Click to edit..'),
+    tooltip     : __('Click to edit..'),
+    placeholder : __('Click to edit..'),
     submitdata  : {authenticity_token: AUTH_TOKEN, format : "json"},
     onblur      : 'nothing',
     oneditcomplete : function(){
@@ -39,8 +39,8 @@ $(document).ready(function() {
     var settings = {
       type : 'text',
       name : $(this).attr('name'),
-      submit : _('Save'),
-      cancel : _('Cancel'),
+      submit : __('Save'),
+      cancel : __('Cancel'),
       width: '100%',
       height: '34px'
     };
@@ -62,7 +62,7 @@ $(document).ready(function() {
       type : 'select',
       name : $(this).attr('name'),
       data : $(this).attr('select_values'),
-      submit : _('Save')
+      submit : __('Save')
     };
     $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
   });

--- a/app/assets/javascripts/spice.js
+++ b/app/assets/javascripts/spice.js
@@ -9,7 +9,7 @@ $(function () {
   var password = $('#spice-area').data('password');
 
   if ((!host) || (!port)) {
-    console.log(_("must set host and port"));
+    console.log(__("must set host and port"));
     return;
   }
 
@@ -30,7 +30,7 @@ function spice_error(e) {
 }
 
 function spice_success(m) {
-  $('#spice-status').text(Jed.sprintf(_('Connected (unencrypted) to: %s'), $('#spice-status').attr('data-host')))
+  $('#spice-status').text(Jed.sprintf(__('Connected (unencrypted) to: %s'), $('#spice-status').attr('data-host')))
   $('#spice-status').addClass('label-success');
 }
 

--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -97,7 +97,7 @@ function hide_columns(){
   if ($('.two-pane-left').length == 0){
     $('.table-two-pane').wrap( "<div class='row'><div class='col-md-3 two-pane-left'></div></div>");
   }
-  var placeholder = spinner_placeholder(_('Loading'));
+  var placeholder = spinner_placeholder(__('Loading'));
   $('.two-pane-left').after("<div class='col-md-9 two-pane-right'><div class='well'>" + placeholder + "</div></div>");
 
 }

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -25,9 +25,6 @@ namespace :locale do
     FileUtils.rm "#{filename}.tmp"
   end
 
-  # just revert to the traditional underscore.
-  GettextI18nRailsJs::JsAndCoffeeParser.js_gettext_function = '_' if defined? GettextI18nRailsJs
-
   desc 'Extract strings from codebase'
   task :find_code => ["gettext:find", "gettext:po_to_json"]
 

--- a/vendor/assets/javascripts/jquery.multi-select.js
+++ b/vendor/assets/javascripts/jquery.multi-select.js
@@ -491,8 +491,8 @@ function multiSelectOnLoad(){
   $('select[multiple]').each(function(i,item){
     $(item).multiSelect({
       disabledClass : 'disabled disabled_item',
-      selectableHeader: $("<div class='ms-header'>" + _('All items') + " <input placeholder='" + _('Filter') + "' class='ms-filter' type='text'><a href='#' title='" + _('Select All') + "' class='ms-select-all pull-right glyphicon glyphicon-plus icon-white'></a></div>"),
-      selectionHeader: $("<div class='ms-header'>" + _('Selected items') + "<a href='#' title='" + _('Deselect All') + "' class='ms-deselect-all pull-right glyphicon glyphicon-minus icon-white'></a></div>")
+      selectableHeader: $("<div class='ms-header'>" + __('All items') + " <input placeholder='" + __('Filter') + "' class='ms-filter' type='text'><a href='#' title='" + __('Select All') + "' class='ms-select-all pull-right glyphicon glyphicon-plus icon-white'></a></div>"),
+      selectionHeader: $("<div class='ms-header'>" + __('Selected items') + "<a href='#' title='" + __('Deselect All') + "' class='ms-deselect-all pull-right glyphicon glyphicon-minus icon-white'></a></div>")
     })
   });
 
@@ -502,7 +502,7 @@ function multiSelectOnLoad(){
       var missing_ids = $.parseJSON(mismatches);
       $.each(missing_ids, function(index,missing_id){
         opt_id = (missing_id +"").replace(/[^A-Za-z0-9]*/gi, '_')+'-selectable';
-        $('#ms-'+$(item).attr('id')).find('#'+opt_id).addClass('delete').tooltip({title: _("Select this since it belongs to a host"), placement: "left"});
+        $('#ms-'+$(item).attr('id')).find('#'+opt_id).addClass('delete').tooltip({title: __("Select this since it belongs to a host"), placement: "left"});
       })
     }
   })


### PR DESCRIPTION
window._ was defined as a custom i18n function which prevents the use
of underscore.js.  This commit changes the use of _ to __ in js files
to be consistent with gettext_i18n_rails_js and to allow the use
of underscore.js.
