### PR TITLE
fixes #1804 - find hosts through nested hostgroups on puppet class search

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -80,7 +80,7 @@ module Hostext
       def search_by_puppetclass(key, operator, value)
         conditions  = sanitize_sql_for_conditions(["puppetclasses.name #{operator} ?", value_to_sql(operator, value)])
         hosts       = Host.authorized(:view_hosts, Host).where(conditions).joins(:puppetclasses).uniq.map(&:id)
-        host_groups = Hostgroup.unscoped.with_taxonomy_scope.where(conditions).joins(:puppetclasses).uniq.map(&:id)
+        host_groups = Hostgroup.unscoped.with_taxonomy_scope.where(conditions).joins(:puppetclasses).uniq.map(&:subtree_ids).flatten.uniq
 
         opts = ''
         opts += "hosts.id IN(#{hosts.join(',')})"             unless hosts.blank?

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -1,0 +1,28 @@
+FactoryGirl.define do
+  factory :host do
+    sequence(:name) { |n| "host#{n}" }
+    domain
+    environment
+
+    trait :with_hostgroup do
+      hostgroup :environment => environment
+    end
+
+    trait :with_puppetclass do
+      puppetclasses { [ FactoryGirl.create(:puppetclass, :environments => [environment]) ] }
+    end
+  end
+
+  factory :hostgroup do
+    sequence(:name) { |n| "hostgroup#{n}" }
+
+    trait :with_parent do
+      association :parent, :factory => :hostgroup
+    end
+
+    trait :with_puppetclass do
+      environment
+      puppetclasses { [ FactoryGirl.create(:puppetclass, :environments => [environment]) ] }
+    end
+  end
+end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -11,6 +11,12 @@ FactoryGirl.define do
     trait :with_puppetclass do
       puppetclasses { [ FactoryGirl.create(:puppetclass, :environments => [environment]) ] }
     end
+
+    trait :with_parameter do
+      after_create do |host,evaluator|
+        FactoryGirl.create(:host_parameter, :host => host)
+      end
+    end
   end
 
   factory :hostgroup do
@@ -24,5 +30,23 @@ FactoryGirl.define do
       environment
       puppetclasses { [ FactoryGirl.create(:puppetclass, :environments => [environment]) ] }
     end
+
+    trait :with_parameter do
+      after_create do |hg,evaluator|
+        FactoryGirl.create(:hostgroup_parameter, :hostgroup => hg)
+      end
+    end
+  end
+
+  factory :parameter do
+    sequence(:name) { |n| "parameter#{n}" }
+    sequence(:value) { |n| "parameter value #{n}" }
+    type 'CommonParameter'
+  end
+  factory :host_parameter, :parent => :parameter, :class => HostParameter do
+    type 'HostParameter'
+  end
+  factory :hostgroup_parameter, :parent => :parameter, :class => GroupParameter do
+    type 'GroupParameter'
   end
 end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  factory :environment do
+    sequence(:name) {|n| "environment#{n}" }
+  end
+
+  factory :environment_class
+
+  factory :puppetclass do
+    sequence(:name) {|n| "class#{n}" }
+
+    ignore do
+      environments []
+    end
+
+    after_create do |pc,evaluator|
+      evaluator.environments.each do |env|
+        FactoryGirl.create :environment_class, :puppetclass_id => pc.id, :environment_id => env.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
The second commit (refs #2189) is optional since it's already fixed, but I thought while I was in here I'd add some more factories for parameters and make the tests a bit more explicit.
