### PR TITLE
fixes #4298 - ldap auth should accept parens in firstname or surname

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ActiveRecord::Base
   validates :auth_source_id, :presence => true
   validates :password_hash, :presence => true, :if => Proc.new {|user| user.manage_password?}
   validates_confirmation_of :password,  :if => Proc.new {|user| user.manage_password?}, :unless => Proc.new {|user| user.password.empty?}
-  validates :firstname, :lastname, :format => {:with => /\A[[:alnum:]\s'_\-\.]*\Z/}, :length => {:maximum => 30}, :allow_nil => true
+  validates :firstname, :lastname, :format => {:with => /\A[[:alnum:]\s'_\-\.()<>;=,]*\z/}, :length => {:maximum => 50}, :allow_nil => true
 
   validate :name_used_in_a_usergroup, :ensure_admin_is_not_renamed, :ensure_admin_remains_admin,
            :ensure_privileges_not_escalated

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -43,7 +43,7 @@ class UserTest < ActiveSupport::TestCase
     @user.firstname = "The Riddle?"
     assert !@user.save
 
-    @user.firstname = " _''. - nah"
+    @user.firstname = "C_r'a-z.y( )<,Na=me;>"
     assert @user.save
   end
 
@@ -51,17 +51,17 @@ class UserTest < ActiveSupport::TestCase
     @user.lastname = "it's the JOKER$$$"
     assert !@user.save
 
-    @user.lastname = " _''. - nah"
+    @user.lastname = "C_r'a-z.y( )<,Na=me;>"
     assert @user.save
   end
 
-  test "firstname should not exceed the 30 characters" do
-    @user.firstname = "a" * 31
+  test "firstname should not exceed the 50 characters" do
+    @user.firstname = "a" * 51
     assert !@user.save
   end
 
-  test "lastname should not exceed the 30 characters" do
-    @user.firstname = "a" * 31
+  test "lastname should not exceed the 50 characters" do
+    @user.firstname = "a" * 51
     assert !@user.save
   end
 


### PR DESCRIPTION
Support for special characters allowed by RFC2253 (except line breaks).  

30 chars also seemed small - e.g. Ahmadinejad (President of Iran) and viola, you're over the limit.
