### PR TITLE
fixes #5631 - API v2 - host and hostgroups show.json.rabl should show all puppetclasses in child node

### DIFF
--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -14,6 +14,10 @@ child :puppetclasses do
   extends "api/v2/puppetclasses/base"
 end
 
+node do |hostgroup|
+  { :all_puppetclasses => partial("api/v2/puppetclasses/base", :object => hostgroup.all_puppetclasses) }
+end
+
 child :config_groups do
   extends "api/v2/config_groups/main"
 end

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -14,6 +14,10 @@ child :puppetclasses do
   extends "api/v2/puppetclasses/base"
 end
 
+node do |host|
+  { :all_puppetclasses => partial("api/v2/puppetclasses/base", :object => host.all_puppetclasses) }
+end
+
 child :config_groups do
   extends "api/v2/config_groups/main"
 end


### PR DESCRIPTION
currently it only shows what is in host_classes or hostgroup_classes and not what is inherited or in config_groups
