### PR TITLE
fixes #4570 - display AIX version differently

### DIFF
--- a/app/services/facts_parser.rb
+++ b/app/services/facts_parser.rb
@@ -30,7 +30,7 @@ module Facts
           end
         elsif os_name[/AIX/i]
           majoraix, tlaix, spaix, yearaix = orel.split("-")
-          orel = majoraix + "." + tlaix + spaix
+          os = majoraix[0,1] + "." + majoraix[1,1]
         elsif os_name[/JUNOS/i]
           majorjunos, minorjunos = orel.split("R")
           orel = majorjunos + "." + minorjunos

--- a/app/services/facts_parser.rb
+++ b/app/services/facts_parser.rb
@@ -30,7 +30,7 @@ module Facts
           end
         elsif os_name[/AIX/i]
           majoraix, tlaix, spaix, yearaix = orel.split("-")
-          os = majoraix[0,1] + "." + majoraix[1,1]
+          orel = majoraix[0,1] + "." + majoraix[1,1]
         elsif os_name[/JUNOS/i]
           majorjunos, minorjunos = orel.split("R")
           orel = majorjunos + "." + minorjunos

--- a/test/unit/facts_parser_test.rb
+++ b/test/unit/facts_parser_test.rb
@@ -91,8 +91,8 @@ class FactsParserTest < ActiveSupport::TestCase
   test "should set os.major and minor for from AIX facts" do
     @importer = Facts::Parser.new(aix_facts)
     assert_equal 'AIX', @importer.operatingsystem.family
-    assert_equal '6100', @importer.operatingsystem.major
-    assert_equal '0604', @importer.operatingsystem.minor
+    assert_equal '6', @importer.operatingsystem.major
+    assert_equal '1', @importer.operatingsystem.minor
   end
 
   private


### PR DESCRIPTION
Previously, AIX versions were displayed as "AIX 7100.0301" With this commit, they are now displayed like "AIX 7.1" where major=7 and minor=1. Previously, the other values included service pack and technology levels which doesn't really belong in the main operating system version.
