### PR TITLE
Fixes #6099 - Bubble CR errors up the stack to the Host so we can display them

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -146,10 +146,6 @@ class ComputeResource < ActiveRecord::Base
     options = vm_instance_defaults.merge(args.to_hash.symbolize_keys)
     logger.debug("creating VM with the following options: #{options.inspect}")
     client.servers.create options
-  rescue Fog::Errors::Error => e
-    logger.debug "Fog error: #{e.message}\n " + e.backtrace.join("\n ")
-    errors.add(:base, e.message.to_s)
-    false
   end
 
   def destroy_vm uuid

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -46,6 +46,9 @@ module Foreman::Model
       args[:groups].reject!(&:empty?) if args.has_key?(:groups)
       args[:security_group_ids].reject!(&:empty?) if args.has_key?(:security_group_ids)
       super(args)
+    rescue Fog::Errors::Error => e
+      logger.debug "Unhandled EC2 error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      raise e
     end
 
     def security_groups vpc=nil

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -69,10 +69,9 @@ module Foreman::Model
       username = images.where(:uuid => args[:image_name]).first.try(:username)
       ssh      = { :username => username, :public_key => key_pair.public }
       super(args.merge(ssh))
-    rescue Exception => e
+    rescue Fog::Errors::Error => e
       logger.debug "Unhandled GCE error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
-      errors.add(:base, e.message.to_s)
-      false
+      raise e
     end
 
     def available_images

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -107,11 +107,11 @@ module Foreman::Model
     def create_vm args = { }
       vm = new_vm(args)
       create_volumes :prefix => vm.name, :volumes => vm.volumes, :backing_id => args[:image_id]
-
       vm.save
     rescue Fog::Errors::Error => e
-      errors.add(:base, e.to_s)
-      false
+      logger.debug "Unhandled LibVirt error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      destroy_vm vm.id if vm
+      raise e
     end
 
     def console uuid

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -24,10 +24,9 @@ module Foreman::Model
 
     def create_vm args = { }
       super(args)
-    rescue Exception => e
+    rescue Fog::Errors::Error => e
       logger.debug "Unhandled Rackspace error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
-      errors.add(:base, e.message.to_s)
-      false
+      raise e
     end
 
     def security_groups

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -282,9 +282,9 @@ module Foreman::Model
         vm.save
       end
     rescue Fog::Errors::Error => e
-      logger.debug e.backtrace
-      errors.add(:base, e.to_s)
-      false
+      logger.debug "Unhandled VMWare error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      destroy_vm vm.id if vm
+      raise e
     end
 
     def new_vm args


### PR DESCRIPTION
As it stands, this will cause "/compute_resources/:id/vms/new" to stop rendering CR errors nicely. We have two options:

1) Be happy with it not rendering nicely - it's an undocumented, unlinked page, for advanced users, and will at least still render the error, just not in a nice way
2) Add something like "orchestrated = true/false" to the create_vm() method, so we can tell if it was called directly or not, and then only rescue when orchestrated == false

I'm for 1) just to keep the code clean, at least the advanced users still get the error, even if it's unstyled.

@domcleal, @ohadlevy thoughts?
