### PR TITLE
fixes #4570 - display AIX OS differently

### DIFF
--- a/app/services/facts_parser.rb
+++ b/app/services/facts_parser.rb
@@ -30,7 +30,7 @@ module Facts
           end
         elsif os_name[/AIX/i]
           majoraix, tlaix, spaix, yearaix = orel.split("-")
-          orel = majoraix + "." + tlaix + spaix
+          os = majoraix[0,1] + "." + majoraix[1,1]
         elsif os_name[/JUNOS/i]
           majorjunos, minorjunos = orel.split("R")
           orel = majorjunos + "." + minorjunos


### PR DESCRIPTION
Previously, AIX versions were displayed as "AIX 7100.0301" With this commit, they are now displayed like "AIX 7.1" where major=7 and minor=1. Previously, the other values included service pack and technology levels which doesn't really belong in the main operating system version.
