### PR TITLE
Bug #3001 - Facts searchable by host id and name

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -3,6 +3,8 @@ module Hostext
     extend ActiveSupport::Concern
 
     included do
+      include ScopedSearchExtensions
+
       has_many :search_parameters, :class_name => 'Parameter', :foreign_key => :reference_id
       belongs_to :search_users, :class_name => 'User', :foreign_key => :owner_id
 
@@ -128,14 +130,6 @@ module Hostext
         end
         conditions.empty? ? [] : "( #{conditions.join(' OR ')} )"
       end
-
-      def value_to_sql(operator, value)
-        return value                 if operator !~ /LIKE/i
-        return value.tr_s('%*', '%') if (value =~ /%|\*/)
-
-        return "%#{value}%"
-      end
-
     end
   end
 end

--- a/app/models/concerns/scoped_search_extensions.rb
+++ b/app/models/concerns/scoped_search_extensions.rb
@@ -1,0 +1,11 @@
+module ScopedSearchExtensions
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def value_to_sql(operator, value)
+      return value                 if operator !~ /LIKE/i
+      return value.tr_s('%*', '%') if (value ~ /%|\*/)
+      return "%#{value}%"
+    end
+  end
+end

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -1,5 +1,7 @@
 class Puppetclass < ActiveRecord::Base
   include Authorizable
+  include ScopedSearchExtensions
+
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   has_many :environment_classes, :dependent => :destroy
   has_many :environments, :through => :environment_classes, :uniq => true
@@ -169,14 +171,6 @@ class Puppetclass < ActiveRecord::Base
 
     puppet_classes = (direct + indirect).uniq
     { :conditions => "puppetclasses.id IN(#{puppet_classes.join(',')})" }
-  end
-
-
-  def self.value_to_sql(operator, value)
-    return value                 if operator !~ /LIKE/i
-    return value.tr_s('%*', '%') if (value ~ /%|\*/)
-
-    return "%#{value}%"
   end
 
 end

--- a/test/functional/api/v1/fact_values_controller_test.rb
+++ b/test/functional/api/v1/fact_values_controller_test.rb
@@ -6,14 +6,23 @@ class Api::V1::FactValuesControllerTest < ActionController::TestCase
     get :index, { }
     assert_response :success
     fact_values = ActiveSupport::JSON.decode(@response.body)
-    assert !fact_values.empty?
+    refute_empty fact_values
   end
 
   test "should get facts for given host only" do
-    get :index, {:host_id => hosts(:one).to_param }
+    get :index, {:host_id => hosts(:one).name }
+    assert_response :success
+    fact_values   = ActiveSupport::JSON.decode(@response.body)
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => hosts(:one).id))
+    assert_equal expected_hash, fact_values
+  end
+
+  test "should get facts for given host id" do
+    get :index, {:host_id => hosts(:one).id }
     assert_response :success
     fact_values = ActiveSupport::JSON.decode(@response.body)
-    assert !fact_values.empty?
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => hosts(:one).id))
+    assert_equal expected_hash, fact_values
   end
 
 end

--- a/test/functional/api/v2/fact_values_controller_test.rb
+++ b/test/functional/api/v2/fact_values_controller_test.rb
@@ -6,14 +6,23 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
     get :index, { }
     assert_response :success
     fact_values = ActiveSupport::JSON.decode(@response.body)
-    assert !fact_values.empty?
+    refute_empty fact_values
   end
 
   test "should get facts for given host only" do
-    get :index, {:host_id => hosts(:one).to_param }
+    get :index, {:host_id => hosts(:one).name }
     assert_response :success
-    fact_values = ActiveSupport::JSON.decode(@response.body)
-    assert !fact_values.empty?
+    fact_values   = ActiveSupport::JSON.decode(@response.body)['results']
+    expected_hash = FactValue.build_facts_hash(FactValue.find_all_by_host_id(hosts(:one).id))
+    assert_equal expected_hash, fact_values
+  end
+
+  test "should get facts for given host id" do
+    get :index, {:host_id => hosts(:one).id }
+    assert_response :success
+    fact_values   = ActiveSupport::JSON.decode(@response.body)['results']
+    expected_hash = FactValue.build_facts_hash(FactValue.find_all_by_host_id(hosts(:one).id))
+    assert_equal expected_hash, fact_values
   end
 
 end


### PR DESCRIPTION
Before, an api call such as foreman/api/v2/host/3232/facts would simply
return no facts, as the `id` field was only searching for a host
name. 

This PR fixes that and now the intermediate `host_id` field
allows to search by name and id by giving the SQL conditions directly to
scoped_search.
