### PR TITLE
fixes #7975 - Subnet names should be unique

### DIFF
--- a/db/migrate/20141021105446_rename_subnet_name_to_unique.rb
+++ b/db/migrate/20141021105446_rename_subnet_name_to_unique.rb
@@ -1,0 +1,12 @@
+class RenameSubnetNameToUnique < ActiveRecord::Migration
+  def up
+    multiple_same_name = Subnet.unscoped.group(:name).count.delete_if {|name, value| value == 1}
+    multiple_same_name.each_key do | subnet_name |
+      subnets_with_same_name = Subnet.where(:name => subnet_name)
+      subnets_with_same_name.each_with_index { |subnet, index |
+        new_name = Subnet.exists?(:name => "#{subnet.name}-#{index}") ? "#{subnet.name}-#{index}-#{SecureRandom.hex(2)}" : "#{subnet.name}-#{index}"
+        subnet.update_attribute(:name, new_name)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Changed subnet name to be unique and to be used by friendly_id.
Created a migration which renames existing subnets with same name.
