### PR TITLE
fixes #6964 - replace default scope that hides users with explicit scope

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,7 +13,7 @@ module Api
 
       def index
         @users = User.
-          authorized(:view_users).
+          authorized(:view_users).except_hidden.
           search_for(*search_options).paginate(paginate_options)
       end
 

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -17,7 +17,7 @@ module Api
 
       def index
         @users = User.
-          authorized(:view_users).
+          authorized(:view_users).except_hidden.
           search_for(*search_options).paginate(paginate_options)
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_mail
-    if User.current && User.current.mail.blank?
+    if User.current && !User.current.hidden? && User.current.mail.blank?
       notice _("Mail is Required")
       redirect_to edit_user_path(:id => User.current)
     end

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -30,7 +30,7 @@ module Foreman::Controller::Authentication
     else
       # We assume we always have a user logged in
       # if authentication is disabled, the user is the built-in admin account
-      set_current_user User.only_admin.first
+      set_current_user User.only_admin.except_hidden.first
     end
   end
 

--- a/app/controllers/concerns/foreman/controller/users_mixin.rb
+++ b/app/controllers/concerns/foreman/controller/users_mixin.rb
@@ -6,6 +6,10 @@ module Foreman::Controller::UsersMixin
     before_filter :clear_params_on_update, :update_admin_flag, :only => :update
   end
 
+  def resource_scope(controller = controller_name)
+    super(controller).except_hidden
+  end
+
   protected
   def set_admin_on_creation
     admin = params[:user].delete :admin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
   skip_before_filter :update_admin_flag, :only => :update
 
   def index
-    @users = User.authorized(:view_users).search_for(params[:search], :order => params[:order]).includes(:auth_source).paginate(:page => params[:page])
+    @users = User.authorized(:view_users).except_hidden.search_for(params[:search], :order => params[:order]).includes(:auth_source).paginate(:page => params[:page])
   end
 
   def new
@@ -117,7 +117,7 @@ class UsersController < ApplicationController
   private
 
   def find_resource(permission = :view_users)
-    editing_self? ? User.current : User.authorized(permission).find(params[:id])
+    editing_self? ? User.current : User.authorized(permission).except_hidden.find(params[:id])
   end
 
   def login_user(user)

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -24,6 +24,7 @@ class Usergroup < ActiveRecord::Base
   # The text item to see in a select dropdown menu
   alias_attribute :select_title, :to_s
   default_scope lambda { order('usergroups.name') }
+  scope :visible, lambda { }
   scoped_search :on => :name, :complete_value => :true
   validate :ensure_uniq_name, :ensure_last_admin_remains_admin
 

--- a/app/services/sso/base.rb
+++ b/app/services/sso/base.rb
@@ -37,7 +37,7 @@ module SSO
     end
 
     def current_user
-      return User.find_by_login(self.user)
+      return User.except_hidden.find_by_login(self.user)
     end
 
   end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -108,7 +108,7 @@
       <div class="tab-pane"  id="info">
         <% if SETTINGS[:login] %>
           <%= selectable_f f, :is_owned_by, option_groups_from_collection_for_select(
-            [User, Usergroup], :all, :table_name, :id_and_type, :select_title,
+            [User, Usergroup], :visible, :table_name, :id_and_type, :select_title,
             @host.is_owned_by || User.current.id_and_type), { :include_blank => _("select an owner") }, { :label => _("Owned By") }
           %>
         <% end %>

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -14,7 +14,7 @@
     <div class="tab-pane active" id="primary">
       <%= text_f f, :name %>
       <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
-      <%= multiple_checkboxes f, :users, @usergroup, User, :label => _("Users") %>
+      <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden, :label => _("Users") %>
     </div>
 
     <div class="tab-pane" id="roles">

--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -13,7 +13,7 @@
   <% for usergroup in @usergroups %>
     <tr>
       <td><%= link_to_if_authorized h(usergroup.name), hash_for_edit_usergroup_path(:id => usergroup.id).merge(:auth_object => usergroup, :authorizer => authorizer) %></td>
-      <td><%= h usergroup.users.map(&:login).to_sentence %></td>
+      <td><%= h usergroup.users.except_hidden.map(&:login).to_sentence %></td>
       <td><%= h usergroup.usergroups.map(&:name).to_sentence %></td>
       <td>
         <%= display_delete_if_authorized hash_for_usergroup_path(:id => usergroup).merge(:auth_object => usergroup, :authorizer => authorizer),

--- a/test/functional/api/v1/users_controller_test.rb
+++ b/test/functional/api/v1/users_controller_test.rb
@@ -154,4 +154,15 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   end
 =end
 
+  test "#index should not show hidden users" do
+    get :index, { :search => "login == #{users(:anonymous).login}" }
+    results = ActiveSupport::JSON.decode(@response.body)
+    assert results.empty?, results.inspect
+  end
+
+  test "#find_resource should not return hidden users" do
+    get :show, { :id => users(:anonymous).id }
+    assert_response :not_found
+  end
+
 end

--- a/test/functional/api/v2/users_controller_test.rb
+++ b/test/functional/api/v2/users_controller_test.rb
@@ -149,4 +149,15 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     end
   end
 
+  test "#index should not show hidden users" do
+    get :index, { :search => "login == #{users(:anonymous).login}" }
+    results = ActiveSupport::JSON.decode(@response.body)
+    assert results['results'].empty?, results.inspect
+  end
+
+  test "#find_resource should not return hidden users" do
+    get :show, { :id => users(:anonymous).id }
+    assert_response :not_found
+  end
+
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -11,12 +11,23 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "#index should not show hidden users" do
+    get :index, { :search => "login = #{users(:anonymous).login}" }, set_session_user
+    assert_response :success
+    assert_empty assigns(:users)
+  end
+
   test "should get edit" do
     u = User.new :login => "foo", :mail => "foo@bar.com", :auth_source => auth_sources(:one)
     assert u.save!
     logger.info "************ ID = #{u.id}"
     get :edit, {:id => u.id}, set_session_user
     assert_response :success
+  end
+
+  test "#edit should not find a hidden user" do
+    get :edit, {:id => users(:anonymous).id}, set_session_user
+    assert_response :not_found
   end
 
   test 'should create regular user' do

--- a/test/unit/sso/base_test.rb
+++ b/test/unit/sso/base_test.rb
@@ -11,7 +11,7 @@ class BaseTest < ActiveSupport::TestCase
   def test_user
     controller = get_controller
     base = SSO::Base.new(controller)
-    base.expects(:user).returns(User.first.login)
+    base.expects(:user).returns(users(:one).login)
     assert_kind_of User, base.current_user
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -645,4 +645,8 @@ class UserTest < ActiveSupport::TestCase
     assert user.destroyed?
   end
 
+  test "auto-complete doesn't show hidden users" do
+    User.complete_for('login = ').each { |ac| refute_match users(:anonymous).login, ac }
+  end
+
 end


### PR DESCRIPTION
My aim is to fix http://projects.theforeman.org/issues/6964, which remained after my attempt to fix a similar issue in 3dd51f407.  This latest error in 6964 is again caused by the default scope hiding users, so associations aren't resolving properly in user roles, which causes problems with role caching.

I could have continued to add workarounds to find users that aren't shown by the default scope, but decided instead to partially implement 6878 (removal of default scopes) and try to hide hidden users at the controller level instead.  It was much easier than I expected, but would appreciate any help thinking of remaining issues where hidden users might be visible when they shouldn't be.

Successfully done a test install with this patch.
