### PR TITLE
Fixes #7819 - Windows facts returned from kernelrelease

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -2,12 +2,7 @@ class PuppetFactParser < FactParser
   attr_reader :facts
 
   def operatingsystem
-    orel = case os_name
-             when /(suse|sles|gentoo)/i
-               facts[:operatingsystemrelease]
-             else
-               facts[:lsbdistrelease] || facts[:operatingsystemrelease]
-           end
+    orel = os_release
 
     if os_name == "Archlinux"
       # Archlinux is rolling release, so it has no release. We use 1.0 always
@@ -144,5 +139,16 @@ class PuppetFactParser < FactParser
 
   def os_name
     facts[:operatingsystem].blank? ? raise(::Foreman::Exception.new("invalid facts, missing operating system value")) : facts[:operatingsystem]
+  end
+
+  def os_release
+    case os_name
+    when /(suse|sles|gentoo)/i
+      facts[:operatingsystemrelease]
+    when /(windows)/i
+      facts[:kernelrelease]
+    else
+      facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+    end
   end
 end


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/FACT-341 operatingsystemreleasereturns a
non-numeric value since facter 2.0. Commit now reads windows opel version from
kernelrelease fact.

This PR substitutes https://github.com/theforeman/foreman/pull/1781 , @kireevco , the ownership of the commit is still assigned to you, we value your contribution.
