### PR TITLE
fixes #4895 - Adds CSRF protection check to the API if a session user is present

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,9 @@ module Api
     include Foreman::Controller::Session
     include Foreman::ThreadSession::Cleaner
 
+    protect_from_forgery
+    skip_before_filter :verify_authenticity_token, :unless => :protect_api_from_forgery?
+
     before_filter :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
     before_filter :session_expiry, :update_activity_time
 
@@ -276,6 +279,10 @@ module Api
       else
         raise ::Foreman::Exception.new(N_("unknown permission for %s"), "#{params[:controller]}##{params[:action]}")
       end
+    end
+
+    def protect_api_from_forgery?
+      session[:user].present?
     end
   end
 end


### PR DESCRIPTION
Replaces #1331 with added tests (had to rework how we only applied this to session users)
