### PR TITLE
Added inline info regarding root password length policy

### DIFF
--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -24,7 +24,7 @@
 
   <%= textarea_f f, :disk, :size => "col-md-8", :rows => "4",
            :help_block => _("What ever text(or ERB template) you use in here, would be used as your OS disk layout options If you want to use the partition table option, delete all of the text from this field") %>
-  <%= password_f f, :root_pass %>
+  <%= password_f f, :root_pass, :help_inline => _("Password should be 8 characters or more")%>
 </div>
 
 <div id='image_provisioning' <%= display? !@host.image_build? %> >


### PR DESCRIPTION
Added inline info regarding root password length policy.
It's better to explain the users the required password length while filling the data, rather than fail and display an error message afterwards.
