### PR TITLE
[DO NOT MERGE] Fixes #7828 - generic version of foreman_url

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -287,7 +287,7 @@ class UnattendedController < ApplicationController
     end
 
     begin
-      render :inline => "<%= unattended_render(@unsafe_template, @template_name).html_safe %>" and return
+      render :inline => "<%= unattended_render(@unsafe_template, { :template_name => @template_name }).html_safe %>" and return
     rescue => exc
       msg = _("There was an error rendering the %s template: ") % (@template_name)
       render :text => msg + exc.message, :status => 500 and return

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -82,7 +82,7 @@ module Orchestration::Compute
     @host      = self
     # For some reason this renders as 'built' in spoof view but 'provision' when
     # actually used. For now, use foreman_url('built') in the template
-    self.compute_attributes[:user_data] = unattended_render(template.template)
+    self.compute_attributes[:user_data] = unattended_render(template)
     self.handle_ca
     return false if errors.any?
     logger.info "Revoked old certificates and enabled autosign for UserData"

--- a/app/models/config_template.rb
+++ b/app/models/config_template.rb
@@ -110,8 +110,11 @@ class ConfigTemplate < ActiveRecord::Base
     if error_msg.empty?
       begin
         @profiles = pxe_default_combos
-        menu = renderer.render_safe(default_template.template, [:default_template_url], {:profiles => @profiles})
+        menu = renderer.unattended_render(default_template, {
+          :allowed_helpers => [:default_template_url],
+          :allowed_variables => {:profiles => @profiles} })
       rescue => e
+        Rails.logger.error e.backtrace.join("\n")
         error_msg = _("failed to process template: %s" % e)
       end
     end
@@ -132,12 +135,15 @@ class ConfigTemplate < ActiveRecord::Base
           end
         end
       rescue => exc
+        Rails.logger.error exc.backtrace.join("\n")
+        error_msg = _("failed to process template: %s" % e)
         error_msgs << "#{proxy}: #{exc.message}"
       end
     end
 
     unless error_msgs.empty?
       msg = _("There was an error creating the PXE Default file: %s") % error_msgs.join(",")
+      Rails.logger.error msg
       return [500, msg]
     end
 


### PR DESCRIPTION
DO NOT MERGE

This is just an idea - `foreman_url` can be used now with empty parameter to
retrieve the `foreman_url` address which is useful in the generic PXELinux
template for Discovery. Unfortunately, from the past this actually returns
unattended_url, thus the empty parameter.

It also adds some exceptions on the log (we are eating them) and also refactors
one method to be private one (it should not be used like that since it does not
add allowed helpers/vars for some templates).

Tests will fail, this is for discussion only.
