### PR TITLE
Fix #4536 - store values correctly

### DIFF
--- a/app/services/cache_manager.rb
+++ b/app/services/cache_manager.rb
@@ -18,6 +18,19 @@ class CacheManager
     delete_old_permission_cache
     create_new_permission_cache
     create_new_filter_cache
-    Setting::General[:fix_db_cache] = false
+    CacheManager.set_cache_setting(false)
+  end
+
+  def self.set_cache_setting(value)
+    flag = Setting::General.find_by_name('fix_db_cache')
+    # we call this from places where setting does not have to exist, in that case we create new record here
+    flag ||= Setting::General.new(:name => 'fix_db_cache',
+                                  :description   => 'Fix DB cache on next Foreman restart',
+                                  :settings_type => 'boolean')
+
+    # we need to call default= and value= explicitly so it stores value in YAML
+    flag.default = false
+    flag.value = value
+    flag.save
   end
 end

--- a/db/migrate/20140219183343_migrate_permissions.rb
+++ b/db/migrate/20140219183343_migrate_permissions.rb
@@ -86,10 +86,7 @@ class MigratePermissions < ActiveRecord::Migration
       migrate_roles
       migrate_user_filters
 
-      flag = Setting::General.find_or_initialize_by_name('fix_db_cache',
-                                                         :description   => 'Fix DB cache on next Foreman restart',
-                                                         :settings_type => 'boolean', :default => false)
-      flag.update_attributes :value => true
+      CacheManager.set_cache_setting(true)
       Rake::Task['db:migrate'].enhance nil do
         Rake::Task['fix_db_cache'].invoke
       end

--- a/db/migrate/20140219183345_add_taxonomy_searches_to_filter.rb
+++ b/db/migrate/20140219183345_add_taxonomy_searches_to_filter.rb
@@ -3,11 +3,7 @@ class AddTaxonomySearchesToFilter < ActiveRecord::Migration
     add_column :filters, :taxonomy_search, :text
 
     # to precache taxonomy search on all existing filters
-    # setting may not exist yet
-    flag = Setting::General.find_or_initialize_by_name('fix_db_cache',
-                                                       :description   => 'Fix DB cache on next Foreman restart',
-                                                       :settings_type => 'boolean', :default => false)
-    flag.update_attributes :value => true
+    CacheManager.set_cache_setting(true)
 
     Rake::Task['db:migrate'].enhance nil do
       Filter.reset_column_information


### PR DESCRIPTION
Setting stores data using YAML but we have to call value= and default=
methods explicitly. Also this DRY-up new setting creation which can
occure on several places. If saving fails for whatever reason (maybe
some new validations in future) we now raise exception so we get error
before it's too late to fix)
