### PR TITLE
fixes #6177 - clear host facts/reports when build=true set over API

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -28,6 +28,7 @@ class Host::Managed < Host::Base
 
   # Custom hooks will be executed after_commit
   after_commit :build_hooks
+  before_save :clear_data_on_build
 
   def build_hooks
     return unless respond_to?(:old) && old && (build? != old.build?)
@@ -193,6 +194,12 @@ class Host::Managed < Host::Base
 
   def clearFacts
     FactValue.where("host_id = #{id}").delete_all
+  end
+
+  def clear_data_on_build
+    return unless respond_to?(:old) && old && build? && !old.build?
+    clearFacts
+    clearReports
   end
 
   def set_token
@@ -440,9 +447,6 @@ class Host::Managed < Host::Base
   # Any existing puppet certificates are deleted
   # Any facts are discarded
   def setBuild
-    clearFacts
-    clearReports
-
     self.build = true
     self.save
     errors.empty?

--- a/test/factories/facts_related.rb
+++ b/test/factories/facts_related.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :fact_name do
+    sequence(:name) {|n| "fact#{n}" }
+  end
+
+  factory :fact_value do
+    fact_name
+    sequence(:value) {|n| "value#{n}" }
+    host
+  end
+end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -22,6 +22,28 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_facts do
+      ignore do
+        fact_count 20
+      end
+      after_create do |host,evaluator|
+        evaluator.fact_count.times do
+          FactoryGirl.create(:fact_value, :host => host)
+        end
+      end
+    end
+
+    trait :with_reports do
+      ignore do
+        report_count 5
+      end
+      after_create do |host,evaluator|
+        evaluator.report_count.times do
+          FactoryGirl.create(:report, :host => host)
+        end
+      end
+    end
+
     trait :on_compute_resource do
       uuid Foreman.uuid
       association :compute_resource, :factory => :ec2_cr

--- a/test/factories/reports_related.rb
+++ b/test/factories/reports_related.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :report do
+    host
+    sequence(:reported_at) { |n| n.minutes.ago }
+    status 0
+    metrics YAML.load("--- \n  time: \n    schedule: 0.00083\n    service: 0.149739\n    mailalias: 0.000283\n    cron: 0.000419\n    config_retrieval: 16.3637869358063\n    package: 0.003989\n    filebucket: 0.000171\n    file: 0.007025\n    exec: 0.000299\n  resources: \n    total: 33\n  changes: {}\n  events: \n    total: 0")
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1299,6 +1299,22 @@ class HostTest < ActiveSupport::TestCase
     assert copy.compute_attributes.nil?
   end
 
+  test 'facts are deleted when build set to true' do
+    host = FactoryGirl.create(:host, :with_facts)
+    assert_present host.fact_values
+    refute host.build?
+    host.update_attributes(:build => true)
+    assert_empty host.fact_values.reload
+  end
+
+  test 'reports are deleted when build set to true' do
+    host = FactoryGirl.create(:host, :with_reports)
+    assert_present host.reports
+    refute host.build?
+    host.update_attributes(:build => true)
+    assert_empty host.reports.reload
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
Ignore the test failure on Katello, that's some other problem.  Foreman's passing fine.
