### PR TITLE
Fixes #6606 - Allow deletion of non-admin users if there's only one admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -425,7 +425,7 @@ class User < ActiveRecord::Base
   end
 
   def ensure_last_admin_is_not_deleted
-    if User.unscoped.only_admin.except_hidden.size <= 1
+    if admin && User.unscoped.only_admin.except_hidden.size <= 1
       errors.add :base, _("Can't delete the last admin account")
       logger.warn "Unable to delete the last admin account"
       false

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -637,4 +637,11 @@ class UserTest < ActiveSupport::TestCase
     assert_raise(Foreman::Exception) { User.as('unknown_user') }
   end
 
+  test "#ensure_last_admin_is_not_deleted with non-admins" do
+    User.unscoped.only_admin.each(&:delete)
+    user = users(:one)
+    assert user.destroy
+    assert user.destroyed?
+  end
+
 end


### PR DESCRIPTION
Apologies if this is a dupe but I searched and didn't see anything in redmine/github.
