### PR TITLE
Fixes #7819 - Fix facter 2.0 windows os version issue.

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -5,6 +5,8 @@ class PuppetFactParser < FactParser
     orel = case os_name
              when /(suse|sles|gentoo)/i
                facts[:operatingsystemrelease]
+             when /(windows)/i
+               facts[:kernelrelease]
              else
                facts[:lsbdistrelease] || facts[:operatingsystemrelease]
            end


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/FACT-341 operatingsystemreleasereturns a non-numeric value since facter 2.0. Commit fixed that issue and now reads windows opel version from kernelrelease fact.
