### PR TITLE
Backport bugfix in hosts form when location is nil

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -30,7 +30,7 @@
 
         <% if show_organization_tab?  %>
           <%= select_f f, :organization_id, Organization.my_organizations, :id, :to_label,
-            { :include_blank => !@host.managed?, :selected => @organization.id},
+            { :include_blank => !@host.managed?, :selected => @organization.try(:id)},
             { :disabled => !@host.new_record?,
               :onchange => 'organization_changed(this);', :label => _("Organization"), :'data-host-id' => @host.id,
             :'data-url' => process_taxonomy_hosts_path,
@@ -39,7 +39,7 @@
 
         <% if show_location_tab? %>
           <%= select_f f, :location_id, Location.my_locations, :id, :to_label,
-            { :include_blank => !@host.managed?, :selected => @location.id },
+            { :include_blank => !@host.managed?, :selected => @location.try(:id) },
             { :disabled => !@host.new_record?,
               :onchange => 'location_changed(this);', :label => _("Location"), :"data-host-id" => @host.id,
               :'data-url' => process_taxonomy_hosts_path, :selected => Location.my_locations,


### PR DESCRIPTION
This commit fixes a bug that has been fixed in
acfbc45886c4d81a2a3ca5af433a6124a0a7191a

Without that commit, a 500 error is generated when there is no location
available for the user when creating a new host.
