### PR TITLE
refs #5190 - updating dependency on apipie-rails, BZ 1102264

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'scoped_search', '>= 2.7.0', '< 3.0.0'
 gem 'net-ldap'
 gem 'ldap_fluff', '>= 0.3.0', '< 1.0.0'
 gem 'uuidtools'
-gem "apipie-rails", "~> 0.2.0", "< 0.2.3"
+gem "apipie-rails", "~> 0.2.4"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oauth'
 gem 'deep_cloneable', '~> 2.0'


### PR DESCRIPTION
so that we can mark apidoc'd routes as deprecated
