### PR TITLE
fixes #5247 - overridable keys displayed on host group when env is inherited

### DIFF
--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -65,7 +65,7 @@ module LookupKeysHelper
   end
 
   def overridable_lookup_keys klass, host
-    klass.class_params.override.where(:environment_classes => {:environment_id => host.environment_id}) + klass.lookup_keys
+    klass.class_params.override.where(:environment_classes => {:environment_id => host.environment}) + klass.lookup_keys
   end
 
   def hostgroup_key_with_diagnostic hostgroup, key


### PR DESCRIPTION
This occurs when the environment on the child host group has an inherited environment ("Inherit parent (production)"), but not when using explicitly set environments.
