### PR TITLE
Fixes #5541 - disallow taxonomy assignment

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -48,7 +48,7 @@ class Filter < ActiveRecord::Base
   validates :search, :presence => true, :unless => Proc.new { |o| o.search.nil? }
   validates_with ScopedSearchValidator
   validates :role, :presence => true
-  validate :same_resource_type_permissions, :not_empty_permissions
+  validate :same_resource_type_permissions, :not_empty_permissions, :allowed_taxonomies
 
   def self.search_by_unlimited(key, operator, value)
     search_by_limited(key, operator, value == 'true' ? 'false' : 'true')
@@ -162,5 +162,15 @@ class Filter < ActiveRecord::Base
 
   def not_empty_permissions
     errors.add(:permissions, _('You must select at least one permission')) if self.permissions.blank? && self.filterings.blank?
+  end
+
+  def allowed_taxonomies
+    if self.organization_ids.present? && !self.allows_organization_filtering?
+      errors.add(:organization_ids, _('You can\'t assign organizations to this resource'))
+    end
+
+    if self.location_ids.present? && !self.allows_location_filtering?
+      errors.add(:location_ids, _('You can\'t assign locations to this resource'))
+    end
   end
 end

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -127,15 +127,17 @@ class FilterTest < ActiveSupport::TestCase
       assert_nil f.taxonomy_search
     end
 
-    test "taxonomies are ignored if resource does not support them" do
-      f = Factory.create(:filter, :search => '', :unlimited => '1',
-                         :organization_ids => [@organization.id, @organization1.id], :location_ids => [@location.id],
-                         :resource_type => 'Bookmark')
-
-      f.reload
-      assert f.valid?
-      assert f.unlimited?
-      assert_nil f.taxonomy_search
+    test "taxonomies can be assigned only if resource allows it" do
+      fb = Factory.build(:filter, :resource_type => 'Bookmark', :organization_ids => [@organization.id])
+      fd = Factory.build(:filter, :resource_type => 'Domain', :organization_ids => [@organization.id])
+      refute_valid fb
+      assert_valid fd
+      fb = Factory.create(:filter, :resource_type => 'Bookmark')
+      fd = Factory.create(:filter, :resource_type => 'Domain')
+      fb.location_ids = [@location.id]
+      refute_valid fb
+      fd.location_ids = [@location.id]
+      assert_valid fd
     end
   end
 


### PR DESCRIPTION
If a filter resource does not support taxonomy assignment, we don't
allow to assign them to filter.
