### PR TITLE
Refs #4611 - db_pending_migration/seed stored in settings

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -21,7 +21,9 @@ class Setting::General < Setting
         self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"), false),
         self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60),
         self.set('max_trend', N_("Max days for Trends graphs"), 30),
-        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), true)
+        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), true),
+        self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true),
+        self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true)
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -1,0 +1,160 @@
+require 'optparse'
+require 'json'
+require 'yaml'
+
+desc "Configure Foreman in-database settings, see rake config -- --help for more details"
+task :config => :environment do
+  class ForemanConfig
+
+    attr_reader :options, :changed_settings
+
+    def initialize
+      @key              = nil
+      @keys             = []
+      @key_values       = {}
+      @changed_settings = []
+    end
+
+    def set_options_key_value(value)
+      unless @key
+        STDERR.puts("Key has to be specified first")
+        exit 2
+      end
+      @keys << @key
+      @key_values[@key] = value
+      @key = nil
+    end
+
+    def parser
+      OptionParser.new do |opt|
+        opt.banner = <<BANNER
+Get or set the Foremen settings.
+
+Options:
+BANNER
+        opt.on("-k",
+               "--key KEY",
+               "If not specified, all keys are displayed") do |val|
+          @key = val
+        end
+
+        opt.on("-v",
+               "--value VALUE",
+               "Set the value. The key must be specified. Complex values (hashes, arrays) are expected to be JSON encoded.") do |val|
+          set_options_key_value(val)
+        end
+
+        opt.on("-u",
+               "--unset",
+               "Unset the key. The key must be specified") do
+          set_options_key_value(:unset)
+        end
+
+        opt.on("-h", "--help", "Show help and exit") do
+          puts opt
+          exit
+        end
+
+        opt.on("-n",
+               "--dry-run",
+               "Don't change thd configuration. Success if no change is needed.") do
+          @dry = true
+        end
+      end
+    end
+
+    def run(args)
+      parser.parse!(args)
+
+      if @key && @key_values.any?
+        puts "Missing value for key '#{ @key }'"
+        exit 2
+      end
+
+      if @key
+        run_single_key
+      elsif @key_values.any?
+        run_key_values
+      else
+        run_all
+      end
+
+      if @dry
+        if changed_settings.empty?
+          exit 0
+        else
+          # dry mode and something would change
+          exit 1
+        end
+      end
+    end
+
+    # just a single key was passed: print the value
+    def run_single_key
+      setting = Setting.find_by_name(@key)
+      puts format_value(setting.settings_type, setting.value)
+    end
+
+    # key-value pairs were provided: try to change that
+    def run_key_values
+      @keys.each do |key|
+        value = @key_values[key]
+        setting = Setting.find_by_name(key)
+        old_value = setting.value
+        if value == :unset
+          value = nil
+        elsif complex_type?(setting.settings_type)
+          setting.value = typecast_value(setting.settings_type, value)
+        else
+          setting.parse_string_value(value)
+        end
+        if setting.valid? && old_value != setting.value
+          setting.save! unless @dry
+          changed_settings << setting
+        end
+        puts format_value(setting.settings_type, setting.value)
+      end
+    end
+
+    # no options: just print all the values
+    def run_all
+      Setting.all.each do |setting|
+        puts "#{setting.name}: #{format_value(setting.settings_type, setting.value)}"
+      end
+    end
+
+    def complex_type?(type)
+      ["hash", "array"].include? type
+    end
+
+    # we expect simple values or JSON encoded hashes or arrays (if applicible)
+    def typecast_value(type, value)
+      if complex_type?(type)
+        # we used JSON over custom format for input because it's easier to parse
+        JSON.parse(value).inspect
+      else
+        value
+      end
+    end
+
+    def format_value(type, value)
+      if complex_type?(type)
+        value.to_json
+      else
+        value
+      end
+    end
+  end
+
+  ARGV.shift
+  ForemanConfig.new.run(ARGV)
+  exit
+end
+
+# The db_pending_* settings are handled by the installer. For case
+# of not installing with installer, we want to ensure the settings to false
+# at the end of the seeding
+Rake::Task['db:seed'].enhance do
+  Setting['db_pending_migration'] = false
+  Setting['db_pending_seed'] = false
+end

--- a/script/foreman-config
+++ b/script/foreman-config
@@ -1,148 +1,48 @@
 #!/usr/bin/env ruby
 
 require 'optparse'
-options = {}
-defaults = {:foreman_path => File.expand_path("../..", __FILE__),
-            :environment => "production",
-            :keys => [],
-            :key_values => {}}
+defaults = { :foreman_path => File.expand_path("../..", __FILE__),
+             :environment => "production"}
+options = defaults.dup
+warn 'foreman-config script is deprecated. Please consider using `foreman-rake config` instead'
 
-options.merge!(defaults)
-changed_settings = []
-
-def set_options_key_value(options, value)
-  unless options.has_key?(:key)
-    STDERR.puts("Key has to be specified first")
-    exit 2
-  end
-  options[:keys] << options[:key]
-  options[:key_values][options[:key]] = value
-  options.delete(:key)
-end
-
-parser = OptionParser.new do |opt|
+option_parser = OptionParser.new do |opt|
   opt.banner = <<BANNER
-Get or set the Foremen settings.
+Wrapper around foreman-rake config task
 
-Options:
+It's kept here for backward compatibility purposes.
+The preffered way should be `foreman-rake config`. See
+`foreman-rake config -- --help` for details.
 BANNER
-  opt.on("-k",
-         "--key KEY",
-         "If not specified, all keys are displayed") do |val|
-    options[:key] = val
-  end
-
-  opt.on("-v",
-         "--value VALUE",
-         "Set the value. The key must be specified. Complex values (hashes, arrays) are expected to be JSON encoded.") do |val|
-    set_options_key_value(options, val)
-  end
-
-  opt.on("-u",
-         "--unset",
-         "Unset the key. The key must be specified") do
-    set_options_key_value(options, :unset)
-  end
-
-  opt.on("-h", "--help", "Show help and exit") do 
-    puts opt
-    exit
-  end
-
   opt.on("-p",
          "--path PATH",
          "Path with Foreman source code (default #{defaults[:foreman_path]})") do |val|
     options[:foreman_path] = val
   end
-
   opt.on("-e",
          "--env ENV",
          "Runtime environment (default #{defaults[:environment]})") do |val|
     options[:environment] = val
   end
-
-  opt.on("-n",
-         "--dry-run",
-         "Don't change thd configuration. Success if no change is needed.") do
-    options[:dry] = true
-  end
+  # pass the -v and -h options to the rake task
+  opt.on('-v') { raise OptionParser::InvalidOption }
+  opt.on('-h') { raise OptionParser::InvalidOption }
 end
 
-parser.parse!
+rake_args = []
+argv = ARGV.dup
 
-# suppress warnings (such as some featuer being disabled)
-verbosity=$VERBOSE
-$VERBOSE=nil
-
-ENV["RAILS_ENV"] = options[:environment]
-
-require File.expand_path("config/boot", options[:foreman_path])
-require File.expand_path("config/application", options[:foreman_path])
-
-Rails.application.require_environment!
-
-Foreman::Application.config.logger = Logger.new("#{Rails.root}/log/foreman-config.log")
-
-require 'json'
-require 'yaml'
-
-# get verbose level back
-$VERBOSE=verbosity
-
-def complex_type?(type)
-  ["hash", "array"].include? type
+begin
+  option_parser.parse! argv
+rescue OptionParser::InvalidOption => e
+  # don't fail on unknown attributes, rather pass it to the rake task
+  e.recover argv
+  rake_args << argv.shift
+  rake_args << argv.shift if !argv.empty? and argv.first !~ /^-/
+  retry
 end
 
-# we expect simple values or JSON encoded hashes or arrays (if applicible)
-def typecast_value(type, value)
-  if complex_type?(type)
-    # we used JSON over custom format for input because it's easier to parse
-    JSON.parse(value).inspect
-  else
-    value
-  end
-end
-
-def format_value(type, value)
-  if complex_type?(type)
-    value.to_json
-  else
-    value
-  end
-end
-
-# show all settings
-if options.has_key?(:key)
-  setting = Setting.find_by_name(options[:key])
-  puts format_value(setting.settings_type, setting.value)
-elsif options[:key_values].any?
-  options[:keys].each do |key|
-    value = options[:key_values][key]
-    setting = Setting.find_by_name(key)
-    old_value = setting.value
-    if value == :unset
-      value = nil
-    elsif complex_type?(setting.settings_type)
-      setting.value = typecast_value(setting.settings_type, value)
-    else
-      setting.parse_string_value(value)
-    end
-    if setting.valid? && old_value != setting.value
-      setting.save! unless options[:dry]
-      changed_settings << setting
-    end
-    puts format_value(setting.settings_type, setting.value)
-  end
-else
-  Setting.all.each do |setting|
-    puts "#{setting.name}: #{format_value(setting.settings_type, setting.value)}"
-  end
-end
-
-if options[:dry]
-  if changed_settings.empty?
-    exit 0
-  else
-    exit 1
-  end
+Dir.chdir(options[:foreman_path]) do
+  ENV['RAILS_ENV'] = options[:environment]
+  exec('rake', 'config', '--', *rake_args)
 end


### PR DESCRIPTION
This way, we can determine in the installer if the rake db:migrate/seed
should be run in the installer.

Later, we also could use this information to inform the entering user that
the application is not in ready state yet: preparation for maintenance
page.

Also, rake-ify scripts/foreman-config so that now you can run:

```
foreman-rake config -- -k key -v value_to_set
```

With all the behaviour keeping from the origin script/foreman-config
(the script/foreman-config is still working, although deprecated)
