### PR TITLE
fixes #3903 - fixed menu links when relative URLs are set

### DIFF
--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -21,7 +21,7 @@ module Menu
     end
 
     def url
-      @context.routes.url_for(url_hash.merge(:only_path=>true))
+      add_relative_path(@context.routes.url_for(url_hash.merge(:only_path=>true)))
     end
 
     def url_hash
@@ -39,5 +39,11 @@ module Menu
       false
     end
 
+    private
+
+    def add_relative_path(path)
+      rurl = @context.config.action_controller.relative_url_root
+      rurl.present? && !path.start_with?(rurl.end_with?('/') ? rurl : "#{rurl}/") ? "#{rurl}#{path}" : path
+    end
   end
 end


### PR DESCRIPTION
Ok this is hack, @abedari. Calling url_for via Application is not the same as
in context. It's ActionDispatch::Routing::RouteSet.url_for vs
ActionView::Helpers::UrlHelper.url_for. The former ignores relative_url setting
of the Rails application.

I could not figure out how to pass correct context/engine from menu builder,
thus this hack - we simply add the prefix if it is configured in Rails app.

If anyone knows, enlighten me. These are Rails internals I am not familiar
with.
