### PR TITLE
Fixes #7369 - External user groups update on login

### DIFF
--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -1,6 +1,7 @@
 class UsergroupsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   before_filter :find_resource, :only => [:edit, :update, :destroy]
+  after_filter  :refresh_external_usergroups, :only => [:create, :update]
 
   def index
     @usergroups = resource_base.paginate :page => params[:page]
@@ -45,5 +46,9 @@ class UsergroupsController < ApplicationController
 
   def find_by_id(permission = :view_usergroups)
     Usergroup.authorized(permission).find(params[:id])
+  end
+
+  def refresh_external_usergroups
+    @usergroup.external_usergroups.map(&:refresh)
   end
 end

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -56,7 +56,7 @@ class AuthSource < ActiveRecord::Base
   end
 
   # Called after creating a new user at login
-  def update_usergroups(login, password)
+  def update_usergroups(login)
   end
 
   # Try to authenticate a user not yet registered against available sources


### PR DESCRIPTION
This forces external user groups associated to the auth source of the user logging in to update, so that users get their external permissions updated on login.
Also there are a few unit tests that were large and I tried to tidy that up.
