### PR TITLE
fixes #3812 Align js lib versions and css between foreman and katello

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,7 +1,7 @@
 group :assets do
   gem 'sass-rails', '~> 3.2.3'
   gem 'uglifier', '>= 1.0.3'
-  gem "jquery-rails", "2.0.3"
+  gem "jquery-rails", "2.2.1"
   gem 'jquery-ui-rails'
   gem "therubyracer", '0.11.3', :require => 'v8'
   gem 'bootstrap-sass', '~> 3.0.3.0'


### PR DESCRIPTION
Katello is using jquery 1.9.1, this patch upgrade foreman jquery to the same version.
