### PR TITLE
fixes #5113 - sort realms by host count

### DIFF
--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -11,6 +11,7 @@ class Realm < ActiveRecord::Base
   has_many_hosts
   has_many :hostgroups
 
+  scoped_search :on => :hosts_count
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :realm_type, :complete_value => true, :rename => :type
 


### PR DESCRIPTION
In order to sort columns, the field needs to be enabled for scoped_search, so currently sorting realms by host count is broken.
