### PR TITLE
fixes #4173 - setting build on existing oVirt VM fails as compute_attributes are missing

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -161,7 +161,7 @@ module Orchestration::Compute
   def compute_update_required?
     return false unless compute_resource.supports_update?
     old.compute_attributes = compute_resource.find_vm_by_uuid(uuid).attributes
-    compute_resource.update_required?(old.compute_attributes, compute_attributes.symbolize_keys)
+    compute_resource.update_required?(old.compute_attributes, (compute_attributes || {}).symbolize_keys)
   end
 
   def find_image


### PR DESCRIPTION
Untested by me, but verified by @fraenki on redmine.
