### PR TITLE
fixes #5427 - skip user roles FK removal if it's missing

### DIFF
--- a/db/migrate/20131114084718_extend_user_role.rb
+++ b/db/migrate/20131114084718_extend_user_role.rb
@@ -1,6 +1,8 @@
 class ExtendUserRole < ActiveRecord::Migration
   def up
-    remove_foreign_key 'user_roles', :name => 'user_roles_user_id_fk'
+    if foreign_keys('user_roles').find { |f| f.options[:name] == 'user_roles_user_id_fk' }.present?
+      remove_foreign_key 'user_roles', :name => 'user_roles_user_id_fk'
+    end
     add_column :user_roles, :owner_type, :string, :default => 'User', :null => false
     rename_column :user_roles, :user_id, :owner_id
 


### PR DESCRIPTION
FKs can be missing if a user migrated (e.g. from sqlite to pgsql) or used the old 'mysql' adapter which didn't support them.

You can test this by comment out the add_foreign_key line in db/migrate/20131114084718_extend_user_role.rb, migrating down VERSION=20131114084718, then migrating up again.  (As long as you're on a DB that supports FKs!)
