### PR TITLE
fixes #7732 - specify join models as Rails 3.2.8 can't reset through associations

### DIFF
--- a/lib/tasks/fix_cached_counters.rake
+++ b/lib/tasks/fix_cached_counters.rake
@@ -5,7 +5,7 @@ task :fix_cached_counters => :environment do
     cl.all.each{|el| cl.reset_counters(el.id, :hosts, :hostgroups)}
     puts "#{cl} corrected"
   end
-  Puppetclass.all.each{|el| Puppetclass.reset_counters(el.id, :hosts, :hostgroups, :lookup_keys)}
+  Puppetclass.all.each{|el| Puppetclass.reset_counters(el.id, :host_classes, :hostgroup_classes, :lookup_keys)}
   puts "Puppetclass corrected"
   Model.all.each{|el| Model.reset_counters(el.id, :hosts)}
   puts "Model corrected"


### PR DESCRIPTION
Rails 3.2.8 (used in our RPM installations) can't resolve models with through associations, so just specify the join models.  https://github.com/rails/rails/commit/3f0bc97912482c2da9e70683b029feb36de74c27 fixed the issue in 3.2.9.

Tested successfully on EL7.
