### PR TITLE
Fixes #6641 - Explcitly add fog-json and fog-brightbox for jenkins

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,5 +1,7 @@
 group :fog do
  gem 'fog', '~> 1.21.0'
  gem 'fog-core', '~> 1.21.0'
+ gem 'fog-json', '1.0.0' # Should be pulled in, but jenkins isn;t for some reason. TODO: investigate why
+ gem 'fog-brightbox', '0.0.2' # ditto
  gem 'unf'
 end


### PR DESCRIPTION
Needed to fix Jenkins, see http://ci.theforeman.org/view/Core/job/test_develop/database=postgresql,ruby=1.9.3/745/consoleText
