### PR TITLE
fixes #6506 - remove x86_64 default for new architecture

### DIFF
--- a/db/migrate/20140707113214_remove_architecture_default.rb
+++ b/db/migrate/20140707113214_remove_architecture_default.rb
@@ -1,0 +1,10 @@
+class RemoveArchitectureDefault < ActiveRecord::Migration
+  def up
+    change_column :architectures, :name, :string, :default => nil
+  end
+
+  def down
+    change_column :architectures, :name, :string, :default => 'x86_64'
+  end
+
+end

--- a/test/functional/architectures_controller_test.rb
+++ b/test/functional/architectures_controller_test.rb
@@ -29,7 +29,7 @@ class ArchitecturesControllerTest < ActionController::TestCase
 
   def test_create_valid
     Architecture.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:architecture => {:name => 'i386'}}, set_session_user
     assert_redirected_to architectures_url
   end
 


### PR DESCRIPTION
rake db:seed already adds "x86_64" to the architectures table. Therefore, there is no reason to add a default that is "invalid" on save, since name must be unique.
