### PR TITLE
Fixes #4710 / #2270 properly

### DIFF
--- a/app/models/concerns/fog_extensions/aws/server.rb
+++ b/app/models/concerns/fog_extensions/aws/server.rb
@@ -34,7 +34,7 @@ module FogExtensions
       end
 
       def ip_addresses
-        [public_ip_address, private_ip_address].flatten.compact
+        [public_ip_address, private_ip_address].flatten.select(&:present?)
       end
 
     end

--- a/app/models/concerns/fog_extensions/model.rb
+++ b/app/models/concerns/fog_extensions/model.rb
@@ -18,5 +18,13 @@ module FogExtensions
       attr.delete(:client)
       attr
     end
+
+    def ip_addresses
+      # Returning an empty array here will skips provider-specific
+      # IP address iteration and falls back on `provided_attributes[:ip]`
+      # from Fog itself
+      []
+    end
+
   end
 end

--- a/app/models/concerns/fog_extensions/rackspace_v2/server.rb
+++ b/app/models/concerns/fog_extensions/rackspace_v2/server.rb
@@ -7,6 +7,10 @@ module FogExtensions
         flavor.name
       end
 
+      def ip_addresses
+        [public_ip_address, private_ip_address].flatten.select(&:present?)
+      end
+
     end
   end
 end


### PR DESCRIPTION
By adding respond_to? we fall back to what we used to use in 1.4.0 and older when ip_addresses is not defined on the compute resource
