### PR TITLE
#Bug 4486 - Taxonomies are not searchable by name

### DIFF
--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -19,9 +19,6 @@ class Location < Taxonomy
         where(conditions)
       }
 
-  scoped_search :on => :title, :complete_value => :true, :default_order => true
-  scoped_search :on => :name, :complete_value => :true
-
   # returns self and parent parameters as a hash
   def parameters include_source = false
     hash = {}

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -18,9 +18,6 @@ class Organization < Taxonomy
       where(conditions)
     }
 
-  scoped_search :on => :title, :complete_value => :true, :default_order => true
-  scoped_search :on => :name, :complete_value => :true
-
   # returns self and parent parameters as a hash
   def parameters include_source = false
     hash = {}

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -25,6 +25,9 @@ class Taxonomy < ActiveRecord::Base
   delegate :import_missing_ids, :inherited_ids, :used_and_selected_or_inherited_ids, :selected_or_inherited_ids, :non_inherited_ids,
            :to => :tax_host
 
+  scoped_search :on => :title, :complete_value => :true, :default_order => true
+  scoped_search :on => :name, :complete_value => :true
+
   default_scope lambda { order(:title) }
 
   def self.locations_enabled


### PR DESCRIPTION
The way scoped_search builds the SQL forces us to define the scoped_search scopes in the top-level object, `Taxonomy` in this case.
