### PR TITLE
Refs #969 - Foreman-side changes for serving templates from the proxy

### DIFF
--- a/db/migrate/20130625113217_add_templates_to_features.rb
+++ b/db/migrate/20130625113217_add_templates_to_features.rb
@@ -1,0 +1,9 @@
+class AddTemplatesToFeatures < ActiveRecord::Migration
+  def self.up
+    Feature.create(:name => 'Templates')
+  end
+
+  def self.down
+    Feature.find_by_name('Templates').destroy
+  end
+end

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -32,6 +32,20 @@ module Foreman
       host     = config.host || request.host
       port     = config.port || request.port
 
+      proxy = @host.try(:subnet).try(:tftp)
+
+      if proxy.present? && proxy.try(:features).map(&:name).include?('Templates') && @host.try(:token).present?
+        url = ProxyAPI::Template.new(:url => proxy.url).template_url
+        if url.nil?
+          logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
+          url = proxy.url
+        end
+        uri      = URI.parse(url)
+        host     = uri.host
+        port     = uri.port
+        protocol = uri.scheme
+      end
+
       url_for :only_path => false, :controller => "/unattended", :action => action,
               :protocol  => protocol, :host => host, :port => port,
               :token     => (@host.token.value unless @host.token.nil?)

--- a/lib/proxy_api/template.rb
+++ b/lib/proxy_api/template.rb
@@ -1,0 +1,21 @@
+module ProxyAPI
+  class Template < ProxyAPI::Resource
+    def initialize args
+      @url     = args[:url] + "/unattended"
+      super args
+    end
+
+    # returns the Template URL for this proxy
+    def template_url
+      if (response = parse(get("templateServer"))) and response["templateServer"].present?
+        return response["templateServer"]
+      end
+    rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
+      EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
+      Net::ProtocolError, RestClient::ResourceNotFound => e
+      logger.warn("failed to obtain template server from smart-proxy #{@url}")
+      nil
+    end
+
+  end
+end

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -1,5 +1,13 @@
 FactoryGirl.define do
   factory :feature do
+    factory :template_feature do
+      name 'Templates'
+    end
+
+    factory :tftp_feature do
+      name 'TFTP'
+    end
+
     trait :dhcp do
       name 'dhcp'
     end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -2,5 +2,8 @@ FactoryGirl.define do
   factory :smart_proxy do
     sequence(:name) {|n| "proxy#{n}" }
     sequence(:url) {|n| "https://somewhere#{n}.net:8443" }
+    factory :template_smart_proxy do
+      features { |sp| [sp.association(:template_feature), sp.association(:tftp_feature) ] }
+    end
   end
 end

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -5,5 +5,9 @@ FactoryGirl.define do
     mask "255.255.255.0"
     association :dhcp, :factory => :smart_proxy
     association :dns, :factory => :smart_proxy
+
+    trait :tftp do
+      association :tftp, :factory => :template_smart_proxy
+    end
   end
 end

--- a/test/functional/api/v2/smart_proxies_controller_test.rb
+++ b/test/functional/api/v2/smart_proxies_controller_test.rb
@@ -25,7 +25,7 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should get index filtered by name" do
-    get :index, { :search => "name=\"TFTP Proxy\"" }
+    get :index, { :search => "name ~ \"*TFTP*\"" }
     assert_response :success
     refute_empty assigns(:smart_proxies)
     smart_proxies = ActiveSupport::JSON.decode(@response.body)

--- a/test/functional/locations_controller_test.rb
+++ b/test/functional/locations_controller_test.rb
@@ -94,6 +94,7 @@ class LocationsControllerTest < ActionController::TestCase
     assert_redirected_to :controller => :locations, :action => :index
     assert_equal flash[:notice], "All hosts previously with no location are now assigned to Location 1"
   end
+
   test "should assign all hosts with no location to selected location and add taxable_taxonomies" do
     location = taxonomies(:location1)
     domain = FactoryGirl.create(:domain, :locations => [taxonomies(:location2)])

--- a/test/lib/proxy_api/template_test.rb
+++ b/test/lib/proxy_api/template_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ProxyApiTemplateTest < ActiveSupport::TestCase
+  def setup
+    @url = "http://localhost:8443"
+    @template = ProxyAPI::Template.new({:url => @url})
+  end
+
+  def fake_response(data)
+    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+    net_http_resp.add_field 'Set-Cookie', 'Monster'
+    RestClient::Response.create(JSON(data), net_http_resp, nil)
+  end
+
+  test "constructor sets url base path with /unattended" do
+    expected = "#{@url}/unattended"
+    assert_equal(expected, @template.url)
+  end
+
+  test "should get template server url" do
+    @template.expects(:get).with('templateServer').returns(fake_response({'templateServer'=>'mytemplateserver'}))
+    assert_equal('mytemplateserver', @template.template_url)
+  end
+
+end


### PR DESCRIPTION
Needs the proxy-side PR to function.

This is a rebase of @GregSutcliffe's original https://github.com/theforeman/foreman/pull/751.
