### PR TITLE
Allow puppet classes to be imported by environment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The Foreman repository/package is licensed as follows:
 
 * The Foreman itself is licensed under GNU GPL v3 or newer
+* app/views/unattended/ztp/provision.erb is under 2-clause BSD license
 * config/locales/ and public/blank.html are MIT licensed
 * lib/tasks/convert.rake is under Revised BSD license
 * extras/noVNC/websockify is LGPL v3 licensed
@@ -17,6 +18,7 @@ The Foreman repository/package is licensed as follows:
 Copyright holders for the Foreman project are in the separate file called
 Contributors, holders for code above are:
 
+  (c) 2013, Juniper Networks
   (c) 2008, Matson Systems, Inc.
   (c) 2010, Ajax.org B.V.
   (c) 2005, Brad Neuberg, bkn3@columbia.edu
@@ -683,6 +685,34 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------------------------------------------------------------------
+
+2-clause BSD license
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the author.
 
 -----------------------------------------------------------------------------
 

--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -6,6 +6,7 @@ module Foreman::Controller::Environments
   def import_environments
     begin
       opts      = params[:proxy].blank? ? { } : { :url => SmartProxy.find(params[:proxy]).try(:url) }
+      opts[:env] = params[:env] unless params[:env].blank?
       @importer = PuppetClassImporter.new(opts)
       @changed  = @importer.changes
     rescue => e

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -19,6 +19,11 @@ module PuppetclassesAndEnvironmentsHelper
     )
   end
 
+  def import_proxy_link hash, env
+    proxy = SmartProxy.puppet_proxies.first
+    display_link_if_authorized(_("Import #{env} from %s") % proxy.name, hash.merge(:proxy => proxy, :env => env))
+  end
+
   private
   def pretty_print classes
     hash = { }
@@ -33,7 +38,5 @@ module PuppetclassesAndEnvironmentsHelper
     hash.keys.sort.map do |key|
       link_to key,{}, {:remote => true, :rel => "popover", :data => {"content" => hash[key].sort.join('<br>').html_safe, "original-title" => key}}
     end.to_sentence.html_safe
-
   end
-
 end

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -21,7 +21,7 @@ module PuppetclassesAndEnvironmentsHelper
 
   def import_proxy_link hash, env
     proxy = SmartProxy.puppet_proxies.first
-    display_link_if_authorized(_("Import #{env} from %s") % proxy.name, hash.merge(:proxy => proxy, :env => env))
+    display_link_if_authorized(_("Import %{env} from %{proxy}") % {:env => env, :proxy => proxy.name}, hash.merge(:proxy => proxy, :env => env))
   end
 
   private

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -16,7 +16,8 @@
       </td>
       <td><%= link_to @host_counter[environment.id] || 0, hosts_path(:search => "environment = #{environment}") %>
       <td>
-        <%= action_buttons(link_to(_('Classes'), puppetclasses_path(:search => "environment = #{environment}")),
+        <%= action_buttons(import_proxy_link(hash_for_import_environments_environments_path, environment.name),
+                           link_to(_("Classes"), puppetclasses_path(:search => "environment = #{environment}")),
                            display_delete_if_authorized(hash_for_environment_path(:id => environment.name), :confirm => "Delete #{environment.name}?")) %>
       </td>
     </tr>

--- a/app/views/unattended/autoyast/PXELinux.erb
+++ b/app/views/unattended/autoyast/PXELinux.erb
@@ -5,4 +5,4 @@ name: Community AutoYaST PXE
 default linux
 label linux
 kernel <%= @kernel %>
-append initrd=<%= @initrd %> ramdisk_size=65536 install=<%= media_path %> autoyast=<%= foreman_url("provision") + "?format=xml" %> textmode=1
+append initrd=<%= @initrd %> ramdisk_size=65536 install=<%= media_path %> autoyast=<%= foreman_url('provision') + '?format=xml' %> textmode=1

--- a/app/views/unattended/autoyast/provision.erb
+++ b/app/views/unattended/autoyast/provision.erb
@@ -39,7 +39,7 @@ name: Community AutoYaST
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
-        <address><%= @host.params["ntp-server"] || "0.opensuse.pool.ntp.org" %></address>
+        <address><%= @host.params['ntp-server'] || '0.opensuse.pool.ntp.org' %></address>
         <initial_sync config:type="boolean">true</initial_sync>
         <options></options>
         <type>server</type>
@@ -84,13 +84,13 @@ name: Community AutoYaST
         <source><![CDATA[
 <% if puppet_enabled %>
           cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" -%>
+<%= snippet 'puppet.conf' -%>
 EOF
 if [ -f "/etc/sysconfig/puppet" ]
 then
-/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= @host.puppetmaster.blank? ? "" : @host.puppetmaster %>/ /etc/sysconfig/puppet
+/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= @host.puppetmaster.blank? ? '' : @host.puppetmaster %>/ /etc/sysconfig/puppet
 fi
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 /sbin/chkconfig puppet on -f
 <% end -%>
 
@@ -105,6 +105,6 @@ fi
   </keyboard>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone><%= @host.params["time-zone"] || "Etc/UTC" %></timezone>
+    <timezone><%= @host.params['time-zone'] || 'Etc/UTC' %></timezone>
   </timezone>
 </profile>

--- a/app/views/unattended/autoyast/provision_sles.erb
+++ b/app/views/unattended/autoyast/provision_sles.erb
@@ -41,7 +41,7 @@ oses:
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
-        <address><%= @host.params["ntp-server"] || "0.opensuse.pool.ntp.org" %></address>
+        <address><%= @host.params['ntp-server'] || '0.opensuse.pool.ntp.org' %></address>
         <initial_sync config:type="boolean">true</initial_sync>
         <options></options>
         <type>server</type>
@@ -87,13 +87,13 @@ oses:
         <source><![CDATA[
 <% if puppet_enabled %>
           cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" -%>
+<%= snippet 'puppet.conf' -%>
 EOF
 if [ -f "/etc/sysconfig/puppet" ]
 then
-/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= @host.puppetmaster.blank? ? "" : @host.puppetmaster %>/ /etc/sysconfig/puppet
+/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= @host.puppetmaster.blank? ? '' : @host.puppetmaster %>/ /etc/sysconfig/puppet
 fi
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 /sbin/chkconfig puppet on -f
 <% end -%>
 
@@ -108,7 +108,7 @@ fi
   </keyboard>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone><%= @host.params["time-zone"] || "Etc/UTC" %></timezone>
+    <timezone><%= @host.params['time-zone'] || 'Etc/UTC' %></timezone>
   </timezone>
   <add-on>
     <add_on_products config:type="list">

--- a/app/views/unattended/jumpstart/finish.erb
+++ b/app/views/unattended/jumpstart/finish.erb
@@ -41,7 +41,7 @@ EOF
 
 /usr/bin/echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" -%>
+<%= snippet 'puppet.conf' -%>
 EOF
 # The x86 version of the puppet package ignores the --config parameter. This should fix that and not hurt other installations
 if [ -f /etc/opt/csw/puppet/puppetd.conf ]

--- a/app/views/unattended/kickstart/PXELinux.erb
+++ b/app/views/unattended/kickstart/PXELinux.erb
@@ -18,11 +18,11 @@ oses:
 default linux
 label linux
 kernel <%= @kernel %>
-<% if @host.operatingsystem.name == "Fedora" and @host.operatingsystem.major.to_i > 16 -%>
-append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> ks.device=bootif network ks.sendmac
-<% elsif @host.operatingsystem.name != "Fedora" and @host.operatingsystem.major.to_i >= 7 -%>
-append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> network ks.sendmac
+<% if @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
+append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac
+<% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
+append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac
 <% else -%>
-append initrd=<%= @initrd %> ks=<%= foreman_url("provision")%> ksdevice=bootif network kssendmac
+append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac
 <% end -%>
 IPAPPEND 2

--- a/app/views/unattended/kickstart/iPXE.erb
+++ b/app/views/unattended/kickstart/iPXE.erb
@@ -12,11 +12,12 @@ oses:
 - RedHat 5
 - RedHat 6
 %>
+<% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
 
 <%# This template will not function with Safemode set to true.
     Please disable it in Settings > Provisioning               %>
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url("provision")%>?static=yes ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> ks=<%= foreman_url('provision')%><%= static %> ksdevice=<%= @host.mac %> network kssendmac ip=${netX/ip} netmask=${netX/netmask} gateway=${netX/gateway} dns=${dns}
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 
 boot

--- a/app/views/unattended/kickstart/provision.erb
+++ b/app/views/unattended/kickstart/provision.erb
@@ -12,7 +12,7 @@ oses:
 - Fedora 19
 %>
 <%
-  rhel_compatible = @host.operatingsystem.family == "Redhat" && @host.operatingsystem.name != "Fedora"
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
@@ -24,16 +24,16 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 skipx
-network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : "dhcp" %> --hostname <%= @host %>
+network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : 'dhcp' %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= os_major >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
-timezone <%= @host.params["time-zone"] || "UTC" %>
+timezone <%= @host.params['time-zone'] || 'UTC' %>
 <% if rhel_compatible && os_major > 4 -%>
 services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
 <% end -%>
 
-<% if @host.operatingsystem.name == "Fedora" -%>
+<% if @host.operatingsystem.name == 'Fedora' -%>
 repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
 <% if puppet_enabled && @host.params['enable-puppetlabs-repo'] && @host.params['enable-puppetlabs-repo'] == 'true' -%>
 repo --name=puppetlabs-products --baseurl=http://yum.puppetlabs.com/fedora/f<%= @host.operatingsystem.major %>/products/<%= @host.architecture %>
@@ -47,7 +47,7 @@ repo --name=puppetlabs-deps --baseurl=http://yum.puppetlabs.com/el/<%= @host.ope
 <% end -%>
 <% end -%>
 
-<% if @host.operatingsystem.name == "Fedora" and os_major <= 16 -%>
+<% if @host.operatingsystem.name == 'Fedora' and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
 bootloader --append="nofb quiet splash=quiet <%=ks_console%>" <%= grub_pass %>
 part biosboot --fstype=biosboot --size=1
@@ -103,7 +103,7 @@ exec < /dev/tty3 > /dev/tty3
 (
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params["ntp-server"] || "0.fedora.pool.ntp.org" %>
+/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
 # update all the base packages from the updates repository
@@ -112,13 +112,13 @@ yum -t -y -e 0 update
 <% if puppet_enabled %>
 echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
 sync

--- a/app/views/unattended/kickstart/provision_rhel.erb
+++ b/app/views/unattended/kickstart/provision_rhel.erb
@@ -19,11 +19,11 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 skipx
-network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : "dhcp" %> --hostname <%= @host %>
+network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : 'dhcp' %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= os_major >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
-timezone <%= @host.params["time-zone"] || "UTC" %>
+timezone <%= @host.params['time-zone'] || 'UTC' %>
 <% if os_major > 4 -%>
 services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
 
@@ -88,10 +88,10 @@ exec < /dev/tty3 > /dev/tty3
 (
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params["ntp-server"] || "0.fedora.pool.ntp.org" %>
+/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<%= snippet "redhat_register" %>
+<%= snippet 'redhat_register' %>
 
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
@@ -102,13 +102,13 @@ yum -t -y -e 0 install puppet
 
 echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
 sync

--- a/app/views/unattended/kickstart/userdata.erb
+++ b/app/views/unattended/kickstart/userdata.erb
@@ -14,7 +14,7 @@ oses:
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>
-<%= snippet "fix_hosts" %>
+<%= snippet 'fix_hosts' %>
 
 <%
   # safemode renderer does not support unary negation
@@ -24,13 +24,13 @@ oses:
 <% if puppet_enabled %>
 yum install -y puppet
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
 # UserData still needs wget to mark as finished

--- a/app/views/unattended/preseed/PXELinux.erb
+++ b/app/views/unattended/preseed/PXELinux.erb
@@ -9,13 +9,13 @@ oses:
 - Ubuntu 13.04
 %>
 
-<% if @host.operatingsystem.name == "Debian" -%>
+<% if @host.operatingsystem.name == 'Debian' -%>
 <% keyboard_params = "auto=true console-keymaps-at/keymap=us keymap=us domain=#{@host.domain}" -%>
 <% else -%>
-<% keyboard_params = "console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us" -%>
+<% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
 default linux
 label linux
 kernel <%= @kernel %>
-append initrd=<%= @initrd %> interface=auto url=<%= foreman_url("provision")%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= keyboard_params %> locale=en_US
+append initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= keyboard_params %> locale=en_US
 IPAPPEND 2

--- a/app/views/unattended/preseed/finish.erb
+++ b/app/views/unattended/preseed/finish.erb
@@ -15,11 +15,11 @@ oses:
 %>
 <% if puppet_enabled %>
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
 /bin/touch /etc/puppet/namespaceauth.conf 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
 /usr/bin/wget --quiet --output-document=/dev/null --no-check-certificate <%= foreman_url %>

--- a/app/views/unattended/preseed/iPXE.erb
+++ b/app/views/unattended/preseed/iPXE.erb
@@ -7,10 +7,10 @@ oses:
 - Debian 7.0
 - Ubuntu 12.04
 %>
-<% if @host.operatingsystem.name == "Debian" -%>
+<% if @host.operatingsystem.name == 'Debian' -%>
 <% keyboard_params = "auto=true console-keymaps-at/keymap=us keymap=us domain=#{@host.domain}" -%>
 <% else -%>
-<% keyboard_params = "console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us" -%>
+<% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
 <% kernel, initrd = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
 <% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>
@@ -18,7 +18,7 @@ oses:
 <%# This template will not function with Safemode set to true.
     Please disable it in Settings > Provisioning               %>
 
-kernel <%= kernel %> interface=auto url=<%= foreman_url("provision")%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=${netX/mac} hostname=<%= @host.name %> <%= keyboard_params %> locale=en_US netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
+kernel <%= kernel %> interface=auto url=<%= foreman_url('provision')%><%= static %> ramdisk_size=10800 root=/dev/rd/0 rw auto netcfg/disable_dhcp=true BOOTIF=${netX/mac} hostname=<%= @host.name %> <%= keyboard_params %> locale=en_US netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true
 initrd <%= initrd %>
 
 boot

--- a/app/views/unattended/preseed/provision.erb
+++ b/app/views/unattended/preseed/provision.erb
@@ -21,7 +21,7 @@ d-i console-setup/variant USA
 d-i console-setup/layout USA
 d-i console-setup/layoutcode string us
 
-<% if @host.operatingsystem.name == "Debian" && @host.operatingsystem.major.to_i >= 7 -%>
+<% if @host.operatingsystem.name == 'Debian' && @host.operatingsystem.major.to_i >= 7 -%>
 d-i keymap select us
 <% end -%>
 
@@ -54,11 +54,11 @@ d-i mirror/udeb/suite string <%= @host.operatingsystem.release_name %>
 
 # Time settings
 d-i clock-setup/utc boolean true
-d-i time/zone string <%= @host.params["time-zone"] || "UTC" %>
+d-i time/zone string <%= @host.params['time-zone'] || 'UTC' %>
 
 # NTP
 d-i clock-setup/ntp boolean true
-d-i clock-setup/ntp-server string <%= @host.params["ntp-server"] || "0.debian.pool.ntp.org" %>
+d-i clock-setup/ntp-server string <%= @host.params['ntp-server'] || '0.debian.pool.ntp.org' %>
 
 # Set alignment for automatic partitioning
 # Choices: cylinder, minimal, optimal
@@ -94,14 +94,14 @@ d-i apt-setup/local1/key string http://apt.puppetlabs.com/pubkey.gpg
 tasksel tasksel/first multiselect minimal
 
 <% if puppet_enabled %>
-  <% if @host.operatingsystem.name == "Ubuntu" and @host.operatingsystem.major.to_i == 10 -%>
-    <% puppet_package = "puppet/lucid-backports" -%>
+  <% if @host.operatingsystem.name == 'Ubuntu' and @host.operatingsystem.major.to_i == 10 -%>
+    <% puppet_package = 'puppet/lucid-backports' -%>
 d-i apt-setup/backports boolean true
   <% else -%>
-    <% puppet_package = "puppet" -%>
+    <% puppet_package = 'puppet' -%>
   <% end -%>
 <% else -%>
-  <% puppet_package = "" -%>
+  <% puppet_package = '' -%>
 <% end -%>
 
 # Install some base packages
@@ -118,4 +118,4 @@ d-i grub-installer/with_other_os boolean true
 
 d-i finish-install/reboot_in_progress note
 
-d-i preseed/late_command string wget <%= foreman_url("finish") %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget <%= foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/app/views/unattended/preseed/userdata.erb
+++ b/app/views/unattended/preseed/userdata.erb
@@ -9,7 +9,7 @@ oses:
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>
-<%= snippet "fix_hosts" %>
+<%= snippet 'fix_hosts' %>
 
 <%
   # safemode renderer does not support unary negation
@@ -20,11 +20,11 @@ oses:
 apt-get update
 apt-get install -y puppet
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
 /bin/touch /etc/puppet/namespaceauth.conf
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? "" : "--server #{@host.puppetmaster}" %> --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% end -%>
 
 # UserData still needs wget to mark as finished

--- a/app/views/unattended/pxe/PXELinux_default.erb
+++ b/app/views/unattended/pxe/PXELinux_default.erb
@@ -21,9 +21,9 @@ LABEL local
 LABEL <%= "#{profile[:template]} - #{profile[:hostgroup]}" %>
      kernel <%= profile[:hostgroup].operatingsystem.kernel(profile[:hostgroup].architecture) %>
 <% case profile[:hostgroup].operatingsystem.pxe_type -%>
-<% when "kickstart" -%>
+<% when 'kickstart' -%>
      append initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> ks=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ksdevice=bootif network kssendmac
-<% when "preseed" -%>
+<% when 'preseed' -%>
      append initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> interface=auto url=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=en_US console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA
 <% end -%>
 

--- a/app/views/unattended/scripts/grubby.erb
+++ b/app/views/unattended/scripts/grubby.erb
@@ -10,4 +10,4 @@ INITRD="/boot/initrd.img"
 wget -O "$KERNEL" "<%= @host.url_for_boot(:kernel) %>"
 wget -O "$INITRD" "<%= @host.url_for_boot(:initrd) %>"
 
-grubby --add-kernel=$KERNEL --initrd=$INITRD  --copy-default --title "<%= @host.operatingsystem %>" --make-default  --args="ks=<%= foreman_url("provision")%>"
+grubby --add-kernel=$KERNEL --initrd=$INITRD  --copy-default --title "<%= @host.operatingsystem %>" --make-default  --args="ks=<%= foreman_url('provision')%>"

--- a/app/views/unattended/snippets/_epel.erb
+++ b/app/views/unattended/snippets/_epel.erb
@@ -7,14 +7,14 @@ name: epel
   epel_url = "http://dl.fedoraproject.org/pub/epel/$major/$arch/epel-release-$os.noarch.rpm"
 
   case @host.operatingsystem.major
-  when "4"
-  epel_url.gsub!("$os","4-10")
-  when "5"
-  epel_url.gsub!("$os","5-4")
-  when "6"
-  epel_url.gsub!("$os","6-8")
+  when '4'
+  epel_url.gsub!("$os",'4-10')
+  when '5'
+  epel_url.gsub!("$os",'5-4')
+  when '6'
+  epel_url.gsub!("$os",'6-8')
   else
-  ""
+  ''
   end
 -%>
 su -c 'rpm -Uvh <%= @host.os.medium_uri(@host, epel_url) %>'

--- a/app/views/unattended/snippets/_puppet.conf.erb
+++ b/app/views/unattended/snippets/_puppet.conf.erb
@@ -3,7 +3,7 @@ kind: snippet
 name: puppet.conf
 %>
 [main]
-<% if @host.operatingsystem.name == "FreeBSD" -%>
+<% if @host.operatingsystem.name == 'FreeBSD' -%>
 vardir = /var/puppet
 logdir = \$vardir/log
 <% else -%>

--- a/app/views/unattended/snippets/_redhat_register.erb
+++ b/app/views/unattended/snippets/_redhat_register.erb
@@ -5,32 +5,32 @@ name: redhat_register
 # Red Hat Registration Snippet
 #
 # Usage, set these params:
-#   spacewalk_type = "site"     (local Spacewalk/Satellite server)
-#                  = "hosted"   (RHN hosted)
+#   spacewalk_type = 'site'     (local Spacewalk/Satellite server)
+#                  = 'hosted'   (RHN hosted)
 #   spacewalk_host = <hostname> (hostname of Spacewalk server, optional for
 #                                RHN hosted)
 #   activation_key = <key>      (activation key string)
 #
 
 <%
-if @host.params["activation_key"]
-    type = @host.params["spacewalk_type"] || "hosted"
+if @host.params['activation_key']
+    type = @host.params['spacewalk_type'] || 'hosted'
 -%>
-# Discovered Activation Key <%= @host.params["activation_key"] %>
-rhn_activation_key="<%= @host.params["activation_key"] -%>"
+# Discovered Activation Key <%= @host.params['activation_key'] %>
+rhn_activation_key="<%= @host.params['activation_key'] -%>"
 
 <% if type == "site" -%>
-satellite_hostname="<%= @host.params["spacewalk_host"] -%>"
+satellite_hostname="<%= @host.params['spacewalk_host'] -%>"
 rhn_cert_file="RHN-ORG-TRUSTED-SSL-CERT"
 <% else -%>
-satellite_hostname="<%= @host.params["spacewalk_host"] || "xmlrpc.rhn.redhat.com" -%>"
+satellite_hostname="<%= @host.params['spacewalk_host'] || 'xmlrpc.rhn.redhat.com' -%>"
 rhn_cert_file="RHNS-CA-CERT"
 <% end -%>
 
 echo "Registering to RHN Satellite at [$satellite_hostname]"
 echo "Using Registration Key [$rhn_activation_key]"
 
-<% if type == "site" -%>
+<% if type == 'site' -%>
 # Obtain our RHN Satellite Certificate
 echo "Obtaining RHN SSL certificate"
 wget http://$satellite_hostname/pub/$rhn_cert_file -O /usr/share/rhn/$rhn_cert_file
@@ -66,6 +66,6 @@ else
 fi
 # Done!
 <% else -%>
-# Not registering - host.params["activation_key"] not found.
+# Not registering - host.params['activation_key'] not found.
 <% end -%>
 # End Red Hat Registration Snippet

--- a/app/views/unattended/ztp/ZTP.erb
+++ b/app/views/unattended/ztp/ZTP.erb
@@ -1,25 +1,17 @@
 <%#
 kind: ZTP
 name: Community Junos ZTP Config
-%>
+-%>
 system {
     host-name <%= @host.shortname %>;
     root-authentication {
       encrypted-password "<%= root_pass %>"; ## SECRET-DATA
-    }
-    static-host-mapping {
-        <%= Setting['foreman_url'] %> alias ztpserver;
     }
     services {
         ssh;
         netconf {
             ssh;
         }
-    }
-    ntp {
-        boot-server 0.pool.ntp.org;
-        server 0.pool.ntp.org;
-        server 1.pool.ntp.org;
     }
     syslog {
         user * {
@@ -53,7 +45,7 @@ event-options {
         then {
             execute-commands {
                 commands {
-                    "op url <%= foreman_url("provision")%>.slax";
+                    "op url <%= foreman_url('provision')%>.slax";
                 }
             }
         }

--- a/app/views/unattended/ztp/disklayout.erb
+++ b/app/views/unattended/ztp/disklayout.erb
@@ -1,0 +1,5 @@
+<%#
+kind: ptable
+name: Community Junos Fake-Disklayout
+%>
+# Not required for Junos ZTP provisioning.

--- a/app/views/unattended/ztp/finish.erb
+++ b/app/views/unattended/ztp/finish.erb
@@ -1,20 +1,23 @@
 <%#
 kind: finish
 name: Community Junos Finish
-%>
+-%>
 system {
     host-name <%= @host %>;
-    #time-zone Europe/Berlin;
+    time-zone <%= @host.params['time-zone'] || 'Etc/UTC' %>;
     root-authentication {
         encrypted-password "<%= root_pass %>"; ## SECRET-DATA
     }
-    static-host-mapping {
-        <%= Setting['foreman_url'] %> alias ztpserver;
+    name-server {
+        <%= @host.subnet.dns_primary || '8.8.8.8' %>;
+        <% if @host.subnet.dns_secondary -%>
+        <%= @host.subnet.dns_secondary %>;
+        <% end -%>
     }
-    #name-server {
-    #    10.0.0.1;
-    #    10.10.0.1;
-    #}
+    ntp {
+        boot-server <%= @host.params['ntp-server'] || '0.pool.ntp.org' %>;
+        server <%= @host.params['ntp-server'] || '0.pool.ntp.org' %>;
+    }
     login {
         message "This device was provisioned by using The Foreman!\nSee http://theforeman.org/ for further information.\n";
         class automation {
@@ -132,8 +135,8 @@ vlans {
 groups {
     fmztp {
         apply-macro conf {
-            package jinstall-<%= @host.architecture %>-4200-<%= @host.operatingsystem.major %>R<%= @host.operatingsystem.minor %>-domestic-signed.tgz;
-            puppet jpuppet-<%= @host.architecture %>-1.0R1.1.tgz;
+            package jinstall-ex-4200-<%= @host.operatingsystem.major %>R<%= @host.operatingsystem.minor %>-domestic-signed.tgz;
+            puppet jpuppet-ex-1.0R1.1.tgz;
         }
     }
 }

--- a/app/views/unattended/ztp/provision.erb
+++ b/app/views/unattended/ztp/provision.erb
@@ -1,0 +1,498 @@
+<%#
+kind: provision
+name: Community Junos SLAX Provisioning
+-%>
+version 1.0;
+
+/* ------------------------------------------------------------------
+ * LICENSE
+ * ------------------------------------------------------------------
+ *
+ * Copyright (c) 2013, Juniper Networks
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: 
+ *
+ * (1) Redistributions of source code must retain the above copyright notice, this 
+ * list of conditions and the following disclaimer. 
+ *
+ * (2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies, 
+ * either expressed or implied, of Juniper Networks.
+ * 
+ *
+ * ------------------------------------------------------------------
+ * AUTHORS AND CONTRIBUTORS
+ * ------------------------------------------------------------------
+ *
+ * Jeremy Schulman, Juniper Networks
+ * - initial release (https://github.com/jeremyschulman/jctyztp/)
+ *
+ * Frank Wall, noris network AG
+ * - adapt for integration in The Foreman
+ * - fix compatibility with older Junos releases
+ * 
+ *
+ * ------------------------------------------------------------------
+ * LIMITATIONS
+ * ------------------------------------------------------------------
+ *
+ * To maintain backwards compatibility with JunOS 11.x (and maybe 
+ * even 10.x) you MUST AVOID all of these:
+ * - global variable $junos-context (introduced with Junos 11.1)
+ * - mutable variables (introduced with JunOS 12.2 -> SLAX 1.1)
+ * - native functions (introduced with JunOS 12.2 -> SLAX 1.1)
+ *
+ * ------------------------------------------------------------------
+ */
+
+/* ------------------------------------------------------------------ */
+/* XML namespaces                                                     */
+/* ------------------------------------------------------------------ */
+
+/* Juniper */
+ns junos = "http://xml.juniper.net/junos/*/junos";
+ns xnm = "http://xml.juniper.net/xnm/1.1/xnm";
+ns jcs = "http://xml.juniper.net/junos/commit-scripts/1.0";
+ns ztp = "http://xml.juniper.net/junos/ztp";
+
+/* EXSLT */
+ns exsl extension = "http://exslt.org/common";
+ns func extension = "http://exslt.org/functions";
+ns str extension = "http://exslt.org/strings";
+
+/* private namespace for this script */
+ns jctyztp = "http://xml.juniper.com/jctyztp/1.0";
+ns fmztp = "http://xml.juniper.com/fmztp/1.0";
+
+/* depending on Junos version relative path may be broken */
+/* import '../import/junos.xsl'; */
+import '/usr/libdata/cscript/import/junos.xsl';
+
+/* ------------------------------------------------------------------ */
+/* Script parameters                                                  */
+/* ------------------------------------------------------------------ */
+
+param $server = 'ztpserver';
+param $mediapath = '<%= @mediapath %>';
+
+/* ------------------------------------------------------------------ */
+/* Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+var $APPNAME = 'foreman-ztp';
+var $SYSLOG = 'user.info';
+var $TMPDIR = '/var/tmp';
+var $JUNOS_CONF = '/var/tmp/junos.conf';
+
+var $ZTP_GROUP_NAME = "fmztp";
+var $ZTP_MACRO_NAME = "conf";
+var $ZTP_LOCKFILE = '/tmp/fmztp.lock';
+
+/* ------------------------------------------------------------------ */
+/* Global variables                                                   */
+/* ------------------------------------------------------------------ */
+
+/* Open a connection to the device API */
+var $jnx = jcs:open();
+
+/* ------------------------------------------------------------------ */
+/*                                MAIN                                */ 
+/* ------------------------------------------------------------------ */
+
+match / {
+
+  /* Terminate on connection error */
+  if(not( $jnx )) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ":ERROR: unable to connect to Junos API");
+    expr fmztp:terminate();
+  }
+  
+  var $running = fmztp:only_once();
+  if( $running ) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": start op script: already running, exiting..." );
+    <xsl:message terminate="yes">;
+  }
+  
+  /* if the $JUNOS_CONF file is not on the device, then */
+  /* download it from the server */
+  if(not( fmztp:file-exists( $JUNOS_CONF ))) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": obtaining device config file");
+    var $cp = fmztp:dl_junos_conf();
+  }
+  
+  /* now load $JUNOS_CONF into the candidate configuration so we can */
+  /* extract the ZTP config */
+  var $ztp_conf = fmztp:ld_junos_conf();
+  var $has_version = $ztp_conf/has_version;
+  var $new_package = $ztp_conf/package;
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": preparing update from ", $has_version, " to ", $new_package );
+  
+  /* if we have a version difference, then we will install the new OS */
+  /* and reboot the device.  the $JUNOS_CONF file will be loaded on */
+  /* after the install process completes */
+  if( $ztp_conf/install ) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": Junos install required" );
+    var $os = fmztp:install_os( $ztp_conf );
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": rebooting in 60 seconds" );
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": SCRIPT-END");
+    expr fmztp:reboot( 1 );
+    expr jcs:close( $jnx );
+  }
+  else {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": no Junos install required" );
+    /* puppet agent is only supported on Junos 12.3R2.5 */
+    if( jcs:regex( "12.3R2.5", $ztp_conf/has_version )) {
+	expr jcs:syslog( $SYSLOG, $APPNAME, ": puppet agent install required" );
+	var $puppet = fmztp:install_puppet( $ztp_conf );
+    }
+    else {
+	expr jcs:syslog( $SYSLOG, $APPNAME, ": os version is ", $has_version, ", but puppet agent is only available on 12.3R2.5" );
+    }
+    var $fini = fmztp:finalize();
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": SCRIPT-END");
+    expr jcs:close( $jnx );
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* HTTP Junos configuration file onto the device                      */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:dl_junos_conf">
+{
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": downloading new Junos conf...");
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", '<%= foreman_url("finish") %>');
+
+  var $get = <file-copy> {
+    <source> '<%= foreman_url("finish") %>';
+    <destination> $JUNOS_CONF;
+    <staging-directory> $TMPDIR;
+  };
+
+  var $got = jcs:execute( $jnx, $get );
+
+  if(not( fmztp:file-exists( $JUNOS_CONF ))) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ":ERROR: unable to find new Junos conf at ", $JUNOS_CONF);
+    expr fmztp:terminate();
+  }
+
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Load the $JUNOS_CONF file into the candidate config and extract    */
+/* the ZTP config from the [edit groups] area.  Do *NOT* commit       */
+/* this configuration yet, since we may need to install the OS first  */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:ld_junos_conf">
+{
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": loading new Junos conf...");
+
+  /* get the current version from the configuration file */
+  
+  var $get_cur_ver = <get-configuration database='committed'> { <configuration> { <version>; }};
+  var $got_cur_ver = jcs:execute( $jnx, $get_cur_ver );
+
+  /* now load the configuration file we got from the ztp server */
+  var $do_load = <load-configuration action="override" url=$JUNOS_CONF format="text">;
+  var $did_load = jcs:execute( $jnx, $do_load );
+  if(not( $did_load/load-success )) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ":ERROR: unable to load config ", $JUNOS_CONF );
+    expr fmztp:terminate();
+  }
+  
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": extracting Junos config parameters...");
+  var $get = <get-configuration> { <configuration> {
+    <version>;
+    <groups> { <name> $ZTP_GROUP_NAME;
+      <apply-macro> { <name> $ZTP_MACRO_NAME;
+      }
+    }
+  }};
+  
+  var $got = jcs:execute( $jnx, $get );
+
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": package: ", $got//data[name = 'package']/value);
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", $mediapath);
+
+  /* create a node-set to store the following elements             */
+  /* has_version = current Junos version string                    */
+  /* package = filename of Junos package (*.tgz)                   */
+  /* mediapath = URL where package is obtained from                */
+  /* install = present if a install is requeired                   */
+  var $ver = $got_cur_ver/version;
+  var $package = $got//data[name = 'package']/value;
+  var $puppet = $got//data[name = 'puppet']/value;
+  var $conf := {
+    <has_version> $ver; 
+    <package> $package;
+    <puppet> $puppet;
+    <url> $mediapath;
+    if(not( jcs:regex( $ver, $package ))) {
+      <install>;
+    }
+  }
+
+  /* @@@ should put some trap here on ensuring that the config */
+  /* @@@ file actually had the correct group/macro defined */
+    
+  <func:result select="$conf">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Junos Software Installation - download the software from the HTTP  */
+/* server and perform the 'request system software add' operation     */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:install_os">
+{
+  param $ztp_conf;
+
+  var $local_image = $TMPDIR _ "/" _ $ztp_conf/package;
+  
+  if( fmztp:file-exists( $local_image )) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": junos image exists, no download needed" );
+  }
+  else {
+  
+    /* request system storage cleanup */
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": cleaning filesystem" );
+    var $clean = jcs:execute( $jnx, 'request-system-storage-cleanup' ); 
+
+    /* file copy .... */
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": downloading junos image..." );    
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", $ztp_conf/url, $ztp_conf/package );
+    var $do_copy = <file-copy> {
+      <source> $ztp_conf/url _ $ztp_conf/package;
+      <destination> $TMPDIR;
+      <staging-directory> $TMPDIR;
+    };
+    var $did_copy = jcs:execute( $jnx, $do_copy );
+    
+    /* trap error here */
+    if( not(fmztp:file-exists( $local_image )) ) {
+        expr jcs:syslog( $SYSLOG, $APPNAME, ": ERROR: unable to download junos image" );
+        expr fmztp:terminate();
+    }
+  }
+  
+  /* request system software add ... */
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": installing junos image" );    
+  var $do_install = <request-package-add> {
+    <no-validate>;
+    <package-name> $local_image;
+  };
+  var $did_install = jcs:execute( $jnx, $do_install );
+  /* @@@ need to trap error here on $did_install */
+  
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": completed installing junos image" );
+   
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Reboot the device given a delay, in minutes                        */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:reboot">
+{
+  param $in_min;
+
+  var $do_reboot = <request-reboot> { <in> $in_min; };
+  var $did_reboot = jcs:execute( $jnx, $do_reboot );
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Puppet Agent Installation - download the software from the HTTP    */
+/* server and perform the 'request system software add' operation     */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:install_puppet">
+{
+  param $ztp_conf;
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": starting puppet installation..." );
+
+  if (fmztp:is-installed("puppet")) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": package puppet is already installed" );
+    <func:result select="true()">;
+  }
+
+  var $local_image = $TMPDIR _ "/" _ $ztp_conf/puppet;
+  
+  if( fmztp:file-exists( $local_image )) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": package puppet exists, no download needed" );
+  }
+  else {
+  
+    /* request system storage cleanup */
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": cleaning filesystem" );
+    var $clean = jcs:execute( $jnx, 'request-system-storage-cleanup' ); 
+
+    /* file copy .... */
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": downloading puppet image..." );    
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", $ztp_conf/url, $ztp_conf/puppet );    
+    var $do_copy = <file-copy> {
+      <source> $ztp_conf/url _ $ztp_conf/puppet;
+      <destination> $TMPDIR;
+      <staging-directory> $TMPDIR;
+    };
+    var $did_copy = jcs:execute( $jnx, $do_copy );
+    
+    /* trap error on $did_copy */
+    if( not(fmztp:file-exists( $local_image )) ) {
+      expr jcs:syslog( $SYSLOG, $APPNAME, ": ERROR: failed to download puppet image" );
+      expr fmztp:terminate();
+    }
+  }
+
+  /* request system software add ... */
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": installing puppet image" );    
+  var $do_install = <request-package-add> {
+    <no-validate>;
+    <package-name> $local_image;
+  };
+  var $did_install = jcs:execute( $jnx, $do_install );
+  
+  /* NOTE: To complete the puppet installation you need to take manual steps, see:
+   *       http://www.juniper.net/techpubs/en_US/release-independent/junos-puppet/information-products/pathway-pages/index.html
+   */
+
+  /* validate installation */
+  if (not(fmztp:is-installed("puppet"))) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": ERROR: failed to install package puppet" );
+    expr fmztp:terminate();
+  }
+
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": completed installing puppet image" );
+   
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Finalize the ZTP process; i.e. after the OS is correct.  Remove    */
+/* the $JUNOS_CONF file and committing the configuration to make      */
+/* it active.                                                         */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:finalize">
+{
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": deleting temp config file...");  
+  var $rm1 = fmztp:file-delete( $JUNOS_CONF );
+
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": sending finish signal to foreman...");  
+  var $do_foreman = <file-copy> {
+      <source> '<%= foreman_url %>';
+      <destination> "/tmp";
+      <staging-directory> "/tmp";
+  };
+  var $did_foreman = jcs:execute( $jnx, $do_foreman );
+
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": deleting ztp lock file...");  
+  var $rm2 = fmztp:file-delete( $ZTP_LOCKFILE );
+
+  /* commit the configuration that was previously loaded */  
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": committing configuration...");  
+  var $commit = jcs:execute( $jnx, 'commit-configuration' );
+  if( $commit//self::xnm:error ) {
+    expr jcs:syslog( $SYSLOG, $APPNAME, ":ERROR: unable to commit configuration: ", $commit//self::xnm:error/message );
+    var $die = fmztp:terminate();
+  }
+
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper routine: check to see if a file exists on the device,       */
+/* returns [ true | false ]                                           */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:file-exists">
+{
+  param $filename;
+  var $ls_file = <file-list> { <path> $filename; };
+  var $ls_got = jcs:execute( $jnx, $ls_file );
+  var $retval = boolean( $ls_got//file-information );
+
+  <func:result select="$retval">;
+}
+
+<func:function name="fmztp:file-delete">
+{
+  param $filename;
+  var $do_rm = <file-delete> { <path> $filename; };
+  var $did_rm = jcs:execute( $jnx, $do_rm );
+  /* @@@ trap error */
+  
+  <func:result select="true()">;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper routine: create a lockfile to make sure the script only     */
+/* runs once, and terminate if it is already running.                 */
+/* returns [ true | false ]                                           */
+/* ------------------------------------------------------------------ */
+
+<func:function name="fmztp:only_once">
+{
+  if( fmztp:file-exists( $ZTP_LOCKFILE )) {
+    <func:result select="true()">;
+  }
+  else {
+    var $do_lock = <file-put> {
+      <filename> $ZTP_LOCKFILE;
+      <encoding> 'ascii';
+      <file-contents> 'locked';
+    };
+    var $did_lock = jcs:execute( $jnx, $do_lock );
+    <func:result select="false()">;
+  }
+}
+
+<func:function name="fmztp:terminate">
+{
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": SCRIPT-FAILED" );
+  var $rm_lock = fmztp:file-delete( $ZTP_LOCKFILE );
+  <xsl:message terminate="yes">;
+}
+
+/* ------------------------------------------------- */
+/* check if software package is installed            */
+/* ------------------------------------------------- */
+<func:function name="fmztp:is-installed">
+{
+  param $string;
+
+  var $do_query = <get-software-information>;
+  var $did_query = jcs:execute( $jnx, $do_query );
+
+  if( jcs:regex( $string, $did_query )) {
+    expr jcs:output("package found: ", $string);
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": package found: ", $string);
+    <func:result select="true()">;
+  }
+  else {
+    expr jcs:output("package NOT found: ", $string);
+    expr jcs:syslog( $SYSLOG, $APPNAME, ": package NOT found: ", $string);
+    <func:result select="false()">;
+  }
+}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,7 +50,8 @@ Ptable.without_auditing do
     { :name => 'Jumpstart mirrored', :os_family => 'Solaris', :source => 'jumpstart/disklayout_mirrored.erb' },
     { :name => 'Kickstart default', :os_family => 'Redhat', :source => 'kickstart/disklayout.erb' },
     { :name => 'Preseed default', :os_family => 'Debian', :source => 'preseed/disklayout.erb' },
-    { :name => 'Preseed custom LVM', :os_family => 'Debian', :source => 'preseed/disklayout_lvm.erb' }
+    { :name => 'Preseed custom LVM', :os_family => 'Debian', :source => 'preseed/disklayout_lvm.erb' },
+    { :name => 'Junos default fake', :os_family => 'Junos', :source => 'ztp/disklayout.erb' }
   ].each do |input|
     next if Ptable.find_by_name(input[:name])
     next if audit_modified? Ptable, input[:name]
@@ -87,6 +88,7 @@ ConfigTemplate.without_auditing do
     { :name => 'Preseed default iPXE', :source => 'preseed/iPXE.erb', :template_kind => kinds[:iPXE] },
     { :name => 'Preseed default user data', :source => 'preseed/userdata.erb', :template_kind => kinds[:user_data] },
     { :name => 'WAIK default PXELinux', :source => 'waik/PXELinux.erb', :template_kind => kinds[:PXELinux], :operatingsystems => os_windows },
+    { :name => "Junos default SLAX", :source => 'ztp/provision.erb', :template_kind => kinds[:provision], :operatingsystems => os_junos },
     { :name => "Junos default ZTP config", :source => 'ztp/ZTP.erb', :template_kind => kinds[:ZTP], :operatingsystems => os_junos },
     { :name => "Junos default finish", :source => 'ztp/finish.erb', :template_kind => kinds[:finish], :operatingsystems => os_junos },
     # snippets

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -79,7 +79,7 @@ namespace :puppet do
       # the on-disk puppet installation
       begin
         puts "Evaluating possible changes to your installation" unless args.batch
-        importer = PuppetClassImporter.new({ :url => proxy.url, :env => arg.envname })
+        importer = PuppetClassImporter.new({ :url => proxy.url, :env => args.envname })
         changes  = importer.changes
       rescue => e
         if args.batch

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -59,7 +59,7 @@ namespace :puppet do
   namespace :import do
     desc "
     Update puppet environments and classes. Optional batch flag triggers run with no prompting\nUse proxy=<proxy name> to import from or get the first one by default"
-    task :puppet_classes,  [:batch] => :environment do | t, args |
+    task :puppet_classes,  [:batch, :envname] => :environment do | t, args |
       args.batch = args.batch == "true"
 
       proxies = SmartProxy.puppet_proxies
@@ -79,7 +79,7 @@ namespace :puppet do
       # the on-disk puppet installation
       begin
         puts "Evaluating possible changes to your installation" unless args.batch
-        importer = PuppetClassImporter.new({ :url => proxy.url })
+        importer = PuppetClassImporter.new({ :url => proxy.url, :env => arg.envname })
         changes  = importer.changes
       rescue => e
         if args.batch

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -22,8 +22,8 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
   test "should contain only the specified environment in changes" do
     proxy = smart_proxies(:puppetmaster)
     importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
-    assert !importer.changes['new']['foreman-testing'].nil?
-    assert importer.changes['new']['foreman-testing-1'].nil?
+    assert !importer.changes['new']['foreman-testing'].present
+    assert importer.changes['new']['foreman-testing-1'].present
   end
 
   test "should return list of envs" do

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PuppetClassImporterTest < ActiveSupport::TestCase
 
   def setup
-    ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["foreman-testing"])
+    ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["foreman-testing","foreman-testing-1"])
     ProxyAPI::Puppet.any_instance.stubs(:classes).returns(mocked_classes)
   end
 
@@ -17,6 +17,13 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
     proxy = smart_proxies(:puppetmaster)
     klass = PuppetClassImporter.new(:url => proxy.url)
     assert_kind_of ProxyAPI::Puppet, klass.send(:proxy)
+  end
+
+  test "should contain only the specified environment in changes" do
+    proxy = smart_proxies(:puppetmaster)
+    importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
+    assert !importer.changes['new']['foreman-testing'].nil?
+    assert importer.changes['new']['foreman-testing-1'].nil?
   end
 
   test "should return list of envs" do


### PR DESCRIPTION
This PR allows user to import puppet classes from a specific environment manually, from both GUI and Rake. 

![screenshot1](https://f.cloud.github.com/assets/3453782/2025672/cb5ffc1c-8880-11e3-9fe1-8cf6bc45193b.jpg)

Developers can click a button to sync the classes they recently created/updated/removed in a specific environment to Foreman, without waiting for the lengthy full class/environment sync to be finished by "ruby193-rake puppet:import:puppet_classes[batch]"
