### PR TITLE
fixes #7772 - avoids multiple ajax requests

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -90,6 +90,7 @@ function onContentLoad(){
 
   $('*[data-ajax-url]').each(function() {
     var url = $(this).data('ajax-url');
+    $(this).removeAttr('data-ajax-url');
     $(this).load(url, function(response, status, xhr) {
       if (status == "error") {
         $(this).closest(".tab-content").find("#spinner").html(__('Failed to fetch: ') + xhr.status + " " + xhr.statusText);


### PR DESCRIPTION
the two-pane (and others) triggers the onContentLoad event, removing the data
attribute from the DOM will ensure its not loaded more than once.
