### PR TITLE
fixes #4289 - fix issue deleting lookup values for hosts

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -28,7 +28,7 @@ module HostCommon
       lookup_values_attributes.each_value do |attribute|
         attr = attribute.dup
         if attr.has_key? :id
-          lookup_value = lookup_values.find attr.delete(:id)
+          lookup_value = LookupValue.where(:id => attr.delete(:id)).first
           if lookup_value
             mark_for_destruction = ActiveRecord::ConnectionAdapters::Column.value_to_boolean attr.delete(:_destroy)
             lookup_value.attributes = attr


### PR DESCRIPTION
I do not really understand why the original line is not working. If I change it to find_by_id I get the error message below. I'm not sure why it is looking for managed_id and id, but this change works around it and I am then able to delete lookup_values from the host edit. Maybe there is a better solution?

"Operation FAILED: Mysql2::Error: Unknown column 'lookup_values.managed_id' in 'where clause': SELECT  `lookup_values`.\* FROM `lookup_values`  WHERE `lookup_values`.`managed_id` = 1 AND `lookup_values`.`id` = 1 LIMIT 1"
