### PR TITLE
Fixes #6998 - Accept native true for overwrite parameter to host API.

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -610,7 +610,7 @@ class Host::Managed < Host::Base
 
   # We have to coerce the value back to boolean. It is not done for us by the framework.
   def overwrite=(value)
-    @overwrite = value == "true"
+    @overwrite = value.to_s == "true"
   end
 
   def require_ip_validation?


### PR DESCRIPTION
I found I had to encode the API parameter Overwrite as `{"overwrite": "true"}` rather than as a native JSON boolean. The quoted form is needed for the UI. This change allows both forms from the API.
