### PR TITLE
Refs #3809 - Use parentheses in method definitions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -308,12 +308,6 @@ Style/LineLength:
 Style/MethodCallParentheses:
   Enabled: false
 
-# Offense count: 422
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/MethodDefParentheses:
-  Enabled: false
-
 # Offense count: 283
 # Configuration parameters: CountComments.
 Style/MethodLength:

--- a/app/controllers/api/v1/config_templates_controller.rb
+++ b/app/controllers/api/v1/config_templates_controller.rb
@@ -89,7 +89,7 @@ module Api
         params[:config_template][:template] = t.read if t.respond_to?(:read)
       end
 
-      def default_template_url template, hostgroup
+      def default_template_url(template, hostgroup)
         url_for :only_path => false, :action => :template, :controller => '/unattended',
                 :id        => template.name, :hostgroup => hostgroup.name
       end

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -88,7 +88,7 @@ module Api
         params[:config_template][:template] = t.read if t.respond_to?(:read)
       end
 
-      def default_template_url template, hostgroup
+      def default_template_url(template, hostgroup)
         url_for :only_path => false, :action => :template, :controller => '/unattended',
                 :id        => template.name, :hostgroup => hostgroup.name
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,15 +152,15 @@ class ApplicationController < ActionController::Base
         model_of_controller.scoped
   end
 
-  def notice notice
+  def notice(notice)
     flash[:notice] = CGI::escapeHTML(notice)
   end
 
-  def error error
+  def error(error)
     flash[:error] = CGI::escapeHTML(error)
   end
 
-  def warning warning
+  def warning(warning)
     flash[:warning] = CGI::escapeHTML(warning)
   end
 
@@ -240,7 +240,7 @@ class ApplicationController < ActionController::Base
     render_403
   end
 
-  def process_success hash = {}
+  def process_success(hash = {})
     hash[:object]                 ||= instance_variable_get("@#{controller_name.singularize}")
     hash[:object_name]            ||= hash[:object].to_s
     unless hash[:success_msg]
@@ -261,7 +261,7 @@ class ApplicationController < ActionController::Base
     redirect_to hash[:success_redirect] and return
   end
 
-  def process_error hash = {}
+  def process_error(hash = {})
     hash[:object] ||= instance_variable_get("@#{controller_name.singularize}")
 
     case action_name
@@ -296,7 +296,7 @@ class ApplicationController < ActionController::Base
     render :text => "Failure: #{message}"
   end
 
-  def redirect_back_or_to url
+  def redirect_back_or_to(url)
     redirect_to request.referer.empty? ? url : :back
   end
 
@@ -355,7 +355,7 @@ class ApplicationController < ActionController::Base
     include
   end
 
-  def errors_hash errors
+  def errors_hash(errors)
     errors.any? ? {:status => N_("Error"), :message => errors.full_messages.join('<br>')} : {:status => N_("OK"), :message =>""}
   end
 

--- a/app/controllers/concerns/foreman/controller/host_details.rb
+++ b/app/controllers/concerns/foreman/controller/host_details.rb
@@ -41,7 +41,7 @@ module Foreman::Controller::HostDetails
   end
 
   private
-  def assign_parameter name, root = ""
+  def assign_parameter(name, root = "")
     taxonomy_scope
     Taxonomy.as_taxonomy @organization, @location do
       if params["#{name}_id"].to_i > 0 and instance_variable_set("@#{name}",name.classify.constantize.find(params["#{name}_id"]))

--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -27,7 +27,7 @@ module Foreman::Controller::TaxonomyMultiple
 
   private
 
-  def update_multiple_taxonomies type
+  def update_multiple_taxonomies(type)
     # simple validations
     if (params[type].nil?) or (id=params[type][:id]).blank?
       error "No #{type.to_s.classify} selected!"

--- a/app/controllers/config_templates_controller.rb
+++ b/app/controllers/config_templates_controller.rb
@@ -102,7 +102,7 @@ class ConfigTemplatesController < ApplicationController
     @history = Audit.descending.where(:auditable_id => @config_template.id, :auditable_type => 'ConfigTemplate')
   end
 
-  def default_template_url template, hostgroup
+  def default_template_url(template, hostgroup)
     url_for :only_path => false, :action => :template, :controller => '/unattended',
       :id => template.name, :hostgroup => hostgroup.name
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,7 +19,7 @@ class HomeController < ApplicationController
 
   private
   # check for exception - set the result code and duration time
-  def exception_watch &block
+  def exception_watch(&block)
     start = Time.now
     result = {}
     begin

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -683,7 +683,7 @@ class HostsController < ApplicationController
     redirect_to hosts_path and return false
   end
 
-  def toggle_hostmode mode = true
+  def toggle_hostmode(mode = true)
     # keep all the ones that were not disabled for notification.
     @hosts.delete_if { |host| host.update_attribute(:enabled, mode) }
     action = mode ? "enabled" : "disabled"
@@ -702,7 +702,7 @@ class HostsController < ApplicationController
     host.url_options = url_options if @host.respond_to?(:url_options)
   end
 
-  def merge_search_filter filter
+  def merge_search_filter(filter)
     if params[:search].empty?
       params[:search] = filter
     else

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -69,7 +69,7 @@ class UnattendedController < ApplicationController
 
   private
 
-  def render_template type
+  def render_template(type)
     if (config = @host.configTemplate({ :kind => type }))
       logger.debug "rendering DB template #{config.name} - #{type}"
       safe_render config
@@ -275,7 +275,7 @@ class UnattendedController < ApplicationController
     ip
   end
 
-  def safe_render template
+  def safe_render(template)
     @template_name = 'Unnamed'
     if template.is_a?(String)
       @unsafe_template  = template

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,15 +28,15 @@ module ApplicationHelper
   end
 
   protected
-  def contract model
+  def contract(model)
     model.to_label
   end
 
-  def show_habtm associations
+  def show_habtm(associations)
     render :partial => 'common/show_habtm', :collection => associations, :as => :association
   end
 
-  def edit_habtm klass, association, prefix = nil, options = {}
+  def edit_habtm(klass, association, prefix = nil, options = {})
     render :partial => 'common/edit_habtm', :locals =>{:prefix => prefix, :klass => klass, :options => options,
                                                        :associations => association.all.sort.delete_if{|e| e == klass}}
   end
@@ -58,7 +58,7 @@ module ApplicationHelper
     link_to_function(name, ("add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\"); turn_textarea_switch();").html_safe, add_html_classes(options, "btn btn-success") )
   end
 
-  def link_to_remove_puppetclass klass, host
+  def link_to_remove_puppetclass(klass, host)
     options = klass.name.size > 28 ? {:'data-original-title'=>klass.name, :rel=>'twipsy'} : {}
     functions_options = { :klass => klass, :host => host, :css_class => ''}
     text = remove_link_to_function(truncate(klass.name, :length => 28), functions_options)
@@ -76,7 +76,7 @@ module ApplicationHelper
                      :class=>options[:css_class])
   end
 
-  def link_to_add_puppetclass klass, host, type
+  def link_to_add_puppetclass(klass, host, type)
     options = klass.name.size > 28 ? {:'data-original-title'=>klass.name, :rel=>'twipsy'} : {}
     function_options = { :klass => klass, :host => host, :type => type }
     text             = add_link_to_function(truncate(klass.name, :length => 28), function_options)
@@ -96,7 +96,7 @@ module ApplicationHelper
                      :class                 => options[:css_class])
   end
 
-  def add_html_classes options, classes
+  def add_html_classes(options, classes)
     options = options.dup unless options.nil?
     options ||= {}
     options[:class] = options[:class].dup if options.has_key? :class
@@ -165,7 +165,7 @@ module ApplicationHelper
     end
   end
 
-  def authorized_edit_habtm klass, association, prefix = nil, options = {}
+  def authorized_edit_habtm(klass, association, prefix = nil, options = {})
     if authorized_for :controller => params[:controller], :action => params[:action]
       return edit_habtm(klass, association, prefix, options)
     end
@@ -173,11 +173,11 @@ module ApplicationHelper
   end
 
   # renders a style=display based on an attribute properties
-  def display? attribute = true
+  def display?(attribute = true)
     "style=#{display(attribute)}"
   end
 
-  def display attribute
+  def display(attribute)
     "display:#{attribute ? 'none' : 'inline'};"
   end
 
@@ -187,11 +187,11 @@ module ApplicationHelper
     controller_name.singularize
   end
 
-  def checked_icon condition
+  def checked_icon(condition)
     image_tag("toggle_check.png") if condition
   end
 
-  def locked_icon condition, hovertext
+  def locked_icon(condition, hovertext)
     ('<span class="glyphicon glyphicon-lock" title="%s"/>' % hovertext).html_safe if condition
   end
 
@@ -213,7 +213,7 @@ module ApplicationHelper
     link_to _("Help"), :action => "welcome" if File.exist?("#{Rails.root}/app/views/#{controller_name}/welcome.html.erb")
   end
 
-  def method_path method
+  def method_path(method)
     send("#{method}_#{controller_name}_path")
   end
 
@@ -229,7 +229,7 @@ module ApplicationHelper
     edit_inline(object, property, options.merge({:type => "edit_select"}))
   end
 
-  def flot_pie_chart name, title, data, options = {}
+  def flot_pie_chart(name, title, data, options = {})
     data = data.map { |k,v| {:label=>k.to_s.humanize, :data=>v} } if  data.is_a?(Hash)
     data.map{|element| element[:label] = truncate(element[:label],:length => 16)}
     header = content_tag(:h4,(options[:show_title]) ? title : '', :class=>'ca pie-title', :'data-original-title'=>_("Expand the chart"), :rel=>'twipsy')
@@ -245,7 +245,7 @@ module ApplicationHelper
                     }.merge(options))
   end
 
-  def flot_chart name, xaxis_label, yaxis_label, data, options = {}
+  def flot_chart(name, xaxis_label, yaxis_label, data, options = {})
     data = data.map { |k,v| {:label=>k.to_s.humanize, :data=>v} } if  data.is_a?(Hash)
     content_tag(:div, nil,
                 { :id    => name,
@@ -259,7 +259,7 @@ module ApplicationHelper
                 }.merge(options))
   end
 
-  def flot_bar_chart name, xaxis_label, yaxis_label, data, options = {}
+  def flot_bar_chart(name, xaxis_label, yaxis_label, data, options = {})
     i=0
     ticks = nil
     if data.is_a?(Array)

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -4,7 +4,7 @@ module AuditsHelper
                    Location Organization Domain Subnet SmartProxy AuthSource Image Role Usergroup Bookmark ConfigGroup)
 
   # lookup the Model representing the numerical id and return its label
-  def id_to_label name, change
+  def id_to_label(name, change)
     return _("N/A") if change.nil?
     case name
       when "ancestry"
@@ -20,7 +20,7 @@ module AuditsHelper
     _("N/A")
   end
 
-  def audit_title audit
+  def audit_title(audit)
     type_name = audited_type audit
     case type_name
       when 'Puppet Class'
@@ -34,7 +34,7 @@ module AuditsHelper
     ""
   end
 
-  def details audit
+  def details(audit)
     if audit.action == 'update'
       Array.wrap(audit.audited_changes).map do |name, change|
         next if change.nil? or change.to_s.empty?
@@ -54,17 +54,17 @@ module AuditsHelper
     end
   end
 
-  def audit_template? audit
+  def audit_template?(audit)
     audit.auditable_type == "ConfigTemplate" && audit.action == 'update' && audit.audited_changes["template"] &&
       audit.audited_changes["template"][0] != audit.audited_changes["template"][1]
   end
 
-  def audit_login? audit
+  def audit_login?(audit)
     name = audit.audited_changes.keys[0] rescue ''
     name == 'last_login_on'
   end
 
-  def audit_action_name audit
+  def audit_action_name(audit)
     return audit.action == 'destroy' ? 'destroyed' : "#{audit.action}d" if main_object? audit
 
     case audit.action
@@ -77,18 +77,18 @@ module AuditsHelper
     end
   end
 
-  def audit_user audit
+  def audit_user(audit)
     return if audit.username.nil?
     login = audit.user.login rescue nil # aliasing the user method sometimes yields strings
     link_to(icon_text('user', audit.username.gsub(_('User'), '')), hash_for_audits_path(:search => login ? "user = #{login}" : "username = \"#{audit.username}\""))
   end
 
-  def audit_time audit
+  def audit_time(audit)
     content_tag :span, _("%s ago") % time_ago_in_words(audit.created_at),
                 { :'data-original-title' => audit.created_at.to_s(:long), :rel => 'twipsy' }
   end
 
-  def audited_icon audit
+  def audited_icon(audit)
     style = 'label-info'
     style = case audit.action
               when 'create'
@@ -116,7 +116,7 @@ module AuditsHelper
     content_tag(:b, icon_text(symbol, type, :class => 'icon-white'), :class => style)
   end
 
-  def audited_type audit
+  def audited_type(audit)
     type_name = case audit.auditable_type
                   when 'HostClass'
                     'Puppet Class'
@@ -132,7 +132,7 @@ module AuditsHelper
     type_name.underscore.titleize
   end
 
-  def audit_remote_address audit
+  def audit_remote_address(audit)
     return if audit.remote_address.empty?
     content_tag :span, :style => 'color:#999;' do
       "(" + audit.remote_address + ")"
@@ -140,7 +140,7 @@ module AuditsHelper
   end
 
   private
-  def main_object? audit
+  def main_object?(audit)
     type = audit.auditable_type.split("::").last rescue ''
     MainObjects.include?(type)
   end

--- a/app/helpers/auth_source_ldaps_helper.rb
+++ b/app/helpers/auth_source_ldaps_helper.rb
@@ -1,6 +1,6 @@
 module AuthSourceLdapsHelper
 
-  def on_the_fly? authsource
+  def on_the_fly?(authsource)
     return false if authsource.new_record?
     authsource.onthefly_register?
   end

--- a/app/helpers/bmc_helper.rb
+++ b/app/helpers/bmc_helper.rb
@@ -1,6 +1,6 @@
 module BmcHelper
 
-  def power_status s
+  def power_status(s)
     if s.downcase == 'on'
       "<span class='label label-success'>#{_('On')}</span>".html_safe
     else

--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -9,7 +9,7 @@ module CommonParametersHelper
     _("Parameters that would be associated with hosts in this %s") % (type)
   end
 
-  def parameter_value_field value
+  def parameter_value_field(value)
     source_name = value[:source_name] ? "(#{value[:source_name]})" : nil
     content_tag :div, :class => "form-group condensed" do
       text_area_tag("value_#{value[:safe_value]}", value[:safe_value], :rows => (value[:safe_value].to_s.lines.count || 1 rescue 1),

--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -5,7 +5,7 @@ module ComputeResourcesHelper
     state ? link : ""
   end
 
-  def vm_state vm
+  def vm_state(vm)
     if vm.state == 'PAUSED'
       ' ' + _("Paused")
     else
@@ -13,15 +13,15 @@ module ComputeResourcesHelper
     end
   end
 
-  def action_string vm
+  def action_string(vm)
     vm.ready? ? ' ' + _("Off") : ' ' + _("On")
   end
 
-  def vm_power_class s
+  def vm_power_class(s)
     "class='label #{s ? "label-success" : "label-default"}'".html_safe
   end
 
-  def vm_power_action vm, authorizer = nil
+  def vm_power_action(vm, authorizer = nil)
     opts = hash_for_power_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :permission => 'power_compute_resources_vms', :authorizer => authorizer)
     html = vm.ready? ? { :confirm =>_("Are you sure you want to power %{act} %{vm}?") % { :act => action_string(vm).downcase.strip, :vm => vm }, :class => "btn btn-danger" } :
                        { :class => "btn btn-info" }
@@ -29,7 +29,7 @@ module ComputeResourcesHelper
     display_link_if_authorized "Power #{action_string(vm)}", opts, html.merge(:method => :put)
   end
 
-  def vm_pause_action vm, authorizer = nil
+  def vm_pause_action(vm, authorizer = nil)
     opts = hash_for_pause_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :permission => 'power_compute_resources_vms', :authorizer => authorizer)
     pause_action = vm.ready? ? _('Pause') : _('Resume')
     html = vm.state.downcase == 'paused' ? { :class => "btn btn-info" } :
@@ -38,7 +38,7 @@ module ComputeResourcesHelper
     display_link_if_authorized pause_action, opts, html.merge(:method => :put)
   end
 
-  def memory_options max_memory
+  def memory_options(max_memory)
     gb = 1024*1024*1024
     opts = [0.25, 0.5, 0.75, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32]
     opts.map{|n| [number_to_human_size(n*gb), (n*gb).to_i] unless n > (max_memory / gb)}.compact
@@ -48,7 +48,7 @@ module ComputeResourcesHelper
     obj.id ? "********" : ""
   end
 
-  def list_datacenters compute
+  def list_datacenters(compute)
     return [] unless compute.uuid || controller.action_name == 'test_connection'
     compute.datacenters
   rescue Foreman::FingerprintException => e

--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -22,7 +22,7 @@ module ComputeResourcesVmsHelper
   end
 
   # little helper to help show VM properties
-  def prop method, title = nil
+  def prop(method, title = nil)
     content_tag :tr do
       result = content_tag(:td) do
         title || method.to_s.humanize

--- a/app/helpers/config_templates_helper.rb
+++ b/app/helpers/config_templates_helper.rb
@@ -1,5 +1,5 @@
 module ConfigTemplatesHelper
-  def combination template
+  def combination(template)
     template.template_combinations.map do |comb|
       str = []
       str << (comb.hostgroup_id.nil? ? _("None") : comb.hostgroup.to_s)
@@ -14,7 +14,7 @@ module ConfigTemplatesHelper
               'ace/mode-diff', 'diff', 'ace/mode-ruby', 'ace/keybinding-vim', 'ace/keybinding-emacs'
   end
 
-  def permitted_actions config_template
+  def permitted_actions(config_template)
     actions = [display_link_if_authorized(_('Clone'), hash_for_clone_config_template_path(:id => config_template))]
 
     if config_template.locked?

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -25,7 +25,7 @@ module DashboardHelper
     data
   end
 
-  def render_overview report, options = {}
+  def render_overview(report, options = {})
     data = [{:label=>_('Active'), :data => report[:active_hosts_ok_enabled],:color => report_color[:active_hosts_ok_enabled]},
             {:label=>_('Error'), :data =>report[:bad_hosts_enabled], :color => report_color[:bad_hosts_enabled]},
             {:label=>_('OK'), :data =>report[:ok_hosts_enabled],:color => report_color[:ok_hosts_enabled]},
@@ -36,12 +36,12 @@ module DashboardHelper
     flot_pie_chart 'overview', _('Host Configuration Status'), data, options.merge(:search => "search_by_legend")
   end
 
-  def render_run_distribution hosts, options = {}
+  def render_run_distribution(hosts, options = {})
     data = count_reports(hosts)
     flot_bar_chart("run_distribution", _("Minutes Ago"), _("Number Of Clients"), data, options)
   end
 
-  def searchable_links name, search, counter
+  def searchable_links(name, search, counter)
     search += " and #{params[:search]}" unless params[:search].blank?
     content_tag :li do
       content_tag(:i, raw('&nbsp;'), :class=>'label', :style => "background-color:" + report_color[counter]) +

--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -1,6 +1,6 @@
 module FactValuesHelper
 
-  def fact_from record
+  def fact_from(record)
     _("%s ago") % time_ago_in_words(record.host.last_compile)
   rescue
     _("N/A")

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,6 +1,6 @@
 module HomeHelper
 
-  def render_menu menu_name
+  def render_menu(menu_name)
     authorized_menu_actions(Menu::Manager.items(menu_name).children).map do |menu|
       items = authorized_menu_actions(menu.children)
       render "home/submenu", :menu_items => items, :menu_title => _(menu.caption), :menu_name => menu.name if items.any?
@@ -24,7 +24,7 @@ module HomeHelper
     choices
   end
 
-  def menu_item_tag item
+  def menu_item_tag(item)
     content_tag(:li,
                 link_to(_(item.caption), item.url, item.html_options.merge(:id => "menu_item_#{item.name}")),
                 :class => "menu_tab_#{item.url_hash[:controller]}_#{item.url_hash[:action]}")

--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -2,7 +2,7 @@ module HostgroupsHelper
   include CommonParametersHelper
   include HostsAndHostgroupsHelper
 
-  def warning_message group
+  def warning_message(group)
     msg = [_("Are you sure?")]
     if group.has_children?
       msg << _("This group has nested groups!") + "\n"

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -1,7 +1,7 @@
 module HostsAndHostgroupsHelper
   include AncestryHelper
 
-  def model_name host
+  def model_name(host)
     name = host.try(:model)
     name = host.compute_resource.name if host.compute_resource
     trunc(name, 14)
@@ -12,7 +12,7 @@ module HostsAndHostgroupsHelper
     hg.sort{ |l, r| l.to_label <=> r.to_label }
   end
 
-  def parent_classes obj
+  def parent_classes(obj)
     return obj.hostgroup.classes if obj.kind_of?(Host::Base) and obj.hostgroup
     return obj.is_root? ? [] : obj.parent.classes if obj.is_a?(Hostgroup)
     []
@@ -46,11 +46,11 @@ module HostsAndHostgroupsHelper
     @operatingsystem.ptables
   end
 
-  def puppet_master_fields f
+  def puppet_master_fields(f)
     "#{puppet_ca(f)} #{puppet_master(f)}".html_safe
   end
 
-  def puppet_ca f
+  def puppet_ca(f)
     # Don't show this if we have no CA proxies, otherwise always include blank
     # so the user can choose not to sign the puppet cert on this host
     proxies = SmartProxy.unscoped.with_features("Puppet CA").with_taxonomy_scope(@location,@organization,:path_ids)
@@ -61,7 +61,7 @@ module HostsAndHostgroupsHelper
                :help_inline => _("Use this puppet server as a CA server") }
   end
 
-  def puppet_master f
+  def puppet_master(f)
     # Don't show this if we have no Puppet proxies, otherwise always include blank
     # so the user can choose not to use puppet on this host
     proxies = SmartProxy.unscoped.with_features("Puppet").with_taxonomy_scope(@location,@organization,:path_ids)
@@ -72,7 +72,7 @@ module HostsAndHostgroupsHelper
                :help_inline => _("Use this puppet server as an initial Puppet Server or to execute puppet runs") }
   end
 
-  def interesting_klasses obj
+  def interesting_klasses(obj)
     classes    = obj.all_puppetclasses
     smart_vars = LookupKey.reorder('').where(:puppetclass_id => classes.map(&:id)).group(:puppetclass_id).count
     class_vars = LookupKey.reorder('').joins(:environment_classes).where(:environment_classes => { :puppetclass_id => classes.map(&:id) }).group('environment_classes.puppetclass_id').count

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -11,7 +11,7 @@ module HostsHelper
                           last_report_tooltip(record))
   end
 
-  def last_report_tooltip record
+  def last_report_tooltip(record)
     opts = { :rel => "twipsy" }
     if @last_reports[record.id]
       opts.merge!( "data-original-title" => _("View last report details"))
@@ -63,7 +63,7 @@ module HostsHelper
       link_to(trunc("  #{record}"), host_path(record))
   end
 
-  def days_ago time
+  def days_ago(time)
     ((Time.now - time) / 1.day).round.to_i
   end
 
@@ -98,12 +98,12 @@ module HostsHelper
       )
   end
 
-  def date ts = nil
+  def date(ts = nil)
     return _("%s ago") % (time_ago_in_words ts) if ts
     _("N/A")
   end
 
-  def template_path opts = {}
+  def template_path(opts = {})
     if (t = @host.configTemplate(opts))
       link_to t, edit_config_template_path(t)
     else
@@ -111,7 +111,7 @@ module HostsHelper
     end
   end
 
-  def selected? host
+  def selected?(host)
     return false if host.nil? or not host.kind_of?(Host::Base) or session[:selected].nil?
     session[:selected].include?(host.id.to_s)
   end
@@ -151,7 +151,7 @@ module HostsHelper
     end
   end
 
-  def name_field host
+  def name_field(host)
     return if host.name.blank?
     (SETTINGS[:unattended] and host.managed?) ? host.shortname : host.name
   end
@@ -193,7 +193,7 @@ module HostsHelper
     end
   end
 
-  def overview_fields host
+  def overview_fields(host)
     fields = [
       [_("Domain"), (link_to(host.domain, hosts_path(:search => "domain = #{host.domain}")) if host.domain)],
       [_("Realm"), (link_to(host.realm, hosts_path(:search => "realm = #{host.realm}")) if host.realm)],
@@ -217,13 +217,13 @@ module HostsHelper
     fields
   end
 
-  def possible_images cr, arch = nil, os = nil
+  def possible_images(cr, arch = nil, os = nil)
     return cr.images unless controller_name == "hosts"
     return [] unless arch && os
     cr.images.where(:architecture_id => arch, :operatingsystem_id => os)
   end
 
-  def state s
+  def state(s)
     s ? ' ' + _("Off") : ' ' + _("On")
   end
 
@@ -262,18 +262,18 @@ module HostsHelper
     )
   end
 
-  def conflict_objects errors
+  def conflict_objects(errors)
     errors.keys.map(&:to_s).grep(/conflict$/).map(&:to_sym)
   end
 
-  def has_conflicts? errors
+  def has_conflicts?(errors)
     conflict_objects(errors).each do |c|
       return true if errors[c.to_sym].any?
     end
     false
   end
 
-  def has_dhcp_lease_errors? errors
+  def has_dhcp_lease_errors?(errors)
     errors.include?(:dhcp_lease_error)
   end
 
@@ -293,7 +293,7 @@ module HostsHelper
     ].compact
   end
 
-  def allocation_text_f f
+  def allocation_text_f(f)
     active = 'Size'
     active = 'None' if f.object.allocation.to_i == 0
     active = 'Full' if f.object.allocation == f.object.capacity

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -1,5 +1,5 @@
 module ImagesHelper
-  def image_field f, opts = {}
+  def image_field(f, opts = {})
     return unless @compute_resource.capabilities.include?(:image)
     images = @compute_resource.available_images
     if images.any?

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -4,15 +4,15 @@ module LayoutHelper
     @page_header       ||= page_header || @content_for_title || page_title.to_s
   end
 
-  def title_actions *elements
+  def title_actions(*elements)
     content_for(:title_actions) { elements.join(" ").html_safe }
   end
 
-  def button_group *elements
+  def button_group(*elements)
     content_tag(:div,:class=>"btn-group") { elements.join(" ").html_safe }
   end
 
-  def search_bar *elements
+  def search_bar(*elements)
     content_for(:search_bar) { elements.join(" ").html_safe }
   end
 
@@ -187,7 +187,7 @@ module LayoutHelper
     end
   end
 
-  def form_to_submit_id f
+  def form_to_submit_id(f)
     object = f.object.respond_to?(:to_model) ? f.object.to_model : f.object
     key = object ? (object.persisted? ? :update : :create) : :submit
     model = if object.class.respond_to?(:humanize_class_name)
@@ -200,7 +200,7 @@ module LayoutHelper
     "aid_#{key}_#{model}"
   end
 
-  def submit_or_cancel f, overwrite = false, args = { }
+  def submit_or_cancel(f, overwrite = false, args = { })
     args[:cancel_path] ||= send("#{controller_name}_path")
     content_tag(:div, :class => "clearfix") do
       content_tag(:div, :class => "form-actions") do
@@ -213,7 +213,7 @@ module LayoutHelper
     end
   end
 
-  def base_errors_for obj
+  def base_errors_for(obj)
     unless obj.errors[:base].blank?
       alert :header => _("Unable to save"),
             :class  => 'alert-danger base in fade',
@@ -221,7 +221,7 @@ module LayoutHelper
     end
   end
 
-  def popover title, msg, options = {}
+  def popover(title, msg, options = {})
     link_to icon_text("info-sign", title), {}, { :remote => true, :rel => "popover", :data => {"content" => msg, "original-title" => title} }.merge(options)
   end
 
@@ -268,7 +268,7 @@ module LayoutHelper
     super record_or_name_or_array, *args, &proc
   end
 
-  def icons i
+  def icons(i)
     content_tag :i, :class=>"glyphicon glyphicon-#{i}" do
       yield
     end
@@ -278,7 +278,7 @@ module LayoutHelper
     (content_tag(:i,"", :class=>"glyphicon glyphicon-#{i} #{opts[:class]}") + " " + text).html_safe
   end
 
-  def alert opts = {}
+  def alert(opts = {})
     opts[:close]  = true if opts[:close].nil?
     opts[:header] ||= _("Warning!")
     opts[:text]   ||= _("Alert")
@@ -293,7 +293,7 @@ module LayoutHelper
     end
   end
 
-  def alert_header text
+  def alert_header(text)
     "<h4 class='alert-heading'>#{text}</h4>".html_safe
   end
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -26,7 +26,7 @@ module LookupKeysHelper
     end
   end
 
-  def show_puppet_class f
+  def show_puppet_class(f)
     # In case of a new smart-var inside a puppetclass (REST nesting only), or a class parameter:
     # Show the parent puppetclass as a context, but permit no change.
     if params["puppetclass_id"]
@@ -41,7 +41,7 @@ module LookupKeysHelper
     end unless @puppetclass # nested smart-vars form in a tab of puppetclass/_form: no edition allowed, and the puppetclass is already visible as a context
   end
 
-  def param_type_selector f
+  def param_type_selector(f)
     selectable_f f, :key_type, options_for_select(LookupKey::KEY_TYPES.map { |e| [_(e),e] }, f.object.key_type),{},
                { :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
                  :help_block => popover(_("Parameter types"),_("<dl>" +
@@ -56,7 +56,7 @@ module LookupKeysHelper
                "</dl>"), :title => _("How values are validated")).html_safe}
   end
 
-  def validator_type_selector f
+  def validator_type_selector(f)
      selectable_f f, :validator_type, options_for_select(LookupKey::VALIDATOR_TYPES.map { |e| [_(e),e]  }, f.object.validator_type),{:include_blank => _("None")},
                 { :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
                   :onchange => 'validatorTypeSelected(this)',
@@ -66,11 +66,11 @@ module LookupKeysHelper
                 "</dl>"), :title => _("Validation types")).html_safe}
   end
 
-  def overridable_lookup_keys klass, host
+  def overridable_lookup_keys(klass, host)
     klass.class_params.override.where(:environment_classes => {:environment_id => host.environment}) + klass.lookup_keys
   end
 
-  def hostgroup_key_with_diagnostic hostgroup, key
+  def hostgroup_key_with_diagnostic(hostgroup, key)
     value, origin = hostgroup.inherited_lookup_value key
     original_value = key.value_before_type_cast value
     diagnostic_helper = popover(_("Additional info"), _("<b>Description:</b> %{desc}<br><b>Type:</b> %{type}<br> <b>Matcher:</b> %{matcher}") % { :desc => key.description, :type => key.key_type, :matcher => origin})
@@ -82,7 +82,7 @@ module LookupKeysHelper
     end
   end
 
-  def host_key_with_diagnostic host, value_hash, key
+  def host_key_with_diagnostic(host, value_hash, key)
      value_for_key = value_hash[key.id] && value_hash[key.id][key.key]
      value, matcher = value_for_key ? [value_for_key[:value], "#{value_for_key[:element]} (#{value_for_key[:element_name]})"] : [key.default_value, _("Default value")]
      original_value = key.value_before_type_cast value

--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -1,7 +1,7 @@
 module OperatingsystemsHelper
   include CommonParametersHelper
 
-  def icon record, opts = {}
+  def icon(record, opts = {})
     return "" if record.blank? or record.name.blank?
     family = case record.name
     when /fedora/i
@@ -40,11 +40,11 @@ module OperatingsystemsHelper
     image_tag(family+".png", opts) + " "
   end
 
-  def os_name record, opts = {}
+  def os_name(record, opts = {})
     icon(record, opts).html_safe << trunc(record.to_label)
   end
 
-  def os_habtm_family type, obj
+  def os_habtm_family(type, obj)
     result = type.where(:os_family => obj.family)
     result.empty? ? type : result
   end

--- a/app/helpers/ptables_helper.rb
+++ b/app/helpers/ptables_helper.rb
@@ -1,6 +1,6 @@
 module PtablesHelper
 
-  def lookup_family value
+  def lookup_family(value)
     names = Operatingsystem.families_as_collection
     names.find { |k| k.value == value }.try(:name)
   end

--- a/app/helpers/puppetca_helper.rb
+++ b/app/helpers/puppetca_helper.rb
@@ -5,7 +5,7 @@ module PuppetcaHelper
                :onchange => "window.location.href = '#{smart_proxy_puppetca_index_path(@proxy)}' + (this.value == '' ? '' : ('?state=' + this.value))"
   end
 
-  def time_column time, opts = {}
+  def time_column(time, opts = {})
     return _("N/A") if time.blank?
     opts[:tense] ||= :past
 

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -1,5 +1,5 @@
 module PuppetclassesAndEnvironmentsHelper
-  def class_update_text pcs, env
+  def class_update_text(pcs, env)
     if pcs.empty?
       _("Empty environment")
     elsif pcs == ["_destroy_"]
@@ -11,18 +11,18 @@ module PuppetclassesAndEnvironmentsHelper
     end
   end
 
-  def import_proxy_select hash
+  def import_proxy_select(hash)
     select_action_button( _('Import'), {}, import_proxy_links(hash, 'btn btn-default'))
   end
 
-  def import_proxy_links hash, classes = nil
+  def import_proxy_links(hash, classes = nil)
     SmartProxy.with_features("Puppet").map do |proxy|
       display_link_if_authorized(_("Import from %s") % proxy.name, hash.merge(:proxy => proxy), :class=>classes)
     end.flatten
   end
 
   private
-  def pretty_print classes
+  def pretty_print(classes)
     hash = { }
     classes.each do |klass|
       if (mod = klass.gsub(/::.*/, ""))

--- a/app/helpers/puppetclasses_helper.rb
+++ b/app/helpers/puppetclasses_helper.rb
@@ -1,7 +1,7 @@
 module PuppetclassesHelper
   include PuppetclassesAndEnvironmentsHelper
   include LookupKeysHelper
-  def rdoc_classes_path environment, name
+  def rdoc_classes_path(environment, name)
     klass = name.gsub('::', '/')
     "puppet/rdoc/#{environment}/classes/#{klass}.html"
   end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -10,7 +10,7 @@ module ReportsHelper
     content_tag(:span, event, :class=>'label ' + style)
   end
 
-  def reports_since builder
+  def reports_since(builder)
     choices = [30,60,90].map{|i| OpenStruct.new :name => n_("%s minute ago", "%s minutes ago", i) % i, :value => i.minutes.ago }
     choices += (1..7).map{|i| OpenStruct.new :name => n_("%s day ago", "%s days ago", i) % i, :value => i.days.ago }
     choices += (1..3).map{|i| OpenStruct.new :name => n_("%s week ago", "%s weeks ago", i) % i, :value => i.week.ago }
@@ -19,11 +19,11 @@ module ReportsHelper
     builder.collection_select :reported_at_gt, choices, :value, :name, {:include_blank => _("Select a period")}
   end
 
-  def metric m
+  def metric(m)
     m.round(4) rescue _("N/A")
   end
 
-  def report_tag level
+  def report_tag(level)
     tag = case level
           when :notice
             "info"

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,6 +1,6 @@
 module SettingsHelper
 
-  def value setting
+  def value(setting)
     if setting.readonly?
       return readonly_field(
           setting, :value,
@@ -15,7 +15,7 @@ module SettingsHelper
     end
   end
 
-  def show_value setting
+  def show_value(setting)
     case setting.settings_type
     when "array"
       "[ " + setting.value.join(", ") + " ]"
@@ -26,7 +26,7 @@ module SettingsHelper
     setting.value
   end
 
-  def short_cat category
+  def short_cat(category)
     category.gsub(/Setting::/,'')
   end
 

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -1,5 +1,5 @@
 module SmartProxiesHelper
-  def proxy_actions proxy, authorizer
+  def proxy_actions(proxy, authorizer)
     [if proxy.features.detect{|f| f.name == "Puppet CA"}
        [display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
                                 merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer)),

--- a/app/helpers/subnets_helper.rb
+++ b/app/helpers/subnets_helper.rb
@@ -1,7 +1,7 @@
 module SubnetsHelper
 
   # expand or minimize the subnet when importing
-  def minimal? subnets
+  def minimal?(subnets)
     subnets.each {|s| return false unless s.errors.empty?}
     subnets.size > 2
   end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,6 +1,6 @@
 module TasksHelper
 
-  def task_status status
+  def task_status(status)
     icon = case status
              when "completed"
                "check"

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -13,7 +13,7 @@ module TaxonomyHelper
     SETTINGS[:locations_enabled] or SETTINGS[:organizations_enabled]
   end
 
-  def organization_dropdown count
+  def organization_dropdown(count)
     text = Organization.current.nil? ? _("Any Organization") : Organization.current.to_label
     if count == 1 && !User.current.admin?
       link_to text, "#"
@@ -22,7 +22,7 @@ module TaxonomyHelper
     end
   end
 
-  def location_dropdown count
+  def location_dropdown(count)
       text = Location.current.nil? ? _("Any Location") : Location.current.to_label
       if count == 1 && !User.current.admin?
         link_to text, "#"
@@ -56,7 +56,7 @@ module TaxonomyHelper
     end
   end
 
-  def option_button text, href, options
+  def option_button(text, href, options)
     field(nil, "", options) do
       link_to(text, href, options)
     end
@@ -94,7 +94,7 @@ module TaxonomyHelper
     is_location? ? mismatches_locations_path : mismatches_organizations_path
   end
 
-  def import_mismatches_taxonomy_path taxonomy
+  def import_mismatches_taxonomy_path(taxonomy)
     is_location? ? import_mismatches_location_path(taxonomy) : import_mismatches_organization_path(taxonomy)
   end
 

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -2,7 +2,7 @@ module TrendsHelper
 
   include CommonParametersHelper
 
-  def trendable_types new_record
+  def trendable_types(new_record)
     options = {_('Environment') => 'Environment', _('Operating system') => 'Operatingsystem',
      _('Model') => 'Model', _('Facts') =>'FactName',_('Host group') => 'Hostgroup', _('Compute resource') => 'ComputeResource'}
     if new_record
@@ -18,7 +18,7 @@ module TrendsHelper
     end
   end
 
-  def trend_title trend
+  def trend_title(trend)
     if trend.fact_value.blank?
       trend.to_label
     else
@@ -26,7 +26,7 @@ module TrendsHelper
     end
   end
 
-  def chart_data trend, from = Setting.max_trend, to = Time.now
+  def chart_data(trend, from = Setting.max_trend, to = Time.now)
     chart_colors = ['#4572A7','#AA4643','#89A54E','#80699B','#3D96AE','#DB843D','#92A8CD','#A47D7C','#B5CA92']
     values = trend.values
     labels = {}

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,19 +1,19 @@
 module UsersHelper
-  def last_login_on_column record
+  def last_login_on_column(record)
     _("%s ago") % time_ago_in_words(record.last_login_on.getlocal) if record.last_login_on
   end
 
-  def auth_source_column record
+  def auth_source_column(record)
     record.auth_source.to_label if record.auth_source
   end
 
-  def contracted_host_list user
+  def contracted_host_list(user)
     content_tag(:span, :id => "contracted_host_list", :style => "display:inline;") do
       content_tag(:span, user.hosts.to_sentence)
     end
   end
 
-  def expanded_host_list user
+  def expanded_host_list(user)
     content_tag(:span, :id => "expanded_host_list", :style => "display:none;") do
     end
   end

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -131,7 +131,7 @@ class AuthSourceLdap < AuthSource
     { :avatar => attr_photo }
   end
 
-  def attributes_values entry
+  def attributes_values(entry)
     Hash[required_ldap_attributes.merge(optional_ldap_attributes).map do |name, value|
       next if value.blank? || (entry[value].blank? && optional_ldap_attributes.keys.include?(name))
       if name.eql? :avatar
@@ -143,7 +143,7 @@ class AuthSourceLdap < AuthSource
     end]
   end
 
-  def store_avatar avatar
+  def store_avatar(avatar)
     avatar_path = "#{Rails.public_path}/assets/avatars"
     avatar_hash = Digest::SHA1.hexdigest(avatar)
     avatar_file = "#{avatar_path}/#{avatar_hash}.jpg"

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -65,7 +65,7 @@ class ComputeResource < ActiveRecord::Base
   end
 
   # allows to create a specific compute class based on the provider.
-  def self.new_provider args
+  def self.new_provider(args)
     raise ::Foreman::Exception.new(N_("must provide a provider")) unless provider = args.delete(:provider)
     self.providers.each do |p|
       return self.provider_class(p).constantize.new(args) if p.downcase == provider.downcase
@@ -82,7 +82,7 @@ class ComputeResource < ActiveRecord::Base
     {:uuid => :identity}
   end
 
-  def test_connection options = {}
+  def test_connection(options = {})
     valid?
   end
 
@@ -91,7 +91,7 @@ class ComputeResource < ActiveRecord::Base
     errors
   end
 
-  def save_vm uuid, attr
+  def save_vm(uuid, attr)
     vm = find_vm_by_uuid(uuid)
     vm.attributes.merge!(attr.symbolize_keys)
     vm.save
@@ -119,13 +119,13 @@ class ComputeResource < ActiveRecord::Base
   end
 
   # returns a new fog server instance
-  def new_vm attr = {}
+  def new_vm(attr = {})
     test_connection
     client.servers.new vm_instance_defaults.merge(attr.to_hash.symbolize_keys) if errors.empty?
   end
 
   # return fog new interface ( network adapter )
-  def new_interface attr = {}
+  def new_interface(attr = {})
     client.interfaces.new attr
   end
 
@@ -134,25 +134,25 @@ class ComputeResource < ActiveRecord::Base
     client.servers
   end
 
-  def find_vm_by_uuid uuid
+  def find_vm_by_uuid(uuid)
     client.servers.get(uuid) || raise(ActiveRecord::RecordNotFound)
   end
 
-  def start_vm uuid
+  def start_vm(uuid)
     find_vm_by_uuid(uuid).start
   end
 
-  def stop_vm uuid
+  def stop_vm(uuid)
     find_vm_by_uuid(uuid).stop
   end
 
-  def create_vm args = {}
+  def create_vm(args = {})
     options = vm_instance_defaults.merge(args.to_hash.symbolize_keys)
     logger.debug("creating VM with the following options: #{options.inspect}")
     client.servers.create options
   end
 
-  def destroy_vm uuid
+  def destroy_vm(uuid)
     find_vm_by_uuid(uuid).destroy
   rescue ActiveRecord::RecordNotFound
     # if the VM does not exists, we don't really care.
@@ -191,7 +191,7 @@ class ComputeResource < ActiveRecord::Base
     false
   end
 
-  def console uuid = nil
+  def console(uuid = nil)
     raise ::Foreman::Exception.new(N_("%s console is not supported at this time"), provider_friendly_name)
   end
 
@@ -263,7 +263,7 @@ class ComputeResource < ActiveRecord::Base
     SecureRandom.hex(8)
   end
 
-  def nested_attributes_for type, opts
+  def nested_attributes_for(type, opts)
     return [] unless opts
     opts = opts.dup #duplicate to prevent changing the origin opts.
     opts.delete("new_#{type}") # delete template

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -27,13 +27,13 @@ module Foreman::Model
       [:image]
     end
 
-    def find_vm_by_uuid uuid
+    def find_vm_by_uuid(uuid)
       client.servers.get(uuid)
     rescue Fog::Compute::AWS::Error
       raise(ActiveRecord::RecordNotFound)
     end
 
-    def create_vm args = { }
+    def create_vm(args = { })
       args = vm_instance_defaults.merge(args.to_hash.symbolize_keys)
       if (name = args[:name])
         args.merge!(:tags => {:Name => name})
@@ -51,7 +51,7 @@ module Foreman::Model
       raise e
     end
 
-    def security_groups vpc = nil
+    def security_groups(vpc = nil)
       groups = client.security_groups
       groups.reject! { |sg| sg.vpc_id != vpc } if vpc
       groups
@@ -70,7 +70,7 @@ module Foreman::Model
       client.flavors
     end
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super
       errors[:user].empty? and errors[:password].empty? and regions
     rescue Fog::Compute::AWS::Error => e

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -60,7 +60,7 @@ module Foreman::Model
       self.url = zone
     end
 
-    def create_vm args = {}
+    def create_vm(args = {})
       #Dot are not allowed in names
       args[:name]        = args[:name].parameterize if args[:name].present?
       args[:external_ip] = args[:external_ip] != '0'

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -22,14 +22,14 @@ module Foreman::Model
       [:build, :image]
     end
 
-    def find_vm_by_uuid uuid
+    def find_vm_by_uuid(uuid)
       client.servers.get(uuid)
     rescue ::Libvirt::RetrieveError => e
       raise(ActiveRecord::RecordNotFound)
     end
 
     # we default to destroy the VM's storage as well.
-    def destroy_vm uuid, args = { }
+    def destroy_vm(uuid, args = { })
       find_vm_by_uuid(uuid).destroy({ :destroy_volumes => true }.merge(args))
     rescue ActiveRecord::RecordNotFound
       true
@@ -51,7 +51,7 @@ module Foreman::Model
       16*1024*1024*1024
     end
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super
       errors[:url].empty? and hypervisor
     rescue => e
@@ -59,11 +59,11 @@ module Foreman::Model
       errors[:base] << e.message
     end
 
-    def new_nic attr = { }
+    def new_nic(attr = { })
       client.nics.new attr
     end
 
-    def new_volume attr = { }
+    def new_volume(attr = { })
       client.volumes.new(attrs.merge(:allocation => '0G'))
     end
 
@@ -85,7 +85,7 @@ module Foreman::Model
       template
     end
 
-    def new_vm attr = { }
+    def new_vm(attr = { })
       test_connection
       return unless errors.empty?
       opts = vm_instance_defaults.merge(attr.to_hash).symbolize_keys
@@ -106,7 +106,7 @@ module Foreman::Model
       vm
     end
 
-    def create_vm args = { }
+    def create_vm(args = { })
       vm = new_vm(args)
       create_volumes :prefix => vm.name, :volumes => vm.volumes, :backing_id => args[:image_id]
       vm.save
@@ -116,7 +116,7 @@ module Foreman::Model
       raise e
     end
 
-    def console uuid
+    def console(uuid)
       vm = find_vm_by_uuid(uuid)
       raise Foreman::Exception.new(N_("VM is not running!")) unless vm.ready?
       password = random_password
@@ -169,7 +169,7 @@ module Foreman::Model
       )
     end
 
-    def create_volumes args
+    def create_volumes(args)
       args[:volumes].each {|vol| validate_volume_capacity(vol)}
 
       # if using image creation, the first volume needs a backing disk set

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -34,7 +34,7 @@ module Foreman::Model
       attrs[:tenant] = name
     end
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super
       errors[:user].empty? and errors[:password] and tenants
     rescue => e
@@ -72,7 +72,7 @@ module Foreman::Model
       raise message
     end
 
-    def destroy_vm uuid
+    def destroy_vm(uuid)
       vm           = find_vm_by_uuid(uuid)
       floating_ips = vm.all_addresses
       floating_ips.each do |address|

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -84,7 +84,7 @@ module Foreman::Model
     end
     private :test_https_required
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super
       if errors[:url].empty? and errors[:username].empty? and errors[:password].empty?
         update_public_key options
@@ -232,7 +232,7 @@ module Foreman::Model
       attrs[:public_key]
     end
 
-    def public_key= key
+    def public_key=(key)
       attrs[:public_key] = key
     end
 
@@ -267,7 +267,7 @@ module Foreman::Model
       end
     end
 
-    def update_public_key options = {}
+    def update_public_key(options = {})
       return unless public_key.blank? || options[:force]
       client
     rescue Foreman::FingerprintException => e
@@ -278,7 +278,7 @@ module Foreman::Model
       @api_version ||= client.api_version
     end
 
-    def ca_cert_store cert
+    def ca_cert_store(cert)
       return if cert.blank?
       OpenSSL::X509::Store.new.add_cert(OpenSSL::X509::Certificate.new(cert))
     rescue => e

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -16,13 +16,13 @@ module Foreman::Model
       [:image]
     end
 
-    def find_vm_by_uuid uuid
+    def find_vm_by_uuid(uuid)
       client.servers.get(uuid)
     rescue Fog::Compute::Rackspace::Error
       raise(ActiveRecord::RecordNotFound)
     end
 
-    def create_vm args = { }
+    def create_vm(args = { })
       super(args)
     rescue Fog::Errors::Error => e
       logger.debug "Unhandled Rackspace error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
@@ -49,7 +49,7 @@ module Foreman::Model
       client.images
     end
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super and flavors
     rescue Excon::Errors::Unauthorized => e
       errors[:base] << e.response.body
@@ -57,7 +57,7 @@ module Foreman::Model
       errors[:base] << e.message
     end
 
-    def region= value
+    def region=(value)
       self.uuid = value
     end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -263,7 +263,7 @@ module Foreman::Model
       }
     end
 
-    def test_connection options = {}
+    def test_connection(options = {})
       super
       if errors[:server].empty? and errors[:user].empty? and errors[:password].empty?
         update_public_key options
@@ -273,7 +273,7 @@ module Foreman::Model
       errors[:base] << e.message
     end
 
-    def parse_args args
+    def parse_args(args)
       args = args.symbolize_keys
 
       # convert rails nested_attributes into a plain, symbolized hash
@@ -294,7 +294,7 @@ module Foreman::Model
 
     # Change network IDs for names only at the point of creation, as IDs are
     # used in the UI for select boxes etc.
-    def parse_networks args
+    def parse_networks(args)
       args = args.deep_dup
       dc_networks = networks
       args["interfaces_attributes"].each do |key, interface|
@@ -306,7 +306,7 @@ module Foreman::Model
       args
     end
 
-    def create_vm args = { }
+    def create_vm(args = { })
       test_connection
       return unless errors.empty?
 
@@ -323,7 +323,7 @@ module Foreman::Model
       raise e
     end
 
-    def new_vm args
+    def new_vm(args)
       args = parse_args args
       opts = vm_instance_defaults.symbolize_keys.merge(args.symbolize_keys)
       client.servers.new opts
@@ -343,7 +343,7 @@ module Foreman::Model
     # Fog calls +cluster.resourcePool.find("Resources")+ that actually calls
     # +searchIndex.FindChild("Resources")+ in RbVmomi that then returns nil
     # because it has no children.
-    def clone_vm args
+    def clone_vm(args)
       args = parse_args args
       path_replace = %r{/Datacenters/#{datacenter}/vm(/|)}
 
@@ -371,7 +371,7 @@ module Foreman::Model
       url
     end
 
-    def server= value
+    def server=(value)
       self.url = value
     end
 
@@ -379,11 +379,11 @@ module Foreman::Model
       uuid
     end
 
-    def datacenter= value
+    def datacenter=(value)
       self.uuid = value
     end
 
-    def console uuid
+    def console(uuid)
       vm = find_vm_by_uuid(uuid)
       raise "VM is not running!" unless vm.ready?
       #TOOD port, password
@@ -393,11 +393,11 @@ module Foreman::Model
       WsProxy.start(:host => vm.hypervisor, :host_port => values[:port], :password => values[:password]).merge(:type => 'vnc')
     end
 
-    def new_interface attr = { }
+    def new_interface(attr = { })
       client.interfaces.new attr
     end
 
-    def new_volume attr = { }
+    def new_volume(attr = { })
       client.volumes.new attr.merge(:size_gb => 10)
     end
 
@@ -405,7 +405,7 @@ module Foreman::Model
       attrs[:pubkey_hash]
     end
 
-    def pubkey_hash= key
+    def pubkey_hash=(key)
       attrs[:pubkey_hash] = key
     end
 
@@ -423,7 +423,7 @@ module Foreman::Model
       client.datacenters.get(datacenter)
     end
 
-    def update_public_key options = {}
+    def update_public_key(options = {})
       return unless pubkey_hash.blank? || options[:force]
       client
     rescue Foreman::FingerprintException => e
@@ -447,7 +447,7 @@ module Foreman::Model
       end
     end
 
-    def unused_vnc_port ip
+    def unused_vnc_port(ip)
       10.times do
         port   = 5901 + rand(64)
         unused = (TCPSocket.connect(ip, port).close rescue true)

--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -20,7 +20,7 @@ module FogExtensions
         attributes[:memory_size].to_i * 1024
       end
 
-      def memory= mem
+      def memory=(mem)
         attributes[:memory_size] = mem.to_i / 1024 if mem
       end
 

--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -66,7 +66,7 @@ module Foreman
         #
         # @param [String] login to find from the database
         # @param [block] block to execute
-        def as login
+        def as(login)
           old_user = current
           self.current = User.unscoped.find_by_login(login)
           raise ::Foreman::Exception.new(N_("Cannot find user %s when switching context"), login) unless self.current.present?
@@ -107,7 +107,7 @@ module Foreman
         #
         # @param [org]
         # @param [block] block to execute
-        def as_org org
+        def as_org(org)
           old_org = current
           self.current = org
           yield if block_given?
@@ -142,7 +142,7 @@ module Foreman
         #
         # @param [location]
         # @param [block] block to execute
-        def as_location location
+        def as_location(location)
           old_location = current
           self.current = location
           yield if block_given?

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -37,7 +37,7 @@ module HostCommon
     accepts_nested_attributes_for :lookup_values
     # Replacement of accepts_nested_attributes_for :lookup_values,
     # to work around the lack of `host_id` column in lookup_values.
-    def lookup_values_attributes= lookup_values_attributes
+    def lookup_values_attributes=(lookup_values_attributes)
       lookup_values_attributes.each_value do |attribute|
         attr = attribute.dup
         if attr.has_key? :id
@@ -55,7 +55,7 @@ module HostCommon
   end
 
   # Returns a url pointing to boot file
-  def url_for_boot file
+  def url_for_boot(file)
     "#{os.medium_uri(self)}/#{os.url_for_boot(file)}"
   end
 
@@ -95,7 +95,7 @@ module HostCommon
     end
   end
 
-  def image_file= file
+  def image_file=(file)
     # We only save a value into the image_file field if the value is not the default path, (which was placed in the entry when it was displayed,)
     # and it is not a directory, (ends in /)
     value = ( (default_image_file == file) or (file =~ /\/\Z/) or file == "") ? nil : file
@@ -115,11 +115,11 @@ module HostCommon
     end
   end
 
-  def param_true? name
+  def param_true?(name)
     params.has_key?(name) && LookupKey::TRUE_VALUES.include?(params[name])
   end
 
-  def param_false? name
+  def param_false?(name)
     params.has_key?(name) && LookupKey::FALSE_VALUES.include?(params[name])
   end
 

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -40,7 +40,7 @@ module NestedAncestryCommon
   end
 
   module ClassMethods
-    def nested_attribute_for *opts
+    def nested_attribute_for(*opts)
 
       opts.each do |field|
 
@@ -75,7 +75,7 @@ module NestedAncestryCommon
     end
   end
 
-  def nested attr
+  def nested(attr)
     self.class.sort_by_ancestry(ancestors.where("#{attr} is not NULL")).last.try(attr) if ancestry.present?
   end
 

--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -31,7 +31,7 @@ module Orchestration
   end
 
   # log and add to errors
-  def failure msg, backtrace = nil, dest = :base
+  def failure(msg, backtrace = nil, dest = :base)
     logger.warn(backtrace ? msg + backtrace.join("\n") : msg)
     errors.add dest, msg
     false
@@ -66,7 +66,7 @@ module Orchestration
   # takes care for running the tasks in order
   # if any of them fail, it rollbacks all completed tasks
   # in order not to keep any left overs in our proxies.
-  def process queue_name
+  def process(queue_name)
     return true if Rails.env == "test"
 
     # queue is empty - nothing to do.
@@ -117,7 +117,7 @@ module Orchestration
     rollback
   end
 
-  def execute opts = {}
+  def execute(opts = {})
     obj, met = opts[:action]
     rollback = opts[:rollback] || false
     # at the moment, rollback are expected to replace set with del in the method name

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -229,7 +229,7 @@ module Orchestration::Compute
     ip
   end
 
-  def ssh_open? ip
+  def ssh_open?(ip)
     begin
       Timeout::timeout(1) do
         begin

--- a/app/models/concerns/orchestration/realm.rb
+++ b/app/models/concerns/orchestration/realm.rb
@@ -25,7 +25,7 @@ module Orchestration::Realm
   end
 
   # Adds the host to the realm, and sets otp if we get one back
-  def set_realm options = {}
+  def set_realm(options = {})
     initialize_realm
     logger.info "#{options[:update] ? 'Update' : 'Add'} realm entry for #{options[:rebuild] ? 'reprovisioned' : 'new'} host #{name}"
     options[:hostname]  = name

--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -63,7 +63,7 @@ class ConfigTemplate < ActiveRecord::Base
     end.uniq.compact
   end
 
-  def self.find_template opts = {}
+  def self.find_template(opts = {})
     raise ::Foreman::Exception.new(N_("Must provide template kind")) unless opts[:kind]
     raise ::Foreman::Exception.new(N_("Must provide an operating systems")) unless opts[:operatingsystem_id]
 

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -66,7 +66,7 @@ class Domain < ActiveRecord::Base
     ProxyAPI::DNS.new(:url => dns.url) if dns and !dns.url.blank?
   end
 
-  def lookup query
+  def lookup(query)
     Net::DNS.lookup query, proxy, resolver
   end
 

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -38,7 +38,7 @@ class Environment < ActiveRecord::Base
     #TODO: this needs to be removed, as PuppetDOC generation no longer works
     # if the manifests are not on the foreman host
     # returns an hash of all puppet environments and their relative paths
-    def puppetEnvs proxy = nil
+    def puppetEnvs(proxy = nil)
 
       url = (proxy || SmartProxy.with_features("Puppet").first).try(:url)
       raise ::Foreman::Exception.new(N_("Can't find a valid Foreman Proxy with a Puppet feature")) if url.blank?

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -88,7 +88,7 @@ class FactValue < ActiveRecord::Base
     output
   end
 
-  def self.build_facts_hash facts
+  def self.build_facts_hash(facts)
     hash = {}
     facts.each do |fact|
       hash[fact.host.to_s] ||= {}
@@ -99,7 +99,7 @@ class FactValue < ActiveRecord::Base
 
   # converts all strings with units (such as 1 MB) to GB scale and Sum them
   # returns an array with total sum and number of elements
-  def self.to_gb fact
+  def self.to_gb(fact)
     values = select(:value).joins(:fact_name).where(:fact_names => {:name => fact}).map do |fv|
       fv.value.to_gb
     end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -298,7 +298,7 @@ class Host::Managed < Host::Base
   end
 
   # returns a configuration template (such as kickstart) to a given host
-  def configTemplate opts = {}
+  def configTemplate(opts = {})
     opts[:kind]               ||= "provision"
     opts[:operatingsystem_id] ||= operatingsystem_id
     opts[:hostgroup_id]       ||= hostgroup_id
@@ -395,7 +395,7 @@ class Host::Managed < Host::Base
     @cached_host_params = nil
   end
 
-  def host_inherited_params include_source = false
+  def host_inherited_params(include_source = false)
     hp = {}
     # read common parameters
     CommonParameter.all.each {|p| hp.update Hash[p.name => include_source ? {:value => p.value, :source => N_('common').to_sym, :safe_value => p.safe_value} : p.value] }
@@ -420,7 +420,7 @@ class Host::Managed < Host::Base
   end
 
   # JSON is auto-parsed by the API, so these should be in the right format
-  def self.import_host_and_facts hostname, facts, certname = nil, proxy_id = nil
+  def self.import_host_and_facts(hostname, facts, certname = nil, proxy_id = nil)
     raise(::Foreman::Exception.new("Invalid Facts, must be a Hash")) unless facts.is_a?(Hash)
     raise(::Foreman::Exception.new("Invalid Hostname, must be a String")) unless hostname.is_a?(String)
 
@@ -475,7 +475,7 @@ class Host::Managed < Host::Base
 
   # this method accepts a puppets external node yaml output and generate a node in our setup
   # it is assumed that you already have the node (e.g. imported by one of the rack tasks)
-  def importNode nodeinfo
+  def importNode(nodeinfo)
     myklasses= []
     # puppet classes
     nodeinfo["classes"].each do |klass|
@@ -514,7 +514,7 @@ class Host::Managed < Host::Base
   # counts each association of a given host
   # e.g. how many hosts belongs to each os
   # returns sorted hash
-  def self.count_distribution association
+  def self.count_distribution(association)
     output = []
     data = group("#{Host.table_name}.#{association}_id").reorder('').count
     associations = association.to_s.camelize.constantize.where(:id => data.keys).all
@@ -532,7 +532,7 @@ class Host::Managed < Host::Base
   # TODO: Merge these two into one method
   # e.g. how many hosts belongs to each os
   # returns sorted hash
-  def self.count_habtm association
+  def self.count_habtm(association)
     counter = Host::Managed.joins(association.tableize.to_sym).group("#{association.tableize.to_sym}.id").reorder('').count
     #Puppetclass.find(counter.keys.compact)...
     association.camelize.constantize.find(counter.keys.compact).map {|i| {:label=>i.to_label, :data =>counter[i.id]}}
@@ -821,7 +821,7 @@ class Host::Managed < Host::Base
     errors.add(:name, _("must not include periods")) if ( managed? && shortname.include?(".") && SETTINGS[:unattended] )
   end
 
-  def assign_hostgroup_attributes attrs = []
+  def assign_hostgroup_attributes(attrs = [])
     attrs.each do |attr|
       value = hostgroup.send("inherited_#{attr}")
       self.send("#{attr}=", value) unless send(attr).present?
@@ -862,7 +862,7 @@ class Host::Managed < Host::Base
   # converts a name into ip address using DNS.
   # if we are managing DNS, we can query the correct DNS server
   # otherwise, use normal systems dns settings to resolv
-  def to_ip_address name_or_ip
+  def to_ip_address(name_or_ip)
     return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
     if dns_ptr_record
       lookup = dns_ptr_record.dns_lookup(name_or_ip)

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -112,7 +112,7 @@ class Hostgroup < ActiveRecord::Base
     parent.classes(self.environment)
   end
 
-  def inherited_lookup_value key
+  def inherited_lookup_value(key)
     ancestors.reverse.each do |hg|
       if (v = LookupValue.where(:lookup_key_id => key.id, :id => hg.lookup_values).first)
         return v.value, hg.to_label
@@ -122,7 +122,7 @@ class Hostgroup < ActiveRecord::Base
   end
 
   # returns self and parent parameters as a hash
-  def parameters include_source = false
+  def parameters(include_source = false)
     hash = {}
     ids = ancestor_ids
     ids << id unless new_record? or self.frozen?

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -10,7 +10,7 @@ class Log < ActiveRecord::Base
     "#{source} #{message}"
   end
 
-  def level= l
+  def level=(l)
     write_attribute(:level_id, LEVELS.index(l))
   end
 

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -120,7 +120,7 @@ class LookupKey < ActiveRecord::Base
     value_before_type_cast default_value
   end
 
-  def value_before_type_cast val
+  def value_before_type_cast(val)
     case key_type.to_sym
       when :json, :array
         val = JSON.dump val
@@ -132,7 +132,7 @@ class LookupKey < ActiveRecord::Base
   end
 
   # Returns the casted value, or raises a TypeError
-  def cast_validate_value value
+  def cast_validate_value(value)
     method = "cast_value_#{key_type}".to_sym
     return value unless self.respond_to? method, true
     self.send(method, value) rescue raise TypeError
@@ -149,7 +149,7 @@ class LookupKey < ActiveRecord::Base
   private
 
   # Generate possible lookup values type matches to a given host
-  def path2matches host
+  def path2matches(host)
     raise ::Foreman::Exception.new(N_("Invalid Host")) unless host.class.model_name == "Host"
     matches = []
     path_elements.each do |rule|
@@ -164,7 +164,7 @@ class LookupKey < ActiveRecord::Base
 
   # translates an element such as domain to its real value per host
   # tries to find the host attribute first, parameters and then fallback to a puppet fact.
-  def attr_to_value host, element
+  def attr_to_value(host, element)
     # direct host attribute
     return host.send(element) if host.respond_to?(element)
     # host parameter
@@ -179,7 +179,7 @@ class LookupKey < ActiveRecord::Base
     self.path = path.tr("\s","").downcase unless path.blank?
   end
 
-  def array2path array
+  def array2path(array)
     raise ::Foreman::Exception.new(N_("invalid path")) unless array.is_a?(Array)
     array.map do |sub_array|
       sub_array.is_a?(Array) ? sub_array.join(KEY_DELM) : sub_array
@@ -198,13 +198,13 @@ class LookupKey < ActiveRecord::Base
     end
   end
 
-  def cast_value_boolean value
+  def cast_value_boolean(value)
     return true if TRUE_VALUES.include? value
     return false if FALSE_VALUES.include? value
     raise TypeError
   end
 
-  def cast_value_integer value
+  def cast_value_integer(value)
     return value.to_i if value.is_a?(Numeric)
 
     if value.is_a?(String)
@@ -220,7 +220,7 @@ class LookupKey < ActiveRecord::Base
     end
   end
 
-  def cast_value_real value
+  def cast_value_real(value)
     return value if value.is_a? Numeric
     if value.is_a?(String)
       if value =~ /\A[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?\Z/
@@ -231,7 +231,7 @@ class LookupKey < ActiveRecord::Base
     end
   end
 
-  def load_yaml_or_json value
+  def load_yaml_or_json(value)
     return value unless value.is_a? String
     begin
       JSON.load value
@@ -240,7 +240,7 @@ class LookupKey < ActiveRecord::Base
     end
   end
 
-  def cast_value_array value
+  def cast_value_array(value)
     return value if value.is_a? Array
     return value.to_a if not value.is_a? String and value.is_a? Enumerable
     value = load_yaml_or_json value
@@ -248,18 +248,18 @@ class LookupKey < ActiveRecord::Base
     value
   end
 
-  def cast_value_hash value
+  def cast_value_hash(value)
     return value if value.is_a? Hash
     value = load_yaml_or_json value
     raise TypeError unless value.is_a? Hash
     value
   end
 
-  def cast_value_yaml value
+  def cast_value_yaml(value)
     value = YAML.load value
   end
 
-  def cast_value_json value
+  def cast_value_json(value)
     value = JSON.load value
   end
 

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -56,7 +56,7 @@ class Medium < ActiveRecord::Base
   end
 
   # Write the image path, with a trailing "/" if required
-  def image_path= path
+  def image_path=(path)
     write_attribute :image_path, "#{path}#{"/" unless path =~ /\/$|^$/}"
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,7 +8,7 @@ class Message < ActiveRecord::Base
     value
   end
 
-  def self.find_or_create val
+  def self.find_or_create(val)
     digest = Digest::SHA1.hexdigest(val)
     Message.where(:digest => digest).first || Message.create(:value => val, :digest => digest)
   end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -100,11 +100,11 @@ class Operatingsystem < ActiveRecord::Base
   #    :enabled => 1,
   #    :gpgcheck => 1
   #  }]
-  def repos host
+  def repos(host)
     []
   end
 
-  def medium_uri host, url = nil
+  def medium_uri(host, url = nil)
     url ||= host.medium.path
     medium_vars_to_uri(url, host.architecture.name, host.os)
   end
@@ -113,7 +113,7 @@ class Operatingsystem < ActiveRecord::Base
     URI.parse(interpolate_medium_vars(url, arch, os)).normalize
   end
 
-  def interpolate_medium_vars path, arch, os
+  def interpolate_medium_vars(path, arch, os)
     return "" if path.empty?
 
     path.gsub('$arch',  arch).
@@ -168,15 +168,15 @@ class Operatingsystem < ActiveRecord::Base
     end
   end
 
-  def kernel arch
+  def kernel(arch)
     bootfile(arch,:kernel)
   end
 
-  def initrd arch
+  def initrd(arch)
     bootfile(arch,:initrd)
   end
 
-  def bootfile arch, type
+  def bootfile(arch, type)
     pxe_prefix(arch) + "-" + eval("#{self.family}::PXEFILES[:#{type}]")
   end
 
@@ -196,7 +196,7 @@ class Operatingsystem < ActiveRecord::Base
   end
 
   #handle things like gpxelinux/ gpxe / pxelinux here
-  def boot_filename host = nil
+  def boot_filename(host = nil)
     "pxelinux.0"
   end
 
@@ -219,7 +219,7 @@ class Operatingsystem < ActiveRecord::Base
     "Unknown"
   end
 
-  def self.shorten_description description
+  def self.shorten_description(description)
     # This method should be overridden in the OS subclass
     # to handle shortening the specific formats of lsbdistdescription
     # returned by Facter on that OS

--- a/app/models/operatingsystems/archlinux.rb
+++ b/app/models/operatingsystems/archlinux.rb
@@ -3,7 +3,7 @@ class Archlinux < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
   # Simple output of the media url
-  def mediumpath host
+  def mediumpath(host)
     medium_uri(host).to_s
   end
 

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -2,11 +2,11 @@ class Debian < Operatingsystem
 
   PXEFILES = {:kernel => "linux", :initrd => "initrd.gz"}
 
-  def preseed_server host
+  def preseed_server(host)
     medium_uri(host).select(:host, :port).compact.join(':')
   end
 
-  def preseed_path host
+  def preseed_path(host)
     medium_uri(host).select(:path, :query).compact.join('?')
   end
 
@@ -36,7 +36,7 @@ class Debian < Operatingsystem
     "Debian"
   end
 
-  def self.shorten_description description
+  def self.shorten_description(description)
     return "" if description.blank?
     s=description
     s.gsub!('GNU/Linux','')

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -7,7 +7,7 @@ class Freebsd < Operatingsystem
   PXEFILES = {}
 
   # Simple output of the media url
-  def mediumpath host
+  def mediumpath(host)
     medium_uri(host).to_s.gsub("x86_64","amd64")
   end
 
@@ -23,11 +23,11 @@ class Freebsd < Operatingsystem
     pxedir + "/" + PXEFILES[file]
   end
 
-  def kernel arch
+  def kernel(arch)
     "memdisk"
   end
 
-  def initrd arch
+  def initrd(arch)
     "boot/FreeBSD-#{arch}-#{release}-mfs.img"
   end
 

--- a/app/models/operatingsystems/gentoo.rb
+++ b/app/models/operatingsystems/gentoo.rb
@@ -2,7 +2,7 @@ class Gentoo < Operatingsystem
 
   PXEFILES = {}
 
-  def mediumpath host
+  def mediumpath(host)
   end
 
   def pxe_type

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -3,7 +3,7 @@ class Junos < Operatingsystem
   PXEFILES = {}
 
   # Simple output of the media url
-  def mediumpath host
+  def mediumpath(host)
     medium_uri(host).to_s
   end
 
@@ -35,15 +35,15 @@ class Junos < Operatingsystem
   end
 
   #handle things like gpxelinux/ gpxe / pxelinux here
-  def boot_filename host = nil
+  def boot_filename(host = nil)
     "ztp.cfg/"+host.mac.gsub(/:/,"").upcase
   end
 
-  def kernel arch
+  def kernel(arch)
     "memdisk"
   end
 
-  def initrd arch
+  def initrd(arch)
     "none"
   end
 

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -4,7 +4,7 @@ class Redhat < Operatingsystem
 
   # outputs kickstart installation medium based on the medium type (NFS or URL)
   # it also convert the $arch string to the current host architecture
-  def mediumpath host
+  def mediumpath(host)
     uri    = medium_uri(host)
 
     case uri.scheme
@@ -34,7 +34,7 @@ class Redhat < Operatingsystem
     "Red Hat"
   end
 
-  def self.shorten_description description
+  def self.shorten_description(description)
     return "" if description.blank?
     s=description
     s.gsub!('Red Hat Enterprise Linux','RHEL')

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -37,7 +37,7 @@ class Solaris < Operatingsystem
     pxedir + "/" + PXEFILES[file]
   end
 
-  def boot_filename host
+  def boot_filename(host)
     #handle things like gpxelinux/ gpxe / pxelinux here
     if host.jumpstart?
       "Solaris-#{major}.#{minor}-#{release_name}-#{host.model.hardware_model}-inetboot"
@@ -56,12 +56,12 @@ class Solaris < Operatingsystem
   end
 
   # Calculates the media's path in relation to the domain and convert host to an IP
-  def media_path medium, domain
+  def media_path(medium, domain)
     resolv_nfs_path medium.media_host, medium.media_dir, domain
   end
 
   # Calculates the jumpstart's path in relation to the domain and convert host to an IP
-  def jumpstart_path medium, domain
+  def jumpstart_path(medium, domain)
     resolv_nfs_path medium.jumpstart_host, medium.jumpstart_dir, domain
   end
 
@@ -79,7 +79,7 @@ class Solaris < Operatingsystem
     true
   end
 
-  def jumpstart_params host, vendor
+  def jumpstart_params(host, vendor)
     # root server and install server are always the same under Foreman
     server_name = host.medium.media_host
     server_ip   = host.domain.resolver.getaddress(server_name).to_s
@@ -108,7 +108,7 @@ class Solaris < Operatingsystem
   end
 
   private
-  def resolv_nfs_path host, dir, domain
+  def resolv_nfs_path(host, dir, domain)
     host += ".#{domain.name}" unless host =~ /\./
     # If host is already an IP then this works fine
     ip = domain.resolver.getaddress(host)

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -18,7 +18,7 @@ class Suse < Operatingsystem
     "SUSE"
   end
 
-  def self.shorten_description description
+  def self.shorten_description(description)
     return "" if description.blank?
     s=description
     s.gsub!('SUSE Linux Enterprise Server','SLES')

--- a/app/models/parameters/location_parameter.rb
+++ b/app/models/parameters/location_parameter.rb
@@ -4,7 +4,7 @@ class LocationParameter < Parameter
   validates :name, :uniqueness => {:scope => :reference_id}
 
   private
-  def enforce_permissions operation
+  def enforce_permissions(operation)
     # We get called again with the operation being set to create
     return true if operation == "edit" and new_record?
     return true if User.current.allowed_to?("#{operation}_locations".to_sym)

--- a/app/models/parameters/organization_parameter.rb
+++ b/app/models/parameters/organization_parameter.rb
@@ -4,7 +4,7 @@ class OrganizationParameter < Parameter
   validates :name, :uniqueness => {:scope => :reference_id}
 
   private
-  def enforce_permissions operation
+  def enforce_permissions(operation)
     # We get called again with the operation being set to create
     return true if operation == "edit" and new_record?
     return true if User.current.allowed_to?("#{operation}_organizations".to_sym)

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -49,7 +49,7 @@ class Puppetclass < ActiveRecord::Base
   end
 
   # returns a hash containing modules and associated classes
-  def self.classes2hash classes
+  def self.classes2hash(classes)
     hash = {}
     for klass in classes
       if (mod = klass.module_name)
@@ -63,7 +63,7 @@ class Puppetclass < ActiveRecord::Base
   end
 
   # For API v2 - eliminate node :puppetclass for each object. returns a hash containing modules and associated classes
-  def self.classes2hash_v2 classes
+  def self.classes2hash_v2(classes)
     hash = {}
     classes.each do |klass|
       if (mod = klass.module_name)
@@ -89,7 +89,7 @@ class Puppetclass < ActiveRecord::Base
   #   Firstly, we prepare the modules tree
   #   Secondly we run puppetdoc over the modulespath and manifestdir for all environments
   # The results are written into document_root/puppet/rdoc/<env>/<class>"
-  def self.rdoc root
+  def self.rdoc(root)
     debug, verbose = false, false
     relocated      = root != "/"             # This is true if the prepare phase copied the modules tree
 
@@ -153,7 +153,7 @@ class Puppetclass < ActiveRecord::Base
   # If the executable Rails,root/script/rdoc_prepare_script exists then it is run
   # and passed a list of all directory paths in all environments.
   # It should return the directory into which it has copied the cleaned modules"
-  def self.prepare_rdoc root
+  def self.prepare_rdoc(root)
     debug, verbose = false, false
 
     prepare_script = Pathname.new(Rails.root) + "script/rdoc_prepare_script.rb"

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -66,7 +66,7 @@ class Report < ActiveRecord::Base
   end
 
   # serialize metrics as YAML
-  def metrics= m
+  def metrics=(m)
     write_attribute(:metrics,m.to_yaml) unless m.nil?
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -55,7 +55,7 @@ class Role < ActiveRecord::Base
     "#{id}-#{name.parameterize}"
   end
 
-  def initialize *args
+  def initialize(*args)
     super(*args)
     self.builtin = 0
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -152,7 +152,7 @@ class Setting < ActiveRecord::Base
     true
   end
 
-  def self.create opts
+  def self.create(opts)
     if (s = Setting.find_by_name(opts[:name].to_s)).nil?
       super opts.merge(:value => SETTINGS[opts[:name].to_sym] || opts[:value])
     else
@@ -160,7 +160,7 @@ class Setting < ActiveRecord::Base
     end
   end
 
-  def self.create! opts
+  def self.create!(opts)
     if (s = Setting.find_by_name(opts[:name].to_s)).nil?
       super opts.merge(:value => SETTINGS[opts[:name].to_sym] || opts[:value])
     else
@@ -190,7 +190,7 @@ class Setting < ActiveRecord::Base
     Rails.cache
   end
 
-  def invalid_value_error error
+  def invalid_value_error(error)
     errors.add(:value, _("is invalid: %s") % error)
   end
 
@@ -242,7 +242,7 @@ class Setting < ActiveRecord::Base
     true
   end
 
-  def self.set name, description, default, value = nil
+  def self.set(name, description, default, value = nil)
     {:name => name, :value => value, :description => description, :default => default}
   end
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -8,7 +8,7 @@ class Source < ActiveRecord::Base
     value
   end
 
-  def self.find_or_create val
+  def self.find_or_create(val)
     digest = Digest::SHA1.hexdigest(val)
     Source.where(:digest => digest).first || Source.create(:value => val, :digest => digest)
   end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -102,7 +102,7 @@ class Subnet < ActiveRecord::Base
   # Indicates whether the IP is within this subnet
   # [+ip+] String: Contains 4 dotted decimal values
   # Returns Boolean: True if if ip is in this subnet
-  def contains? ip
+  def contains?(ip)
     IPAddr.new("#{network}/#{mask}", Socket::AF_INET).include? IPAddr.new(ip, Socket::AF_INET)
   end
 
@@ -114,7 +114,7 @@ class Subnet < ActiveRecord::Base
     !!(dhcp and dhcp.url and !dhcp.url.blank?)
   end
 
-  def dhcp_proxy attrs = {}
+  def dhcp_proxy(attrs = {})
     @dhcp_proxy ||= ProxyAPI::DHCP.new({:url => dhcp.url}.merge(attrs)) if dhcp?
   end
 
@@ -122,7 +122,7 @@ class Subnet < ActiveRecord::Base
     !!(tftp and tftp.url and !tftp.url.blank?)
   end
 
-  def tftp_proxy attrs = {}
+  def tftp_proxy(attrs = {})
     @tftp_proxy ||= ProxyAPI::TFTP.new({:url => tftp.url}.merge(attrs)) if tftp?
   end
 
@@ -131,7 +131,7 @@ class Subnet < ActiveRecord::Base
     !!(dns and dns.url and !dns.url.blank?)
   end
 
-  def dns_proxy attrs = {}
+  def dns_proxy(attrs = {})
     @dns_proxy ||= ProxyAPI::DNS.new({:url => dns.url}.merge(attrs)) if dns?
   end
 
@@ -143,7 +143,7 @@ class Subnet < ActiveRecord::Base
     self.boot_mode == Subnet::BOOT_MODES[:dhcp]
   end
 
-  def unused_ip mac = nil
+  def unused_ip(mac = nil)
     logger.debug "Not suggesting IP Address for #{to_s} as IPAM is disabled" and return unless ipam?
     if self.ipam == IPAM_MODES[:dhcp] && dhcp?
       # we have DHCP proxy so asking it for free IP
@@ -179,7 +179,7 @@ class Subnet < ActiveRecord::Base
   end
 
   # imports subnets from a dhcp smart proxy
-  def self.import proxy
+  def self.import(proxy)
     return unless proxy.features.include?(Feature.find_by_name("DHCP"))
     ProxyAPI::DHCP.new(:url => proxy.url).subnets.map do |s|
       # do not import existing networks.

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -25,7 +25,7 @@ class Location < Taxonomy
   scoped_search :on => :name, :complete_value => :true
 
   # returns self and parent parameters as a hash
-  def parameters include_source = false
+  def parameters(include_source = false)
     hash = {}
     ids = ancestor_ids
     ids << id unless new_record? or self.frozen?

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -25,7 +25,7 @@ class Organization < Taxonomy
   scoped_search :on => :name, :complete_value => :true
 
   # returns self and parent parameters as a hash
-  def parameters include_source = false
+  def parameters(include_source = false)
     hash = {}
     ids = ancestor_ids
     ids << id unless new_record? or self.frozen?

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -53,7 +53,7 @@ class Taxonomy < ActiveRecord::Base
     end
   end
 
-  def self.as_taxonomy org, location
+  def self.as_taxonomy(org, location)
     Organization.as_org org do
       Location.as_location location do
         yield if block_given?

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -16,7 +16,7 @@ class Trend < ActiveRecord::Base
 
   private
 
-  def destroy_values ids = []
+  def destroy_values(ids = [])
     TrendCounter.where(:trend_id => ids).delete_all
     Trend.where(:id => ids).delete_all
   end

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -3,7 +3,7 @@ module Classification
     delegate :hostgroup, :environment_id, :puppetclass_ids, :classes,
              :to => :host
 
-    def initialize args = { }
+    def initialize(args = { })
       @host = args[:host]
       @safe_render = SafeRender.new(:variables => { :host => host } )
     end
@@ -33,7 +33,7 @@ module Classification
       end.map(&:path_elements).flatten(1).uniq
     end
 
-    def values_hash options = {}
+    def values_hash(options = {})
       values = {}
       path2matches.each do |match|
         LookupValue.where(:match => match).where(:lookup_key_id => class_parameters.map(&:id)).each do |value|
@@ -100,7 +100,7 @@ module Classification
 
     # translates an element such as domain to its real value per host
     # tries to find the host attribute first, parameters and then fallback to a puppet fact.
-    def attr_to_value element
+    def attr_to_value(element)
       # direct host attribute
       return host.send(element) if host.respond_to?(element)
       # host parameter
@@ -111,7 +111,7 @@ module Classification
       end
     end
 
-    def path_elements path = nil
+    def path_elements(path = nil)
       path.split.map do |paths|
         paths.split(LookupKey::KEY_DELM).map do |element|
           element

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -4,7 +4,7 @@ module FogExtensions
   module Vsphere
     class MiniServers
 
-      def initialize client, dc
+      def initialize(client, dc)
         @client = client
         @dc     = client.send(:find_datacenters, dc)[0]
       end

--- a/app/services/foreman/importer_puppetclass.rb
+++ b/app/services/foreman/importer_puppetclass.rb
@@ -1,7 +1,7 @@
 class Foreman::ImporterPuppetclass
   attr_reader :name, :module, :parameters
 
-  def initialize opts = { }
+  def initialize(opts = { })
     @name = opts["name"] || raise("must provide a puppet class name")
     @module     = opts["module"]
     @parameters = opts["params"] || { }
@@ -22,7 +22,7 @@ class Foreman::ImporterPuppetclass
 
   # Auto-detects the best validator type for the given (correctly typed) value.
   # JSON and YAML are better undetected, to prevent the simplest strings to match.
-  def self.suggest_key_type value, default = nil, detect_json_or_yaml = false
+  def self.suggest_key_type(value, default = nil, detect_json_or_yaml = false)
     case value
     when String
       begin

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -11,7 +11,7 @@ require 'timeout'
 class Foreman::Provision::SSH
   attr_reader :template, :uuid, :results, :address, :username, :options
 
-  def initialize address, username = "root", options = { }
+  def initialize(address, username = "root", options = { })
     @username = username
     @address  = address
     @template = options.delete(:template) || raise("must provide a template")

--- a/app/services/foreman/version.rb
+++ b/app/services/foreman/version.rb
@@ -5,7 +5,7 @@ module Foreman
     attr_reader :version, :major, :minor, :build, :tag, :short, :notag
     alias_method :full, :version
 
-    def initialize givenversion = nil
+    def initialize(givenversion = nil)
       if givenversion
         @version = givenversion
       else

--- a/app/services/foreman/wrapped_exception.rb
+++ b/app/services/foreman/wrapped_exception.rb
@@ -1,7 +1,7 @@
 module Foreman
 
   class WrappedException < ::Foreman::Exception
-    def initialize wrapped_exception, message, *params
+    def initialize(wrapped_exception, message, *params)
       super(message, *params)
       @wrapped_exception = wrapped_exception
     end

--- a/app/services/menu/manager.rb
+++ b/app/services/menu/manager.rb
@@ -80,7 +80,7 @@ module Menu
         push(Item.new(name, options), options)
       end
 
-      def sub_menu name, options = {}, &block
+      def sub_menu(name, options = {}, &block)
         push(Toggle.new(name, options[:caption]), options)
         current = @parent
         @parent = name
@@ -88,7 +88,7 @@ module Menu
         @parent = current
       end
 
-      def divider options = {}
+      def divider(options = {})
         push(Divider.new(:divider, options), options)
       end
 

--- a/app/services/menu/node.rb
+++ b/app/services/menu/node.rb
@@ -41,7 +41,7 @@ module Menu
       @children.inject(1) {|sum, node| sum + node.size}
     end
 
-    def each &block
+    def each(&block)
       yield self
       children { |child| child.each(&block) }
     end

--- a/app/services/orchestration/queue.rb
+++ b/app/services/orchestration/queue.rb
@@ -10,16 +10,16 @@ module Orchestration
       @items = []
     end
 
-    def create options
+    def create(options)
       options[:status] ||= default_status
       items << Task.new(options)
     end
 
-    def delete item
+    def delete(item)
       @items.delete item
     end
 
-    def find_by_name name
+    def find_by_name(name)
       items.each {|task| return task if task.name == name}
     end
 

--- a/app/services/orchestration/task.rb
+++ b/app/services/orchestration/task.rb
@@ -2,7 +2,7 @@ module Orchestration
   class Task
     attr_reader :name, :status, :priority, :action, :timestamp
 
-    def initialize opts
+    def initialize(opts)
       @name      = opts[:name]
       @status    = opts[:status]
       @priority  = opts[:priority] || 0
@@ -10,7 +10,7 @@ module Orchestration
       update_ts
     end
 
-    def status=s
+    def status=(s)
       if Orchestration::Queue::STATUS.include?(s)
         update_ts
         @status = s
@@ -23,7 +23,7 @@ module Orchestration
       "#{name}\t #{priority}\t #{status}\t #{action}"
     end
 
-    def as_json options = {}
+    def as_json(options = {})
       super :only => [:name, :timestamp, :status]
     end
 
@@ -33,7 +33,7 @@ module Orchestration
     end
 
     # sort based on priority
-    def <=> other
+    def <=>(other)
       self.priority <=> other.priority
     end
 

--- a/app/services/smart_proxies/puppet_ca.rb
+++ b/app/services/smart_proxies/puppet_ca.rb
@@ -4,7 +4,7 @@ class SmartProxies::PuppetCA
 
   attr_reader :name, :state, :fingerprint, :valid_from, :expires_at, :smart_proxy_id
 
-  def initialize opts
+  def initialize(opts)
     @name, @state, @fingerprint, @valid_from, @expires_at, @smart_proxy_id = opts.flatten
     @valid_from = Time.parse(@valid_from) unless @valid_from.blank?
     @expires_at = Time.parse(@expires_at) unless @expires_at.blank?
@@ -54,7 +54,7 @@ class SmartProxies::PuppetCA
 
   def to_s; name end
 
-  def <=> other
+  def <=>(other)
     self.name <=> other.name
   end
 

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -32,7 +32,7 @@ class ActiveRecord::Base
   # ActiveRecord Callback class
   class EnsureNotUsedBy
     attr_reader :klasses, :logger
-    def initialize *attribute
+    def initialize(*attribute)
       @klasses = attribute
       @logger  = Rails.logger
     end

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -1,12 +1,12 @@
 module Foreman
 
   class Exception < ::StandardError
-    def initialize message, *params
+    def initialize(message, *params)
       @message = message
       @params = params
     end
 
-    def self.calculate_error_code classname, message
+    def self.calculate_error_code(classname, message)
       return 'ERF00-0000' if classname.nil? or message.nil?
       basename = classname.split(':').last
       class_hash = Zlib::crc32(basename) % 100

--- a/lib/foreman/gettext/support.rb
+++ b/lib/foreman/gettext/support.rb
@@ -12,7 +12,7 @@ module Foreman
         end
       end
 
-      def self.register_available_locales locale_domain, locale_dir
+      def self.register_available_locales(locale_domain, locale_dir)
         locale_type = detect_locale_type
 
         if Rails.env.development?
@@ -35,7 +35,7 @@ module Foreman
         end
       end
 
-      def self.add_text_domain locale_domain, locale_dir
+      def self.add_text_domain(locale_domain, locale_dir)
         FastGettext.add_text_domain locale_domain,
           :path => locale_dir,
           :type => detect_locale_type,

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -13,7 +13,7 @@ module Foreman
                           :preseed_server, :preseed_path, :provisioning_type ]
 
 
-    def render_safe template, allowed_methods = [], allowed_vars = {}
+    def render_safe(template, allowed_methods = [], allowed_vars = {})
 
       if Setting[:safemode_render]
         box = Safemode::Box.new self, allowed_methods
@@ -46,7 +46,7 @@ module Foreman
       end
     end
 
-    def snippet name, options = {}
+    def snippet(name, options = {})
       if (template = ConfigTemplate.where(:name => name, :snippet => true).first)
         logger.debug "rendering snippet #{template.name}"
         begin
@@ -63,7 +63,7 @@ module Foreman
       end
     end
 
-    def snippet_if_exists name
+    def snippet_if_exists(name)
       snippet name, :silent => true
     end
 
@@ -73,7 +73,7 @@ module Foreman
       prefix + text.gsub(/\n/, "\n#{prefix}")
     end
 
-    def unattended_render template, template_name = nil
+    def unattended_render(template, template_name = nil)
       content = template.respond_to?(:template) ? template.template : template
       template_name ||= template.respond_to?(:name) ? template.name : 'Unnamed'
       allowed_variables = ALLOWED_VARIABLES.reduce({}) do |mapping, var|
@@ -84,7 +84,7 @@ module Foreman
     end
     alias_method :pxe_render, :unattended_render
 
-    def unattended_render_to_temp_file content, prefix = id.to_s, options = {}
+    def unattended_render_to_temp_file(content, prefix = id.to_s, options = {})
       file = ""
       Tempfile.open(prefix, Rails.root.join('tmp') ) do |f|
         f.print(unattended_render(content))

--- a/lib/net.rb
+++ b/lib/net.rb
@@ -5,7 +5,7 @@ module Net
     include Net::Validations
     attr_accessor :hostname, :proxy, :logger
 
-    def initialize opts = {}
+    def initialize(opts = {})
       # set all attributes
       opts.each do |k,v|
         self.send("#{k}=",v) if self.respond_to?("#{k}=")
@@ -30,7 +30,7 @@ module Net
     end
 
     # Compares two records by their attributes
-    def == other
+    def ==(other)
       return false unless other.respond_to? :attrs
       self.attrs == other.attrs
     end

--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -2,7 +2,7 @@ module Net::DHCP
   class Record < Net::Record
     attr_accessor :ip, :mac, :network, :nextServer, :filename
 
-    def initialize opts = { }
+    def initialize(opts = { })
       super(opts)
       self.mac     = validate_mac self.mac
       self.network = validate_network self.network
@@ -49,7 +49,7 @@ module Net::DHCP
       self == proxy.record(network, mac)
     end
 
-    def == other
+    def ==(other)
       return false unless other.present?
       if attrs[:hostname].blank?
         # If we're converting an 'ad-hoc' lease created by a host booting outside of Foreman's knowledge,

--- a/lib/net/dhcp/sparc_record.rb
+++ b/lib/net/dhcp/sparc_record.rb
@@ -4,7 +4,7 @@ module Net::DHCP
       :install_server_name, :install_server_ip, :jumpstart_server_path,
       :root_server_hostname, :root_server_ip, :install_path
 
-    def initialize opts = { }
+    def initialize(opts = { })
       super(opts)
       raise "Must define a dhcp vendor" if vendor.blank?
     end

--- a/lib/net/dns.rb
+++ b/lib/net/dns.rb
@@ -11,7 +11,7 @@ module Net
     # [+query+]: IP or hostname
     # Returns: a new DNS record object, A or PTR accordingly
     # We query DNS directly, as its faster then to query our own proxy.
-    def self.lookup query, proxy, resolver = Resolv::DNS.new
+    def self.lookup(query, proxy, resolver = Resolv::DNS.new)
       Timeout::timeout(3) do
         if (query =~ Validations::IP_REGEXP)
           n = resolver.getname(query).to_s
@@ -39,7 +39,7 @@ module Net
     class Record < Net::Record
       attr_accessor :ip, :resolver, :type
 
-      def initialize opts = { }
+      def initialize(opts = { })
         super(opts)
         self.ip = validate_ip self.ip
         self.resolver ||= Resolv::DNS.new
@@ -58,7 +58,7 @@ module Net
         raise "Abstract class"
       end
 
-      def dns_lookup ip_or_name
+      def dns_lookup(ip_or_name)
         DNS.lookup(ip_or_name, proxy, resolver)
       end
 

--- a/lib/net/dns/a_record.rb
+++ b/lib/net/dns/a_record.rb
@@ -2,7 +2,7 @@ module Net
   module DNS
     class ARecord < DNS::Record
 
-      def initialize opts = { }
+      def initialize(opts = { })
         super opts
         @type = "A"
       end

--- a/lib/net/dns/ptr_record.rb
+++ b/lib/net/dns/ptr_record.rb
@@ -1,7 +1,7 @@
 module Net
   module DNS
     class PTRRecord < DNS::Record
-      def initialize opts = { }
+      def initialize(opts = { })
         super opts
         @type = "PTR"
       end

--- a/lib/net/validations.rb
+++ b/lib/net/validations.rb
@@ -10,7 +10,7 @@ module Net
     class Error < RuntimeError;
     end
 
-    def valid_mac? mac
+    def valid_mac?(mac)
       return false if mac.nil?
 
       case mac.size
@@ -26,29 +26,29 @@ module Net
     module_function :valid_mac?
 
     # validates the ip address
-    def validate_ip ip
+    def validate_ip(ip)
       raise Error, "Invalid IP Address #{ip}" unless (ip =~ IP_REGEXP)
       ip
     end
 
-    def validate_mask mask
+    def validate_mask(mask)
       raise Error, "Invalid Subnet Mask #{mask}" unless (mask =~ MASK_REGEXP)
       mask
     end
 
     # validates the mac
-    def validate_mac mac
+    def validate_mac(mac)
       raise Error, "Invalid MAC #{mac}" unless valid_mac? mac
       mac
     end
 
     # validates the hostname
-    def validate_hostname hostname
+    def validate_hostname(hostname)
       raise Error, "Invalid hostname #{hostname}" unless (hostname =~ HOST_REGEXP)
       hostname
     end
 
-    def validate_network network
+    def validate_network(network)
       begin
         validate_ip(network)
       rescue Error
@@ -58,12 +58,12 @@ module Net
     end
 
     # ensures that the ip address does not contain any leading spaces or invalid strings
-    def self.normalize_ip ip
+    def self.normalize_ip(ip)
       return unless ip.present?
       ip.split(".").map(&:to_i).join(".")
     end
 
-    def self.normalize_mac mac
+    def self.normalize_mac(mac)
       return unless mac.present?
       m = mac.downcase
       case m
@@ -82,7 +82,7 @@ module Net
       end
     end
 
-    def self.normalize_hostname hostname
+    def self.normalize_hostname(hostname)
       hostname.downcase! if hostname.present?
       hostname
     end

--- a/lib/proxy_api/bmc.rb
+++ b/lib/proxy_api/bmc.rb
@@ -2,7 +2,7 @@ module ProxyAPI
   class BMC < ProxyAPI::Resource
     SUPPORTED_BOOT_DEVICES = %w[disk cdrom pxe bios]
 
-    def initialize args
+    def initialize(args)
       @target = args[:host_ip] || '127.0.0.1'
       @url = args[:url] + "/bmc"
       super args
@@ -23,7 +23,7 @@ module ProxyAPI
     end
 
     # Perform a boot operation on the bmc device
-    def boot args
+    def boot(args)
       # valid additional arguments args[:reboot] = true|false, args[:persistent] = true|false
       #  put "/bmc/:host/chassis/config/?:function?/?:action?" do
       case args[:function]
@@ -43,7 +43,7 @@ module ProxyAPI
     end
 
     # Perform a power operation on the bmc device
-    def power args
+    def power(args)
       # get "/bmc/:host/chassis/power/:action"
       # put "/bmc/:host/chassis/power/:action"
       case args[:action]
@@ -65,7 +65,7 @@ module ProxyAPI
     end
 
     # perform an identify operation on the bmc device
-    def identify args
+    def identify(args)
       # get "/bmc/:host/chassis/identify/:action"
       # put "/bmc/:host/chassis/identify/:action"
       case args[:action]
@@ -83,7 +83,7 @@ module ProxyAPI
     end
 
     # perform a lan get operation on the bmc device
-    def lan args
+    def lan(args)
       # get "/bmc/:host/lan/:action"
       case args[:action]
       when "ip", "netmask", "mac", "gateway"
@@ -100,7 +100,7 @@ module ProxyAPI
 
     private
 
-    def bmc_url_for controller,action
+    def bmc_url_for(controller,action)
       case controller
       when "lan"
         "/#{@target}/lan/#{action}"

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class DHCP < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url  = args[:url] + "/dhcp"
       super args
     end
@@ -14,13 +14,13 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to retrieve DHCP subnets"))
     end
 
-    def subnet subnet
+    def subnet(subnet)
       parse get(subnet)
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to retrieve DHCP subnet"))
     end
 
-    def unused_ip subnet, mac = nil
+    def unused_ip(subnet, mac = nil)
       params = {}
       params.merge!({:mac => mac}) if mac.present?
 
@@ -39,7 +39,7 @@ module ProxyAPI
     # [+subnet+] : String in dotted decimal format
     # [+mac+]    : String in coloned sextuplet format
     # Returns    : Hash or false
-    def record subnet, mac
+    def record(subnet, mac)
       response = parse(get("#{subnet}/#{mac}"))
       attrs = response.merge(:network => subnet, :proxy => self)
       if response.keys.grep(/Sun/i).empty?
@@ -58,7 +58,7 @@ module ProxyAPI
     # [+mac+]    : String in coloned sextuplet format
     # [+args+]   : Hash containing DHCP values. The :mac key is taken from the mac parameter
     # Returns    : Boolean status
-    def set subnet, args
+    def set(subnet, args)
       raise "Must define a subnet" if subnet.empty?
       raise "Must provide arguments" unless args.is_a?(Hash)
       parse(post(args, subnet.to_s))
@@ -70,7 +70,7 @@ module ProxyAPI
     # [+subnet+] : String in dotted decimal format
     # [+mac+]    : String in coloned sextuplet format
     # Returns    : Boolean status
-    def delete subnet, mac
+    def delete(subnet, mac)
       parse super("#{subnet}/#{mac}")
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway

--- a/lib/proxy_api/dns.rb
+++ b/lib/proxy_api/dns.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class DNS < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url  = args[:url] + "/dns"
       super args
     end
@@ -9,7 +9,7 @@ module ProxyAPI
     # [+fqdn+] : String containing the FQDN of the host
     # [+args+] : Hash containing :value and :type: The :fqdn key is taken from the fqdn parameter
     # Returns  : Boolean status
-    def set args
+    def set(args)
       parse post(args, "")
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to set DNS entry"))
@@ -18,7 +18,7 @@ module ProxyAPI
     # Deletes a DNS entry
     # [+key+] : String containing either a FQDN or a dotted quad plus .in-addr.arpa.
     # Returns    : Boolean status
-    def delete key
+    def delete(key)
       parse(super("#{key}"))
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway

--- a/lib/proxy_api/features.rb
+++ b/lib/proxy_api/features.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class Features < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url  = args[:url] + "/features"
       super args
     end

--- a/lib/proxy_api/proxy_exception.rb
+++ b/lib/proxy_api/proxy_exception.rb
@@ -4,7 +4,7 @@ module ProxyAPI
 
     attr_reader :url
 
-    def initialize url, exception, message, *params
+    def initialize(url, exception, message, *params)
       super(exception, message, *params)
       @url = url
     end

--- a/lib/proxy_api/puppet.rb
+++ b/lib/proxy_api/puppet.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class Puppet < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url  = args[:url] + "/puppet"
       super args
     end
@@ -11,13 +11,13 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to get environments from Puppet"))
     end
 
-    def environment env
+    def environment(env)
       parse(get "environments/#{env}")
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to get environment from Puppet"))
     end
 
-    def classes env
+    def classes(env)
       return if env.blank?
       pcs = parse(get "environments/#{env}/classes")
       Hash[pcs.map { |k| [k.keys.first, Foreman::ImporterPuppetclass.new(k.values.first)] }]
@@ -27,7 +27,7 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to get classes from Puppet for %s"), env)
     end
 
-    def run hosts
+    def run(hosts)
       parse(post({:nodes => hosts}, "run"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to execute Puppet run"))

--- a/lib/proxy_api/puppetca.rb
+++ b/lib/proxy_api/puppetca.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class Puppetca < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url  = args[:url] + "/puppet/ca"
       super args
     end
@@ -11,13 +11,13 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to get PuppetCA autosign"))
     end
 
-    def set_autosign certname
+    def set_autosign(certname)
       parse(post("", "autosign/#{certname}"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to set PuppetCA autosign for %s"), certname)
     end
 
-    def del_autosign certname
+    def del_autosign(certname)
       parse(delete("autosign/#{certname}"))
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway
@@ -26,13 +26,13 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to delete PuppetCA autosign for %s"), certname)
     end
 
-    def sign_certificate certname
+    def sign_certificate(certname)
       parse(post("", certname))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to sign PuppetCA certificate for %s"), certname)
     end
 
-    def del_certificate certname
+    def del_certificate(certname)
       parse(delete("#{certname}"))
     rescue RestClient::ResourceNotFound
       # entry doesn't exists anyway

--- a/lib/proxy_api/realm.rb
+++ b/lib/proxy_api/realm.rb
@@ -1,7 +1,7 @@
 module ProxyAPI
   class Realm < Resource
 
-    def initialize args
+    def initialize(args)
       @url  = "#{args[:url]}/realm/#{args[:realm_name]}"
       super args
     end
@@ -9,7 +9,7 @@ module ProxyAPI
     # Creates a Realm Host entry
     # [+args+] : Hash containing at a minimum :hostname
     # Returns  : JSON Result
-    def create args
+    def create(args)
       parse(post(args, ""))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to create realm entry"))
@@ -18,7 +18,7 @@ module ProxyAPI
     # Deletes a Realm Host entry
     # [+key+] : String containing the hostname
     # Returns : Boolean status
-    def delete key
+    def delete(key)
       parse(super(key))
     rescue
       # maybe the entry was already deleted

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -50,7 +50,7 @@ module ProxyAPI
     # Returns: Response, if the operation is GET, or true for POST, PUT and DELETE.
     #      OR: false if a HTTP error is detected
     # TODO: add error message handling
-    def parse response
+    def parse(response)
       if response and response.code >= 200 and response.code < 300
         return response.body.present? ? JSON.parse(response.body) : true
       else
@@ -62,7 +62,7 @@ module ProxyAPI
     end
 
     # Perform GET operation on the supplied path
-    def get path = nil, payload = {}
+    def get(path = nil, payload = {})
       # This ensures that an extra "/" is not generated
       if path
         resource[URI.escape(path)].get payload
@@ -72,17 +72,17 @@ module ProxyAPI
     end
 
     # Perform POST operation with the supplied payload on the supplied path
-    def post payload, path = ""
+    def post(payload, path = "")
       resource[path].post payload
     end
 
     # Perform PUT operation with the supplied payload on the supplied path
-    def put payload, path = ""
+    def put(payload, path = "")
       resource[path].put payload
     end
 
     # Perform DELETE operation on the supplied path
-    def delete path
+    def delete(path)
       resource[path].delete
     end
   end

--- a/lib/proxy_api/tftp.rb
+++ b/lib/proxy_api/tftp.rb
@@ -1,6 +1,6 @@
 module ProxyAPI
   class TFTP < ProxyAPI::Resource
-    def initialize args
+    def initialize(args)
       @url     = args[:url] + "/tftp"
       @variant = args[:variant]
       super args
@@ -11,7 +11,7 @@ module ProxyAPI
     # [+args+] : Hash containing
     #    :pxeconfig => String containing the configuration
     # Returns  : Boolean status
-    def set mac, args
+    def set(mac, args)
       parse(post(args, "#{@variant}/#{mac}"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to set TFTP boot entry for %s"), mac)
@@ -20,7 +20,7 @@ module ProxyAPI
     # Deletes a TFTP boot entry
     # [+mac+] : String in coloned sextuplet format
     # Returns : Boolean status
-    def delete mac
+    def delete(mac)
       parse(super("#{@variant}/#{mac}"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to delete TFTP boot entry for %s"), mac)
@@ -31,7 +31,7 @@ module ProxyAPI
     #   :prefix => String containing the location within the TFTP tree to store the file
     #   :path   => String containing the URL of the file to download
     # Returns    : Boolean status
-    def fetch_boot_file args
+    def fetch_boot_file(args)
       parse(post(args, "fetch_boot_file"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to fetch TFTP boot file"))
@@ -53,7 +53,7 @@ module ProxyAPI
     # [+args+] : Hash containing
     #   :menu => String containing the menu text
     # Returns    : Boolean status
-    def create_default args
+    def create_default(args)
       parse(post(args, "create_default"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to create default TFTP boot menu"))

--- a/lib/timed_cached_store.rb
+++ b/lib/timed_cached_store.rb
@@ -32,7 +32,7 @@ class TimedCachedStore < ActiveSupport::Cache::MemoryStore
   end
 
   protected
-  def delete_if_expired name
+  def delete_if_expired(name)
     if expired?(name)
       @data[ts_field(name)] = nil
       delete(name)
@@ -41,14 +41,14 @@ class TimedCachedStore < ActiveSupport::Cache::MemoryStore
     nil
   end
 
-  def expired? name
+  def expired?(name)
     ts = @data[ts_field(name)]
     ts and (Time.now >= ts[:expires_at])
   rescue
     false
   end
 
-  def ts_field name
+  def ts_field(name)
     "#{name}_timestamp"
   end
 

--- a/lib/ws_proxy.rb
+++ b/lib/ws_proxy.rb
@@ -16,7 +16,7 @@ class WsProxy
     end
   end
 
-  def self.start attributes
+  def self.start(attributes)
     proxy = WsProxy.new(attributes)
     proxy.start_proxy
   end
@@ -63,7 +63,7 @@ class WsProxy
     Rails.logger
   end
 
-  def execute cmd
+  def execute(cmd)
 
     logger.debug "Starting VNC Proxy: #{cmd}"
     Open3::popen3(cmd) do |stdin, stdout, stderr|

--- a/test/functional/api/v1/hosts_controller_test.rb
+++ b/test/functional/api/v1/hosts_controller_test.rb
@@ -139,7 +139,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
-  def set_remote_user_to user
+  def set_remote_user_to(user)
     @request.env['REMOTE_USER'] = user.login
   end
 

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -146,7 +146,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
-  def set_remote_user_to user
+  def set_remote_user_to(user)
     @request.env['REMOTE_USER'] = user.login
   end
 

--- a/test/functional/audits_controller_test.rb
+++ b/test/functional/audits_controller_test.rb
@@ -15,7 +15,7 @@ class AuditsControllerTest < ActionController::TestCase
     @request.session[:user] = users(:one).id
     users(:one).roles       = [Role.find_by_name('Anonymous'), Role.find_by_name('Viewer')]
   end
-  def user_with_viewer_rights_should_fail_to edit_audit
+  def user_with_viewer_rights_should_fail_to(edit_audit)
     setup_user
     get :edit, {:id => Audit.first.id}
     assert @response.status == '403 Forbidden'

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -154,7 +154,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
     SETTINGS[:login] ? {:user => User.current.id, :expires_at => 5.minutes.from_now} : {}
   end
 
-  def setup_user operation, type = 'compute_resources'
+  def setup_user(operation, type = 'compute_resources')
     super(operation, type, "id = #{@compute_resource.id}")
   end
 

--- a/test/functional/compute_resources_vms_controller_test.rb
+++ b/test/functional/compute_resources_vms_controller_test.rb
@@ -12,7 +12,7 @@ class ComputeResourcesVmsControllerTest < ActionController::TestCase
 #    Fog.unmock!
   end
 
-  def setup_user operation, type = 'compute_resources_vms'
+  def setup_user(operation, type = 'compute_resources_vms')
     super(operation, type, "id = #{@compute_resource.id}")
   end
 

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -59,7 +59,7 @@ class HostgroupsControllerTest < ActionController::TestCase
     assert !Hostgroup.exists?(hostgroup.id)
   end
 
-  def setup_user operation, type = 'hostgroups'
+  def setup_user(operation, type = 'hostgroups')
     super
   end
 

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -144,7 +144,7 @@ class HostsControllerTest < ActionController::TestCase
     refute assigns(:host).mac
   end
 
-  def setup_user operation, type = 'hosts', filter = nil
+  def setup_user(operation, type = 'hosts', filter = nil)
     super
   end
 
@@ -395,7 +395,7 @@ class HostsControllerTest < ActionController::TestCase
     assert_redirected_to "/users/login"
   end
 
-  def set_remote_user_to user
+  def set_remote_user_to(user)
     @request.env['REMOTE_USER'] = user.login
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,7 +88,7 @@ Spork.prefork do
       SETTINGS[:login] ? {:user => users(:admin).id, :expires_at => 5.minutes.from_now} : {}
     end
 
-    def as_user user
+    def as_user(user)
       saved_user   = User.current
       User.current = user.is_a?(User) ? user : users(user)
       result = yield
@@ -96,7 +96,7 @@ Spork.prefork do
       result
     end
 
-    def as_admin &block
+    def as_admin(&block)
       as_user :admin, &block
     end
 
@@ -131,7 +131,7 @@ Spork.prefork do
     end
 
     # if a method receieves a block it will be yielded just before user save
-    def setup_user operation, type = "", search = nil, user = :one
+    def setup_user(operation, type = "", search = nil, user = :one)
       @one = users(user)
       as_admin do
         permission = Permission.find_by_name("#{operation}_#{type}") || FactoryGirl.create(:permission, :name => "#{operation}_#{type}")

--- a/test/unit/bookmark_test.rb
+++ b/test/unit/bookmark_test.rb
@@ -29,7 +29,7 @@ class BookmarkTest < ActiveSupport::TestCase
 
   private
 
-  def enable_login &block
+  def enable_login(&block)
     login            = SETTINGS[:login]
     SETTINGS[:login] = true
     User.current = users(:one)

--- a/test/unit/domain_parameter_test.rb
+++ b/test/unit/domain_parameter_test.rb
@@ -26,7 +26,7 @@ class DomainParameterTest < ActiveSupport::TestCase
     assert parameter2.valid?
   end
 
-  def setup_user operation, type = 'domains'
+  def setup_user(operation, type = 'domains')
     super(operation, type) do |user|
       user.domains.destroy_all
     end

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -27,7 +27,7 @@ class HostgroupTest < ActiveSupport::TestCase
     assert !other_host_group.save
   end
 
-  def setup_user operation
+  def setup_user(operation)
     super operation, "hostgroups"
   end
 

--- a/test/unit/puppet_fact_importer_test.rb
+++ b/test/unit/puppet_fact_importer_test.rb
@@ -69,7 +69,7 @@ class PuppetFactImporterTest < ActiveSupport::TestCase
     importer.import!
   end
 
-  def value fact
+  def value(fact)
     FactValue.joins(:fact_name).where(:host_id => @host.id, :fact_names => { :name => fact }).first.try(:value)
   end
 end

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -316,14 +316,14 @@ class SettingTest < ActiveSupport::TestCase
 
   private
 
-  def check_parsed_value settings_type, expected_value, string_value
+  def check_parsed_value(settings_type, expected_value, string_value)
     setting = Setting.new(:name => "foo", :default => "default", :settings_type => settings_type)
     setting.parse_string_value(string_value)
 
     assert_equal expected_value, setting.value
   end
 
-  def check_parsed_value_failure settings_type, string_value
+  def check_parsed_value_failure(settings_type, string_value)
     setting = Setting.new(:name => "foo", :default => "default", :settings_type => settings_type)
     setting.parse_string_value(string_value)
 
@@ -331,7 +331,7 @@ class SettingTest < ActiveSupport::TestCase
     assert setting.errors[:value].join(";").include?("is invalid")
   end
 
-  def check_frozen_change attr_name, value
+  def check_frozen_change(attr_name, value)
     assert Setting.find_or_create_by_name(:name => "foo", :default => 5, :description => "test foo")
     setting = Setting.find_by_name("foo")
 
@@ -340,7 +340,7 @@ class SettingTest < ActiveSupport::TestCase
     assert setting.errors[attr_name].join(";").include?("is not allowed to change")
   end
 
-  def check_zero_value_not_allowed_for setting_name
+  def check_zero_value_not_allowed_for(setting_name)
     setting = Setting.find_or_create_by_name(setting_name, :value => 0, :default => 30)
     setting.value = 0
 
@@ -350,7 +350,7 @@ class SettingTest < ActiveSupport::TestCase
     assert_valid setting
   end
 
-  def check_length_must_be_under_8 setting_name
+  def check_length_must_be_under_8(setting_name)
     setting = Setting.find_or_create_by_name(setting_name, :default => 30)
     setting.value = 123456789
 
@@ -360,7 +360,7 @@ class SettingTest < ActiveSupport::TestCase
     assert_valid setting
   end
 
-  def check_empty_array_allowed_for setting_name
+  def check_empty_array_allowed_for(setting_name)
     setting = Setting.find_or_create_by_name(setting_name, :value => [], :default => [])
     setting.value = []
     assert_valid setting
@@ -369,24 +369,24 @@ class SettingTest < ActiveSupport::TestCase
     assert_valid setting
   end
 
-  def check_correct_type_for type, value
+  def check_correct_type_for(type, value)
     assert Setting.create(:name => "foo", :default => value, :description => "test foo")
     assert_equal type, Setting.find_by_name("foo").try(:settings_type)
   end
 
-  def check_properties_saved_and_loaded_ok options = {}
+  def check_properties_saved_and_loaded_ok(options = {})
     assert Setting.find_or_create_by_name(options)
     s = Setting.find_by_name options[:name]
     assert_equal options[:value], s.value
     assert_equal options[:default], s.default
   end
 
-  def check_setting_did_not_save_with options = {}
+  def check_setting_did_not_save_with(options = {})
      setting = Setting.new(options)
      assert !setting.save
   end
 
-  def check_value_returns_from_cache_with options = {}
+  def check_value_returns_from_cache_with(options = {})
     name = options[:name].to_s
 
     #cache must be cleared on create

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -134,7 +134,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal u, User.try_to_login(u.login, 'password')
   end
 
-  def setup_user operation
+  def setup_user(operation)
     super operation, "users"
   end
 


### PR DESCRIPTION
This was done in a minute with --auto-correct, it just adds parentheses to method definitions with parameters to comply with the standard, `def method(parameter, parameter)`
