### PR TITLE
Fix instance where a domain id is indicated, but no hostname is given.  ...

### DIFF
--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -44,7 +44,7 @@ module Nic
     end
 
     def hostname
-      unless domain.nil?
+      unless domain.nil? or name.empty?
         "#{name}.#{domain.name}"
       else
         name


### PR DESCRIPTION
...The model was asking the proxy to try and create a record that looks like ".domain.com", and if you were trying to create a second host with the same characteristics (blank hostname, domain name non-nil) on its interface, the proxy would properly fail with a "Entity already exists" error.
