### PR TITLE
fixes #7066 - add back $login interpolation for LDAP service account usernames

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -55,7 +55,7 @@ class AuthSource < ActiveRecord::Base
   end
 
   # Called after creating a new user at login
-  def update_usergroups(login)
+  def update_usergroups(login, password)
   end
 
   # Try to authenticate a user not yet registered against available sources

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -404,7 +404,7 @@ class User < ActiveRecord::Base
       # The default user can't auto create users, we need to change to Admin for this to work
       User.as_anonymous_admin do
         if user.save
-          AuthSource.find(attrs[:auth_source_id]).update_usergroups(login)
+          AuthSource.find(attrs[:auth_source_id]).update_usergroups(login, password)
           logger.info "User '#{user.login}' auto-created from #{user.auth_source}"
         else
           logger.info "Failed to save User '#{user.login}' #{user.errors.full_messages}"

--- a/test/factories/auth_source_ldap.rb
+++ b/test/factories/auth_source_ldap.rb
@@ -20,6 +20,11 @@ FactoryGirl.define do
     server_type 'active_directory'
   end
 
+  trait :service_account do
+    account 'foremanservice'
+    account_password 'f0rem4n'
+  end
+
   factory :free_ipa_auth_source,         :traits => [:free_ipa]
   factory :active_directory_auth_source, :traits => [:active_directory]
   factory :posix_auth_source,            :traits => [:posix]

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -464,7 +464,7 @@ class UserTest < ActiveSupport::TestCase
 
   test ".try_to_auto_create_user" do
     AuthSourceLdap.any_instance.stubs(:authenticate).returns({ :firstname => "Foo", :lastname => "Bar", :mail => "baz@qux.com" })
-    AuthSourceLdap.any_instance.stubs(:update_usergroups).returns(true)
+    AuthSourceLdap.any_instance.expects(:update_usergroups).with('non_existing_user_1', 'password').returns(true)
 
     ldap_server = AuthSource.find_by_name("ldap-server")
 


### PR DESCRIPTION
In cases where an LDAP connection is required outside of the context of user
authentication (e.g. validation of external user group name), an error is
thrown.  Users are recommended to use dedicated service accounts for this
new feature.

---

Wiki page for the new ERF code: http://projects.theforeman.org/projects/foreman/wiki/ERF42-9972.  I'll put something similar in the 1.6 release notes and manual.

The change to the authenticate? call that Leah mentioned in comment 3 of the bug report has been fixed with the UID lookup bit in https://github.com/Katello/ldap_fluff/pull/32 ([el6 scratchbuild](http://koji.katello.org/koji/taskinfo?taskID=143824)).
