### PR TITLE
fixes #3892 - process REMOTE_USER_GROUP_N and REMOTE_USER_GROUP_#, add user to external user groups.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,7 +208,11 @@ class User < ActiveRecord::Base
       User.as :admin do
         options = { :name => auth_source_name }
         auth_source = AuthSource.where(options).first || AuthSourceExternal.create!(options)
+        external_groups = attrs.delete(:groups)
         user = User.create!(attrs.merge(:auth_source => auth_source))
+        if external_groups.present?
+          user.usergroups = ExternalUsergroup.where(:auth_source_id => auth_source, :name => external_groups).map(&:usergroup).uniq
+        end
         user.post_successful_login
       end
       return true

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -31,6 +31,12 @@ module SSO
     def authenticated?
       return false unless (self.user = request.env[CAS_USERNAME])
       attrs = { :login => self.user }.merge(additional_attributes)
+      group_count = request.env['REMOTE_USER_GROUP_N'].to_i
+      if group_count > 0
+        attrs[:groups] = []
+        group_count.times { |i| attrs[:groups]<< request.env["REMOTE_USER_GROUP_#{i+1}"] }
+      end
+
       return false unless User.find_or_create_external_user(attrs, Setting['authorize_login_delegation_auth_source_user_autocreate'])
       store
       true

--- a/test/factories/user_related.rb
+++ b/test/factories/user_related.rb
@@ -3,6 +3,12 @@ FactoryGirl.define do
     sequence(:name) {|n| "usergroup#{n}" }
   end
 
+  factory :external_usergroup do
+    sequence(:name) {|n| "external_usergroup#{n}" }
+    usergroup { FactoryGirl.create :usergroup }
+    auth_source { FactoryGirl.create :auth_source_external }
+  end
+
   factory :user do
     auth_source { AuthSourceInternal.first }
     password 'password'

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -409,6 +409,18 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'foobar@example.com', user.mail
     assert_equal 'Foo', user.firstname
     assert_equal 'Bar', user.lastname
+
+    # with existing user groups that are assigned
+    apache_source = AuthSourceExternal.find_or_create_by_name('apache_module')
+    usergroup = FactoryGirl.create :usergroup
+    FactoryGirl.create :external_usergroup, :usergroup => usergroup, 
+                                            :auth_source => apache_source, 
+                                            :name => usergroup.name
+    assert User.find_or_create_external_user({:login => 'not_existing_user_4',
+                                              :groups => [usergroup.name, 'does-not-exists-for-sure-123']},
+                                             apache_source.name)
+    user = User.find_by_login('not_existing_user_4')
+    assert_equal [usergroup], user.usergroups
   end
 
 


### PR DESCRIPTION
The configuration for this feature consists of enabling

```
LookupUserGroupsIter REMOTE_USER_GROUP
```

for

```
<LocationMatch ^/users/(ext)?login$>
```

and defining the mapping of external group names for EXTERNAL auth source to Foreman groups.
