### PR TITLE
fixes #4691 - add search for hosts' managed status

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -13,6 +13,7 @@ module Hostext
       scoped_search :on => :ip,            :complete_value => true
       scoped_search :on => :comment,       :complete_value => true
       scoped_search :on => :enabled,       :complete_value => {:true => true, :false => false}, :rename => :'status.enabled'
+      scoped_search :on => :managed,       :complete_value => {:true => true, :false => false}
       scoped_search :on => :owner_type,    :complete_value => true, :only_explicit => true
       scoped_search :on => :owner_id,      :complete_value => true, :only_explicit => true
       scoped_search :on => :puppet_status, :offset => 0, :word_size => Report::BIT_NUM*4, :complete_value => {:true => true, :false => false}, :rename => :'status.interesting'

--- a/db/migrate/20140318221513_change_host_managed_default_to_false.rb
+++ b/db/migrate/20140318221513_change_host_managed_default_to_false.rb
@@ -1,0 +1,11 @@
+class ChangeHostManagedDefaultToFalse < ActiveRecord::Migration
+  def self.up
+    Host.unscoped.where(:managed => nil).update_all(:managed => false)
+    change_column :hosts, :managed, :boolean, :null => false, :default => false
+  end
+
+  def self.down
+    change_column :hosts, :managed, :boolean, :null => true
+  end
+end
+


### PR DESCRIPTION
a DB migration is needed, as this field has no default value at the moment
