### PR TITLE
preper for #5188 - host details should include subscription status

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -377,5 +377,6 @@ function setPowerState(item, status){
   }else{
     $('#loading_power_state').text(_('Unknown power state'))
   }
+  power_actions.hide();
   $('[rel="twipsy"]').tooltip();
 }

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -184,8 +184,10 @@ module HostsHelper
         content_tag :tr do
           content_tag(:td, _("%s Template") % kind) +
             content_tag(:td,
-          link_to_if_authorized(icon_text('pencil'), hash_for_edit_config_template_path(:id => tmplt.to_param), :title => _("Edit"), :rel=>"external") +
-          link_to(icon_text('eye-open'), url_for(:controller => '/unattended', :action => kind, :hostname => @host.name), :title => _("Review"), :"data-provisioning-template" => true ))
+                        action_buttons(
+                            display_link_if_authorized(_("Edit"), hash_for_edit_config_template_path(:id => tmplt.to_param), :rel=>"external"),
+                            link_to(_("Review"), url_for(:controller => '/unattended', :action => kind, :hostname => @host.name), :"data-provisioning-template" => true ))
+            )
         end
       end.join(" ").html_safe
     end

--- a/app/views/hosts/_overview.html.erb
+++ b/app/views/hosts/_overview.html.erb
@@ -1,19 +1,6 @@
-<table class="table table-bordered table-striped">
+<table id="properties_table" class="table table-bordered table-striped">
   <tr>
-    <th><%= _('Details') %></th>
-  </tr>
-  <tr>
-    <td>
-      <% show_appropriate_host_buttons(@host).each do |btn| %>
-        <%= btn %>
-      <% end %>
-    </td>
-  </tr>
-</table>
-<table class="table table-bordered table-striped">
-  <tr>
-    <th><%= _('Properties') %></th>
-    <th></th>
+    <th colspan="2"><%= _('Properties') %></th>
   </tr>
   <% overview_fields(host).each do |name, value| %>
     <tr>

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -6,6 +6,16 @@
 
 <div id="host-show" class="row" data-history-url='<%= host_path(@host)%>'>
   <div class="col-md-4">
+    <table id="details_table" class="table table-bordered table-striped">
+      <tr><th><%= _('Details') %></th></tr>
+      <tr>
+        <td>
+          <% show_appropriate_host_buttons(@host).each do |btn| %>
+            <%= btn %>
+          <% end %>
+        </td>
+      </tr>
+    </table>
     <ul id="myTab" class="nav nav-tabs">
       <li class="active"><a href="#properties" data-toggle="tab"><%= _('Properties') %></a></li>
       <li><a href="#metrics" data-toggle="tab"><%= _('Metrics') %></a></li>


### PR DESCRIPTION
The implementation of 5188 is going to be a deface script in katello plugin, this pr places id's and make this page a little more standard, to make the deface work simple.
