### PR TITLE
Fixes #6549 - Add :tests_to_skip to plugin registration block

### DIFF
--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -33,8 +33,10 @@ module Foreman #:nodoc:
   class Plugin
 
     @registered_plugins = {}
+    @tests_to_skip = {}
     class << self
-      attr_reader :registered_plugins
+      attr_reader   :registered_plugins
+      attr_accessor :tests_to_skip
       private :new
 
       def def_field(*names)
@@ -155,6 +157,17 @@ module Foreman #:nodoc:
     # Removes item from the given menu
     def delete_menu_item(menu, item)
       Menu::Manager.map(menu).delete(item)
+    end
+
+    def tests_to_skip(hash)
+      # Format is { "testclass" => [ "skip1", "skip2" ] }
+      hash.each do |testclass,tests|
+        if self.class.tests_to_skip[testclass].nil?
+          self.class.tests_to_skip[testclass] = tests
+        else
+          self.class.tests_to_skip[testclass] = self.class.tests_to_skip[testclass].push(tests).flatten.uniq
+        end
+      end
     end
 
     def security_block(name, &block)

--- a/test/lib/custom_runner.rb
+++ b/test/lib/custom_runner.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class CustomRunnerTest < ActiveSupport::TestCase
+
+  test "custom runner is working" do
+    # This should always be skipped if the runner is working
+    assert false, "Custom runner has failed"
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,12 @@ Spork.prefork do
   require 'capybara/rails'
   require 'factory_girl_rails'
 
+  # Use our custom test runner, and register a fake plugin to skip a specific test
+  Foreman::Plugin.register :skip_test do
+    tests_to_skip "CustomRunnerTest" => [ "custom runner is working" ]
+  end
+  require 'test_runner'
+
   # Turn of Apipie validation for tests
   Apipie.configuration.validate = false
 

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -1,0 +1,31 @@
+class ForemanMiniTest < MiniTest::Unit
+
+  def _run_suites(suites, type)
+    suites.each do |suite|
+      next unless type == :test
+      next unless suite.respond_to? "test_methods"
+      next unless Foreman::Plugin.tests_to_skip.keys.include?(suite.to_s)
+
+      # Extend test_methods to filter out skipped tests
+      class << suite
+        alias_method :test_methods_without_filtering, :test_methods
+        def test_methods
+          test_methods_without_filtering.reject do |test|
+            # use a substring match, as test => "test_0010_foo" and string => "foo"
+            Foreman::Plugin.tests_to_skip[self.to_s].detect do |string|
+              if test[string]
+                puts "skipping #{self.to_s}##{test}"
+                string
+              end
+            end
+          end
+        end
+      end
+    end
+
+    super(suites, type)
+  end
+
+end
+
+MiniTest::Unit.runner = ForemanMiniTest.new

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -223,4 +223,15 @@ class PluginTest < ActiveSupport::TestCase
     end
     assert FiltersHelperOverrides.can_override?("TestEngine::TestResource")
   end
+
+  def test_can_merge_tests_to_skip_arrays
+    @klass.register :foo do
+      tests_to_skip "FooTest" => [ "test1", "test2" ]
+    end
+    @klass.register :bar do
+      tests_to_skip "FooTest" => [ "test3", "test4" ]
+    end
+    assert_equal [ "test1", "test2", "test3", "test4" ], @klass.tests_to_skip["FooTest"]
+  end
+
 end


### PR DESCRIPTION
This PR allows a plugin to do something like

```
Foreman::Plugin.register :foreman_discovery do                                 
  tests_to_skip "EncryptableTest" => ["this string IS encryptable and NOT decryptable"],
                "HostTest" => ["should not save without a hostname"]
end
```

i.e. a map of test types to arrays of test names to skip

~~This is detected where `test` (which is aliased against `it` later in the test_helper) is defined - we jump in and monkeypatch MiniTest to check if this is a prohibited test class+name. If it is, we just define the test as a skip.~~
This alters the array of tests to run by using a custom test runner. We step into the `_run_suite` method and add an extra round of filtering against `Foreman::Plugin.tests_to_skip`

This is slight hacky - the downside is:
1) ~~monkey_patching MiniTest~~ replacing `_run_suite` and not calling `super`
2) ~~it only works for the newer `test "foo" ... end` style tests, `def test_foo ... end` can't be caught this way~~   fixed.

Feedback welcome - as I'm out of ideas as to how to do it better :)
