### PR TITLE
refs #2127 - instantiate exception and pass i18n arg correctly

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -2,7 +2,7 @@ class PasswordCrypt
   ALGORITHMS = {'MD5' => '$1$', 'SHA256' => '$5$', 'SHA512' => '$6$'}
 
   def self.passw_crypt(passwd, hash_alg = 'MD5')
-    raise Foreman::Exception N_("Unsupported password hash function '%s'") % hash_alg unless ALGORITHMS.has_key?(hash_alg)
+    raise Foreman::Exception.new(N_("Unsupported password hash function '%s'"), hash_alg) unless ALGORITHMS.has_key?(hash_alg)
     passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")
   end
 


### PR DESCRIPTION
<pre>
2.0.0-p353 :001 > PasswordCrypt.passw_crypt("a", "b")
NoMethodError: undefined method `Exception' for Foreman:Module
    from /home/dcleal/code/foreman/foreman/app/services/password_crypt.rb:5:in `passw_crypt'
</pre>


<pre>
2.0.0-p353 :001 > PasswordCrypt.passw_crypt("a", "b")
Foreman::Exception: ERF42-5628 [Foreman::Exception]: »Unsupported password hash function 'b'«
    from /home/dcleal/code/foreman/foreman/app/services/password_crypt.rb:5:in `passw_crypt'
</pre>
