### PR TITLE
fixes #4245 'New window' button for SPICE console does not work

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -227,7 +227,7 @@ module Foreman::Model
       http.use_ssl = (ca_url.scheme == 'https')
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       request = Net::HTTP::Get.new(ca_url.path)
-      http.request(request).to_s
+      http.request(request).body
     end
 
     private


### PR DESCRIPTION
With to_s this is returning something like '#Net::HTTPOK:0x007fbd31708f28' instead of the cert and the connection fails when using the 'New window' button.
