### PR TITLE
Fixes #5696 - Allow taxonomy and roles display

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -4,15 +4,13 @@
 
   <ul class='nav nav-tabs' data-tabs='tabs'>
     <li class='active'><a href='#primary' data-toggle='tab'><%= _('User') %></a></li>
-    <% unless @editing_self || @user.admin? %>
-      <% if show_location_tab? %>
-        <li><a href='#locations' data-toggle='tab'><%= _('Locations') %></a></li>
-      <% end %>
-      <% if show_organization_tab? %>
-        <li><a href='#organizations' data-toggle='tab'><%= _('Organizations') %></a></li>
-      <% end %>
-      <li><a href='#roles' data-toggle='tab'><%= _('Roles') %></a></li>
+    <% if show_location_tab? %>
+      <li><a href='#locations' data-toggle='tab'><%= _('Locations') %></a></li>
     <% end %>
+    <% if show_organization_tab? %>
+      <li><a href='#organizations' data-toggle='tab'><%= _('Organizations') %></a></li>
+    <% end %>
+    <li><a href='#roles' data-toggle='tab'><%= _('Roles') %></a></li>
   </ul>
 
   <div class='tab-content'>
@@ -46,30 +44,29 @@
         <%= password_f f, :password_confirmation, :label => _('Verify') %>
       </div>
     </div>
-    <% unless @editing_self || @user.admin? %>
-      <div class='tab-pane' id='roles'>
-        <%= checkbox_f f, :admin if User.current.can_change_admin_flag? %>
-        <%= multiple_checkboxes f, :roles, @user, Role.givable.for_current_user,
-                                 { :label => _('Roles') } %>
+
+    <div class='tab-pane' id='roles'>
+      <%= checkbox_f f, :admin if User.current.can_change_admin_flag? %>
+      <%= multiple_checkboxes f, :roles, @user, Role.givable.for_current_user,
+                               { :label => _('Roles')}, {:disabled => @editing_self ? Role.givable.for_current_user.pluck(:id) : false } %>
+    </div>
+
+    <% if show_location_tab? %>
+      <div class='tab-pane' id='locations'>
+        <%= location_selects(f, @user.used_or_selected_location_ids,
+                             { :disabled => @editing_self ? Location.pluck(:id) : @user.used_location_ids,
+                               :label    => :none } ,
+                             { :onchange => 'taxonomy_added(this, "location")' } ) %>
       </div>
+    <% end %>
 
-      <% if show_location_tab? %>
-        <div class='tab-pane' id='locations'>
-          <%= location_selects(f, @user.used_or_selected_location_ids,
-                               { :disabled => @user.used_location_ids,
-                                 :label    => :none } ,
-                               { :onchange => 'taxonomy_added(this, "location")' } ) %>
-        </div>
-      <% end %>
-
-      <% if show_organization_tab? %>
-        <div class='tab-pane' id='organizations'>
-          <%= organization_selects(f, @user.used_or_selected_organization_ids,
-                                   { :disabled => @user.used_organization_ids,
-                                     :label => :none },
-                                   { :onchange => 'taxonomy_added(this, "organization")' } ) %>
-        </div>
-      <% end %>
+    <% if show_organization_tab? %>
+      <div class='tab-pane' id='organizations'>
+        <%= organization_selects(f, @user.used_or_selected_organization_ids,
+                                 { :disabled => @editing_self ? Organization.pluck(:id) : @user.used_organization_ids,
+                                   :label => :none },
+                                 { :onchange => 'taxonomy_added(this, "organization")' } ) %>
+      </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
We can display all user details in user form. If users are editing
themself they can see taxonomies and roles they are assigned (if they
have sufficient privileges). They can't reassign any of these objects.
