### PR TITLE
Fixes #6763 - Correctly choose autocomplete search scope for taxonomies ...

### DIFF
--- a/app/controllers/concerns/foreman/controller/auto_complete_search.rb
+++ b/app/controllers/concerns/foreman/controller/auto_complete_search.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::AutoCompleteSearch
   def auto_complete_search
     begin
       model = controller_name == "hosts" ? Host::Managed : model_of_controller
-      @items = model.complete_for(params[:search])
+      @items = model.complete_for(params[:search], {:controller => controller_name})
       @items = @items.map do |item|
         category = (['and','or','not','has'].include?(item.to_s.sub(/^.*\s+/,''))) ? _('Operators') : ''
         part = item.to_s.sub(/^.*\b(and|or)\b/i) {|match| match.sub(/^.*\s+/,'')}

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -31,6 +31,14 @@ class Taxonomy < ActiveRecord::Base
 
   default_scope lambda { order(:title) }
 
+  scope :completer_scope, lambda{|opts|
+    if opts[:controller] == 'organizations'
+      Organization.completer_scope opts
+    elsif opts[:controller] == 'locations'
+      Location.completer_scope opts
+    end
+  }
+
   def self.locations_enabled
     enabled?(:location)
   end


### PR DESCRIPTION
...depenant on controller. 
Corrects scoped search mistakenly setting the wrong class on locations/organizations for auto-complete.
