### PR TITLE
fixes #2785 - host model clone method also copies relationships using deep_cloneable gem

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -75,15 +75,11 @@ class HostsController < ApplicationController
 
   # Clone the host
   def clone
-    @clone_host = @host
-    new = @host.dup
-    new.name = nil
-    new.mac = nil
-    new.ip = nil
+    @clone_host = @host.clone
+    @host = @clone_host
     load_vars_for_ajax
     flash[:warning] = _("The marked fields will need reviewing")
-    new.valid?
-    @host = new
+    @host.valid?
     render :action => :new
   end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -624,17 +624,12 @@ class Host::Managed < Host::Base
   end
 
   def clone
-    new = super
-    new.puppetclasses = puppetclasses
-    # Clone any parameters as well
-    host_parameters.each{|param| new.host_parameters << HostParameter.new(:name => param.name, :value => param.value, :nested => true)}
-    interfaces.each {|int| new.interfaces << int.clone }
-    # clear up the system specific attributes
-    [:name, :mac, :ip, :uuid, :certname, :last_report].each do |attr|
-      new.send "#{attr}=", nil
-    end
-    new.puppet_status = 0
-    new
+    # .dup uses deep_cloneable gem
+    # do not copy system specific attributes
+    host = self.dup(:include => [:host_config_groups, :host_classes, :host_parameters],
+                    :except  => [:name, :mac, :ip, :uuid, :certname, :last_report])
+    host.puppet_status = 0
+    host
   end
 
   def bmc_nic

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1201,6 +1201,27 @@ class HostTest < ActiveSupport::TestCase
     assert_equal classes, enc['classes']
   end
 
+  test 'clone host including its relationships' do
+    host = hosts(:one)
+    copy = host.clone
+    assert_equal host.host_classes.map(&:puppetclass_id), copy.host_classes.map(&:puppetclass_id)
+    assert_equal host.host_parameters.map(&:name), copy.host_parameters.map(&:name)
+    assert_equal host.host_parameters.map(&:value), copy.host_parameters.map(&:value)
+    assert_equal host.host_config_groups.map(&:config_group_id), copy.host_config_groups.map(&:config_group_id)
+  end
+
+  test 'clone host should not copy name, system fields (mac, ip, etc) or interfaces' do
+    host = hosts(:one)
+    copy = host.clone
+    assert copy.name.blank?
+    assert copy.mac.blank?
+    assert copy.ip.blank?
+    assert copy.uuid.blank?
+    assert copy.certname.blank?
+    assert copy.last_report.blank?
+    assert_empty copy.interfaces
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
previously, the `clone` method in managed.rb was not used.  The hosts_controller `clone` method now uses the model method.
