### PR TITLE
Feature #359 hostname spoofing for unattended inst

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -102,14 +102,14 @@ class UnattendedController < ApplicationController
   end
 
   def find_host_by_spoof
-    spoof = params.delete("spoof")
-    return nil if spoof.blank?
+    ip, name = params.delete('spoof'), params.delete('hostname')
+    return nil if ip.blank? && name.blank?
     @spoof = true
-    Host.find_by_ip(spoof)
+    Host.find_by_ip(ip) || Host.find_by_name(name)
   end
 
   def find_host_by_token
-    token = params.delete("token")
+    token = params.delete('token')
     return nil if token.blank?
     # Quirk: ZTP requires the .slax suffix
     if ( result = token.match(/^([a-z0-9-]+)(.slax)$/i) )

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -183,7 +183,7 @@ module HostsHelper
           content_tag(:td, _("%s Template") % kind) +
             content_tag(:td,
           link_to_if_authorized(icon_text('pencil'), hash_for_edit_config_template_path(:id => tmplt.to_param), :title => _("Edit"), :rel=>"external") +
-          link_to(icon_text('eye-open'), url_for(:controller => '/unattended', :action => kind, :spoof => @host.ip), :title => _("Review"), :"data-provisioning-template" => true ))
+          link_to(icon_text('eye-open'), url_for(:controller => '/unattended', :action => kind, :hostname => @host.name), :title => _("Review"), :"data-provisioning-template" => true ))
         end
       end.join(" ").html_safe
     end

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -67,6 +67,11 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+   test "should support spoof using hostname" do
+    get :provision, {:hostname => hosts(:ubuntu).name}, set_session_user
+    assert_response :success
+  end
+
   test "should provide pxe config for redhat" do
     get :PXELinux, {:spoof => hosts(:redhat).ip}, set_session_user
     assert_response :success


### PR DESCRIPTION
This patch extends the support for 'spoofing' unattended installs to
allow passing the hostname instead of the IP address.

http://projects.theforeman.org/issues/359
