### PR TITLE
Fixes #5929 - Taxonomy filter obey permissions

### DIFF
--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -121,7 +121,7 @@ module TaxonomyHelper
   def taxonomy_selects(f, selected_ids, taxonomy, label, options = {}, options_html = {})
     options[:disabled] = Array.wrap(options[:disabled])
     options[:label]    ||= _(label)
-    multiple_selects f, label.downcase, taxonomy, selected_ids, options, options_html
+    multiple_selects f, label.downcase, taxonomy.authorized("assign_#{label.downcase}", taxonomy), selected_ids, options, options_html
   end
 
 end

--- a/app/models/concerns/dirty_associations.rb
+++ b/app/models/concerns/dirty_associations.rb
@@ -1,0 +1,63 @@
+# ActiveModel::Dirty does not support associations but it's sometime it'd be useful
+# so you could ask like this
+#   @user.role_ids_was
+#
+# This concern can be used exactly for this. Note that it does not detect changes to
+# associated object but just change of the collection itself.
+#
+# Also note one difference to built-in attribute dirty cache for new records. With
+# this concern we don't wait on saving the record which results in following behavior
+#   @user = User.new
+#   @user.role_ids = [8]
+#   @user.role_ids = [8, 9]
+#   @user.role_ids_was # => [8]
+module DirtyAssociations
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # usage:
+    #   class Model
+    #     dirty_has_many_associations :organizations, :locations
+    def dirty_has_many_associations(*args)
+      args.each do |association|
+        association_ids = association.to_s.singularize + '_ids'
+
+        # result for :organizations
+        #   def organization_ids_with_change_detection=(organizations)
+        #     organizations ||= []
+        #     @organization_ids_changed = organizations.uniq.select(&:present?).map(&:to_i).sort != organization_ids.sort
+        #     @organization_ids_was = organization_ids.clone
+        #     self.organization_ids_without_change_detection = organizations
+        #   end
+        define_method "#{association_ids}_with_change_detection=" do |collection|
+          collection ||= [] # in API, #{association}_ids is converted to nil if user sent empty array
+          instance_variable_set("@#{association_ids}_changed", collection.uniq.select(&:present?).map(&:to_i).sort != self.send(association_ids).sort)
+          instance_variable_set("@#{association_ids}_was", self.send(association_ids).clone)
+          self.send("#{association_ids}_without_change_detection=", collection)
+        end
+        alias_method_chain("#{association_ids}=", :change_detection)
+
+        # result for :organizations
+        #   def organization_ids_changed?
+        #     @organization_ids_changed
+        #   end
+        define_method "#{association_ids}_changed?" do
+          instance_variable_get("@#{association_ids}_changed")
+        end
+
+        # result for :organizations
+        #   def organization_ids_was
+        #     @organization_ids_was ||= organization_ids
+        #   end
+        define_method "#{association_ids}_was" do
+          value = instance_variable_get("@#{association_ids}_was")
+          if value.nil?
+            instance_variable_set("@#{association_ids}_was", self.send(association_ids))
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/dirty_associations_test.rb
+++ b/test/lib/dirty_associations_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class DummyDirtyAssociationsModel
+  def organization_ids
+    @organization_ids ||= []
+  end
+  attr_writer :organization_ids
+
+  include DirtyAssociations
+  dirty_has_many_associations :organizations
+end
+
+class DirtyAssociationsTest < ActiveSupport::TestCase
+  def setup
+    @tester = DummyDirtyAssociationsModel.new
+    @tester.organization_ids = [1, 2]
+  end
+
+  test "value change sets change flag" do
+    assert @tester.organization_ids_changed?
+  end
+
+  test "value change stores previous value" do
+    assert_equal @tester.organization_ids_was, []
+    @tester.organization_ids = [3]
+    assert_equal @tester.organization_ids_was, [1, 2]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,7 +84,7 @@ Spork.prefork do
 
     def as_user user
       saved_user   = User.current
-      User.current = users(user)
+      User.current = user.is_a?(User) ? user : users(user)
       result = yield
       User.current = saved_user
       result
@@ -101,6 +101,18 @@ Spork.prefork do
       result = yield
       new_taxonomy.class.current = saved_taxonomy
       result
+    end
+
+    def disable_taxonomies
+      org_settings = SETTINGS[:organizations_enabled]
+      SETTINGS[:organizations_enabled] = false
+      loc_settings = SETTINGS[:locations_enabled]
+      SETTINGS[:locations_enabled] = false
+      result = yield
+    ensure
+      SETTINGS[:organizations_enabled] = org_settings
+      SETTINGS[:locations_enabled] = loc_settings
+      return result
     end
 
     def setup_users


### PR DESCRIPTION
With this patch you can assign permissions like assign_organizations and
assign_locations to particular user so that they can then assign taxonomies
only from set of taxonomies granted by their filters.
