### PR TITLE
Define auth_source for group.

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -20,6 +20,7 @@ class AuthSource < ActiveRecord::Base
 
   before_destroy EnsureNotUsedBy.new(:users)
   has_many :users
+  has_many :usergroups
 
   validates :name, :presence => true, :uniqueness => true, :length => { :maximum => 60 }
 

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -18,7 +18,7 @@
 class AuthSource < ActiveRecord::Base
   audited :allow_mass_assignment => true
 
-  before_destroy EnsureNotUsedBy.new(:users)
+  before_destroy EnsureNotUsedBy.new(:users, :usergroups)
   has_many :users
   has_many :usergroups
 

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -16,8 +16,7 @@ class Usergroup < ActiveRecord::Base
 
 
   has_many_hosts :as => :owner
-  validates :name, :length => { :maximum => 255 }
-  validates_uniqueness_of :name, :scope => [ :name, :auth_source_id ]
+  validates :name, :length => { :maximum => 255 }, :uniqueness => { :scope => [ :name, :auth_source_id ] }, :presence => true
   belongs_to :auth_source
   before_destroy EnsureNotUsedBy.new(:hosts, :usergroups)
 

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -16,7 +16,9 @@ class Usergroup < ActiveRecord::Base
 
 
   has_many_hosts :as => :owner
-  validates :name, :uniqueness => true, :length => { :maximum => 255 }
+  validates :name, :length => { :maximum => 255 }
+  validates_uniqueness_of :name, :scope => [ :name, :auth_source_id ]
+  belongs_to :auth_source
   before_destroy EnsureNotUsedBy.new(:hosts, :usergroups)
 
   # The text item to see in a select dropdown menu

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -12,6 +12,8 @@
       <%= text_f f, :name %>
       <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
       <%= multiple_checkboxes f, :users, @usergroup, User, :label => _("Users") %>
+
+      <%= select_f f, :auth_source_id, AuthSource.all, :id, :to_label %>
     </div>
 
     <div class="tab-pane" id="roles">

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -13,7 +13,7 @@
       <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
       <%= multiple_checkboxes f, :users, @usergroup, User, :label => _("Users") %>
 
-      <%= select_f f, :auth_source_id, AuthSource.all, :id, :to_label %>
+      <%= select_f f, :auth_source_id, AuthSource.all, :id, :to_label, :label => _("Authorized by") %>
     </div>
 
     <div class="tab-pane" id="roles">

--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -11,7 +11,7 @@
   </tr>
   <% for usergroup in @usergroups %>
     <tr>
-      <td><%= link_to_if_authorized h(usergroup.name), hash_for_edit_usergroup_path(:id => usergroup.id).merge(:auth_object => usergroup, :authorizer => authorizer) %></td>
+      <td><%= link_to_if_authorized h(usergroup.name + (usergroup.auth_source.name == AuthSourceInternal.first.name ? '' : ' (' + usergroup.auth_source.name + ')')), hash_for_edit_usergroup_path(:id => usergroup.id).merge(:auth_object => usergroup, :authorizer => authorizer) %></td>
       <td><%= h usergroup.users.map(&:login).to_sentence %></td>
       <td><%= h usergroup.usergroups.map(&:name).to_sentence %></td>
       <td>

--- a/db/migrate/20140331153749_add_auth_source_id_to_usergroup.rb
+++ b/db/migrate/20140331153749_add_auth_source_id_to_usergroup.rb
@@ -1,5 +1,14 @@
 class AddAuthSourceIdToUsergroup < ActiveRecord::Migration
   def change
-    add_column :usergroups, :auth_source_id, :integer, :default => AuthSourceInternal.first.id, :null => false;
+    add_column :usergroups, :auth_source_id, :integer, :null => true
+    add_foreign_key :usergroups, :auth_sources, :name => "usergroups_auth_source_id_fk"
+    add_index :usergroups, [:name, :auth_source_id], :unique => true
+  end
+
+  def up
+    if (internal = AuthSourceInternal.first).present?
+      Usergroup.update_all(:auth_source_id => internal.id)
+    end
+    change_column :usergroups, :auth_source_id, :null => false
   end
 end

--- a/db/migrate/20140331153749_add_auth_source_id_to_usergroup.rb
+++ b/db/migrate/20140331153749_add_auth_source_id_to_usergroup.rb
@@ -1,0 +1,5 @@
+class AddAuthSourceIdToUsergroup < ActiveRecord::Migration
+  def change
+    add_column :usergroups, :auth_source_id, :integer, :default => AuthSourceInternal.first.id, :null => false;
+  end
+end


### PR DESCRIPTION
Factored out auth_source changes from https://github.com/theforeman/foreman/pull/1328 (and https://github.com/theforeman/foreman/pull/529).

Relaxing usergroups.name uniqueness to usergroups(name, auth_source_id).
