### PR TITLE
fixes #4590 - convert VMware SCSI controller type during creation

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -239,6 +239,10 @@ module Foreman::Model
         args[collection] = nested_attributes_for(collection, nested_attrs) if nested_attrs
       end
 
+      if args[:scsi_controller_type].present?
+        args[:scsi_controller] = {:type => args.delete(:scsi_controller_type)}
+      end
+
       args.reject! { |k, v| v.nil? }
       args
     end

--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -34,10 +34,6 @@ module FogExtensions
         scsi_controller.type
       end
 
-      def scsi_controller_type= type
-        scsi_controller[:type] = type
-      end
-
     end
   end
 end

--- a/test/unit/compute_resources/vmware_test.rb
+++ b/test/unit/compute_resources/vmware_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 class VmwareTest < ActiveSupport::TestCase
   test "#create_vm calls new_vm when network provisioning" do
-    attrs_in = HashWithIndifferentAccess.new("cpus"=>"1", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
+    attrs_in = HashWithIndifferentAccess.new("cpus"=>"1", "scsi_controller_type"=>"ParaVirtualSCSIController", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
     # All keys must be symbolized
-    attrs_out = {:cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}]}
+    attrs_out = {:cpus=>"1", :interfaces=>[{:type=>"VirtualVmxnet3", :network=>"Test network", :_delete=>""}], :volumes=>[{:size_gb=>"1", :_delete=>""}], :scsi_controller=>{:type=>"ParaVirtualSCSIController"}}
 
     mock_vm = mock('vm')
     mock_vm.expects(:save).returns(mock_vm)


### PR DESCRIPTION
Based on @witlessbird's analysis here: http://projects.theforeman.org/issues/4590#note-13

Converts the SCSI controller type while we're generating the hash to pass to Fog, instead of changing the behaviour of its model.
