### PR TITLE
fixes #6342 - ignore empty hashes inside cr_attrs when using compute profile

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -541,9 +541,15 @@ class Host::Managed < Host::Base
   end
 
   def set_compute_attributes
-    return unless compute_attributes.empty?
+    return unless compute_attributes_empty?
     return unless compute_profile_id && compute_resource_id
     self.compute_attributes = compute_resource.compute_profile_attributes_for(compute_profile_id)
+  end
+
+  def compute_attributes_empty?
+    # ignore cases where cr_attrs => {"volumes_attributes" => {}} as hashes must be present for
+    # non-CR profile provisioning, but aren't needed if a profile is in use
+    compute_attributes.reject { |k,v| v.is_a?(Hash) && v.empty? }.empty?
   end
 
   def set_ip_address


### PR DESCRIPTION
This problem's a little tricky, but I _think_ it's the right thing to do.  Feedback welcome.

If you're creating a host with a host group that has a compute profile, supplying compute_attributes isn't required.  However if you're creating a host without a profile, you need to supply volume_attributes etc so the VM can be created (these params are expected by the CR models).  Hammer always supplies them, but it doesn't know if a compute profile will be used or not, so I think it's best if we ignore empty sub-params and use the compute profile.
