### PR TITLE
Fixes #5468 - prevent Chrome from autofilling passwords

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -101,6 +101,12 @@ function onContentLoad(){
   });
 
   multiSelectOnLoad();
+
+  // Removes the value from fake password field.
+  $("#fakepassword").val("");
+  $('form').on('click', 'input[type="submit"]', function() {
+    $("#fakepassword").remove();
+  });
 }
 
 function remove_fields(link) {

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -480,6 +480,8 @@ function onHostEditLoad(){
 }
 
 $(document).on('submit',"[data-submit='progress_bar']", function() {
+  // onContentLoad function clears any un-wanted parameters from being sent to the server by
+  // binding 'click' function before this submit. see '$('form').on('click', 'input[type="submit"]', function()'
   submit_host();
   return false;
 });

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -50,6 +50,8 @@ module LayoutHelper
   end
 
   def password_f(f, attr, options = {})
+    password_field_tag(:fakepassword, nil, :style => 'display: none') +
+    # The actual field.
     field(f, attr, options) do
       options[:autocomplete] ||= "off"
       options[:placeholder] ||= password_placeholder(f.object)


### PR DESCRIPTION
1) Create a dummy password field above each password field in password_f
2) Hide that field with css and clear its value.
