### PR TITLE
Fixes #7561 - 'No. of CPU' search URL is incorrect

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -4,7 +4,7 @@ $.fn.flot_pie = function(){
     var label_exists = false;
     var target = $(el);
     var max={data:0}, sum = 0;
-    $(target.data('series')).each(function(i, el){sum = sum + el.data; if (max.data< el.data) max = el})
+    $(target.data('series')).each(function(i, el){sum = sum + el.data; if (max.data< el.data) max = el;});
     $.plot(target, target.data('series'), {
       colors: ['#0099d3', '#393f44','#00618a','#505459','#057d9f','#025167'],
       series: {
@@ -17,7 +17,7 @@ $.fn.flot_pie = function(){
             radius: 0.001,
             formatter: function(label, series) {
                 if (label_exists) {
-                    return ''
+                    return '';
                 }else{
                     label_exists = true;
                     return '<div class="percent">' + Math.round(100 * max.data / sum) + '%</div>' + max.label;
@@ -45,7 +45,7 @@ $.fn.flot_pie = function(){
       search_on_click(event, item);
     });
   });
-}
+};
 
 function expanded_pie(target, data){
   $.plot(target, data, {
@@ -110,7 +110,7 @@ $.fn.flot_bar = function(){
     });
     bind_hover_event(target, function(item){return "<b>" + target.data('yaxis-label') + ":</b> " + item.datapoint[1];});
   });
-}
+};
 
 function flot_time_chart(target, data, legendOptions){
   var chart_options = {
@@ -140,17 +140,17 @@ function flot_time_chart(target, data, legendOptions){
       borderWidth: 0
     },
     legend: legendOptions
-  }
+  };
   $.plot($(target), data , chart_options);
   bind_hover_event(target, function(item){return "<b>" + item.series.label + ":</b> " + item.series.data[item.dataIndex][1];});
-  target.bind("plotselected", function (event, ranges) {flot_zoom(target, chart_options, ranges)});
+  target.bind("plotselected", function (event, ranges) {flot_zoom(target, chart_options, ranges);});
 }
 
 $.fn.flot_chart = function(){
   $(this).each(function(i,el){
     flot_time_chart($(el), $(el).data('series'), chart_legend_options($(el)) );
   });
-}
+};
 
 function chart_legend_options(item){
   if(item.data('series').length == 1) return {show: false};
@@ -164,7 +164,7 @@ function chart_legend_options(item){
         labelFormatter: function(label, series) {
           return '<a rel="twipsy" data-original-title="' + __('Details') + '" href="' + series.href + '">' + label + '</a>';
         }
-      }
+      };
     case "hide":
       return {show: false};
     default:
@@ -226,20 +226,21 @@ function search_on_click(event, item) {
   if (link == undefined) return;
   if (link.indexOf("search_by_legend") != -1){
     var selector = '.label[style*="background-color:' + item.series.color +'"]';
-    link = $(event.currentTarget).parents('.stats-well').find(selector).next('a').attr('href')
+    link = $(event.currentTarget).parents('.stats-well').find(selector).next('a').attr('href');
     if (link == undefined) // we are on the overview page - no stats-well parent
       link = $(event.currentTarget).parents('#dashboard').find(selector).next('a').attr('href');
   } else {
-    if (link.indexOf("~VAL2~") != -1) {
+    if (link.indexOf("~VAL1~") != -1 || link.indexOf("~VAL2~") != -1) {
       var strSplit = item.series.label.split(" ");
       var val1 = strSplit[0];
-      var val2 = strSplit[1];
+      var val2 = (strSplit.length > 1) ? strSplit[1] : "";
+      link = link.replace("~VAL1~", val1);
       link = link.replace("~VAL2~", val2);
     } else {
-      var val1 = item.series.label;
-      if (val1.indexOf(" ") != -1) val1 = '"' + val1 +'"';
+      var val = item.series.label;
+      if (val.indexOf(" ") != -1) val = '"' + val + '"';
+      link = link.replace("~VAL~", val);
     }
-    link = link.replace("~VAL1~", val1);
   }
   event.preventDefault();
   window.location.href = link;
@@ -251,17 +252,17 @@ function get_pie_chart(div, url) {
     $('body').append('<div id="' + div + '" class="modal fade"><div class="modal-dialog"><div class="modal-content"></div></div></div>');
     $("#"+div+" .modal-content").append('<div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button><h4 class="modal-title">' + __('Fact Chart') + '</h4></div>')
         .append('<div id="' + div + '-body" class="fact_chart modal-body">' + __('Loading') + ' ...</div>')
-        .append('<div class="modal-footer"></div>')
+        .append('<div class="modal-footer"></div>');
 
     $("#"+div).modal('show');
     $("#"+div).on('shown.bs.modal', function() {
       $.getJSON(url, function(data) {
         var target = $("#"+div+"-body");
         target.empty();
-        expanded_pie(target, data.values)
+        expanded_pie(target, data.values);
         target.attr('data-url', foreman_url("/hosts?search=facts." + data.name + "~~VAL1~"));
-      })
-    })
+      });
+    });
   } else {$("#"+div).modal('show');}
 }
 
@@ -337,9 +338,9 @@ $(function() {
   $(".statistics-pie").flot_pie();
   $(".statistics-bar").flot_bar();
   $(".statistics-chart").flot_chart();
-  $(document).on('click', '.reset-zoom', function () {reset_zoom(this)});
-  $(document).on('click', '.legend .legendColorBox, .legend .legendLabel', function() { legend_selected(this)});
-  $(document).on('click', '#legendContainer .legendColorBox, .legendContainer .legendLabel', function() { ext_legend_selected(this)});
+  $(document).on('click', '.reset-zoom', function () {reset_zoom(this);});
+  $(document).on('click', '.legend .legendColorBox, .legend .legendLabel', function() { legend_selected(this);});
+  $(document).on('click', '#legendContainer .legendColorBox, .legendContainer .legendLabel', function() { ext_legend_selected(this);});
 });
 
 $(window).resize(function() {

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -2,12 +2,12 @@ module StatisticsHelper
   def charts
     options = {:class => "statistics-pie small", :expandable => true, :'border' => 0, :show_title => true}
     [
-      flot_pie_chart("os_dist",_("OS Distribution"), @os_count, options.merge(:search => "os_description=~VAL1~")),
-      flot_pie_chart("arch_dist",_("Architecture Distribution"), @arch_count, options.merge( :search => "facts.architecture=~VAL1~")),
-      flot_pie_chart("env_dist",_("Environments Distribution"), @env_count, options.merge( :search => "environment=~VAL1~" )),
+      flot_pie_chart("os_dist",_("OS Distribution"), @os_count, options.merge(:search => "os_description=~VAL~")),
+      flot_pie_chart("arch_dist",_("Architecture Distribution"), @arch_count, options.merge( :search => "facts.architecture=~VAL~")),
+      flot_pie_chart("env_dist",_("Environments Distribution"), @env_count, options.merge( :search => "environment=~VAL~" )),
       flot_pie_chart("cpu_num",_("Number of CPUs"), @cpu_count,options.merge( :search => "facts.processorcount=~VAL1~")),
-      flot_pie_chart("hardware",_("Hardware"), @model_count, options.merge( :search => "facts.manufacturer~~VAL1~")),
-      flot_pie_chart("class_dist",_("Class Distribution"), @klass_count, options.merge( :search => "class=~VAL1~")),
+      flot_pie_chart("hardware",_("Hardware"), @model_count, options.merge( :search => "facts.manufacturer~~VAL~")),
+      flot_pie_chart("class_dist",_("Class Distribution"), @klass_count, options.merge( :search => "class=~VAL~")),
       flot_pie_chart("mem_usage",_("Average memory usage"), [{:label=>_("free memory"), :data=>@mem_free},{:label=>_("used memory"),:data=>@mem_size-@mem_free}], options),
       flot_pie_chart("swap_usage",_("Average swap usage"), [{:label=>_("free swap"), :data=>@swap_free},{:label=>_("used swap"), :data=>@swap_size-@swap_free}], options)
     ]


### PR DESCRIPTION
I may run some performance testing, checking if I can make the Javascript run faster.

For example, most of the time `~VAL~` is being replaced, thus checking it firstly can save some time.
Another one is to separate the first `if` (the one that check if it's `~VAL1~` or `~VAL2~`) into `if-else if` form.

Unless, you think this is unnecessary...

I have tested this on my machine and it works well. 

Oh yeah, if someone specifies `~VAL2~` but the value is one word, `~VAL2~` is replaced with "". Is that fine?
