### PR TITLE
fixes #5453 - ensure all VMware compute attribute keys are symbolized

### DIFF
--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
       user 'ec2user'
       password 'ec2password'
       url 'eu-west-1'
+      after_build { |host| host.class.skip_callback(:create, :after, :setup_key_pair) }
     end
 
     trait :gce do
@@ -25,12 +26,14 @@ FactoryGirl.define do
       provider 'Openstack'
       user 'osuser'
       password 'ospassword'
+      after_build { |host| host.class.skip_callback(:create, :after, :setup_key_pair) }
     end
 
     trait :ovirt do
       provider 'Ovirt'
       user 'ovirtuser'
       password 'ovirtpassword'
+      after_build { |host| host.class.skip_callback(:create, :before, :update_public_key) }
     end
 
     trait :rackspace do
@@ -46,14 +49,15 @@ FactoryGirl.define do
       password 'vpassword'
       sequence(:server) { |n| "#{n}.example.com" }
       datacenter 'vdatacenter'
+      after_build { |host| host.class.skip_callback(:create, :before, :update_public_key) }
     end
 
-    factory :ec2_cr, :traits => [:ec2]
-    factory :gce_cr, :traits => [:gce]
-    factory :libvirt_cr, :traits => [:libvirt]
-    factory :openstack_cr, :traits => [:openstack]
-    factory :ovirt_cr, :traits => [:ovirt]
-    factory :rackspace_cr, :traits => [:rackspace]
-    factory :vmware_cr, :traits => [:vmware]
+    factory :ec2_cr, :class => Foreman::Model::EC2, :traits => [:ec2]
+    factory :gce_cr, :class => Foreman::Model::GCE, :traits => [:gce]
+    factory :libvirt_cr, :class => Foreman::Model::Libvirt, :traits => [:libvirt]
+    factory :openstack_cr, :class => Foreman::Model::Openstack, :traits => [:openstack]
+    factory :ovirt_cr, :class => Foreman::Model::Ovirt, :traits => [:ovirt]
+    factory :rackspace_cr, :class => Foreman::Model::Rackspace, :traits => [:rackspace]
+    factory :vmware_cr, :class => Foreman::Model::Vmware, :traits => [:vmware]
   end
 end

--- a/test/unit/compute_resources/vmware_test.rb
+++ b/test/unit/compute_resources/vmware_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class VmwareTest < ActiveSupport::TestCase
+  test "#create_vm calls new_vm when network provisioning" do
+    attrs_in = HashWithIndifferentAccess.new("cpus"=>"1", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
+    # All keys must be symbolized
+    attrs_out = {:cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}]}
+
+    mock_vm = mock('vm')
+    mock_vm.expects(:save).returns(mock_vm)
+    mock_network = mock('network')
+    mock_network.stubs('id').returns('network-17')
+    mock_network.stubs('name').returns('Test network')
+
+    cr = FactoryGirl.build(:vmware_cr)
+    cr.expects(:new_vm).with(attrs_out).returns(mock_vm)
+    cr.expects(:test_connection)
+    cr.expects(:networks).returns([mock_network])
+    assert_equal mock_vm, cr.create_vm(attrs_in)
+  end
+
+  test "#new_vm merges defaults with user args and creates server" do
+    attrs_in = {:cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}]}
+    attrs_out = {:name => 'test', :cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}]}
+
+    mock_vm = mock('new server')
+    mock_servers = mock('client.servers')
+    mock_servers.expects(:new).with(attrs_out).returns(mock_vm)
+    mock_client = mock('client')
+    mock_client.expects(:servers).returns(mock_servers)
+
+    cr = FactoryGirl.build(:vmware_cr)
+    cr.expects(:vm_instance_defaults).returns(HashWithIndifferentAccess.new(:name => 'test', :cpus => '2', :interfaces => [mock('iface')], :volumes => [mock('vol')]))
+    cr.expects(:client).returns(mock_client)
+    assert_equal mock_vm, cr.new_vm(attrs_in)
+  end
+
+  test "#create_vm calls clone_vm when image provisioning" do
+    attrs_in = HashWithIndifferentAccess.new("image_id"=>"2","cpus"=>"1", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
+    # All keys must be symbolized
+    attrs_out = {:image_id=>"2", :cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}]}
+
+    mock_vm = mock('vm')
+    mock_network = mock('network')
+    mock_network.stubs('id').returns('network-17')
+    mock_network.stubs('name').returns('Test network')
+
+    cr = FactoryGirl.build(:vmware_cr)
+    cr.expects(:clone_vm).with(attrs_out).returns(mock_vm)
+    cr.expects(:test_connection)
+    cr.expects(:networks).returns([mock_network])
+    assert_equal mock_vm, cr.create_vm(attrs_in)
+  end
+end


### PR DESCRIPTION
The bug was caused by string keys used in our hashes instead of symbols.  Symbols are important as fog is checking for them, so it wasn't converting a string class name into the real class here: https://github.com/fog/fog/blob/master/lib/fog/vsphere/models/compute/interface.rb#L25-L31

In 1.4, the args hash passed from the controller into create_vm got symbolised here: https://github.com/theforeman/foreman/blob/1.4-stable/app/models/compute_resources/foreman/model/vmware.rb#L95

It's very important that it's symbolised before we use nested_attributes_for, else the inner hashes (of interfaces + volumes) aren't symbolised when they're stored in an indifferent hash.

We lost this in 1.5 here: https://github.com/theforeman/foreman/blob/1.5-stable/app/models/compute_resources/foreman/model/vmware.rb#L113-L124

This PR adds symbolize_keys back into the same position and updates the clone_vm path to expect symbols too.
