### PR TITLE
fixes #3475 - make it possible to force the 401 status.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
         login_user(user)
       end
     else
-      if params[:status]
+      if params[:status] && params[:status] == 401
         render :layout => 'login', :status => params[:status]
       else
         render :layout => 'login'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,7 +70,11 @@ class UsersController < ApplicationController
         login_user(user)
       end
     else
-      render :layout => 'login'
+      if params[:status]
+        render :layout => 'login', :status => params[:status]
+      else
+        render :layout => 'login'
+      end
     end
   end
 


### PR DESCRIPTION
With this patch, it will be possible to specify

```
ErrorDocument 401 /users/login?status=401
```

to force the preservation of the 401 status.
