### PR TITLE
fixes #3767 - add new host to hosts menu

### DIFF
--- a/app/services/menu/loader.rb
+++ b/app/services/menu/loader.rb
@@ -39,6 +39,8 @@ module Menu
 
         menu.sub_menu :hosts_menu,      :caption => N_('Hosts') do
           menu.item :hosts,             :caption => N_('All hosts')
+          menu.item :newhost,           :caption => N_('New host'),
+                    :url_hash => {:controller => '/hosts', :action => 'new'}
           if SETTINGS[:unattended]
             menu.divider                :caption => N_('Provisioning Setup')
             menu.item :operatingsystems,:caption => N_('Operating systems')


### PR DESCRIPTION
Adds "New host" to the "Hosts" menu in the top-bar.
