### PR TITLE
Fixes #8005 - Convert allowed NIC types to strings

### DIFF
--- a/app/helpers/interfaces_helper.rb
+++ b/app/helpers/interfaces_helper.rb
@@ -1,9 +1,7 @@
 module InterfacesHelper
   def interfaces_types
-    @types ||= [
-      [_("Interface"), Nic::Managed],
-      [_("Bond"), Nic::Bond],
-      [_("BMC"), Nic::BMC]
-    ]
+    @types ||= Nic::Base.allowed_types.collect do |nic_type|
+      [_(nic_type.humanized_name), nic_type]
+    end
   end
 end

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -48,6 +48,24 @@ module Nic
       type.split("::").last
     end
 
+    def self.humanized_name
+      # provide class name as a default value
+      name.split("::").last
+    end
+
+    def self.type_by_name(name)
+      allowed_types.find{|nic_class| nic_class.humanized_name.downcase == name.to_s.downcase}
+    end
+
+    # NIC types have to be registered to to expose them to users
+    def self.register_type(type)
+      allowed_types << type
+    end
+
+    def self.allowed_types
+      @allowed_types ||= []
+    end
+
     protected
 
     def uniq_fields_with_hosts
@@ -80,10 +98,9 @@ module Nic
     def require_host?
       true
     end
+
   end
 
-  require_dependency 'nic/interface'
-
-  TYPES = [ Nic::Managed, Nic::Bond, Nic::BMC ]
-
 end
+
+require_dependency 'nic/interface'

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -16,5 +16,11 @@ module Nic
                           :password => password })
     end
 
+    def self.humanized_name
+      N_('BMC')
+    end
+
   end
+
+  Base.register_type(BMC)
 end

--- a/app/models/nic/bond.rb
+++ b/app/models/nic/bond.rb
@@ -29,10 +29,16 @@ module Nic
       self.attached_devices = attached_devices_identifiers.tap { |a| a.delete(identifier) }.join(SEPARATOR)
     end
 
+    def self.humanized_name
+      N_('Bond')
+    end
+
     private
 
     def ensure_virtual
       self.virtual = true
     end
   end
+
+  Base.register_type(Bond)
 end

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -12,6 +12,10 @@ module Nic
       @dhcp_record ||= host.jumpstart? ? Net::DHCP::SparcRecord.new(dhcp_attrs) : Net::DHCP::Record.new(dhcp_attrs)
     end
 
+    def self.human_name
+      N_('Bootable')
+    end
+
     protected
 
     def dhcp_attrs

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -37,6 +37,10 @@ module Nic
       end
     end
 
+    def self.humanized_name
+      N_('Interface')
+    end
+
     protected
 
     def uniq_fields_with_hosts
@@ -56,6 +60,8 @@ module Nic
     end
 
   end
+
+  Base.register_type(Managed)
 end
 
 require_dependency 'nic/bmc'

--- a/app/views/api/v2/errors/custom_error.json.rabl
+++ b/app/views/api/v2/errors/custom_error.json.rabl
@@ -1,0 +1,3 @@
+node :message do
+  locals[:message]
+end

--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,3 +1,6 @@
 object @interface
 
-attributes :id, :name, :type, :ip, :mac
+attributes :id, :name, :ip, :mac
+node :type do |i|
+  i.class.humanized_name.downcase
+end

--- a/app/views/api/v2/interfaces/types/bmc.json.rabl
+++ b/app/views/api/v2/interfaces/types/bmc.json.rabl
@@ -1,3 +1,1 @@
-attributes :username, :password, :provider
-
-extends "api/v2/interfaces/types/managed"
+attributes :username, :password, :provider, :virtual

--- a/app/views/api/v2/interfaces/types/bond.json.rabl
+++ b/app/views/api/v2/interfaces/types/bond.json.rabl
@@ -1,3 +1,1 @@
-attributes :mode, :attached_devices, :bond_options
-
-extends "api/v2/interfaces/types/managed"
+attributes :mode, :attached_devices, :bond_options, :virtual

--- a/test/functional/api/v2/interfaces_controller_test.rb
+++ b/test/functional/api/v2/interfaces_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::V2::InterfacesControllerTest < ActionController::TestCase
   valid_attrs = { 'name' => "test.foreman.com", 'ip' => "10.0.1.1", 'mac' => "AA:AA:AA:AA:AA:AA",
                   'username' => "foo", 'password' => "bar", 'provider' => "IPMI",
-                  'type' => "Nic::BMC" }
+                  'type' => "bmc" }
 
   def setup
     @host = FactoryGirl.create(:host)
@@ -23,13 +23,26 @@ class Api::V2::InterfacesControllerTest < ActionController::TestCase
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
+    assert "bmc", show_response["type"]
   end
 
   test "create interface" do
     assert_difference('@host.interfaces.count') do
       post :create, { :host_id => @host.to_param, :interface => valid_attrs }
     end
-    assert_response 201
+    assert_response :success
+  end
+
+  test "create interface with old style type" do
+    assert_difference('@host.interfaces.count') do
+      post :create, { :host_id => @host.to_param, :interface => valid_attrs.merge('type' => 'Nic::BMC') }
+    end
+    assert_response :success
+  end
+
+  test "create interface with unknown type" do
+    post :create, { :host_id => @host.to_param, :interface => valid_attrs.merge('type' => 'UNKNOWN') }
+    assert_response :unprocessable_entity
   end
 
   test "username and password are set on POST (create)" do

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -116,4 +116,44 @@ class NicTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "allowed type registration" do
+
+    setup do
+      class DefaultTestNic < Nic::Base
+      end
+
+      class HumanizedTestNic < Nic::Base
+        def self.humanized_name
+          "Custom"
+        end
+      end
+
+      class DisallowedTestNic < Nic::Base
+      end
+
+      Nic::Base.allowed_types.clear
+      Nic::Base.register_type(DefaultTestNic)
+      Nic::Base.register_type(HumanizedTestNic)
+    end
+
+    test "base registers allowed nic types" do
+      expected_types = [DefaultTestNic, HumanizedTestNic]
+      assert_equal expected_types.map(&:name), Nic::Base.allowed_types.map(&:name)
+    end
+
+    test "type_by_name returns nil for an unknown name" do
+      assert_equal nil, Nic::Base.type_by_name("UNKNOWN_NAME")
+    end
+
+    test "type_by_name finds the class" do
+      assert_equal HumanizedTestNic, Nic::Base.type_by_name("custom")
+    end
+
+    test "type_by_name returns nil for classes that aren't allowed" do
+      assert_equal nil, Nic::Base.type_by_name("DisallowedTestNic")
+    end
+
+  end
+
 end


### PR DESCRIPTION
- allowed NIC type classes need to be registered now
- api for interfaces use lowercase human readable values for defining types
- fixed output of api's create action to the standard format
