### PR TITLE
fixes #7608 - Override all puppetclass parameters in one click

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -44,6 +44,17 @@ class PuppetclassesController < ApplicationController
     end
   end
 
+  def override
+    pclass = Puppetclass.find(params[:id])
+    pname = pclass.name
+    pclass.class_params.each do |p|
+      p.override = true
+      p.save
+    end
+    notice _("Successfully overriden all parameters of puppetclass #{pname}")
+    redirect_to puppetclasses_url
+  end
+
   # form AJAX methods
   def parameters
     puppetclass = Puppetclass.find(params[:id])

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -1,8 +1,7 @@
 class PuppetclassesController < ApplicationController
   include Foreman::Controller::Environments
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
-  before_filter :find_by_name, :only => [:edit, :update, :destroy, :override]
+  before_filter :find_resource, :only => [:edit, :update, :destroy, :override]
   before_filter :setup_search_options, :only => :index
   before_filter :reset_redirect_to_url, :only => :index
   before_filter :store_redirect_to_url, :only => :edit
@@ -48,23 +47,11 @@ class PuppetclassesController < ApplicationController
   def override
     if @puppetclass.class_params.present?
       @puppetclass.class_params.each do |class_param|
-        class_param.update_attribute(:override, true)
+        class_param.update_attribute(:override, params[:enable])
       end
-      notice _("Successfully overriden all parameters of puppetclass %{name}" % { :name => @puppetclass.name })
+      notice _("Successfully set as %{message} all parameters of puppetclass %{name}" % { :message => params[:message], :name => @puppetclass.name })
     else
       error _("No parameters to override for puppetclass %{name}" % { :name => @puppetclass.name })
-    end
-    redirect_to puppetclasses_url
-  end
-
-  def unoverride
-    if @puppetclass.class_params.present?
-      @puppetclass.class_params.each do |class_param|
-        class_param.update_attribute(:override, false)
-      end
-      notice _("Successfully set as not overriden all parameters of puppetclass %{name}" % { :name => @puppetclass.name })
-    else
-      error _("No parameters to change for puppetclass %{name}" % { :name => @puppetclass.name })
     end
     redirect_to puppetclasses_url
   end
@@ -115,25 +102,13 @@ class PuppetclassesController < ApplicationController
     session[:redirect_to_url] = nil
   end
 
-<<<<<<< HEAD
-=======
-  def find_by_name
-    not_found and return if params[:id].blank?
-    pc = resource_base.includes(:class_params => [:environment_classes, :environments, :lookup_values])
-    @puppetclass = (params[:id] =~ /\A\d+\Z/) ? pc.find(params[:id]) : pc.find_by_name(params[:id])
-    not_found and return unless @puppetclass
-  end
-
   def action_permission
     case params[:action]
       when 'override'
         :override
-      when 'unoverride'
-        :unoverride
       else
         super
     end
   end
 
->>>>>>> fixes #7608 added unoverride
 end

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -2,6 +2,7 @@ class PuppetclassesController < ApplicationController
   include Foreman::Controller::Environments
   include Foreman::Controller::AutoCompleteSearch
   before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_filter :find_by_name, :only => [:edit, :update, :destroy, :override]
   before_filter :setup_search_options, :only => :index
   before_filter :reset_redirect_to_url, :only => :index
   before_filter :store_redirect_to_url, :only => :edit
@@ -45,13 +46,26 @@ class PuppetclassesController < ApplicationController
   end
 
   def override
-    pclass = Puppetclass.find(params[:id])
-    pname = pclass.name
-    pclass.class_params.each do |p|
-      p.override = true
-      p.save
+    if @puppetclass.class_params.present?
+      @puppetclass.class_params.each do |class_param|
+        class_param.update_attribute(:override, true)
+      end
+      notice _("Successfully overriden all parameters of puppetclass %{name}" % { :name => @puppetclass.name })
+    else
+      error _("No parameters to override for puppetclass %{name}" % { :name => @puppetclass.name })
     end
-    notice _("Successfully overriden all parameters of puppetclass #{pname}")
+    redirect_to puppetclasses_url
+  end
+
+  def unoverride
+    if @puppetclass.class_params.present?
+      @puppetclass.class_params.each do |class_param|
+        class_param.update_attribute(:override, false)
+      end
+      notice _("Successfully set as not overriden all parameters of puppetclass %{name}" % { :name => @puppetclass.name })
+    else
+      error _("No parameters to change for puppetclass %{name}" % { :name => @puppetclass.name })
+    end
     redirect_to puppetclasses_url
   end
 
@@ -101,4 +115,25 @@ class PuppetclassesController < ApplicationController
     session[:redirect_to_url] = nil
   end
 
+<<<<<<< HEAD
+=======
+  def find_by_name
+    not_found and return if params[:id].blank?
+    pc = resource_base.includes(:class_params => [:environment_classes, :environments, :lookup_values])
+    @puppetclass = (params[:id] =~ /\A\d+\Z/) ? pc.find(params[:id]) : pc.find_by_name(params[:id])
+    not_found and return unless @puppetclass
+  end
+
+  def action_permission
+    case params[:action]
+      when 'override'
+        :override
+      when 'unoverride'
+        :unoverride
+      else
+        super
+    end
+  end
+
+>>>>>>> fixes #7608 added unoverride
 end

--- a/app/helpers/puppetclasses_helper.rb
+++ b/app/helpers/puppetclasses_helper.rb
@@ -5,15 +5,7 @@ module PuppetclassesHelper
     klass = name.gsub('::', '/')
     "puppet/rdoc/#{environment}/classes/#{klass}.html"
   end
-  def is_overriden puppetclass
-    if puppetclass.class_params.empty?
-      return false
-    end
-    puppetclass.class_params.each do |param|
-      if param[:override] == false
-        return false
-      end
-    end
-    return true
+  def overridden? puppetclass
+    puppetclass.class_params.present? && puppetclass.class_params.map(&:override).all? 
   end
 end

--- a/app/helpers/puppetclasses_helper.rb
+++ b/app/helpers/puppetclasses_helper.rb
@@ -5,4 +5,15 @@ module PuppetclassesHelper
     klass = name.gsub('::', '/')
     "puppet/rdoc/#{environment}/classes/#{klass}.html"
   end
+  def is_overriden puppetclass
+    if puppetclass.class_params.empty?
+      return false
+    end
+    puppetclass.class_params.each do |param|
+      if param[:override] == false
+        return false
+      end
+    end
+    return true
+  end
 end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -518,7 +518,7 @@ Foreman::AccessControl.map do |map|
                                           :"api/v1/puppetclasses" => [:create],
                                           :"api/v2/puppetclasses" => [:create]
                                         }
-    map.permission :edit_puppetclasses,    {:puppetclasses => [:edit, :update, :override, :unoverride],
+    map.permission :edit_puppetclasses,    {:puppetclasses => [:edit, :update, :override ],
                                           :"api/v1/puppetclasses" => [:update],
                                           :"api/v2/puppetclasses" => [:update],
                                           :"api/v1/lookup_keys" => [:create, :update, :destroy],

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -518,7 +518,7 @@ Foreman::AccessControl.map do |map|
                                           :"api/v1/puppetclasses" => [:create],
                                           :"api/v2/puppetclasses" => [:create]
                                         }
-    map.permission :edit_puppetclasses,    {:puppetclasses => [:edit, :update],
+    map.permission :edit_puppetclasses,    {:puppetclasses => [:edit, :update, :override, :unoverride],
                                           :"api/v1/puppetclasses" => [:update],
                                           :"api/v2/puppetclasses" => [:update],
                                           :"api/v1/lookup_keys" => [:create, :update, :destroy],

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -25,8 +25,9 @@
       <td><%= puppetclass.global_class_params_count %> </td>
       <td><%= puppetclass.lookup_keys_count %> </td>
       <td>
-        <%= link_to "Override", { :controller => "puppetclasses",:action => "override" , :id => puppetclass.id } , :confirm => _("Override %s?") % puppetclass.name %>
-        <%= display_delete_if_authorized hash_for_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer),
+       <%= link_to "Override", { :controller => "puppetclasses",:action => "override" , :id => puppetclass.name } , :confirm => _("This will set all parameters of the class %s as overriden.Accept ?") % puppetclass.name if is_overriden(puppetclass) == false %>
+       <%= link_to "UnOverride", { :controller => "puppetclasses",:action => "unoverride" , :id => puppetclass.name } , :confirm => _("This will undo the Overriden of all parameters of the class %s.Accept ?") % puppetclass.name if is_overriden(puppetclass) == true %>
+       <%= display_delete_if_authorized hash_for_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer),
                                          :confirm => _("Delete %s?") % puppetclass.name %>
       </td>
     </tr>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -25,6 +25,7 @@
       <td><%= puppetclass.global_class_params_count %> </td>
       <td><%= puppetclass.lookup_keys_count %> </td>
       <td>
+        <%= link_to "Override", { :controller => "puppetclasses",:action => "override" , :id => puppetclass.id } , :confirm => _("Override %s?") % puppetclass.name %>
         <%= display_delete_if_authorized hash_for_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer),
                                          :confirm => _("Delete %s?") % puppetclass.name %>
       </td>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -25,10 +25,10 @@
       <td><%= puppetclass.global_class_params_count %> </td>
       <td><%= puppetclass.lookup_keys_count %> </td>
       <td>
-       <%= link_to "Override", { :controller => "puppetclasses",:action => "override" , :id => puppetclass.name } , :confirm => _("This will set all parameters of the class %s as overriden.Accept ?") % puppetclass.name if is_overriden(puppetclass) == false %>
-       <%= link_to "UnOverride", { :controller => "puppetclasses",:action => "unoverride" , :id => puppetclass.name } , :confirm => _("This will undo the Overriden of all parameters of the class %s.Accept ?") % puppetclass.name if is_overriden(puppetclass) == true %>
-       <%= display_delete_if_authorized hash_for_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer),
-                                         :confirm => _("Delete %s?") % puppetclass.name %>
+       <%= action_buttons( 
+       display_delete_if_authorized(hash_for_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer), :confirm => _("Delete %s?") % puppetclass.name, :action => :delete  ),
+       link_to_if(puppetclass.class_params.present? && !overridden?(puppetclass), 'Override Parameters', :controller => "puppetclasses",:action => "override" , :message => 'overridden', :enable => true,  :id => puppetclass.name , :confirm => _("This will set parameters of the class %s as overridden.Accept ?") % puppetclass.name ){},
+       link_to_if(puppetclass.class_params.present? && overridden?(puppetclass), 'Default Parameters', :controller => "puppetclasses",:action => "override" , :message => 'defaults', :enable => false , :id => puppetclass.name , :confirm => _("This will reset parameters to default values %s.Accept ?") % puppetclass.name ){}) %>
       </td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ Foreman::Application.routes.draw do
       get 'import_environments'
       post 'obsolete_and_new'
       get 'auto_complete_search'
+      get 'override'
     end
     member do
       post 'parameters'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,6 @@ Foreman::Application.routes.draw do
       post 'obsolete_and_new'
       get 'auto_complete_search'
       get 'override'
-      get 'unoverride'
     end
     member do
       post 'parameters'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Foreman::Application.routes.draw do
       post 'obsolete_and_new'
       get 'auto_complete_search'
       get 'override'
+      get 'unoverride'
     end
     member do
       post 'parameters'


### PR DESCRIPTION
proposed patch for #7608 adding a link on the puppetclasses page to set all parameters of the selected class to overriden
