### PR TITLE
fixes #5222 - Log ldap attributes in debug-level logging

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -61,6 +61,7 @@ class AuthSourceLdap < AuthSource
       return nil
     end
     # return user's attributes
+    logger.debug "Retrieved LDAP Attributes for #{login}: #{attrs}"
     attrs
   rescue Net::LDAP::LdapError => text
     raise "LdapError: %s" % text


### PR DESCRIPTION
Helps to see the whole process.  Looks like this:

```
LDAP-Auth with User uid=foreman,cn=sysaccounts,cn=etc,dc=bitbin,dc=de
DN found for stbenjam: uid=stbenjam,cn=users,cn=accounts,dc=bitbin,dc=de
Retrieved LDAP Attributes for stbenjam: {:firstname=>"Stephen", :lastname=>"Benjamin", :mail=>"stephen@bitbin.de", :avatar_hash=>"5d2f0b335c4a1875a575445c6d12fb072c73c075"}
Authenticated user Stephen Benjamin against LDAP-astriaporta authentication source
```
