### PR TITLE
fix: Unassigned hosts outside stats box

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -17,7 +17,7 @@
     padding-top: 10px;
   }
   .stats-well {
-    min-height: 341px;
+    min-height: 423px;
   }
   .statistics-bar{
    height: 270px;


### PR DESCRIPTION
This fixes the problem where the Unassigned hosts stats show up outside the stats box in dashboard.
