### PR TITLE
Fixes #6580 - XSS in operating system name/description (CVE-2014-3531)

### DIFF
--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -39,7 +39,7 @@ module OperatingsystemsHelper
   end
 
   def os_name record, opts = {}
-    "#{icon(record, opts)} #{record.to_label}".html_safe
+    icon(record, opts).html_safe << record.to_label
   end
 
   def os_habtm_family type, obj


### PR DESCRIPTION
The problem here is a misuse of .html_safe
.html_safe just turns the String into a SafeBuffer. 

``` ruby
> os_name(operatingsystem).html_safe
"<img alt=\"Aix\" src=\"/assets/AIX.png\" />  T<script>alert(1)</script>O"
> os_name(operatingsystem).html_safe.class
ActiveSupport::SafeBuffer
```

That doesn't escape anything, but if we append anything to that string, the new string will be escaped. 

``` ruby
> os_name(operatingsystem).html_safe + "<script></script>"
"<img alt=\"Aix\" src=\"/assets/AIX.png\" />  T<script>alert(1)</script>O&lt;script&gt;&lt;/script&gt;"
```

It's useful to avoid concatenations of tags, for instance one string ending with "<script>" and another one starting with "alert(1)</script>" will not concatenate into a real script. 

In short, html_safe does not sanitize the input, it just tells Rails the string is "html_safe", but prevents future concatenations to make it unsafe. 

`"#{icon(record, opts)} #{record.to_label}".html_safe` comes from user input and is not safe.

The current patch assumes 'family' in OS is safe. It does not come from user input but from a hash in the source app/models/operatingsystem.rb so I think it should be OK.
