### PR TITLE
fixes #2776 - smart class parameter override fails validation

### DIFF
--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -35,11 +35,11 @@ class LookupValue < ActiveRecord::Base
   end
 
   def validate_and_cast_value
-    return true if self.marked_for_destruction?
+    return true if self.marked_for_destruction? or !self.value.is_a? String
     begin
       self.value = lookup_key.cast_validate_value self.value
       true
-    rescue
+    rescue StandardError, SyntaxError => e
       errors.add(:value, _("is invalid %s") % lookup_key.key_type)
       false
     end

--- a/test/fixtures/lookup_keys.yml
+++ b/test/fixtures/lookup_keys.yml
@@ -58,3 +58,12 @@ five_same_name:
   path: 'organization,location'
   override: true
   is_param: true
+
+six:
+  key: yaml_test
+  key_type: yaml
+  validator_rule: 
+  default_value: "--- \nfoo: bar\n"
+  path: 'organization,location'
+  override: true
+  is_param: true

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -127,4 +127,20 @@ class LookupKeyTest < ActiveSupport::TestCase
     end
   end
 
+  test "smart class parameter accepts valid data" do
+    as_admin do
+      lk = LookupValue.new(:value => "---\nfoo:\n  bar: baz", :match => "hostgroup=Common", :lookup_key => lookup_keys(:six))
+      assert lk.valid?
+      assert lk.save!
+    end
+  end
+
+  test "smart class parameter validation detects invalid data" do
+    as_admin do
+      lk = LookupValue.new(:value => "---\n[[\n;", :match => "hostgroup=Common", :lookup_key => lookup_keys(:six))
+      refute lk.valid?
+      assert lk.errors.messages[:value].include? "is invalid yaml"
+    end
+  end
+
 end


### PR DESCRIPTION
validate_and_cast_value in lookup_value.rb is being called twice.  In the second run, the yaml is already cast to a native data type.  YAML.load(YAML.load(value)) fails of course.

I suspect the culprit is Rails calling before_validation twice?

This makes sure we don't try to cast a native data type other than String here, which fixes the problem.
