### PR TITLE
Fixes #7401 - Add support for bonds

### DIFF
--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -38,7 +38,10 @@ module Api
           param :virtual, :bool, :desc => N_("Alias or VLAN device")
           param :identifier, String, :desc => N_("Device identifier, e.g. eth0 or eth1.1")
           param :tag, String, :desc => N_("VLAN tag, this attribute has precedence over the subnet VLAN ID")
-          param :physical_device, String, :desc => N_("Identifier of physical interface to which this interface belongs to. e.g. eth1")
+          param :attached_to, String, :desc => N_("Identifier of the interface to which this interface belongs, e.g. eth1")
+          param :mode, String, :desc => N_("Bond mode of the interface, e.g. balance-rr")
+          param :attached_devices, Array, :desc => N_("Identifiers of slave interfaces, e.g. ['eth1', 'eth2']")
+          param :bond_options, String, :desc => N_("Space separated options, e.g. miimon=100")
         end
       end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -24,7 +24,7 @@ class HostsController < ApplicationController
   before_filter :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_filter :set_host_type, :only => [:update]
   before_filter :find_multiple, :only => MULTIPLE_ACTIONS
-  helper :hosts, :reports
+  helper :hosts, :reports, :interfaces
 
   def index(title = nil)
     begin

--- a/app/helpers/interfaces_helper.rb
+++ b/app/helpers/interfaces_helper.rb
@@ -1,0 +1,9 @@
+module InterfacesHelper
+  def interfaces_types
+    @types ||= [
+      [_("Interface"), Nic::Managed],
+      [_("Bond"), Nic::Bond],
+      [_("BMC"), Nic::BMC]
+    ]
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -56,7 +56,7 @@ class Host::Managed < Host::Base
       :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
       :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :primary_interface, :interfaces,
-      :has_primary_interface?
+      :has_primary_interface?, :bond_interfaces, :interfaces_with_identifier, :managed_interfaces
   end
 
   attr_reader :cached_host_params

--- a/app/models/nic/bond.rb
+++ b/app/models/nic/bond.rb
@@ -1,0 +1,38 @@
+module Nic
+  class Bond < Managed
+    SEPARATOR = ','
+    MODES     = %w(balance-rr active-backup balance-xor broadcast 802.3ad balance-tlb balance-alb)
+    validates :mode, :presence => true, :inclusion => { :in => MODES }
+    validates :attached_devices, :format => { :with => /\A[a-z0-9#{SEPARATOR}.:_-]+\Z/ }, :allow_blank => true
+
+    before_save :ensure_virtual
+
+    def virtual
+      true
+    end
+    alias_method :virtual?, :virtual
+
+    def attached_devices=(devices)
+      devices = devices.split(SEPARATOR) if devices.is_a?(String)
+      super(devices.map { |i| i.downcase.strip }.join(SEPARATOR))
+    end
+
+    def attached_devices_identifiers
+      attached_devices.split(SEPARATOR)
+    end
+
+    def add_slave(identifier)
+      self.attached_devices = attached_devices_identifiers.push(identifier).uniq.join(SEPARATOR)
+    end
+
+    def remove_slave(identifier)
+      self.attached_devices = attached_devices_identifiers.tap { |a| a.delete(identifier) }.join(SEPARATOR)
+    end
+
+    private
+
+    def ensure_virtual
+      self.virtual = true
+    end
+  end
+end

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -7,7 +7,7 @@ module Nic
 
     validate :normalize_ip
 
-    validates :physical_device, :presence => true, :if => Proc.new { |o| o.virtual && !o.bridge }
+    validates :attached_to, :presence => true, :if => Proc.new { |o| o.virtual && o.instance_of?(Nic::Managed) && !o.bridge? }
 
     attr_accessible :name, :subnet_id, :subnet, :domain_id, :domain
 
@@ -26,6 +26,10 @@ module Nic
 
     def vlanid
       self.tag.blank? ? self.subnet.vlanid : self.tag
+    end
+
+    def bridge?
+      !!bridge
     end
 
     def bridge

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -6,8 +6,9 @@ module Nic
 
     # Interface normally are not executed by them self, so we use the host queue and related methods.
     # this ensures our orchestration works on both a host and a managed interface
-    delegate :progress_report_id, :require_ip_validation?, :overwrite?, :capabilities, :compute_resource,
+    delegate :progress_report_id, :require_ip_validation?, :capabilities, :compute_resource,
              :image_build?, :pxe_build?, :pxe_build?, :ip_available?, :mac_available?, :to => :host
+    delegate :overwrite?, :to => :host, :allow_nil => true
 
     # this ensures we can create an interface even when there is no host queue
     # e.g. outside to Host nested attributes

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,8 +1,9 @@
 class FactParser
   delegate :logger, :to => :Rails
-  VIRTUAL = '\A([a-z0-9]+)_(\d+)\Z'
-  BRIDGES = '\A(vir)?br\d+\Z'
-  VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}/
+  VIRTUAL = /\A([a-z0-9]+)_(\d+)\Z/
+  BRIDGES = /\A(vir)?br\d+\Z/
+  BONDS = /\A(bond\d+)|(lagg\d+)\Z/
+  VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
   def self.parser_for(type)
     parsers[type.to_s] || parsers[:puppet]
@@ -99,10 +100,10 @@ class FactParser
   def set_additional_attributes(attributes, name)
     if name =~ VIRTUAL_NAMES
       attributes[:virtual] = true
-      if $1.nil?
+      if $1.nil? && name =~ BRIDGES
         attributes[:bridge] = true
       else
-        attributes[:physical_device] = $1
+        attributes[:attached_to] = $1
 
         if @facts[:vlans].present?
           vlans = @facts[:vlans].split(',')

--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -3,4 +3,4 @@ object @interface
 extends "api/v2/interfaces/base"
 
 attributes :username, :password, :provider, :subnet_id, :subnet_name, :domain_id, :domain_name, :created_at, :updated_at,
-           :managed, :virtual, :identifier, :tag, :physical_device
+           :managed, :virtual, :identifier, :tag, :attached_to, :mode, :attached_devices, :bond_options

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -1,4 +1,4 @@
-<%= selectable_f f, :type, [[_("Interface"), Nic::Managed], [_("BMC"), Nic::BMC]], {},
+<%= selectable_f f, :type, interfaces_types, {},
                  :class => 'interface_type', :disabled => !f.object.new_record? %>
 
 <%= text_f f, :mac %>
@@ -18,17 +18,3 @@
 
 <%= checkbox_f f, :managed,
                :help_inline => _("Should this interface be managed via DHCP and DNS smart proxy and should it be configured during provisioning?") %>
-
-
-<% virtual_id = dom_id(f.object, "virtual_form") %>
-<%= checkbox_f f, :virtual,
-               :disabled => !f.object.new_record?,
-               :label => _("Virtual NIC"),
-               :help_inline => _("Enable if this is an alias or VLAN interface"),
-               :onclick => "$(this).closest('div.clearfix').siblings('div.#{virtual_id}').toggle()" %>
-
-<% style = f.object.virtual ? '' : 'display:none' %>
-<%= content_tag :div, :style => style, :class => virtual_id do %>
-  <%= text_f f, :tag, :help_inline => _("Inherits from subnet VLAN ID if not set") %>
-  <%= text_f f, :physical_device %>
-<% end %>

--- a/app/views/nic/_virtual_form.html.erb
+++ b/app/views/nic/_virtual_form.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :tag, :help_inline => _("Inherits from subnet VLAN ID if not set") %>
+<%= text_f f, :attached_to, :help_inline => _("Identifier of the interface to which this interface belongs, e.g. eth1"),
+           :required => local_assigns[:attached_to_required] %>

--- a/app/views/nic/bonds/_bond.html.erb
+++ b/app/views/nic/bonds/_bond.html.erb
@@ -1,0 +1,9 @@
+<%= render 'nic/base_form', :f => f %>
+
+<%= content_tag :span, :class => 'bond_fields' do %>
+  <%= selectable_f f, :mode, Nic::Bond::MODES %>
+  <%= text_f f, :attached_devices, :help_inline => _('comma separated interface identifiers') %>
+  <%= text_f f, :bond_options, :help_inline => _('space separated options, e.g. miimon=100') %>
+<% end %>
+
+<%= f.hidden_field :virtual, :value => true %>

--- a/app/views/nic/manageds/_managed.html.erb
+++ b/app/views/nic/manageds/_managed.html.erb
@@ -1,1 +1,13 @@
 <%= render 'nic/base_form', :f => f %>
+
+<% virtual_id = dom_id(f.object, "virtual_form") %>
+<%= checkbox_f f, :virtual,
+               :disabled => !f.object.new_record?,
+               :label => _("Virtual NIC"),
+               :help_inline => _("Enable if this is an alias or VLAN interface"),
+               :onclick => "$(this).closest('div.clearfix').siblings('div.#{virtual_id}').toggle()" %>
+
+<% hidden_class = f.object.virtual ? '' : 'hidden' %>
+<%= content_tag :div, :class => "#{virtual_id} #{hidden_class}" do %>
+  <%= render 'nic/virtual_form', :f => f, :attached_to_required => true %>
+<% end %>

--- a/db/migrate/20140910111148_add_bond_attributes_to_nic_base.rb
+++ b/db/migrate/20140910111148_add_bond_attributes_to_nic_base.rb
@@ -1,0 +1,17 @@
+require_dependency 'nic/base'
+
+class AddBondAttributesToNicBase < ActiveRecord::Migration
+  def self.up
+    add_column :nics, :mode, :string, :null => false, :default => Nic::Bond::MODES.first
+    add_column :nics, :attached_devices, :string, :default => '', :null => false
+    add_column :nics, :bond_options, :string, :default => '', :null => false
+    rename_column :nics, :physical_device, :attached_to
+  end
+
+  def self.down
+    rename_column :nics, :attached_to, :physical_device
+    remove_column :nics, :bond_options
+    remove_column :nics, :attached_devices
+    remove_column :nics, :mode
+  end
+end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -96,6 +96,7 @@ FactoryGirl.define do
   end
   factory :nic_base do
     sequence(:identifier) { |n| "eth#{n}" }
+    sequence(:mac) { |n| "00:00:00:00:00:#{n.to_s(16).rjust(2, '0')}" }
   end
   factory :nic_interface, :class => Nic::Interface, :parent => :nic_base do
     type 'Nic::Interface'
@@ -105,5 +106,9 @@ FactoryGirl.define do
   end
   factory :nic_bmc, :class => Nic::Interface, :parent => :nic_base do
     type 'Nic::BMC'
+  end
+  factory :nic_bond, :class => Nic::Bond, :parent => :nic_base do
+    type 'Nic::Bond'
+    mode 'balance-rr'
   end
 end

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -82,25 +82,25 @@ class FactParserTest < ActiveSupport::TestCase
 
     result = parser.send(:set_additional_attributes, {}, 'eth0_0')
     assert result[:virtual]
-    assert_equal 'eth0', result[:physical_device]
+    assert_equal 'eth0', result[:attached_to]
     assert_equal '', result[:tag]
     refute result[:bridge]
 
     result = parser.send(:set_additional_attributes, {}, 'eth0_1')
     assert result[:virtual]
-    assert_equal 'eth0', result[:physical_device]
+    assert_equal 'eth0', result[:attached_to]
     assert_equal '1', result[:tag]
     refute result[:bridge]
 
     result = parser.send(:set_additional_attributes, {}, 'eth0_2')
     assert result[:virtual]
-    assert_equal 'eth0', result[:physical_device]
+    assert_equal 'eth0', result[:attached_to]
     assert_equal '2', result[:tag]
     refute result[:bridge]
 
     result = parser.send(:set_additional_attributes, {}, 'eth0_4')
     assert result[:virtual]
-    assert_equal 'eth0', result[:physical_device]
+    assert_equal 'eth0', result[:attached_to]
     assert_equal '', result[:tag]
     refute result[:bridge]
   end
@@ -110,13 +110,13 @@ class FactParserTest < ActiveSupport::TestCase
 
     result = parser.send(:set_additional_attributes, {}, 'br0')
     assert result[:virtual]
-    assert_empty result[:physical_device]
+    assert_empty result[:attached_to]
     assert_empty result[:tag]
     assert result[:bridge]
 
     result = parser.send(:set_additional_attributes, {}, 'virbr0')
     assert result[:virtual]
-    assert_empty result[:physical_device]
+    assert_empty result[:attached_to]
     assert_empty result[:tag]
     assert result[:bridge]
   end

--- a/test/unit/nics/bond_test.rb
+++ b/test/unit/nics/bond_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class BondTest < ActiveSupport::TestCase
+  setup do
+    disable_orchestration
+  end
+
+  test 'is always virtual' do
+    host = FactoryGirl.create(:host)
+    bond = FactoryGirl.create(:nic_bond, :host => host)
+    assert bond.virtual
+    assert_valid bond
+
+    bond = FactoryGirl.create(:nic_bond, :virtual => false, :host => host)
+    assert bond.virtual
+  end
+
+  test 'attached devices are stripped and downcased' do
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => 'Eth0, ETH1 ,   eth2    ')
+    assert_equal "eth0,eth1,eth2", bond.attached_devices
+  end
+
+  test 'attached devices can be also specified as an array' do
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => ['Eth0', 'ETH1 ','   eth2    '])
+    assert_equal "eth0,eth1,eth2", bond.attached_devices
+  end
+
+  test 'attached devices interfaces can be accessed as an array' do
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => 'eth0,eth1,eth2')
+    assert_equal %w(eth0 eth1 eth2), bond.attached_devices_identifiers
+  end
+
+  test '#add_slave adds identifier to attached_devices' do
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => '')
+    assert bond.add_slave('eth0')
+    assert_equal %w(eth0), bond.attached_devices_identifiers
+
+    assert bond.add_slave('eth1')
+    assert_equal %w(eth0 eth1), bond.attached_devices_identifiers
+
+    assert bond.add_slave('eth0')
+    assert_equal %w(eth0 eth1), bond.attached_devices_identifiers
+
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => 'eth1,eth2')
+    assert bond.add_slave('eth0')
+    assert_equal %w(eth1 eth2 eth0), bond.attached_devices_identifiers
+  end
+
+  test '#remove_slave remove identifier from attached_devices' do
+    bond = FactoryGirl.build(:nic_bond, :attached_devices => 'eth0,eth1,eth2')
+    assert bond.remove_slave('eth1')
+    assert_equal %w(eth0 eth2), bond.attached_devices_identifiers
+    assert bond.remove_slave('eth8')
+    assert_equal %w(eth0 eth2), bond.attached_devices_identifiers
+
+    assert bond.remove_slave('eth0')
+    assert_equal %w(eth2), bond.attached_devices_identifiers
+
+    assert bond.remove_slave('eth2')
+    assert_equal [], bond.attached_devices_identifiers
+
+    assert bond.remove_slave('eth2')
+    assert_equal [], bond.attached_devices_identifiers
+  end
+end


### PR DESCRIPTION
Renames physical_device to attached_to and move the virtual device
form out of BMC.
Extends the form for Bond devices
Allows configuration of bonds in KS template
Parsing of Bond interfaces from facts
