### PR TITLE
Fixes #7588 - pagination info not a button and aligned

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -239,6 +239,7 @@ select{padding: initial;}
 }
 .grey, .gray{color: #808080 !important;}
 .lightgrey, .lightgray {color: #999 !important;}
+.darkgrey, .darkgray{color: #606060 !important;}
 .black{color: #000 !important;}
 
 .form-group.condensed{margin-bottom: 0;}
@@ -363,4 +364,10 @@ table tr td:last-child {
 
 .config_group, .selected_config_group   {
   min-height: 30px;
+}
+
+.pagination {
+  display: table-cell;
+  vertical-align: bottom;
+  float: none;
 }

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -245,10 +245,15 @@ module LayoutHelper
              end
            end.html_safe
     html += options[:more].html_safe if options[:more]
-    content_tag(:div, :class=>"col-md-5") do
-      content_tag(:ul, :class => 'pagination') do
-        content_tag(:li, link_to(html, "#"), :class=>"pull-left")
-      end
+    content_tag(:div, :class => "col-md-5 hidden-xs") do
+      content_tag(:div, html, :class => "pull-left pull-bottom darkgray pagination")
+    end
+  end
+
+  def will_paginate_with_info(collection = nil, options = {})
+    content_tag(:div, :id => "pagination", :class => "row") do
+      page_entries_info(collection, options) +
+        will_paginate(collection, options)
     end
   end
 

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -21,5 +21,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @architectures %>
-<%= will_paginate @architectures %>
+<%= will_paginate_with_info @architectures %>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -2,5 +2,4 @@
 
 <%= render :partial => 'list', :locals =>{:audits => @audits}%>
 
-<%= page_entries_info @audits %>
-<%= will_paginate @audits %>
+<%= will_paginate_with_info @audits %>

--- a/app/views/autosign/index.html.erb
+++ b/app/views/autosign/index.html.erb
@@ -16,5 +16,4 @@
       </tr>
   <% end %>
 </table>
-<%= page_entries_info @autosign %>
-<%= will_paginate @autosign %>
+<%= will_paginate_with_info @autosign %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -21,5 +21,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @bookmarks %>
-<%= will_paginate @bookmarks %>
+<%= will_paginate_with_info @bookmarks %>

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -19,5 +19,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @common_parameters %>
-<%= will_paginate     @common_parameters %>
+<%= will_paginate_with_info @common_parameters %>

--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -19,6 +19,5 @@
   <% end %>
 </table>
 
-<%= page_entries_info @compute_profiles %>
-<%= will_paginate     @compute_profiles %>
+<%= will_paginate_with_info @compute_profiles %>
 

--- a/app/views/compute_resources/index.html.erb
+++ b/app/views/compute_resources/index.html.erb
@@ -20,5 +20,4 @@
 <% end %>
 </table>
 
-<%= page_entries_info @compute_resources %>
-<%= will_paginate @compute_resources %>
+<%= will_paginate_with_info @compute_resources %>

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -29,6 +29,5 @@
   <% end %>
 </table>
 
-<%= page_entries_info @config_groups %>
-<%= will_paginate     @config_groups %>
+<%= will_paginate_with_info @config_groups %>
 

--- a/app/views/config_templates/index.html.erb
+++ b/app/views/config_templates/index.html.erb
@@ -31,5 +31,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @config_templates %>
-<%= will_paginate @config_templates %>
+<%= will_paginate_with_info @config_templates %>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -16,5 +16,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @domains %>
-<%= will_paginate     @domains %>
+<%= will_paginate_with_info @domains %>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -24,5 +24,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @environments %>
-<%= will_paginate @environments %>
+<%= will_paginate_with_info @environments %>

--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -15,5 +15,4 @@
              :locals  => { :parent => @parent } %>
 
 </table>
-<%= page_entries_info @fact_values %>
-<%= will_paginate @fact_values %>
+<%= will_paginate_with_info @fact_values %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -46,5 +46,4 @@
   <% end %>
   </tbody>
 </table>
-<%= page_entries_info @filters %>
-<%= will_paginate @filters %>
+<%= will_paginate_with_info @filters %>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -19,5 +19,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @hostgroups %>
-<%= will_paginate     @hostgroups %>
+<%= will_paginate_with_info @hostgroups %>

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -30,8 +30,7 @@
   <% end %>
 </table>
 
-  <%= page_entries_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>
-  <%= will_paginate hosts %>
+  <%= will_paginate_with_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>
   </div>
 </div>
   <%= content_tag(:div, :class => "form-actions") do %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -50,5 +50,4 @@
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
-<%= page_entries_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>
-<%= will_paginate hosts %>
+<%= will_paginate_with_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -26,5 +26,4 @@
 <% end %>
 </table>
 
-<%= page_entries_info @images %>
-<%= will_paginate     @images %>
+<%= will_paginate_with_info @images %>

--- a/app/views/lookup_keys/index.html.erb
+++ b/app/views/lookup_keys/index.html.erb
@@ -20,5 +20,4 @@
   </tr>
 <% end %>
 </table>
-<%= page_entries_info @lookup_keys %>
-<%= will_paginate     @lookup_keys %>
+<%= will_paginate_with_info @lookup_keys %>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -24,5 +24,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @media %>
-<%= will_paginate     @media %>
+<%= will_paginate_with_info @media %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -23,5 +23,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @models %>
-<%= will_paginate     @models %>
+<%= will_paginate_with_info @models %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -19,5 +19,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @operatingsystems %>
-<%= will_paginate @operatingsystems %>
+<%= will_paginate_with_info @operatingsystems %>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -19,5 +19,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @ptables %>
-<%= will_paginate     @ptables %>
+<%= will_paginate_with_info @ptables %>

--- a/app/views/puppetca/index.html.erb
+++ b/app/views/puppetca/index.html.erb
@@ -32,5 +32,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @certificates  %>
-<%= will_paginate @certificates %>
+<%= will_paginate_with_info @certificates %>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -32,5 +32,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @puppetclasses %>
-<%= will_paginate @puppetclasses %>
+<%= will_paginate_with_info @puppetclasses %>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -16,5 +16,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @realms %>
-<%= will_paginate     @realms %>
+<%= will_paginate_with_info @realms %>

--- a/app/views/reports/_list.html.erb
+++ b/app/views/reports/_list.html.erb
@@ -35,5 +35,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @reports %>
-<%= will_paginate @reports %>
+<%= will_paginate_with_info @reports %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -25,5 +25,4 @@
     <% end %>
   </tbody>
 </table>
-<%= page_entries_info @roles %>
-<%= will_paginate     @roles %>
+<%= will_paginate_with_info @roles %>

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -20,5 +20,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @smart_proxies %>
-<%= will_paginate @smart_proxies %>
+<%= will_paginate_with_info @smart_proxies %>

--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -25,5 +25,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @subnets %>
-<%= will_paginate     @subnets %>
+<%= will_paginate_with_info @subnets %>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -37,5 +37,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @taxonomies %>
-<%= will_paginate     @taxonomies %>
+<%= will_paginate_with_info @taxonomies %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -40,8 +40,7 @@
   <% end %>
 </table>
 
-<%= page_entries_info @trends %>
-<%= will_paginate @trends %>
+<%= will_paginate_with_info @trends %>
 <% unless TrendCounter.unconfigured? %>
   <%= _("Last updated %s ago") % (time_ago_in_words TrendCounter.order(:created_at).last.created_at) %>
 <% end %>

--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -22,5 +22,4 @@
     </tr>
   <% end %>
 </table>
-<%= page_entries_info @usergroups %>
-<%= will_paginate @usergroups %>
+<%= will_paginate_with_info @usergroups %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,5 +29,4 @@
   <% end %>
 </table>
 
-<%= page_entries_info @users %>
-<%= will_paginate @users %>
+<%= will_paginate_with_info @users %>


### PR DESCRIPTION
To properly align our pagination info label and pager we need to add a new row.
I created a helper for this. Also now on extra-small devices the info box hides
because otherwise it kinda break the end of the page. There is one snag -
sometimes we display "X items selected" there but since items are already
visually checked and since users usually do not see the whole page on small
devices, this is not an issue I think. Opinions?

This replaces https://github.com/theforeman/foreman/pull/1797

Please do not merge, this is for review. Once this is approved I will carry on
with changing all the index ERB pages (need to touch them all).
