### PR TITLE
Send apidoc hashes in headers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -131,6 +131,9 @@ module Foreman
     # Catching Invalid JSON Parse Errors with Rack Middleware
     config.middleware.insert_before ActionDispatch::ParamsParser, "Middleware::CatchJsonParseErrors"
 
+    # Add apidoc hash in headers for smarter caching
+    config.middleware.use "Middleware::ApidocHashInHeaders"
+
   end
 
   def self.setup_console

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -69,3 +69,13 @@ class IdentifierDottableValidator < Apipie::Validator::BaseValidator
         "dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
   end
 end
+
+require 'digest/md5'
+require 'json'
+
+Apipie.reload_documentation
+all_docs = Apipie.available_versions.inject({}) { |all, version|
+  all[version] = Apipie.to_json(version)
+  all
+}
+Rails.configuration.apipie_apidoc_hash = Digest::MD5.hexdigest(JSON.dump(all_docs))

--- a/lib/middleware/apidoc_hash_in_headers.rb
+++ b/lib/middleware/apidoc_hash_in_headers.rb
@@ -1,0 +1,13 @@
+module Middleware
+  class ApidocHashInHeaders
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers.merge!( 'Apipie-Apidoc-Hash' => Rails.configuration.apipie_apidoc_hash )
+      return [status, headers, body]
+    end
+  end
+end

--- a/test/lib/middleware/apidoc_hash_in_headers_test.rb
+++ b/test/lib/middleware/apidoc_hash_in_headers_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ApidocHashInHeadersTest < ActiveSupport::TestCase
+
+  def setup
+    @app = mock("Target Rack Application")
+    @app.stubs(:call).returns([200, { }, "Target app"])
+
+    Rails.configuration.apipie_apidoc_hash = "0fc63869c106a448116c45ea061dd852"
+  end
+
+  test "adding apipie hash to headers" do
+
+    middleware = Middleware::ApidocHashInHeaders.new(@app)
+    code, env = middleware.call(env_for('http://admin.example.com'))
+
+    assert_equal Rails.configuration.apipie_apidoc_hash, env["Apipie-Apidoc-Hash"]
+  end
+
+  def env_for url, opts={}
+    Rack::MockRequest.env_for(url, opts)
+  end
+
+end


### PR DESCRIPTION
This patch makes the server to compute MD5 of API docs during start and register middleware which is responsibe for sending this hash in headers of each response. This way the API client (CLI) can find out if the API has changed.
