### PR TITLE
Allow manual invokation of the IP suggestion logic.

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -538,6 +538,12 @@ $(document).on('change', '.interface_domain', function () {
   interface_domain_selected(this);
 });
 
+$(document).on('click', '#suggest_new_ip', function (e) {
+  $('#host_ip').val('')
+  interface_subnet_selected($('#host_subnet_id'));
+  e.preventDefault();
+});
+
 $(document).on('change', '.interface_subnet', function () {
   interface_subnet_selected(this);
 });

--- a/app/views/hosts/_unattended.html.erb
+++ b/app/views/hosts/_unattended.html.erb
@@ -25,7 +25,7 @@
         <span id="subnet_select">
           <%= render 'common/domain', :item => @host %>
         </span>
-        <%= text_f f, :ip, :autocomplete => 'off',
+        <%= text_f f, :ip, :autocomplete => 'off', :help_block => link_to("Suggest new", '#', :id => 'suggest_new_ip'),
           :help_inline => popover(_("IP address auto-suggest"), _("An IP address will be auto-suggested if you have a DHCP-enabled Smart Proxy on the subnet selected above.<br/><br/>The IP address can be left blank when:<br/><ul><li>provisioning tokens are enabled</li><li>the domain does not manage DNS</li><li>the subnet does not manage reverse DNS</li><li>and the subnet does not manage DHCP reservations</li></ul>"), :title => _("IP address for this host")).html_safe %>
         <%= f.fields_for :interfaces do |interfaces| %>
           <%= render 'hosts/interfaces', :f => interfaces  %>


### PR DESCRIPTION
Add the ability to manually request a new IP for a host.

This is useful if the IP that's previously picked up from DHCP isn't what's needed.

![screen shot 2014-04-11 at 10 02 07](https://cloud.githubusercontent.com/assets/98526/2677813/04359956-c158-11e3-90a5-9ad4c23eff96.png)
