### PR TITLE
Fixes #6117 - clean usergroup cache

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,8 @@ class User < ActiveRecord::Base
   has_many :cached_usergroups, :through => :cached_usergroup_members, :source => :usergroup
   has_many :cached_roles,      :through => :cached_user_roles,        :source => :role, :uniq => true
   has_many :hostgroups,        :through => :user_hostgroups
-  has_many :usergroups,        :through => :usergroup_member
-  has_many :roles,             :through => :user_roles, :dependent => :destroy
+  has_many :usergroups,        :through => :usergroup_member, :dependent => :destroy
+  has_many :roles,             :through => :user_roles,       :dependent => :destroy
   has_many :filters,           :through => :cached_roles
   has_many :permissions,       :through => :filters
   has_many :cached_usergroup_members

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -529,6 +529,29 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "chaging hostgroup should update cache" do
+    u = FactoryGirl.create(:user)
+    g1 = FactoryGirl.create(:usergroup)
+    g2 = FactoryGirl.create(:usergroup)
+    assert_empty u.usergroups
+    assert_empty u.cached_usergroups
+    u.usergroups = [g1, g2]
+    u.reload
+    assert_equal [g1.id, g2.id].sort, u.cached_usergroup_ids.sort
+
+    u.usergroups = [g2]
+    u.reload
+    assert_equal [g2.id].sort, u.cached_usergroup_ids.sort
+
+    u.usergroups = [g1]
+    u.reload
+    assert_equal [g1.id].sort, u.cached_usergroup_ids.sort
+
+    u.usergroups = []
+    u.reload
+    assert_empty u.cached_usergroups
+  end
+
 #  Uncomment after users get access to children taxonomies of their current taxonomies.
 #
 #  test 'default taxonomy inclusion validator takes into account inheritance' do


### PR DESCRIPTION
Dependent destroy was missing on through association from user side.
