### PR TITLE
Feature #7805 - Add several security related HTTP headers - security hardening.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'deep_cloneable', '~> 2.0'
 gem 'foreigner', '~> 1.4.2'
 gem 'validates_lengths_from_database',  '~> 0.2.0'
 gem 'friendly_id', '~> 4.0'
+gem 'secure_headers', '~> 1.3.3'
 
 if RUBY_VERSION =~ /^1\.8/
   # Older version of safemode for Ruby 1.8, as the latest causes regexp overflows (#2100)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,6 +6,7 @@ module Api
     include Foreman::ThreadSession::Cleaner
     include FindCommon
 
+    ensure_security_headers
     protect_from_forgery
     skip_before_filter :verify_authenticity_token, :unless => :protect_api_from_forgery?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include Foreman::ThreadSession::Cleaner
   include FindCommon
 
+  ensure_security_headers
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
   rescue_from Exception, :with => :generic_exception if Rails.env.production?

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,20 @@
+::SecureHeaders::Configuration.configure do |config|
+  config.hsts = {
+    :max_age            => 20.years.to_i,
+    :include_subdomains => true
+  }
+  config.x_frame_options = 'SAMEORIGIN'
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = {
+    :value => 1,
+    :mode  => 'block'
+  }
+  config.csp = {
+    :enforce     => true,
+    :default_src => 'self',
+    :frame_src   => 'self',
+    :connect_src => 'self',
+    :style_src   => 'inline self',
+    :script_src  => 'eval inline self'
+  }
+end

--- a/test/functional/application_controller_subclass_test.rb
+++ b/test/functional/application_controller_subclass_test.rb
@@ -107,4 +107,18 @@ class TestableControllerTest < ActionController::TestCase
       assert_equal @request.filtered_parameters, @params
     end
   end
+
+  context "secure headers in HTTP response" do
+    it "should include safe values" do
+      get :index
+      assert_equal @response.headers['X-Frame-Options'], 'SAMEORIGIN'
+      assert_equal @response.headers['X-XSS-Protection'], '1; mode=block'
+      assert_equal @response.headers['X-Content-Type-Options'], 'nosniff'
+      assert_equal @response.headers['Content-Security-Policy'], \
+        "default-src 'self'; connect-src 'self'; font-src 'self'; " +
+        "frame-src 'self'; img-src 'self' data:; media-src 'self'; " +
+        "object-src 'self'; script-src 'unsafe-eval' 'unsafe-inline' " +
+        "'self'; style-src 'unsafe-inline' 'self';"
+    end
+  end
 end

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -28,7 +28,11 @@ class AccessPermissionsTest < ActiveSupport::TestCase
 
     # App controller stubs
     "testable/index", "api/testable/index", "api/testable/raise_error",
-    "api/v2/testable/index", "api/v2/testable/create"
+    "api/v2/testable/index", "api/v2/testable/create",
+
+    # Content Security Policy report forwarding endpoint - noop if not configured.
+    # See https://github.com/twitter/secureheaders/issues/113
+    "content_security_policy/scribe"
   ]
 
   MAY_SKIP_AUTHORIZED = [ "about/index" ]


### PR DESCRIPTION
This commit uses secure_headers gem and configures several HTTP
security related headers to be sent by server:
- Content Security Policy
- HTTP Strict Transport Security
- X-XSS-Protection
- X-Frame-Options
- X-Content-Type-Options
  All of these enable browser protections on client side and make
  exploitation of common web flaws harder.

Options, especially CSP ones, can be made more restrictive in the future, which I refrain from doing right now to not introduce regressions.
