### PR TITLE
Fix "`ruby_20` is not a valid platform"

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,7 +1,9 @@
 group :development do
   gem 'maruku'
   gem "term-ansicolor"
-  gem "rubocop", "0.24.1", :platforms => [:ruby_19, :ruby_20]
+  if RUBY_VERSION =~ /^1\.9|^2/
+    gem 'rubocop', '0.24.1'
+  end
 #  gem 'rack-mini-profiler'
 
   # for generating i18n files

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -17,5 +17,7 @@ group :test do
   gem 'spork'
   gem 'factory_girl_rails', '~> 1.2', :require => false
   gem 'oj'
-  gem 'rubocop-checkstyle_formatter', :platforms => [:ruby_19, :ruby_20]
+    if RUBY_VERSION =~ /^1\.9|^2/
+    gem 'rubocop-checkstyle_formatter'
+  end
 end


### PR DESCRIPTION
:ruby_20 is unknown platform for older bundler versions
