### PR TITLE
fixes #7372 - API v2 - accept PUT/POST requests with wrapped root node to add/remove has_many associations of child nodes

### DIFF
--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -50,22 +50,44 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should update associated architectures by ids" do
+  test "should update associated architectures by ids with UNWRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
       put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { },
-                     :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ]
-                   }
+                     :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ] }
     end
     assert_response :success
   end
 
-  test "should update associated architectures by name" do
+  test "should update associated architectures by name with UNWRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
       put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { },
-                     :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ]
-                   }
+                     :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ] }
+    end
+    assert_response :success
+  end
+
+  test "should add association of architectures by ids with WRAPPED node" do
+    os = operatingsystems(:redhat)
+    assert_difference('os.architectures.count') do
+      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id }] } }
+    end
+    assert_response :success
+  end
+
+  test "should add association of architectures by name with WRAPPED node" do
+    os = operatingsystems(:redhat)
+    assert_difference('os.architectures.count') do
+      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name }] } }
+    end
+    assert_response :success
+  end
+
+  test "should remove association of architectures with WRAPPED node" do
+    os = operatingsystems(:redhat)
+    assert_difference('os.architectures.count', -1) do
+      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => {:architectures => [] } }
     end
     assert_response :success
   end


### PR DESCRIPTION
previous commit bbf64d9900262e42afaec6dd84934ae601c1d4f3 only checks for has_many associations of child nodes if the request was not wrapped (no root node). Since POST/PUT is documented as wrapped, it should support this to.
Therefore, there will be two main ways to add/remove associations, either by

1) passing *_ids

{ 
   "operatingsystem": { 
      "name": "CentOs", 
      "config_template_ids": [36, 12, 40] 
  } 
}

2) Passing child nodes

{ 
  "operatingsystem": { 
     "name": "CentOs", 
     "config_templates": [ { 
           "id": 36, 
          "name": "CentOS-enabled-post" 
      }, { 
          "id": 12, 
           "name": "Grubby Default" 
      }, { 
          "id": 40, 
           "name": "Katello Kickstart Default", 
      }
     ] 
   } 
}
