### PR TITLE
fixes #5612 - use correct permissions for authz in parameters API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -233,7 +233,7 @@ module Api
             resource_identifying_attributes.each do |key|
               find_method = "find_by_#{key}"
               model = md[1].classify.constantize
-              controller = "#{md[1].pluralize}_#{controller_name}"
+              controller = md[1].pluralize
               authorized_scope = model.authorized("#{action_permission}_#{controller}")
               @nested_obj ||= authorized_scope.send(find_method, params[param])
             end

--- a/app/controllers/api/v1/common_parameters_controller.rb
+++ b/app/controllers/api/v1/common_parameters_controller.rb
@@ -11,7 +11,7 @@ module Api
 
       def index
         @common_parameters = CommonParameter.
-          authorized(:view_globals).
+          authorized(:view_globals, CommonParameter).
           search_for(*search_options).
           paginate(paginate_options)
       end

--- a/app/controllers/api/v2/common_parameters_controller.rb
+++ b/app/controllers/api/v2/common_parameters_controller.rb
@@ -12,7 +12,7 @@ module Api
 
       def index
         @common_parameters = CommonParameter.
-          authorized(:view_globals).
+          authorized(:view_globals, CommonParameter).
           search_for(*search_options).
           paginate(paginate_options)
       end

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -127,4 +127,18 @@ class Api::TestableControllerTest < ActionController::TestCase
       assert_response :success
     end
   end
+
+  context 'nested objects' do
+    it "should use auth scope of nested object" do
+      ctrl = Api::TestableController.new
+      ctrl.expects(:params).at_least_once.returns(HashWithIndifferentAccess.new(:domain_id => 1, :action => 'index'))
+      ctrl.expects(:allowed_nested_id).at_least_once.returns(['domain_id'])
+      ctrl.expects(:resource_identifying_attributes).at_least_once.returns(['id'])
+      scope = mock('scope')
+      obj = mock('domain')
+      scope.expects(:find_by_id).with(1).returns(obj)
+      Domain.expects(:authorized).with('view_domains').returns(scope)
+      assert_equal obj, ctrl.send(:find_required_nested_object)
+    end
+  end
 end


### PR DESCRIPTION
Two changes here - one is a change to the common parameters controllers to match the UI controller, so it authorises with the correct permission.

The second changes the API controller from using permissions like "view_domains_parameters" instead of "view_domains" when viewing parameters _of that domain_.  I can't see any permissions that rely on this two-part naming convention...
