### PR TITLE
Revert "Fixes #7013 - pin apipie-rails to < 0.2.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'scoped_search', '>= 2.7.0', '< 3.0.0'
 gem 'net-ldap'
 gem 'ldap_fluff', '>= 0.3.0', '< 1.0.0'
 gem 'uuidtools'
-gem "apipie-rails", "~> 0.2.0", "< 0.2.3"
+gem "apipie-rails", "~> 0.2.0"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oauth'
 gem 'deep_cloneable', '~> 2.0'


### PR DESCRIPTION
This reverts commit 33a90a9eecef8cc7105706a9d492f01d39e55b2a.

apipie-rails 0.2.4 restores 1.8 compatibility.
