### PR TITLE
refs #7401 - fix markdown syntax in API doc

### DIFF
--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -40,7 +40,7 @@ module Api
           param :tag, String, :desc => N_("VLAN tag, this attribute has precedence over the subnet VLAN ID")
           param :attached_to, String, :desc => N_("Identifier of the interface to which this interface belongs, e.g. eth1")
           param :mode, String, :desc => N_("Bond mode of the interface, e.g. balance-rr")
-          param :attached_devices, Array, :desc => N_("Identifiers of slave interfaces, e.g. ['eth1', 'eth2']")
+          param :attached_devices, Array, :desc => N_("Identifiers of slave interfaces, e.g. `['eth1', 'eth2']`")
           param :bond_options, String, :desc => N_("Space separated options, e.g. miimon=100")
         end
       end


### PR DESCRIPTION
<pre>
$ rake apipie:cache
 ___________________________________________________________________________
| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "eth1, eth2" for md_link([
|   md_entity("lsquo"),
|   "eth1",
|   md_entity("rsquo"),
|   ", ",
|   md_entity("lsquo"),
|   "eth2",
|   md_entity("rsquo")
| ], nil)
| Available refs are []
+---------------------------------------------------------------------------
!/home/dcleal/.rvm/gems/ruby-2.0.0-p353@foreman/gems/maruku-0.7.2/lib/maruku/output/to_html.rb:656:in `to_html_link'
!/home/dcleal/.rvm/gems/ruby-2.0.0-p353@foreman/gems/maruku-0.7.2/lib/maruku/output/to_html.rb:891:in `block in array_to_html'
!/home/dcleal/.rvm/gems/ruby-2.0.0-p353@foreman/gems/maruku-0.7.2/lib/maruku/output/to_html.rb:879:in `each'
!/home/dcleal/.rvm/gems/ruby-2.0.0-p353@foreman/gems/maruku-0.7.2/lib/maruku/output/to_html.rb:879:in `array_to_html'
\___________________________________________________________________________

Not creating a link for ref_id = "eth1, eth2".
</pre>
