### PR TITLE
fixes #6003 - don't render object directly

### DIFF
--- a/app/views/api/v2/users/main.json.rabl
+++ b/app/views/api/v2/users/main.json.rabl
@@ -5,10 +5,14 @@ extends "api/v2/users/base"
 attributes :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :last_login_on, :created_at, :updated_at
 
 if SETTINGS[:locations_enabled]
-  attributes :default_location
+  child :default_location => :default_location do
+    extends "api/v2/taxonomies/base", :taxonomy => :location
+  end
 end
 
 if SETTINGS[:organizations_enabled]
-  attributes :default_organization
+  child :default_organization => :default_organization do
+    extends "api/v2/taxonomies/base"
+  end
 end
 

--- a/test/functional/api/v2/users_controller_test.rb
+++ b/test/functional/api/v2/users_controller_test.rb
@@ -33,7 +33,7 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     get :show, { :id => users(:one).id }
     show_response = ActiveSupport::JSON.decode(@response.body)
 
-    assert_equal taxonomies(:location1).id, show_response['default_location']['location']['id']
+    assert_equal taxonomies(:location1).id, show_response['default_location']['id']
     assert_equal nil, show_response['default_organization']
   end
 


### PR DESCRIPTION
```
undefined method `key?' for #<JSON::Ext::Generator::State:0x0000000e782a68>
```
