### PR TITLE
Fixes #6777: Ensure associations respect organization boundaries.

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -120,6 +120,7 @@ class Host::Managed < Host::Base
   validates :environment_id,  :presence => true
   validates :organization_id, :presence => true, :if => Proc.new {|host| host.managed? && SETTINGS[:organizations_enabled] }
   validates :location_id,     :presence => true, :if => Proc.new {|host| host.managed? && SETTINGS[:locations_enabled] }
+  validates_with OrganizationAssociationValidator, :if => Proc.new {|host| host.managed? && SETTINGS[:organizations_enabled] }
 
   if SETTINGS[:unattended]
     # handles all orchestration of smart proxies.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -380,6 +380,14 @@ class User < ActiveRecord::Base
     sweeper.expire_fragment(TopbarSweeper.fragment_name(id))
   end
 
+  def allowed_organizations
+    admin? ? Organization.scoped : self.organizations
+  end
+
+  def allowed_locations
+    admin? ? Location.scoped : self.locations
+  end
+
   private
 
   def prepare_password

--- a/app/validators/organization_association_validator.rb
+++ b/app/validators/organization_association_validator.rb
@@ -1,0 +1,63 @@
+class OrganizationAssociationValidator < ActiveModel::Validator
+
+  def validate(record)
+    if record.class.respond_to?(:reflect_on_all_associations) && belongs_to_organization?(record)
+      record.class.reflect_on_all_associations.each do |association|
+
+        if (association_record = record.send(association.name))
+          if belongs_to_organization?(association_record)
+
+            association_records = association_record.is_a?(Array) ? association_record : [association_record]
+            association_records.each do |association_rec|
+              check_belongs_to(record, association_rec)
+            end
+
+          elsif has_many_organizations?(association_record)
+
+            add_error(record, association_record) if !organizations(association_record).include?(record.organization)
+
+          end
+        end
+
+      end
+    end
+  end
+
+  def check_belongs_to(record, association_record)
+
+    if belongs_to_organization?(record)
+      add_error(record, association_record) if record.organization != association_record.organization
+    elsif has_many_organizations?(record)
+      add_error(record, association_record) if organizations(record).include?(association_record.organization)
+    end
+
+  end
+
+  def class_name(record)
+    record.class.name.split('::').last
+  end
+
+  def add_error(record, association_record)
+    message = _("#{class_name(record)} and #{class_name(association_record)} '#{association_record.id}' do not belong to the same organization and cannot be associated")
+    message = record.errors[:base] << message
+  end
+
+  def belongs_to_organization?(record)
+    record = record.first if record.is_a?(Array)
+    defined?(record.class) && record.class.respond_to?(:reflect_on_association) && record.class.reflect_on_association(:organization)
+  end
+
+  def has_many_organizations?(record)
+    record = record.first if record.is_a?(Array)
+    defined?(record.class) && record.class.respond_to?(:reflect_on_association) && record.class.reflect_on_association(:organizations)
+  end
+
+  def organizations(association_record)
+    if association_record.class == User
+      association_record.allowed_organizations
+    else
+      association_record.organizations
+    end
+  end
+
+end

--- a/test/fixtures/taxable_taxonomies.yml
+++ b/test/fixtures/taxable_taxonomies.yml
@@ -123,3 +123,33 @@ twentyfour:
   taxonomy: organization1
   taxable: myrealm
   taxable_type: Realm
+
+twentyfive:
+  taxonomy: organization1
+  taxable: one
+  taxable_type: "Medium"
+
+twentysix:
+  taxonomy: organization1
+  taxable: yourdomain
+  taxable_type: "Domain"
+
+twentyseven:
+  taxonomy: organization1
+  taxable: common
+  taxable_type: "Hostgroup"
+
+twentyeight:
+  taxonomy: organization1
+  taxable: unusual
+  taxable_type: "Hostgroup"
+
+twentynine:
+  taxonomy: organization1
+  taxable: restricted
+  taxable_type: "User"
+
+thirty:
+  taxonomy: organization1
+  taxable: inherited
+  taxable_type: "Hostgroup" 

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -66,7 +66,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
     as_admin do
       ["a", "b", "c"].each  {|name| Puppetclass.create :name => name}
       for name in ["env1", "env2"] do
-        e = Environment.create!(:name => name)
+        e = Environment.create!(:name => name, :organizations => [taxonomies(:organization1)])
         e.puppetclasses += [Puppetclass.find_by_name("a"), Puppetclass.find_by_name("b"), Puppetclass.find_by_name("c")]
       end
     end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -178,6 +178,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test 'user with view host rights and ownership is set should succeed in viewing host1 but fail for host2' do
     setup_user_and_host "view", "owner_id = #{users(:one).id} and owner_type = User"
+    @one.organizations << @host1.organization
     as_admin do
       @host1.owner = @one
       @host2.owner = users(:two)
@@ -677,7 +678,7 @@ class HostsControllerTest < ActionController::TestCase
   test "update multiple organization imports taxable_taxonomies rows if succeeds on optimistic import" do
     @request.env['HTTP_REFERER'] = hosts_path
     organization = taxonomies(:organization1)
-    assert_difference "organization.taxable_taxonomies.count", 10 do
+    assert_difference "organization.taxable_taxonomies.count", 6 do
       post :update_multiple_organization, {
                                          :organization => {:id => organization.id, :optimistic_import => "yes"},
                                          :host_ids => Host.all.map(&:id)

--- a/test/functional/organizations_controller_test.rb
+++ b/test/functional/organizations_controller_test.rb
@@ -94,7 +94,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
   test "should assign all hosts with no organization to selected organization and add taxable_taxonomies" do
     organization = taxonomies(:organization1)
-    assert_difference "organization.taxable_taxonomies.count", 10 do
+    assert_difference "organization.taxable_taxonomies.count", 6 do
       post :assign_all_hosts, {:id => organization.id}, set_session_user
     end
   end
@@ -150,7 +150,7 @@ class OrganizationsControllerTest < ActionController::TestCase
       post :create, {:organization => {:name => "organization_dup_name",
                                        :environment_ids => organization_dup.environment_ids,
                                        :hostgroup_ids => organization_dup.hostgroup_ids,
-                                       :subnet_ids => organization_dup.hostgroup_ids,
+                                       :subnet_ids => organization_dup.subnet_ids,
                                        :domain_ids => organization_dup.domain_ids,
                                        :medium_ids => organization_dup.medium_ids,
                                        :user_ids => organization_dup.user_ids,

--- a/test/unit/host_observer_test.rb
+++ b/test/unit/host_observer_test.rb
@@ -22,7 +22,7 @@ class HostObserverTest < ActiveSupport::TestCase
     host = as_admin do
       Setting[:token_duration] = 30
       host = Host.create! :name => "foo", :mac => "aabbeeddccff", :ip => "2.3.4.244", :managed => true, :ptable => ptables(:one), :medium => media(:one),
-        :build => true, :architecture => architectures(:x86_64), :environment => Environment.first, :puppet_proxy_id => smart_proxies(:one).id,
+        :build => true, :architecture => architectures(:x86_64), :environment => environments(:production), :puppet_proxy_id => smart_proxies(:one).id,
         :domain => Domain.first, :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one),
         :root_pass => "xybxa6JUkz63w", :url_options => {:host => 'foreman', :protocol => "http://"},
         :location => taxonomies(:location1), :organization => taxonomies(:organization1)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -71,7 +71,6 @@ class HostTest < ActiveSupport::TestCase
   test "should be valid using 64-bit mac address" do
     host = hosts(:one)
     host.mac = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
-    host.save!
     assert_equal true, host.valid?
   end
 

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -47,10 +47,10 @@ class MediumTest < ActiveSupport::TestCase
   end
 
   test "should destroy and nullify host.medium_id if medium is in use but host.build? is false" do
-    medium = Medium.new :name => "Archlinux mirror", :path => "http://www.google.com"
+    host = hosts(:one)
+    medium = Medium.new :name => "Archlinux mirror", :path => "http://www.google.com", :organizations => [host.organization]
     assert medium.save!
 
-    host = hosts(:one)
     refute host.build?
     host.medium = medium
     host.os.media << medium
@@ -64,10 +64,10 @@ class MediumTest < ActiveSupport::TestCase
   end
 
   test "should not destroy if medium has hosts that are in build mode" do
-    medium = Medium.new :name => "Archlinux mirror", :path => "http://www.google.com"
+    host = hosts(:one)
+    medium = Medium.new :name => "Archlinux mirror", :path => "http://www.google.com", :organizations => [host.organization]
     assert medium.save!
 
-    host = hosts(:one)
     host.build = true
     host.medium = medium
     host.os.media << medium

--- a/test/unit/organization_association_validator_test.rb
+++ b/test/unit/organization_association_validator_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class OrganizationAssociationValidatorTest < ActiveSupport::TestCase
+
+  def setup
+    @validatable = Validatable.new
+  end
+
+  test "valid if all associations belong to the same Organization" do
+    assert @validatable.valid?
+    assert_empty @validatable.errors[:base]
+  end
+
+  test "invalid if any associations belong to another Organization" do
+    @validatable.organization = Organization.new(:name => 'test_name')
+
+    assert @validatable.invalid?
+    refute_empty @validatable.errors[:base]
+  end
+
+end
+
+class Validatable
+  include ActiveModel::Validations
+  validates_with OrganizationAssociationValidator
+
+  attr_accessor :organization
+
+  def initialize
+    @organization = Organization.new(:name => "validatable")
+    @@reflections = [Reflection.new(:test, @organization), Reflection.new(:organization, @organization)]
+  end
+
+  def self.reflect_on_association(association)
+    @@reflections.find { |reflect| reflect.name == association }
+  end
+
+  def self.reflect_on_all_associations
+    @@reflections
+  end
+
+  def test
+    self.class.reflect_on_association(:test)
+  end
+
+end
+
+class Reflection < Validatable
+
+  attr_accessor :name, :id
+
+  def initialize(name, organization)
+    @name = name
+    @id = name
+    @organization = organization
+  end
+
+end

--- a/test/unit/organization_test.rb
+++ b/test/unit/organization_test.rb
@@ -115,11 +115,11 @@ class OrganizationTest < ActiveSupport::TestCase
     assert_equal selected_ids[:compute_resource_ids].sort, compute_resource_ids.sort
     # match to manually generated taxable_taxonomies
     assert_equal selected_ids[:environment_ids], [environments(:production).id]
-    assert_equal selected_ids[:hostgroup_ids], []
+    assert_equal selected_ids[:hostgroup_ids].sort, [hostgroups(:unusual).id, hostgroups(:common).id, hostgroups(:inherited).id].sort
     assert_equal selected_ids[:subnet_ids], [subnets(:one).id]
-    assert_equal selected_ids[:domain_ids], [domains(:mydomain).id]
-    assert_equal selected_ids[:medium_ids], []
-    assert_equal selected_ids[:user_ids], []
+    assert_equal selected_ids[:domain_ids].sort, [domains(:mydomain).id, domains(:yourdomain).id].sort
+    assert_equal selected_ids[:medium_ids], [media(:one).id]
+    assert_equal selected_ids[:user_ids], [users(:restricted).id]
     assert_equal selected_ids[:smart_proxy_ids].sort, [smart_proxies(:puppetmaster).id, smart_proxies(:one).id, smart_proxies(:two).id, smart_proxies(:three).id, smart_proxies(:realm).id].sort
     assert_equal selected_ids[:config_template_ids], [config_templates(:mystring2).id]
     assert_equal selected_ids[:compute_resource_ids], [compute_resources(:one).id]

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -649,4 +649,20 @@ class UserTest < ActiveSupport::TestCase
     User.complete_for('login = ').each { |ac| refute_match users(:anonymous).login, ac }
   end
 
+  test "allowed_organizations for admin" do
+    assert_equal users(:admin).allowed_organizations.length, Organization.all.count
+  end
+
+  test "allowed_locations for admin" do
+    assert_equal users(:admin).allowed_locations.length, Location.all.count
+  end
+
+  test "allowed_organizations for restricted user" do
+    assert_equal users(:restricted).allowed_organizations, [taxonomies(:organization1)]
+  end
+
+  test "allowed_locations for restricted user" do
+    assert_empty users(:restricted).allowed_locations
+  end
+
 end


### PR DESCRIPTION
Resources that contain a belongs to relationship to Organization
should only be associated to other resources that are within that
organization. Further, two resources that belong to different
organizations should not be allowed to be associated to one another.

This issue manifests itself among hosts and most Katello resources.
For hosts, resources that are not available in the hosts organization
should not be allowed to be associated to the host. In Katello,
resources are allowed to belong to a single organization and should
not be allowed to cross boundaries. For example, a product in organization
A should not be allowed to be associated with a GPG key in organization
B.

Finally, this solution takes the approach of validating the association
relationships at the model level to ensure no inconsistent data can
be created at any layer of the application.
