### PR TITLE
Fixes #6532 - Updates in api for roles and permissions

### DIFF
--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -9,8 +9,9 @@ module Api
 
       api :GET, "/filters/", "List all filters."
       param :search, String, :desc => "filter results", :required => false
-      param :page, String, :desc => "paginate results"
-      param :per_page, String, :desc => "number of entries per request"
+      param :order, String, :desc => "sort results", :required => false
+      param :page, String, :desc => "paginate results", :required => false
+      param :per_page, String, :desc => "number of entries per request", :required => false
 
       def index
         @filters = resource_scope.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/permissions_controller.rb
+++ b/app/controllers/api/v2/permissions_controller.rb
@@ -19,12 +19,20 @@ module Api
         else
           @permissions = Permission.all
         end
+        @permissions = @permissions.paginate(paginate_options)
       end
 
       api :GET, "/permissions/:id/", "Show a permission."
       param :id, :identifier, :required => true
 
       def show
+      end
+
+      api :GET, "/permissions/resource_types/", "List available resource types."
+      def resource_types
+        @resource_types = Permission.resources
+        @total = @resource_types.size
+        render :resource_types, :layout => 'api/v2/layouts/index_layout'
       end
 
     end

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -4,8 +4,10 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/roles/", "List all roles."
-      param :page, String, :desc => "paginate results"
-      param :per_page, String, :desc => "number of entries per request"
+      param :search, String, :desc => "Filter results", :required => false
+      param :order, String, :desc => "Sort results", :required => false
+      param :page, String, :desc => "paginate results", :required => false
+      param :per_page, String, :desc => "number of entries per request", :required => false
 
       def index
         @roles = Role.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -3,7 +3,7 @@ module Api
     class UsergroupsController < V2::BaseController
       before_filter :find_resource, :only => %w{show update destroy}
 
-      api :GET, "/usergroups/", "List all usergroups."
+      api :GET, "/usergroups/", "List all user groups."
       param :page, String, :desc => "paginate results"
       param :per_page, String, :desc => "number of entries per request"
       param :search, String, :desc => "filter results"
@@ -15,7 +15,7 @@ module Api
           search_for(*search_options).paginate(paginate_options)
       end
 
-      api :GET, "/usergroups/:id/", "Show a usergroup."
+      api :GET, "/usergroups/:id/", "Show a user group."
       param :id, :identifier, :required => true
 
       def show
@@ -24,10 +24,13 @@ module Api
       def_param_group :usergroup do
         param :usergroup, Hash, :action_aware => true do
           param :name, String, :required => true
+          param :user_ids, Array, :require => false
+          param :usergroup_ids, Array, :require => false
+          param :role_ids, Array, :require => false
         end
       end
 
-      api :POST, "/usergroups/", "Create a usergroup."
+      api :POST, "/usergroups/", "Create a user group."
       param_group :usergroup, :as => :create
 
       def create
@@ -35,7 +38,7 @@ module Api
         process_response @usergroup.save
       end
 
-      api :PUT, "/usergroups/:id/", "Update a usergroup."
+      api :PUT, "/usergroups/:id/", "Update a user group."
       param :id, String, :required => true
       param_group :usergroup
 
@@ -43,7 +46,7 @@ module Api
         process_response @usergroup.update_attributes(params[:usergroup])
       end
 
-      api :DELETE, "/usergroups/:id/", "Delete a usergroup."
+      api :DELETE, "/usergroups/:id/", "Delete a user group."
       param :id, String, :required => true
 
       def destroy

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -18,7 +18,7 @@ class Usergroup < ActiveRecord::Base
   has_many :parents,    :through => :usergroup_parents, :source => :usergroup, :dependent => :destroy
 
   has_many_hosts :as => :owner
-  validates :name, :uniqueness => true, :length => { :maximum => 255 }
+  validates :name, :uniqueness => true, :length => { :maximum => 255 }, :presence => true
 
   # The text item to see in a select dropdown menu
   alias_attribute :select_title, :to_s

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -222,7 +222,8 @@ Foreman::AccessControl.map do |map|
     map.permission :create_filters,  {:filters => [:new, :create],
                                       :'api/v2/filters' => [:create]}
     map.permission :edit_filters,    {:filters => [:edit, :update], :permissions => [:index],
-                                      :'api/v2/filters' => [:update], :'api/v2/permissions' => [:index, :show]}
+                                      :'api/v2/filters' => [:update],
+                                      :'api/v2/permissions' => [:index, :show, :resource_types]}
     map.permission :destroy_filters, {:filters => [:destroy],
                                       :'api/v2/filters' => [:destroy]}
   end

--- a/app/views/api/v2/filters/main.json.rabl
+++ b/app/views/api/v2/filters/main.json.rabl
@@ -2,4 +2,13 @@ object @filter
 
 extends "api/v2/filters/base"
 
-attributes :search, :resource_type, :role_id, :created_at, :updated_at
+attributes :search, :resource_type, :unlimited?, :created_at, :updated_at
+
+
+child :role do
+  extends "api/v2/roles/base"
+end
+
+child :permissions do
+  extends "api/v2/permissions/base"
+end

--- a/app/views/api/v2/filters/show.json.rabl
+++ b/app/views/api/v2/filters/show.json.rabl
@@ -2,10 +2,6 @@ object @filter
 
 extends "api/v2/filters/main"
 
-child :permissions => :permissions do
-  extends "api/v2/permissions/base"
-end
-
 # TODO: Fix when https://github.com/theforeman/foreman/pull/1208 is merged
 if SETTINGS[:organizations_enabled]
   child :organizations => :organizations do

--- a/app/views/api/v2/permissions/base.json.rabl
+++ b/app/views/api/v2/permissions/base.json.rabl
@@ -1,3 +1,3 @@
 object @permission
 
-attributes :name, :id
+attributes :name, :id, :resource_type

--- a/app/views/api/v2/permissions/resource_types.json.rabl
+++ b/app/views/api/v2/permissions/resource_types.json.rabl
@@ -1,0 +1,3 @@
+collection @resource_types
+
+node(:name) { |type| type }

--- a/app/views/api/v2/usergroups/show.json.rabl
+++ b/app/views/api/v2/usergroups/show.json.rabl
@@ -9,3 +9,7 @@ end
 child :users do
   extends "api/v2/users/base"
 end
+
+child :roles do
+  extends "api/v2/roles/base"
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -110,7 +110,11 @@ Foreman::Application.routes.draw do
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
         end
       end
-      resources :permissions, :only => [:index, :show]
+      resources :permissions, :only => [:index, :show] do
+        collection do
+          get :resource_types
+        end
+      end
 
       resources :filters, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]

--- a/test/functional/api/v2/permissions_controller_test.rb
+++ b/test/functional/api/v2/permissions_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Api::V2::PermissionsControllerTest < ActionController::TestCase
+
+  def assert_response_not_empty
+    assert_response :success
+    assert_not_empty ActiveSupport::JSON.decode(@response.body)
+  end
+
+  test "should get index" do
+    get :index
+    assert_not_nil assigns(:permissions)
+    assert_response_not_empty
+  end
+
+  test "should show individual record" do
+    get :show, { :id => permissions(:view_architectures).to_param }
+    assert_response_not_empty
+  end
+
+  test "should list resource types" do
+    get :resource_types
+    assert_not_nil assigns(:resource_types)
+    assert_response_not_empty
+  end
+
+end

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -14,14 +14,19 @@ class UsergroupTest < ActiveSupport::TestCase
     one = FactoryGirl.create(:usergroup)
     two = FactoryGirl.build(:usergroup, :name => one.name)
 
-    assert !two.valid?
+    refute two.valid?
+  end
+
+  test "name can't be blank" do
+    group = FactoryGirl.build(:usergroup, :name => "")
+    refute group.valid?
   end
 
   test "name is unique across user as well as usergroup" do
     user = User.create :auth_source => auth_sources(:one), :login => "user", :mail  => "user@someware.com"
     usergroup = FactoryGirl.build(:usergroup, :name => user.login)
 
-    assert !usergroup.valid?
+    refute usergroup.valid?
   end
 
   def populate_usergroups


### PR DESCRIPTION
- usergroups#show lists associated roles
- listing available resource types
- filters#show lists associated roles
- filters#index lists associated roles and permissions and orders the results
- pagination in permissions#index
- missing parameters in apidocs for usergroups and roles
- required name for usergroups
