### PR TITLE
fixes #5214 - pin ancestry for Ruby 1.8 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'json'
 gem 'rest-client', :require => 'rest_client'
 gem "audited-activerecord", "3.0.0"
 gem "will_paginate", "~> 3.0.2"
-gem "ancestry", "~> 2.0"
+gem "ancestry", "~> 2.0.0"
 gem 'scoped_search', '>= 2.6.2'
 gem 'net-ldap'
 gem 'uuidtools'


### PR DESCRIPTION
Tests running manually: http://ci.theforeman.org/job/test_develop_pull_request/7323/
