### PR TITLE
fixes #7299 - do not display 'Mismatches Report' button when no view-host

### DIFF
--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -1,6 +1,6 @@
 <% title taxonomy_upcase %>
 
-<% title_actions display_link_if_authorized((_("New %s") % taxonomy_title), hash_for_new_taxonomy_path), link_to(_("Mismatches Report"), mismatches_taxonomies_path, :class => 'btn btn-default'), help_path %>
+<% title_actions display_link_if_authorized((_("New %s") % taxonomy_title), hash_for_new_taxonomy_path), display_link_if_authorized(_("Mismatches Report"), mismatches_taxonomies_path, :class => 'btn btn-default'), help_path %>
 
 <% if @count_nil_hosts > 0 %>
 <div class="alert alert-warning alert-block">


### PR DESCRIPTION
The view-host permissions is required to view mismatches.
