### PR TITLE
Fixes #7013 - pin apipie-rails to < 0.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'scoped_search', '>= 2.7.0', '< 3.0.0'
 gem 'net-ldap'
 gem 'ldap_fluff', '>= 0.3.0', '< 1.0.0'
 gem 'uuidtools'
-gem "apipie-rails", "~> 0.2.0"
+gem "apipie-rails", "~> 0.2.0", "< 0.2.3"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oauth'
 gem 'deep_cloneable', '~> 2.0'


### PR DESCRIPTION
0.2.3 was released with a Ruby 1.8.7 incompatible syntax method
definition. [This](http://ci.theforeman.org/view/Core/job/test_develop/795/database=postgresql,ruby=1.8.7/console) has been breaking test_develop in Jenkins for a day.

<s>The fix on apipie-rails should be trivial, I'm working on it.</s>

There's a fix for it at https://github.com/Apipie/apipie-rails/pull/272
