### PR TITLE
Fixes #7344 - ignore saving errors during fact parsing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -213,7 +213,9 @@ Style/ClassCheck:
 # Offense count: 83
 # Configuration parameters: CountComments.
 Style/ClassLength:
-  Max: 1340
+  Max: 1000
+  Exclude:
+    - 'test/**/*'
 
 # Offense count: 3
 Style/ClassVars:

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -199,8 +199,14 @@ module Host
       iface.host = self
       update_virtuals(iface.identifier_was, name) if iface.identifier_changed? && !iface.virtual? && iface.persisted?
       iface.attrs = attributes
-      logger.debug "Saving #{name} NIC interface for host #{self.name}"
-      iface.save!
+
+      logger.debug "Saving #{name} NIC for host #{self.name}"
+      result = iface.save
+      result or begin
+        logger.warn "Saving #{name} NIC for host #{self.name} failed, skipping because:"
+        iface.errors.full_messages.each { |e| logger.warn " #{e}"}
+        false
+      end
     end
 
     def update_virtuals(old, new)

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,7 +1,7 @@
 class FactParser
   delegate :logger, :to => :Rails
   VIRTUAL = '\A([a-z0-9]+)_(\d+)\Z'
-  BRIDGES = '\Abr\d+\Z'
+  BRIDGES = '\A(vir)?br\d+\Z'
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}/
 
   def self.parser_for(type)


### PR DESCRIPTION
@GregSutcliffe and @ohadlevy, could you please test the patch on affected machines? I was not able to reproduce some of your issues.
