### PR TITLE
fixes #7191 - move API response logger to named filter so it can be skipped

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -15,9 +15,7 @@ module Api
 
     respond_to :json
 
-    after_filter do
-      logger.debug "Body: #{response.body}"
-    end
+    after_filter :log_response_body
 
     rescue_from StandardError, :with => lambda { |error|
       logger.error "#{error.message} (#{error.class})\n#{error.backtrace.join("\n")}"
@@ -209,6 +207,10 @@ module Api
           end
         end
       end
+    end
+
+    def log_response_body
+      logger.debug { "Body: #{response.body}" }
     end
 
     private


### PR DESCRIPTION
Will be used like this: https://github.com/domcleal/foreman_bootdisk/commit/843f0b495a6c25133d3248433d4b7e9433b3b985
