### PR TITLE
Fixes #7450 - do not mark non-required fields

### DIFF
--- a/test/unit/helpers/layout_helper_test.rb
+++ b/test/unit/helpers/layout_helper_test.rb
@@ -19,6 +19,8 @@ class LayoutHelperTest < ActionView::TestCase
     assert is_required?(f, :title)
     refute is_required?(f, :environment_id)
     refute is_required?(f, :parent_id)
+    f = ActionView::Helpers::FormBuilder.new(:host, Host::Managed.new, @host, {}, {})
+    refute is_required?(f, :architecture_id) # not required because of :if
+    refute is_required?(f, :mac)             # not required because of :unless
   end
-
 end


### PR DESCRIPTION
If validation is conditional we don't mark fields as required by
default. Also fixes disabling by override using :required option.
