### PR TITLE
fixes #4123 - libvirt imaging support using backing volumes

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -162,6 +162,29 @@ function enable_libvirt_dropdown(item){
   item.show();
 }
 
+function libvirt_image_selected(item){
+  var template = $(item).val();
+  if (template) {
+    var url = $(item).attr('data-url');
+    $(item).indicator_show();
+    $.ajax({
+      type:'post',
+      url: url,
+      data:'template_id=' + template,
+      success: function(result){
+        capacity = $('#storage_volumes').children('.fields').find('[id$=capacity]')[0];
+        if (parseInt(capacity.value.slice(0, -1), 10) < parseInt(result.capacity, 10))
+          capacity.value = result.capacity + 'G';
+        $('#storage_volumes').children('.fields').find('[id$=format_type]')[0].value = 'qcow2';
+      },
+      complete: function(){
+        $(item).indicator_hide();
+        $('[rel="twipsy"]').tooltip();
+      }
+    })
+  }
+}
+
 function ec2_vpcSelected(form){
   sg_select = $('.security_group_ids')
   sg_select.empty();

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -28,6 +28,7 @@ class ImagesController < ApplicationController
   end
 
   def update
+    params[:image].except!(:password) if params[:image][:password].blank?
     if @image.update_attributes(params[:image])
       process_success :success_redirect => compute_resource_path(@compute_resource)
     else

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -1,11 +1,11 @@
 module ImagesHelper
-  def image_field f
+  def image_field f, opts = {}
     return unless @compute_resource.capabilities.include?(:image)
     images = @compute_resource.available_images
     if images.any?
       return select_f(f, :uuid, images.to_a.sort! { |a, b| a.name.downcase <=> b.name.downcase }, :id, :name, {}, :label => _('Image'))
     else
-      text_f f, :uuid, :label => _("Image ID"), :help_inline => _("Image ID as provided by the compute resource, e.g. ami-..")
+      text_f f, :uuid, :label => opts[:label] || _("Image ID"), :help_inline => opts[:help_inline] || _("Image ID as provided by the compute resource, e.g. ami-..")
     end
   end
 end

--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -5,6 +5,8 @@ module FogExtensions
 
       include ActionView::Helpers::NumberHelper
 
+      attr_accessor :image_id
+
       def to_s
         name
       end

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -8,7 +8,7 @@ module Orchestration::DHCP
   end
 
   def dhcp?
-    name.present? and ip.present? and !subnet.nil? and subnet.dhcp? and managed? and capabilities.include?(:build)
+    name.present? && ip_available? && mac_available? && !subnet.nil? && subnet.dhcp? && managed?
   end
 
   def dhcp_record

--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -123,8 +123,4 @@ module Orchestration::DNS
     status
   end
 
-  def ip_available?
-    ip.present? || (capabilities.include?(:image) && compute_resource.provided_attributes.keys.include?(:ip))
-  end
-
 end

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -7,7 +7,7 @@ module Orchestration::SSHProvision
   end
 
   def ssh_provision?
-    compute_attributes.present? && capabilities.include?(:image) && !image.try(:user_data) && provision_method == 'image'
+    compute_attributes.present? && image_build? && !image.try(:user_data)
   end
 
   protected

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -10,7 +10,7 @@ module Orchestration::TFTP
   end
 
   def tftp?
-    !!(subnet and subnet.tftp?) and (operatingsystem and operatingsystem.pxe_variant) and managed? and capabilities.include?(:build) and provision_method != 'image'
+    !!(subnet and subnet.tftp?) and (operatingsystem and operatingsystem.pxe_variant) and managed? and pxe_build?
   end
 
   def tftp

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -2,6 +2,8 @@ class Host::Managed < Host::Base
   include ReportCommon
   include Hostext::Search
 
+  PROVISION_METHODS = %w[build image]
+
   has_many :host_classes, :dependent => :destroy, :foreign_key => :host_id
   has_many :puppetclasses, :through => :host_classes
   belongs_to :hostgroup
@@ -45,7 +47,8 @@ class Host::Managed < Host::Base
   class Jail < ::Safemode::Jail
     allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup, :location,
       :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
-      :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization
+      :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
+      :image_build?, :pxe_build?
   end
 
   attr_reader :cached_host_params
@@ -131,12 +134,14 @@ class Host::Managed < Host::Base
     validates :mac, :presence => true, :unless => Proc.new { |host| host.compute? or !host.managed }
     validates :root_pass, :length => {:minimum => 8, :message => _('should be 8 characters or more')},
                           :presence => {:message => N_('should not be blank - consider setting a global or host group default')},
-                          :unless => Proc.new { |host| !host.managed or capabilities.include?(:image) }
+                          :if => Proc.new { |host| host.managed && pxe_build? }
     validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :if => Proc.new { |host| host.require_ip_validation? }
     validates :ptable_id, :presence => {:message => N_("cant be blank unless a custom partition has been defined")},
-                          :if => Proc.new { |host| host.managed and host.disk.empty? and not defined?(Rake) and host.provision_method != 'image' and capabilities.include?(:build) }
+                          :if => Proc.new { |host| host.managed and host.disk.empty? and not defined?(Rake) and pxe_build? }
     validates :serial, :format => {:with => /[01],\d{3,}n\d/, :message => N_("should follow this format: 0,9600n8")},
                        :allow_blank => true, :allow_nil => true
+    validates :provision_method, :inclusion => {:in => PROVISION_METHODS, :message => N_('is unknown')}, :if => Proc.new {|host| host.managed?}
+    validate :provision_method_in_capabilities
     after_validation :set_compute_attributes
   end
 
@@ -485,7 +490,7 @@ class Host::Managed < Host::Base
   end
 
   def can_be_built?
-    managed? and SETTINGS[:unattended] and capabilities.include?(:build) ? build == false : false
+    managed? and SETTINGS[:unattended] and pxe_build? and !build?
   end
 
   def jumpstart?
@@ -497,7 +502,7 @@ class Host::Managed < Host::Base
     assign_hostgroup_attributes(%w{environment_id domain_id puppet_proxy_id puppet_ca_proxy_id compute_profile_id})
     if SETTINGS[:unattended] and (new_record? or managed?)
       assign_hostgroup_attributes(%w{operatingsystem_id architecture_id})
-      assign_hostgroup_attributes(%w{medium_id ptable_id subnet_id}) if capabilities.include?(:build)
+      assign_hostgroup_attributes(%w{medium_id ptable_id subnet_id}) if pxe_build?
     end
   end
 
@@ -551,10 +556,10 @@ class Host::Managed < Host::Base
     # if it's not managed there's nowhere to specify an IP anyway
     return false unless managed?
     # if the CR will provide an IP, then don't validate yet
-    return false if compute? && compute_resource.provided_attributes.keys.include?(:ip)
+    return false if compute_provides?(:ip)
     ip_for_dns     = (subnet.present? && subnet.dns_id.present?) || (domain.present? && domain.dns_id.present?)
     ip_for_dhcp    = subnet.present? && subnet.dhcp_id.present?
-    ip_for_token   = Setting[:token_duration] == 0 && !capabilities.include?(:image)
+    ip_for_token   = Setting[:token_duration] == 0 && (pxe_build? || (image_build? && image.try(:user_data?)))
     # Any of these conditions will require an IP, so chain with OR
     ip_for_dns or ip_for_dhcp or ip_for_token
   end
@@ -713,6 +718,18 @@ class Host::Managed < Host::Base
     read_attribute(:compute_profile_id) || hostgroup.try(:compute_profile_id)
   end
 
+  def provision_method
+    read_attribute(:provision_method) || capabilities.first.to_s
+  end
+
+  def image_build?
+    self.provision_method == 'image'
+  end
+
+  def pxe_build?
+    self.provision_method == 'build'
+  end
+
   private
 
   def lookup_value_match
@@ -772,7 +789,7 @@ class Host::Managed < Host::Base
         errors.add("#{e}_id".to_sym, _("%{value} does not belong to %{os} operating system") % { :value => value, :os => os })
         status = false
       end
-    end if SETTINGS[:unattended] and managed? and os and capabilities.include?(:build)
+    end if SETTINGS[:unattended] and managed? and os and pxe_build?
 
     puppetclasses.select("puppetclasses.id,puppetclasses.name").uniq.each do |e|
       unless environment.puppetclasses.map(&:id).include?(e.id)
@@ -832,5 +849,9 @@ class Host::Managed < Host::Base
     @tax_organization ||= TaxHost.new(organization, self)
   end
 
+  def provision_method_in_capabilities
+    return unless managed?
+    errors.add(:provision_method, _('is an unsupported provisioning method')) unless capabilities.map(&:to_s).include?(self.provision_method)
+  end
 
 end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -21,7 +21,8 @@ module Nic
 
     # Interface normally are not executed by them self, so we use the host queue and related methods.
     # this ensures our orchestration works on both a host and a managed interface
-    delegate :progress_report_id, :require_ip_validation?, :overwrite?, :capabilities, :managed?, :compute_resource, :to => :host
+    delegate :progress_report_id, :require_ip_validation?, :overwrite?, :capabilities, :managed?, :compute_resource,
+             :image_build?, :pxe_build?, :pxe_build?, :ip_available?, :mac_available?, :to => :host
 
     # this ensures we can create an interface even when there is no host queue
     # e.g. outside to Host nested attributes

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -7,7 +7,7 @@ attributes :ip, :environment_id, :environment_name, :last_report, :mac,
            :subnet_id, :subnet_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
            :comment, :disk, :installed_at, :model_id, :model_name, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
            :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
-           :compute_profile_id, :compute_profile_name,
+           :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
            :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
            :last_compile, :last_freshcheck, :serial, :source_file_id, :puppet_status
 

--- a/app/views/compute_resources_vms/form/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/form/_libvirt.html.erb
@@ -31,3 +31,17 @@
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start')} if new && controller_name != "compute_attributes" %>
+
+<%
+   arch ||= nil ; os ||= nil
+   images = possible_images(compute_resource, arch, os)
+-%>
+<div id='image_selection'>
+  <%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')},
+             { :disabled    => images.empty? || (params[:host] && params[:host][:provision_method] == 'build'),
+               :'data-url'  => template_selected_compute_resource_path(compute_resource),
+               :onchange    => 'libvirt_image_selected(this);',
+               :help_inline => :indicator,
+               :help_block  => _("Image to use"),
+               :label => _('Image')} %>
+</div>

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -6,14 +6,14 @@
 <span id="os_select">
   <%= render 'common/os_selection/architecture', :item => @host %>
 </span>
-<% build_provisioning = f.object.capabilities && f.object.capabilities.include?(:build) && !@host.image %>
+
 <div id='provisioning_method' <%= display? (@host.capabilities.size < 2)  %> >
   <%= field(f, :provision_method, :label => _('Provisioning Method')) do
-      radio_button_f(f, :provision_method, :value=>'build', :checked=> build_provisioning, :text=> _("Network Based"))+
-      radio_button_f(f, :provision_method, :value=>'image', :checked=> !build_provisioning, :text=> _("Image Based"))
+      radio_button_f(f, :provision_method, :value=>'build', :checked=> @host.pxe_build?, :text=> _("Network Based"))+
+      radio_button_f(f, :provision_method, :value=>'image', :checked=> @host.image_build?, :text=> _("Image Based"))
   end %>
 </div>
-<div id='network_provisioning' <%= display? !build_provisioning  %> >
+<div id='network_provisioning' <%= display? !@host.pxe_build? %> >
   <% if @host.new_record? or @host.type_changed? -%>
       <%= checkbox_f f, :build, :checked => true, :help_inline => _("Enable this host for provisioning") %>
   <% end %>
@@ -27,7 +27,7 @@
   <%= password_f f, :root_pass %>
 </div>
 
-<div id='image_provisioning' <%= display? build_provisioning      %> >
+<div id='image_provisioning' <%= display? !@host.image_build? %> >
 
 </div>
 <!-- this section is used for displaying the provisioning scripts-->

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -4,16 +4,7 @@
   <%= f.hidden_field :compute_resource_id, :value => @compute_resource.id %>
   <%= select_f f, :operatingsystem_id, Operatingsystem.all, :id, :to_label %>
   <%= select_f f, :architecture_id, Architecture.all, :id, :to_label %>
-  <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
-  <% if @compute_resource.provider == 'Ovirt' %>
-    <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
-  <% end %>
-  <%= image_field(f) %>
-  <%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
-  <% if @compute_resource.provider == 'EC2' %>
-    <%# TODO - Get IAM roles from AWS and display in select drop %>
-    <%= text_f f, :iam_role, :help_inline => _("(optional) IAM Role for Fog to use when creating this image.") %>
-  <% end %>
+  <%= render "images/form/#{@compute_resource.provider.downcase}", :f => f %>
 
   <%= submit_or_cancel f, false, :cancel_path => @compute_resource %>
 <% end %>

--- a/app/views/images/form/_ec2.html.erb
+++ b/app/views/images/form/_ec2.html.erb
@@ -1,0 +1,5 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
+<%# TODO - Get IAM roles from AWS and display in select drop %>
+<%= text_f f, :iam_role, :help_inline => _("(optional) IAM Role for Fog to use when creating this image.") %>

--- a/app/views/images/form/_gce.html.erb
+++ b/app/views/images/form/_gce.html.erb
@@ -1,0 +1,2 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>

--- a/app/views/images/form/_libvirt.html.erb
+++ b/app/views/images/form/_libvirt.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
+<%= image_field(f, :label => _("Image path"), :help_inline => _("Full path to backing image used to create new volumes.")) %>

--- a/app/views/images/form/_openstack.html.erb
+++ b/app/views/images/form/_openstack.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>

--- a/app/views/images/form/_ovirt.html.erb
+++ b/app/views/images/form/_ovirt.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
+<%= image_field(f) %>

--- a/app/views/images/form/_rackspace.html.erb
+++ b/app/views/images/form/_rackspace.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>

--- a/app/views/images/form/_vmware.html.erb
+++ b/app/views/images/form/_vmware.html.erb
@@ -1,0 +1,2 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>

--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,4 +1,4 @@
 group :fog do
- gem 'fog', '~> 1.19.0'
+ gem 'fog', '~> 1.20.0'
  gem 'unf'
 end

--- a/db/migrate/20140304184854_add_provision_method_to_hosts.rb
+++ b/db/migrate/20140304184854_add_provision_method_to_hosts.rb
@@ -1,0 +1,12 @@
+class AddProvisionMethodToHosts < ActiveRecord::Migration
+  def self.up
+    add_column :hosts, :provision_method, :string
+    Host::Managed.unscoped.each do |h|
+      h.update_attribute(:provision_method, h.capabilities.first)
+    end
+  end
+
+  def self.down
+    remove_column :hosts, :provision_method
+  end
+end

--- a/foreman.spec
+++ b/foreman.spec
@@ -179,8 +179,8 @@ Meta Package to install requirements for ovirt support
 %package compute
 Summary: Foreman Compute Resource support via fog
 Group:  Applications/System
-Requires: %{?scl_prefix}rubygem-fog >= 1.19.0
-Requires: %{?scl_prefix}rubygem-fog < 1.20.0
+Requires: %{?scl_prefix}rubygem-fog >= 1.20.0
+Requires: %{?scl_prefix}rubygem-fog < 1.21.0
 Requires: %{?scl_prefix}rubygem-unf
 Requires: %{name} = %{version}-%{release}
 Obsoletes: foreman-fog < 1.0.0

--- a/test/fixtures/hosts.yml
+++ b/test/fixtures/hosts.yml
@@ -17,6 +17,7 @@ one:
   location: location1
   organization: organization1
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 two:
   type: Host::Managed
@@ -34,6 +35,7 @@ two:
   compute_resource: one
   location: location1
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 otherfullhost:
   type: Host::Managed
@@ -49,6 +51,7 @@ otherfullhost:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 anotherfullhost:
   type: Host::Managed
@@ -64,6 +67,7 @@ anotherfullhost:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 myfullhost:
   type: Host::Managed
@@ -78,6 +82,7 @@ myfullhost:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 redhat:
   type: Host::Managed
@@ -95,6 +100,7 @@ redhat:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 ubuntu:
   type: Host::Managed
@@ -112,6 +118,7 @@ ubuntu:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 # Need a host with both build=true and managed=true for some tests
 ubuntu2:
@@ -131,6 +138,7 @@ ubuntu2:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 minimal:
   type: Host::Managed
@@ -146,6 +154,7 @@ minimal:
   domain: useless
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 sol10host:
   type: Host::Managed
@@ -162,6 +171,7 @@ sol10host:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 suse:
   type: Host::Managed
@@ -179,6 +189,7 @@ suse:
   puppet_proxy: puppetmaster
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 dhcp:
   type: Host::Managed
@@ -196,6 +207,7 @@ dhcp:
   managed: true
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 sp_dhcp:
   type: Host::Managed
@@ -212,6 +224,7 @@ sp_dhcp:
   managed: true
   compute_resource: one
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 db_host:
   type: Host::Managed
@@ -229,6 +242,7 @@ db_host:
   compute_resource: one
   hostgroup: db
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 owned_by_restricted:
   type: Host::Managed
@@ -249,6 +263,7 @@ owned_by_restricted:
   owner: restricted
   owner_type: User
   root_pass: xybxa6JUkz63w
+  provision_method: build
 
 noip:
   type: Host::Managed
@@ -264,3 +279,4 @@ noip:
   subnet: one
   puppet_proxy: puppetmaster
   compute_resource: one
+  provision_method: build


### PR DESCRIPTION
TODO:
- [x] fix test failure (root_pass validation isn't working properly when capabilities are both image + build)
- [x] no obvious error when template volume doesn't exist
