### PR TITLE
fixes #4201 - update operating system by label

### DIFF
--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -74,6 +74,12 @@ module Api
         render :json => e.to_s, :status => :unprocessable_entity
       end
 
+      protected
+
+      def resource_identifying_attributes
+        %w(to_label id)
+      end
+
     end
   end
 end

--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -44,4 +44,5 @@ class OperatingsystemsController < ApplicationController
       process_error
     end
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,14 +240,14 @@ Foreman::Application.routes.draw do
           get 'auto_complete_search'
         end
       end
-    end
 
-    resources :operatingsystems, :except => [:show] do
-      member do
-        get 'bootfiles'
-      end
-      collection do
-        get 'auto_complete_search'
+      resources :operatingsystems, :except => [:show] do
+        member do
+          get 'bootfiles'
+        end
+        collection do
+          get 'auto_complete_search'
+        end
       end
     end
     resources :media, :except => [:show] do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -71,14 +71,16 @@ Foreman::Application.routes.draw do
 
       resources :models, :except => [:new, :edit]
 
-      resources :operatingsystems, :except => [:new, :edit] do
-        get :bootfiles, :on => :member
-        resources :parameters, :except => [:new, :edit] do
-          collection do
-            delete '/', :to => :reset
+      constraints(:id => /[^\/]+/) do
+        resources :operatingsystems, :except => [:new, :edit] do
+          get :bootfiles, :on => :member
+          resources :parameters, :except => [:new, :edit] do
+            collection do
+              delete '/', :to => :reset
+            end
           end
+          resources :os_default_templates, :except => [:new, :edit]
         end
-        resources :os_default_templates, :except => [:new, :edit]
       end
 
       resources :puppetclasses, :except => [:new, :edit] do

--- a/test/fixtures/operatingsystems.yml
+++ b/test/fixtures/operatingsystems.yml
@@ -14,6 +14,7 @@ redhat:
   major: 6
   minor: 1
   type: Redhat
+  description: RHEL 6.1
   ptables: one
   architectures: x86_64
   media: one

--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -21,7 +21,6 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:operatingsystem)
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
-
   end
 
   test "should create os" do
@@ -31,7 +30,6 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:operatingsystem)
   end
-
 
   test "should not create os without version" do
     assert_difference('Operatingsystem.count', 0) do
@@ -70,6 +68,18 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
                    }
     end
     assert_response :success
+  end
+
+  test "should show os if id is fullname" do
+    get :show, { :id => operatingsystems(:redhat).fullname }
+    assert_response :success
+    assert_equal operatingsystems(:redhat), assigns(:operatingsystem)
+  end
+
+  test "should show os if id is description" do
+    get :show, { :id => operatingsystems(:redhat).description }
+    assert_response :success
+    assert_equal operatingsystems(:redhat), assigns(:operatingsystem)
   end
 
 end


### PR DESCRIPTION
operatingsystem_names uses `to_label` which returns description if it exists or fullname (name, major, minor)
