### PR TITLE
Fixes #4515 - Add support for dynamic bindings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "ancestry", "~> 2.0"
 gem 'scoped_search', '>= 2.6.2'
 gem 'net-ldap'
 gem 'uuidtools'
-gem "apipie-rails", "~> 0.0.23"
+gem "apipie-rails", "~> 0.1.1"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oauth'
 gem 'deep_cloneable'

--- a/app/services/menu/loader.rb
+++ b/app/services/menu/loader.rb
@@ -1,3 +1,11 @@
+# We require these files explicitly as the menu classes can't be reloaded
+# to keep the singletons working.
+require 'menu/node'
+require 'menu/item'
+require 'menu/divider'
+require 'menu/toggle'
+require 'menu/manager'
+
 module Menu
   class Loader
     def self.load

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,6 @@
 require File.expand_path('../boot', __FILE__)
+require 'apipie/middleware/checksum_in_headers'
+
 
 require 'rails/all'
 
@@ -131,6 +133,9 @@ module Foreman
 
     # Catching Invalid JSON Parse Errors with Rack Middleware
     config.middleware.insert_before ActionDispatch::ParamsParser, "Middleware::CatchJsonParseErrors"
+
+    # Add apidoc hash in headers for smarter caching
+    config.middleware.use "Apipie::Middleware::ChecksumInHeaders"
 
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,13 +71,6 @@ module Foreman
     config.autoload_paths += %W(#{config.root}/app/models/trends)
     config.autoload_paths += %W(#{config.root}/app/models/taxonomies)
 
-    # Load the following paths only once in development environment
-    # this is useful to keep singletons from reloading.
-    if Rails.env.development?
-      config.autoload_once_paths += Dir["#{config.root}/app/services/foreman"]
-      config.autoload_once_paths += Dir["#{config.root}/app/services/menu"]
-    end
-
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -3,7 +3,8 @@ Apipie.configure do |config|
   config.app_info = "The Foreman is aimed to be a single address for all machines life cycle management."
   config.copyright = ""
   config.api_base_url = "/api"
-  config.api_controllers_matcher = "#{Rails.root}/app/controllers/api/**/*.rb"
+  config.api_controllers_matcher = ["#{Rails.root}/app/controllers/api/**/*.rb"]
+  config.ignored = []
   config.ignored_by_recorder = %w[]
   config.doc_base_url = "/apidoc"
   config.use_cache = Rails.env.production?
@@ -12,6 +13,9 @@ Apipie.configure do |config|
   config.reload_controllers = Rails.env.development?
   config.markup = Apipie::Markup::Markdown.new if Rails.env.development? and defined? Maruku
   config.default_version = "v1"
+  config.update_checksum = true
+  config.checksum_path = ['/api/', '/apidoc/']
+
 end
 
 # special type of validator: we say that it's not specified

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -1,5 +1,6 @@
 require 'foreman/access_permissions'
 require 'menu/loader'
+require 'foreman/plugin'
 require 'foreman/renderer'
 require 'foreman/controller'
 require 'net'

--- a/foreman.spec
+++ b/foreman.spec
@@ -64,7 +64,7 @@ Requires: %{?scl_prefix}rubygem(rabl) >= 0.7.5
 Requires: %{?scl_prefix}rubygem(rake) >= 0.8.3
 Requires: %{?scl_prefix}rubygem(ruby_parser) >= 3.0.0
 Requires: %{?scl_prefix}rubygem(audited-activerecord) >= 3.0.0
-Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.0.23
+Requires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
 Requires: %{?scl_prefix}rubygem(bundler_ext)
 Requires: %{?scl_prefix}rubygem(thin)
 Requires: %{?scl_prefix}rubygem(fast_gettext) >= 0.8.0
@@ -80,7 +80,7 @@ Requires: %{?scl_prefix}rubygem(foreigner) >= 1.4.2
 Requires: %{?scl_prefix}rubygem(deep_cloneable)
 BuildRequires: %{?scl_prefix}rubygem(ancestry) >= 2.0.0
 BuildRequires: %{?scl_prefix}rubygem(ancestry) < 3.0.0
-BuildRequires: %{?scl_prefix}rubygem(apipie-rails) >= 0.0.23
+BuildRequires: %{?scl_prefix}rubygem(apipie-rails) >= 0.1.1
 BuildRequires: %{?scl_prefix}rubygem(audited-activerecord) >= 3.0.0
 BuildRequires: %{?scl_prefix}rubygem(bundler_ext)
 BuildRequires: %{?scl_prefix}rubygem(gettext) >= 1.9.3
@@ -472,7 +472,7 @@ ln -sv %{_localstatedir}/log/%{name} %{buildroot}%{_datadir}/%{name}/log
 # Put tmp files in %{_localstatedir}/run/%{name}
 ln -sv %{_localstatedir}/run/%{name} %{buildroot}%{_datadir}/%{name}/tmp
 
-# Symlink plugin settings directory to 
+# Symlink plugin settings directory to
 ln -sv %{_sysconfdir}/%{name}/plugins %{buildroot}%{_datadir}/%{name}/config/settings.plugins.d
 
 # Create VERSION file
@@ -532,6 +532,7 @@ fi
 # We need to run the db:migrate after the install transaction
 %{foreman_rake} db:migrate >> %{_localstatedir}/log/%{name}/db_migrate.log 2>&1 || :
 %{foreman_rake} db:seed >> %{_localstatedir}/log/%{name}/db_seed.log 2>&1 || :
+%{foreman_rake} apipie:cache >> %{_localstatedir}/log/%{name}/apipie_cache.log 2>&1 || :
 (/sbin/service foreman status && /sbin/service foreman restart) >/dev/null 2>&1
 exit 0
 

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -24,7 +24,7 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     "audits/create", "audits/destroy", "audits/edit", "audits/new", "audits/update",
 
     # Apipie
-    "apipie/apipies/index",
+    "apipie/apipies/index", "apipie/apipies/apipie_checksum",
 
     # API app controller stub
     "api/testable/index", "api/testable/raise_error"


### PR DESCRIPTION
I reworked PR https://github.com/theforeman/foreman/pull/1157
Most of the functionality was moved to Apipie (https://github.com/Apipie/apipie-rails/pull/215)
In Foreman we just use the middleware. The headers are now called `Apipie-Checksum` and are added just to calls to `/api` and `/apidoc`.

I fixed controller matcher setup so that it can be extended by plugins.
