### PR TITLE
fixes #4659 - added foreman-tail tool

### DIFF
--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -10,8 +10,10 @@ SYSCONFDIR = ENV['SYSCONFDIR'] || "#{PREFIX}/etc"
 LOCALSTATEDIR = ENV['LOCALSTATEDIR'] || "#{PREFIX}/var"
 SHAREDSTAREDIR = ENV['SHAREDSTAREDIR'] || "#{LOCALSTATEDIR}/lib"
 DATAROOTDIR = DATADIR = ENV['DATAROOTDIR'] || "#{PREFIX}/share"
-DEBUGDIR = ENV['DEBUGDIR'] || "#{DATAROOTDIR}/foreman/script/foreman-debug.d"
 MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
+
+def is_redhat; File.exist?("/etc/redhat-release"); end
+def is_debian; File.exist?("/etc/debian-release"); end
 
 file BUILDDIR do
   mkdir BUILDDIR
@@ -27,17 +29,39 @@ file "#{BUILDDIR}/foreman-debug.8.gz" => "man/foreman-debug.8.asciidoc" do |t|
   sh "gzip -f9 #{BUILDDIR}/foreman-debug.8"
 end
 
+file "#{BUILDDIR}/foreman-tail.8.gz" => "man/foreman-tail.8.asciidoc" do |t|
+  sh "a2x -d manpage -f manpage -D #{BUILDDIR}/ #{t.prerequisites[0]}"
+  sh "gzip -f9 #{BUILDDIR}/foreman-tail.8"
+end
+
 task :build => [
   BUILDDIR,
   "#{BUILDDIR}/foreman-rake.8.gz",
   "#{BUILDDIR}/foreman-debug.8.gz",
+  "#{BUILDDIR}/foreman-tail.8.gz",
 ]
 
 task :install => :build do |t|
   mkdir_p "#{MANDIR}/man8"
   cp "#{BUILDDIR}/foreman-rake.8.gz", "#{MANDIR}/man8/"
   cp "#{BUILDDIR}/foreman-debug.8.gz", "#{MANDIR}/man8/"
-  mkdir_p "#{DEBUGDIR}"
+  cp "#{BUILDDIR}/foreman-tail.8.gz", "#{MANDIR}/man8/"
+
+  # foreman-tail
+  TAILDIR = ENV['TAILDIR'] || "script/foreman-tail.d"
+  mkdir_p "#{DATAROOTDIR}/foreman/#{TAILDIR}"
+  cp Dir.glob("#{TAILDIR}/common/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+  if is_redhat
+    cp Dir.glob("#{TAILDIR}/redhat/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+  elsif is_debian
+    cp Dir.glob("#{TAILDIR}/debian/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+  else
+    raise "Unsupported system"
+  end
+
+  # foreman-debug
+  DEBUGDIR = ENV['DEBUGDIR'] || "script/foreman-debug.d"
+  mkdir_p "#{DATAROOTDIR}/foreman/#{DEBUGDIR}"
 end
 
 task :default => :build

--- a/foreman.spec
+++ b/foreman.spec
@@ -426,6 +426,7 @@ install -d -m0750 %{buildroot}%{_localstatedir}/log/%{name}
 install -d -m0750 %{buildroot}%{_localstatedir}/log/%{name}/plugins
 install -Dp -m0755 script/%{name}-debug %{buildroot}%{_sbindir}/%{name}-debug
 install -Dp -m0755 script/%{name}-rake %{buildroot}%{_sbindir}/%{name}-rake
+install -Dp -m0755 script/%{name}-tail %{buildroot}%{_sbindir}/%{name}-tail
 install -Dp -m0644 %{confdir}/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 install -Dp -m0755 %{confdir}/%{name}.init %{buildroot}%{_initrddir}/%{name}
 install -Dp -m0644 %{confdir}/%{name}.logrotate %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
@@ -442,6 +443,7 @@ install -Dpm0644 %{confdir}/%{name}.gpg %{buildroot}%{_sysconfdir}/pki/rpm-gpg/R
 cp -p Gemfile.in %{buildroot}%{_datadir}/%{name}/Gemfile.in
 cp -p -r app bundler.d config config.ru extras lib locale Rakefile script %{buildroot}%{_datadir}/%{name}
 rm -rf %{buildroot}%{_datadir}/%{name}/extras/{jumpstart,spec}
+
 # remove all test units from produciton release
 find %{buildroot}%{_datadir}/%{name} -type d -name "test" |xargs rm -rf
 
@@ -495,6 +497,7 @@ rm -rf %{buildroot}
 %{_initrddir}/%{name}
 %{_sbindir}/%{name}-debug
 %{_sbindir}/%{name}-rake
+%{_sbindir}/%{name}-tail
 %{_mandir}/man8
 %config(noreplace) %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}

--- a/man/foreman-tail.8.asciidoc
+++ b/man/foreman-tail.8.asciidoc
@@ -1,0 +1,53 @@
+foreman\-tail(8)
+================
+:man source:  foreman-tail
+:man manual:  Foreman Manual
+
+NAME
+----
+foreman-tail - Tool for calling tail on Foreman logs
+
+SYNOPSIS
+--------
+
+foreman-tail
+
+foreman-tail rails
+
+foreman-tail [component]
+
+foreman-tail -l
+
+foreman-tail -h
+
+DESCRIPTION
+-----------
+
+The foreman-tail is an utility which calls tail with appropriate log files.
+
+OPTIONS
+-------
+
+When used without any parameters, it tails all relevant Foreman log files.
+
+When used with one or more parameters, it tails those provided.
+
+Foreman plugins can extend foreman-tail, use this command to find all
+possible components that are valid:
+
+    foreman-tail -l
+
+Example components are "rails" for Rails production log or "proxy" for Foreman
+Proxy production logs. There are components for Apache http daemon, Puppet
+Master or cron available.
+
+SEE ALSO
+--------
+
+*foreman-debug*(8)
+
+GETTING HELP
+------------
+
+For support, please see http://theforeman.org/support.html, the
+foreman-users@googlegroups.com mailing list or #theforeman on Freenode.

--- a/script/foreman-tail
+++ b/script/foreman-tail
@@ -1,0 +1,21 @@
+#!/bin/bash
+dir=/usr/share/foreman/script/foreman-tail.d
+opts="-Fn100"
+
+if [ "$1" == "-h" ]; then
+  man foreman-tail; exit 1
+fi
+if [ "$1" == "-l" ]; then
+  ls $dir | cut -d- -f2; exit 1
+fi
+
+if [ -z "$1" ]; then
+  tail $opts $(eval echo $(cat $dir/*))
+else
+  if [ "$#" -eq 1 ]; then
+    tail $opts $(eval echo $(cat $dir/*-$1))
+  else
+    args=$(IFS=","; echo "$*")
+    tail $opts $(cat $(eval echo $dir/*-{$args}))
+  fi
+fi

--- a/script/foreman-tail.d/common/05-foreman_cron
+++ b/script/foreman-tail.d/common/05-foreman_cron
@@ -1,0 +1,1 @@
+/var/log/foreman/cron.log

--- a/script/foreman-tail.d/common/10-foreman_seed
+++ b/script/foreman-tail.d/common/10-foreman_seed
@@ -1,0 +1,1 @@
+/var/log/foreman/db_{migrate,seed}.log

--- a/script/foreman-tail.d/common/60-puppetmaster
+++ b/script/foreman-tail.d/common/60-puppetmaster
@@ -1,0 +1,1 @@
+/var/log/puppet/masterhttp.log

--- a/script/foreman-tail.d/common/80-proxy
+++ b/script/foreman-tail.d/common/80-proxy
@@ -1,0 +1,1 @@
+/var/log/foreman-proxy/{access,proxy}.log

--- a/script/foreman-tail.d/common/90-rails
+++ b/script/foreman-tail.d/common/90-rails
@@ -1,0 +1,1 @@
+/var/log/foreman/production.log

--- a/script/foreman-tail.d/debian/00-syslog
+++ b/script/foreman-tail.d/debian/00-syslog
@@ -1,0 +1,2 @@
+/var/log/syslog
+/var/log/daemon.log

--- a/script/foreman-tail.d/debian/50-httpd
+++ b/script/foreman-tail.d/debian/50-httpd
@@ -1,0 +1,1 @@
+/var/log/apache2/*.log

--- a/script/foreman-tail.d/redhat/00-syslog
+++ b/script/foreman-tail.d/redhat/00-syslog
@@ -1,0 +1,1 @@
+/var/log/messages

--- a/script/foreman-tail.d/redhat/30-named
+++ b/script/foreman-tail.d/redhat/30-named
@@ -1,0 +1,1 @@
+/var/log/named/*.log

--- a/script/foreman-tail.d/redhat/50-httpd
+++ b/script/foreman-tail.d/redhat/50-httpd
@@ -1,0 +1,1 @@
+/var/log/httpd/*.log


### PR DESCRIPTION
Handy tool for tailing logs, plugin ready. Katello can easily add own logs.

http://koji.katello.org/koji/taskinfo?taskID=91983
