### PR TITLE
Fixes #3976 - Add permissions to viewer user role

### DIFF
--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -64,6 +64,17 @@ Foreman::AccessControl.map do |map|
                    :"api/v2/bookmarks" => [:destroy]
   end
 
+  map.security_block :compute_profiles do |map|
+    map.permission :view_compute_profiles, { :compute_profiles          => [:index, :show, :auto_complete_search],
+                                             :"api/v2/compute_profiles" => [:index, :show] }
+    map.permission :create_compute_profiles, { :compute_profiles        => [:new, :create],
+                                             :"api/v2/compute_profiles" => [:create] }
+    map.permission :edit_compute_profiles, { :compute_profiles          => [:edit, :update],
+                                             :"api/v2/compute_profiles" => [:update] }
+    map.permission :destroy_compute_profiles, { :compute_profiles          => [:destroy],
+                                                :"api/v2/compute_profiles" => [:destroy] }
+  end
+
   map.security_block :compute_resources do |map|
     ajax_actions = [:test_connection]
     map.permission :view_compute_resources,    {:compute_resources => [:index, :show, :auto_complete_search, :ping, :available_images],
@@ -76,11 +87,9 @@ Foreman::AccessControl.map do |map|
                                                 :"api/v2/compute_resources" => [:create]
     }
     map.permission :edit_compute_resources,    {:compute_resources => [:edit, :update].push(*ajax_actions),
-                                                :compute_profiles => [:new, :create, :edit, :update, :destroy, :index, :show, :auto_complete_search],
                                                 :compute_attributes => [:new, :create, :edit, :update],
                                                 :"api/v1/compute_resources" => [:update],
                                                 :"api/v2/compute_resources" => [:update],
-                                                :"api/v2/compute_profiles" => [:index, :show, :create, :update, :destroy],
                                                 :"api/v2/compute_attributes" => [:create, :update]
     }
     map.permission :destroy_compute_resources, {:compute_resources => [:destroy],

--- a/db/seeds.d/03-permissions.rb
+++ b/db/seeds.d/03-permissions.rb
@@ -32,6 +32,10 @@ permissions = [
     ['ConfigTemplate', 'destroy_templates'],
     ['ConfigTemplate', 'deploy_templates'],
     ['ConfigTemplate', 'lock_templates'],
+    ['ConfigGroup', 'view_config_groups'],
+    ['ConfigGroup', 'create_config_groups'],
+    ['ConfigGroup', 'edit_config_groups'],
+    ['ConfigGroup', 'destroy_config_groups'],
     [nil, 'access_dashboard'],
     ['Domain', 'view_domains'],
     ['Domain', 'create_domains'],
@@ -42,6 +46,10 @@ permissions = [
     ['Environment', 'edit_environments'],
     ['Environment', 'destroy_environments'],
     ['Environment', 'import_environments'],
+    ['ExternalUsergroups', 'view_external_usergroups'],
+    ['ExternalUsergroups', 'create_external_usergroups'],
+    ['ExternalUsergroups', 'edit_external_usergroups'],
+    ['ExternalUsergroups', 'destroy_external_usergroups'],
     ['LookupKey', 'view_external_variables'],
     ['LookupKey', 'create_external_variables'],
     ['LookupKey', 'edit_external_variables'],
@@ -155,3 +163,4 @@ permissions = [
 permissions.each do |resource, permission|
   Permission.find_or_create_by_resource_type_and_name resource, permission
 end
+

--- a/db/seeds.d/03-roles.rb
+++ b/db/seeds.d/03-roles.rb
@@ -1,4 +1,8 @@
 # Roles
+def view_permissions
+  Permission.all.map(&:name).select { |permission_name| permission_name.match /view/ }.map(&:to_sym)
+end
+
 default_permissions =
     { 'Manager'               => [:view_architectures, :create_architectures, :edit_architectures, :destroy_architectures,
                                   :view_authenticators, :create_authenticators, :edit_authenticators, :destroy_authenticators,
@@ -35,12 +39,7 @@ default_permissions =
       'Edit partition tables' => [:view_ptables, :create_ptables, :edit_ptables, :destroy_ptables],
       'View hosts'            => [:view_hosts],
       'Edit hosts'            => [:view_hosts, :edit_hosts, :create_hosts, :destroy_hosts, :build_hosts],
-      'Viewer'                => [:view_hosts, :view_puppetclasses, :view_hostgroups, :view_domains, :view_operatingsystems,
-                                  :view_locations, :view_media, :view_models, :view_environments, :view_architectures,
-                                  :view_ptables, :view_globals, :view_external_variables, :view_authenticators,
-                                  :access_settings, :access_dashboard, :view_reports, :view_facts, :view_smart_proxies,
-                                  :view_subnets, :view_statistics, :view_organizations, :view_usergroups, :view_users,
-                                  :view_audit_logs, :view_realms],
+      'Viewer'                => (view_permissions << [:access_settings, :access_dashboard]).flatten,
       'Site manager'          => [:view_architectures, :view_audit_logs, :view_authenticators, :access_dashboard,
                                   :view_domains, :view_environments, :import_environments, :view_external_variables,
                                   :create_external_variables, :edit_external_variables, :destroy_external_variables,

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -156,4 +156,19 @@ class SeedsTest < ActiveSupport::TestCase
     assert Location.find_by_name('seed_test_a')
   end
 
+  test "all access permissions are created by permissions seed" do
+    seed
+    access_permissions = Foreman::AccessControl.permissions.reject(&:public?).map(&:name).map(&:to_s)
+    seeded_permissions = Permission.all.map(&:name)
+    # Check all access control have a matching seeded permission
+    assert_equal [], access_permissions - seeded_permissions
+    # Check all seeded permissions have a matching access control
+    assert_equal [], seeded_permissions - access_permissions
+  end
+
+  test "viewer role contains all view permissions" do
+    seed
+    view_permissions = Permission.all.select { |permission| permission.name.match(/view/) }
+    assert_equal [], view_permissions - Role.find_by_name('Viewer').permissions
+  end
 end


### PR DESCRIPTION
Also, compute_profiles permissions actually work now, they are useless as of now as they aren't associated with any route. I had to add external_usergroups and config_groups permissions to the seeds file too.
