### PR TITLE
fixes #4155 - associate and disassociate vms using the api

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -115,6 +115,13 @@ Return value may either be one of the following:
         process_response @host.puppetrun!
       end
 
+      api :PUT, "/hosts/:id/disassociate", "Disassociate the host from a VM."
+      param :id, :identifier_dottable, :required => true
+      def disassociate
+        @host.disassociate!
+        render 'api/v2/hosts/show'
+      end
+
       api :PUT, "/hosts/:id/power", "Run power operation on host."
       param :id, :identifier_dottable, :required => true
       param :power_action, String, :required => true, :desc => "power action, valid actions are ('on', 'start')', ('off', 'stop'), ('soft', 'reboot'), ('cycle', 'reset'), ('state', 'status')"
@@ -170,6 +177,8 @@ Return value may either be one of the following:
             :ipmi_boot
           when 'console'
             :console
+          when 'disassociate'
+            :edit
           else
             super
         end

--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -45,12 +45,10 @@ class ComputeResourcesController < ApplicationController
     count = 0
     if @compute_resource.respond_to?(:associated_host)
       @compute_resource.vms(:eager_loading => true).each do |vm|
-        if Host.where(:uuid => vm.identity).empty?
+        if Host.for_vm(@compute_resource, vm).empty?
           host = @compute_resource.associated_host(vm)
           if host.present?
-            host.uuid = vm.identity
-            host.compute_resource_id = @compute_resource.id
-            host.save!(:validate => false) # don't want to trigger callbacks
+            host.associate!(@compute_resource, vm)
             count += 1
           end
         end

--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -31,14 +31,12 @@ class ComputeResourcesVmsController < ApplicationController
   def associate
     @compute_resource = find_compute_resource(:edit_compute_resources)
     @vm = find_vm
-    if Host.where(:uuid => @vm.identity).any?
+    if Host.for_vm(@compute_resource, @vm).any?
       process_error(:error_msg => _("VM already associated with a host"), :redirect => compute_resource_vm_path(:compute_resource_id => params[:compute_resource_id], :id => @vm.identity))
     else
       host = @compute_resource.associated_host(@vm) if @compute_resource.respond_to?(:associated_host)
       if host.present?
-        host.uuid = @vm.identity
-        host.compute_resource_id = @compute_resource.id
-        host.save!(:validate => false) # don't want to trigger callbacks
+        host.associate!(@compute_resource, @vm)
         process_success(:success_msg => _("VM associated to host %s") % host.name, :success_redirect => host_path(host))
       else
         process_error(:error_msg => _("No host found to associate this VM with"), :redirect => compute_resource_vm_path(:compute_resource_id => params[:compute_resource_id], :id => @vm.identity))

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -275,11 +275,8 @@ class HostsController < ApplicationController
     if @host.uuid.nil? && @host.compute_resource_id.nil?
       process_error :error_msg => _("Host %s is not associated with a VM") % @host.name, :redirect => :back
     else
-      @host.uuid = nil
-      @host.compute_resource_id = nil
-      @host.save!(:validate => false) # don't want to trigger callbacks
-      msg = _("%s has been disassociated from VM") % (@host.name)
-      process_success :success_msg => msg, :success_redirect => :back
+      @host.disassociate!
+      process_success :success_msg => _("%s has been disassociated from VM") % (@host.name), :success_redirect => :back
     end
   end
 
@@ -434,9 +431,7 @@ class HostsController < ApplicationController
 
   def update_multiple_disassociate
     @hosts.each do |host|
-      host.uuid = nil
-      host.compute_resource_id = nil
-      host.save(:validate => false)
+      host.disassociate!
     end
     notice _('Updated hosts: Disassociated from VM')
     redirect_back_or_to hosts_path

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -329,8 +329,9 @@ Foreman::AccessControl.map do |map|
                                     :puppetclasses => pc_ajax_actions,
                                     :subnets => subnets_ajax_actions,
                                     :"api/v1/hosts" => [:update],
-                                    :"api/v2/hosts" => [:update],
-                                    :"api/v2/interfaces" => [:create, :update, :destroy]
+                                    :"api/v2/hosts" => [:update, :disassociate],
+                                    :"api/v2/interfaces" => [:create, :update, :destroy],
+                                    :"api/v2/compute_resources" => [:associate]
                                   }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy],
                                     :"api/v1/hosts" => [:destroy],

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -171,6 +171,7 @@ Foreman::Application.routes.draw do
           get :available_networks, :on => :member
           get :available_storage_domains, :on => :member
           get 'available_clusters/(:cluster_id)/available_networks', :to => 'compute_resources#available_networks', :on => :member
+          put :associate, :on => :member
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
           resources :compute_attributes, :only => [:create, :update]
@@ -205,6 +206,7 @@ Foreman::Application.routes.draw do
         resources :hosts, :except => [:new, :edit] do
           get :status, :on => :member
           put :puppetrun, :on => :member
+          put :disassociate, :on => :member
           put :boot, :on => :member
           put :power, :on => :member
           post :facts, :on => :collection

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -153,6 +153,14 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should disassociate host" do
+    host = FactoryGirl.create(:host, :on_compute_resource)
+    assert host.compute?
+    put :disassociate, { :id => host.to_param }
+    assert_response :success
+    refute host.reload.compute?
+  end
+
   def fact_json
     @json  ||= JSON.parse(Pathname.new("#{Rails.root}/test/fixtures/brslc022.facts.json").read)
   end


### PR DESCRIPTION
I'm not sure I see a how to associate individual vm's, but this would allow disassociations and mass associations for compute resources. 
