### PR TITLE
refs #7587 - pwstrength stylesheet is part of app.css, not standalone

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,5 +1,4 @@
 <%= javascript 'users', 'password_strength' %>
-<%= stylesheet 'password_strength' %>
 
 <%= form_for @user do |f| %>
   <%= base_errors_for @user %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,4 @@
 <%= javascript 'users', 'password_strength' %>
-<%= stylesheet 'password_strength' %>
 <% title _("Users") %>
 
 <% title_actions  display_link_if_authorized(_("New User"), hash_for_new_user_path) %>


### PR DESCRIPTION
Causes errors on a production install otherwise as it tries to precompile at runtime, which is unnecessary.  (application.scss contains a `require_tree .`)
