### PR TITLE
fixes #6441 - allows filtering of parameters per controller

### DIFF
--- a/app/controllers/concerns/foreman/controller/filter_parameters.rb
+++ b/app/controllers/concerns/foreman/controller/filter_parameters.rb
@@ -1,0 +1,35 @@
+module Foreman::Controller::FilterParameters
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def filter_parameters(*names)
+      @filter_parameters = names
+    end
+
+    def filter_parameters_options
+      @filter_parameters
+    end
+  end
+
+  def process_action(*args)
+    if needs_filtering?(request.filtered_parameters)
+      request.filtered_parameters.merge!(filter.filter(request.filtered_parameters))
+    end
+    super
+  end
+
+  private
+
+  def filter
+    ActionDispatch::Http::ParameterFilter.new(self.class.filter_parameters_options)
+  end
+
+  def needs_filtering?(params)
+    if(self.class.filter_parameters_options)
+      (self.class.filter_parameters_options.map(&:to_s) & params.keys).size > 0
+    else
+      false
+    end
+  end
+end
+


### PR DESCRIPTION
there is an issue where certain parameters for particular
controllers are causing the log to fill up. This allows the ability
to filter parameters by controller.

This allows each controller to add additional parameters to filter.
In a controller, to filter parameters name and description, you can add the following:

include Foreman::Controller::FilterParameters
filter_parameters :name, :description
