### PR TITLE
fixes #7331 - delete unassigned os default templates

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -271,7 +271,7 @@ class ApplicationController < ActionController::Base
     logger.info "Failed to save: #{hash[:object].errors.full_messages.join(", ")}" if hash[:object].respond_to?(:errors)
     hash[:error_msg] ||= [hash[:object].errors[:base] + hash[:object].errors[:conflict].map{|e| _("Conflict - %s") % e}].flatten
     hash[:error_msg] = [hash[:error_msg]].flatten
-    hash[:error_msg] = hash[:error_msg].join("<br/>")
+    hash[:error_msg] = hash[:error_msg].to_sentence
     if hash[:render]
       flash.now[:error] = CGI::escapeHTML(hash[:error_msg]) unless hash[:error_msg].empty?
       render hash[:render]

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -19,7 +19,7 @@ class Operatingsystem < ActiveRecord::Base
   has_and_belongs_to_many :config_templates
   has_many :os_default_templates, :dependent => :destroy
   accepts_nested_attributes_for :os_default_templates, :allow_destroy => true,
-    :reject_if => lambda { |v| v[:config_template_id].blank? }
+    :reject_if => :reject_empty_config_template
 
   validates :major, :numericality => {:greater_than_or_equal_to => 0}, :presence => { :message => N_("Operating System version is required") }
   has_many :os_parameters, :dependent => :destroy, :foreign_key => :reference_id, :inverse_of => :operatingsystem
@@ -252,6 +252,13 @@ class Operatingsystem < ActiveRecord::Base
     eval("#{self.family}::PXEFILES").values.collect do |img|
       medium_vars_to_uri("#{medium.path}/#{pxedir}/#{img}", architecture.name, self)
     end
+  end
+
+  def reject_empty_config_template(attributes)
+    template_exists = attributes[:id].present?
+    config_template_id_empty = attributes[:config_template_id].blank?
+    attributes.merge!({:_destroy => 1}) if template_exists && config_template_id_empty
+    (!template_exists && config_template_id_empty)
   end
 
 end

--- a/app/models/os_default_template.rb
+++ b/app/models/os_default_template.rb
@@ -8,4 +8,8 @@ class OsDefaultTemplate < ActiveRecord::Base
   def name
     "#{operatingsystem} - #{template_kind}"
   end
+
+  def to_label
+    name
+  end
 end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -40,6 +40,7 @@ class ActiveRecord::Base
     def before_destroy(record)
       klasses.each do |klass|
         record.send(klass.to_sym).each do |what|
+          what = what.to_label unless what.is_a? String
           record.errors.add :base, _("%{record} is used by %{what}") % { :record => record, :what => what }
         end
       end

--- a/test/functional/operatingsystems_controller_test.rb
+++ b/test/functional/operatingsystems_controller_test.rb
@@ -89,4 +89,38 @@ class OperatingsystemsControllerTest < ActionController::TestCase
       assert_match /not recognized for searching/, flash[:error]
     end
   end
+
+  context 'os_default_template' do
+    setup do
+      @template_kind = FactoryGirl.create(:template_kind)
+      @config_template = FactoryGirl.create(:config_template, :template_kind_id => @template_kind.id)
+    end
+
+    test 'valid os_default_template should be saved' do
+      operatingsystem = Operatingsystem.first
+      put :update, {:id => operatingsystem.id, :operatingsystem =>
+          {:os_default_templates_attributes => [{:config_template_id => @config_template.id, :template_kind_id => @template_kind.id} ]}}, set_session_user
+      refute_empty operatingsystem.os_default_templates
+      assert_redirected_to operatingsystems_url
+    end
+
+    test 'invalid os_default_template should be rejected' do
+      operatingsystem = Operatingsystem.create({ :name => "PalmOS", :major => 1, :minor => 2 })
+      put :update, {:id => operatingsystem.id,
+                    :operatingsystem => {:os_default_templates_attributes => [{ :config_template_id => nil, :template_kind_id => @template_kind.id }]} }, set_session_user
+
+      assert_empty operatingsystem.os_default_templates
+    end
+
+    test 'empty config_template should be destroyed' do
+      operatingsystem = Operatingsystem.create({:name => "BESYS", :major => 3, :minor => 0,
+                                                :os_default_templates_attributes => [{:config_template_id => @config_template.id, :template_kind_id => @template_kind.id}]})
+      assert_difference 'OsDefaultTemplate.count', -1 do
+        os_default_template_id = operatingsystem.os_default_templates.first.id
+        put :update, {:id => operatingsystem.id,
+                      :operatingsystem => {:os_default_templates_attributes => {0 => { :id => os_default_template_id, :config_template_id => '', :template_kind_id => @template_kind.id }}}}, set_session_user
+
+      end
+    end
+  end
 end

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -321,4 +321,29 @@ class OperatingsystemTest < ActiveSupport::TestCase
 
   end
 
+  context 'os default templates' do
+    setup do
+      @template_kind = FactoryGirl.create(:template_kind)
+      @config_template = FactoryGirl.create(:config_template, :template_kind_id => @template_kind.id)
+      @os = operatingsystems(:centos5_3)
+      @os.update_attributes(:os_default_templates_attributes =>
+                               [{ :config_template_id => @config_template.id, :template_kind_id => @template_kind.id }]
+      )
+    end
+
+    test 'should create os default templates' do
+      assert_valid @os
+      assert_equal(@os.os_default_templates.last.template_kind_id, @template_kind.id)
+      assert_equal(@os.os_default_templates.last.config_template_id, @config_template.id)
+    end
+
+    test 'should remove os default template' do
+      # Association deleted, yet template_kind and config_template not.
+      assert_difference('@os.os_default_templates.length', -1) do
+        @os.update_attributes(:os_default_templates_attributes => { :id => @os.os_default_templates.last.id, :_destroy => 1 })
+      end
+      assert_valid @template_kind
+      assert_valid @config_template
+    end
+  end
 end


### PR DESCRIPTION
**The problem**: Previously assigned config template is not deleted when unassigning it. Therefore, can never delete the config template (the error will raise that it belongs to os_default_template).
**The fix**: adds `ruby :_destroy => 1` to existing os_default_template, if the config_template_id is blank.
