### PR TITLE
fixes #6696 - API v2 - specify the key in which parameters would be wrapped rather than passing model name

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class HostsController < V2::BaseController
 
-      wrap_parameters Host::Base, :include => (Host::Base.attribute_names + ['image_file', 'is_owned_by', 'overwrite', 'progress_report_id'])
+      wrap_parameters :host, :include => (Host::Base.attribute_names + ['image_file', 'is_owned_by', 'overwrite', 'progress_report_id'])
 
       include Api::Version2
       #TODO - should TaxonomyScope be here.  It wasn't here previously

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -57,6 +57,14 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should update host without :host root node and rails wraps it correctly" do
+    put :update, { :id => hosts(:two).to_param, :name => 'newhostname' }
+    request_parameters = @request.env['action_dispatch.request.request_parameters']
+    assert request_parameters[:host]
+    assert_equal 'newhostname', request_parameters[:host][:name]
+    assert_response :success
+  end
+
   test "should destroy hosts" do
     assert_difference('Host.count', -1) do
       delete :destroy, { :id => hosts(:one).to_param }


### PR DESCRIPTION
specify `:host` as key rather than passing class name `Host::Base` which was incorrectly resolved to `params[:base]`
