### PR TITLE
Add support for 64-bit MAC addresses, fixes #5915

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -132,7 +132,7 @@ class Host::Managed < Host::Base
     include HostTemplateHelpers
 
     validates :ip, :uniqueness => true, :if => Proc.new {|host| host.require_ip_validation?}
-    validates :mac, :uniqueness => true, :format => {:with => Net::Validations::MAC_REGEXP}, :unless => Proc.new { |host| host.compute? or !host.managed }
+    validates :mac, :uniqueness => true, :mac_address => true, :unless => Proc.new { |host| host.compute? or !host.managed }
     validates :architecture_id, :operatingsystem_id, :domain_id, :presence => true, :if => Proc.new {|host| host.managed}
     validates :mac, :presence => true, :unless => Proc.new { |host| host.compute? or !host.managed }
     validates :root_pass, :length => {:minimum => 8, :message => _('should be 8 characters or more')},

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -12,7 +12,7 @@ module Nic
 
     before_validation :normalize_mac
 
-    validates :mac, :uniqueness => true, :presence => true, :format => {:with => Net::Validations::MAC_REGEXP}
+    validates :mac, :uniqueness => true, :presence => true, :mac_address => true
 
     validate :uniq_with_hosts
 

--- a/app/validators/mac_address_validator.rb
+++ b/app/validators/mac_address_validator.rb
@@ -1,0 +1,7 @@
+class MacAddressValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless Net::Validations.valid_mac? value
+      record.errors[attribute] << (options[:message] || _("is not a valid MAC address"))
+    end
+  end
+end

--- a/test/lib/net/validations_test.rb
+++ b/test/lib/net/validations_test.rb
@@ -4,9 +4,35 @@ require 'net'
 class ValidationsTest < ActiveSupport::TestCase
   include Net::Validations
 
-  test "mac address should be valid" do
+  describe "valid_mac?" do
+    test "nil is not valid" do
+      Net::Validations.valid_mac?(nil).must_be_same_as false
+    end
+
+    test "48-bit MAC address is valid" do
+      Net::Validations.valid_mac?("aa:bb:cc:dd:ee:ff").must_be_same_as true
+    end
+
+    test "64-bit MAC address is valid" do
+      Net::Validations.valid_mac?("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd").must_be_same_as true
+    end
+
+    test "MAC address is not valid" do
+      Net::Validations.valid_mac?("aa:bb:cc:dd:ee").must_be_same_as false
+      Net::Validations.valid_mac?("aa:bb:cc:dd:ee:ff:gg:11").must_be_same_as false
+      Net::Validations.valid_mac?("aa:bb:cc:dd:ee:zz").must_be_same_as false
+    end
+  end
+
+  test "48-bit mac address should be valid" do
     assert_nothing_raised Net::Validations::Error do
       validate_mac "aa:bb:cc:dd:ee:ff"
+    end
+  end
+
+  test "64-bit mac address should be valid" do
+    assert_nothing_raised Net::Validations::Error do
+      validate_mac "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
     end
   end
 
@@ -46,21 +72,46 @@ class ValidationsTest < ActiveSupport::TestCase
   end
 
   describe "mac normalization" do
+    context "when 48-bit MAC address" do
+      let(:mac) { "aa:bb:cc:dd:ee:ff" }
 
-    let(:mac) { "aa:bb:cc:dd:ee:ff" }
+      test "should normalize dash separated format" do
+        Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff").must_equal(mac)
+      end
 
-    test "should normalize dash separated format" do
-      Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff").must_equal(mac)
+      test "should normalize condensed format" do
+        Net::Validations.normalize_mac("aabbccddeeff").must_equal(mac)
+      end
+
+      test "should keep colon separated format" do
+        Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff").must_equal(mac)
+      end
     end
 
-    test "should normalize condensed format" do
-      Net::Validations.normalize_mac("aabbccddeeff").must_equal(mac)
+    context "when 64-bit MAC address" do
+      let(:mac) { "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd" }
+
+      test "should normalize dash separated format" do
+        Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff-00-11-22-33-44-55-66-77-88-99-aa-bb-cc-dd").must_equal(mac)
+      end
+
+      test "should normalize condensed format" do
+        Net::Validations.normalize_mac("aabbccddeeff00112233445566778899aabbccdd").must_equal(mac)
+      end
+
+      test "should keep colon separated format" do
+        Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd").must_equal(mac)
+      end
     end
 
-    test "should keep colon separated format" do
-      Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff").must_equal(mac)
-    end
+    context "when invalid MAC address" do
+      test "should handle invalid MAC address length" do
+        assert_nil Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:gg:11")
+      end
 
+      test "should handle invalid MAC address characters" do
+        assert_nil Net::Validations.normalize_mac("aa:bb:cc:dd:ee:zz")
+      end
+    end
   end
-
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -53,6 +53,28 @@ class HostTest < ActiveSupport::TestCase
     assert_equal "aa:bb:cc:dd:ee:ff", host.mac
   end
 
+  test "should fix 64-bit mac address hyphens" do
+    host = Host.create :name => "myhost", :mac => "aa-bb-cc-dd-ee-ff-00-11-22-33-44-55-66-77-88-99-aa-bb-cc-dd"
+    assert_equal "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd", host.mac
+  end
+
+  test "should fix 64-bit mac address" do
+    host = Host.create :name => "myhost", :mac => "aabbccddeeff00112233445566778899aabbccdd"
+    assert_equal "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd", host.mac
+  end
+
+  test "should keep valid 64-bit mac address" do
+    host = Host.create :name => "myhost", :mac => "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
+    assert_equal "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd", host.mac
+  end
+
+  test "should be valid using 64-bit mac address" do
+    host = hosts(:one)
+    host.mac = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
+    host.save!
+    assert_equal true, host.valid?
+  end
+
   test "should fix ip address if a leading zero is used" do
     host = Host.create :name => "myhost", :mac => "aabbccddeeff", :ip => "123.01.02.03"
     assert_equal "123.1.2.3", host.ip

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -29,6 +29,12 @@ class NicTest < ActiveSupport::TestCase
     assert i.errors.keys.include?(:mac)
   end
 
+  test "should be valid with 64-bit mac address" do
+    i = Nic::Base.new :mac => "babbccddeeff00112233445566778899aabbccdd", :host => hosts(:one)
+    assert i.valid?
+    assert !i.errors.keys.include?(:mac)
+  end
+
   test "should fail on invalid dns name" do
     i = Nic::Managed.new :mac => "dabbccddeeff", :host => hosts(:one), :name => "invalid_dns_name"
     assert !i.valid?
@@ -38,6 +44,11 @@ class NicTest < ActiveSupport::TestCase
   test "should fix mac address" do
     interface = Nic::Base.create! :mac => "cabbccddeeff", :host => hosts(:one)
     assert_equal "ca:bb:cc:dd:ee:ff", interface.mac
+  end
+
+  test "should fix 64-bit mac address" do
+    interface = Nic::Base.create! :mac => "babbccddeeff00112233445566778899aabbccdd", :host => hosts(:one)
+    assert_equal "ba:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd", interface.mac
   end
 
   test "should fix ip address if a leading zero is used" do


### PR DESCRIPTION
This would allow Infiniband interfaces to be managed by Foreman.  I have not tested this outside of local unit tests, so I would not consider it ready for merging.
