### PR TITLE
fixes #4234 - cannot edit host's puppet parameters

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -113,7 +113,6 @@ class Host::Managed < Host::Base
   # some shortcuts
   alias_attribute :os, :operatingsystem
   alias_attribute :arch, :architecture
-  alias_attribute :fqdn, :name
 
   validates :environment_id, :presence => true
 
@@ -152,6 +151,11 @@ class Host::Managed < Host::Base
 
   def shortname
     domain.nil? ? name : name.chomp("." + domain.name)
+  end
+
+  # we should guarantee the fqdn is always fully qualified
+  def fqdn
+    name.include?('.') ? name : "#{name}.#{domain}"
   end
 
   # method to return the correct owner list for host edit owner select dropbox
@@ -770,8 +774,8 @@ class Host::Managed < Host::Base
         old_domain = Domain.find(changed_attributes["domain_id"])
         self.name.chomp!("." + old_domain.to_s)
       end
-      # if our host is in short name, append the domain name
-      self.name += ".#{domain}" unless name =~ /\./i
+      # name should be fqdn
+      self.name = fqdn
     end
     # A managed host we should know the domain for; and the shortname shouldn't include a period
     errors.add(:name, _("must not include periods")) if managed? and shortname.include? "."

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -112,6 +112,16 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "lookup value has right matcher for a host" do
+    assert_difference('LookupValue.where(:lookup_key_id => lookup_keys(:five).id, :match => "fqdn=abc.mydomain.net").count') do 
+      h = Host.create! :name => "abc", :mac => "aabbecddeeff", :ip => "2.3.4.3",
+        :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat),
+        :subnet => subnets(:one), :architecture => architectures(:x86_64), :puppet_proxy => smart_proxies(:puppetmaster),
+        :environment => environments(:production), :disk => "empty partition",
+        :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lookup_keys(:five).id, "value"=>"some_value"}}
+    end
+  end
+
   test "should import facts from json stream" do
     h=Host.new(:name => "sinn1636.lan")
     h.disk = "!" # workaround for now


### PR DESCRIPTION
The lookup_value_match is getting "fqdn" before the normalize_hostname validation runs,  so we should make sure fqdn is always really fully qualified.
