### PR TITLE
Fixes #8043 - Statistic links to OS

### DIFF
--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -2,7 +2,7 @@ module StatisticsHelper
   def charts
     options = {:class => "statistics-pie small", :expandable => true, :'border' => 0, :show_title => true}
     [
-      flot_pie_chart("os_dist",_("OS Distribution"), @os_count, options.merge(:search => "os_description=~VAL~")),
+      flot_pie_chart("os_dist",_("OS Distribution"), @os_count, options.merge(:search => "os_title=~VAL~")),
       flot_pie_chart("arch_dist",_("Architecture Distribution"), @arch_count, options.merge( :search => "facts.architecture=~VAL~")),
       flot_pie_chart("env_dist",_("Environments Distribution"), @env_count, options.merge( :search => "environment=~VAL~" )),
       flot_pie_chart("cpu_num",_("Number of CPUs"), @cpu_count,options.merge( :search => "facts.processorcount=~VAL1~")),

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -65,6 +65,7 @@ module Hostext
         scoped_search :on => :installed_at,                         :complete_value => true, :only_explicit => true
         scoped_search :in => :operatingsystem, :on => :name,        :complete_value => true, :rename => :os
         scoped_search :in => :operatingsystem, :on => :description, :complete_value => true, :rename => :os_description
+        scoped_search :in => :operatingsystem, :on => :title,       :complete_value => true, :rename => :os_title
         scoped_search :in => :operatingsystem, :on => :major,       :complete_value => true, :rename => :os_major
         scoped_search :in => :operatingsystem, :on => :minor,       :complete_value => true, :rename => :os_minor
         scoped_search :in => :operatingsystem, :on => :id,          :complete_value => false,:rename => :os_id, :complete_enabled => false


### PR DESCRIPTION
Click on the chart for Operating Systems on /statistics. It'll redirect you to a search on os_description for Hosts.  It should instead search on title to ensure it'll show what the chart shows. The chart itself counts operating systems looking at their title.
