### PR TITLE
fixes #5780 - API v2 - RESTful way to add/remove many-to-many association one at a time rather than passing all id's

### DIFF
--- a/app/controllers/api/v2/architectures_controller.rb
+++ b/app/controllers/api/v2/architectures_controller.rb
@@ -49,6 +49,18 @@ module Api
         process_response @architecture.destroy
       end
 
+      api :POST, "/architectures/:architecture_id/links/operatingsystems", N_("Add operating system to architecture")
+      param :architecture_id, :identifier, :required => true
+      param :operatingsystems, Array, :required => true, :desc => N_("Array of operating system IDs")
+      def add
+      end
+
+      api :DELETE, "/architectures/:architecture_id/links/operatingsystems/:id", N_("Remove operating system from architecture")
+      param :architecture_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -20,13 +20,18 @@ module Api
       end
 
       def_param_group :taxonomies do
-        param :location_ids, Array, :required => false, :desc => N_("REPLACE locations with given ids") if SETTINGS[:locations_enabled]
-        param :organization_ids, Array, :required => false, :desc => N_("REPLACE organizations with given ids.") if SETTINGS[:organizations_enabled]
+        param :location_ids, Array, :required => false, :desc => N_("REPLACE locations with given IDs") if SETTINGS[:locations_enabled]
+        param :organization_ids, Array, :required => false, :desc => N_("REPLACE organizations with given IDs") if SETTINGS[:organizations_enabled]
       end
 
       def_param_group :taxonomy_scope do
         param :location_id, Integer, :required => false, :desc => N_("Scope by locations") if SETTINGS[:locations_enabled]
         param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations") if SETTINGS[:organizations_enabled]
+      end
+
+      def_param_group :taxonomies_associations do
+        param :locations, Array, :required => false, :desc => N_("Array of location IDs") if SETTINGS[:locations_enabled]
+        param :organizations, Array, :required => false, :desc => N_("Array of organization IDs") if SETTINGS[:organizations_enabled]
       end
 
       before_filter :setup_has_many_params, :only => [:create, :update]

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -134,6 +134,20 @@ module Api
         render 'api/v2/hosts/index', :layout => 'api/v2/layouts/index_layout'
       end
 
+      api :POST, "/compute_resources/:compute_resource_id/links/locations", N_("Add location to compute resource")
+      api :POST, "/compute_resources/:compute_resource_id/links/organizations", N_("Add organization to compute resource")
+      param :compute_resource_id, :identifier, :required => true
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/compute_resources/:compute_resource_id/links/locations/:id", N_("Remove location from compute resource")
+      api :DELETE, "/compute_resources/:compute_resource_id/links/organizations/:id", N_("Remove organization from compute resource")
+      param :compute_resource_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def action_permission

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -84,6 +84,23 @@ module Api
         render :json => msg, :status => status
       end
 
+      api :POST, "/config_templates/:config_template_id/links/operatingsystems", N_("Add operating system to provisioning template")
+      api :POST, "/config_templates/:config_template_id/links/locations", N_("Add location to provisioning template")
+      api :POST, "/config_templates/:config_template_id/links/organizations", N_("Add organization to provisioning template")
+      param :config_template_id, :identifier, :required => true
+      param :operatingsystems, Array, :required => false, :desc => N_("Array of operating system IDs")
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/config_templates/:config_template_id/links/operatingsystems/:id", N_("Remove operating system from provisioning template")
+      api :DELETE, "/config_templates/:config_template_id/links/locations/:id", N_("Remove location from provisioning template")
+      api :DELETE, "/config_templates/:config_template_id/links/organizations/:id", N_("Remove organization from provisioning template")
+      param :config_templates, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def process_operatingsystems

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -75,6 +75,23 @@ module Api
         process_response @domain.destroy
       end
 
+      api :POST, "/domains/:domain_id/links/subnets", N_("Add subnet to domain")
+      api :POST, "/domains/:domain_id/links/locations", N_("Add location to domain")
+      api :POST, "/domains/:domain_id/links/organizations", N_("Add organization to domain")
+      param :domain_id, :identifier, :required => true
+      param :subnets, Array, :required => false, :desc => N_("Array of subnet IDs")
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/domains/:domain_id/links/subnets/:id", N_("Remove subnet from domain")
+      api :DELETE, "/domains/:domain_id/links/locations/:id", N_("Remove location from domain")
+      api :DELETE, "/domains/:domain_id/links/organizations/:id", N_("Remove organization from domain")
+      param :domain_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -57,6 +57,20 @@ module Api
         process_response @environment.destroy
       end
 
+      api :POST, "/environments/:environment_id/links/locations", N_("Add location to environment")
+      api :POST, "/environments/:environment_id/links/organizations", N_("Add organization to environment")
+      param :environment_id, :identifier, :required => true
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/environments/:environment_id/links/locations/:id", N_("Remove location from environment")
+      api :DELETE, "/environments/:environment_id/links/organizations/:id", N_("Remove organization from environment")
+      param :environment_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -79,6 +79,26 @@ module Api
         process_response @hostgroup.save
       end
 
+      api :POST, "/hostgroups/:hostgroup_id/links/locations", N_("Add location to host group")
+      api :POST, "/hostgroups/:hostgroup_id/links/organizations", N_("Add organization to host group")
+      api :POST, "/hosts/:host_id/links/puppetclasses", N_("Add puppetclass to host")
+      api :POST, "/hosts/:host_id/links/config_groups", N_("Add config group to host")
+      param :hostgroup_id, :identifier, :required => true
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      param :puppetclasses, Array, :required => false, :desc => N_("Array of puppetclass IDs")
+      param :config_groups, Array, :required => false, :desc => N_("Array of config group IDs")
+      def add
+      end
+
+      api :DELETE, "/hostgroups/:hostgroup_id/links/locations/:id", N_("Remove location from host group")
+      api :DELETE, "/hostgroups/:hostgroup_id/links/organizations/:id", N_("Remove organization from host group")
+      api :DELETE, "/hosts/:host_id/links/puppetclasses/:id", N_("Remove puppetclass from host")
+      api :DELETE, "/hosts/:host_id/links/config_groups/:id", N_("Remove config group from host")
+      param :hostgroup_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def action_permission

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -169,6 +169,21 @@ Return value may either be one of the following:
         render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
       end
 
+      api :POST, "/hosts/:host_id/links/puppetclasses", N_("Add puppetclass to host")
+      api :POST, "/hosts/:host_id/links/config_groups", N_("Add config group to host")
+      param :host_id, :identifier, :required => true
+      param :puppetclasses, Array, :required => false, :desc => N_("Array of puppetclass IDs")
+      param :config_groups, Array, :required => false, :desc => N_("Array of config group IDs")
+      def add
+      end
+
+      api :DELETE, "/hosts/:host_id/links/puppetclasses/:id", N_("Remove puppetclass from host")
+      api :DELETE, "/hosts/:host_id/links/config_groups/:id", N_("Remove config group from host")
+      param :host_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def action_permission

--- a/app/controllers/api/v2/locations_controller.rb
+++ b/app/controllers/api/v2/locations_controller.rb
@@ -2,7 +2,8 @@ module Api
   module V2
     class LocationsController < V2::BaseController
 
-      apipie_concern_subst(:a_resource => N_("a location"), :resource => "location")
+      apipie_concern_subst(:a_resource => N_("a location"), :resource => "location",
+                           :res_id => ":location_id", :opp_resource => "organization", :opp_resources => "organizations")
       include Api::V2::TaxonomiesController
 
     end

--- a/app/controllers/api/v2/many_to_many_controller.rb
+++ b/app/controllers/api/v2/many_to_many_controller.rb
@@ -1,0 +1,111 @@
+module Api
+  module V2
+    class ManyToManyController < V2::BaseController
+
+      include Api::Version2
+      include Api::TaxonomyScope
+      skip_before_filter :setup_has_many_params
+
+      before_filter :ensure_association_is_allowed
+      before_filter :find_required_nested_object
+      before_filter :find_associated_objects_to_add, :only => :create
+      before_filter :find_associated_objects_to_remove, :only => :destroy
+
+      def create
+        if @associated_objects.any?
+          @nested_obj.send(params[:association]) << @associated_objects
+          logger.info "Added #{@associated_objects.first.class.to_s} ids #{@associated_objects.pluck(:id).join(', ')} to #{@nested_obj.class.to_s} #{@nested_obj.id}"
+          render :json => {}, :status => 204
+        else
+          error_msg = _("Resource %{association_class} not found for id %{param_id}") % { :association_class => params[:association].classify, :param_id => params[params[:association]] }
+          logger.error error_msg
+          render :json => {:message => error_msg}, :status => :unprocessable_entity, :layout => 'api/v2/layouts/error_layout'
+        end
+      end
+
+      def destroy
+        if @associated_objects.any?
+          @nested_obj.send(params[:association]).delete(@associated_objects)
+          logger.info "Removed #{@associated_objects.first.class.to_s} ids #{@associated_objects.pluck(:id).join(', ')} from #{@nested_obj.class.to_s} #{@nested_obj.id} if association previously existed"
+          render :json => {}, :status => 204
+        else
+          error_msg = _("Resource %{association_class} not found for id %{param_id}") % { :association_class => params[:association].classify, :param_id => params[:id] }
+          logger.error error_msg
+          render :json => {:message => error_msg}, :status => :unprocessable_entity, :layout => 'api/v2/layouts/error_layout'
+        end
+      end
+
+      private
+
+      def find_associated_objects_to_add
+        if params.keys.any? { |k| k == params[:association] }
+          key = params[:association]
+          ids = params[key]
+          find_associated(key, ids)
+        else
+          raise _("You must pass a parameter '%{association}' with value that is an integer or array of integers") % { :association => params[:association] }
+        end
+      end
+
+      def find_associated_objects_to_remove
+        key = params[:association]
+        ids = params[:id]
+        find_associated(key, ids)
+      end
+
+      def find_associated(key, ids)
+        ids = ids.to_s if ids.kind_of?(Integer)
+        ids = ids.split(',') if ids.kind_of?(String) #convert to Array in case of a comma-delimitted string ("1,2,3") or number string ("2") rather than Array
+        ids = Array(ids).map(&:to_i) #convert array of strings to arrange of integers. Note: "string".to_i = 0
+        if ids.all? { |p| p > 0 }
+          model = key.classify.constantize
+          @associated_objects = model.where(:id => ids)
+        else
+          raise _("%{key} values must be an integer or array of integers") % {:key => key}
+        end
+      end
+
+      def allowed_nested_id
+        allowed_associations.keys
+      end
+
+      def allowed_associations
+        {'architecture_id' => ['operatingsystems'],
+         'compute_resource_id' => ['locations', 'organizations'],
+         'config_template_id' => ['operatingsystems', 'locations', 'organizations'],
+         'domain_id' => ['subnets', 'locations', 'organizations'],
+         'environment_id' => ['locations', 'organizations'],
+         'host_id' => ['puppetclasses', 'config_groups'],
+         'hostgroup_id' => ['locations', 'organizations', 'puppetclasses', 'config_groups'],
+         'location_id' => ['users', 'smart_proxies', 'subnets', 'compute_resources', 'media', 'config_templates', 'domains',
+                         'realms', 'environments', 'hostgroups', 'organizations'],
+         'medium_id' => ['operatingsystems', 'locations', 'organizations'],
+         'operatingsystem_id' => ['architectures', 'ptables', 'media', 'config_templates'],
+         'organization_id' => ['users', 'smart_proxies', 'subnets', 'compute_resources', 'media', 'config_templates', 'domains',
+                         'realms', 'environments', 'hostgroups', 'locations'],
+         'ptable_id' => ['operatingsystems'],
+         'realm_id' => ['locations', 'organizations'],
+         'role_id' => ['users', 'usergroups'],
+         'smart_proxy_id' => ['locations', 'organizations'],
+         'subnet_id' => ['domains', 'locations', 'organizations'],
+         'usergroup_id' => ['roles', 'users'],
+         'user_id' => ['roles', 'usergroups', 'locations', 'organizations']
+        }
+      end
+
+      def resource_identifying_attributes
+        %w(id)
+      end
+
+      def ensure_association_is_allowed
+        params.keys.each do |key|
+          if key.match(/(\w+)_id$/)
+            allowed = allowed_associations[key]
+            raise ActionController::RoutingError.new(_("route not found")) unless allowed.include?(params[:association])
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -72,6 +72,23 @@ Solaris and Debian media may also use $release.
         process_response @medium.destroy
       end
 
+      api :POST, "/media/:medium_id/links/operatingsystems", N_("Add location to operating system")
+      api :POST, "/media/:medium_id/links/locations", N_("Add location to medium")
+      api :POST, "/media/:medium_id/links/organizations", N_("Add organization to medium")
+      param :medium_id, :identifier, :required => true
+      param :operatingsystems, Array, :required => false, :desc => N_("Array of operating system IDs")
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/media/:medium_id/links/operatingsystems/:id", N_("Remove location from operating system")
+      api :DELETE, "/media/:medium_id/links/locations/:id", N_("Remove location from medium")
+      api :DELETE, "/media/:medium_id/links/organizations/:id", N_("Remove organization from medium")
+      param :medium_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -82,6 +82,27 @@ module Api
         render :json => e.to_s, :status => :unprocessable_entity
       end
 
+      api :POST, "/operatingsystems/:operatingsystem_id/links/architectures", N_("Add architecture to operating system")
+      api :POST, "/operatingsystems/:operatingsystem_id/links/ptables", N_("Add partition table to operating system")
+      api :POST, "/operatingsystems/:operatingsystem_id/links/media", N_("Add medium to operating system")
+      api :POST, "/operatingsystems/:operatingsystem_id/links/config_templates", N_("Add provisioning template to operating system")
+      param :operatingsystem_id, :identifier, :required => true
+      param :architectures, Array, :required => false, :desc => N_("Array of IDs")
+      param :ptables, Array, :required => false, :desc => N_("Array of IDs")
+      param :media, Array, :required => false, :desc => N_("Array of IDs")
+      param :config_templates, Array, :required => false, :desc => N_("Array of IDs")
+      def add
+      end
+
+      api :DELETE, "/operatingsystems/:operatingsystem_id/links/architectures/:id", N_("Remove architecture from operating system")
+      api :DELETE, "/operatingsystems/:operatingsystem_id/links/ptables/:id", N_("Remove partition table from operating system")
+      api :DELETE, "/operatingsystems/:operatingsystem_id/links/media/:id", N_("Remove medium from operating system")
+      api :DELETE, "/operatingsystems/:operatingsystem_id/links/config_templates/:id", N_("Remove provisioning template from operating system")
+      param :operatingsystem_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/organizations_controller.rb
+++ b/app/controllers/api/v2/organizations_controller.rb
@@ -2,7 +2,8 @@ module Api
   module V2
     class OrganizationsController < V2::BaseController
 
-      apipie_concern_subst(:a_resource => N_("an organization"), :resource => "organization")
+      apipie_concern_subst(:a_resource => N_("an organization"), :resource => "organization",
+                           :res_id => ":organization_id", :opp_resource => "location", :opp_resources => "locations")
       include Api::V2::TaxonomiesController
 
     end

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -51,6 +51,18 @@ module Api
         process_response @ptable.destroy
       end
 
+      api :POST, "/ptables/:ptable_id/links/operatingsystems", N_("Add operating system to ptable")
+      param :ptable_id, :identifier, :required => true
+      param :operatingsystems, Array, :required => true, :desc => N_("Array of IDs")
+      def add
+      end
+
+      api :DELETE, "/ptables/:ptable_id/links/operatingsystems/:id", N_("Remove operating system from ptable")
+      param :ptable_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/realms_controller.rb
+++ b/app/controllers/api/v2/realms_controller.rb
@@ -55,6 +55,21 @@ module Api
       def destroy
         process_response @realm.destroy
       end
+
+      api :POST, "/realms/:realm_id/links/locations", N_("Add location to realm")
+      api :POST, "/realms/:realm_id/links/organizations", N_("Add organization to realm")
+      param :realm_id, :identifier, :required => true
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/realms/:realm_id/links/locations/:id", N_("Remove location from realm")
+      api :DELETE, "/realms/:realm_id/links/organizations/:id", N_("Remove organization from realm")
+      param :realm_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
     end
   end
 end

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -47,6 +47,21 @@ module Api
         process_response @role.destroy
       end
 
+      api :POST, "/roles/:role_id/links/users", N_("Add user to role")
+      api :POST, "/roles/:role_id/links/usergroups", N_("Add user to role")
+      param :role_id, :identifier, :required => true
+      param :users, Array, :required => false, :desc => N_("Array of IDs")
+      param :usergroups, Array, :required => false, :desc => N_("Array of IDs")
+      def add
+      end
+
+      api :DELETE, "/roles/:role_id/links/users/:id", N_("Remove user from role")
+      api :DELETE, "/roles/:role_id/links/usergroups/:id", N_("Remove usergroup from role")
+      param :role_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -59,6 +59,20 @@ module Api
         process_response @smart_proxy.refresh.blank? && @smart_proxy.save
       end
 
+      api :POST, "/smart_proxyies/:smart_proxy_id/links/locations", N_("Add location to smart_proxy")
+      api :POST, "/smart_proxyies/:smart_proxy_id/links/organizations", N_("Add organization to smart_proxy")
+      param :smart_proxy_id, :identifier, :required => true
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/smart_proxyies/:smart_proxy_id/links/locations/:id", N_("Remove location from smart_proxy")
+      api :DELETE, "/smart_proxyies/:smart_proxy_id/links/organizations/:id", N_("Remove organization from smart_proxy")
+      param :smart_proxy_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def action_permission

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -70,6 +70,23 @@ module Api
         process_response @subnet.destroy
       end
 
+      api :POST, "/subnets/:subnet_id/links/domains", N_("Add domain to subnet")
+      api :POST, "/subnets/:subnet_id/links/locations", N_("Add location to subnet")
+      api :POST, "/subnets/:subnet_id/links/organizations", N_("Add organization to subnet")
+      param :subnet_id, :identifier, :required => true
+      param :domains, Array, :required => false, :desc => N_("Array of domain IDs")
+      param_group :taxonomies_associations, ::Api::V2::BaseController
+      def add
+      end
+
+      api :DELETE, "/subnets/:subnet_id/links/domains/:id", N_("Remove domain from subnet")
+      api :DELETE, "/subnets/:subnet_id/links/locations/:id", N_("Remove location from subnet")
+      api :DELETE, "/subnets/:subnet_id/links/organizations/:id", N_("Remove organization from subnet")
+      param :subnet_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -50,6 +50,21 @@ module Api
         process_response @usergroup.destroy
       end
 
+      api :POST, "/usergroups/:usergroup_id/links/roles", N_("Add role to user group")
+      api :POST, "/usergroups/:usergroup_id/links/users", N_("Add user to user group")
+      param :usergroup_id, :identifier, :required => true
+      param :users, Array, :required => false, :desc => N_("Array of IDs")
+      param :usergroups, Array, :required => false, :desc => N_("Array of IDs")
+      def add
+      end
+
+      api :DELETE, "/usergroups/:usergroup_id/links/roles/:id", N_("Remove role from user group")
+      api :DELETE, "/usergroups/:usergroup_id/links/users/:id", N_("Remove user from user group")
+      param :usergroup_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -92,6 +92,27 @@ module Api
         end
       end
 
+      api :POST, "/users/:user_id/links/roles", N_("Add role to user")
+      api :POST, "/users/:user_id/links/usergroups", N_("Add user group to user")
+      api :POST, "/users/:user_id/links/locations", N_("Add location to user")
+      api :POST, "/users/:user_id/links/organizations", N_("Add organization to user")
+      param :user_id, :identifier, :required => true
+      param :roles, Array, :required => false, :desc => N_("Array of IDs")
+      param :usergroups, Array, :required => false, :desc => N_("Array of IDs")
+      param :locations, Array, :required => false, :desc => N_("Array of location IDs")
+      param :organizations, Array, :required => false, :desc => N_("Array of organization IDs")
+      def add
+      end
+
+      api :DELETE, "/users/:user_id/links/roles/:id", N_("Remove role from user")
+      api :DELETE, "/users/:user_id/links/usergroups/:id", N_("Remove user group from user")
+      api :DELETE, "/users/:user_id/links/locations/:id", N_("Remove location from user")
+      api :DELETE, "/users/:user_id/links/organizations/:id", N_("Remove organization from user")
+      param :user_id, :identifier, :required => true
+      param :id, String, :required => true, :desc => N_("ID or comma-delimited list of IDs")
+      def remove
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -73,6 +73,48 @@ module Api::V2::TaxonomiesController
     render :json => {:error => {:message => (_('Cannot delete %{current} because it has nested %{sti_name}.') % { :current => @taxonomy.title, :sti_name => @taxonomy.sti_name }) } }
   end
 
+  api :POST, "/:resource_id/:res_id/links/users", N_("Add user to :resource")
+  api :POST, "/:resource_id/:res_id/links/smart_proxies", N_("Add smart proxy to :resource")
+  api :POST, "/:resource_id/:res_id/links/subnets", N_("Add subnet to :resource")
+  api :POST, "/:resource_id/:res_id/links/compute_resources", N_("Add compute resource to :resource")
+  api :POST, "/:resource_id/:res_id/links/media", N_("Add medium to :resource")
+  api :POST, "/:resource_id/:res_id/links/config_templates", N_("Add provisioning template to :resource")
+  api :POST, "/:resource_id/:res_id/links/domains", N_("Add domain to :resource")
+  api :POST, "/:resource_id/:res_id/links/realms", N_("Add realm to :resource")
+  api :POST, "/:resource_id/:res_id/links/environments", N_("Add environment to :resource")
+  api :POST, "/:resource_id/:res_id/links/hostgroups", N_("Add hostgroup to :resource")
+  api :POST, "/:resource_id/:res_id/links/:opp_resources", N_("Add :opp_resource to :resource")
+  param :res_id, Integer, :desc => N_("id of :resource")
+  param :users, Array, :required => false, :desc => N_("Array of user IDs")
+  param :smart_proxies, Array, :required => false, :desc => N_("Array of smart proxy IDs")
+  param :subnets, Array, :required => false, :desc => N_("Array of subnet IDs")
+  param :compute_resources, Array, :required => false, :desc => N_("Array of compute resource IDs")
+  param :media, Array, :required => false, :desc => N_("Array of media IDs")
+  param :config_templates, Array, :required => false, :desc => N_("Array of template IDs")
+  param :domains, Array, :required => false, :desc => N_("Array of domain IDs")
+  param :realms, Array, :required => false, :desc => N_("Array of realm IDs")
+  param :environments, Array, :required => false, :desc => N_("Array of environment IDs")
+  param :hostgroups, Array, :required => false, :desc => N_("Array of hostgroup IDs")
+  param :opp_resources, Array, :required => false, :desc => N_("Array of IDs")
+  def add
+  end
+
+  api :DELETE, "/:resource_id/:res_id/links/users/:id", N_("Remove user from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/smart_proxies/:id", N_("Remove smart proxy from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/subnets/:id", N_("Remove subnet from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/compute_resources/:id", N_("Remove compute resource from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/media/:id", N_("Remove medium from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/config_templates/:id", N_("Remove provisioning template from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/domains/:id", N_("Remove domain from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/realms/:id", N_("Remove realm from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/environments/:id", N_("Remove environment from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/hostgroups/:id", N_("Remove hostgroup from :resource")
+  api :DELETE, "/:resource_id/:res_id/links/:opp_resources/:id", N_("Remove :opp_resource from :resource")
+  param :res_id, Integer, :desc => N_("id of :resource")
+  param :id, String, :required => true, :desc => N_("id or comma-delimited list of id's")
+  def remove
+  end
+
   private
 
   def params_match_database

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -16,6 +16,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 class UserRole < ActiveRecord::Base
+
+  audited :associated_with => :role, :allow_mass_assignment => true
+
   belongs_to :owner, :polymorphic => true
   belongs_to :role
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -19,7 +19,8 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :edit_architectures,
                    :architectures => [:edit, :update],
                    :"api/v1/architectures" => [:update],
-                   :"api/v2/architectures" => [:update]
+                   :"api/v2/architectures" => [:update],
+                   :"api/v2/many_to_many" => [:create, :destroy]
     map.permission :destroy_architectures,
                    :architectures => [:destroy],
                    :"api/v1/architectures" => [:destroy],
@@ -483,7 +484,8 @@ Foreman::AccessControl.map do |permission_set|
                                        :"api/v1/operatingsystems" => [:update],
                                        :"api/v2/operatingsystems" => [:update],
                                        :"api/v2/parameters" => [:create, :update, :destroy, :reset],
-                                       :"api/v2/os_default_templates" => [:create, :update, :destroy]
+                                       :"api/v2/os_default_templates" => [:create, :update, :destroy],
+                                       :"api/v2/many_to_many" => [:create, :destroy]
                                      }
     map.permission :destroy_operatingsystems, {:operatingsystems => [:destroy],
                                              :"api/v1/operatingsystems" => [:destroy],
@@ -548,7 +550,9 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :create_roles,  {:roles => [:new, :create, :clone],
                                     :'api/v2/roles' => [:create]}
     map.permission :edit_roles,    {:roles => [:edit, :update],
-                                    :'api/v2/roles' => [:update]}
+                                    :'api/v2/roles' => [:update],
+                                    :'api/v2/many_to_many' => [:create, :destroy]
+                                   }
     map.permission :destroy_roles, {:roles => [:destroy],
                                     :'api/v2/roles' => [:destroy]}
   end
@@ -673,7 +677,8 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :edit_users,
                    :users => [:edit, :update].push(*ajax_actions),
                    :"api/v1/users" => [:update],
-                   :"api/v2/users" => [:update]
+                   :"api/v2/users" => [:update],
+                   :"api/v2/many_to_many" => [:create, :destroy]
     map.permission :destroy_users,
                    :users => [:destroy],
                    :"api/v1/users" => [:destroy],

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -378,6 +378,65 @@ Foreman::Application.routes.draw do
       end
       get 'orchestration/(:id)/tasks', :to => 'tasks#index'
       resources :plugins, :only => [:index]
+
+      # many-to-many routes
+      post   'architectures/:architecture_id/links/:association', :to => 'many_to_many#create'
+      delete 'architectures/:architecture_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'compute_resources/:compute_resource_id/links/:association', :to => 'many_to_many#create'
+      delete 'compute_resources/:compute_resource_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'config_templates/:config_template_id/links/:association', :to => 'many_to_many#create'
+      delete 'config_templates/:config_template_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'domains/:domain_id/links/:association', :to => 'many_to_many#create'
+      delete 'domains/:domain_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'environments/:environment_id/links/:association', :to => 'many_to_many#create'
+      delete 'environments/:environment_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'hosts/:host_id/links/:association', :to => 'many_to_many#create'
+      delete 'hosts/:host_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'hostgroups/:hostgroup_id/links/:association', :to => 'many_to_many#create'
+      delete 'hostgroups/:hostgroup_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'locations/:location_id/links/:association', :to => 'many_to_many#create'
+      delete 'locations/:location_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'media/:medium_id/links/:association', :to => 'many_to_many#create'
+      delete 'media/:medium_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'operatingsystems/:operatingsystem_id/links/:association', :to => 'many_to_many#create'
+      delete 'operatingsystems/:operatingsystem_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'organizations/:organization_id/links/:association', :to => 'many_to_many#create'
+      delete 'organizations/:organization_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'ptables/:ptable_id/links/:association', :to => 'many_to_many#create'
+      delete 'ptables/:ptable_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'ptables/:ptable_id/links/:association', :to => 'many_to_many#create'
+      delete 'ptables/:ptable_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'realms/:realm_id/links/:association', :to => 'many_to_many#create'
+      delete 'realms/:realm_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'roles/:role_id/links/:association', :to => 'many_to_many#create'
+      delete 'roles/:role_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'smart_proxies/:smart_proxy_id/links/:association', :to => 'many_to_many#create'
+      delete 'smart_proxies/:smart_proxy_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'subnets/:subnet_id/links/:association', :to => 'many_to_many#create'
+      delete 'subnets/:subnet_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'usergroups/:usergroup_id/links/:association', :to => 'many_to_many#create'
+      delete 'usergroups/:usergroup_id/links/:association/:id', :to => 'many_to_many#destroy'
+
+      post   'users/:user_id/links/:association', :to => 'many_to_many#create'
+      delete 'users/:user_id/links/:association/:id', :to => 'many_to_many#destroy'
+
     end
   end
 end

--- a/db/seeds.d/04-admin.rb
+++ b/db/seeds.d/04-admin.rb
@@ -7,11 +7,13 @@ src_hidden = AuthSourceHidden.find_by_type "AuthSourceHidden"
 # maintenance tasks etc.
 unless User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
   User.without_auditing do
-    user = User.new(:login => User::ANONYMOUS_ADMIN, :firstname => "Anonymous", :lastname => "Admin")
-    user.admin = true
-    user.auth_source = src_hidden
-    User.current = user
-    raise "Unable to create anonymous admin user: #{format_errors user}" unless user.save
+    UserRole.without_auditing do
+      user = User.new(:login => User::ANONYMOUS_ADMIN, :firstname => "Anonymous", :lastname => "Admin")
+      user.admin = true
+      user.auth_source = src_hidden
+      User.current = user
+      raise "Unable to create anonymous admin user: #{format_errors user}" unless user.save
+    end
   end
 end
 
@@ -19,33 +21,37 @@ end
 # It should be removed and replaced by per-user OAuth tokens (#1301)
 unless User.unscoped.find_by_login(User::ANONYMOUS_API_ADMIN).present?
   User.without_auditing do
-    user = User.new(:login => User::ANONYMOUS_API_ADMIN, :firstname => "API", :lastname => "Admin")
-    user.admin = true
-    user.auth_source = src_hidden
-    User.current = user
-    raise "Unable to create anonymous API user: #{format_errors user}" unless user.save
+    UserRole.without_auditing do
+      user = User.new(:login => User::ANONYMOUS_API_ADMIN, :firstname => "API", :lastname => "Admin")
+      user.admin = true
+      user.auth_source = src_hidden
+      User.current = user
+      raise "Unable to create anonymous API user: #{format_errors user}" unless user.save
+    end
   end
 end
 
 # First real admin user account
 unless User.unscoped.only_admin.except_hidden.present?
   User.without_auditing do
-    User.as_anonymous_admin do
-      admin_user = ENV['SEED_ADMIN_USER'].present? ? ENV['SEED_ADMIN_USER'] : 'admin'
-      user = User.new(:login     => admin_user,
-                      :firstname => ENV['SEED_ADMIN_FIRST_NAME'] || "Admin",
-                      :lastname  => ENV['SEED_ADMIN_LAST_NAME'] || "User",
-                      :mail      => (ENV['SEED_ADMIN_EMAIL'] || Setting[:administrator]).dup)
-      user.admin = true
-      user.auth_source = src_internal
-      if ENV['SEED_ADMIN_PASSWORD'].present?
-        user.password = ENV['SEED_ADMIN_PASSWORD']
-      else
-        random = User.random_password
-        user.password = random
-        puts "Login credentials: #{user.login} / #{random}" unless Rails.env.test?
+    UserRole.without_auditing do
+      User.as_anonymous_admin do
+        admin_user = ENV['SEED_ADMIN_USER'].present? ? ENV['SEED_ADMIN_USER'] : 'admin'
+        user = User.new(:login     => admin_user,
+                        :firstname => ENV['SEED_ADMIN_FIRST_NAME'] || "Admin",
+                        :lastname  => ENV['SEED_ADMIN_LAST_NAME'] || "User",
+                        :mail      => (ENV['SEED_ADMIN_EMAIL'] || Setting[:administrator]).dup)
+        user.admin = true
+        user.auth_source = src_internal
+        if ENV['SEED_ADMIN_PASSWORD'].present?
+          user.password = ENV['SEED_ADMIN_PASSWORD']
+        else
+          random = User.random_password
+          user.password = random
+          puts "Login credentials: #{user.login} / #{random}" unless Rails.env.test?
+        end
+        raise "Unable to create admin user: #{format_errors user}" unless user.save
       end
-      raise "Unable to create admin user: #{format_errors user}" unless user.save
     end
   end
 end

--- a/test/fixtures/user_roles.yml
+++ b/test/fixtures/user_roles.yml
@@ -13,3 +13,8 @@ user_restricted_manage_hosts_role:
 user_restricted_manage_compute_resources:
   owner: restricted
   role_id: 11
+
+usergroup_superadmins_role:
+  owner_id: 1
+  owner_type: 'Usergroup'
+  role_id: 11

--- a/test/fixtures/usergroups.yml
+++ b/test/fixtures/usergroups.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
+
+superadmins:
+  name: 'Super Administrators'
+  id: 1
+
+managers:
+  name: 'Managers'
+  id: 2

--- a/test/functional/api/v2/many_to_many_controller_test.rb
+++ b/test/functional/api/v2/many_to_many_controller_test.rb
@@ -1,0 +1,237 @@
+require 'test_helper'
+
+class Api::V2::ManyToManyControllerTest < ActionController::TestCase
+
+  ######### Add/Remove Role to/from User
+  test "should add one role to a user" do
+    user = users(:two)
+    assert_difference('user.roles.count') do
+      post :create, { :user_id => user.id, :association => 'roles', :roles => roles(:edit_hosts).id }
+    end
+    assert_response :success
+  end
+
+  test "should add multiple roles to a user" do
+    user = users(:two)
+    assert_difference('user.roles.count', 2) do
+      post :create, { :user_id => user.id, :association => 'roles', :roles => [roles(:edit_hosts).id, roles(:manage_compute_resources).id] }
+    end
+    assert_response :success
+  end
+
+  test "should add multiple roles to a user even if input is in deliminated string of ids rather than array" do
+    user = users(:two)
+    assert_difference('user.roles.count', 2) do
+      post :create, { :user_id => user.id, :association => 'roles', :roles => "#{roles(:edit_hosts).id}, #{roles(:manage_compute_resources).id}" }
+    end
+    assert_response :success
+  end
+
+  test "should not add role that does not exist to user" do
+    user = users(:two)
+    assert_difference('user.roles.count', 0) do
+      post :create, { :user_id => user.id, :association => 'roles', :roles => 123456789000 }
+    end
+    assert_response :unprocessable_entity
+    result = ActiveSupport::JSON.decode(@response.body)
+    assert_includes result['message'], "Resource Role not found for id"
+  end
+
+  test "should remove a role from a user" do
+    user = users(:restricted)
+    assert_difference('user.roles.count', -1) do
+      delete :destroy, { :user_id => user.id, :association => 'roles', :id => roles(:viewer).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove multiple roles from a user" do
+    user = users(:restricted)
+    assert_difference('user.roles.count', -2) do
+      delete :destroy, { :user_id => user.id, :association => 'roles', :id => "#{roles(:manage_hosts).id},#{roles(:manage_compute_resources).id}" }
+    end
+    assert_response :success
+  end
+
+  test "should give error if trying to removing role the does not exist from user" do
+    user = users(:two)
+    assert_difference('user.roles.count', 0) do
+      post :destroy, { :user_id => user.id, :association => 'roles', :id => 123456789000 }
+    end
+    assert_response :unprocessable_entity
+    result = ActiveSupport::JSON.decode(@response.body)
+    assert_includes result['message'], "Resource Role not found for id"
+  end
+
+  ######### Add/Remove User to/from Role
+  test "should add one user to a role" do
+    role = roles(:edit_hosts)
+    assert_difference('role.users.count') do
+      post :create, { :role_id => role.id, :association => 'users', :users => users(:two).id }
+    end
+    assert_response :success
+  end
+
+  test "should add multiple users to a role" do
+    role = roles(:edit_hosts)
+    assert_difference('role.users.count', 2) do
+      post :create, { :role_id => role.id, :association => 'users', :users => [users(:two).id, users(:internal).id] }
+    end
+    assert_response :success
+  end
+
+  test "should not add user that does not exist to role" do
+    role = roles(:edit_hosts)
+    assert_difference('role.users.count', 0) do
+      post :create, { :role_id => role.id, :association => 'users', :users => 123456 }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should remove a user from a role" do
+    role = roles(:viewer)
+    assert_difference('role.users.count', -1) do
+      delete :destroy, { :role_id => role.id, :association => 'users', :id => users(:restricted).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove multiple users from a role" do
+    role = roles(:viewer)
+    role.users << users(:internal)
+    assert_difference('role.users.count', -2) do
+      delete :destroy, { :role_id => role.id, :association => 'users', :id => "#{users(:restricted).id}, #{users(:internal).id}" }
+    end
+    assert_response :success
+  end
+
+
+  ######### Add/Remove Architecture to/from Operating system
+  test "should add one architecture to a operatingsystem" do
+    operatingsystem = operatingsystems(:redhat)
+    assert_difference('operatingsystem.architectures.count') do
+      post :create, { :operatingsystem_id => operatingsystem.id, :association => 'architectures', :architectures => architectures(:sparc).id }
+    end
+    assert_response :success
+  end
+
+  test "should add multiple architectures to a operatingsystem" do
+    operatingsystem = operatingsystems(:redhat)
+    assert_difference('operatingsystem.architectures.count', 2) do
+      post :create, { :operatingsystem_id => operatingsystem.id, :association => 'architectures', :architectures => [architectures(:sparc).id, architectures(:s390).id] }
+    end
+    assert_response :success
+  end
+
+  test "should not add architecture that does not exist to operatingsystem" do
+    operatingsystem = operatingsystems(:redhat)
+    assert_difference('operatingsystem.architectures.count', 0) do
+      post :create, { :operatingsystem_id => operatingsystem.id, :association => 'architectures', :architectures => 9999999999 }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should remove a architecture from a operatingsystem" do
+    operatingsystem = operatingsystems(:redhat)
+    assert_difference('operatingsystem.architectures.count', -1) do
+      delete :destroy, { :operatingsystem_id => operatingsystem.id, :association => 'architectures', :id => architectures(:x86_64).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove multiple architectures from a operatingsystem" do
+    operatingsystem = operatingsystems(:redhat)
+    operatingsystem.architectures << architectures(:sparc)
+    assert_difference('operatingsystem.architectures.count', -2) do
+      delete :destroy, { :operatingsystem_id => operatingsystem.id, :association => 'architectures', :id => "#{architectures(:x86_64).id}, #{architectures(:sparc).id}" }
+    end
+    assert_response :success
+  end
+
+
+  ######### Add/Remove Role to/from Usergroup
+  test "should add one role to a usergroup" do
+    usergroup = usergroups(:superadmins)
+    assert_difference('usergroup.roles.count') do
+      post :create, { :usergroup_id => usergroup.id, :association => 'roles', :roles => roles(:edit_hosts).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove a role from a usergroup" do
+    usergroup = usergroups(:superadmins)
+    assert_difference('usergroup.roles.count', -1) do
+      delete :destroy, { :usergroup_id => usergroup.id, :association => 'roles', :id => roles(:manage_compute_resources).id }
+    end
+    assert_response :success
+  end
+
+  ######### Add/Remove Environment to/from Location
+  test "should add one environment to a location" do
+    location = taxonomies(:location1)
+    assert_difference('location.environments.count') do
+      post :create, { :location_id => location.id, :association => 'environments', :environments => environments(:global_puppetmaster).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove an environment from a location" do
+    location = taxonomies(:location1)
+    assert_difference('location.environments.count', -1) do
+      delete :destroy, { :location_id => location.id, :association => 'environments', :id => environments(:production).id }
+    end
+    assert_response :success
+  end
+
+  ######### Add/Remove Puppetclass to/from Host
+  test "should add one puppetclass to a host" do
+    host = hosts(:one)
+    assert_difference('host.puppetclasses.count') do
+      post :create, { :host_id => host.id, :association => 'puppetclasses', :puppetclasses => puppetclasses(:two).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove an puppetclass from a host" do
+    host = hosts(:one)
+    assert_difference('host.puppetclasses.count', -1) do
+      delete :destroy, { :host_id => host.id, :association => 'puppetclasses', :id => puppetclasses(:one).id }
+    end
+    assert_response :success
+  end
+
+  ######### Add/Remove Config Group to/from location
+  test "should add one config_group to a hostgroup" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.config_groups.count') do
+      post :create, { :hostgroup_id => hostgroup.id, :association => 'config_groups', :config_groups => config_groups(:two).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove an config_group from a hostgroup" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.config_groups.count', -1) do
+      delete :destroy, { :hostgroup_id => hostgroup.id, :association => 'config_groups', :id => config_groups(:one).id }
+    end
+    assert_response :success
+  end
+
+  ######### Add/Remove Location to/from Organization
+  test "should add one location to an organization" do
+    organization = taxonomies(:organization1)
+    assert_difference('organization.locations.count') do
+      post :create, { :organization_id => organization.id, :association => 'locations', :locations => taxonomies(:location2).id }
+    end
+    assert_response :success
+  end
+
+  test "should remove a location from an organization" do
+    organization = taxonomies(:organization1)
+    assert_difference('organization.locations.count', -1) do
+      delete :destroy, { :organization_id => organization.id, :association => 'locations', :id => taxonomies(:location1).id }
+    end
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
Note: Related to PR https://github.com/theforeman/foreman/pull/1773 to add auditing when adding/removing
