### PR TITLE
fixes #4125 [Openstack] - host with auto assigned IPs can't be deleted

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -68,8 +68,8 @@ module Foreman::Model
       vm           = find_vm_by_uuid(uuid)
       floating_ips = vm.all_addresses
       floating_ips.each do |address|
-        client.disassociate_address(uuid, address['ip'])
-        client.release_address(address['id'])
+        client.disassociate_address(uuid, address['ip']) rescue true
+        client.release_address(address['id']) rescue true
       end
       super(uuid)
     rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
This patch allows deleting hosts which has auto assigned IPs from nova-network by configuration.
It ignores errors when IPs are disassociated and released from host.
