### PR TITLE
Fixes #5941 - Handle nil comparison object in DHCP::Record.valid?

### DIFF
--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -50,6 +50,7 @@ module Net::DHCP
     end
 
     def == other
+      return false unless other.present?
       if attrs[:hostname].blank?
         # If we're converting an 'ad-hoc' lease created by a host booting outside of Foreman's knowledge,
         # then :hostname will be blank on the incoming lease - if the ip/mac still match, then this

--- a/test/lib/net/dhcp_test.rb
+++ b/test/lib/net/dhcp_test.rb
@@ -71,4 +71,13 @@ class DhcpTest < ActiveSupport::TestCase
                                     "proxy" => subnets(:one).dhcp_proxy)
     assert record1.conflicts.empty?
   end
+
+  test "dhcp record validation should return false when proxy returns nil" do
+    ProxyAPI::DHCP.any_instance.stubs(:record).returns(nil)
+    record1 = Net::DHCP::Record.new(:hostname => "test1", :mac => "aa:bb:cc:dd:ee:ff",
+                                    :network => "127.0.0.0", :ip => "127.0.0.1",
+                                    "proxy" => subnets(:one).dhcp_proxy)
+    refute record1.valid?
+  end
+
 end


### PR DESCRIPTION
As tested in IRC:

```
[15:00:35] <gwmngilfen> wojtasfs: try applying this patch http://pastie.org/9223201
[15:00:42] <gwmngilfen> then restart foreman and retry your script
[15:02:02] <wojtasfs> trying
[15:02:42] <wojtasfs> jupi! it's working, great thanks ;)
```
