### PR TITLE
Fixes #4927 - Extend foreman-debug to look for extensions provided by pl...

### DIFF
--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -10,6 +10,7 @@ SYSCONFDIR = ENV['SYSCONFDIR'] || "#{PREFIX}/etc"
 LOCALSTATEDIR = ENV['LOCALSTATEDIR'] || "#{PREFIX}/var"
 SHAREDSTAREDIR = ENV['SHAREDSTAREDIR'] || "#{LOCALSTATEDIR}/lib"
 DATAROOTDIR = DATADIR = ENV['DATAROOTDIR'] || "#{PREFIX}/share"
+DEBUGDIR = ENV['DEBUGDIR'] || "#{DATAROOTDIR}/foreman/script/foreman-debug.d"
 MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
 
 file BUILDDIR do
@@ -36,6 +37,7 @@ task :install => :build do |t|
   mkdir_p "#{MANDIR}/man8"
   cp "#{BUILDDIR}/foreman-rake.8.gz", "#{MANDIR}/man8/"
   cp "#{BUILDDIR}/foreman-debug.8.gz", "#{MANDIR}/man8/"
+  mkdir_p "#{DEBUGDIR}"
 end
 
 task :default => :build

--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -259,6 +259,14 @@ add_files /etc/{sysconfig,default}/libvirt*
 add_files /etc/sysconfig/pgsql
 add_cmd "foreman-rake plugins" "plugin_list"
 
+# Look for any debug extensions provided by plugins
+if [ -d "/usr/share/foreman/script/foreman-debug.d" ]; then
+    for extension in "/usr/share/foreman/script/foreman-debug.d/*.sh"; do
+        printv "Processing extension $extension"
+        source $extension
+    done
+fi
+
 qprintf "\n\n"
 qprintf "%10s %s\n" "HOSTNAME:" "$(hostname -f 2>/dev/null)"
 qprintf "%10s %s\n" "OS:" "$OS"


### PR DESCRIPTION
...ugins.

This assumes a directory called /usr/share/foreman/debug. Any *.debug
file in there is sourced. The expectation is that plugins would put
files into this locations and can add files or commands as necessary
