### PR TITLE
Fixes #7591 - Inconsistent terminology around Login vs Sign Out

### DIFF
--- a/app/services/menu/loader.rb
+++ b/app/services/menu/loader.rb
@@ -18,7 +18,7 @@ module Menu
                   :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
         menu.divider
         menu.item :logout,
-                  :caption => N_('Sign out'),
+                  :caption => N_('Log out'),
                   :html => {:method => :post},
                   :url_hash => {:controller => '/users', :action => 'logout'}
       end


### PR DESCRIPTION
Used `grep -rn --color '[Ss]ign [Oo]ut' foreman/` to find all occurrences of 'Sign out', 'sign out', 'Sign Out' or 'sign Out' in Foreman.
