### PR TITLE
Fixes #5692 - correct counts in cached_counters

### DIFF
--- a/app/models/concerns/counter_cache_fix.rb
+++ b/app/models/concerns/counter_cache_fix.rb
@@ -1,0 +1,26 @@
+# Fix for counter cache not being updated on related model updates.
+# See: https://github.com/rails/rails/issues/9722
+# TODO: remove when upgrading to Rails 4.x
+# inspired by fix from http://stackoverflow.com/a/11569554/1091445
+
+module CounterCacheFix
+  extend ActiveSupport::Concern
+
+  included do
+    after_update :update_counter_caches
+
+    def update_counter_caches
+      self.changes.each do |key, (old_value, new_value)|
+        if key =~ /_id/
+          association = self.association(key.sub(/_id$/, '').to_sym)
+          if association.options[ :counter_cache ]
+            counter_name = self.class.name.underscore.split("/")[0].pluralize.to_sym
+            association.klass.reset_counters(old_value, counter_name) if old_value
+            association.klass.reset_counters(new_value, counter_name) if new_value
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -6,6 +6,8 @@ module HostCommon
   extend ActiveSupport::Concern
 
   included do
+    include CounterCacheFix
+
     counter_cache = "#{model_name.split(":").first.pluralize.downcase}_count".to_sym  # e.g. :hosts_count
 
     belongs_to :architecture,    :counter_cache => counter_cache

--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -1,5 +1,7 @@
 class ConfigGroupClass < ActiveRecord::Base
   include Authorizable
+  include CounterCacheFix
+
   audited :associated_with => :config_group, :allow_mass_assignment => true
   attr_accessible :config_group_id, :puppetclass_id
 

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -2,6 +2,8 @@ module Host
   class Base < ActiveRecord::Base
     include Foreman::STI
     include Authorizable
+    include CounterCacheFix
+
     self.table_name = :hosts
     OWNER_TYPES = %w(User Usergroup)
 

--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -1,5 +1,7 @@
 class HostClass < ActiveRecord::Base
   include Authorizable
+  include CounterCacheFix
+
   validates_lengths_from_database
   audited :associated_with => :host, :allow_mass_assignment => true
   belongs_to_host :foreign_key => :host_id

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -1,5 +1,7 @@
 class HostgroupClass < ActiveRecord::Base
   include Authorizable
+  include CounterCacheFix
+
   audited :associated_with => :hostgroup, :allow_mass_assignment => true
   belongs_to :hostgroup
   belongs_to :puppetclass, :counter_cache => :hostgroups_count

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -1,5 +1,6 @@
 class LookupKey < ActiveRecord::Base
   include Authorizable
+  include CounterCacheFix
 
   KEY_TYPES = [N_("string"), N_("boolean"), N_("integer"), N_("real"), N_("array"), N_("hash"), N_("yaml"), N_("json")]
   VALIDATOR_TYPES = [N_("regexp"), N_("list") ]

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -1,5 +1,7 @@
 class LookupValue < ActiveRecord::Base
   include Authorizable
+  include CounterCacheFix
+
   validates_lengths_from_database
   audited :associated_with => :lookup_key, :allow_mass_assignment => true
 

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -3,7 +3,12 @@ require 'test_helper'
 class ArchitectureTest < ActiveSupport::TestCase
   setup do
     User.current = users :admin
+    Architecture.all.each do |a| #because we load from fixtures, counters aren't updated
+      Architecture.reset_counters(a.id,:hosts)
+      Architecture.reset_counters(a.id,:hostgroups)
+    end
   end
+
   test "should not save without a name" do
     architecture = Architecture.new
     assert_not architecture.save

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -5,6 +5,11 @@ class DomainTest < ActiveSupport::TestCase
     User.current = users(:admin)
     @new_domain = Domain.new
     @domain = domains(:mydomain)
+    Domain.all.each do |d| #because we load from fixtures, counters aren't updated
+      Domain.reset_counters(d.id,:hosts)
+      Domain.reset_counters(d.id,:hostgroups)
+    end
+
   end
 
   test "should not save without a name" do
@@ -66,6 +71,14 @@ class DomainTest < ActiveSupport::TestCase
     domain = domains(:yourdomain)
     assert_difference "domain.hosts_count" do
       hosts(:one).update_attribute(:domain, domain)
+      domain.reload
+    end
+  end
+
+  test "should update hosts_count on domain_id change" do
+    domain = domains(:yourdomain)
+    assert_difference "domain.hosts_count" do
+      hosts(:one).update_attribute(:domain_id, domain.id)
       domain.reload
     end
   end

--- a/test/unit/environment_test.rb
+++ b/test/unit/environment_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class EnvironmentTest < ActiveSupport::TestCase
+  def setup
+    Environment.all.each do |e| #because we load from fixtures, counters aren't updated
+      Environment.reset_counters(e.id,:hosts)
+      Environment.reset_counters(e.id,:hostgroups)
+    end
+  end
+
   test "should have name" do
     env = Environment.new
     assert !env.valid?

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -3,7 +3,12 @@ require 'test_helper'
 class OperatingsystemTest < ActiveSupport::TestCase
   setup do
     User.current = users :admin
+    Operatingsystem.all.each do |o| #because we load from fixtures, counters aren't updated
+      Operatingsystem.reset_counters(o.id,:hosts)
+      Operatingsystem.reset_counters(o.id,:hostgroups)
+    end
   end
+
   test "shouldn't save with blank attributes" do
     operating_system = Operatingsystem.new
     assert !operating_system.save


### PR DESCRIPTION
This was caused by a rails bug. (https://github.com/rails/rails/issues/9722)
Also fixes related bugs #6210, #6716 and #6813.
We should consider creating a migration to clean up any incorrect cached counters caused by these bugs.
Once we upgrade to rails 4.x we can remove this mixin.
