### PR TITLE
fixes #5671 - LookupValue name should be matcher, value is too long

### DIFF
--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -12,7 +12,7 @@ class LookupValue < ActiveRecord::Base
   attr_accessor :host_or_hostgroup
 
   serialize :value
-  attr_name :value
+  attr_name :match
 
   scope :default, lambda { where(:match => "default").limit(1) }
 
@@ -21,7 +21,7 @@ class LookupValue < ActiveRecord::Base
   scoped_search :in => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
 
   def name
-    value
+    match
   end
 
   def value_before_type_cast

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -123,7 +123,7 @@ class HostgroupTest < ActiveSupport::TestCase
   end
 
   test "should find associated lookup_values" do
-    assert_equal [lookup_values(:hostgroupcommon), lookup_values(:four)], hostgroups(:common).lookup_values.sort
+    assert_equal [lookup_values(:hostgroupcommon), lookup_values(:four)].map(&:id).sort, hostgroups(:common).lookup_values.map(&:id).sort
   end
 
   test "should find associated lookup_values with unsafe SQL name" do
@@ -133,7 +133,7 @@ class HostgroupTest < ActiveSupport::TestCase
     lv = lookup_values(:four)
     lv.match = "hostgroup=#{hostgroup.name}"
     lv.save!
-    assert_equal [lookup_values(:hostgroupcommon), lookup_values(:four)], hostgroup.lookup_values.sort
+    assert_equal [lookup_values(:hostgroupcommon), lookup_values(:four)].map(&:id).sort, hostgroup.lookup_values.map(&:id).sort
   end
 
   # test NestedAncestryCommon methods generate by class method nested_attribute_for


### PR DESCRIPTION
I can't figure out why we'd ever want the value of a lookup_value to be the name, but open to ideas.  @isratrade?
