### PR TITLE
changed os minor attribute to not required

### DIFF
--- a/app/controllers/api/v1/operatingsystems_controller.rb
+++ b/app/controllers/api/v1/operatingsystems_controller.rb
@@ -31,7 +31,7 @@ module Api
       param :operatingsystem, Hash, :required => true do
         param :name, /\A(\S+)\Z/, :required => true
         param :major, String, :required => true
-        param :minor, String, :required => true
+        param :minor, String
         param :description, String
         param :family, String
         param :release_name, String

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -31,7 +31,7 @@ module Api
         param :operatingsystem, Hash, :action_aware => true do
           param :name, /\A(\S+)\Z/, :required => true
           param :major, String, :required => true
-          param :minor, String, :required => true
+          param :minor, String
           param :description, String
           param :family, String
           param :release_name, String


### PR DESCRIPTION
Bug: API required OS minor when creating a new os.

This is in contrast to the gui, some operating systems like Fedora do not have a minor version.
