### PR TITLE
Fixes #4884 : remove duplicate slashes from the gravatar url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
     # don't force SSL on localhost
     return true if request.host=~/localhost|127.0.0.1/
     # finally - redirect
-    redirect_to :protocol => 'https' and return if request.protocol != 'https' and not request.ssl?
+    redirect_to :protocol => 'https' and return if request.protocol != 'https://' and not request.ssl?
   end
 
   # This filter is called before FastGettext set_gettext_locale and sets user-defined locale

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -349,7 +349,7 @@ module ApplicationHelper
 
   def gravatar_url(email, default_image)
     return default_image if email.blank?
-    "#{request.protocol}//secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=mm&s=30"
+    "#{request.protocol}secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=mm&s=30"
   end
 
   def readonly_field(object, property, options={})


### PR DESCRIPTION
The issue is that request.protocol returns http:// instead of http. The code assumed no trailing slashes
