### PR TITLE
Fixes #5926 - hide sensitive parameter values

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery.multi-select
 //= require settings
 //= require jquery.gridster
+//= require hidden_values
 
 $(document).on('ContentLoad', function(){onContentLoad()});
 

--- a/app/assets/javascripts/hidden_values.js
+++ b/app/assets/javascripts/hidden_values.js
@@ -1,0 +1,41 @@
+function turn_text_switch() {
+  $('.hidden_value_text_switch').each(function (index, switch_field) {
+    if ($(switch_field).attr('data-switch-active') != 'true') {
+      $(switch_field).change(function () {
+        value = $("#common_parameter_value")[0];
+        value.type = (this.checked ? 'password' : 'text');
+      });
+      $(this).attr('data-switch-active', 'true');
+    }
+  })
+}
+
+function turn_textarea_switch() {
+  $('.hidden_value_textarea_switch').each(function (index, switch_field) {
+    if ($(switch_field).attr('data-switch-active') != 'true') {
+      $(switch_field).change(function () {
+        var source = $(this).closest('tr').children('td.value').children()[0];
+        if (this.checked) {
+          var target = '<input class="form-control" type="password" id="' + source.id + '" name="' + source.name + '" value ="' + source.value + '"></input>'
+        } else {
+          var target = '<textarea class="form-control" cols="40" id="' + source.id + '" name="' + source.name + '" placeholder="Value" rows="1">' + source.value + '</textarea>'
+        }
+        $(source).replaceWith(target);
+      });
+      this.value = '1';
+      $(this).attr('data-switch-active', 'true');
+    }
+  })
+}
+
+// normal page load trigger
+$(document).ready(turn_text_switch);
+
+// two-pane ajax trigger
+$(document).ajaxComplete(turn_text_switch);
+
+// normal page load trigger
+$(document).ready(turn_textarea_switch);
+
+// two-pane ajax trigger
+$(document).ajaxComplete(turn_textarea_switch);

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -392,12 +392,13 @@ function use_image_selected(element){
 function override_param(item){
   var param = $(item).closest('tr');
   var n = param.find('[id^=name_]').text();
-  var v = param.find('[id^=value_]').val();
+  var param_value = param.find('[id^=value_]');
+  var v = param_value.val();
 
   $('#parameters').find('.btn-success').click();
-  var new_param = param.closest('.tab-pane').find('[id*=host_host_parameters]:visible').last().parent().parent();
+  var new_param = param.closest('.tab-pane').find('td.col-md-6 [id*=host_host_parameters]:visible').parent().parent().last();
   new_param.find('[id$=_name]').val(n);
-  new_param.find('[id$=_value]').val(v);
+  new_param.find('td.col-md-6 [id$=_value]').val(v == param_value.data('hidden-value') ? '' : v);
   mark_params_override();
 }
 

--- a/app/controllers/api/v1/common_parameters_controller.rb
+++ b/app/controllers/api/v1/common_parameters_controller.rb
@@ -26,6 +26,7 @@ module Api
       param :common_parameter, Hash, :required => true do
         param :name, String, :required => true
         param :value, String, :required => true
+        param :hidden_value, [true, false]
       end
 
       def create
@@ -38,6 +39,7 @@ module Api
       param :common_parameter, Hash, :required => true do
         param :name, String
         param :value, String
+        param :hidden_value, [true, false]
       end
 
       def update

--- a/app/controllers/api/v2/common_parameters_controller.rb
+++ b/app/controllers/api/v2/common_parameters_controller.rb
@@ -27,6 +27,7 @@ module Api
         param :common_parameter, Hash, :action_aware => true do
           param :name, String, :required => true
           param :value, String, :required => true
+          param :hidden_value, [true, false]
         end
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
       render((partial.nil? ? association.to_s.singularize + "_fields" : partial), :f => builder)
     end
-    link_to_function(name, ("add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\")").html_safe, add_html_classes(options, "btn btn-success") )
+    link_to_function(name, ("add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\"); turn_textarea_switch();").html_safe, add_html_classes(options, "btn btn-success") )
   end
 
   def link_to_remove_puppetclass klass, host

--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -11,8 +11,8 @@ module CommonParametersHelper
 
   def parameter_value_field value
     content_tag :div, :class => "form-group condensed"  do
-      text_area_tag("value_#{value[:value]}", value[:value], :rows => (value[:value].to_s.lines.count || 1 rescue 1),
-                    :class => "col-md-5", :disabled => true) +
+      text_area_tag("value_#{value[:safe_value]}", value[:safe_value], :rows => (value[:safe_value].to_s.lines.count || 1 rescue 1),
+                    :class => "col-md-5", :disabled => true, :'data-hidden-value' => Parameter.hidden_value) +
       content_tag(:span, :class => "help-block") { popover(_("Additional info"), _("<b>Source:</b> %s") % _(value[:source].to_s))}
     end
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -391,14 +391,14 @@ class Host::Managed < Host::Base
   def host_inherited_params include_source = false
     hp = {}
     # read common parameters
-    CommonParameter.all.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('common').to_sym} : p.value] }
+    CommonParameter.all.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('common').to_sym, :safe_value => p.safe_value} : p.value] }
     # read organization and location parameters
     hp.update organization.parameters(include_source) if SETTINGS[:organizations_enabled] && organization
     hp.update location.parameters(include_source)     if SETTINGS[:locations_enabled] && location
     # read domain parameters
-    domain.domain_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('domain').to_sym} : p.value] } unless domain.nil?
+    domain.domain_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('domain').to_sym, :safe_value => p.safe_value} : p.value] } unless domain.nil?
     # read OS parameters
-    operatingsystem.os_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('os').to_sym} : p.value] } unless operatingsystem.nil?
+    operatingsystem.os_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('os').to_sym, :safe_value => p.safe_value} : p.value] } unless operatingsystem.nil?
     # read group parameters only if a host belongs to a group
     hp.update hostgroup.parameters(include_source) if hostgroup
     hp

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -125,7 +125,7 @@ class Hostgroup < ActiveRecord::Base
     # otherwise we might be overwriting the hash in the wrong order.
     groups = ids.size == 1 ? [self] : Hostgroup.includes(:group_parameters).sort_by_ancestry(Hostgroup.find(ids))
     groups.each do |hg|
-      hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym} : p.value }
+      hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym, :safe_value => p.safe_value} : p.value }
     end
     hash
   end

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -24,6 +24,18 @@ class Parameter < ActiveRecord::Base
     end
   end
 
+  def safe_value
+    self.hidden_value? ? self.hidden_value : self.value
+  end
+
+  def hidden_value
+    self.class.hidden_value
+  end
+
+  def self.hidden_value
+    '*' * 5
+  end
+
   private
 
   def set_priority

--- a/app/views/api/v1/common_parameters/show.json.rabl
+++ b/app/views/api/v1/common_parameters/show.json.rabl
@@ -1,3 +1,3 @@
 object @common_parameter
 
-attributes :id, :name, :value
+attributes :id, :name, :value, :hidden_value

--- a/app/views/api/v2/common_parameters/main.json.rabl
+++ b/app/views/api/v2/common_parameters/main.json.rabl
@@ -2,4 +2,4 @@ object @common_parameter
 
 extends "api/v2/common_parameters/base"
 
-attributes :created_at, :updated_at
+attributes :created_at, :updated_at, :hidden_value

--- a/app/views/common_parameters/_form.html.erb
+++ b/app/views/common_parameters/_form.html.erb
@@ -1,6 +1,11 @@
 <%= form_for @common_parameter do |f| %>
   <%= base_errors_for @common_parameter %>
   <%= text_f f, :name %>
-  <%= text_f f, :value, :size => "col-md-8" %>
+  <% if @common_parameter.hidden_value? %>
+    <%= password_f f, :value, :size => "col-md-8", :value => @common_parameter.value %>
+  <% else %>
+    <%= text_f f, :value, :size => "col-md-8" %>
+  <% end %>
+  <%= checkbox_f f, :hidden_value, :class => 'hidden_value_text_switch', :checked => f.object.hidden_value? %>
   <%= submit_or_cancel f %>
 <% end %>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,3 +1,4 @@
+<% disabled = (not authorized_via_my_scope("host_editing", "edit_params")) %>
 <div class="fields">
   <table class="row">
   <tr class="form-group <%= 'has-error' if f.object.errors.any? %>">
@@ -7,14 +8,28 @@
     </td>
     <% end %>
     <td class="col-md-2">
-      <%= f.text_field(:name,  :class => "form-control", :disabled => (not authorized_via_my_scope("host_editing", "edit_params")), :placeholder => _("Name")) %>
+      <%= f.text_field(:name,  :class => "form-control", :disabled => disabled, :placeholder => _("Name")) %>
     </td>
-    <td class="col-md-7">
-      <%= f.text_area(:value, :class => "form-control", :rows => line_count(f, :value), :disabled => (not authorized_via_my_scope("host_editing", "edit_params")), :placeholder => _("Value")) %>
+    <td class="col-md-6 value">
+      <% if f.object.hidden_value? %>
+        <%= f.password_field(:value, :class => 'form-control',
+                             :disabled => disabled,
+                             :value => f.object.value) %>
+      <% else %>
+        <%= f.text_area(:value,
+                        :class => "form-control",
+                        :rows => line_count(f, :value),
+                        :disabled => disabled,
+                        :placeholder => _("Value")) %>
+      <% end %>
     </td>
-    <td class="col-md-1">
+    <td class="col-md-2">
     <span class="help-block">
-      <%= link_to_remove_fields('', f) if authorized_via_my_scope("host_editing", "destroy_params") %>
+      <%= f.check_box(:hidden_value,
+                      :class => 'hidden_value_textarea_switch',
+                      :onclick => 'turn_textarea_switch()',
+                      :disabled => disabled) %> <%= _('hide') %><br />
+      <%= link_to_remove_fields('', f) if authorized_via_my_scope("host_editing", "destroy_params") %><%= _('remove') %>
     </span>
     </td>
     <span class="help-block">

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -11,7 +11,7 @@
   <% for common_parameter in @common_parameters %>
     <tr>
       <td><%= link_to_if_authorized h(common_parameter), hash_for_edit_common_parameter_path(:id => common_parameter.id).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'edit_globals') %></td>
-      <td style='overflow-wrap: break-word;'><%= trunc(common_parameter.value,80  ) %></td>
+      <td style='overflow-wrap: break-word;'><%= trunc(common_parameter.safe_value, 80) %></td>
       <td class="ra">
         <%= display_delete_if_authorized hash_for_common_parameter_path(:id => common_parameter).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'destroy_globals'),
                                          :confirm => _("Delete %s?") % common_parameter.name %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,6 +111,7 @@ Foreman::Application.configure do |app|
                   dashboard
                   auth_source_ldap
                   subnets
+                  hidden_values
                  )
   stylesheets = %w( )
 

--- a/db/migrate/20140522122215_add_hidden_value_to_parameter.rb
+++ b/db/migrate/20140522122215_add_hidden_value_to_parameter.rb
@@ -1,0 +1,5 @@
+class AddHiddenValueToParameter < ActiveRecord::Migration
+  def change
+    add_column :parameters, :hidden_value, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
User can check to hide value when creating or editing global parameter.
The value is masked by **\* and is also not displayed when overriding.

This is meant as short-term solution. Long-term we should move to smart variables and smart class parameters and add proper password support there. I know that similar patch would be handy for smart variables and smart class parameters, but it seems too much work which would be dropped later.
