### PR TITLE
Fixes #6476 - oVirt VM association with multiple interfaces

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -217,7 +217,7 @@ module Foreman::Model
     end
 
     def associated_host(vm)
-      Host.authorized(:view_hosts, Host).where(:mac => vm.mac).first
+      Host.authorized(:view_hosts, Host).where(:mac => vm.interfaces.map { |i| i.mac }).first
     end
 
     def self.provider_friendly_name

--- a/test/unit/compute_resources/ovirt_test.rb
+++ b/test/unit/compute_resources/ovirt_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class OvirtTest < ActiveSupport::TestCase
+  test "#associated_host matches any NIC" do
+    host = FactoryGirl.create(:host, :mac => 'ca:d0:e6:32:16:97')
+    cr = FactoryGirl.build(:ovirt_cr)
+    iface1 = mock('iface1', :mac => '36:48:c5:c9:86:f2')
+    iface2 = mock('iface2', :mac => 'ca:d0:e6:32:16:97')
+    vm = mock('vm', :interfaces => [iface1, iface2])
+    assert_equal host, as_admin { cr.associated_host(vm) }
+  end
+end


### PR DESCRIPTION
Replaces #1555 with a test.
