### PR TITLE
Fixes #5088 #2524 - adding taxonomy related parameters to apidocs

### DIFF
--- a/app/controllers/api/v2/architectures_controller.rb
+++ b/app/controllers/api/v2/architectures_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/architectures/", N_("List all architectures")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @architectures = Architecture.

--- a/app/controllers/api/v2/audits_controller.rb
+++ b/app/controllers/api/v2/audits_controller.rb
@@ -7,10 +7,7 @@ module Api
 
       api :GET, "/audits/", N_("List all audits")
       api :GET, "/hosts/:host_id/audits/", N_("List all audits for a given host")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         Audit.unscoped { @audits = Audit.authorized(:view_audit_logs).search_for(*search_options).paginate(paginate_options) }

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -5,8 +5,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/auth_source_ldaps/", N_("List all LDAP authentication sources")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :pagination, ::Api::V2::BaseController
 
       def index
         @auth_source_ldaps = AuthSourceLdap.paginate(paginate_options)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -8,6 +8,22 @@ module Api
         app_info N_("Foreman v2 is stable and recommended for use. You may use v2 by either passing 'version=2' in the Accept Header or using api/v2/ in the URL.")
       end
 
+      def_param_group :pagination do
+        param :page, String, :desc => N_("paginate results")
+        param :per_page, String, :desc => N_("number of entries per request")
+      end
+
+      def_param_group :search_and_pagination do
+        param :search, String, :desc => N_("filter results")
+        param :order, String, :desc => N_("sort results")
+        param_group :pagination, ::Api::V2::BaseController
+      end
+
+      def_param_group :taxonomies do
+        param :location_ids, Array, :required => false, :desc => N_("REPLACE locations with given ids") if SETTINGS[:locations_enabled]
+        param :organization_ids, Array, :required => false, :desc => N_("REPLACE organizations with given ids.") if SETTINGS[:organizations_enabled]
+      end
+
       before_filter :setup_has_many_params, :only => [:create, :update]
       before_filter :check_content_type
       # ensure include_root_in_json = false for V2 only

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -24,6 +24,12 @@ module Api
         param :organization_ids, Array, :required => false, :desc => N_("REPLACE organizations with given ids.") if SETTINGS[:organizations_enabled]
       end
 
+      def_param_group :taxonomy_scope do
+        param :location_id, Integer, :required => false, :desc => N_("Scope by locations") if SETTINGS[:locations_enabled]
+        param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations") if SETTINGS[:organizations_enabled]
+      end
+
+
       before_filter :setup_has_many_params, :only => [:create, :update]
       before_filter :check_content_type
       # ensure include_root_in_json = false for V2 only

--- a/app/controllers/api/v2/bookmarks_controller.rb
+++ b/app/controllers/api/v2/bookmarks_controller.rb
@@ -4,8 +4,7 @@ module Api
       before_filter :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/bookmarks/", N_("List all bookmarks")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :pagination, ::Api::V2::BaseController
 
       def index
         @bookmarks = Bookmark.paginate(paginate_options)

--- a/app/controllers/api/v2/common_parameters_controller.rb
+++ b/app/controllers/api/v2/common_parameters_controller.rb
@@ -5,10 +5,7 @@ module Api
       before_filter(:only => %w{show update destroy}) { find_resource('globals') }
 
       api :GET, "/common_parameters/", N_("List all global parameters.")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @common_parameters = CommonParameter.

--- a/app/controllers/api/v2/compute_profiles_controller.rb
+++ b/app/controllers/api/v2/compute_profiles_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/compute_profiles", N_("List of compute profiles")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @compute_profiles = ComputeProfile.authorized(:view_config_profiles).

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -15,10 +15,7 @@ module Api
                                               :available_resource_pools, :available_storage_domains]
 
       api :GET, "/compute_resources/", N_("List all compute resources")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @compute_resources = resource_scope.search_for(*search_options).paginate(paginate_options)
@@ -43,6 +40,7 @@ module Api
           param :tenant, String, :desc => N_("for Openstack only")
           param :server, String, :desc => N_("for Vmware")
           param :set_console_password, :bool, :desc => N_("for Libvirt and Vmware only")
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -15,6 +15,7 @@ module Api
                                               :available_resource_pools, :available_storage_domains]
 
       api :GET, "/compute_resources/", N_("List all compute resources")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/config_groups_controller.rb
+++ b/app/controllers/api/v2/config_groups_controller.rb
@@ -5,10 +5,7 @@ module Api
       before_filter :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/config_groups", N_("List of config groups")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @config_groups = ConfigGroup.authorized(:view_config_groups).search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -11,10 +11,7 @@ module Api
       before_filter :process_operatingsystems, :only => [:create, :update]
 
       api :GET, "/config_templates/", N_("List provisioning templates")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @config_templates = ConfigTemplate.
@@ -40,6 +37,7 @@ module Api
                 :desc => N_("Array of template combinations (hostgroup_id, environment_id)")
           param :operatingsystem_ids, Array, :desc => N_("Array of operating system IDs to associate with the template")
           param :locked, :bool, :desc => N_("Whether or not the template is locked for editing")
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -11,6 +11,7 @@ module Api
       before_filter :process_operatingsystems, :only => [:create, :update]
 
       api :GET, "/config_templates/", N_("List provisioning templates")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -19,10 +19,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/domains/", N_("List of domains")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @domains = Domain.
@@ -42,6 +39,7 @@ module Api
           param :fullname, String, :required => false, :allow_nil => true, :desc => N_("Description of the domain")
           param :dns_id, :number, :required => false, :allow_nil => true, :desc => N_("DNS proxy to use within this domain")
           param :domain_parameters_attributes, Array, :required => false, :desc => N_("Array of parameters (name, value)")
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -19,6 +19,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/domains/", N_("List of domains")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/environments/", N_("List all environments")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @environments = Environment.
@@ -28,6 +25,7 @@ module Api
       def_param_group :environment do
         param :environment, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/environments/", N_("List all environments")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/fact_values_controller.rb
+++ b/app/controllers/api/v2/fact_values_controller.rb
@@ -5,10 +5,7 @@ module Api
 
       api :GET, "/fact_values/", N_("List all fact values")
       api :GET, "/hosts/:host_id/facts/", N_("List all fact values of a given host")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         values = resource_scope.includes(:fact_name, :host).search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/filters/", N_("List all filters")
-      param :search, String, :desc => N_("filter results"), :required => false
-      param :order, String, :desc => N_("sort results"), :required => false
-      param :page, String, :desc => N_("paginate results"), :required => false
-      param :per_page, String, :desc => N_("number of entries per request"), :required => false
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @filters = resource_scope.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy clone}
 
       api :GET, "/hostgroups/", N_("List all host groups")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy clone}
 
       api :GET, "/hostgroups/", N_("List all host groups")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @hostgroups = Hostgroup.
@@ -40,6 +37,7 @@ module Api
           param :domain_id, :number
           param :realm_id, :number
           param :puppet_proxy_id, :number
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -14,10 +14,7 @@ module Api
       add_puppetmaster_filters :facts
 
       api :GET, "/hosts/", N_("List all hosts")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @hosts = resource_scope.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/images_controller.rb
+++ b/app/controllers/api/v2/images_controller.rb
@@ -5,10 +5,7 @@ module Api
       before_filter :find_compute_resource
 
       api :GET, "/compute_resources/:compute_resource_id/images/", N_("List all images for a compute resource")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
       param :compute_resource_id, :identifier, :required => true
 
       def index

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -21,6 +21,7 @@ Solaris and Debian media may also use $release.
       OS_FAMILY_INFO = N_("Operating system family, available values: %{operatingsystem_families}")
 
       api :GET, "/media/", N_("List all installation media")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -21,10 +21,7 @@ Solaris and Debian media may also use $release.
       OS_FAMILY_INFO = N_("Operating system family, available values: %{operatingsystem_families}")
 
       api :GET, "/media/", N_("List all installation media")
-      param :search, String, :desc => N_("filter results"), :required => false
-      param :order, String, :desc => N_("sort results"), :required => false
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @media = Medium.
@@ -44,6 +41,7 @@ Solaris and Debian media may also use $release.
           param :path, String, :required => true, :desc => PATH_INFO
           param :os_family, String, :require => false, :desc => OS_FAMILY_INFO
           param :operatingsystem_ids, Array, :require => false
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/models_controller.rb
+++ b/app/controllers/api/v2/models_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/models/", N_("List all hardware models")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @models = Model.

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -9,10 +9,7 @@ module Api
       before_filter :find_resource, :only => %w{show edit update destroy bootfiles}
 
       api :GET, "/operatingsystems/", N_("List all operating systems")
-      param :search, String, :desc => N_("filter results"), :required => false
-      param :order, String, :desc => N_("sort results"), :required => false
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @operatingsystems = Operatingsystem.

--- a/app/controllers/api/v2/os_default_templates_controller.rb
+++ b/app/controllers/api/v2/os_default_templates_controller.rb
@@ -10,8 +10,7 @@ module Api
 
       api :GET, '/operatingsystems/:operatingsystem_id/os_default_templates', N_('List default templates combinations for an operating system')
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :pagination, ::Api::V2::BaseController
 
       def index
         @os_default_templates = nested_obj.os_default_templates.paginate(paginate_options)

--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -14,8 +14,7 @@ module Api
       api :GET, "/smart_class_parameters/:smart_class_parameter_id/override_values", N_("List of override values for a specific smart class parameter")
       param :smart_variable_id, :identifier, :required => false
       param :smart_class_parameter_id, :identifier, :required => false
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :pagination, ::Api::V2::BaseController
 
       def index
       end

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -27,10 +27,7 @@ module Api
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
       param :location_id, String, :desc => N_("ID of location")
       param :organization_id, String, :desc => N_("ID of organization")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @parameters = nested_obj.send(parameters_method).search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/ptables/", N_("List all partition tables")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @ptables = Ptable.

--- a/app/controllers/api/v2/puppetclasses_controller.rb
+++ b/app/controllers/api/v2/puppetclasses_controller.rb
@@ -15,10 +15,7 @@ module Api
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
       param :environment_id, String, :desc => N_("ID of environment")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         values   = Puppetclass.authorized(:view_puppetclasses).search_for(*search_options) unless nested_obj

--- a/app/controllers/api/v2/realms_controller.rb
+++ b/app/controllers/api/v2/realms_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/realms/", N_("List of realms")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @realms = Realm.
@@ -30,6 +27,7 @@ module Api
           param :name, String, :required => true, :desc => N_("The realm name, e.g. EXAMPLE.COM")
           param :realm_proxy_id, :number, :required => true, :allow_nil => true, :desc => N_("Proxy to use for this realm")
           param :realm_type, String, :required => true, :desc => N_("Realm type, e.g. FreeIPA or Active Directory")
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/realms_controller.rb
+++ b/app/controllers/api/v2/realms_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/realms/", N_("List of realms")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -9,10 +9,7 @@ module Api
       add_puppetmaster_filters :create
 
       api :GET, "/reports/", N_("List all reports")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @reports = Report.

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/roles/", N_("List all roles")
-      param :search, String, :desc => N_("Filter results"), :required => false
-      param :order, String, :desc => N_("Sort results"), :required => false
-      param :page, String, :desc => N_("paginate results"), :required => false
-      param :per_page, String, :desc => N_("number of entries per request"), :required => false
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @roles = Role.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -5,10 +5,7 @@ module Api
       before_filter :find_resource, :only => %w{show update}
 
       api :GET, "/settings/", N_("List all settings")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @settings = Setting.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -15,10 +15,7 @@ module Api
       param :hostgroup_id, :identifier, :required => false
       param :puppetclass_id, :identifier, :required => false
       param :environment_id, :identifier, :required => false
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
       end

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy refresh}
 
       api :GET, "/smart_proxies/", N_("List all smart proxies")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @smart_proxies = SmartProxy.authorized(:view_smart_proxies).includes(:features).
@@ -29,6 +26,7 @@ module Api
         param :smart_proxy, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
           param :url, String, :required => true
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy refresh}
 
       api :GET, "/smart_proxies/", N_("List all smart proxies")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/smart_variables_controller.rb
+++ b/app/controllers/api/v2/smart_variables_controller.rb
@@ -12,10 +12,7 @@ module Api
       param :host_id, :identifier, :required => false
       param :hostgroup_id, :identifier, :required => false
       param :puppetclass_id, :identifier, :required => false
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
       end

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, '/subnets', N_("List of subnets")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -8,10 +8,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, '/subnets', N_("List of subnets")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @subnets = Subnet.
@@ -43,6 +40,7 @@ module Api
           param :tftp_id, :number, :desc => N_("TFTP Proxy to use within this subnet")
           param :dns_id, :number, :desc => N_("DNS Proxy to use within this subnet")
           param :boot_mode, String, :desc => N_('Default boot mode for interfaces assigned to this subnet, valid values are "Static", "DHCP"')
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/api/v2/template_kinds_controller.rb
+++ b/app/controllers/api/v2/template_kinds_controller.rb
@@ -3,10 +3,7 @@ module Api
     class TemplateKindsController < V2::BaseController
 
       api :GET, "/template_kinds/", N_("List all template kinds")
-      param :search, String, :desc => N_("filter results"), :required => false
-      param :order, String, :desc => N_("sort results"), :required => false
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @template_kinds = TemplateKind.search_for(*search_options).paginate(paginate_options)

--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -4,10 +4,7 @@ module Api
       before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/usergroups/", N_("List all user groups")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @usergroups = Usergroup.

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -10,8 +10,8 @@ module Api
       include Api::TaxonomyScope
 
       api :GET, "/users/", N_("List all users")
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
-
       def index
         @users = User.
           authorized(:view_users).except_hidden.

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -10,10 +10,7 @@ module Api
       include Api::TaxonomyScope
 
       api :GET, "/users/", N_("List all users")
-      param :search, String, :desc => N_("filter results")
-      param :order, String, :desc => N_("sort results")
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
         @users = User.
@@ -38,6 +35,7 @@ module Api
           param :default_location_id, Integer if SETTINGS[:locations_enabled]
           param :default_organization_id, Integer if SETTINGS[:organizations_enabled]
           param :auth_source_id, Integer, :required => true
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/concerns/api/taxonomy_scope.rb
+++ b/app/controllers/concerns/api/taxonomy_scope.rb
@@ -7,8 +7,12 @@ module Api
     end
 
     def set_taxonomy_scope
-      Location.current ||= @location = Location.find_by_id(params[:location_id]) if SETTINGS[:locations_enabled]
-      Organization.current ||= @organization = Organization.find_by_id(params[:organization_id]) if SETTINGS[:organizations_enabled]
+      if SETTINGS[:locations_enabled]
+        Location.current ||= @location = Location.find_by_id(params[:location_id])
+      end
+      if SETTINGS[:organizations_enabled]
+        Organization.current ||= @organization = Organization.find_by_id(params[:organization_id])
+      end
     end
 
   end

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -29,10 +29,7 @@ module Api::V2::TaxonomiesController
   end
 
   api :GET, '/:resource_id', N_('List all :resource_id')
-  param :search, String, :desc => N_("filter results")
-  param :order, String, :desc => N_("sort results")
-  param :page, String, :desc => N_("paginate results")
-  param :per_page, String, :desc => N_("number of entries per request")
+  param_group :search_and_pagination, ::Api::V2::BaseController
   def index
     if @nested_obj
       #@taxonomies = @domain.locations.search_for(*search_options).paginate(paginate_options)


### PR DESCRIPTION
- new param group `taxonomy` for taxable resources
- new param group `taxonomy_scope` for index actions of taxable resources
- pagination and search param moved to a group `search_and_pagination` to reduce duplicities
