### PR TITLE
fixes #7054 - list all routes for each resource in /v2/api

### DIFF
--- a/app/views/api/v2/home/index.json.rabl
+++ b/app/views/api/v2/home/index.json.rabl
@@ -1,25 +1,13 @@
 object false
 child(:links => "links") do
-
-  # gather index methods of resources
-  index_method_description_apis = Apipie.app.resource_descriptions['v2'].map do |name, resource_description|
-    method_description = resource_description.method_description(:index)
-    if(method_description)
-      method_description.method_apis_to_json.first
+  Apipie.app.resource_descriptions['v2'].map do |name, resource_description|
+    object false
+    child(:resource => name ) do
+      resource_description.method_descriptions.each do |method_description|
+        api = method_description.method_apis_to_json.first
+        url, description = api[:api_url], api[:short_description]
+        node(description.chomp(".")) { url } if api && url && description
+      end
     end
-  end.compact
-
-  # add additional actions
-  %w(home#status).each do |additional_action|
-    if (description = Apipie.app[additional_action]) and
-        (api = description.method_apis_to_json.first)
-      index_method_description_apis << api
-    end
-  end
-
-  # render links
-  index_method_description_apis.each do |api|
-    url, description = api[:api_url], api[:short_description]
-    node(description.chomp(".")) { url }
   end
 end


### PR DESCRIPTION
- Lists all documented actions for each resource in v2 api instead of just the routes with an index action.
