### PR TITLE
Fixes #6756 - exposes vmware resource pools and folders through the API

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -6,7 +6,8 @@ module Api
       include Api::TaxonomyScope
 
       before_filter :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,
-                                              :available_networks, :available_clusters, :available_storage_domains]
+                                              :available_clusters, :available_folders, :available_networks,
+                                              :available_resource_pools, :available_storage_domains]
 
       api :GET, "/compute_resources/", "List all compute resources."
       param :search, String, :desc => "filter results"
@@ -76,6 +77,13 @@ module Api
         render :available_clusters, :layout => 'api/v2/layouts/index_layout'
       end
 
+      api :GET, "/compute_resources/:id/available_folders", "List available folders for a compute resource"
+      param :id, :identifier, :required => true
+      def available_folders
+        @available_folders = @compute_resource.available_folders
+        render :available_folders, :layout => 'api/v2/layouts/index_layout'
+      end
+
       api :GET, "/compute_resources/:id/available_networks", "List available networks for a compute resource"
       api :GET, "/compute_resources/:id/available_clusters/:cluster_id/available_networks", "List available networks for a compute resource cluster"
       param :id, :identifier, :required => true
@@ -83,6 +91,14 @@ module Api
       def available_networks
         @available_networks = @compute_resource.available_networks(params[:cluster_id])
         render :available_networks, :layout => 'api/v2/layouts/index_layout'
+      end
+
+      api :GET, "/compute_resources/:id/available_clusters/:cluster_id/available_resource_pools", "List resource pools for a compute resource cluster"
+      param :id, :identifier, :required => true
+      param :cluster_id, String, :required => true
+      def available_resource_pools
+        @available_resource_pools = @compute_resource.available_resource_pools({ :cluster_id => params[:cluster_id] })
+        render :available_resource_pools, :layout => 'api/v2/layouts/index_layout'
       end
 
       api :GET, "/compute_resources/:id/available_storage_domains", "List storage_domains for a compute resource"
@@ -114,7 +130,7 @@ module Api
 
       def action_permission
         case params[:action]
-          when 'available_images', 'available_clusters', 'available_networks', 'available_storage_domains', 'associate'
+          when 'available_images', 'available_clusters', 'available_folders', 'available_networks', 'available_resource_pools', 'available_storage_domains', 'associate'
             :view
           else
             super

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -207,6 +207,14 @@ class ComputeResource < ActiveRecord::Base
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end
 
+  def available_folders
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
+  def available_resource_pools
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
   def available_storage_domains
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -43,6 +43,10 @@ module Foreman::Model
       client.datacenters.all
     end
 
+    def cluster(cluster)
+      dc.clusters.get(cluster)
+    end
+
     def clusters
       dc.clusters
     end
@@ -55,12 +59,25 @@ module Foreman::Model
       dc.networks.all(:accessible => true)
     end
 
+    def resource_pools(opts ={})
+      cluster = cluster(opts[:cluster_id])
+      cluster.resource_pools.all(:accessible => true)
+    end
+
     def available_clusters
       clusters
     end
 
+    def available_folders
+      folders
+    end
+
     def available_networks(cluster_id=nil)
       networks
+    end
+
+    def available_resource_pools(opts={})
+      resource_pools({ :cluster_id => opts[:cluster_id] })
     end
 
     def available_storage_domains

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -68,8 +68,8 @@ Foreman::AccessControl.map do |map|
     ajax_actions = [:test_connection]
     map.permission :view_compute_resources,    {:compute_resources => [:index, :show, :auto_complete_search, :ping, :available_images],
                                                 :"api/v1/compute_resources" => [:index, :show],
-                                                :"api/v2/compute_resources" => [:index, :show, :available_images, :available_clusters, :available_networks,
-                                                                                :available_storage_domains]
+                                                :"api/v2/compute_resources" => [:index, :show, :available_images, :available_clusters, :available_folders,
+                                                                                :available_networks, :available_resource_pools, :available_storage_domains]
     }
     map.permission :create_compute_resources,  {:compute_resources => [:new, :create].push(*ajax_actions),
                                                 :"api/v1/compute_resources" => [:create],

--- a/app/views/api/v2/compute_resources/available_folders.rabl
+++ b/app/views/api/v2/compute_resources/available_folders.rabl
@@ -1,0 +1,3 @@
+collection @available_folders
+
+attribute :name, :id, :parent, :datacenter, :path, :type

--- a/app/views/api/v2/compute_resources/available_resource_pools.rabl
+++ b/app/views/api/v2/compute_resources/available_resource_pools.rabl
@@ -1,0 +1,3 @@
+collection @available_resource_pools
+
+attribute :name, :id

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -172,9 +172,11 @@ Foreman::Application.routes.draw do
           resources :images, :except => [:new, :edit]
           get :available_images, :on => :member
           get :available_clusters, :on => :member
+          get :available_folders, :on => :member
           get :available_networks, :on => :member
           get :available_storage_domains, :on => :member
           get 'available_clusters/(:cluster_id)/available_networks', :to => 'compute_resources#available_networks', :on => :member
+          get 'available_clusters/(:cluster_id)/available_resource_pools', :to => 'compute_resources#available_resource_pools', :on => :member
           put :associate, :on => :member
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]

--- a/test/functional/api/v2/compute_resources_controller_test.rb
+++ b/test/functional/api/v2/compute_resources_controller_test.rb
@@ -176,6 +176,36 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     assert !available_clusters.empty?
   end
 
+  test "should get available vmware folders" do
+    folder = Object.new
+    folder.stubs(:name).returns('vmware_folder')
+    folder.stubs(:id).returns('group-12345')
+    folder.stubs(:datacenter).returns('DC-1')
+    folder.stubs(:parent).returns('cluster-12345')
+    folder.stubs(:path).returns('/Datacenters/DC-1/vm/cluster-12345/vmware_folder')
+    folder.stubs(:type).returns('vm')
+
+    Foreman::Model::Vmware.any_instance.stubs(:available_folders).returns([folder])
+
+    get :available_folders, { :id => compute_resources(:vmware).to_param, :cluster_id => '123-456-789' }
+    assert_response :success
+    available_folders = ActiveSupport::JSON.decode(@response.body)
+    assert !available_folders.empty?
+  end
+
+  test "should get available vmware resource pools" do
+    resource_pool = Object.new
+    resource_pool.stubs(:name).returns('Resource Pool 1')
+    resource_pool.stubs(:id).returns('resgroup-12345')
+
+    Foreman::Model::Vmware.any_instance.stubs(:available_resource_pools).returns([resource_pool])
+
+    get :available_resource_pools, { :id => compute_resources(:vmware).to_param, :cluster_id => '123-456-789' }
+    assert_response :success
+    available_resource_pools = ActiveSupport::JSON.decode(@response.body)
+    assert !available_resource_pools.empty?
+  end
+
   test "should get available vmware storage domains" do
     storage_domain = Object.new
     storage_domain.stubs(:name).returns('test_vmware_cluster')


### PR DESCRIPTION
This lets users get a list of resource pools and folders through the v2 API.
