### PR TITLE
fixes #6234 - fixes sorting on compute resources and subnets

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -26,6 +26,7 @@ class ComputeResource < ActiveRecord::Base
   validates :provider, :presence => true, :inclusion => { :in => proc { self.providers } }
   validates :url, :presence => true
   scoped_search :on => :name, :complete_value => :true
+  scoped_search :on => :type, :complete_value => :true
   scoped_search :on => :id, :complete_value => :true
   before_save :sanitize_url
   has_many_hosts

--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th><%= sort :name, :as => s_("Subnet|Name") %></th>
     <th><%= sort :network, :as => s_("Subnet|Network") %></th>
-    <th><%= sort :domains, :as => _("Domains") %></th>
+    <th><%= _("Domains") %></th>
     <th><%= sort :vlanid, :as => s_('Subnet|Vlanid') %></th>
     <th><%= _("DHCP Proxy") %></th>
     <th></th>


### PR DESCRIPTION
- Enabled sorting for CR types
- Domains under subnets has multiple values so it shouldn't be sortable
