### PR TITLE
Fixes #5936 - Only call fact_name_class.maximum if necessary

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -48,13 +48,15 @@ class FactImporter
   end
 
   def add_new_facts
-    fact_names      = fact_name_class.maximum(:id, :group => 'name')
     facts_to_create = facts.keys - db_facts.keys
     # if the host does not exists yet, we don't have an host_id to use the fact_values table.
-    method          = host.new_record? ? :build : :create!
-    facts_to_create.each do |name|
-      host.fact_values.send(method, :value => facts[name],
-                            :fact_name_id  => fact_names[name] || fact_name_class.create!(:name => name).id)
+    if not facts_to_create.empty?
+      method          = host.new_record? ? :build : :create!
+      fact_names      = fact_name_class.maximum(:id, :group => 'name')
+      facts_to_create.each do |name|
+        host.fact_values.send(method, :value => facts[name],
+                              :fact_name_id  => fact_names[name] || fact_name_class.create!(:name => name).id)
+      end
     end
 
     @counters[:added] = facts_to_create.size


### PR DESCRIPTION
This patch stops calling fact_name_class.maximum every
time facts are uploaded, doing only the query when it's
strictly necessary (basically, when there are facts to create).

This optimization reduces the number of DB queries, which
might have a big impact when the size of the fact_names
table is significantly big.
