### PR TITLE
Fixes 4287: Correctly skip template associations when looking for matches

### DIFF
--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -55,22 +55,27 @@ class ConfigTemplate < ActiveRecord::Base
     # first filter valid templates to our OS and requested template kind.
     templates = ConfigTemplate.joins(:operatingsystems, :template_kind).where('operatingsystems.id' => opts[:operatingsystem_id], 'template_kinds.name' => opts[:kind])
 
-
     # once a template has been matched, we no longer look for others.
 
     if opts[:hostgroup_id] and opts[:environment_id]
       # try to find a full match to our host group and environment
-      template = templates.joins(:hostgroups, :environments).where("hostgroups.id" => opts[:hostgroup_id], "environments.id" => opts[:environment_id]).first
+      template ||= templates.joins(:template_combinations).where(
+        "template_combinations.hostgroup_id" => opts[:hostgroup_id],
+        "template_combinations.environment_id" => opts[:environment_id]).first
     end
 
     if opts[:hostgroup_id]
       # try to find a match with our hostgroup only
-      template ||= templates.joins(:hostgroups).where("hostgroups.id" => opts[:hostgroup_id]).first
+      template ||= templates.joins(:template_combinations).where(
+        "template_combinations.hostgroup_id" => opts[:hostgroup_id],
+        "template_combinations.environment_id" => nil).first
     end
 
     if opts[:environment_id]
       # search for a template based only on our environment
-      template ||= templates.joins(:environments).where("environments.id" => opts[:environment_id]).first
+      template ||= templates.joins(:template_combinations).where(
+        "template_combinations.hostgroup_id" => nil,
+        "template_combinations.environment_id" => opts[:environment_id]).first
     end
 
     # fall back to the os default template

--- a/test/factories/config_template.rb
+++ b/test/factories/config_template.rb
@@ -1,0 +1,24 @@
+FactoryGirl.define do
+  factory :config_template do
+    sequence(:name) { |n| "config_template#{n}" }
+    sequence(:template) { |n| "template content #{n}" }
+
+    template_kind
+  end
+
+  factory :template_combination do
+    config_template
+    hostgroup
+    environment
+  end
+
+  factory :os_default_template do
+    config_template
+    operatingsystem
+    template_kind
+  end
+
+  factory :template_kind do
+    sequence(:name) { |n| "template_kind_#{n}" }
+  end
+end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :operatingsystem do
+    sequence(:name) { |n| "operatingsystem#{n}" }
+    sequence(:major) { |n| n }
+  end
+end


### PR DESCRIPTION
Separate `if` clauses was causing the system to look for incorrect matches (i.e a template which has both an environment and hostgroup association for hostgroup only)
