### PR TITLE
Fixes #5180 - in_taxonomy clears out Taxonomy.current

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -94,6 +94,15 @@ Spork.prefork do
       as_user :admin, &block
     end
 
+    def in_taxonomy(taxonomy)
+      new_taxonomy = taxonomies(taxonomy)
+      saved_taxonomy = new_taxonomy.class.current
+      new_taxonomy.class.current = new_taxonomy
+      result = yield
+      new_taxonomy.class.current = saved_taxonomy
+      result
+    end
+
     def setup_users
       User.current = users :admin
       user = User.find_by_login("one")

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -468,23 +468,23 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "return location and child ids for non-admin user" do
-    user = users(:one)
-    User.current = user
-    location = taxonomies(:location1)
-    Location.current = location
-    assert user.locations << location
-    assert child = Location.create!(:name => 'child location', :parent_id => location.id)
-    assert_equal [location.id, child.id].sort, user.location_and_child_ids
+    as_user :one do
+      in_taxonomy :location1 do
+        assert User.current.locations << Location.current
+        assert child = Location.create!(:name => 'child location', :parent_id => Location.current.id)
+        assert_equal [Location.current.id, child.id].sort, User.current.location_and_child_ids
+      end
+    end
   end
 
   test "return organization and child ids for non-admin user" do
-    user = users(:one)
-    User.current = user
-    organization = taxonomies(:organization1)
-    Organization.current = organization
-    assert user.organizations << organization
-    assert child = Organization.create!(:name => 'child organization', :parent_id => organization.id)
-    assert_equal [organization.id, child.id].sort, user.organization_and_child_ids
+    as_user :one do
+      in_taxonomy :organization1 do
+        assert User.current.organizations << Organization.current
+        assert child = Organization.create!(:name => 'child organization', :parent_id => Organization.current.id)
+        assert_equal [Organization.current.id, child.id].sort, User.current.organization_and_child_ids
+      end
+    end
   end
 
 #  Uncomment after users get access to children taxonomies of their current taxonomies.


### PR DESCRIPTION
This fixes broken tests in here https://github.com/theforeman/foreman/commit/53516db7c7646ec76ce449793a4bc8048d48b787 that set Location.current and Organization.current but did not clear them and made other tests fail.
