### PR TITLE
fixes #5490 - ambiguous column in taxonomix pluck on Rails 3.2.8

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -63,14 +63,14 @@ module Taxonomix
     def taxable_ids(loc = which_location, org = which_organization, inner_method = which_ancestry_method)
       if SETTINGS[:locations_enabled] && loc
         inner_ids_loc = if Location.ignore?(self.to_s)
-                          self.pluck(:id)
+                          self.pluck("#{table_name}.id")
                         else
                           inner_select(loc, inner_method)
                         end
       end
       if SETTINGS[:organizations_enabled] && org
         inner_ids_org = if Organization.ignore?(self.to_s)
-                          self.pluck(:id)
+                          self.pluck("#{table_name}.id")
                         else
                           inner_select(org, inner_method)
                         end


### PR DESCRIPTION
You can reproduce this on a stock EL6 installation or under Rails 3.2.8 with PostgreSQL.  Enable locations, add a location with "All smart proxies" ticked, then visit the new host form.

@isratrade could you review please?
