### PR TITLE
fixes #5869 - permit accents in user names on Ruby 1.8

### DIFF
--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
@@ -45,6 +46,9 @@ class UserTest < ActiveSupport::TestCase
 
     @user.firstname = "C_r'a-z.y( )<,Na=me;>"
     assert @user.save
+
+    @user.firstname = "é ô à"
+    assert @user.save
   end
 
   test "lastname should have the correct format" do
@@ -52,6 +56,9 @@ class UserTest < ActiveSupport::TestCase
     assert !@user.save
 
     @user.lastname = "C_r'a-z.y( )<,Na=me;>"
+    assert @user.save
+
+    @user.lastname = "é ô à"
     assert @user.save
   end
 


### PR DESCRIPTION
Replaces #1387, uses a slightly stricter regex (more like the original) but adds tests based on the comments from that PR.
