### PR TITLE
fixes #7982 - remove non-alphanumeric chars in title

### DIFF
--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -1,7 +1,7 @@
 module Parameterizable
 
   def self.parameterize(string)
-    string.gsub(/[\/.]/, '-').gsub(/[!*'();:@&=+$,?%#\[\]]/, '').chomp('-')
+    string.gsub(/[\/.>]/, '-').gsub(/[<!*'();:@&=+$,?%#\[\]]/, '').chomp('-')
   end
 
   module ById

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -135,6 +135,10 @@ class Operatingsystem < ActiveRecord::Base
     self.description = str
   end
 
+  def to_param
+    Parameterizable.parameterize("#{id}-#{title}")
+  end
+
   def release
     "#{major}#{('.' + minor.to_s) unless minor.blank?}"
   end

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'test_helper'
 
 class OperatingsystemTest < ActiveSupport::TestCase
@@ -347,4 +348,11 @@ class OperatingsystemTest < ActiveSupport::TestCase
       assert_valid @config_template
     end
   end
+
+  test 'name can include utf-8 and non-alpha numeric chars' do
+    operatingsystem = FactoryGirl.build(:operatingsystem, :name => '<applet>מערכתההפעלהשלי', :major => 4)
+    assert operatingsystem.valid?
+    assert_equal("#{operatingsystem.id}-applet-מערכתההפעלהשלי 4", operatingsystem.to_param)
+  end
+
 end


### PR DESCRIPTION
Parameterize Operatingsystem.title to avoid non-alphanumeric characters in title (and friendly_id)
