### PR TITLE
fixes #6402 - use standard success/error handlers in UI controllers

### DIFF
--- a/app/controllers/autosign_controller.rb
+++ b/app/controllers/autosign_controller.rb
@@ -4,13 +4,8 @@ class AutosignController < ApplicationController
     @proxy = SmartProxy.authorized(:view_smart_proxies_autosign).find(params[:smart_proxy_id])
     setup_proxy
 
-    begin
-      autosign = @api.autosign
-    rescue => e
-      autosign = []
-      error e
-    end
-    @autosign = autosign.paginate :page => params[:page], :per_page => 20
+    autosign = @api.autosign
+    @autosign = autosign.paginate :page => params[:page], :per_page => Setting::General.entries_per_page
   end
 
   def new

--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -11,7 +11,7 @@ module Foreman::Controller::Environments
       @changed  = @importer.changes
     rescue => e
       if e.message =~ /puppet feature/i
-        error "We did not find a foreman proxy that can provide the information, ensure that you have at least one Proxy with the puppet feature turned on."
+        error _("No smart proxy was found to import environments from, ensure that at least one smart proxy is registered with the 'puppet' feature.")
         redirect_to :controller => controller_path and return
       else
         raise e
@@ -21,16 +21,16 @@ module Foreman::Controller::Environments
     if @changed["new"].size > 0 or @changed["obsolete"].size > 0 or @changed["updated"].size > 0
       render "common/_puppetclasses_or_envs_changed"
     else
-      notice "No changes to your environments detected"
+      notice _("No changes to your environments detected")
       redirect_to :controller => controller_path
     end
   end
 
   def obsolete_and_new
     if (errors = ::PuppetClassImporter.new.obsolete_and_new(params[:changed])).empty?
-      notice "Successfully updated environments and puppetclasses from the on-disk puppet installation"
+      notice _("Successfully updated environments and Puppet classes from the on-disk Puppet installation")
     else
-      error "Failed to update the environments and puppetclasses from the on-disk puppet installation<br/>" + errors.join("<br>")
+      error _("Failed to update environments and Puppet classes from the on-disk Puppet installation: %s") % errors.to_sentence
     end
     redirect_to :controller => controller_path
   end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -190,7 +190,7 @@ class HostsController < ApplicationController
     if @host.puppetrun!
       notice _("Successfully executed, check log files for more details")
     else
-      error @host.errors[:base]
+      error @host.errors[:base].to_sentence
     end
     redirect_to host_path(@host)
   end

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -18,10 +18,9 @@ class PuppetclassesController < ApplicationController
   def create
     @puppetclass = Puppetclass.new(params[:puppetclass])
     if @puppetclass.save
-      notice _("Successfully created puppetclass.")
-      redirect_to puppetclasses_url
+      process_success
     else
-      render :action => 'new'
+      process_error
     end
   end
 
@@ -30,20 +29,19 @@ class PuppetclassesController < ApplicationController
 
   def update
     if @puppetclass.update_attributes(params[:puppetclass])
-      notice _("Successfully updated puppetclass.")
+      notice _("Successfully updated %s." % @puppetclass.to_s)
       redirect_back_or_default(puppetclasses_url)
     else
-      render :action => 'edit'
+      process_error
     end
   end
 
   def destroy
     if @puppetclass.destroy
-      notice _("Successfully destroyed puppetclass.")
+      process_success
     else
-      error @puppetclass.errors.full_messages.join("<br/>")
+      process_error
     end
-    redirect_to puppetclasses_url
   end
 
   # form AJAX methods

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,11 +24,10 @@ class ReportsController < ApplicationController
   def destroy
     @report = resource_base.find(params[:id])
     if @report.destroy
-      notice _("Successfully destroyed report.")
+      process_success :success_msg => _("Successfully destroyed report.")
     else
-      error @report.errors.full_messages.join("<br/>")
+      process_error
     end
-    redirect_to reports_url
   end
 
 end

--- a/app/services/smart_proxies/puppet_ca.rb
+++ b/app/services/smart_proxies/puppet_ca.rb
@@ -30,14 +30,10 @@ class SmartProxies::PuppetCA
 
       def find(proxy, name)
         all(proxy).select{|c| c.name == name}.first
-      rescue
-        raise ActiveRecord::RecordNotFound
       end
 
       def find_by_state(proxy, state)
-         all(proxy).select{|c| c.state == state}
-      rescue
-        raise ActiveRecord::RecordNotFound
+        all(proxy).select{|c| c.state == state}
       end
     end
 

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -95,7 +95,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
         }
       }, set_session_user
     assert_redirected_to environments_url
-    assert_equal "Successfully updated environments and puppetclasses from the on-disk puppet installation", flash[:notice]
+    assert_equal "Successfully updated environments and Puppet classes from the on-disk Puppet installation", flash[:notice]
     assert Environment.find_by_name("env1").puppetclasses.map(&:name).sort == ["a", "b", "c"]
   end
   test "should handle disk environment containing less classes" do
@@ -114,7 +114,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
         }
       }, set_session_user
     assert_redirected_to environments_url
-    assert_equal "Successfully updated environments and puppetclasses from the on-disk puppet installation", flash[:notice]
+    assert_equal "Successfully updated environments and Puppet classes from the on-disk Puppet installation", flash[:notice]
     envs = Environment.find_by_name("env1").puppetclasses.map(&:name).sort
     assert envs == ["a", "b", "c"]
   end
@@ -133,7 +133,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
         }
       }, set_session_user
     assert_redirected_to environments_url
-    assert_equal "Successfully updated environments and puppetclasses from the on-disk puppet installation", flash[:notice]
+    assert_equal "Successfully updated environments and Puppet classes from the on-disk Puppet installation", flash[:notice]
     assert Environment.find_by_name("env3").puppetclasses.map(&:name).sort == []
   end
 


### PR DESCRIPTION
In two controllers (hosts, puppetca), we passed non-string objects to `error` which caused errors trying to escape them (no .to_s was done).  Instead of stringifying them, I've simply updated controllers to more consistently use our process_\* error handlers and where they're not used, to not pass HTML in notice strings.

The changes to puppetca_controller simplify it considerably and mean useful error messages now get back to the user (not the old fake AR ones) via Foreman::Exception.
