### PR TITLE
fixes #5242 - Keep user's attributes and group membership up-to-date even during subsequent logons

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,7 +205,7 @@ class User < ActiveRecord::Base
       external_groups = attrs.delete(:groups)
       groups = user.usergroups.includes(:external_usergroups).where('usergroups.id not in (?)', ExternalUsergroup.where(:auth_source_id => auth_source).pluck(:usergroup_id))
       if user.auth_source_id == auth_source.first.id
-        user.update_attributes(attrs)
+        user.update_attributes(attrs.delete_if { |k, v| v.blank? })
         groups = (groups + ExternalUsergroup.where(:auth_source_id => auth_source, :name => external_groups).map(&:usergroup)).uniq
       end
       user.usergroups = groups

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,10 +201,10 @@ class User < ActiveRecord::Base
 
   def self.find_or_create_external_user(attrs, auth_source_name)
     if (user = unscoped.find_by_login(attrs[:login]))
-      auth_source = AuthSource.where(:name => auth_source_name)
+      auth_source = AuthSource.find_by_name(auth_source_name)
       external_groups = attrs.delete(:groups)
       groups = user.usergroups.includes(:external_usergroups).where('usergroups.id not in (?)', ExternalUsergroup.where(:auth_source_id => auth_source).pluck(:usergroup_id))
-      if user.auth_source_id == auth_source.first.id
+      if auth_source && user.auth_source_id == auth_source.first.id
         user.update_attributes(attrs.delete_if { |k, v| v.blank? })
         groups = (groups + ExternalUsergroup.where(:auth_source_id => auth_source, :name => external_groups).map(&:usergroup)).uniq
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,6 +201,10 @@ class User < ActiveRecord::Base
 
   def self.find_or_create_external_user(attrs, auth_source_name)
     if (user = unscoped.find_by_login(attrs[:login]))
+      if user.auth_source.is_a? AuthSourceExternal
+        external_groups = attrs.delete(:groups)
+        user.update_attributes(attrs)
+      end
       return true
     elsif auth_source_name.nil?
       return false


### PR DESCRIPTION
Building on top of https://github.com/theforeman/foreman/pull/1390 and https://github.com/theforeman/foreman/pull/1328, we will update user's attributes and group membership.

It is only done for users in AuthSourceExternal, even if group memberships from groups related to the AuthSourceExternal external groups are revoked from any user.
