### PR TITLE
Fixes #6337 - VM tab is hidden when we deselect profile

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -3,7 +3,8 @@ $(document).on('AddedClass', function(event, link){load_puppet_class_parameters(
 
 function computeResourceSelected(item){
   var compute = $(item).val();
-  if(compute=='') { //Bare Metal
+  if (compute == '' && /compute_resource/.test($(item).attr('name'))) {
+    //Bare metal compute resource
     $('#mac_address').show();
     $("#model_name").show();
     $('#compute_resource').empty();
@@ -11,9 +12,8 @@ function computeResourceSelected(item){
     $("#compute_resource_tab").hide();
     $("#compute_profile").hide();
     update_capabilities('build');
-  }
-  else
-  {
+  } else {
+    //Real compute resource or any compute profile
     $('#mac_address').hide();
     $("#model_name").hide();
     $("#compute_resource_tab").show();


### PR DESCRIPTION
The event `computeResourceSelected` is called `onChange` for both the Compute Resource selector and the Compute Profile selector in the Host#edit form. Before this patch, choosing a Compute Profile, then no Compute Profile (empty entry in the dropdown) would close the Virtual Machine tab, even though a Compute Resource was still selected. 

It required a minor tweak to make the function only close the Virtual Machine tab only when the Compute Resource selector goes to Bare Metal. When Compute Profile "None" is selected, it just removes all settings set by any other Compute Profile previously.
