### PR TITLE
Fixes #5468 - prevent Chrome from autofilling passwords

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -49,12 +49,17 @@ module LayoutHelper
     end
   end
 
-  def password_f(f, attr, options = {})
+  def password_f(f, attr, options = {}, prevent_complete = true)
     field(f, attr, options) do
       options[:autocomplete] ||= "off"
       options[:placeholder] ||= password_placeholder(f.object)
       addClass options, "form-control"
-      f.password_field attr, options
+      if prevent_complete
+        f.text_field(attr, options) +
+          javascript_tag("document.getElementById('#{f.object_name}_#{attr}').type = 'password'")
+      else
+        f.password_field attr, options
+      end
     end
   end
 


### PR DESCRIPTION
@domcleal how about this?

Since our login screen does not use our helper, we can prevent this for all the
password fields in the Foreman app.

Here is the login form:

```
app/views/users/login.html.erb
21:              <%= password_field_tag "login[password]",nil, :class=>"form-control" %>
```

We are changing the behavior for all the rest:

```
app/helpers/layout_helper.rb
52:  def password_f(f, attr, options = {}, prevent_complete = true)
61:        f.password_field attr, options

app/views/hostgroups/_form.html.erb
54:      <%= password_f f, :root_pass, :help_inline => _("Password should be 8 characters or more")%>

app/views/hosts/_operating_system.html.erb
27:  <%= password_f f, :root_pass, :help_inline => _("Password should be 8 characters or more")%>

app/views/hosts/_interfaces.html.erb
23:      <%= password_f f, :password, ifs_bmc_opts(f.object) %>

app/views/images/form/_libvirt.html.erb
2:<%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>

app/views/images/form/_vmware.html.erb
2:<%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>

app/views/images/form/_ovirt.html.erb
2:<%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>

app/views/auth_source_ldaps/_form.html.erb
25:      <%= password_f f, :account_password, :help_inline => _("Use this account to authenticate, <i>optional</i>").html_safe 

app/views/compute_resources/form/_vmware.html.erb
3:<%= password_f f, :password, :placeholder => password_placeholder(f.object) %>

app/views/compute_resources/form/_openstack.html.erb
3:<%= password_f f, :password %>

app/views/compute_resources/form/_ec2.html.erb
2:<%= password_f f, :password, :label => _("Secret Key") %>

app/views/compute_resources/form/_ovirt.html.erb
3:<%= password_f f, :password %>

app/views/compute_resources/form/_rackspace.html.erb
3:<%= password_f f, :password, :label => _("API Key") %>

app/views/users/_form.html.erb
43:        <%= password_f f, :password, :label => _('Password') %>
44:        <%= password_f f, :password_confirmation, :label => _('Verify') %>
(END)
```
