### PR TITLE
fixes #4307 New VMware VM creation does not respect NIC type selection

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -95,11 +95,6 @@ module Foreman::Model
     def create_vm args = { }
       dc_networks = networks
       args["interfaces_attributes"].each do |key, interface|
-        # Convert interface type to RbVmomi class
-        unless nictypes.has_key? interface["type"]
-          raise "Unknown NIC type: #{interface["type"]}"
-        end
-        interface["type"] = ("RbVmomi::VIM::" + interface["type"]).constantize
         # Convert network id into name
         net = dc_networks.find { |n| n.id == interface["network"] }
         raise "Unknown Network ID: #{interface["network"]}" if net.nil?


### PR DESCRIPTION
Fog 1.19.0 now does the constantize for us, the code needs to be removed
