### PR TITLE
In host's edit page, show the source for the value of puppet class parameters

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -10,10 +10,11 @@ module CommonParametersHelper
   end
 
   def parameter_value_field value
+    source_name = value[:source_name] ? "(#{value[:source_name]})" : nil
     content_tag :div, :class => "form-group condensed" do
       text_area_tag("value_#{value[:safe_value]}", value[:safe_value], :rows => (value[:safe_value].to_s.lines.count || 1 rescue 1),
                     :class => "col-md-5", :disabled => true, :'data-hidden-value' => Parameter.hidden_value) +
-      content_tag(:span, :class => "help-block") { popover(_("Additional info"), _("<b>Source:</b> %s") % _(value[:source].to_s))}
+      content_tag(:span, :class => "help-block") { popover(_("Additional info"), _("<b>Source:</b> %{type} %{name}") % {:type => _(value[:source].to_s), :name => source_name})}
     end
   end
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -84,7 +84,7 @@ module LookupKeysHelper
 
   def host_key_with_diagnostic host, value_hash, key
      value_for_key = value_hash[key.id] && value_hash[key.id][key.key]
-     value, matcher = value_for_key ? [value_for_key[:value], value_for_key[:element]] : [key.default_value, _("Default value")]
+     value, matcher = value_for_key ? [value_for_key[:value], "#{value_for_key[:element]} (#{value_for_key[:element_name]})"] : [key.default_value, _("Default value")]
      original_value = key.value_before_type_cast value
      no_value = value.nil? && key.lookup_values.find_by_match("fqdn=#{host.fqdn}")
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -402,9 +402,10 @@ class Host::Managed < Host::Base
     hp.update organization.parameters(include_source) if SETTINGS[:organizations_enabled] && organization
     hp.update location.parameters(include_source)     if SETTINGS[:locations_enabled] && location
     # read domain parameters
-    domain.domain_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('domain').to_sym, :safe_value => p.safe_value} : p.value] } unless domain.nil?
+    domain.domain_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('domain').to_sym, :safe_value => p.safe_value, :source_name => domain.name} : p.value] } unless domain.nil?
     # read OS parameters
-    operatingsystem.os_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('os').to_sym, :safe_value => p.safe_value} : p.value] } unless operatingsystem.nil?
+    operatingsystem.os_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('os').to_sym, :safe_value => p.safe_value, :source_name => operatingsystem.to_label} : p.value] } unless operatingsystem.nil?
+
     # read group parameters only if a host belongs to a group
     hp.update hostgroup.parameters(include_source) if hostgroup
     hp

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -405,7 +405,6 @@ class Host::Managed < Host::Base
     domain.domain_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('domain').to_sym, :safe_value => p.safe_value, :source_name => domain.name} : p.value] } unless domain.nil?
     # read OS parameters
     operatingsystem.os_parameters.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('os').to_sym, :safe_value => p.safe_value, :source_name => operatingsystem.to_label} : p.value] } unless operatingsystem.nil?
-
     # read group parameters only if a host belongs to a group
     hp.update hostgroup.parameters(include_source) if hostgroup
     hp

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -128,7 +128,8 @@ class Hostgroup < ActiveRecord::Base
     # otherwise we might be overwriting the hash in the wrong order.
     groups = ids.size == 1 ? [self] : Hostgroup.includes(:group_parameters).sort_by_ancestry(Hostgroup.find(ids))
     groups.each do |hg|
-      hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym, :safe_value => p.safe_value} : p.value }
+
+      hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym, :safe_value => p.safe_value, :source_name => hg.title} : p.value }
     end
     hash
   end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -130,6 +130,7 @@ class Hostgroup < ActiveRecord::Base
     groups.each do |hg|
       hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym, :safe_value => p.safe_value, :source_name => hg.title} : p.value }
    end
+
     hash
   end
 

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -128,9 +128,8 @@ class Hostgroup < ActiveRecord::Base
     # otherwise we might be overwriting the hash in the wrong order.
     groups = ids.size == 1 ? [self] : Hostgroup.includes(:group_parameters).sort_by_ancestry(Hostgroup.find(ids))
     groups.each do |hg|
-
       hg.group_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('hostgroup').to_sym, :safe_value => p.safe_value, :source_name => hg.title} : p.value }
-    end
+   end
     hash
   end
 

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -35,7 +35,7 @@ class Location < Taxonomy
     # otherwise we might be overwriting the hash in the wrong order.
     locs = ids.size == 1 ? [self] : Location.includes(:location_parameters).sort_by_ancestry(Location.find(ids))
     locs.each do |loc|
-      loc.location_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('location').to_sym} : p.value }
+      loc.location_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('location').to_sym, :source_name => loc.title} : p.value }
     end
     hash
   end

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -35,7 +35,7 @@ class Organization < Taxonomy
     # otherwise we might be overwriting the hash in the wrong order.
     orgs = ids.size == 1 ? [self] : Organization.includes(:organization_parameters).sort_by_ancestry(Organization.find(ids))
     orgs.each do |org|
-      org.organization_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('organization').to_sym} : p.value }
+      org.organization_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('organization').to_sym, :source_name => org.title} : p.value }
     end
     hash
   end

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -42,9 +42,10 @@ module Classification
           key = class_parameters.detect{|k| k.id == value.lookup_key_id }
           name = key.to_s
           element = match.split(LookupKey::EQ_DELM).first
+          element_name = match.split(LookupKey::EQ_DELM).last
           next if options[:skip_fqdn] && element=="fqdn"
           if values[key_id][name].nil?
-            values[key_id][name] = {:value => value.value, :element => element}
+            values[key_id][name] = {:value => value.value, :element => element, :element_name => element_name}
           else
             if key.path.index(element) < key.path.index(values[key_id][name][:element])
               values[key_id][name] = {:value => value.value, :element => element}

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -81,6 +81,17 @@ class ClassificationTest < ActiveSupport::TestCase
     assert_equal({pc.name => {lkey.key => 'overridden value'}}, classparam.enc)
   end
 
+  test "#values_hash should contain element's name" do
+    env = FactoryGirl.create(:environment)
+    pc = FactoryGirl.create(:puppetclass, :environments => [env])
+    lkey = FactoryGirl.create(:lookup_key, :as_smart_class_param, :with_override, :puppetclass => pc)
+    classparam = Classification::ClassParam.new
+    classparam.expects(:environment_id).returns(env.id)
+    classparam.expects(:puppetclass_ids).returns(Array.wrap(pc).map(&:id))
+    classparam.expects(:attr_to_value).with('comment').returns('override')
+    assert_equal({pc.id => {lkey.key => { :value => 'overridden value', :element => 'comment', :element_value => 'override'}}}, classparam.send(:values_hash))
+  end
+
   private
 
   attr_reader :classification

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -89,7 +89,7 @@ class ClassificationTest < ActiveSupport::TestCase
     classparam.expects(:environment_id).returns(env.id)
     classparam.expects(:puppetclass_ids).returns(Array.wrap(pc).map(&:id))
     classparam.expects(:attr_to_value).with('comment').returns('override')
-    assert_equal({pc.id => {lkey.key => { :value => 'overridden value', :element => 'comment', :element_value => 'override'}}}, classparam.send(:values_hash))
+    assert_equal({lkey.id => {lkey.key => { :value => 'overridden value', :element => 'comment', :element_name => 'override'}}}, classparam.send(:values_hash))
   end
 
   private


### PR DESCRIPTION
Currently, on the edit hosts page, under the parameters tab, if a parameter was overridden in the host's hostgroup (or that hostgroup's hostgroup), the additional information popup for that parameter says "Matcher: hostgroup."

![screen shot 2014-08-07 at 5 33 25 pm](https://cloud.githubusercontent.com/assets/4042349/3851389/fc038b6e-1e93-11e4-9e80-41d775df765c.png)

This is not very useful because the parameter's value could be coming from the hostgroup or a grandparent hostgroup. It would be more useful to display the actual hostgroup's name so that we know precisely from which parent the parameter's overridden value is coming from. 

![screen shot 2014-08-07 at 5 39 05 pm](https://cloud.githubusercontent.com/assets/4042349/3851415/7660d574-1e94-11e4-822d-df05ebc84b39.png)
