### PR TITLE
fixes #2127: added support for root password hashing other than MD5

### DIFF
--- a/app/helpers/unattended_helper.rb
+++ b/app/helpers/unattended_helper.rb
@@ -6,7 +6,7 @@ module UnattendedHelper
   end
 
   def grub_pass
-    @grub ? "--md5pass=#{@host.root_pass}": ""
+    @grub ? "--md5pass=#{@host.grub_pass}": ""
   end
 
   def root_pass

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -105,7 +105,12 @@ module HostCommon
   end
 
   def crypt_root_pass
-    self.root_pass = root_pass.empty? ? nil : (root_pass.starts_with?('$') ? root_pass : root_pass.crypt("$1$#{SecureRandom.base64(6)}"))
+    unless root_pass.empty?
+      unencrypted_pass = root_pass
+      self.root_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass :
+          (operatingsystem.nil? ? PasswordCrypt.passw_crypt(unencrypted_pass) : PasswordCrypt.passw_crypt(unencrypted_pass, operatingsystem.password_hash))
+      self.grub_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)
+    end
   end
 
   def param_true? name

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -28,6 +28,7 @@ class Operatingsystem < ActiveRecord::Base
   validates :minor, :numericality => {:greater_than_or_equal_to => 0}, :allow_nil => true, :allow_blank => true
   validates :name, :presence => true, :format => {:with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.")}
   validates :description, :uniqueness => true, :allow_blank => true
+  validates :password_hash, :inclusion => { :in => PasswordCrypt::ALGORITHMS }
   before_validation :downcase_release_name
   #TODO: add validation for name and major uniqueness
 

--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -1,0 +1,12 @@
+class PasswordCrypt
+  ALGORITHMS = {'MD5' => '$1$', 'SHA256' => '$5$', 'SHA512' => '$6$'}
+
+  def self.passw_crypt(passwd, hash_alg = 'MD5')
+    raise Foreman::Exception N_("Unsupported password hash function '%s'") % hash_alg unless ALGORITHMS.has_key?(hash_alg)
+    passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")
+  end
+
+  def self.grub2_passw_crypt(passw)
+    self.passw_crypt(passw, 'MD5')
+  end
+end

--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -24,7 +24,7 @@
       <div id="release_name" <%= display?(!@operatingsystem.use_release_name?) %>>
         <%= text_f f, :release_name, :help_inline => _("e.g. karmic, lucid, hw0910 etc") %>
       </div>
-
+      <%= select_f f, :password_hash, PasswordCrypt::ALGORITHMS.keys, :to_s, :to_s, {}, { :label => _("Root password hash"), :help_inline => _("Hash function to use. Change takes effect for new or updated hosts.")} %>
       <%= multiple_checkboxes f, :architectures, @operatingsystem, Architecture, :label => _("Architectures") %>
     </div>
 

--- a/db/migrate/20140912113254_add_password_hash_to_operatingsystem.rb
+++ b/db/migrate/20140912113254_add_password_hash_to_operatingsystem.rb
@@ -1,0 +1,5 @@
+class AddPasswordHashToOperatingsystem < ActiveRecord::Migration
+  def change
+    add_column :operatingsystems, :password_hash, :string, :default => 'MD5'
+  end
+end

--- a/db/migrate/20140912114124_add_grub_password_to_hosts.rb
+++ b/db/migrate/20140912114124_add_grub_password_to_hosts.rb
@@ -1,0 +1,5 @@
+class AddGrubPasswordToHosts < ActiveRecord::Migration
+  def change
+    add_column :hosts, :grub_pass, :string, :default => ""
+  end
+end

--- a/db/migrate/20140912145052_add_grub_password_to_hostgroup.rb
+++ b/db/migrate/20140912145052_add_grub_password_to_hostgroup.rb
@@ -1,0 +1,5 @@
+class AddGrubPasswordToHostgroup < ActiveRecord::Migration
+  def change
+    add_column :hostgroups, :grub_pass, :string, :default => ""
+  end
+end


### PR DESCRIPTION
This is an alternative (to https://github.com/theforeman/foreman/pull/1736) implementation. Instead of having a global setting, a per-os attribute has been introduced. 
