### PR TITLE
fixes #5224 - Don't update a user with blank LDAP attribute values

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,7 +167,7 @@ class User < ActiveRecord::Base
         # update with returned attrs, maybe some info changed in LDAP
         old_hash = user.avatar_hash
         User.as :admin do
-          user.update_attributes(attrs.slice(:firstname, :lastname, :mail, :avatar_hash))
+          user.update_attributes(attrs.slice(:firstname, :lastname, :mail, :avatar_hash).delete_if { |k, v| v.blank? })
         end if attrs.is_a? Hash
 
         # clean up old avatar if it exists and the image isn't in use by anyone else

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -91,6 +91,18 @@ class UserTest < ActiveSupport::TestCase
     assert_not_equal last_login, User.find(user.id).last_login_on
   end
 
+  test "ldap user attribute should be updated when not blank" do
+    AuthSourceLdap.any_instance.stubs(:authenticate).returns({ :firstname => "Foo" })
+    u = User.try_to_login("foo", "password")
+    assert_equal u.firstname, "Foo"
+  end
+
+  test "ldap user attribute should not be updated when blank" do
+    AuthSourceLdap.any_instance.stubs(:authenticate).returns({ :mail => "" })
+    u = User.try_to_login("foo", "password")
+    assert_equal u.mail, "foo@bar.com"
+  end
+
   test "should not be able to delete the admin account" do
     assert !User.find_by_login("admin").destroy
   end


### PR DESCRIPTION
If a user does not have an e-mail address, Foreman will prompt for one when they login.  But, if they're logging in via LDAP and their LDAP attrs has a blank mail, Foreman will update the user with the blank value, and then prompt the user again for an e-mail address.
