### PR TITLE
fixes #3946 Add default values for settings example. Update local config.

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -4,21 +4,24 @@ class Setting::General < Setting
   def self.load_defaults
     # Check the table exists
     return unless super
-    protocol=SETTINGS[:require_ssl] ? 'https' : 'http'
+    protocol = SETTINGS[:require_ssl] ? 'https' : 'http'
+    domain = Facter.value(:domain) || SETTINGS[:domain]
+    administrator = "root@#{domain}"
+    foreman_url = "#{protocol}://#{Facter.value(:fqdn) || SETTINGS[:fqdn]}"
+    email_reply_address = "Foreman-noreply@#{domain}"
 
     self.transaction do
-      domain = Facter.value(:domain)
       [
-        self.set('administrator', N_("The default administrator email address"), "root@#{domain}"),
-        self.set('foreman_url', N_("URL where your Foreman instance is reachable (see also Provisioning > unattended_url)"), "#{protocol}://#{Facter.value(:fqdn)}"),
-        self.set('email_reply_address', N_("Email reply address for emails that Foreman is sending"), "Foreman-noreply@#{domain}"),
+        self.set('administrator', N_("The default administrator email address"), administrator),
+        self.set('foreman_url', N_("URL where your Foreman instance is reachable (see also Provisioning > unattended_url)"), foreman_url),
+        self.set('email_reply_address', N_("Email reply address for emails that Foreman is sending"), email_reply_address),
         self.set('entries_per_page', N_("Number of records shown per page in Foreman"), 20),
-        self.set('fix_db_cache', N_('Fix DB cache on next Foreman restart'),false),
-        self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"),false),
-        self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"),false),
-        self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"),60),
-        self.set('max_trend', N_("Max days for Trends graphs"),30),
-        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"),true)
+        self.set('fix_db_cache', N_('Fix DB cache on next Foreman restart'), false),
+        self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"), false),
+        self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"), false),
+        self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60),
+        self.set('max_trend', N_("Max days for Trends graphs"), 30),
+        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), true)
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -8,11 +8,12 @@ class Setting::Provisioning < Setting
     ssl_cert     = "#{SETTINGS[:puppetvardir]}/ssl/certs/#{Facter.value(:fqdn)}.pem"
     ssl_ca_file  = "#{SETTINGS[:puppetvardir]}/ssl/certs/ca.pem"
     ssl_priv_key = "#{SETTINGS[:puppetvardir]}/ssl/private_keys/#{Facter.value(:fqdn)}.pem"
+    unattended_url = "http://#{Facter.value(:fqdn) || SETTINGS[:fqdn]}"
 
     self.transaction do
       [
         self.set('root_pass', N_("Default encrypted root password on provisioned hosts"), nil),
-        self.set('unattended_url', N_("URL hosts will retrieve templates from during build (normally http as many installers don't support https)"), "http://#{Facter.value(:fqdn)}"),
+        self.set('unattended_url', N_("URL hosts will retrieve templates from during build (normally http as many installers don't support https)"), unattended_url),
         self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true),
         self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert),
         self.set('ssl_ca_file', N_( "SSL CA file that Foreman will use to communicate with its proxies"), ssl_ca_file),

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,8 +87,6 @@ module Foreman
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    config.i18n.enforce_available_locales = false
-    I18n.config.enforce_available_locales = false
 
     # Disable fieldWithErrors divs
     config.action_view.field_error_proc = Proc.new {|html_tag, instance| "#{html_tag}".html_safe }

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,6 +87,8 @@ module Foreman
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = false
+    I18n.config.enforce_available_locales = false
 
     # Disable fieldWithErrors divs
     config.action_view.field_error_proc = Proc.new {|html_tag, instance| "#{html_tag}".html_safe }

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -5,8 +5,8 @@
 :unattended: true
 :login: true
 :require_ssl: false
-:locations_enabled: false
-:organizations_enabled: false
+:locations_enabled: true
+:organizations_enabled: true
 #JSONP or "JSON with padding" is a complement to the base JSON data format.
 #It provides a method to request JSON data from a server in a different domain.
 :support_jsonp: false
@@ -15,3 +15,8 @@
 
 # Mark translated strings with X characters (for developers)
 :mark_translated: false
+
+# Local administrative settings for application domain, fqdn, foreman URL,
+# administrator email address etc.
+:domain: 'localdomain.net'
+:fqdn: 'localhost.localdomain.net'

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -5,8 +5,8 @@
 :unattended: true
 :login: true
 :require_ssl: false
-:locations_enabled: true
-:organizations_enabled: true
+:locations_enabled: false
+:organizations_enabled: false
 #JSONP or "JSON with padding" is a complement to the base JSON data format.
 #It provides a method to request JSON data from a server in a different domain.
 :support_jsonp: false
@@ -17,6 +17,7 @@
 :mark_translated: false
 
 # Local administrative settings for application domain, fqdn, foreman URL,
-# administrator email address etc.
-:domain: 'localdomain.net'
-:fqdn: 'localhost.localdomain.net'
+# administrator email address etc. If you don't have a Puppet provisioning
+# system you may want to uncomment to setup your project on your local machine.
+#:domain: 'localdomain.net'
+#:fqdn: 'localhost.localdomain.net'


### PR DESCRIPTION
```
- Disable I18n default locales since is deprecated
- Add default values in settings example for app config
    * administrator email
    * Foreman app URLs
```
