### PR TITLE
1.5 fix: Unassigned hosts outside stats box

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -18,6 +18,7 @@
   }
   .stats-well {
     min-height: 363px;
+    overflow: auto;
   }
   .statistics-bar{
    height: 270px;


### PR DESCRIPTION
Decided for auto instead since hidden could potentially clip content. Auto will add a scrollbar if need be but should never happen since we only define the min-height.
