### PR TITLE
fixes #6618 - provide an indentation helper for provisioning templates

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -49,7 +49,7 @@ class Host::Managed < Host::Base
     allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup, :location,
       :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
-      :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?
+      :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent
   end
 
   attr_reader :cached_host_params

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -6,7 +6,7 @@ module Foreman
     ALLOWED_HELPERS = [ :foreman_url, :grub_pass, :snippet, :snippets,
 			:snippet_if_exists, :ks_console, :root_pass,
 			:multiboot, :jumpstart_path, :install_path, :miniroot,
-			:media_path, :param_true?, :param_false?, :match ]
+			:media_path, :param_true?, :param_false?, :match, :indent ]
 
     ALLOWED_VARIABLES = [ :arch, :host, :osver, :mediapath, :static,
                           :repos, :dynamic, :kernel, :initrd,
@@ -65,6 +65,12 @@ module Foreman
 
     def snippet_if_exists name
       snippet name, :silent => true
+    end
+
+    def indent(count)
+      return unless block_given? && text=yield.to_s
+      prefix = " " * count
+      prefix + text.gsub(/\n/, "\n#{prefix}")
     end
 
     def unattended_render template

--- a/test/unit/host_jail_test.rb
+++ b/test/unit/host_jail_test.rb
@@ -5,7 +5,7 @@ class HostJailTest < ActiveSupport::TestCase
     allowed = [:name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup, :location,
                :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
                :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
-               :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?]
+               :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent]
 
     allowed.each do |m|
       assert Host::Managed::Jail.allowed?(m), "Method #{m} is not available in Host::Managed::Jail while should be allowed."

--- a/test/unit/renderer_test.rb
+++ b/test/unit/renderer_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class RendererTest < ActiveSupport::TestCase
+  include Foreman::Renderer
+
+  test "should indent a string" do
+    indented = indent 4 do
+      "foo\nbar\nbaz"
+    end
+    assert_equal indented, "    foo\n    bar\n    baz"
+  end
+
+end
+


### PR DESCRIPTION
This is useful for OpenStack cloud-init templates, where I want to use existing Foreman snippets but need to indent every line.  e.g. `indent 4, snippet("foo")`
