### PR TITLE
Feature #4521 - Openstack block device options

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -1,6 +1,6 @@
 // AJAX load vm listing
 $(function() {
-  $('#vms, #images_list').each(function() {
+  $('#vms, #images_list, #volumes_list').each(function() {
     var url = $(this).attr('data-url');
     $(this).load(url + ' table', function(response, status, xhr) {
       if (status == "error") {

--- a/app/controllers/volumes_controller.rb
+++ b/app/controllers/volumes_controller.rb
@@ -1,0 +1,63 @@
+class VolumesController < ApplicationController
+  before_filter :find_compute_resource
+
+  def index
+    # Listing volumes in /hosts/new consumes this method as JSON
+    values = @compute_resource.volumes.search_for(params[:search], :order => params[:order])
+    respond_to do |format|
+      format.html { @volumes = values.paginate :page => params[:page] }
+      format.json { render :json => values }
+    end
+  end
+
+  def sync 
+    old_uuids = @compute_resource.volumes.map(&:uuid)
+    sync_stats = create_update_volumes(old_uuids)
+    new_uuids = @compute_resource.volumes.map(&:uuid)
+    sync_stats[:removed] = clean_old_volumes(old_uuids - new_uuids)
+
+    message =  _("Sync completed: <br/>") 
+    message += _(" - %s volumes created <br/>") % sync_stats[:created]
+    message += _(" - %s volumes updated <br/>") % sync_stats[:updated]
+    message += _(" - %s volumes removed <br/>") % sync_stats[:removed]
+     
+    process_success(:success_redirect => compute_resource_path(@compute_resource), 
+                    :success_msg      => message)
+  end
+
+
+  private
+
+  def find_compute_resource
+    @compute_resource = ComputeResource.find(params[:compute_resource_id])
+  end
+
+  def create_update_volumes(uuids)
+    counter = { :updated => 0, :created => 0 }
+    @compute_resource.available_volumes.each do |volume|
+      if uuids.include?(volume.id)
+        #update attributes
+        counter[:updated] += 1
+      else
+        @compute_resource.volumes.create(:name => volume.name, :uuid => volume.id,
+                                         :size => volume.size, :status => volume.status, 
+                                         :availability_zone => volume.availability_zone) 
+        counter[:created] += 1
+      end
+    end
+    
+    counter
+  end
+
+  def clean_old_volumes(uuids)
+    counter = 0
+    uuids.each do |uuid|
+      if (old_volume = @compute_resource.volumes.find_by_uuid(uuid))
+        old_volume.destroy
+        counter += 1
+      end
+    end
+   
+    counter
+  end
+end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -22,7 +22,8 @@ class ComputeResource < ActiveRecord::Base
   scoped_search :on => :id, :complete_value => :true
   before_save :sanitize_url
   has_many_hosts
-  has_many :images, :dependent => :destroy
+  has_many :images,  :dependent => :destroy
+  has_many :volumes, :dependent => :destroy
   before_validation :set_attributes_hash
   has_many :compute_attributes, :dependent => :destroy
   has_many :compute_profiles, :through => :compute_attributes

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -6,6 +6,12 @@ module FogExtensions
       included do
         alias_method_chain :security_groups, :no_id
         attr_writer :security_group, :network # floating IP
+
+        def block_device_mapping
+          [ FogExtensions::Openstack::Server::BlockDeviceMapping::Block.new ]
+        end
+
+        def block_device_mapping_attributes=(attrs); end
       end
 
       def to_s

--- a/app/models/concerns/fog_extensions/openstack/server/block_device_mapping.rb
+++ b/app/models/concerns/fog_extensions/openstack/server/block_device_mapping.rb
@@ -1,0 +1,21 @@
+module FogExtensions
+  module Openstack
+    module Server
+      module BlockDeviceMapping
+
+        class Block
+          extend ActiveSupport::Concern
+
+          attr_accessor :device_name, :delete_on_termination, :volume_id
+          attr_accessor :_destroy
+
+          # These methods are used to trick form_builder into thinking this is
+          # an ActiveRecord model so that the form is showed properly.
+          def persisted?; end
+          def id; end
+        end
+
+      end
+    end
+  end
+end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,0 +1,8 @@
+class Volume < ActiveRecord::Base
+  belongs_to :compute_resource
+
+  scoped_search :on => :name,   :complete_value => true
+  scoped_search :on => :status, :complete_value => true
+  scoped_search :on => :availability_zone, :complete_value => true
+  scoped_search :in => :compute_resources, :on => :name, :complete_value => :true, :rename => "compute_resource"
+end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -351,6 +351,12 @@ Foreman::AccessControl.map do |map|
     }
   end
 
+  map.security_block :volumes do |map|
+    map.permission :view_volumes, { :volumes => [:index, :auto_complete_search] } 
+  end
+
+
+
   if SETTINGS[:locations_enabled]
     map.security_block :locations do |map|
       map.permission :view_locations, {:locations =>  [:index, :show, :auto_complete_search, :mismatches],

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -9,6 +9,9 @@
 <ul class="nav nav-tabs" data-tabs="tabs">
   <li class="active"><a href="#primary" data-toggle="tab"><%= _("Compute Resource") %></a></li>
   <li><a href="#vms" data-toggle="tab"><%= _("Virtual Machines") %></a></li>
+  <% if @compute_resource.capabilities.include?(:volume) %>
+    <li><a href="#volumes" data-toggle="tab"><%= _("Volumes") %></a></li>
+  <% end %>
   <% if @compute_resource.capabilities.include?(:image) %>
     <li><a href="#images" data-toggle="tab"><%= _("Images") %></a></li>
   <% end %>
@@ -44,6 +47,17 @@
       <%= _('Loading virtual machines information ...') %>
     </p>
   </div>
+  <% if @compute_resource.capabilities.include?(:volume) %>
+    <div id="volumes" class="tab-pane">
+      <%= title_actions(display_link_if_authorized(_("Sync volumes"), hash_for_sync_compute_resource_volumes_path(:compute_resource_id => @compute_resource.id), :method => :put, :class => "btn btn-default", :data=>{:target=>"full-page"})) %>
+      <div id="volumes_list" data-url=<%= compute_resource_volumes_path(@compute_resource) %>>
+        <p id="spinner">
+          <%= image_tag '/assets/spinner.gif' %>
+          <%= _('Loading Volumes information') %> ...
+        </p>
+      </div>
+    </div>
+  <% end %>
   <% if @compute_resource.capabilities.include?(:image) %>
     <div id="images" class="tab-pane">
       <%= title_actions(display_link_if_authorized(_("New Image"), hash_for_new_compute_resource_image_path(:compute_resource_id => @compute_resource.id), :class => "btn btn-success", :data=>{:target=>"full-page"})) %>
@@ -55,7 +69,7 @@
       </div>
     </div>
   <% end %>
-  <div id="compute_profiles" class="tab-pane">
+    <div id="compute_profiles" class="tab-pane">
     <table class="table table-bordered table-striped table-two-pane">
       <tr>
         <th><%= _("Compute profile") %></th>

--- a/app/views/compute_resources_vms/form/_openstack.html.erb
+++ b/app/views/compute_resources_vms/form/_openstack.html.erb
@@ -15,3 +15,20 @@
 <%= select_f f, :security_group, compute_resource.security_groups, :name, :name, { :include_blank => _("None") }, :label => _("Security group")  %>
 <%= selectable_f f, :network, compute_resource.address_pools, { :include_blank => _("None") }, { :label => _("Floating IP network") } %>
 
+<br/>
+<div class="children_fields">
+  <%= new_child_fields_template(f, :block_device_mapping, {
+        :object  => compute_resource.new_block,
+        :partial => 'compute_resources_vms/form/openstack/block_device_mapping',
+        :form_builder_attrs => { :compute_resource => compute_resource } } ) %>
+
+  <%= field_set_tag "Block device mapping", :id => "storage_volumes", :title => _('Block device mapping') do %>
+    <%= f.fields_for :block_device_mapping do |i| %>
+      <%= render 'compute_resources_vms/form/openstack/block_device_mapping', :f => i, :compute_resource => compute_resource %>
+    <% end %>
+    <%= add_child_link '+ ' + _("Add block"), :block_device_mapping,
+                     { :class => "info", :title => _('add new volume/image block') } %>
+  <% end %>
+</div>
+
+

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -4,6 +4,6 @@
   <%= text_f f, :capacity, :class => "col-md-2", :label => _("Size (GB)"), :onchange => 'capacity_edit(this)' %>
   <%= allocation_text_f f %>
     <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "col-md-2", :label => _("Type"),
-                   :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-danger disable-unsupported' }) %>
+                    :help_inline => remove_child_link("X", f, { :method => :'_delete', :title => _('remove volume'), :class => 'label label-danger disable-unsupported' }) %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/openstack/_block_device_mapping.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_block_device_mapping.html.erb
@@ -1,0 +1,9 @@
+<div class="fields">
+  <div class="form-group">
+    <%= text_f f, :device_name, :class => "col-md-2", :placeholder => _('path, e.g: /dev/vda'),
+                  :help_inline => remove_child_link('X', f, { :title => _('remove block'), :class => 'label label-danger' } ) %>
+    <%= checkbox_f f, :delete_on_termination, :label => _('Ephemeral') %>
+    <%= select_f f, :volume_id, compute_resource.available_volumes, :uuid, :name,
+                    :class => "col-md-2", :placeholder => _("Choose volume/image") %>
+  </div>
+</div>

--- a/app/views/compute_resources_vms/show/_openstack.html.erb
+++ b/app/views/compute_resources_vms/show/_openstack.html.erb
@@ -15,5 +15,6 @@
     <%= prop :tenant %>
     <%= prop :flavor_with_object, "Flavor" %>
     <%= prop :security_groups, "Security Groups" %>
+    <%= prop :volumes, "Volumes" %>
   </table>
 </div>

--- a/app/views/hosts/_compute.html.erb
+++ b/app/views/hosts/_compute.html.erb
@@ -1,6 +1,7 @@
 <%= fields_for "#{type}[compute_attributes]", @host ? @host.compute_object : compute_resource.new_vm(vm_attrs) do |compute| %>
   <% if compute.object %>
     <div id='update_not_supported' class='alert alert-info hide'><%= _("VM editing is not implemented for this provider") %></div>
+
     <%= render :partial => "compute_resources_vms/form/#{compute_resource.provider.downcase}",
                :locals => { :f => compute, :compute_resource => compute_resource}.merge(args_for_compute_resource_partial(@host)) %>
   <% else %>

--- a/app/views/volumes/index.html.erb
+++ b/app/views/volumes/index.html.erb
@@ -1,0 +1,25 @@
+<% title _("Volumes") %>
+
+<% title_actions display_link_if_authorized(_("Sync volumes"), hash_for_sync_compute_resource_volumes_path(:compute_resource_id => @compute_resource.id), :method => :put) %>
+
+<table class="table table-bordered table-striped" data-table='inline'>
+  <thead>
+  <tr>
+    <th><%= s_("Volume|Name") %></th>
+    <th><%= s_("Volume|Status") %></th>
+    <th><%= s_("Volume|Size") %></th>
+    <th><%= s_("Volume|Availability Zone") %></th>
+  </tr>
+  </thead>
+  <% @volumes.each do |volume| %>
+  <tr>
+    <td><%= volume.name %></td>
+    <td><%= volume.status %></td>
+    <td><%= volume.size %></td>
+    <td><%= volume.availability_zone %></td>
+  </tr>
+<% end %>
+</table>
+
+<%= page_entries_info @volumes %>
+<%= will_paginate     @volumes %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,7 +297,12 @@ Foreman::Application.routes.draw do
           get 'provider_selected'
           put  'test_connection'
         end
-        resources :images, :except => [:show]
+        resources :images,  :except => [:show]
+        resources :volumes, :only   => [:index] do
+          collection do
+            put 'sync'
+          end
+        end
       end
     end
 

--- a/db/migrate/20140224233823_create_volumes.rb
+++ b/db/migrate/20140224233823_create_volumes.rb
@@ -1,0 +1,18 @@
+class CreateVolumes < ActiveRecord::Migration
+  def up
+    create_table :volumes do |t|
+      t.integer :compute_resource_id
+      t.string :uuid
+      t.string :name
+      t.string :status
+      t.string :size
+      t.string :availability_zone
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :volumes
+  end
+end


### PR DESCRIPTION
http://projects.theforeman.org/issues/4521
New hosts should be able to be provisioned using block device mapping
Block device mapping should support ephemeral disks
Host#view should show volumes attached to it if its an Openstack VM.
Openstack Compute Resources should show volumes.

Some screenshots - http://imgur.com/a/Dbtwg 

Tests will follow.
