### PR TITLE
Fixes #6536 Appends the keys of AuthSourceInternal and AuthSourceHidden ...

### DIFF
--- a/test/lib/foreman/model/auth_source_name_test.rb
+++ b/test/lib/foreman/model/auth_source_name_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class AuthSourceNameTest < ActiveSupport::TestCase
+    def setup
+    User.current = users(:admin)
+    end
+
+    test "auth_source should not allow 'Internal' or 'Hidden' as names for ldap and external auths" do
+        record = AuthSourceLdap.create(:name => "Internal")
+        assert_not record.valid?
+        assert record.errors[:name].include?(_("Internal is a reserved name."))
+
+        record = AuthSourceLdap.create(:name => "Hidden")
+        assert_not record.valid?
+        assert record.errors[:name].include?(_("Hidden is a reserved name."))
+
+        record = AuthSourceExternal.create(:name => "Internal")
+        assert_not record.valid?
+        assert record.errors[:name].include?(_("Internal is a reserved name."))
+
+        record = AuthSourceExternal.create(:name => "Hidden")
+        assert_not record.valid?
+        assert record.errors[:name].include?(_("Hidden is a reserved name."))
+    end
+end


### PR DESCRIPTION
...by their MD5 hashes to make keywords 'Internal' and 'Hidden' available to Administrators when naming External Auth Sources
