### PR TITLE
Fixes #6518 - lookup the bmc smartproxy via subnets.id

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -24,8 +24,9 @@ module Nic
 
 
     def proxy
-      # try to find a bmc proxy in the same subnet as our bmc device
-      proxy   = SmartProxy.with_features("BMC").joins(:subnets).where(['dhcp_id = ? or tftp_id = ?', subnet_id, subnet_id]).first if subnet_id
+      if subnet.present?
+        proxy = subnet.proxies.select { |proxy| proxy.features.map(&:name).include?("BMC") }.first
+      end
       proxy ||= SmartProxy.with_features("BMC").first
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?
       ProxyAPI::BMC.new({ :host_ip  => ip,

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -128,6 +128,10 @@ class Subnet < ActiveRecord::Base
     end.compact
   end
 
+  def proxies
+    [dhcp, tftp, dns].compact
+  end
+
   private
 
   def validate_ranges


### PR DESCRIPTION
Discussion started in #1569 
