### PR TITLE
fixes #6830 - add host search on compute_resource_id used in 1.5 auth migrations

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -39,6 +39,7 @@ module Hostext
       scoped_search :in => :puppet_proxy, :on => :name,    :complete_value => true, :rename => :puppetmaster
       scoped_search :in => :puppet_ca_proxy, :on => :name,    :complete_value => true, :rename => :puppet_ca
       scoped_search :in => :compute_resource, :on => :name,    :complete_value => true, :rename => :compute_resource
+      scoped_search :in => :compute_resource, :on => :id,      :complete_value => true, :rename => :compute_resource_id, :only_explicit => true
       scoped_search :in => :image, :on => :name, :complete_value => true
 
       scoped_search :in => :puppetclasses, :on => :name, :complete_value => true, :rename => :class, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_puppetclass


### PR DESCRIPTION
To reproduce this:
1. check out 1.4-stable
2. add a CR
3. add a non-admin user
4. edit the user, under Filters, set "must be" on the CR
5. check out develop or this branch
6. rake db:migrate

Usually it fails as compute_resource_id is an unknown search and db/migrate/20140219183343_migrate_permissions.rb tries to create filters with it.

(Warning, running db:seed seems to fail for me due to #6873, but migration is fine.)
