### PR TITLE
Fixes #4755 - use_cache in development

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -7,7 +7,7 @@ Apipie.configure do |config|
   config.ignored = []
   config.ignored_by_recorder = %w[]
   config.doc_base_url = "/apidoc"
-  config.use_cache = Rails.env.production?
+  config.use_cache = Rails.env.production? || File.directory?(config.cache_dir)
   config.validate = false
   config.force_dsl = true
   config.reload_controllers = Rails.env.development?
@@ -15,7 +15,11 @@ Apipie.configure do |config|
   config.default_version = "v1"
   config.update_checksum = true
   config.checksum_path = ['/api/', '/apidoc/']
+end
 
+unless Apipie.configuration.use_cache
+  warn "The Apipie cache is turned off.\n" \
+    "  To improve perforance of your API clients turn it on by running 'rake apipie:cache' and restart the server."
 end
 
 # special type of validator: we say that it's not specified


### PR DESCRIPTION
When using API with dynamic bindings in development mode, the client is slow. Every time the server is restarted it needs to load all the controllers and documentation before first API request. It seems to be more comfortable to develeop with use_cache turned on and run rake apipie:cache when it is necessary to refresh the cache.

This patch turns the cache on when in production or when the apipie-cache exists. If the server starts with the cache turned off, it spits suggestion to turn the cache on.

Makes sense?
