### PR TITLE
Add textarea auto-resizing

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -1,5 +1,6 @@
 $(document).on('ContentLoad', function(){onHostEditLoad()});
 $(document).on('AddedClass', function(event, link){load_puppet_class_parameters(link)});
+$(document).on('click', '#params-tab', function() { resizeTextareaAll(); });
 
 function computeResourceSelected(item){
   var compute = $(item).val();
@@ -609,4 +610,17 @@ function disable_vm_form_fields() {
     $(this).attr("disabled", "disabled");
   });
   $("a.disable-unsupported").remove();
+}
+
+function resizeTextareaAll () {
+  $('textarea').each(function() {
+    if (this.scrollHeight !== undefined){
+      if (this.scrollHeight <= 100){
+        this.style.height = this.scrollHeight+ 'px';
+      }
+      else{
+        this.style.height = 100+'px';
+      }
+    }
+  });
 }


### PR DESCRIPTION
Previously, on viewing the edit page for a host or a hostgroup, on the Parameters tab, the height of a parameter value would be calculated by the number of newline characters in it, or by default, be set to 1.

To make values easier to read, this automatically resizes them to expand to their entire content (up to a maximum of 100 pixels) when the Parameters tab is clicked.
