### PR TITLE
VmWare max cpu core RAM should be 32G not 16G.

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -38,7 +38,7 @@ module Foreman::Model
     end
 
     def max_memory
-      16*1024*1024*1024
+      32*1024*1024*1024
     end
 
     def datacenters


### PR DESCRIPTION
To fix this Ticket; 
Bug #5901: Unable to select more than 8 cores in VMware template - Foreman
http://projects.theforeman.org/issues/5901
Bug #5901: Unable to select more than 8 cores in VMware template - Foreman
Added by Jon Skarpeteig 5 months ago. Updated 17 days ago. Status:  New Start date: 05/23/2014
Priority:   Normal  Due date:    Assigned To:   -   % Done:  0% Category:   Compute resources - VMware       Target version:    -        Difficulty:    trivial     Bugzilla link:  
Found in release:   1.5.0   Pull request:    Story points   - Velocity based estimate   -

Description  VMware itself supports up to 32 cores (on a single CPU). Max 32 virtual sockets combined.  E.G:
1 x 32
2 x 16
4 x 8
8 x 4 
are all valid configurations
 Related issues Related to Foreman - Bug #2314: Smaller grains for Libvirt VM RAM needed 
