### PR TITLE
fixes #4152 - fix syntax error in _form.html.erb for hosts and hostgroups

### DIFF
--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -36,7 +36,7 @@
       <% if @environment or @hostgroup.environment %>
         <%= render 'puppetclasses/class_selection', :obj => @hostgroup %>
       <% else %>
-        <%= alert :class => 'alert-warning', :text =>  _('Please select an environment first') %><
+        <%= alert :class => 'alert-warning', :text =>  _('Please select an environment first') %>
       <% end %>
     </div>
 

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -80,7 +80,7 @@
         <% if @environment or @hostgroup %>
           <%= render 'puppetclasses/class_selection', :obj => @host %>
         <% else %>
-          <%= alert :class => 'alert-warning', :text =>  _('Please select an environment first') %><
+          <%= alert :class => 'alert-warning', :text =>  _('Please select an environment first') %>
         <% end %>
       </div>
 


### PR DESCRIPTION
This change is necessary; otherwise, plugins (like katello) that deface the host or hostgroups will experience errors rendering the form.
