### PR TITLE
fixes #6749 - fix API v2 examples in docs that show error messages by re-ordering functional tests

### DIFF
--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -17,11 +17,6 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     assert_equal template["name"], config_templates(:pxekickstart).name
   end
 
-  test "should not create invalid" do
-    post :create
-    assert_response 422
-  end
-
   test "should create valid" do
     ConfigTemplate.any_instance.stubs(:valid?).returns(true)
     valid_attrs = { :template => "This is a test template", :template_kind_id => template_kinds(:ipxe).id, :name => "RandomName" }
@@ -31,9 +26,8 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     assert_response 200
   end
 
-  test "should not update invalid" do
-    put :update, { :id              => config_templates(:pxekickstart).to_param,
-                   :config_template => { :name => "" } }
+  test "should not create invalid" do
+    post :create
     assert_response 422
   end
 
@@ -43,6 +37,12 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
                    :config_template => { :template => "blah" } }
     template = ActiveSupport::JSON.decode(@response.body)
     assert_response :ok
+  end
+
+  test "should not update invalid" do
+    put :update, { :id              => config_templates(:pxekickstart).to_param,
+                   :config_template => { :name => "" } }
+    assert_response 422
   end
 
   test "should not destroy template with associated hosts" do

--- a/test/functional/api/v2/domains_controller_test.rb
+++ b/test/functional/api/v2/domains_controller_test.rb
@@ -16,16 +16,16 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     assert !show_response.empty?
   end
 
-  test "should not create invalid domain" do
-    post :create, { :domain => { :fullname => "" } }
-    assert_response :unprocessable_entity
-  end
-
   test "should create valid domain" do
     post :create, { :domain => { :name => "domain.net" } }
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
+  end
+
+  test "should not create invalid domain" do
+    post :create, { :domain => { :fullname => "" } }
+    assert_response :unprocessable_entity
   end
 
   test "should update valid domain" do


### PR DESCRIPTION
Since Apipie generates the example json based on the first test of each type, then order of the tests need to be such that the valid test is first and then the invalid test is afterwards
