### PR TITLE
Fixes #6608 - expose disk usage info through available_storage_domains API

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -86,9 +86,11 @@ module Api
       end
 
       api :GET, "/compute_resources/:id/available_storage_domains", "List storage_domains for a compute resource"
+      api :GET, "/compute_resources/:id/available_storage_domains/:storage_domain", "List attributes for a given storage_domain"
       param :id, :identifier, :required => true
+      param :storage_domain, String
       def available_storage_domains
-        @available_storage_domains = @compute_resource.available_storage_domains
+        @available_storage_domains = @compute_resource.available_storage_domains(params[:storage_domain])
         render :available_storage_domains, :layout => 'api/v2/layouts/index_layout'
       end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -47,6 +47,14 @@ module Foreman::Model
       dc.clusters
     end
 
+    def datastores(opts ={})
+      if opts[:storage_domain]
+        dc.datastores.get(opts[:storage_domain])
+      else
+        dc.datastores.all(:accessible => true)
+      end
+    end
+
     def folders
       dc.vm_folders.sort_by{|f| f.path}
     end
@@ -63,8 +71,8 @@ module Foreman::Model
       networks
     end
 
-    def available_storage_domains
-      datastores
+    def available_storage_domains(storage_domain=nil)
+      datastores({:storage_domain => storage_domain})
     end
 
     def nictypes
@@ -223,10 +231,6 @@ module Foreman::Model
 
     def scsi_controller_default_type
       "VirtualLsiLogicController"
-    end
-
-    def datastores
-      dc.datastores.all(:accessible => true)
     end
 
     def test_connection options = {}

--- a/app/views/api/v2/compute_resources/available_storage_domains.rabl
+++ b/app/views/api/v2/compute_resources/available_storage_domains.rabl
@@ -1,3 +1,3 @@
 collection @available_storage_domains
 
-attribute :name, :id
+attribute :name, :id, :capacity, :freespace, :uncommitted

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -174,6 +174,7 @@ Foreman::Application.routes.draw do
           get :available_clusters, :on => :member
           get :available_networks, :on => :member
           get :available_storage_domains, :on => :member
+          get 'available_storage_domains/(:storage_domain)', :to => 'compute_resources#available_storage_domains', :on => :member
           get 'available_clusters/(:cluster_id)/available_networks', :to => 'compute_resources#available_networks', :on => :member
           put :associate, :on => :member
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]

--- a/test/functional/api/v2/compute_resources_controller_test.rb
+++ b/test/functional/api/v2/compute_resources_controller_test.rb
@@ -157,7 +157,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
 
     Foreman::Model::Vmware.any_instance.stubs(:available_networks).returns([network])
 
-    get :available_networks, { :id => compute_resources(:ovirt).to_param, :cluster_id => '123-456-789' }
+    get :available_networks, { :id => compute_resources(:vmware).to_param, :cluster_id => '123-456-789' }
     assert_response :success
     available_networks = ActiveSupport::JSON.decode(@response.body)
     assert !available_networks.empty?
@@ -170,7 +170,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
 
     Foreman::Model::Vmware.any_instance.stubs(:available_clusters).returns([cluster])
 
-    get :available_clusters, { :id => compute_resources(:ovirt).to_param }
+    get :available_clusters, { :id => compute_resources(:vmware).to_param }
     assert_response :success
     available_clusters = ActiveSupport::JSON.decode(@response.body)
     assert !available_clusters.empty?
@@ -181,9 +181,9 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     storage_domain.stubs(:name).returns('test_vmware_cluster')
     storage_domain.stubs(:id).returns('my11-test35-uuid99')
 
-    Foreman::Model::Vmware.any_instance.stubs(:available_storage_domains).returns([storage_domain])
+    Foreman::Model::Vmware.any_instance.expects(:available_storage_domains).with(nil).returns([storage_domain])
 
-    get :available_storage_domains, { :id => compute_resources(:ovirt).to_param }
+    get :available_storage_domains, { :id => compute_resources(:vmware).to_param }
     assert_response :success
     available_storage_domains = ActiveSupport::JSON.decode(@response.body)
     assert !available_storage_domains.empty?


### PR DESCRIPTION
Extends the existing available_storage_domains API by adding the freespace, capacity, and uncommitted values.
