### PR TITLE
fixes #4672 - added template_name template variable

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -276,20 +276,20 @@ class UnattendedController < ApplicationController
   end
 
   def safe_render template
-    template_name = ""
+    @template_name = 'Unnamed'
     if template.is_a?(String)
       @unsafe_template  = template
     elsif template.is_a?(ConfigTemplate)
       @unsafe_template  = template.template
-      template_name = template.name
+      @template_name = template.name
     else
       raise "unknown template"
     end
 
     begin
-      render :inline => "<%= unattended_render(@unsafe_template).html_safe %>" and return
+      render :inline => "<%= unattended_render(@unsafe_template, @template_name).html_safe %>" and return
     rescue Exception => exc
-      msg = _("There was an error rendering the %s template: ") % (template_name)
+      msg = _("There was an error rendering the %s template: ") % (@template_name)
       render :text => msg + exc.message, :status => 500 and return
     end
   end

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -36,7 +36,7 @@ module Orchestration::SSHProvision
     template   = configTemplate(:kind => "finish")
     @host      = self
     logger.info "generating template to upload to #{name}"
-    self.template_file = unattended_render_to_temp_file(template.template)
+    self.template_file = unattended_render_to_temp_file(template)
   end
 
   def delSSHProvisionScript; end

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -70,12 +70,12 @@ module Orchestration::TFTP
     # work around for ensuring that people can use @host as well, as tftp templates were usually confusing.
     @host = self
     if build?
-      pxe_render configTemplate({:kind => os.template_kind}).template
+      pxe_render configTemplate({:kind => os.template_kind})
     else
       if os.template_kind == "PXEGrub"
-        pxe_render ConfigTemplate.find_by_name("PXEGrub default local boot").template
+        pxe_render ConfigTemplate.find_by_name("PXEGrub default local boot")
       else
-        pxe_render ConfigTemplate.find_by_name("PXELinux default local boot").template
+        pxe_render ConfigTemplate.find_by_name("PXELinux default local boot")
       end
     end
   rescue => e

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -50,7 +50,7 @@ module Foreman
       if (template = ConfigTemplate.where(:name => name, :snippet => true).first)
         logger.debug "rendering snippet #{template.name}"
         begin
-          return unattended_render(template.template)
+          return unattended_render(template)
         rescue Exception => exc
           raise "The snippet '#{name}' threw an error: #{exc}"
         end
@@ -73,11 +73,14 @@ module Foreman
       prefix + text.gsub(/\n/, "\n#{prefix}")
     end
 
-    def unattended_render template
+    def unattended_render template, template_name = nil
+      content = template.respond_to?(:template) ? template.template : template
+      template_name ||= template.respond_to?(:name) ? template.name : 'Unnamed'
       allowed_variables = ALLOWED_VARIABLES.reduce({}) do |mapping, var|
          mapping.update(var => instance_variable_get("@#{var}"))
       end
-      render_safe template, ALLOWED_HELPERS, allowed_variables
+      allowed_variables[:template_name] = template_name
+      render_safe content, ALLOWED_HELPERS, allowed_variables
     end
     alias_method :pxe_render, :unattended_render
 

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -38,8 +38,8 @@ class RendererTest < ActiveSupport::TestCase
     test "#{renderer_name} should render a snippet" do
       send "setup_#{renderer_name}"
       snippet = mock("snippet")
-      snippet.expects(:name).returns("test")
-      snippet.expects(:template).returns("content")
+      snippet.stubs(:name).returns("test")
+      snippet.stubs(:template).returns("content")
       ConfigTemplate.expects(:where).with(:name => "test", :snippet => true).returns([snippet])
       tmpl = snippet('test')
       assert_equal 'content', tmpl
@@ -50,6 +50,22 @@ class RendererTest < ActiveSupport::TestCase
       ConfigTemplate.expects(:where).with(:name => "test", :snippet => true).returns([])
       assert_nil snippet_if_exists('test')
     end
+
+    test "#{renderer_name} should render unnamed template" do
+      send "setup_#{renderer_name}"
+      tmpl = unattended_render('x<%= @template_name %>')
+      assert_equal 'xUnnamed', tmpl
+    end
+
+    test "#{renderer_name} should render template name" do
+      send "setup_#{renderer_name}"
+      template = mock('template')
+      template.stubs(:template).returns('x<%= @template_name %>')
+      template.stubs(:name).returns('abc')
+      tmpl = unattended_render(template)
+      assert_equal 'xabc', tmpl
+    end
+
   end
 
 end


### PR DESCRIPTION
I would like to implement this handy feature in the community templates:

```
%post
snippet_if_exists("#{@template_name} Post")
```

Etc. Got snippet_if_exists function already, forgot to add template_name. Here
it is.

The community-templates change will come post 1.5 to give users some time to
migrate.
