### PR TITLE
Fixes #6710 - unicode characters in url parameters

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -2,6 +2,7 @@ class Architecture < ActiveRecord::Base
   include Authorizable
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   validates_lengths_from_database
@@ -16,9 +17,5 @@ class Architecture < ActiveRecord::Base
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :hosts_count
-
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 
 end

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -23,6 +23,7 @@ class AuthSourceLdap < AuthSource
 
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   validates :host, :presence => true, :length => {:maximum => 60}, :allow_nil => true
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :presence => true, :if => Proc.new { |auth| auth.onthefly_register? }
@@ -104,10 +105,6 @@ class AuthSourceLdap < AuthSource
 
   def users_in_group(name)
     ldap_con.user_list(name)
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   private

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -2,6 +2,7 @@ class Bookmark < ActiveRecord::Base
   include Authorizable
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
 
@@ -34,7 +35,4 @@ class Bookmark < ActiveRecord::Base
     self.owner ||= User.current
   end
 
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 end

--- a/app/models/compute_profile.rb
+++ b/app/models/compute_profile.rb
@@ -3,6 +3,7 @@ class ComputeProfile < ActiveRecord::Base
   include Authorizable
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
   attr_accessible :name
@@ -21,9 +22,5 @@ class ComputeProfile < ActiveRecord::Base
   default_scope lambda { order('compute_profiles.name') }
 
   scope :visibles, lambda { includes(:compute_attributes).where('compute_attributes.id > 0') }
-
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 
 end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -3,6 +3,7 @@ class ComputeResource < ActiveRecord::Base
   include Taxonomix
   include Encryptable
   include Authorizable
+  include Parameterizable::ByIdName
   encrypts :password
 
   class_attribute :supported_providers
@@ -94,10 +95,6 @@ class ComputeResource < ActiveRecord::Base
     vm = find_vm_by_uuid(uuid)
     vm.attributes.merge!(attr.symbolize_keys)
     vm.save
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   def to_label

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -36,7 +36,7 @@ module NestedAncestryCommon
   alias_method :get_label, :get_title
 
   def to_param
-    "#{id}-#{get_title.parameterize}"
+    Parameterizable.parameterize("#{id}-#{get_title}")
   end
 
   module ClassMethods

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -1,0 +1,54 @@
+module Parameterizable
+
+  def self.parameterize(string)
+    string.gsub('/', '-').gsub(/[!*'();:@&=+$,?%#\[\]]/, '').chomp('-')
+  end
+
+  module ById
+    extend ActiveSupport::Concern
+
+    included do
+      def to_param
+        id.to_s
+      end
+
+      def self.from_param(id)
+        self.find(id.to_i)
+      end
+    end
+  end
+
+  module ByIdName
+    extend ActiveSupport::Concern
+
+    included do
+      def to_param
+        # remove characters unsafe for urls, keep unicode ones
+        Parameterizable.parameterize("#{id}-#{name}")
+      end
+
+      def self.from_param(id_name)
+        self.find(id_name.to_i)
+      end
+    end
+  end
+
+  module ByName
+    extend ActiveSupport::Concern
+
+    # Warning:
+    # This parameterization is allowed only for resources that have url-safe names!
+    # Check the name format validator before use.
+
+    included do
+      def to_param
+        name
+      end
+
+      def self.from_param(name)
+        self.find_by_name(name)
+      end
+    end
+  end
+
+end

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -1,6 +1,7 @@
 class ConfigGroup < ActiveRecord::Base
   audited :allow_mass_assignment => true
   include Authorizable
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
 
@@ -19,10 +20,6 @@ class ConfigGroup < ActiveRecord::Base
   scoped_search :on => :config_group_classes_count
 
   default_scope lambda { order('config_groups.name') }
-
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 
   # the following methods are required for app/views/puppetclasses/_class_selection.html.erb
   alias_method :classes, :puppetclasses

--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -3,6 +3,7 @@ class ConfigTemplate < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include Taxonomix
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
   audited :allow_mass_assignment => true
@@ -45,10 +46,6 @@ class ConfigTemplate < ActiveRecord::Base
 
   class Jail < Safemode::Jail
     allow :name
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   def clone

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -6,6 +6,8 @@ class Domain < ActiveRecord::Base
   friendly_id :name
   include Taxonomix
   include StripLeadingAndTrailingDot
+  include Parameterizable::ByIdName
+
   audited :allow_mass_assignment => true
 
   validates_lengths_from_database
@@ -40,10 +42,6 @@ class Domain < ActiveRecord::Base
 
   class Jail < Safemode::Jail
     allow :name, :fullname
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   # return the primary name server for our domain based on DNS lookup

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -3,6 +3,7 @@ class Environment < ActiveRecord::Base
   friendly_id :name
   include Taxonomix
   include Authorizable
+  include Parameterizable::ByName
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
@@ -28,10 +29,6 @@ class Environment < ActiveRecord::Base
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :hosts_count
   scoped_search :on => :hostgroups_count
-
-  def to_param
-    name
-  end
 
   class << self
 

--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -1,4 +1,6 @@
 class FactName < ActiveRecord::Base
+  include Parameterizable::ByIdName
+
   SEPARATOR = '::'
 
   validates_lengths_from_database
@@ -23,10 +25,6 @@ class FactName < ActiveRecord::Base
   before_save :set_name, :if => Proc.new { |fact| fact.short_name.blank? }
 
   has_ancestry
-
-  def to_param
-    name
-  end
 
   def set_name
     self.short_name = self.name.split(SEPARATOR).last

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -3,6 +3,7 @@ module Host
     include Foreman::STI
     include Authorizable
     include CounterCacheFix
+    include Parameterizable::ByName
 
     self.table_name = :hosts
     extend FriendlyId
@@ -134,10 +135,6 @@ module Host
         hash[fact.fact_name.name] = fact.value
       end
       hash
-    end
-
-    def to_param
-      name
     end
 
     def ==(comparison_object)

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -98,7 +98,7 @@ class LookupKey < ActiveRecord::Base
   end
 
   def to_param
-    "#{id}-#{key.parameterize}"
+    Parameterizable.parameterize("#{id}-#{key}")
   end
 
   def to_s

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -3,6 +3,7 @@ class Puppetclass < ActiveRecord::Base
   include ScopedSearchExtensions
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
@@ -43,10 +44,6 @@ class Puppetclass < ActiveRecord::Base
   scoped_search :in => :class_params, :on => :key, :complete_value => :true, :only_explicit => true
 
   scope :not_in_any_environment, lambda { includes(:environment_classes).where(:environment_classes => {:environment_id => nil}) }
-
-  def to_param
-    name
-  end
 
   # returns a hash containing modules and associated classes
   def self.classes2hash(classes)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -20,6 +20,8 @@ class Role < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
 
+  include Parameterizable::ByIdName
+
   # Built-in roles
   BUILTIN_DEFAULT_USER  = 1
   BUILTIN_ANONYMOUS     = 2
@@ -50,10 +52,6 @@ class Role < ActiveRecord::Base
   validates :builtin, :inclusion => { :in => 0..2 }
 
   scoped_search :on => :name, :complete_value => true
-
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 
   def initialize(*args)
     super(*args)

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -3,6 +3,7 @@ class SmartProxy < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include Taxonomix
+  include Parameterizable::ByIdName
   audited :allow_mass_assignment => true
 
   attr_accessible :name, :url, :location_ids, :organization_ids
@@ -58,10 +59,6 @@ class SmartProxy < ActiveRecord::Base
     else
       hostname
     end
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   def self.smart_proxy_ids_for(hosts)

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -7,6 +7,7 @@ class Subnet < ActiveRecord::Base
   extend FriendlyId
   friendly_id :network
   include Taxonomix
+  include Parameterizable::ByIdName
   audited :allow_mass_assignment => true
 
   validates_lengths_from_database :except => [:gateway]
@@ -65,10 +66,6 @@ class Subnet < ActiveRecord::Base
 
   def self.ipam_modes_with_translations
     modes_with_translations(IPAM_MODES)
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   # Subnets are displayed in the form of their network network/network mask

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -2,6 +2,7 @@ class Location < Taxonomy
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::LocationModel
+  include Parameterizable::ByIdName
 
   has_and_belongs_to_many :organizations
   has_many_hosts :dependent => :nullify
@@ -36,10 +37,6 @@ class Location < Taxonomy
       loc.location_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('location').to_sym, :source_name => loc.title} : p.value }
     end
     hash
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   def dup

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -2,6 +2,7 @@ class Organization < Taxonomy
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::OrganizationModel
+  include Parameterizable::ByIdName
 
   has_and_belongs_to_many :locations
   has_many_hosts :dependent => :nullify
@@ -36,10 +37,6 @@ class Organization < Taxonomy
       org.organization_parameters.each {|p| hash[p.name] = include_source ? {:value => p.value, :source => N_('organization').to_sym, :source_name => org.title} : p.value }
     end
     hash
-  end
-
-  def to_param
-    "#{id}-#{name.parameterize}"
   end
 
   def dup

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -11,7 +11,7 @@ class Trend < ActiveRecord::Base
   scope :types, lambda { where(:fact_value => nil) }
 
   def to_param
-    "#{id}-#{to_label.parameterize}"
+    Parameterizable.parameterize("#{id}-#{to_label}")
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ActiveRecord::Base
   alias_method :name, :to_label
 
   def to_param
-    "#{id}-#{login.parameterize}"
+    Parameterizable.parameterize("#{id}-#{login}")
   end
 
   def <=>(other)

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -3,6 +3,7 @@ class Usergroup < ActiveRecord::Base
   include Authorizable
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts), :ensure_last_admin_group_is_not_deleted
@@ -31,10 +32,6 @@ class Usergroup < ActiveRecord::Base
   validate :ensure_uniq_name, :ensure_last_admin_remains_admin
 
   accepts_nested_attributes_for :external_usergroups, :reject_if => lambda { |a| a[:name].blank? }, :allow_destroy => true
-
-  def to_param
-    "#{id}-#{name.parameterize}"
-  end
 
   # This methods retrieves all user addresses in a usergroup
   # Returns: Array of strings representing the user's email addresses

--- a/app/services/smart_proxies/puppet_ca.rb
+++ b/app/services/smart_proxies/puppet_ca.rb
@@ -1,6 +1,7 @@
 require "time"
 
 class SmartProxies::PuppetCA
+  include Parameterizable::ByIdName
 
   attr_reader :name, :state, :fingerprint, :valid_from, :expires_at, :smart_proxy_id
 
@@ -49,8 +50,6 @@ class SmartProxies::PuppetCA
     Rails.cache.delete("ca_#{proxy.id}") if Rails.env.production?
     ProxyAPI::Puppetca.new({:url => proxy.url}).del_certificate name
   end
-
-  def to_param; name end
 
   def to_s; name end
 

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -15,7 +15,7 @@
       <td><%=h architecture.operatingsystems.map(&:to_label).to_sentence %></td>
       <td><%= link_to architecture.hosts_count, hosts_path(:search => "architecture = #{architecture}") %>
       <td align="right">
-        <%= display_delete_if_authorized hash_for_architecture_path(:id => architecture.name).merge(:auth_object => architecture, :authorizer => authorizer),
+        <%= display_delete_if_authorized hash_for_architecture_path(:id => architecture).merge(:auth_object => architecture, :authorizer => authorizer),
                                          :confirm => _("Delete %s?") % architecture.name %>
       </td>
     </tr>

--- a/app/views/auth_source_ldaps/index.html.erb
+++ b/app/views/auth_source_ldaps/index.html.erb
@@ -14,7 +14,7 @@
   </tr>
   <% for auth_source_ldap in @auth_source_ldaps %>
     <tr>
-      <td><%=link_to_if_authorized trunc(auth_source_ldap.name), hash_for_edit_auth_source_ldap_path(:id => auth_source_ldap.id) %></td>
+      <td><%=link_to_if_authorized trunc(auth_source_ldap.name), hash_for_edit_auth_source_ldap_path(:id => auth_source_ldap) %></td>
       <td><%=h auth_source_ldap.host %></td>
       <td><%=checked_icon auth_source_ldap.onthefly_register %></td>
       <td><%=checked_icon auth_source_ldap.tls %></td>

--- a/app/views/bookmarks/_form.html.erb
+++ b/app/views/bookmarks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @bookmark, :url => (@bookmark.new_record? ? bookmarks_path : bookmark_path(:id => @bookmark.id)) do |f| %>
+<%= form_for @bookmark, :url => (@bookmark.new_record? ? bookmarks_path : bookmark_path(:id => @bookmark)) do |f| %>
   <%= base_errors_for @bookmark %>
   <%= text_f f, :name %>
   <%= textarea_f f, :query, :value => params[:query], :size => "col-md-8" , :rows=> '3' %>

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <% for common_parameter in @common_parameters %>
     <tr>
-      <td><%= link_to_if_authorized trunc(common_parameter), hash_for_edit_common_parameter_path(:id => common_parameter.id).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'edit_globals') %></td>
+      <td><%= link_to_if_authorized trunc(common_parameter), hash_for_edit_common_parameter_path(:id => common_parameter).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'edit_globals') %></td>
       <td style='overflow-wrap: break-word;'><%= trunc(common_parameter.safe_value, 80) %></td>
       <td class="ra">
         <%= display_delete_if_authorized hash_for_common_parameter_path(:id => common_parameter).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'destroy_globals'),

--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -15,7 +15,7 @@
         <% if @config_template.locked? -%>
         <%= alert :class => 'alert-warning', :header => '',
             :text  => icon_text("warning-sign", (_("Warning: This template is locked. You may only change the associations. Please %s it to customize.") %
-                                                link_to(_('clone'), hash_for_clone_config_template_path(:id => @config_template.id))).html_safe) %>
+                                                link_to(_('clone'), hash_for_clone_config_template_path(:id => @config_template))).html_safe) %>
 
         <% else -%>
         <%= alert :class => 'alert-success', :header => '',

--- a/app/views/domains/_form.html.erb
+++ b/app/views/domains/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @domain, :url => (@domain.new_record? ? domains_path : domain_path(:id => @domain.id)) do |f| %>
+<%= form_for @domain, :url => (@domain.new_record? ? domains_path : domain_path(:id => @domain)) do |f| %>
   <%= base_errors_for @domain %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("Domain") %></a></li>

--- a/app/views/environments/_form.html.erb
+++ b/app/views/environments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @environment, :url => (@environment.new_record? ? environments_path : environment_path(:id => @environment.id)) do |f| %>
+<%= form_for @environment, :url => (@environment.new_record? ? environments_path : environment_path(:id => @environment)) do |f| %>
   <%= base_errors_for @environment %>
   <% if show_taxonomy_tabs? %>
     <ul class="nav nav-tabs" data-tabs="tabs">

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -12,13 +12,13 @@
   <% @environments.each do |environment| %>
     <tr>
       <td>
-        <%= link_to_if_authorized trunc(environment.name), hash_for_edit_environment_path(:id => environment.name).merge(:auth_object => environment, :authorizer => authorizer) %>
+        <%= link_to_if_authorized trunc(environment.name), hash_for_edit_environment_path(:id => environment).merge(:auth_object => environment, :authorizer => authorizer) %>
       </td>
       <td><%= link_to environment.hosts_count, hosts_path(:search => "environment = #{environment}") %>
       <td>
         <%= action_buttons(link_to(_('Classes'), puppetclasses_path(:search => "environment = #{environment}")),
-                           import_proxy_links(hash_for_import_environments_environments_path(:env => environment.name)),
-                           display_delete_if_authorized(hash_for_environment_path(:id => environment.name).merge(:auth_object => environment, :authorizer => authorizer), :confirm => "Delete #{environment.name}?")) %>
+                           import_proxy_links(hash_for_import_environments_environments_path(:env => environment)),
+                           display_delete_if_authorized(hash_for_environment_path(:id => environment).merge(:auth_object => environment, :authorizer => authorizer), :confirm => "Delete #{environment.name}?")) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -1,9 +1,9 @@
 <% title(_("Edit %s") % @host) %>
 <% if SETTINGS[:unattended] %>
   <% title_actions display_link_if_authorized((@host.managed? ? _("Unmanage host") : _("Manage host")),
-    hash_for_toggle_manage_host_path(:id => @host.name).merge(:auth_object => @host, :permission => 'edit_hosts'), {:method => :put}),
+    hash_for_toggle_manage_host_path(:id => @host).merge(:auth_object => @host, :permission => 'edit_hosts'), {:method => :put}),
     display_link_if_authorized(_("Disassociate host"),
-    hash_for_disassociate_host_path(:id => @host.name).merge(:auth_object => @host, :permission => 'edit_hosts'), :method => :put) %>
+    hash_for_disassociate_host_path(:id => @host).merge(:auth_object => @host, :permission => 'edit_hosts'), :method => :put) %>
 <% end %>
 
 <%= render :partial => 'hosts/form' %>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -13,7 +13,7 @@
   </tr>
   <% for medium in @media %>
     <tr>
-      <td><%= link_to_if_authorized trunc(medium), hash_for_edit_medium_path(:id => medium.id).merge(:auth_object => medium, :authorizer => authorizer) %></td>
+      <td><%= link_to_if_authorized trunc(medium), hash_for_edit_medium_path(:id => medium).merge(:auth_object => medium, :authorizer => authorizer) %></td>
       <td><%= medium.path %></td>
       <td><%= lookup_family(medium.os_family) %></td>
       <td><%= medium.operatingsystems.map(&:to_label).to_sentence %></td>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <% for operatingsystem in @operatingsystems %>
     <tr>
-      <td><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem.id).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
+      <td><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
       <td class="ra"><%= link_to operatingsystem.hosts_count, hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
       <td class="ra">
         <%= display_delete_if_authorized hash_for_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer),

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <% for ptable in @ptables %>
     <tr>
-      <td><%= link_to_if_authorized trunc(ptable), hash_for_edit_ptable_path(:id => ptable.id).merge(:auth_object => ptable, :authorizer => authorizer) %></td>
+      <td><%= link_to_if_authorized trunc(ptable), hash_for_edit_ptable_path(:id => ptable).merge(:auth_object => ptable, :authorizer => authorizer) %></td>
       <td><%= lookup_family(ptable.os_family) %></td>
       <td><%= ptable.operatingsystems.map(&:to_label).to_sentence %></td>
       <td>

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -1,6 +1,6 @@
 <%= javascript "lookup_keys" %>
 
-<%= form_for @puppetclass, :url => (@puppetclass.new_record? ? puppetclasses_path : puppetclass_path(:id => @puppetclass.id)) do |f| %>
+<%= form_for @puppetclass, :url => (@puppetclass.new_record? ? puppetclasses_path : puppetclass_path(:id => @puppetclass)) do |f| %>
   <%= base_errors_for @puppetclass %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _('Puppet Class') %></a></li>

--- a/app/views/realms/_form.html.erb
+++ b/app/views/realms/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @realm, :url => (@realm.new_record? ? realms_path : realm_path(:id => @realm.id)) do |f| %>
+<%= form_for @realm, :url => (@realm.new_record? ? realms_path : realm_path(:id => @realm)) do |f| %>
   <%= base_errors_for @realm %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("Realm") %></a></li>

--- a/app/views/reports/_list.html.erb
+++ b/app/views/reports/_list.html.erb
@@ -29,7 +29,7 @@
       <td><%= report_event_column(report.skipped, "label-info") %></td>
       <td><%= report_event_column(report.pending, "label-info") %></td>
       <td align="right">
-        <%= display_delete_if_authorized hash_for_report_path(:id => report.id).merge(:auth_object => report, :authorizer => authorizer),
+        <%= display_delete_if_authorized hash_for_report_path(:id => report).merge(:auth_object => report, :authorizer => authorizer),
                                          :confirm => _("Delete report for %s?") % report.host.try(:name) %>
       </td>
     </tr>

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -12,7 +12,7 @@
   </tr>
   <% for proxy in @smart_proxies %>
     <tr>
-      <td><%= link_to_if_authorized trunc(proxy.name), hash_for_edit_smart_proxy_path(:id => proxy.id).merge(:auth_object => proxy, :authorizer => authorizer) %></td>
+      <td><%= link_to_if_authorized trunc(proxy.name), hash_for_edit_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer) %></td>
       <td><%=h proxy.url %></td>
       <td><%=h proxy.features.to_sentence %></td>
       <td><%= action_buttons(*proxy_actions(proxy, authorizer)) %></td>

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -36,7 +36,7 @@
             <td><%= h usergroup.name %></td>
             <td><%= h usergroup.auth_source %></td>
             <td><%= display_link_if_authorized(_('Refresh'),
-                                               hash_for_refresh_external_usergroup_path(:id => usergroup.id),
+                                               hash_for_refresh_external_usergroup_path(:id => usergroup),
                                                :method => :put, :id => usergroup.id,
                                                :class => "btn btn-default", :title => _('Synchronize group from authentication source')) %>
             </td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,7 @@
   </tr>
   <% for user in @users %>
     <tr>
-      <td><%= avatar_image_tag user, :class => "avatar" %> <%=link_to_if_authorized trunc(user.login), hash_for_edit_user_path(:id => user.id).merge(:auth_object => user, :authorizer => authorizer) %></td>
+      <td><%= avatar_image_tag user, :class => "avatar" %> <%=link_to_if_authorized trunc(user.login), hash_for_edit_user_path(:id => user).merge(:auth_object => user, :authorizer => authorizer) %></td>
       <td><%=h user.firstname %></td>
       <td><%=h user.lastname %></td>
       <td><%=h user.mail %></td>

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -2,4 +2,5 @@ class ActiveRecord::Base
   extend Host::Hostmix
   include HasManyCommon
   include StripWhitespace
+  include Parameterizable::ById
 end

--- a/test/functional/architectures_controller_test.rb
+++ b/test/functional/architectures_controller_test.rb
@@ -34,24 +34,24 @@ class ArchitecturesControllerTest < ActionController::TestCase
   end
 
   def test_edit
-    get :edit, {:id => Architecture.first.name}, set_session_user
+    get :edit, {:id => Architecture.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_edit_submit_button_id
-    get :edit, {:id => Architecture.first.name}, set_session_user
+    get :edit, {:id => Architecture.first}, set_session_user
     assert_select "[data-id='aid_update_architecture']"
   end
 
   def test_update_invalid
     Architecture.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Architecture.first.name}, set_session_user
+    put :update, {:id => Architecture.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Architecture.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Architecture.first.name}, set_session_user
+    put :update, {:id => Architecture.first}, set_session_user
     assert_redirected_to architectures_url
   end
 
@@ -59,7 +59,7 @@ class ArchitecturesControllerTest < ActionController::TestCase
     architecture = Architecture.first
     architecture.hosts.delete_all
     architecture.hostgroups.delete_all
-    delete :destroy, {:id => architecture.name}, set_session_user
+    delete :destroy, {:id => architecture}, set_session_user
     assert_redirected_to architectures_url
     assert !Architecture.exists?(architecture.id)
   end

--- a/test/functional/audits_controller_test.rb
+++ b/test/functional/audits_controller_test.rb
@@ -17,7 +17,7 @@ class AuditsControllerTest < ActionController::TestCase
   end
   def user_with_viewer_rights_should_fail_to(edit_audit)
     setup_user
-    get :edit, {:id => Audit.first.id}
+    get :edit, {:id => Audit.first}
     assert @response.status == '403 Forbidden'
   end
 

--- a/test/functional/domains_controller_test.rb
+++ b/test/functional/domains_controller_test.rb
@@ -24,19 +24,19 @@ class DomainsControllerTest < ActionController::TestCase
   end
 
   def test_edit
-    get :edit, {:id => Domain.first.name}, set_session_user
+    get :edit, {:id => Domain.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_invalid
     Domain.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Domain.first.name}, set_session_user
+    put :update, {:id => Domain.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Domain.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Domain.first.name}, set_session_user
+    put :update, {:id => Domain.first}, set_session_user
     assert_redirected_to domains_url
   end
 
@@ -45,7 +45,7 @@ class DomainsControllerTest < ActionController::TestCase
     domain.hosts.clear
     domain.hostgroups.clear
     domain.subnets.clear
-    delete :destroy, {:id => domain.name}, set_session_user
+    delete :destroy, {:id => domain}, set_session_user
     assert_redirected_to domains_url
     assert !Domain.exists?(domain.id)
   end

--- a/test/functional/realms_controller_test.rb
+++ b/test/functional/realms_controller_test.rb
@@ -24,19 +24,19 @@ class RealmsControllerTest < ActionController::TestCase
   end
 
   def test_edit
-    get :edit, {:id => Realm.first.name}, set_session_user
+    get :edit, {:id => Realm.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_invalid
     Realm.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Realm.first.name}, set_session_user
+    put :update, {:id => Realm.first}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Realm.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Realm.first.name}, set_session_user
+    put :update, {:id => Realm.first}, set_session_user
     assert_redirected_to realms_url
   end
 
@@ -44,7 +44,7 @@ class RealmsControllerTest < ActionController::TestCase
     realm = Realm.first
     realm.hosts.clear
     realm.hostgroups.clear
-    delete :destroy, {:id => realm.name}, set_session_user
+    delete :destroy, {:id => realm}, set_session_user
     assert_redirected_to realms_url
     assert !Realm.exists?(realm.id)
   end
@@ -56,7 +56,7 @@ class RealmsControllerTest < ActionController::TestCase
 
   def user_with_viewer_rights_should_fail_to_edit_a_realm
     setup_users
-    get :edit, {:id => Realm.first.id}
+    get :edit, {:id => Realm.first}
     assert @response.status == '403 Forbidden'
   end
 

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -27,7 +27,7 @@ class RolesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:roles)
     assert_equal Role.all.sort, [assigns(:roles)].flatten.sort
 
-    assert_tag :tag => 'a', :attributes => { :href => '/roles/1-manager/edit' },
+    assert_tag :tag => 'a', :attributes => { :href => '/roles/1-Manager/edit' },
       :content => 'Manager'
   end
 

--- a/test/unit/concerns/parameterizable_test.rb
+++ b/test/unit/concerns/parameterizable_test.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+require 'test_helper'
+
+class ParameterizableTest < ActiveSupport::TestCase
+
+  describe 'parameterize' do
+
+    it 'should strip disallowed url characters and keep unicode ones' do
+      assert_equal '1-žščřďťň', Parameterizable.parameterize("1-žšč!*'();:@&=+$,?%#[]řďťň")
+    end
+
+    it 'should convert slashes to dashes' do
+      assert_equal '1-ž-šč-řďťň', Parameterizable.parameterize("1-ž/šč!*'();:@&=+$,/?%#[]řďťň")
+    end
+
+    it 'should strip trailing dashes' do
+      assert_equal '1', Parameterizable.parameterize("1-[]")
+    end
+
+  end
+
+end

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -328,4 +328,10 @@ class HostgroupTest < ActiveSupport::TestCase
     assert_equal _("is too long (maximum is 0 characters)"),  hostgroup.errors[:name].first
   end
 
+  test "to_param" do
+    parent = FactoryGirl.create(:hostgroup, :name => 'a')
+    hostgroup = Hostgroup.new(:parent => parent, :name => 'b')
+    assert_equal "#{hostgroup.id}-a-b",  hostgroup.to_param
+  end
+
 end


### PR DESCRIPTION
Original methods to_param defined on resources called name.parameterize
to get rid of url-unsafe characters. This function also strips off unicode
characters.
Another problem was in one unified search function for all parameterization approaches. It used to fail when a name was parameterized to blank string or when a name contained only numbers.

Changes:
- parameterization extracted into a separate module Parameterizable
- each resource defines methods 'to_param' and 'from_param' to ensure correct search
- views updated to always use to_param when building links
- parameterization changed to id+name for resources where it wasn't safe to rely only on names
- default parameter is id
