### PR TITLE
Fixes #6786 - Handle error when no params get sent

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -72,7 +72,7 @@ module Api::V2::TaxonomiesController
 
   def params_match_database
     # change params[:select_all_types] to params[:ignore_types] to match database
-    if params[taxonomy_single.to_sym][:select_all_types]
+    if params[taxonomy_single.to_sym].try(:[], :select_all_types)
       params[taxonomy_single.to_sym][:ignore_types] = params[taxonomy_single.to_sym][:select_all_types]
       params[taxonomy_single.to_sym]                = params[taxonomy_single.to_sym].reject { |k, v| k == "select_all_types" }
       return params[taxonomy_single.to_sym]

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -33,6 +33,11 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test "should return an error for no params" do
+    post :create
+    assert_response :unprocessable_entity
+  end
+
   test "should create valid location" do
     post :create, { :location => { :name => "Test Location" } }
     assert_response :success


### PR DESCRIPTION
Basically, no organization params are getting sent as the bug reporter is not
using json and not using wrapped params. You can also test this by doing:

``` bash
curl -u admin:changeme -X POST http://localhost:3000/api/v2/organizations -d "name=Test"
```

Or simply:

``` bash
curl -u admin:changeme -X POST http://localhost:3000/api/v2/organizations
```

This change prevents the following error from getting raised:

```
Processing by Api::V2::OrganizationsController#create as JSON
  Parameters: {"description"=>"biz", "name"=>"foo", "label"=>"bar", "apiv"=>"v2"}
Expire fragment views/tabs_and_title_records-1 (0.1ms)
Authorized user admin(Admin User)
undefined method `[]' for nil:NilClass (NoMethodError)
/usr/share/foreman/app/controllers/concerns/api/v2/taxonomies_controller.rb:75:in `params_match_database'
...
```
