### PR TITLE
Fixes #7971 - DHCP hostname commutative conflict fix

### DIFF
--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -51,7 +51,7 @@ module Net::DHCP
 
     def ==(other)
       return false unless other.present?
-      if attrs[:hostname].blank?
+      if other.attrs[:hostname].blank? || attrs[:hostname].blank?
         # If we're converting an 'ad-hoc' lease created by a host booting outside of Foreman's knowledge,
         # then :hostname will be blank on the incoming lease - if the ip/mac still match, then this
         # isn't a conflict

--- a/test/lib/net/dhcp_test.rb
+++ b/test/lib/net/dhcp_test.rb
@@ -42,6 +42,7 @@ class DhcpTest < ActiveSupport::TestCase
     record2 = Net::DHCP::Record.new(:hostname => "test", :mac => "aa:bb:cc:dd:ee:ff",
                                     :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
     assert_equal record1, record2
+    assert_equal record2, record1
   end
 
   test "record should not be equal if their attrs are not the same" do


### PR DESCRIPTION
When I was reproducing a bug related to pull request #1430 I noticed that in my
case (Ruby 2.0) it's not the `self` object without hostname set, but always
`other` object.

This check should be commutative, I am not sure if Ruby optimizes the call or
this has changed somehow in the runtime. But since hostname of the new host is
always set (we have a validator for this), adding commutative property should
not work.

I believe this should fix a problem I have with OpenStack (Discovery) installer
(RHBZ#1152516).
