### PR TITLE
Fixes #4196 "Power ON this machine" disappeared for new VMWare hosts

### DIFF
--- a/app/views/compute_resources_vms/form/_vmware.html.erb
+++ b/app/views/compute_resources_vms/form/_vmware.html.erb
@@ -38,4 +38,4 @@
 
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
-<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new and show_vm_name? %>
+<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new and controller_name != 'compute_attributes' %>


### PR DESCRIPTION
If you look at this change at other compute resurces in commit c6e02bd3cf59da85d3e97b0a7b2c221003eb494c, this must have been be a typo mistake :)
