### PR TITLE
Refs #6760: Validator to ensure associations are authorized.

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -2,6 +2,8 @@ module Authorizable
   extend ActiveSupport::Concern
 
   included do
+    validates_with AuthorizeAssociationsValidator
+
     # permission can be nil (therefore we use Proc instead of lambda)
     # same applies for resource class
     #
@@ -24,6 +26,7 @@ module Authorizable
       return false if User.current.nil?
       User.current.can?(permission, self)
     end
+
   end
 
   module ClassMethods

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -14,6 +14,8 @@ class Host::Managed < Host::Base
   belongs_to :owner, :polymorphic => true
   belongs_to :compute_resource
   belongs_to :image
+  belongs_to :domain
+  belongs_to :subnet
 
   belongs_to :location
   belongs_to :organization

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -367,6 +367,14 @@ class User < ActiveRecord::Base
     sweeper.expire_fragment(TopbarSweeper.fragment_name(id))
   end
 
+  def allowed_organizations
+    admin? ? Organization.scoped : self.organizations
+  end
+
+  def allowed_locations
+    admin? ? Location.scoped : self.locations
+  end
+
   private
 
   def prepare_password

--- a/app/validators/authorize_associations_validator.rb
+++ b/app/validators/authorize_associations_validator.rb
@@ -22,7 +22,7 @@ class AuthorizeAssociationsValidator < ActiveModel::Validator
 
       record.class.reflect_on_all_associations.each do |association|
 
-        if check_authorization?(association, exemptions)
+        if check_authorization?(record, association, exemptions)
 
           permission = exemptions[association.name] || "view_#{association.klass.name.downcase.pluralize}"
           check_association(record, association, permission)
@@ -30,7 +30,6 @@ class AuthorizeAssociationsValidator < ActiveModel::Validator
         end
       end
     end
-  rescue NameError => e
   end
 
   def check_association(record, association, permission)
@@ -97,10 +96,11 @@ class AuthorizeAssociationsValidator < ActiveModel::Validator
     association_name.to_s.singularize == 'organization'
   end
 
-  def check_authorization?(association, exemptions)
+  def check_authorization?(record, association, exemptions)
+    klass = association.options.include?(:polymorphic) ? record.send(association.foreign_type) : association.klass
     !exemptions[association.name] &&
-      association.klass &&
-      association.klass.respond_to?(:authorized) &&
+      klass &&
+      klass.respond_to?(:authorized) &&
       association.name != 'taxonomies'
   end
 

--- a/app/validators/authorize_associations_validator.rb
+++ b/app/validators/authorize_associations_validator.rb
@@ -1,0 +1,107 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+class AuthorizeAssociationsValidator < ActiveModel::Validator
+
+  def validate(record)
+    if record.class.respond_to?(:reflect_on_all_associations)
+      exemptions = if record.respond_to?(:association_authorization_overrides)
+                     record.association_authorization_overrides
+                   else
+                     {}
+                   end
+
+      record.class.reflect_on_all_associations.each do |association|
+
+        if check_authorization?(association, exemptions)
+
+          permission = exemptions[association.name] || "view_#{association.klass.name.downcase.pluralize}"
+          check_association(record, association, permission)
+
+        end
+      end
+    end
+  rescue NameError => e
+  end
+
+  def check_association(record, association, permission)
+    if association.macro.to_sym == :has_many
+      has_many_authorized?(record, association, permission)
+    elsif association.macro.to_sym == :belongs_to
+      belongs_to_authorized?(record, association, permission)
+    end
+  end
+
+  def belongs_to_authorized?(record, association, permission)
+    permitted = false
+    name = association.name
+    association_record = record.send(name)
+    return true if association_record.nil?
+
+    if organization?(name)
+      permitted = user.allowed_organizations.include?(association_record)
+    elsif location?(name)
+      permitted = user.allowed_locations.include?(association_record)
+    else
+      permitted = association_record.authorized?(permission)
+    end
+
+    add_error(record, name, association_record) if !permitted
+  end
+
+  def has_many_authorized?(record, association, permission)
+    permitted = []
+    name = association.name
+    association_record = record.send(name)
+
+    if organization?(name)
+      permitted = user.allowed_organizations
+    elsif location?(name)
+      permitted = user.allowed_locations
+    else
+      permitted = association.klass.authorized(permission)
+    end
+
+    permitted = association_record - permitted
+    add_error(record, name, permitted) if !permitted.empty?
+  end
+
+  def add_error(record, association_name, unauthorized)
+    if unauthorized.is_a?(Array)
+      message = "not found for ids '#{unauthorized.map(&:id)}'"
+    else
+      message = "not found by id '#{unauthorized.id}'"
+    end
+
+    record.errors[association_name] << message
+  end
+
+  def user
+    ::User.current
+  end
+
+  def location?(association_name)
+    association_name.to_s.singularize == 'location'
+  end
+
+  def organization?(association_name)
+    association_name.to_s.singularize == 'organization'
+  end
+
+  def check_authorization?(association, exemptions)
+    !exemptions[association.name] &&
+      association.klass &&
+      association.klass.respond_to?(:authorized) &&
+      association.name != 'taxonomies'
+  end
+
+end

--- a/test/unit/authorize_associations_validator_test.rb
+++ b/test/unit/authorize_associations_validator_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+class AuthorizeAssociationsValidatorTest < ActiveSupport::TestCase
+
+  def setup
+    @validatable = Validatable.new
+  end
+
+  test "valid if all associations aren't authorized" do
+    assert @validatable.valid?
+    assert_empty @validatable.errors[:belongs_to_class]
+    assert_empty @validatable.errors[:has_many_class]
+  end
+
+  test "invalid if belongs_to association isn't authorized" do
+    @validatable.belongs_to = false
+
+    assert @validatable.invalid?
+    refute_empty @validatable.errors[:belongs_to_class]
+  end
+
+  test "invalid if has_many association isn't authorized" do
+    @validatable.has_many = false
+
+    assert @validatable.invalid?
+    refute_empty @validatable.errors[:has_many_class]
+  end
+
+  test "invalid if has_many and belongs_to associations aren't authorized" do
+    assert @validatable.valid?
+
+    @validatable.has_many = false
+    @validatable.belongs_to = false
+
+    assert @validatable.invalid?
+    refute_empty @validatable.errors[:belongs_to_class]
+    refute_empty @validatable.errors[:has_many_class]
+  end
+
+  test "valid if associations haven't changed" do
+    assert @validatable.valid?
+
+    @validatable.has_many = false
+    @validatable.belongs_to = false
+    @validatable.has_many_changed = false
+    @validatable.belongs_to_changed = false
+
+    assert @validatable.valid?
+    assert_empty @validatable.errors[:belongs_to_class]
+    assert_empty @validatable.errors[:has_many_class]
+  end
+
+end
+
+class Association
+
+  @@collection = []
+
+  attr_accessor :authorized, :id
+
+  def initialize(authorized)
+    @authorized = authorized
+    @@collection << self if authorized
+  end
+
+  def authorized?(permission)
+    @authorized
+  end
+
+  def self.authorized(permission)
+    @@collection
+  end
+
+end
+
+class Reflection
+
+  attr_accessor :name, :macro
+
+  def initialize(name, macro)
+    @name = name
+    @macro = macro
+  end
+
+  def klass
+    Association
+  end
+
+end
+
+class Validatable
+  include ActiveModel::Validations
+  validates_with AuthorizeAssociationsValidator
+
+  attr_accessor :has_many, :belongs_to, :has_many_changed, :belongs_to_changed
+
+  def initialize(belongs_to = true, has_many = true)
+    @has_many = has_many
+    @belongs_to = belongs_to
+    self.errors[:belongs_to_class] = []
+    self.errors[:has_many_class] = []
+  end
+
+  def self.reflect_on_association(association)
+    Reflection.new(association, association.to_s.split('_class')[0])
+  end
+
+  def self.reflect_on_all_associations
+    [
+      Reflection.new(:belongs_to_class, :belongs_to),
+      Reflection.new(:has_many_class, :has_many)
+    ]
+  end
+
+  def association_authorizations
+    {
+      :belongs_to_class   => :view_belongs_to,
+      :has_many_class     => :view_has_many,
+    }
+  end
+
+  def belongs_to_class
+    Association.new(@belongs_to)
+  end
+
+  def has_many_class
+    [Association.new(@has_many), Association.new(@has_many)]
+  end
+
+  def has_many_class_changed?
+    @has_many_changed
+  end
+
+  def belongs_to_class_changed?
+    @belongs_to_changed
+  end
+
+end

--- a/test/unit/concerns/authorizable_test.rb
+++ b/test/unit/concerns/authorizable_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class AuthorizableTest < ActiveSupport::TestCase
+
+  def setup
+    ::User.current = users(:admin)
+  end
+
+  test "classes including Authorizable should be invalid if user does not belong to the organization" do
+    authorizables = ActiveRecord::Base.send(:subclasses).select { |klass| klass.ancestors.include?(Authorizable) }
+
+    authorizables.each do |authorizable_class|
+      @authorizable = authorizable_class.new
+
+      if @authorizable.respond_to?(:organizations)
+        @authorizable.organizations << taxonomies(:organization1)
+
+        ::User.current = users(:restricted)
+        @authorizable.valid?
+        refute_empty @authorizable.errors[:organizations]
+
+        ::User.current.organizations << taxonomies(:organization1)
+        @authorizable.valid?
+        assert_empty @authorizable.errors[:organizations]
+
+        ::User.current.organizations = []
+      end
+    end
+  end
+
+  test "classes including Authorizable should be invalid if user does not belong to the location" do
+    authorizables = ActiveRecord::Base.send(:subclasses).select { |klass| klass.ancestors.include?(Authorizable) }
+
+    authorizables.each do |authorizable_class|
+      @authorizable = authorizable_class.new
+
+      if @authorizable.respond_to?(:locations)
+        @authorizable.locations << taxonomies(:location1)
+
+        ::User.current = users(:restricted)
+        @authorizable.valid?
+        refute_empty @authorizable.errors[:locations]
+
+        ::User.current.locations << taxonomies(:location1)
+        @authorizable.valid?
+        assert_empty @authorizable.errors[:locations]
+
+        ::User.current.locations = []
+      end
+    end
+  end
+
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -715,4 +715,20 @@ class UserTest < ActiveSupport::TestCase
     User.complete_for('login = ').each { |ac| refute_match users(:anonymous).login, ac }
   end
 
+  test "allowed_organizations for admin" do
+    assert_equal users(:admin).allowed_organizations.length, Organization.all.count
+  end
+
+  test "allowed_locations for admin" do
+    assert_equal users(:admin).allowed_locations.length, Location.all.count
+  end
+
+  test "allowed_organizations for restricted user" do
+    assert_empty users(:restricted).allowed_organizations
+  end
+
+  test "allowed_locations for restricted user" do
+    assert_empty users(:restricted).allowed_locations
+  end
+
 end

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -89,7 +89,7 @@ class UsergroupTest < ActiveSupport::TestCase
     disable_orchestration
     @ug1 = Usergroup.find_or_create_by_name :name => "ug1"
     @h1  = hosts(:one)
-    @h1.update_attributes :owner => @ug1
+    @h1.update_attributes! :owner => @ug1
     @ug1.destroy
     assert_equal @ug1.errors.full_messages[0], "ug1 is used by #{@h1}"
   end


### PR DESCRIPTION
My goal was to create the validator and an example model as a starting place prior to attempting full coverage.

Please see for a test scenario - http://projects.theforeman.org/issues/6760
Also, a corresponding beginning usage in Katello - https://github.com/Katello/katello/pull/4483

The idea is to define what resources a model is associated to that should be checked upon association and the permission that corresponds. There is the possibility that this may need to be evolved for derived permissions (e.g. in Katello repositories derive their permissions from Products).
