### PR TITLE
fixes #5038 - remove empty label causing template edit box indentation

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -149,13 +149,15 @@ module LayoutHelper
       content_tag :div, :class => "form-group #{error.empty? ? "" : 'has-error'}",
                   :id          => options.delete(:control_group_id) do
 
-        label   = options.delete(:label)
+        label   = options[:label] == :none ? '' : options.delete(:label)
         label ||= ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
             s_(clazz.gettext_translation_for_attribute_name attr)) if f
-        label_tag(attr, label, :class => "col-md-2 control-label") +
-            content_tag(:div, :class => size_class) do
-              yield.html_safe + help_block.html_safe
-            end.html_safe + help_inline.html_safe
+        label   = label.present? ? label_tag(attr, label, :class => "col-md-2 control-label") : ''
+
+        label.html_safe +
+           content_tag(:div, :class => size_class) do
+             yield.html_safe + help_block.html_safe
+           end.html_safe + help_inline.html_safe
       end.html_safe
     end
   end

--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -32,7 +32,7 @@
             </div>
           </div>
         </div>
-        <%= textarea_f f, :template, :class => "template_text", :label =>'',:size => "max", :'data-file-name' => @config_template.name %>
+        <%= textarea_f f, :template, :class => "template_text", :label =>:none,:size => "max", :'data-file-name' => @config_template.name %>
 
 
         <%= file_field_f f, :template, :class => "template_file",:size => "col-md-12",
@@ -41,7 +41,7 @@
                        :help_block => _("The Audit Comment field is saved with the template auditing to document the template changes") %>
       </div>
       <div class="tab-pane" id="template_type">
-        <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>'', :help_inline=>_('Snippet') %>
+        <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet') %>
 
         <div id="kind_selector" <%= display? @config_template.snippet %>>
           <%= select_f f, :template_kind_id, TemplateKind.all, :id, :name, {:include_blank => true}, {:label => _("Type")} %>

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -19,7 +19,7 @@
   <% hosts.each do |host| %>
     <tr>
       <td class="ca">
-        <%= f.check_box(:host_ids, {:label => "", :help_inline => "", :multiple => true, :onclick => 'hostChecked(this)', :id => "host_ids_#{host.id}", :class => 'host_select_boxes', }, host.id) %>
+        <%= f.check_box(:host_ids, {:label => :none, :help_inline => "", :multiple => true, :onclick => 'hostChecked(this)', :id => "host_ids_#{host.id}", :class => 'host_select_boxes', }, host.id) %>
       </td>
       <td><%= name_column(host) %> </td>
       <td class="hidden-xs"><%= (icon(host.os, :size => "18x18") + trunc(" #{host.os.to_label}",14)).html_safe if host.os %></td>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -57,7 +57,7 @@
         <div class='tab-pane' id='locations'>
           <%= location_selects(f, @user.used_or_selected_location_ids,
                                { :disabled => @user.used_location_ids,
-                                 :label    => '' } ,
+                                 :label    => :none } ,
                                { :onchange => 'taxonomy_added(this, "location")' } ) %>
         </div>
       <% end %>
@@ -66,7 +66,7 @@
         <div class='tab-pane' id='organizations'>
           <%= organization_selects(f, @user.used_or_selected_organization_ids,
                                    { :disabled => @user.used_organization_ids,
-                                     :label => '' },
+                                     :label => :none },
                                    { :onchange => 'taxonomy_added(this, "organization")' } ) %>
         </div>
       <% end %>


### PR DESCRIPTION
The stray &lt;label&gt; element caused the template box to be bumped over to the right.  You'll see this in Firefox, and occasionally I think I saw it in Chrome.

The element's now left out when the label's blank, or if :none is given to be explicit.
