### PR TITLE
Fixes #6357 - taxonomy_added is not defined while selecting/updating user's taxonomy

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,4 @@
+<%= javascript 'users' %>
 <% title _("Users") %>
 
 <% title_actions  display_link_if_authorized(_("New User"), hash_for_new_user_path) %>


### PR DESCRIPTION
This fixes the problem with javascript and users. I've seen the trick used in compute_resource_vms (javascript for the Virtual Machine tab is loaded through Host#new, trends, etc.. 

However there is one case that intrigues me a bit, javascript nfs_visibility in Media _form is loaded through the form only and it works in the two-pane view.
