### PR TITLE
Fixes #6620: Allow plugins to define a file to be included in test_helper.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -261,6 +261,11 @@ Spork.prefork do
     helper Rails.application.routes.url_helpers
   end
 
+  Rails.application.railties.engines.each do |engine|
+    support_file = "#{engine.root}/test/support/foreman_test_helper_additions.rb"
+    require support_file if File.exists?(support_file)
+  end
+
 end
 
 Spork.each_run do


### PR DESCRIPTION
For some plugins additions to the test_helper are needed to allow
the test suite to pass. This checks if a file test/support/foreman_support
exists and requires it after all the Foreman test setup is done.
