### PR TITLE
Fixes #7522 - made CA textarea editable for oVirt/RHEV

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -271,7 +271,7 @@ module Foreman::Model
       return unless public_key.blank? || options[:force]
       client
     rescue Foreman::FingerprintException => e
-      self.public_key = e.fingerprint
+      self.public_key = e.fingerprint if self.public_key.blank?
     end
 
     def api_version

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -10,5 +10,6 @@
                  :'data-url' => test_connection_compute_resources_path) + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
 <% quotas = (f.object.uuid.nil? && controller.action_name != 'test_connection') ? [] : f.object.quotas.all rescue []%>
 <%= select_f f, :ovirt_quota, quotas, :id, :name, {}, :label => _("Quota ID") %>
-<%= textarea_f f, :public_key, :disabled => true, :label => _("CA Certificate"), :size => "col-md-8" %>
+<%= textarea_f f, :public_key, :label => _("X509 Certification Authorities"), :size => "col-md-8",
+  :placeholder => _("Optionally provide a CA, or a correctly ordered CA chain. If left blank, a self-signed CA will be populated automatically by the server during the first request.") %>
 <%= f.hidden_field(:public_key) if f.object.uuid.present? %>


### PR DESCRIPTION
DO NOT MERGE

I don't know why but the helper popover does not work for me. It is AJAX based
I understand but this is what I see in logs:

```
Started GET "/compute_resources/provider_selected" for 127.0.0.1 at 2014-09-18 21:32:04 +0200
Processing by ComputeResourcesController#provider_selected as JS
  User Load (0.2ms)  SELECT "users".* FROM "users" WHERE "users"."id" = ? LIMIT 1  [["id", 1]]
Setting current user thread-local variable to admin
   (0.2ms)  SELECT COUNT(*) FROM "taxonomies" WHERE "taxonomies"."type" IN ('Organization')
Setting current organization thread-local variable to none
   (0.1ms)  SELECT COUNT(*) FROM "taxonomies" WHERE "taxonomies"."type" IN ('Location')
Setting current location thread-local variable to none
  AuthSource Load (0.2ms)  SELECT "auth_sources".* FROM "auth_sources" WHERE "auth_sources"."id" = 1 LIMIT 1
   (0.1ms)  SELECT id FROM "taxonomies" WHERE "taxonomies"."type" IN ('Location') LIMIT 1
   (0.1ms)  SELECT id FROM "taxonomies" WHERE "taxonomies"."type" IN ('Organization') LIMIT 1
Completed 500 Internal Server Error in 10.8ms

Foreman::Exception (ERF42-1330 [Foreman::Exception]: must provide a provider):
  app/models/compute_resource.rb:69:in `new_provider'
  app/controllers/compute_resources_controller.rb:79:in `provider_selected'
  app/models/concerns/foreman/thread_session.rb:33:in `clear_thread'
  lib/middleware/catch_json_parse_errors.rb:9:in `call'
```

Anyone?
