### PR TITLE
Fixes #5221: Adds a helper method to allow a model instance to inquire i...

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -19,5 +19,10 @@ module Authorizable
         Authorizer.new(User.current).find_collection(resource || self, :permission => permission)
       end
     }
+
+    def authorized?(permission)
+      return false if User.current.nil?
+      User.current.can?(permission, self)
+    end
   end
 end


### PR DESCRIPTION
...f the instance is authorized for a particular permission.

Model instances can be asked directly if they are authorized for a particular
permission by, for example, calling 'instance.authorized?(:view_model)'. This
abstracts and centralizes some of the repetitiveness of having to instantiate
an authorizer and pass the instance to the 'can?' method as the object of inquiry.
