### PR TITLE
fixes #6091 - menu removal wasn't traversing menu hierarchy

### DIFF
--- a/app/services/menu/manager.rb
+++ b/app/services/menu/manager.rb
@@ -94,9 +94,12 @@ module Menu
 
       # Removes a menu item
       def delete(name)
-        if found = self.find(name)
-          @menu_items.remove!(found)
+        @menu_items.each do |item|
+          if item.name == name && !item.parent.nil?
+            return item.parent.remove!(item)
+          end
         end
+        nil
       end
 
       # Checks if a menu item exists

--- a/test/unit/menu_mapper_test.rb
+++ b/test/unit/menu_mapper_test.rb
@@ -167,6 +167,18 @@ class MenuMapperTest < ActiveSupport::TestCase
     assert_nil menu_mapper.find(:test_overview)
   end
 
+  def test_delete_in_sub_menu
+    menu_mapper = Menu::Manager::Mapper.new(:test_menu, {})
+    menu_mapper.sub_menu :test_sub_menu,      :caption => "Sub Menu" do
+      menu_mapper.item :test_sub_overview, :url_hash => { :controller => 'hosts', :action => 'show'}
+    end
+    assert_not_nil menu_mapper.find(:test_sub_overview)
+
+    assert_not_nil menu_mapper.delete(:test_sub_overview)
+
+    assert_nil menu_mapper.find(:test_sub_overview)
+  end
+
   def test_delete_missing
     menu_mapper = Menu::Manager::Mapper.new(:test_menu, {})
     assert_nil menu_mapper.delete(:test_missing)


### PR DESCRIPTION
This will need backport to 1.5-stable as the foreman_openstack_simplify plugin in Staypuft depends on it.
