### PR TITLE
fixes #7317 - skip rubocop rake tasks if library isn't installed

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,6 +1,10 @@
 if RUBY_VERSION >= "1.9.3"
-  require 'rubocop/rake_task'
+  begin
+    require 'rubocop/rake_task'
 
-  desc 'Run RuboCop'
-  RuboCop::RakeTask.new(:rubocop)
+    desc 'Run RuboCop'
+    RuboCop::RakeTask.new(:rubocop)
+  rescue LoadError
+    # rubocop unavailable
+  end
 end


### PR DESCRIPTION
Package or package build environments won't have rubocop installed as it's in the test bundler group.  This skips load errors in the same way as jenkins.rake etc.

http://koji.katello.org/koji/taskinfo?taskID=147311 (:-1: nightlies without patch)
http://koji.katello.org/koji/taskinfo?taskID=147331 (:+1: with patch)
