### PR TITLE
Fixes #6891: Taxonomies couldn't be seeded after initial run of seeds.

### DIFF
--- a/db/seeds.d/05-taxonomies.rb
+++ b/db/seeds.d/05-taxonomies.rb
@@ -1,13 +1,17 @@
 # Create an initial organization if specified
 if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION']
   Organization.without_auditing do
-    Organization.find_or_create_by_name(:name => ENV['SEED_ORGANIZATION'])
+    User.current = User.anonymous_admin
+    Organization.find_or_create_by_name!(:name => ENV['SEED_ORGANIZATION'])
+    User.current = nil
   end
 end
 
 # Create an initial location if specified
 if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION']
   Location.without_auditing do
-    Location.find_or_create_by_name(:name => ENV['SEED_LOCATION'])
+    User.current = User.anonymous_admin
+    Location.find_or_create_by_name!(:name => ENV['SEED_LOCATION'])
+    User.current = nil
   end
 end

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -131,4 +131,29 @@ class SeedsTest < ActiveSupport::TestCase
     seed
     assert_equal [], Audit.all
   end
+
+  test "seed organization when environment SEED_ORGANIZATION specified" do
+    with_env('SEED_ORGANIZATION' => 'seed_test') do
+      seed
+    end
+    assert Organization.find_by_name('seed_test')
+
+    with_env('SEED_ORGANIZATION' => 'seed_test2') do
+      seed
+    end
+    assert Organization.find_by_name('seed_test2')
+  end
+
+  test "seed location when environment SEED_LOCATION specified" do
+    with_env('SEED_LOCATION' => 'seed_test') do
+      seed
+    end
+    assert Location.find_by_name('seed_test')
+
+    with_env('SEED_LOCATION' => 'seed_test_a') do
+      seed
+    end
+    assert Location.find_by_name('seed_test_a')
+  end
+
 end


### PR DESCRIPTION
On a clean run of seeds, a seed prior to the taxonomies sets User.current.
On subsequent runs, errors are thrown since User.current is not thrown
and taxonomy creation expects this.
