### PR TITLE
Fixes #3309 - Support deep merging of hash and array structures in smart class parameters

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -158,6 +158,33 @@ function toggleOverrideValue(item) {
   override_value_div.toggle(override);
 }
 
+function changeCheckboxEnabledStatus(checkbox, shouldEnable) {
+  if (shouldEnable) {
+    $(checkbox).attr('disabled', null);
+  }
+  else {
+    $(checkbox).attr('checked', false);
+    $(checkbox).attr('disabled', 'disabled');
+  }
+}
+
+function keyTypeChange(item) {
+  var reloadedItem = $(item);
+  var keyType = reloadedItem.val();
+  var fields = reloadedItem.closest('.fields');
+  var mergeOverrides = fields.find("[id$='_merge_overrides']");
+  var avoidDuplicates = fields.find("[id$='_avoid_duplicates']");
+  changeCheckboxEnabledStatus(mergeOverrides, keyType == 'array' || keyType == 'hash');
+  changeCheckboxEnabledStatus(avoidDuplicates, keyType == 'array' && $(mergeOverrides).attr('checked') == 'checked');
+}
+
+function mergeOverridesChanged(item) {
+  var fields = $(item).closest('.fields');
+  var keyType = fields.find("[id$='_key_type']").val();
+  var avoidDuplicates = fields.find("[id$='_avoid_duplicates']");
+  changeCheckboxEnabledStatus(avoidDuplicates, keyType == 'array' && item.checked);
+}
+
 function filterByEnvironment(item){
   if ($(item).val()=="") {
     $('ul.smart-var-tabs li[data-used-environments] a').removeClass('text-muted');

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -42,6 +42,8 @@ module Api
         param :override_value_order, String
         param :parameter_type, String
         param :required, :bool
+        param :merge_overrides, :bool
+        param :avoid_duplicates, :bool
       end
 
       def update

--- a/app/controllers/api/v2/smart_variables_controller.rb
+++ b/app/controllers/api/v2/smart_variables_controller.rb
@@ -33,6 +33,8 @@ module Api
           param :validator_type, String
           param :validator_rule, String
           param :variable_type, String
+          param :merge_overrides, :bool
+          param :avoid_duplicates, :bool
         end
       end
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -41,9 +41,9 @@ module LookupKeysHelper
     end unless @puppetclass # nested smart-vars form in a tab of puppetclass/_form: no edition allowed, and the puppetclass is already visible as a context
   end
 
-  def param_type_selector(f)
+  def param_type_selector(f, options = {})
     selectable_f f, :key_type, options_for_select(LookupKey::KEY_TYPES.map { |e| [_(e),e] }, f.object.key_type),{},
-               { :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
+                 options.merge({ :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
                  :help_block => popover(_("Parameter types"),_("<dl>" +
                "<dt>String</dt> <dd>Everything is taken as a string.</dd>" +
                "<dt>Boolean</dt> <dd>Common representation of boolean values are accepted.</dd>" +
@@ -53,7 +53,7 @@ module LookupKeysHelper
                "<dt>Hash</dt> <dd>A valid JSON or YAML input, that must evaluate to an object/map/dict/hash.</dd>" +
                "<dt>YAML</dt> <dd>Any valid YAML input.</dd>" +
                "<dt>JSON</dt> <dd>Any valid JSON input.</dd>" +
-               "</dl>"), :title => _("How values are validated")).html_safe}
+               "</dl>"), :title => _("How values are validated")).html_safe})
   end
 
   def validator_type_selector(f)

--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -3,4 +3,4 @@ object @smart_class_parameter
 extends "api/v2/smart_class_parameters/base"
 
 attributes :description, :override, :parameter_type, :default_value, :required, :validator_type, :validator_rule,
-           :override_value_order, :override_values_count, :created_at, :updated_at
+           :merge_overrides, :avoid_duplicates, :override_value_order, :override_values_count, :created_at, :updated_at

--- a/app/views/api/v2/smart_variables/main.json.rabl
+++ b/app/views/api/v2/smart_variables/main.json.rabl
@@ -3,5 +3,5 @@ object @smart_variable
 extends "api/v2/smart_variables/base"
 
 attributes :description, :parameter_type, :default_value, :validator_type, :validator_rule,
-           :override_value_order, :override_values_count,
+           :override_value_order, :override_values_count, :merge_overrides, :avoid_duplicates,
            :puppetclass_id, :puppetclass_name, :created_at, :updated_at

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -1,7 +1,7 @@
 <div id='<%= (f.object.key || 'new_lookup_keys').to_s.gsub(' ','_') + '_' + f.object.id.to_s %>' class='tab-pane fields' >
   <% is_param = f.object.is_param %>
 
-  <%= text_f(f, :environment_classes, :value => f.object.environment_classes.map(&:environment).to_sentence, :label=> _('Puppet Environments'),:size => "col-md-8", :disabled=>true) if is_param%>
+  <%= text_f(f, :environment_classes, :value => f.object.environment_classes.map(&:environment).to_sentence, :label => _('Puppet Environments'),:size => "col-md-8", :disabled=>true) if is_param%>
 
   <%= remove_child_link(_("Remove %s?") % (f.object.new_record? ? _("Variable") : f.object), f , {:class => 'btn btn-danger hide'}) unless controller_name == "lookup_keys" %>
   <%= text_f f, :key, :disabled => f.object.is_param, :size => "col-md-8"  %>
@@ -9,11 +9,11 @@
   <%= textarea_f f, :description, :rows => :auto, :size => "col-md-8"  %>
 
   <%= show_puppet_class f %>
-  <%= checkbox_f(f, :override, :onchange=>'toggleOverrideValue(this)', :size => "col-md-8",
+  <%= checkbox_f(f, :override, :onchange => 'toggleOverrideValue(this)', :size => "col-md-8",
                  :help_block => _("Whether the smart-variable should override the Puppet class default value.")
       ) if is_param%>
 
-  <%= param_type_selector f  %>
+  <%= param_type_selector(f, :onchange => 'keyTypeChange(this)')  %>
   <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast,:size => "col-md-8", :disabled => (f.object.is_param && !f.object.override), :rows => :auto,
                  :help_block => _("Value to use when there is no match") %>
   <div <%= "id=#{(f.object.key || 'new_lookup_keys').to_s.gsub(' ','_')}_lookup_key_override_value" %> style=<%= "display:none;" if (f.object.is_param && !f.object.override) %>>
@@ -25,6 +25,11 @@
     <%= text_f f, :validator_rule, :size => "col-md-8", :disabled => f.object.validator_type.blank? %>
 
     <legend><%= _("Override value for specific hosts") %></legend>
+    <%= checkbox_f(f, :merge_overrides, :onchange => 'mergeOverridesChanged(this)',
+                      :disabled => !f.object.supports_merge?, :size => "col-md-8",
+                      :help_block => _("Should the matchers continue to look for matches after first find (only array/hash type).")) %>
+    <%= checkbox_f(f, :avoid_duplicates, :disabled => (!f.object.supports_uniq? || !f.object.merge_overrides), :size => "col-md-8",
+                   :help_block => _("Should the matched result avoid duplicate values (only array type).")) %>
     <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :size => "col-md-8", :value => f.object.path,
                    :help_block => popover(_("The order in which values are resolved"),
                                           _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"), :title => _("The order in which values are resolved")).html_safe

--- a/db/migrate/20140826104209_add_merge_overrides_and_avoid_duplicates_to_lookup_key.rb
+++ b/db/migrate/20140826104209_add_merge_overrides_and_avoid_duplicates_to_lookup_key.rb
@@ -1,0 +1,6 @@
+class AddMergeOverridesAndAvoidDuplicatesToLookupKey < ActiveRecord::Migration
+  def change
+    add_column :lookup_keys, :merge_overrides, :boolean
+    add_column :lookup_keys, :avoid_duplicates, :boolean
+  end
+end

--- a/test/fixtures/environment_classes.yml
+++ b/test/fixtures/environment_classes.yml
@@ -53,3 +53,4 @@ nine:
   puppetclass: three
   environment: global_puppetmaster
   lookup_key_id: nil
+  

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -162,4 +162,42 @@ class LookupKeyTest < ActiveSupport::TestCase
     smart_variable2 = LookupKey.new(:key => "smart-varialble", :path => "hostgroup", :puppetclass => Puppetclass.first, :default_value => "default2")
     refute_valid smart_variable2
   end
+
+  test "should not be able to merge overrides for a string" do
+    key = FactoryGirl.build(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'string', :merge_overrides => true,
+                            :puppetclass => puppetclasses(:one))
+    refute_valid key
+    assert_equal key.errors[:merge_overrides].first, _("can only be set for array or hash")
+  end
+
+  test "should be able to merge overrides for a hash" do
+    key = FactoryGirl.build(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'hash', :merge_overrides => true,
+                            :default_value => {}, :puppetclass => puppetclasses(:one))
+    assert_valid key
+  end
+
+  test "should not be able to avoid duplicates for a hash" do
+    key = FactoryGirl.build(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'hash', :merge_overrides => true, :avoid_duplicates => true,
+                            :default_value => {}, :puppetclass => puppetclasses(:one))
+    refute_valid key
+    assert_equal key.errors[:avoid_duplicates].first, _("can only be set for arrays that have merge_overrides set to true")
+  end
+
+  test "should be able to merge overrides for a array" do
+    key = FactoryGirl.build(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'array', :merge_overrides => true, :avoid_duplicates => true,
+                            :default_value => [], :puppetclass => puppetclasses(:one))
+    assert_valid key
+  end
+
+  test "should not be able to avoid duplicates when merge_override is false" do
+    key = FactoryGirl.build(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'array', :merge_overrides => false, :avoid_duplicates => true,
+                            :default_value => [], :puppetclass => puppetclasses(:one))
+    refute_valid key
+    assert_equal key.errors[:avoid_duplicates].first, _("can only be set for arrays that have merge_overrides set to true")
+  end
 end


### PR DESCRIPTION
This relates to feature 3636 which states a couple of changes to the way `lookup_keys` work
I'm creating a PR to get comments of this part of the change and to see that I'm in the right direction
