### PR TITLE
Fixes #5750 - Add Org Ids to Users BZ1092656

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -33,6 +33,7 @@ module Api
           param :admin, :bool, :required => false, :desc => "Is an admin account?"
           param :password, String, :required => true
           param :default_location_id, Integer if SETTINGS[:locations_enabled]
+          param :organization_ids, Array, :required => false, :desc => N_("List of organizations ids")
           param :default_organization_id, Integer if SETTINGS[:organizations_enabled]
           param :auth_source_id, Integer, :required => true
         end
@@ -44,7 +45,6 @@ module Api
         Adds role 'Anonymous' to the user by default
       DOC
       param_group :user, :as => :create
-
       def create
         if @user.save
           process_success


### PR DESCRIPTION
Unable to create a user from the api with a default-organization-id set.
validation is present to check that a user's default-organization must
be a member user's organizations. the only way to pass validation is to
allow passing both organization and default organization during
creation.
