### PR TITLE
fixes #4016 - create libvirt hosts with pre-provisioned volumes

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -229,3 +229,19 @@ function allocation_switcher(element, action) {
   }
   return false;
 }
+
+function libvirt_volume_selected(item){
+  selected = $(item).val();
+  dropdown = $(item).closest('select');
+  new_vol   = $(item).parentsUntil('.fields').parent().find('#new_vol');
+  switch (selected) {
+    case '':
+      enable_libvirt_dropdown(new_vol);
+      break;
+    default:
+      disable_libvirt_dropdown(new_vol);
+      break;
+  }
+  return false;
+}
+

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -1,9 +1,12 @@
 <div class="fields">
   <div class="form-group">
-  <%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :class => "col-md-2", :label => _("Storage pool") %>
-  <%= text_f f, :capacity, :class => "col-md-2", :label => _("Size (GB)"), :onchange => 'capacity_edit(this)' %>
-  <%= allocation_text_f f %>
-    <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "col-md-2", :label => _("Type"),
-                   :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-danger disable-unsupported' }) %>
+    <% volumes = f.object && f.object.try(:new_record?) ? compute_resource.free_volumes : compute_resource.volumes -%>
+    <%= selectable_f f, :key, volumes.collect { |p| [ "#{p.name} (#{p.path})", p.key ] }, {:include_blank => _("New")}, :class => "span2", :label => _("Storage Pool Volumes"), :onchange => 'libvirt_volume_selected(this)', :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-danger disable-unsupported' }) %>
+    <div id='new_vol' class='<%= 'hide' if f.object.key != nil && current_page?(:action => 'new') %>'>
+      <%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :class => "col-md-2", :label => _("Storage pool") %>
+      <%= text_f f, :capacity, :class => "col-md-2", :label => _("Size (GB)"), :onchange => 'capacity_edit(this)' %>
+      <%= allocation_text_f f %>
+    </div>
+    <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "col-md-2", :label => _("Type") %>
   </div>
 </div>


### PR DESCRIPTION
This allows foreman to create hosts on volumes that already exist on the host. You can mix and match both new volumes and current volumes in the same host. This should also allow foreman to manage hosts on multipath devices (SAN), which libvirt storage pools only support as read-only.

Also FYI, the form has "#{p.name} (#{p.path})" because multipath devices have a random character serial for their name but show a more proper name in the path.

To-do:
Test deleting a host using a multipath device. Delete will fail, so need to handle it. Currently if you attach a pre-provisioned lvm storage volume it will delete it when you delete the host, same as normal. 

I've thought about only offering a list of unused volumes in the form. Libvirt and fog are super slow though, so I'm not sure if this is a good idea even if it makes it more dummy proof. Thoughts?
