### PR TITLE
fixes #7931 - use controller_path instead of name in find_resource

### DIFF
--- a/app/controllers/concerns/find_common.rb
+++ b/app/controllers/concerns/find_common.rb
@@ -15,7 +15,7 @@ module FindCommon
   end
 
   def resource_class
-    @resource_class ||= resource_name.classify.constantize
+    @resource_class ||= controller_path.singularize.classify.constantize
   end
 
   def resource_scope(controller = controller_name)


### PR DESCRIPTION
If I have a controller, "ForemanPlugin::UnicornsController", controller_name.singularize will return "unicorn" -- which will not constantize for a plugin.  It needs to use controller_path instead.
