### PR TITLE
Fixes #6768 - Hammer set-parameter does not work

### DIFF
--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -28,11 +28,14 @@ module Api
       param :operatingsystem_id, String, :desc => "id of operating system"
       param :location_id, String, :desc => "id of location"
       param :organization_id, String, :desc => "id of organization"
+      param :search, String, :desc => "filter results"
+      param :order, String, :desc => "sort results"
       param :page, String, :desc => "paginate results"
       param :per_page, String, :desc => "number of entries per request"
 
+
       def index
-        @parameters = nested_obj.send(parameters_method).paginate(paginate_options)
+        @parameters = nested_obj.send(parameters_method).search_for(*search_options).paginate(paginate_options)
         @total = nested_obj.send(parameters_method).count
       end
 

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -6,6 +6,8 @@ class Parameter < ActiveRecord::Base
   validates :name, :presence => true, :format => {:with => /\A\S*\Z/, :message => N_("can't contain white spaces")}
   validates :reference_id, :presence => {:message => N_("parameters require an associated domain, operating system, host or host group")}, :unless => Proc.new {|p| p.nested or p.is_a? CommonParameter}
 
+  scoped_search :on => :name, :complete_value => true
+
   default_scope lambda { order("parameters.name") }
 
   attr_accessor :nested


### PR DESCRIPTION
Added scoped search to parameters. It helps hammer search parameters the same way as any other resource.
