### PR TITLE
Fixes #6999 - User logout susceptible to CSRF

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -376,4 +376,10 @@ class ApplicationController < ActionController::Base
     request.headers["X-Foreman-Layout"] == 'two-pane' && params[:action] != 'index'
   end
 
+  # Called from ActionController::RequestForgeryProtection, overrides
+  # nullify session which is the default behavior for unverified requests in Rails 3.
+  # On Rails 4 we can get rid of this and use the strategy ':exception'.
+  def handle_unverified_request
+    raise ::Foreman::Exception.new(N_("Invalid authenticity token"))
+  end
 end

--- a/app/services/menu/loader.rb
+++ b/app/services/menu/loader.rb
@@ -14,6 +14,7 @@ module Menu
 
       Manager.map :user_menu do |menu|
         menu.item :logout,               :caption => N_('Sign out'),
+                  :html => {:method => :post},
                   :url_hash => {:controller => '/users', :action => 'logout'}
         menu.item :my_account,           :caption => N_('My account'),
                   :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,7 +207,7 @@ Foreman::Application.routes.draw do
       collection do
         get 'login'
         post 'login'
-        get 'logout'
+        post 'logout'
         get 'extlogin'
         get 'extlogout'
         get 'auth_source_selected'

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -343,4 +343,27 @@ class UsersControllerTest < ActionController::TestCase
       assert_equal taxonomies(:organization1), updated_user.default_organization
     end
   end
+
+  context "CSRF" do
+    setup do
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    teardown do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    test "throws exception when CSRF token is invalid or not present" do
+      assert_raises Foreman::Exception do
+        post :logout, {}, set_session_user
+      end
+    end
+
+    test "allows logout when CSRF token is correct" do
+      @controller.expects(:verify_authenticity_token).returns(true)
+      post :logout, {}, set_session_user
+      assert_response :found
+      assert_redirected_to "/users/login"
+    end
+  end
 end


### PR DESCRIPTION
To avoid CSRF, logout is changed to be a POST request so
protect_from_forgery checks the CSRF token. However, in Rails 3 the only
strategy available is to nullify the session of the attacker.
This means the request will leave a warning in the logs and will go
through UsersController. Since the session is cleared at that point, the
attacked user won't be logged out, while the attacker will get a login
page in return.

This issue is probably worth revisiting on the update to Rails 4 to
raise an exception when CSRF tokens are not correct.
