### PR TITLE
Fixes #6057 - highlight active tab based on current URL.

### DIFF
--- a/app/assets/javascripts/topbar.js
+++ b/app/assets/javascripts/topbar.js
@@ -44,16 +44,19 @@ $(document).on('mouseleave','.loc-submenu', function(){
 });
 
 function mark_active_menu() {
+  var menus = $('.menu_tab_dropdown'),
+      path = window.location.pathname + window.location.search,
+      link = $("[href='%s'".replace('%s', path));
+
+  menus.removeClass('active');
   $("[class^='menu_tab_']").removeClass('active');
-  // if there is no menu for controller_action mark controller_index as active menu
-  var active_menu = $('.menu_tab_'+$('#current_tab').data('controller')+'_'+$('#current_tab').data('action'))
-  if (!active_menu.exists()){
-    active_menu = $('.menu_tab_'+$('#current_tab').data('controller')+'_index')
-  }
-  active_menu.addClass('active');
-  $('.menu_tab_dropdown').each(function(){
-    if ($(this).find('.active').length >0) {$(this).addClass('active')}
-  })
+
+  menus.each(function(index, element) {
+    element = $(element);
+    if (element.find(link).length) {
+      element.addClass('active');
+    }
+  });
 }
 
 function is_mobile() {

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -29,7 +29,6 @@
   </button>
   <div class="container">
     <!-- menu -->
-    <%= content_tag :div,nil, :id=>'current_tab', :data=>{:controller=>controller_name, :action=>action_name} %>
     <% if User.current %>
       <% cache(TopbarSweeper.fragment_name) do %>
         <ul class="nav navbar-nav navbar-menu navbar-collapse collapse" id="menu">


### PR DESCRIPTION
Highlight the active menu tab based on the current URL
rather than relying on the controller and action.  This
fixes a problem where top level menus that contain plugin
menu items were not being highlighted when active.

http://projects.theforeman.org/issues/6057
