### PR TITLE
fixes #6857 improve two-pane load times

### DIFF
--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -51,6 +51,7 @@ function two_pane_open(item){
   $.ajax({
     type:'GET',
     url: href,
+    headers: {"X-Foreman-Layout": "two-pane"},
     success: function(response){
       right_pane_content(response);
     },
@@ -70,6 +71,7 @@ function two_pane_submit(){
   $.ajax({
     type:'POST',
     url: url,
+    headers: {"X-Foreman-Layout": "two-pane"},
     data: $('form').serialize(),
     success: function(response){
       right_pane_content(response);
@@ -120,9 +122,8 @@ function hide_columns(){
 function right_pane_content(response){
   if (handle_redirect(response)) return; //session expired redirect to login
 
-  var form_content = $("#content form.well", response);
-  if (form_content.length){
-    $('.two-pane-right').html(form_content);
+  if (!$("#content", response).length){
+    $('.two-pane-right').html(response);
     $('.two-pane-right form').prepend("<div class='fr close-button'><a class='two-pane-close' href='#'>&times;</a></div>");
     $('.form-actions a').addClass('two-pane-close');
     fix_multi_checkbox();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_filter :set_taxonomy, :require_mail, :check_empty_taxonomy
   before_filter :welcome, :only => :index, :unless => :api_request?
   before_filter :authorize
+  layout :display_layout?
 
   attr_reader :original_search_parameter
 
@@ -217,6 +218,11 @@ class ApplicationController < ActionController::Base
     (@remote_user = request.env["REMOTE_USER"]).present?
   end
 
+  def display_layout?
+    return nil if two_pane?
+    "application"
+  end
+
   private
   def detect_notices
     @notices = current_user.notices
@@ -364,6 +370,10 @@ class ApplicationController < ActionController::Base
 
   def errors_hash errors
     errors.any? ? {:status => N_("Error"), :message => errors.full_messages.join('<br>')} : {:status => N_("OK"), :message =>""}
+  end
+
+  def two_pane?
+    request.headers["X-Foreman-Layout"] == 'two-pane' && params[:action] != 'index'
   end
 
 end

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -1,3 +1,4 @@
+<%= javascript "nfs_visibility" %>
 <% title _("Installation Media") %>
 
 <% title_actions display_link_if_authorized(_("New Medium"), hash_for_new_medium_path), help_path %>


### PR DESCRIPTION
when using two-panes, the layout is dropped and never used, we can skip generating it on the server side and improve page load time.
