### PR TITLE
Fixes #5664 - Host filters can use taxonomies

### DIFF
--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -12,4 +12,7 @@ $(document).ready(function () {
   $('#filter_unlimited').change(function () {
     $('#search').prop('disabled', $(this).prop('checked'));
   });
+
+  $('li a[href="#organizations"]').toggle($('#filter_resource_type').data('allow-organizations'));
+  $('li a[href="#locations"]').toggle($('#filter_resource_type').data('allow-locations'));
 });

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,5 +1,6 @@
 class PermissionsController < ApplicationController
   include FiltersHelper
+  include TaxonomyHelper
   respond_to :js
 
   def index
@@ -7,6 +8,12 @@ class PermissionsController < ApplicationController
     @permissions = Permission.find_all_by_resource_type(type)
     @search_path = search_path(type)
     @granular = granular?(type)
+
+    if @granular
+      resource_class = Filter.get_resource_class(type)
+      @show_organizations = show_organization_tab? && resource_class.allows_organization_filtering?
+      @show_locations = show_location_tab? && resource_class.allows_location_filtering?
+    end
   end
 
   private

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -20,4 +20,18 @@ module Authorizable
       end
     }
   end
+
+  module ClassMethods
+    def allows_taxonomy_filtering?(taxonomy)
+      scoped_search_definition.fields.has_key?(taxonomy)
+    end
+
+    def allows_organization_filtering?
+      allows_taxonomy_filtering?(:organization_id)
+    end
+
+    def allows_location_filtering?
+      allows_taxonomy_filtering?(:location_id)
+    end
+  end
 end

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -44,8 +44,14 @@ module Hostext
       scoped_search :in => :fact_values, :on => :value, :in_key=> :fact_names, :on_key=> :name, :rename => :facts, :complete_value => true, :only_explicit => true
       scoped_search :in => :search_parameters, :on => :value, :on_key=> :name, :complete_value => true, :rename => :params, :ext_method => :search_by_params, :only_explicit => true
 
-      scoped_search :in => :location, :on => :title, :rename => :location, :complete_value => true         if SETTINGS[:locations_enabled]
-      scoped_search :in => :organization, :on => :title, :rename => :organization, :complete_value => true if SETTINGS[:organizations_enabled]
+      if SETTINGS[:locations_enabled]
+        scoped_search :in => :location, :on => :title, :rename => :location, :complete_value => true
+        scoped_search :in => :location, :on => :id, :rename => :location_id, :complete_value => true
+      end
+      if SETTINGS[:organizations_enabled]
+        scoped_search :in => :organization, :on => :title, :rename => :organization, :complete_value => true
+        scoped_search :in => :organization, :on => :id, :rename => :organization_id, :complete_value => true
+      end
       scoped_search :in => :config_groups, :on => :name, :complete_value => true, :rename => :config_group, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_config_group
 
       if SETTINGS[:unattended]

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -87,6 +87,14 @@ class Filter < ActiveRecord::Base
     end
   end
 
+  def allows_organization_filtering?
+    granular? && resource_class.allows_organization_filtering?
+  end
+
+  def allows_location_filtering?
+    granular? && resource_class.allows_location_filtering?
+  end
+
   def search_condition
     searches = [self.search, self.taxonomy_search].compact
     searches = searches.map { |s| parenthesize(s) } if searches.size > 1
@@ -98,6 +106,9 @@ class Filter < ActiveRecord::Base
   def build_taxonomy_search
     orgs = build_taxonomy_search_string('organization')
     locs = build_taxonomy_search_string('location')
+
+    orgs = [] if !granular? || !resource_class.allows_organization_filtering?
+    locs = [] if !granular? || !resource_class.allows_location_filtering?
 
     if self.organizations.empty? && self.locations.empty?
       self.taxonomy_search = nil

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -25,7 +25,9 @@
       <% end %>
 
       <%= selectable_f(f, :resource_type, Permission.resources_with_translations,
-                       {:include_blank => _('(Miscellaneous)')}, {:'data-url' => permissions_path}) %>
+                       {:include_blank => _('(Miscellaneous)')}, {:'data-url' => permissions_path,
+                                                                  :'data-allow-organizations' => @filter.allows_organization_filtering?,
+                                                                  :'data-allow-locations' => @filter.allows_location_filtering?,}) %>
 
       <%= multiple_selects f, :permissions, Permission.where(:resource_type => f.object.resource_type),
                            f.object.permissions.map(&:id), :label => _("Permission") %>

--- a/app/views/permissions/index.js.erb
+++ b/app/views/permissions/index.js.erb
@@ -18,3 +18,17 @@ search.catcomplete({source: function( request, response ) {
   $('#granular_form').hide();
   $('#filter_unlimited').prop('checked', true);
 <% end %>
+
+<% if @show_organizations %>
+  $('li a[href="#organizations"]').show();
+<% else %>
+  $('li a[href="#organizations"]').hide();
+<% end %>
+$('#filter_resource_type').attr('data-allow-organizations', <%= !!@show_organizations %>);
+
+<% if @show_locations %>
+  $('li a[href="#locations"]').show();
+<% else %>
+  $('li a[href="#locations"]').hide();
+<% end %>
+$('#filter_resource_type').attr('data-allow-locations', <%= !!@show_locations %>);

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -140,6 +140,29 @@ class FilterTest < ActiveSupport::TestCase
     assert_nil f.taxonomy_search
   end
 
+  test "taxonomies are ignored if resource does not support them" do
+    o1 = Factory.create :organization
+    o2 = Factory.create :organization
+    l = Factory.create :location
+    f = Factory.create(:filter, :search => '', :unlimited => '1',
+                       :organization_ids => [o1.id, o2.id], :location_ids => [l.id],
+                       :resource_type => 'Bookmark')
+
+    f.reload
+    assert f.valid?
+    assert f.unlimited?
+    assert_nil f.taxonomy_search
+  end
+
+  test "#allows_*_filtering" do
+    fb = Factory.create(:filter, :resource_type => 'Bookmark')
+    fd = Factory.create(:filter, :resource_type => 'Domain')
+    refute fb.allows_organization_filtering?
+    refute fb.allows_location_filtering?
+    assert fd.allows_organization_filtering?
+    assert fd.allows_location_filtering?
+  end
+
   test "search string composition" do
     f = Factory.build :filter, :search => nil, :taxonomy_search => nil
     assert_equal '', f.search_condition


### PR DESCRIPTION
Also disables taxonomy filters on resources that do not support them.
