### PR TITLE
fixes #7253 - change nil admin field on users to false, matches usergroups

### DIFF
--- a/app/controllers/concerns/foreman/controller/users_mixin.rb
+++ b/app/controllers/concerns/foreman/controller/users_mixin.rb
@@ -13,7 +13,7 @@ module Foreman::Controller::UsersMixin
   protected
   def set_admin_on_creation
     admin = params[:user].delete :admin
-    @user = User.new(params[:user]) { |u| u.admin = admin }
+    @user = User.new(params[:user]) { |u| u.admin = admin unless admin.nil? }
   end
 
   def clear_params_on_update

--- a/db/migrate/20140908192300_change_nil_admin_users_to_false.rb
+++ b/db/migrate/20140908192300_change_nil_admin_users_to_false.rb
@@ -1,0 +1,14 @@
+class FakeUser < ActiveRecord::Base
+  set_table_name 'users'
+end
+
+class ChangeNilAdminUsersToFalse < ActiveRecord::Migration
+  def self.up
+    FakeUser.where(:admin => nil).update_all(:admin => false)
+    change_column :users, :admin, :boolean, :null => false, :default => false
+  end
+
+  def self.down
+    change_column :users, :admin, :boolean, :null => true, :default => nil
+  end
+end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -40,6 +40,7 @@ class UsersControllerTest < ActionController::TestCase
       }
     }, set_session_user
     assert_redirected_to users_path
+    refute User.find_by_login('foo').admin
   end
 
   test 'should create admin user' do
@@ -53,6 +54,7 @@ class UsersControllerTest < ActionController::TestCase
       }
     }, set_session_user
     assert_redirected_to users_path
+    assert User.find_by_login('foo').admin
   end
 
   test "should update user" do


### PR DESCRIPTION
When the admin field was nil, admin_changed? in user model validations can
evaluate to true if the field changed from nil to false.

---

I have a test that I wrote for nil/false transitions prior to realising the schema was broken, but I think it's fairly pointless when the schema now prevents nil admins.  Let me know if you'd prefer it.

Marking as a 1.6.0 blocker as it involves a schema change and is a regression, I'd rather not put that in a point release.

Reproducer in the bug report comments.
