### PR TITLE
Bug #4120: Fix for border-collapse:collapse tables in Firefox

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -145,3 +145,9 @@ background-color: white;
 
 .popover{max-width: none}
 
+@-moz-document url-prefix() {
+  /* Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+  *, *:before, *:after {
+    background-clip: padding-box;
+  }
+}


### PR DESCRIPTION
This little fix addresses the problem with border-collapse:collapse,
which makes some lines dissapear on tables. Cellspacing would also fix this
but it's deprecated and styles outside of CSS.
There is a bug open upstream for this:
https://bugzilla.mozilla.org/show_bug.cgi?id=688556

I tried setting the style for .table > tbody > tr:after and before,
but it did not fix the problem.

http://projects.theforeman.org/issues/4120
