### PR TITLE
fixes #4581 Implement available_networks API for VMware

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -51,8 +51,24 @@ module Foreman::Model
       dc.vm_folders.sort_by{|f| f.path}
     end
 
-    def networks
-      dc.networks.all(:accessible => true)
+    def networks(opts ={})
+      if opts[:cluster_id]
+        dc.networks.all(:accessible => true, :id => opts[:cluster_id])
+      else
+        dc.networks.all(:accessible => true)
+      end
+    end
+
+    def available_clusters
+      clusters
+    end
+
+    def available_networks(cluster_id)
+      cluster_networks = networks({:cluster_id => cluster_id})
+    end
+
+    def available_storage_domains
+      datastores
     end
 
     def nictypes

--- a/test/fixtures/compute_resources.yml
+++ b/test/fixtures/compute_resources.yml
@@ -72,3 +72,12 @@ ovirt:
   password: 12345
   uuid: 1234567891011
   type: Foreman::Model::Ovirt
+
+vmware:
+  name: Vmware
+  description: vmware resource
+  url: https://myvmware/api
+  user: MyString
+  password: 123456
+  uuid: 1234567891011
+  type: Foreman::Model::Vmware

--- a/test/functional/api/v2/compute_resources_controller_test.rb
+++ b/test/functional/api/v2/compute_resources_controller_test.rb
@@ -149,4 +149,44 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     available_storage_domains = ActiveSupport::JSON.decode(@response.body)
     assert !available_storage_domains.empty?
   end
+
+  test "should get available vmware networks" do
+    network = Object.new
+    network.stubs(:name).returns('test_vmware_network')
+    network.stubs(:id).returns('my11-test35-uuid99')
+
+    Foreman::Model::Vmware.any_instance.stubs(:available_networks).returns([network])
+
+    get :available_networks, { :id => compute_resources(:ovirt).to_param, :cluster_id => '123-456-789' }
+    assert_response :success
+    available_networks = ActiveSupport::JSON.decode(@response.body)
+    assert !available_networks.empty?
+  end
+
+  test "should get available vmware clusters" do
+    cluster = Object.new
+    cluster.stubs(:name).returns('test_vmware_cluster')
+    cluster.stubs(:id).returns('my11-test35-uuid99')
+
+    Foreman::Model::Vmware.any_instance.stubs(:available_clusters).returns([cluster])
+
+    get :available_clusters, { :id => compute_resources(:ovirt).to_param }
+    assert_response :success
+    available_clusters = ActiveSupport::JSON.decode(@response.body)
+    assert !available_clusters.empty?
+  end
+
+  test "should get available vmware storage domains" do
+    storage_domain = Object.new
+    storage_domain.stubs(:name).returns('test_vmware_cluster')
+    storage_domain.stubs(:id).returns('my11-test35-uuid99')
+
+    Foreman::Model::Vmware.any_instance.stubs(:available_storage_domains).returns([storage_domain])
+
+    get :available_storage_domains, { :id => compute_resources(:ovirt).to_param }
+    assert_response :success
+    available_storage_domains = ActiveSupport::JSON.decode(@response.body)
+    assert !available_storage_domains.empty?
+  end
+
 end


### PR DESCRIPTION
Implemented the available_networks, available_clusters, and available_storage_domains for VMware compute resources.The API for this was initially added in #4222.
