### PR TITLE
Fixes #4960 - undefined method `host_classes_path' when editing filter

### DIFF
--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -23,9 +23,11 @@ module FiltersHelper
     prefix, suffix = path.split('/', 2)
     if path.include?("/") && Rails.application.routes.mounted_helpers.method_defined?(prefix)
       # handle mounted engines
-      send(prefix).send(suffix)
+      engine = send(prefix)
+      engine.send(suffix) if engine.respond_to?(suffix)
     else
-      send(path.tr("/", "_"))
+      path = path.tr("/", "_")
+      send(path) if respond_to?(path)
     end
   end
 end

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -45,7 +45,8 @@
 
         <%= autocomplete_f f, :search,
                            :disabled => f.object.unlimited?,
-                           :path => resource_path(f.object.resource_type), :control_group_id => 'search_group' %>
+                           :path => resource_path(f.object.resource_type) || "",
+                           :control_group_id => 'search_group' %>
       </div>
     </div>
 


### PR DESCRIPTION
Host classes don't have any UI controller and therefore the *_path method doesn't exist. The search box is not displayed for host classes at all so I just put blank string as default value for the search path.
