### PR TITLE
fixes #4776 - support session[:expires_at] for api requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,9 +2,11 @@ module Api
   #TODO: inherit from application controller after cleanup
   class BaseController < ActionController::Base
     include Foreman::Controller::Authentication
+    include Foreman::Controller::Session
     include Foreman::ThreadSession::Cleaner
 
     before_filter :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
+    before_filter :session_expiry, :update_activity_time
 
     cache_sweeper :topbar_sweeper
 

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -1,0 +1,50 @@
+module Foreman::Controller::Session
+  extend ActiveSupport::Concern
+
+  def session_expiry
+    return if ignore_api_request?
+    if session[:expires_at].blank? || (session[:expires_at].utc - Time.now.utc).to_i < 0
+      session[:original_uri] = request.fullpath
+      backup_session_content { expire_session }
+    end
+  rescue => e
+    logger.warn "failed to determine if user sessions needs to be expired, expiring anyway: #{e}"
+    expire_session
+  end
+
+  # Backs up some state from a user's session around a supplied block, which
+  # will usually expire or reset the session in some way
+  def backup_session_content
+    save_items = session.to_hash.slice('organization_id', 'location_id', 'original_uri').symbolize_keys
+    yield if block_given?
+    session.merge!(save_items)
+  end
+
+  def update_activity_time
+    return if ignore_api_request?
+    session[:expires_at] = Setting[:idle_timeout].minutes.from_now.utc
+  end
+
+  def expire_session
+    logger.info "Session for #{User.current} is expired."
+    reset_session
+    if api_request?
+      render :text => '', :status => 401
+    else
+      sso = get_sso_method
+      if sso.nil? || !sso.support_expiration?
+        flash[:warning] = _("Your session has expired, please login again")
+        redirect_to main_app.login_users_path
+      else
+        redirect_to sso.expiration_url
+      end
+    end
+  end
+
+  # If an API is invoked from the UI, the session will include an :expires_at.
+  # When :expires_at is received, it must be managed and the request denied
+  # when an expiration has occurred; otherwise, it may be ignored.
+  def ignore_api_request?
+    api_request? && session[:expires_at].blank?
+  end
+end

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -26,6 +26,26 @@ class Api::TestableControllerTest < ActionController::TestCase
     end
   end
 
+  context "API session expiration" do
+    test "request succeeds if no session[:expires_at] is included" do
+      # this would be typical of API initiated directly or from cli
+      get :index
+      assert_response :success
+    end
+
+    test "request fails if session expired" do
+      # this would be typical of API initiated from a web ui session
+      get :index, {}, { :expires_at => 5.days.ago.utc }
+      assert_response :unauthorized
+    end
+
+    test "request succeeds if session has not expired" do
+      # this would be typical of API initiated from a web ui session
+      get :index, {}, { :expires_at => 5.days.from_now.utc }
+      assert_response :success
+    end
+  end
+
   context "API usage when authentication is disabled" do
     setup do
       User.current = nil


### PR DESCRIPTION
There are situations where the UI needs to invoke requests
on the API controllers; therefore, we need to ensure that
the session expiration accounts for them.  This is a common
for plugins, such as Katello, which leverage the
APIs extensively to support both the web UI and CLI.

With these changes, if an API request is received with
session[:expires_at], it will be evaluated and updated by the
server.  This will be the case for requests from the web-UI.

If an API request is received without session[:expires_at],
no evaluation or updating of an expiration timer will
be performed.  This latter case is the existing behavior
for the API requests (e.g via API or CLI) and will continue
to be supported.
