### PR TITLE
fixes #7218 - authorize hosts welcome page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,8 @@ class ApplicationController < ActionController::Base
   before_filter :set_gettext_locale_db, :set_gettext_locale
   before_filter :session_expiry, :update_activity_time, :unless => proc {|c| !SETTINGS[:login] || c.remote_user_provided? || c.api_request? }
   before_filter :set_taxonomy, :require_mail, :check_empty_taxonomy
-  before_filter :welcome, :only => :index, :unless => :api_request?
   before_filter :authorize
+  before_filter :welcome, :only => :index, :unless => :api_request?
   layout :display_layout?
 
   attr_reader :original_search_parameter


### PR DESCRIPTION
When there are no hosts, the welcome page is displayed. This makes sure authorize is called before that.
