### PR TITLE
fixes #7314 - Set settings explicitly instead of stubbing Settings

### DIFF
--- a/test/functional/smart_proxy_auth_test.rb
+++ b/test/functional/smart_proxy_auth_test.rb
@@ -30,7 +30,7 @@ class SmartProxyAuthApiTest < ActionController::TestCase
   end
 
   def test_successful_smart_proxy_authentication_in_api_controller
-    Setting.stubs(:[]).with(:restrict_registered_puppetmasters).returns(false)
+    Setting[:restrict_registered_puppetmasters] = false
     @controller.stubs(:auth_smart_proxy).returns(true)
 
     assert @controller.require_puppetmaster_or_login

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -5,11 +5,11 @@ class RendererTest < ActiveSupport::TestCase
   include Foreman::Renderer
 
   def setup_normal_renderer
-    Setting.stubs(:[]).with(:safemode_render).returns(false)
+    Setting[:safemode_render] = false
   end
 
   def setup_safemode_renderer
-    Setting.stubs(:[]).with(:safemode_render).returns(true)
+    Setting[:safemode_render] = true
   end
 
   [:normal_renderer, :safemode_renderer].each do |renderer_name|


### PR DESCRIPTION
`test_successful_smart_proxy_authentication_in_api_controller` in `test/functional/smart_proxy_auth_test.rb` is failing in my plug-in, although it's not a valid failure.

The Foreman test just outright stubs auth_smart_proxy to be true, however, this doesn't seem to stub out the plug-in's chain method.  My chained method called a Setting that's not stubbed, which results in this failure:

```
unexpected invocation: Setting(id: integer, name: string, value: text, description:
text, category: string, settings_type: string, default: text, created_at: datetime,
updated_at: datetime).[](:require_ssl_puppetmasters)...
```

It seems the easiest solution here is to not be stubbing settings, as just setting them outright works in most cases. The only exception I see is the seeds_test, which is fine as is.

I can also just wait until plug-ins can disable Foreman tests, but I'd rather not disable any unless I have to.  This fixes the last failing test for foreman_salt (hopefully).
