### PR TITLE
Fixes #7648 - order of template kinds fixed

### DIFF
--- a/app/models/os_default_template.rb
+++ b/app/models/os_default_template.rb
@@ -5,6 +5,8 @@ class OsDefaultTemplate < ActiveRecord::Base
   validates :config_template_id, :presence => true
   validates :template_kind_id, :presence => true, :uniqueness => {:scope => :operatingsystem_id}
 
+  default_scope joins(:template_kind).order('template_kinds.name')
+
   def name
     "#{operatingsystem} - #{template_kind}"
   end


### PR DESCRIPTION
Nice one. I made this global, won't hurt?

When testing this watch for this SQL statement:

`ConfigTemplate Load (0.1ms)  SELECT "config_templates".* FROM
"config_templates" INNER JOIN "config_templates_operatingsystems" ON
"config_templates"."id" =
"config_templates_operatingsystems"."config_template_id" WHERE
"config_templates_operatingsystems"."operatingsystem_id" = 2 AND
"config_templates"."template_kind_id" = 1 ORDER BY config_templates.name`

As you can see, it is ordered by name now. No index, amount of records in kinds
is low and index would not be used anyway.
