### PR TITLE
Fixes #2283 , #3135 - add config option for proxy_request_timeout

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -23,7 +23,8 @@ class Setting::General < Setting
         self.set('max_trend', N_("Max days for Trends graphs"), 30),
         self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), true),
         self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true),
-        self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true)
+        self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true),
+        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60)
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -6,8 +6,7 @@ module ProxyAPI
     def initialize(args)
       raise("Must provide a protocol and host when initialising a smart-proxy connection") unless (url =~ /^http/)
 
-      # Each request is limited to 60 seconds
-      @connect_params = {:timeout => 60, :open_timeout => 10, :headers => { :accept => :json },
+      @connect_params = {:timeout => Setting[:proxy_request_timeout], :open_timeout => 10, :headers => { :accept => :json },
                         :user => args[:user], :password => args[:password]}
 
       # We authenticate only if we are using SSL


### PR DESCRIPTION
This PR accompanies https://github.com/theforeman/smart-proxy/pull/219 for smart-proxy.
We're implementing a build pipeline using Jenkins, Nexus, The Foreman and puppet. From Jenkins we trigger a puppet run using APIv2 calls that updates the RPM and redploys the app to wildfly. We need to wait for the puppetssh command to finish before we can trigger downstream jobs like Webtests, and sometimes puppet takes a bit longer than the default timeout of 60 seconds.

This PR adds a new configuration option :proxy_request_timeout, much like the :request_timeout in hammer CLI, and in the least intrusive way: via settings.yaml. Default is 60 secods, so no change to previous behaviour.

This also fixes importing of utterly large module sets from puppet as mentioned in the bug reports from the commit message title.
