### PR TITLE
fixes #4015 add image functionality to oVirt/RHEV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ foreman_client
 doc/apidoc*
 .rbenv*
 .rvmrc*
-.ruby-version
-.ruby-gemset
+.ruby-version*
+.ruby-gemset*
 locale/*.mo
 locale/*/*.pox
 locale/*/LC_MESSAGES

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -368,8 +368,11 @@ function update_provisioning_image(){
         $.each(result, function() {
           image_options.append($("<option />").val(this.image.uuid).text(this.image.name));
         });
-        if (image_options.find('option').length > 0)
+        if (image_options.find('option').length > 0) {
           image_options.attr('disabled', false);
+          $('#host_compute_attributes_template').val(image_options.val());
+          ovirt_hwpSelected(image_options);
+        }
       }
     })
 }
@@ -496,11 +499,19 @@ $(document).on('submit',"[data-submit='progress_bar']", function() {
 $(document).on('change', '#host_provision_method_build', function () {
   $('#network_provisioning').show();
   $('#image_provisioning').hide();
+  $('#image_selection select').attr('disabled', true);
+  $('#host_compute_attributes_template').attr('disabled', false);
 });
 
 $(document).on('change', '#host_provision_method_image', function () {
   $('#network_provisioning').hide();
   $('#image_provisioning').show();
+  var image_options = $('#image_selection select');
+  image_options.attr('disabled', false);
+  var template_options = $('#host_compute_attributes_template');
+  template_options.attr('disabled', true);
+  template_options.val(image_options.val());
+  ovirt_hwpSelected(image_options);
 });
 
 $(document).on('change', '.interface_domain', function () {

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -11,7 +11,7 @@ module Foreman::Model
     end
 
     def capabilities
-      [:build]
+      [:build, :image]
     end
 
     def supports_update?
@@ -109,6 +109,9 @@ module Foreman::Model
     def create_vm(args = {})
       #ovirt doesn't accept '.' in vm name.
       args[:name] = args[:name].parameterize
+      if (image_id = args[:image_id])
+        args.merge!({:template => image_id})
+      end
       vm = super({ :first_boot_dev => 'network', :quota => ovirt_quota }.merge(args))
       begin
         create_interfaces(vm, args[:interfaces_attributes])

--- a/app/models/concerns/fog_extensions/ovirt/server.rb
+++ b/app/models/concerns/fog_extensions/ovirt/server.rb
@@ -5,6 +5,8 @@ module FogExtensions
 
       include ActionView::Helpers::NumberHelper
 
+      attr_accessor :image_id
+
       def state
         status
       end
@@ -13,7 +15,7 @@ module FogExtensions
 
       def volumes_attributes=(attrs);  end
 
-     def poweroff
+      def poweroff
         service.vm_action(:id =>id, :action => :shutdown)
       end
 

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -47,6 +47,8 @@ module Orchestration::SSHProvision
       credentials = { :key_data => [compute_resource.key_pair.secret] }
     elsif vm.respond_to?(:password) and vm.password.present?
       credentials = { :password => vm.password, :auth_methods => ["password"] }
+    elsif image.respond_to?(:password) and image.password.present?
+      credentials = { :password => image.password, :auth_methods => ["password"] }
     else
       raise ::Foreman::Exception.new(N_('Unable to find proper authentication method'))
     end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -136,7 +136,7 @@ class Host::Managed < Host::Base
     validates :root_pass, :length => {:minimum => 8, :message => _('should be 8 characters or more')}
     validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :if => Proc.new { |host| host.require_ip_validation? }
     validates :ptable_id, :presence => {:message => N_("cant be blank unless a custom partition has been defined")},
-                          :if => Proc.new { |host| host.managed and host.disk.empty? and not defined?(Rake) and capabilities.include?(:build) }
+                          :if => Proc.new { |host| host.managed and host.disk.empty? and not defined?(Rake) and host.provision_method != 'image' and capabilities.include?(:build) }
     validates :serial, :format => {:with => /[01],\d{3,}n\d/, :message => N_("should follow this format: 0,9600n8")},
                        :allow_blank => true, :allow_nil => true
     after_validation :set_compute_attributes

--- a/app/views/compute_resources_vms/form/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/form/_ovirt.html.erb
@@ -43,3 +43,17 @@
 </div>
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new && controller_name != "compute_attributes" %>
+
+<%
+   arch ||= nil ; os ||= nil
+   images = possible_images(compute_resource, arch, os)
+-%>
+
+<div id='image_selection'>
+  <%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')},
+             { :disabled    => true, :'data-url' => hardware_profile_selected_compute_resource_path(compute_resource),
+               :onchange    => 'ovirt_hwpSelected(this);',
+               :help_inline => :indicator,
+               :help_block  => _("Image to use")} %>
+</div>
+

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -6,15 +6,15 @@
 <span id="os_select">
   <%= render 'common/os_selection/architecture', :item => @host %>
 </span>
-<% image_provisioning = f.object.capabilities && f.object.capabilities.include?(:image) %>
+<% build_provisioning = f.object.capabilities && f.object.capabilities.include?(:build) %>
 <div id='provisioning_method' <%= display? (@host.capabilities.size < 2)  %> >
   <%= field(f, :provision_method, :label => _('Provisioning Method')) do
-      radio_button_f(f, :provision_method, :value=>'build', :checked=> !image_provisioning, :text=> _("Network Based"))+
-      radio_button_f(f, :provision_method, :value=>'image', :checked=> image_provisioning, :text=> _("Image Based"))
+      radio_button_f(f, :provision_method, :value=>'build', :checked=> build_provisioning, :text=> _("Network Based"))+
+      radio_button_f(f, :provision_method, :value=>'image', :checked=> !build_provisioning, :text=> _("Image Based"))
   end %>
 </div>
-<div id='network_provisioning' <%= display? image_provisioning  %> >
-  <% if @host.new_record? or @host.type_changed? %>
+<div id='network_provisioning' <%= display? !build_provisioning  %> >
+  <% if @host.new_record? or @host.type_changed? -%>
       <%= checkbox_f f, :build, :checked => true, :help_inline => _("Enable this host for provisioning") %>
   <% end %>
   <span id="media_select">
@@ -27,7 +27,7 @@
   <%= password_f f, :root_pass %>
 </div>
 
-<div id='image_provisioning' <%= display? !image_provisioning      %> >
+<div id='image_provisioning' <%= display? build_provisioning      %> >
 
 </div>
 <!-- this section is used for displaying the provisioning scripts-->

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -5,6 +5,9 @@
   <%= select_f f, :operatingsystem_id, Operatingsystem.all, :id, :to_label %>
   <%= select_f f, :architecture_id, Architecture.all, :id, :to_label %>
   <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+  <% if @compute_resource.provider == 'Ovirt' %>
+    <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
+  <% end %>
   <%= image_field(f) %>
   <%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
   <% if @compute_resource.provider == 'EC2' %>

--- a/db/migrate/20140115130443_add_password_to_images.rb
+++ b/db/migrate/20140115130443_add_password_to_images.rb
@@ -1,0 +1,5 @@
+class AddPasswordToImages < ActiveRecord::Migration
+  def change
+    add_column :images, :password, :string
+  end
+end


### PR DESCRIPTION
Using oVirt templates as images including using finish provisioing templates is something we really need to speed up provisioning under oVirt. This adds the ability to add in images to oVirt compute resources, specifying user & password to use to SSH in & run finish templates.
