### PR TITLE
Bug #6483: oVirt network dropdown not being populated

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -276,9 +276,11 @@ module HostsHelper
   end
 
   def args_for_compute_resource_partial(host)
-    { :arch => host.try(:architecture_id)    || (params[:host] && params[:host][:architecture_id]),
-      :os   => host.try(:operatingsystem_id) || (params[:host] && params[:host][:operatingsystem_id])
-    }
+    args = {}
+    args[:arch] = host.try(:architecture_id) || (params[:host] && params[:host][:architecture_id])
+    args[:os] = host.try(:operatingsystem_id) || (params[:host] && params[:host][:operatingsystem_id])
+    args[:selected_cluster] = vm_attrs['cluster'] if defined?(vm_attrs)
+    args
   end
 
   def show_appropriate_host_buttons(host)

--- a/app/views/compute_attributes/_form.html.erb
+++ b/app/views/compute_attributes/_form.html.erb
@@ -7,7 +7,7 @@
 
   <%= fields_for 'compute_attribute[vm_attrs]', @set.compute_resource.new_vm(@set.vm_attrs) do |f2| %>
       <%= render :partial => "compute_resources_vms/form/#{@set.compute_resource.provider.downcase}",
-                 :locals => { :f => f2, :compute_resource => @set.compute_resource } %>
+                 :locals => { :f => f2, :compute_resource => @set.compute_resource, :selected_cluster => @set.vm_attrs['cluster'] } %>
   <% end %>
 
   <% if f.object.new_record? %>

--- a/app/views/compute_resources_vms/form/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/form/_ovirt.html.erb
@@ -16,16 +16,18 @@
                :label       => _('Template') } %>
 <%= f.hidden_field :template if !new %>
 
+<% selected_cluster ||= params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
+
 <div class='compute_profile'>
   <%= selectable_f f, :cores, 1..compute_resource.max_cpu_count, { }, :class => "col-md-2", :label => _('Cores') %>
   <%= selectable_f f, :memory, memory_options(compute_resource.max_memory), { }, :class => "col-md-2", :label => _('Memory') %>
   <div class="children_fields">
     <%= new_child_fields_template(f, :interfaces, {
         :object  => compute_resource.new_interface,
-        :partial => 'compute_resources_vms/form/ovirt/network', :form_builder_attrs => { :clusters => clusters, :compute_resource => compute_resource } }) %>
+        :partial => 'compute_resources_vms/form/ovirt/network', :form_builder_attrs => { :selected_cluster => selected_cluster, :compute_resource => compute_resource } }) %>
     <%= field_set_tag _("Network interfaces"), :id => "network_interfaces", :title => _('Networks') do %>
       <%= f.fields_for :interfaces do |i| %>
-        <%= render 'compute_resources_vms/form/ovirt/network', :f => i, :clusters => clusters, :compute_resource => compute_resource %>
+        <%= render 'compute_resources_vms/form/ovirt/network', :f => i, :selected_cluster => selected_cluster, :compute_resource => compute_resource %>
       <% end %>
       <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
     <% end %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -4,8 +4,7 @@
     <% disabled = (f.object.persisted? == "true" || f.object.persisted? == true) %>
     <%= text_f f, :name, :disabled => disabled, :class => "col-md-2", :label => _('Name') %>
     <%= f.hidden_field :name if disabled %>
-    <% selected_cluster = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
-    <% selected_cluster ||= clusters.size == 1 ? clusters.first.id : nil %>
+    <% selected_cluster ||= compute_resource.clusters.first.id %>
     <%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
                  { }, :disabled => disabled, :class => "col-md-2",
                  :help_inline   => remove_child_link("X", f, { :method => :'_delete', :title => _('remove network interface'), :class => 'label label-danger' }),

--- a/app/views/hosts/_compute.html.erb
+++ b/app/views/hosts/_compute.html.erb
@@ -2,7 +2,7 @@
   <% if compute.object %>
     <div id='update_not_supported' class='alert alert-info hide'><%= _("VM editing is not implemented for this provider") %></div>
     <%= render :partial => "compute_resources_vms/form/#{compute_resource.provider.downcase}",
-               :locals => { :f => compute, :compute_resource => compute_resource}.merge(args_for_compute_resource_partial(@host)) %>
+               :locals => { :f => compute, :compute_resource => compute_resource }.merge(args_for_compute_resource_partial(@host)) %>
   <% else %>
     <div class="alert alert-block alert-danger base in fade">
       <% if @host %>


### PR DESCRIPTION
Bug 6483 is more visible when a RHEV/oVirt compute resource have more than 1 cluster. 

In RHEV, NICs are attached to cluster. The Network dropdown is populated when a cluster is selected. Problem is when the ovirt forms (_ovirt.html.erb, ovirt/_network.html.erb) are loaded initially, "selected_cluster" is always nil (when 2 or more cluster is available in the compute resource) unless someone manually pick another cluster in the Cluster dropdown, which sets the selected_cluster via AJAX call. 

The fix is to pass the save selected_cluster directly to the views.  
