### PR TITLE
fixes #4673 - make default sort order descending on count columns

### DIFF
--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -5,7 +5,7 @@
   <tr>
     <th><%= sort :name, :as => s_("Architecture|Name") %></th>
     <th><%= _("Operating Systems") %></th>
-    <th><%= sort :hosts_count, :as => _("Hosts") %></th>
+    <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
     <th></th>
   </tr>
   <% for architecture in @architectures %>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -5,7 +5,7 @@
 <table class="table table-bordered table-striped table-two-pane">
   <tr>
     <th><%= sort :name, :as => s_("Domain|Fullname") %></th>
-    <th><%= sort :hosts_count, :as => _("Hosts") %></th>
+    <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
     <th></th>
   </tr>
   <% for domain in @domains %>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -5,7 +5,7 @@
 <table class="table table-bordered table-striped table-two-pane">
   <tr>
     <th><%= sort :name, :as => s_('Environment|Name') %></th>
-    <th><%= sort :hosts_count, :as => _('Hosts') %></th>
+    <th><%= sort :hosts_count, :as => _('Hosts'), :default => "DESC" %></th>
     <th></th>
   </tr>
 

--- a/app/views/lookup_keys/index.html.erb
+++ b/app/views/lookup_keys/index.html.erb
@@ -5,7 +5,7 @@
   <tr>
     <th><%= sort :key, :as => _("Variable") %></th>
     <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-    <th><%= sort :values_count, :as => _('Number of values') %></th>
+    <th><%= sort :values_count, :as => _('Number of values'), :default => "DESC" %></th>
     <th></th>
   </tr>
 

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -7,7 +7,7 @@
     <th><%= sort :name, :as => s_("Model|Name") %></th>
     <th><%= sort :vendor_class, :as => _("Vendor class") %></th>
     <th><%= sort :hardware_model, :as => s_("Model|Hardware model") %></th>
-    <th><%= sort :hosts_count, :as => _("Hosts") %></th>
+    <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
     <th></th>
   </tr>
   <% for model in @models %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -4,7 +4,7 @@
 <table class="table table-bordered table-striped table-two-pane">
   <tr>
     <th><%= sort :name, :as => s_("Operatingsystem|Name") %></th>
-    <th><%= sort :hosts_count, :as => _("Hosts") %></th>
+    <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
     <th></th>
   </tr>
   <% for operatingsystem in @operatingsystems %>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -7,9 +7,9 @@
     <th><%= sort :name, :as => s_("Puppetclass|Name") %></th>
     <th><%= sort :environment, :as => _("Environments and documentation") %></th>
     <th><%= _('Host group') %></th>
-    <th><%= sort :hosts_count, :as => _('Hosts') %></th>
-    <th><%= sort :params_count, :as => _('Parameters') %></th>
-    <th><%= sort :variables_count, :as => _('Variables') %></th>
+    <th><%= sort :hosts_count, :as => _('Hosts'), :default => "DESC" %></th>
+    <th><%= sort :params_count, :as => _('Parameters'), :default => "DESC" %></th>
+    <th><%= sort :variables_count, :as => _('Variables'), :default => "DESC" %></th>
     <th></th>
   </tr>
   <% for puppetclass in @puppetclasses %>


### PR DESCRIPTION
Scoped Search 2.7.1 now supports default orders.
