### PR TITLE
fixes #4641 Ensure default user role only after we save/update.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,8 @@ class User < ActiveRecord::Base
 
   attr_protected :password_hash, :password_salt, :admin
   attr_accessor :password, :password_confirmation
+  after_save :ensure_default_role
   before_destroy EnsureNotUsedBy.new(:direct_hosts, :hostgroups), :ensure_hidden_users_are_not_deleted, :ensure_last_admin_is_not_deleted
-  after_commit :ensure_default_role
 
   belongs_to :auth_source
   belongs_to :default_organization, :class_name => 'Organization'
@@ -487,7 +487,9 @@ class User < ActiveRecord::Base
 
   def ensure_default_role
     role = Role.find_by_name('Anonymous')
-    self.roles << role unless self.role_ids.include?(role.id)
+    if role.present?
+      self.roles << role unless self.role_ids.include?(role.id)
+    end
   end
 
   def default_location_inclusion

--- a/db/seeds.d/11-roles.rb
+++ b/db/seeds.d/11-roles.rb
@@ -60,7 +60,7 @@ default_user_permissions = [:view_hosts, :view_puppetclasses, :view_hostgroups, 
                             :view_authenticators, :access_settings, :access_dashboard,
                             :view_reports, :view_subnets, :view_facts, :view_locations,
                             :view_organizations, :view_statistics, :view_realms]
-anonymous_permissions    = [:view_hosts, :view_bookmarks, :view_tasks]
+anonymous_permissions    = [:view_bookmarks, :view_tasks]
 
 Role.without_auditing do
   default_permissions.each do |role_name, permission_names|

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -393,7 +393,7 @@ default_user_17_0:
   permission: view_realms
 anonymous_1_0:
   filter: anonymous_1
-  permission: view_hosts
+  permission: view_tasks
 destroy_hosts_1_0:
   filter: destroy_hosts_1
   permission: destroy_hosts

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -63,7 +63,7 @@ class UsersControllerTest < ActionController::TestCase
   test "role changes should expire topbar cache" do
     user = FactoryGirl.create(:user, :with_mail)
     role1 = FactoryGirl.create :role
-    UserRole.any_instance.expects(:expire_topbar_cache).once
+    UserRole.any_instance.expects(:expire_topbar_cache).at_least(1)
     put :update, { :id => user.id, :user => {:role_ids => [role1.id]} }, set_session_user
   end
 

--- a/test/unit/user_role_test.rb
+++ b/test/unit/user_role_test.rb
@@ -16,10 +16,11 @@ class UserRoleTest < ActiveSupport::TestCase
   test "cache user roles" do
     user             = FactoryGirl.create :user
     user_role        = FactoryGirl.create :user_user_role, :owner => user
-    cached_user_role = user.cached_user_roles.first
+    cached_user_roles = user.cached_user_roles.map(&:role)
 
-    assert_equal user_role.role, cached_user_role.role
-    assert_equal user_role, cached_user_role.user_role
+    user.roles.each do |role|
+      assert_include cached_user_roles, role
+    end
   end
 
   test "cache usergroup roles" do
@@ -27,9 +28,9 @@ class UserRoleTest < ActiveSupport::TestCase
 
     users = @semiadmin_users + [@admin_user] + [@superadmin_user]
     users.each do |user|
-      cached_user_role = user.cached_user_roles.first
-      assert_equal user_role.role, cached_user_role.role
-      assert_equal user_role, cached_user_role.user_role
+      cached_user_roles = user.cached_user_roles
+      assert_include cached_user_roles.map(&:role), user_role.role
+      assert_include cached_user_roles.map(&:user_role), user_role
     end
   end
 
@@ -41,8 +42,7 @@ class UserRoleTest < ActiveSupport::TestCase
 
     users = @semiadmin_users + [@admin_user] + [@superadmin_user]
     users.each  do |user|
-      cached_user_role = user.cached_user_roles.first
-      assert_equal new_role, cached_user_role.role
+      assert_include user.cached_user_roles.map(&:role), new_role
     end
   end
 
@@ -53,13 +53,13 @@ class UserRoleTest < ActiveSupport::TestCase
 
     users = [@admin_user, @superadmin_user]
     users.each do |user|
-      cached_user_role = user.cached_user_roles.first
-      assert_equal user_role.role, cached_user_role.role
+     assert_include user.cached_user_roles.map(&:role), user_role.role
     end
 
     users = @semiadmin_users
     users.each do |user|
-      assert_empty user.cached_user_roles
+      assert_not_empty user.cached_user_roles
+      assert_equal user.cached_user_roles.length, 1
     end
   end
 

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -120,19 +120,19 @@ class UsergroupTest < ActiveSupport::TestCase
     two          = FactoryGirl.create(:role)
 
     record.roles = [one, two]
-    assert_equal 2, user.reload.cached_user_roles.size
+    assert_equal 3, user.reload.cached_user_roles.size
 
     assert record.update_attributes(:role_ids => [ two.id ])
-    assert_equal 1, user.reload.cached_user_roles.size
+    assert_equal 2, user.reload.cached_user_roles.size
 
     record.role_ids = [ ]
-    assert_equal 0, user.reload.cached_user_roles.size
-
-    assert record.update_attribute(:role_ids, [ one.id ])
     assert_equal 1, user.reload.cached_user_roles.size
 
-    record.roles<< two
+    assert record.update_attribute(:role_ids, [ one.id ])
     assert_equal 2, user.reload.cached_user_roles.size
+
+    record.roles << two
+    assert_equal 3, user.reload.cached_user_roles.size
   end
 
   test 'add_users adds users in list and does not add nonexistent users' do


### PR DESCRIPTION
## Solution

Use `after_save` callback to save a user role.
Add default user role for users who don't have a role assigned.
## Problems

I tries to write a regression test, and even though I use `test_after_commit` gem, the test didn't fail. So I removed it.
