### PR TITLE
Fixes #6476 - oVirt VM association with multiple interfaces

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -217,7 +217,7 @@ module Foreman::Model
     end
 
     def associated_host(vm)
-      Host.authorized(:view_hosts, Host).where(:mac => vm.mac).first
+      Host.authorized(:view_hosts, Host).where(:mac => vm.interfaces.map { |i| i.mac }).first
     end
 
     def self.provider_friendly_name


### PR DESCRIPTION
I have no tests with this PR.  I could not work out how to unit test an instance of Fog::Compute::Ovirt::Server and as far as I could tell no tests already existed for the majority of the Foreman::Model::Ovirt class.

I'd be happy to add tests if someone can offer some guidance or examples to reference.
