### PR TITLE
Re-submitting #1204 - allow puppet classes to be imported by environment

### DIFF
--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -6,6 +6,7 @@ module Foreman::Controller::Environments
   def import_environments
     begin
       opts      = params[:proxy].blank? ? { } : { :url => SmartProxy.find(params[:proxy]).try(:url) }
+      opts[:env] = params[:env] unless params[:env].blank?
       @importer = PuppetClassImporter.new(opts)
       @changed  = @importer.changes
     rescue => e

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -19,6 +19,11 @@ module PuppetclassesAndEnvironmentsHelper
     )
   end
 
+  def import_proxy_link hash, env
+    proxy = SmartProxy.puppet_proxies.first
+    display_link_if_authorized(_("Import #{env} from %s") % proxy.name, hash.merge(:proxy => proxy, :env => env))
+  end
+
   private
   def pretty_print classes
     hash = { }
@@ -33,7 +38,5 @@ module PuppetclassesAndEnvironmentsHelper
     hash.keys.sort.map do |key|
       link_to key,{}, {:remote => true, :rel => "popover", :data => {"content" => hash[key].sort.join('<br>').html_safe, "original-title" => key}}
     end.to_sentence.html_safe
-
   end
-
 end

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -21,7 +21,7 @@ module PuppetclassesAndEnvironmentsHelper
 
   def import_proxy_link hash, env
     proxy = SmartProxy.puppet_proxies.first
-    display_link_if_authorized(_("Import #{env} from %s") % proxy.name, hash.merge(:proxy => proxy, :env => env))
+    display_link_if_authorized(_("Import %{env} from %{proxy}") % {:env => env, :proxy => proxy.name}, hash.merge(:proxy => proxy, :env => env))
   end
 
   private

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -12,16 +12,13 @@ module PuppetclassesAndEnvironmentsHelper
   end
 
   def import_proxy_select hash
-    select_action_button( _('Import'), {},
-      SmartProxy.puppet_proxies.map do |proxy|
-        display_link_if_authorized(_("Import from %s") % proxy.name, hash.merge(:proxy => proxy), :class=>'btn btn-default')
-      end.flatten
-    )
+    select_action_button( _('Import'), {}, import_proxy_links(hash))
   end
 
-  def import_proxy_link hash, env
-    proxy = SmartProxy.puppet_proxies.first
-    display_link_if_authorized(_("Import %{env} from %{proxy}") % {:env => env, :proxy => proxy.name}, hash.merge(:proxy => proxy, :env => env))
+  def import_proxy_links hash
+    SmartProxy.puppet_proxies.map do |proxy|
+      display_link_if_authorized(_("Import from %s") % proxy.name, hash.merge(:proxy => proxy), :class=>'btn btn-default')
+    end.flatten
   end
 
   private

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -16,7 +16,8 @@
       </td>
       <td><%= link_to @host_counter[environment.id] || 0, hosts_path(:search => "environment = #{environment}") %>
       <td>
-        <%= action_buttons(link_to(_('Classes'), puppetclasses_path(:search => "environment = #{environment}")),
+        <%= action_buttons(import_proxy_link(hash_for_import_environments_environments_path, environment.name),
+                           link_to(_("Classes"), puppetclasses_path(:search => "environment = #{environment}")),
                            display_delete_if_authorized(hash_for_environment_path(:id => environment.name), :confirm => "Delete #{environment.name}?")) %>
       </td>
     </tr>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -16,7 +16,7 @@
       </td>
       <td><%= link_to @host_counter[environment.id] || 0, hosts_path(:search => "environment = #{environment}") %>
       <td>
-        <%= action_buttons(import_proxy_link(hash_for_import_environments_environments_path, environment.name),
+        <%= action_buttons(import_proxy_links(hash_for_import_environments_environments_path(:env => environment.name)),
                            link_to(_("Classes"), puppetclasses_path(:search => "environment = #{environment}")),
                            display_delete_if_authorized(hash_for_environment_path(:id => environment.name), :confirm => "Delete #{environment.name}?")) %>
       </td>

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -79,7 +79,7 @@ namespace :puppet do
       # the on-disk puppet installation
       begin
         puts "Evaluating possible changes to your installation" unless args.batch
-        importer = PuppetClassImporter.new({ :url => proxy.url, :env => arg.envname })
+        importer = PuppetClassImporter.new({ :url => proxy.url, :env => args.envname })
         changes  = importer.changes
       rescue => e
         if args.batch

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -59,7 +59,7 @@ namespace :puppet do
   namespace :import do
     desc "
     Update puppet environments and classes. Optional batch flag triggers run with no prompting\nUse proxy=<proxy name> to import from or get the first one by default"
-    task :puppet_classes,  [:batch] => :environment do | t, args |
+    task :puppet_classes,  [:batch, :envname] => :environment do | t, args |
       args.batch = args.batch == "true"
 
       proxies = SmartProxy.puppet_proxies
@@ -79,7 +79,7 @@ namespace :puppet do
       # the on-disk puppet installation
       begin
         puts "Evaluating possible changes to your installation" unless args.batch
-        importer = PuppetClassImporter.new({ :url => proxy.url })
+        importer = PuppetClassImporter.new({ :url => proxy.url, :env => arg.envname })
         changes  = importer.changes
       rescue => e
         if args.batch

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -22,8 +22,8 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
   test "should contain only the specified environment in changes" do
     proxy = smart_proxies(:puppetmaster)
     importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
-    assert !importer.changes['new']['foreman-testing'].nil?
-    assert importer.changes['new']['foreman-testing-1'].nil?
+    assert !importer.changes['new']['foreman-testing'].present
+    assert importer.changes['new']['foreman-testing-1'].present
   end
 
   test "should return list of envs" do

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -22,8 +22,8 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
   test "should contain only the specified environment in changes" do
     proxy = smart_proxies(:puppetmaster)
     importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
-    assert !importer.changes['new']['foreman-testing'].present
-    assert importer.changes['new']['foreman-testing-1'].present
+    assert importer.changes['new'].include?('foreman-testing')
+    assert !importer.changes['new'].include?('foreman-testing-1')
   end
 
   test "should return list of envs" do

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PuppetClassImporterTest < ActiveSupport::TestCase
 
   def setup
-    ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["foreman-testing"])
+    ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["foreman-testing","foreman-testing-1"])
     ProxyAPI::Puppet.any_instance.stubs(:classes).returns(mocked_classes)
   end
 
@@ -17,6 +17,13 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
     proxy = smart_proxies(:puppetmaster)
     klass = PuppetClassImporter.new(:url => proxy.url)
     assert_kind_of ProxyAPI::Puppet, klass.send(:proxy)
+  end
+
+  test "should contain only the specified environment in changes" do
+    proxy = smart_proxies(:puppetmaster)
+    importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
+    assert !importer.changes['new']['foreman-testing'].nil?
+    assert importer.changes['new']['foreman-testing-1'].nil?
   end
 
   test "should return list of envs" do


### PR DESCRIPTION
This PR allows user to import puppet classes from a specific environment manually, from both GUI and Rake.

![screenshot1](https://f.cloud.github.com/assets/3453782/2096036/de48bce2-8ef7-11e3-9691-b2d82a8293e6.jpg)

Developers can click a button to sync the classes they recently created/updated/removed in a specific environment to Foreman, without waiting for the lengthy full class/environment sync to be finished by "ruby193-rake puppet:import:puppet_classes[batch]"
