### PR TITLE
fixes #1875: users without 'view_hosts' permission do not see 'Bare Metal' option on the 'New Host' screen

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -317,4 +317,9 @@ module HostsHelper
     end
     data
   end
+
+  def available_compute_resources
+    [([[_('Bare Metal'), '']] if User.current.allowed_to?(:view_hosts)),
+    ComputeResource.with_taxonomy_scope_override(@location,@organization).authorized(:view_compute_resources).collect {|c| [c.to_label, c.id]}].compact.flatten(1)
+  end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -53,8 +53,7 @@
             :'data-url' => (@host.new_record? || @host.type_changed?) ? process_hostgroup_hosts_path : hostgroup_or_environment_selected_hosts_path,
             :help_inline => :indicator } %>
 
-        <%= select_f f, :compute_resource_id, ComputeResource.with_taxonomy_scope_override(@location,@organization).authorized(:view_compute_resources), :id, :to_label,
-          { :include_blank => _('Bare Metal') },
+        <%= selectable_f f, :compute_resource_id, available_compute_resources,
           {:label => _('Deploy on'), :disabled => !@host.new_record?, :'data-url' => compute_resource_selected_hosts_path,
             :onchange => 'computeResourceSelected(this);',
             :help_inline => :indicator } if SETTINGS[:unattended] && @host.new_record? || @host.compute_resource_id %>

--- a/test/unit/helpers/hosts_helper_test.rb
+++ b/test/unit/helpers/hosts_helper_test.rb
@@ -1,4 +1,26 @@
 require 'test_helper'
 
 class HostsHelperTest < ActionView::TestCase
+
+  def test_admin_should_see_compute_resources_and_bare_metal_options
+    assert as_admin { available_compute_resources[0] }.include?("Bare Metal")
+  end
+
+  def test_user_without_view_hosts_should_not_see_bare_metal_option
+    permission = FactoryGirl.create(:permission, :name => 'view_compute_resources')
+    role = FactoryGirl.build(:role, :permissions => [permission])
+    user = users(:one)
+    user.roles << role
+
+    assert !(as_user(:one) { available_compute_resources }.collect{|cr| cr[0]}.include?("Bare Metal"))
+  end
+
+  def test_user_without_view_computeresources_should_not_see_them
+    permission = FactoryGirl.create(:permission, :name => 'view_hosts')
+    role = FactoryGirl.build(:role, :permissions => [permission])
+    user = users(:one)
+    user.roles << role
+
+    assert (as_user(:one) { available_compute_resources }.none? {|cr| cr[0] != "Bare Metal"})
+  end
 end


### PR DESCRIPTION
Do not merge before https://github.com/theforeman/foreman/pull/1549 has been merged, as this PR depends on the updated 'anonymous' role.
