### PR TITLE
fixes: #3596 Validation failed: User has this hostgroup already

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -48,9 +48,9 @@ class HostgroupsController < ApplicationController
     @hostgroup = Hostgroup.new(params[:hostgroup])
     if @hostgroup.save
       # Add the new hostgroup to the user's filters
-      @hostgroup.users << User.current unless User.current.admin? or @hostgroup.users.include?(User.current)
       @hostgroup.users << subscribed_users
       @hostgroup.users << users_in_ancestors
+      @hostgroup.users << User.current unless User.current.admin? or @hostgroup.users.include?(User.current)
       process_success
     else
       load_vars_for_ajax

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -126,6 +126,36 @@ class HostgroupsControllerTest < ActionController::TestCase
     assert_equal one, Hostgroup.find_by_name("second").users.first
   end
 
+  test 'users subscribed to all hostgroups should be always added to hostgroup created by non-admin users' do
+    setup_user 'create'
+    @one.update_attributes(:subscribe_to_all_hostgroups => true)
+    as_admin do
+      @two = users(:two)
+      @two.update_attributes(:subscribe_to_all_hostgroups => true)
+      @two.save!
+    end
+    post :create, { 'hostgroup' => { 'name'=>'first' } }, set_session_user.merge(:user => @one.id)
+    assert_equal 2, Hostgroup.find_by_name('first').users.length
+    assert_equal @one, Hostgroup.find_by_name('first').users.first
+    assert_equal @two, Hostgroup.find_by_name('first').users.last
+  end
+
+  test "users subscribed to all hostgroups should be always added to hostgroup created by non-admin user when the creater is already added to the new hosrgroup's ancestors" do
+    setup_user 'create'
+    as_admin do
+      Hostgroup.new(:name => "root").save
+      Hostgroup.find_by_name("root").users << @one
+      @two = users(:two)
+      @two.update_attributes(:subscribe_to_all_hostgroups => true)
+      @two.save!
+    end
+    post :create, {"hostgroup" => {"name"=>"first" , "parent_id"=> Hostgroup.find_by_name("root").id}},
+                  set_session_user.merge(:user => @one.id)
+    assert_equal 2, Hostgroup.find_by_name('first').users.length
+    assert_equal @one, Hostgroup.find_by_name('first').users.first
+    assert_equal @two, Hostgroup.find_by_name('first').users.last
+  end
+
   test "hostgroup rename changes matcher" do
     hostgroup = hostgroups(:common)
     put :update, {:id => hostgroup.id, :hostgroup => {:name => 'new_common'}}, set_session_user


### PR DESCRIPTION
Fixed the code ordering issue that triggers bug #3596

http://projects.theforeman.org/issues/3596

the bug is triggered when a non-admin user (with "Automatically add new host groups to this use" ticked) creates a new host group.
