### PR TITLE
Fixes #6518 - lookup the bmc smartproxy via subnets.id

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -25,7 +25,7 @@ module Nic
 
     def proxy
       # try to find a bmc proxy in the same subnet as our bmc device
-      proxy   = SmartProxy.with_features("BMC").joins(:subnets).where(['dhcp_id = ? or tftp_id = ?', subnet_id, subnet_id]).first if subnet_id
+      proxy   = SmartProxy.with_features("BMC").joins(:subnets).where(['subnets.id = ?', subnet_id]).first if subnet_id
       proxy ||= SmartProxy.with_features("BMC").first
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?
       ProxyAPI::BMC.new({ :host_ip  => ip,


### PR DESCRIPTION
This fixes 6518, by picking the smartproxy to use via subnet_id.  Before it was trying to find a dhcp_id or tftp_id that matched the subnet_id, but since it's a subnet id it really should be comparing subnets.id.

I'm not sure how it was working most of the time before, but with this change it works all of the time.
