### PR TITLE
DO NOT MERGE fixes #6715 - revert API v2 GET response to wrapped parameters using object node

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -8,7 +8,8 @@ module Api
         app_info "Foreman v2 is stable and recommended for use. You may use v2 by either passing 'version=2' in the Accept Header or using api/v2/ in the URL."
       end
 
-      before_filter :setup_has_many_params_unwrapped, :setup_has_many_params, :only => [:create, :update]
+      before_filter :setup_has_many_params, :only => [:create, :update]
+      before_filter :setup_has_many_params_unwrapped, :only => [:create, :update]
 
       layout 'api/v2/layouts/index_layout', :only => :index
 
@@ -60,7 +61,7 @@ module Api
       # the method coverts an unwrapped child node array of objects (ex. 'domains': [{'id': 1, 'name': xyz.com'}])
       # to magic method (ex. domain_ids => [1]) for the purpose of adding/removing associations (POST / PUTd)
       def setup_has_many_params_unwrapped
-        params.each do |k,v|
+        params.dup.each do |k,v|
           if v.kind_of?(Array)
             magic_method_ids = "#{k.singularize}_ids"
             magic_method_names = "#{k.singularize}_names"

--- a/app/views/api/v2/common_parameters/base.json.rabl
+++ b/app/views/api/v2/common_parameters/base.json.rabl
@@ -1,3 +1,3 @@
-object @common_parameter
+object @common_parameter => :parameter
 
 attributes :id, :name, :value

--- a/app/views/api/v2/common_parameters/create.json.rabl
+++ b/app/views/api/v2/common_parameters/create.json.rabl
@@ -1,3 +1,3 @@
-object @common_parameter
+object @common_parameter => :parameter
 
 extends "api/v2/common_parameters/show"

--- a/app/views/api/v2/common_parameters/main.json.rabl
+++ b/app/views/api/v2/common_parameters/main.json.rabl
@@ -1,4 +1,4 @@
-object @common_parameter
+object @common_parameter => :parameter
 
 extends "api/v2/common_parameters/base"
 

--- a/app/views/api/v2/common_parameters/show.json.rabl
+++ b/app/views/api/v2/common_parameters/show.json.rabl
@@ -1,3 +1,3 @@
-object @common_parameter
+object @common_parameter => :parameter
 
 extends "api/v2/common_parameters/main"

--- a/app/views/api/v2/override_values/base.json.rabl
+++ b/app/views/api/v2/override_values/base.json.rabl
@@ -1,3 +1,3 @@
-object @override_value
+object @override_value => :override_value
 
 attributes :id, :match, :value

--- a/app/views/api/v2/override_values/create.json.rabl
+++ b/app/views/api/v2/override_values/create.json.rabl
@@ -1,3 +1,3 @@
-object @override_value
+object @override_value => :override_value
 
 extends "api/v2/override_values/show"

--- a/app/views/api/v2/override_values/main.json.rabl
+++ b/app/views/api/v2/override_values/main.json.rabl
@@ -1,4 +1,4 @@
-object @override_value
+object @override_value => :override_value
 
 extends "api/v2/override_values/base"
 

--- a/app/views/api/v2/override_values/show.json.rabl
+++ b/app/views/api/v2/override_values/show.json.rabl
@@ -1,3 +1,3 @@
-object @override_value
+object @override_value => :override_value
 
 extends "api/v2/override_values/main"

--- a/app/views/api/v2/parameters/base.json.rabl
+++ b/app/views/api/v2/parameters/base.json.rabl
@@ -1,3 +1,3 @@
-object @parameter
+object @parameter => :parameter
 
 attributes :id, :name, :value

--- a/app/views/api/v2/parameters/create.json.rabl
+++ b/app/views/api/v2/parameters/create.json.rabl
@@ -1,3 +1,3 @@
-object @parameter
+object @parameter => :parameter
 
 extends "api/v2/parameters/show"

--- a/app/views/api/v2/parameters/main.json.rabl
+++ b/app/views/api/v2/parameters/main.json.rabl
@@ -1,4 +1,4 @@
-object @parameter
+object @parameter => :parameter
 
 extends "api/v2/parameters/base"
 

--- a/app/views/api/v2/parameters/show.json.rabl
+++ b/app/views/api/v2/parameters/show.json.rabl
@@ -1,3 +1,3 @@
-object @parameter
+object @parameter => :parameter
 
 extends "api/v2/parameters/main"

--- a/app/views/api/v2/parameters/update.json.rabl
+++ b/app/views/api/v2/parameters/update.json.rabl
@@ -1,3 +1,3 @@
-object @parameter
+object @parameter => :parameter
 
 extends "api/v2/parameters/show"

--- a/app/views/api/v2/smart_class_parameters/base.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/base.json.rabl
@@ -1,4 +1,4 @@
-object @smart_class_parameter
+object @smart_class_parameter => :smart_class_parameter
 
 attribute :parameter
 attributes :id

--- a/app/views/api/v2/smart_class_parameters/create.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/create.json.rabl
@@ -1,3 +1,3 @@
-object @smart_class_parameter
+object @smart_class_parameter => :smart_class_parameter
 
 extends "api/v2/smart_class_parameters/show"

--- a/app/views/api/v2/smart_class_parameters/destroy.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/destroy.json.rabl
@@ -1,3 +1,3 @@
-object @smart_class_parameter
+object @smart_class_parameter => :smart_class_parameter
 
 extends "api/v2/smart_class_parameters/show"

--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -1,4 +1,4 @@
-object @smart_class_parameter
+object @smart_class_parameter => :smart_class_parameter
 
 extends "api/v2/smart_class_parameters/base"
 

--- a/app/views/api/v2/smart_class_parameters/show.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/show.json.rabl
@@ -1,4 +1,4 @@
-object @smart_class_parameter
+object @smart_class_parameter => :smart_class_parameter
 
 extends "api/v2/smart_class_parameters/main"
 

--- a/app/views/api/v2/smart_variables/base.json.rabl
+++ b/app/views/api/v2/smart_variables/base.json.rabl
@@ -1,4 +1,4 @@
-object @smart_variable
+object @smart_variable => :smart_variable
 
 attribute :variable
 attributes :id

--- a/app/views/api/v2/smart_variables/create.json.rabl
+++ b/app/views/api/v2/smart_variables/create.json.rabl
@@ -1,3 +1,3 @@
-object @smart_variable
+object @smart_variable => :smart_variable
 
 extends "api/v2/smart_variables/show"

--- a/app/views/api/v2/smart_variables/destroy.json.rabl
+++ b/app/views/api/v2/smart_variables/destroy.json.rabl
@@ -1,3 +1,3 @@
-object @smart_variable
+object @smart_variable => :smart_variable
 
 extends "api/v2/smart_variables/show"

--- a/app/views/api/v2/smart_variables/main.json.rabl
+++ b/app/views/api/v2/smart_variables/main.json.rabl
@@ -1,4 +1,4 @@
-object @smart_variable
+object @smart_variable => :smart_variable
 
 extends "api/v2/smart_variables/base"
 

--- a/app/views/api/v2/smart_variables/show.json.rabl
+++ b/app/views/api/v2/smart_variables/show.json.rabl
@@ -1,4 +1,4 @@
-object @smart_variable
+object @smart_variable => :smart_variable
 
 extends "api/v2/smart_variables/main"
 

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -14,7 +14,7 @@ module Rabl
     end
 
     def default_options
-      return {:root => false, :object_root => false} if api_version.to_i > 1
+      return {:root => false, :object_root => false} if api_version.to_i == 2
       {}
     end
 
@@ -22,6 +22,16 @@ module Rabl
       collection_without_defaults(data, options)
     end
     alias_method_chain :collection, :defaults
+
+    def child_default_options
+      return {:object_root => false} if api_version.to_i == 2
+      {}
+    end
+
+    def child_with_defaults(data, options = child_default_options , &block)
+      child_without_defaults(data, options, &block)
+    end
+    alias_method_chain :child, :defaults
 
     # extending this helper defined in module Rabl::Helpers allows users to
     # overwrite the object root name in show rabl views.  Two options:
@@ -31,7 +41,7 @@ module Rabl
       # custom object root
       return params['root_name'] if respond_to?(:params) && params['root_name'].present? && !['false', false].include?(params['root_name'])
       # no object root for v2
-      return nil if !respond_to?(:params) || api_version.to_i > 1 || ['false', false].include?(params['root_name'])
+      return nil if !respond_to?(:params) || ['false', false].include?(params['root_name'])
       # otherwise return super since v1 has object root (config.include_child_root = true)
       super
     end

--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -14,7 +14,7 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     assert_response :success
     template = ActiveSupport::JSON.decode(@response.body)
     assert !template.empty?
-    assert_equal template["name"], config_templates(:pxekickstart).name
+    assert_equal template["config_template"]["name"], config_templates(:pxekickstart).name
   end
 
   test "should create valid" do
@@ -22,12 +22,12 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     valid_attrs = { :template => "This is a test template", :template_kind_id => template_kinds(:ipxe).id, :name => "RandomName" }
     post :create, { :config_template => valid_attrs }
     template = ActiveSupport::JSON.decode(@response.body)
-    assert template["name"] == "RandomName"
+    assert template["config_template"]["name"] == "RandomName"
     assert_response 200
   end
 
   test "should not create invalid" do
-    post :create
+    post :create, { :config_template => {:name => ""} }
     assert_response 422
   end
 

--- a/test/functional/api/v2/domains_controller_test.rb
+++ b/test/functional/api/v2/domains_controller_test.rb
@@ -85,7 +85,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     #assert child nodes are included in response'
     NODES = ["locations", "organizations", "parameters", "subnets"]
     NODES.sort.each do |node|
-      assert show_response.keys.include?(node), "'#{node}' child node should be in response but was not"
+      assert show_response["domain"].keys.include?(node), "'#{node}' child node should be in response but was not"
     end
   end
 

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -327,7 +327,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     facts    = fact_json['facts']
     post :facts, {:name => hostname, :facts => facts}, set_session_user
     assert_response :unprocessable_entity
-    assert_equal 'A stub failure', JSON.parse(response.body)['error']['errors']['foo'].first
+    assert_equal 'A stub failure', JSON.parse(response.body)['error']['host']['errors']['foo'].first
   end
 
   context 'BMC proxy operations' do

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -24,7 +24,7 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     NODES = ["users", "smart_proxies", "subnets", "compute_resources", "media", "config_templates",
              "domains", "environments", "hostgroups", "organizations", "parameters"].sort
     NODES.each do |node|
-      assert show_response.keys.include?(node), "'#{node}' child node should be in response but was not"
+      assert show_response['location'].keys.include?(node), "'#{node}' child node should be in response but was not"
     end
   end
 
@@ -129,8 +129,8 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     assert response.kind_of?(Hash)
     klass_name = obj.class.name.downcase
     assert "location", klass_name
-    assert response.kind_of?(Hash)
-    assert_equal obj.id, response["id"]
+    assert response['location'].kind_of?(Hash)
+    assert_equal obj.id, response['location']["id"]
   end
 
   test "object name on show can be specified" do

--- a/test/functional/api/v2/media_controller_test.rb
+++ b/test/functional/api/v2/media_controller_test.rb
@@ -33,7 +33,7 @@ class Api::V2::MediaControllerTest < ActionController::TestCase
 
   test "should update medium" do
     name = Medium.first.name
-    put :update, { :id => Medium.first.id.to_param, :name => "#{name}".to_param }
+    put :update, { :id => Medium.first.id.to_param, :medium => {:name => "#{name}".to_param } }
     assert_response :success
   end
 

--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -53,8 +53,8 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should update associated architectures by ids" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { },
-                     :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ]
+      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => {
+                       :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ] }
                    }
     end
     assert_response :success
@@ -63,8 +63,8 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should update associated architectures by name" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { },
-                     :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ]
+      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => {
+                     :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ] }
                    }
     end
     assert_response :success

--- a/test/functional/api/v2/os_default_templates_controller_test.rb
+++ b/test/functional/api/v2/os_default_templates_controller_test.rb
@@ -38,8 +38,8 @@ class Api::V2::OsDefaultTemplatesControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:os_default_template)
     response = ActiveSupport::JSON.decode(@response.body)
-    assert !response.empty?
-    assert_equal response['config_template_id'], config_templates(:pxe_local_default).id
+    assert !response['os_default_template'].empty?
+    assert_equal config_templates(:pxe_local_default).id, response['os_default_template']['config_template_id']
   end
 
   test 'should destroy os_default_template for os' do

--- a/test/functional/api/v2/override_values_controller_test.rb
+++ b/test/functional/api/v2/override_values_controller_test.rb
@@ -37,14 +37,14 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     get :show,  {:smart_variable_id => lookup_keys(:two).to_param, :id => lookup_values(:four).to_param }
     assert_response :success
     results = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty results
-    assert_equal "hostgroup=Common", results['match']
+    assert_not_empty results['override_value']
+    assert_equal "hostgroup=Common", results['override_value']['match']
   end
   test "should show specific override values for specific smart class parameter" do
     get :show,  {:smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).to_param }
     results = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty results
-    assert_equal "hostgroup=Common", results['match']
+    assert_not_empty results['override_value']
+    assert_equal "hostgroup=Common", results['override_value']['match']
     assert_response :success
   end
 

--- a/test/functional/api/v2/parameters_controller_test.rb
+++ b/test/functional/api/v2/parameters_controller_test.rb
@@ -73,7 +73,7 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
     get :show, {:operatingsystem_id => operatingsystems(:redhat).to_param,:id => param.name }
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal param.id, show_response['id']
+    assert_equal param.id, show_response['parameter']['id']
   end
 
   test "should create host parameter" do

--- a/test/functional/api/v2/realms_controller_test.rb
+++ b/test/functional/api/v2/realms_controller_test.rb
@@ -79,11 +79,11 @@ class Api::V2::RealmsControllerTest < ActionController::TestCase
     get :show, { :id => realms(:myrealm).to_param }
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
-    assert !show_response.empty?
+    assert !show_response['realm'].empty?
     #assert child nodes are included in response'
     NODES = ["locations", "organizations"]
     NODES.sort.each do |node|
-      assert show_response.keys.include?(node), "'#{node}' child node should be in response but was not"
+      assert show_response['realm'].keys.include?(node), "'#{node}' child node should be in response but was not"
     end
   end
 

--- a/test/functional/api/v2/template_combinations_controller_test.rb
+++ b/test/functional/api/v2/template_combinations_controller_test.rb
@@ -12,9 +12,9 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
   test "should get template combination" do
     get :show, { :config_template_id => config_templates(:mystring2).to_param, :id => template_combinations(:two).id }
     assert_response :success
-    template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert !template_combination.empty?
-    assert_equal template_combination["config_template_id"], template_combinations(:two).config_template_id
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert !response['template_combination'].empty?
+    assert_equal response['template_combination']["config_template_id"], template_combinations(:two).config_template_id
   end
 
   test "should create valid" do
@@ -23,10 +23,10 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
       post :create, { :template_combination => { :environment_id => environments(:production).id, :hostgroup_id => hostgroups(:unusual).id },
         :config_template_id => config_templates(:mystring2).id }
     end
-    template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert template_combination["environment_id"] == environments(:production).id
-    assert template_combination["hostgroup_id"] == hostgroups(:unusual).id
-    assert template_combination["config_template_id"] == config_templates(:mystring2).id
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert response['template_combination']["environment_id"] == environments(:production).id
+    assert response['template_combination']["hostgroup_id"] == hostgroups(:unusual).id
+    assert response['template_combination']["config_template_id"] == config_templates(:mystring2).id
     assert_response 200
   end
 

--- a/test/functional/api/v2/users_controller_test.rb
+++ b/test/functional/api/v2/users_controller_test.rb
@@ -36,8 +36,8 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     get :show, { :id => users(:one).id }
     show_response = ActiveSupport::JSON.decode(@response.body)
 
-    assert_equal taxonomies(:location1).id, show_response['default_location']['id']
-    assert_equal nil, show_response['default_organization']
+    assert_equal taxonomies(:location1).id, show_response['user']['default_location']['id']
+    assert_equal nil, show_response['user']['default_organization']
   end
 
   test "should update user" do


### PR DESCRIPTION
Currently, the Foreman API v2 returns unwrapped params for GET and supports wrapped/unwrapped for POST/PUT but (nearly) all the functional tests are using wrapped params which means that the current documentation shows wrapped params. The goal is to be consistent, either wrapped or unwrapped, for tests, documentation, and api v2 usage by katello and hammer.  This PR represents the work to change Foreman to wrapped params. 
