### PR TITLE
Fixes #8048: n+1 query selecting multiple hosts

### DIFF
--- a/app/views/hosts/_selected_hosts.html.erb
+++ b/app/views/hosts/_selected_hosts.html.erb
@@ -12,7 +12,10 @@
         </tr>
       </thead>
       <tbody>
-        <% hosts.each do |host| %>
+        <% associations = [:hostgroup, :environment] %>
+        <% associations << :organization if SETTINGS[:organizations_enabled]  %>
+        <% associations << :location     if SETTINGS[:locations_enabled]  %>
+        <% hosts.includes(*associations).each do |host| %>
           <tr>
             <td><%=h host %> </td>
             <td><%=h host.try(:hostgroup) %></td>


### PR DESCRIPTION
Sample data for 200 hosts selected, organizations and locations enabled.
- Click on change environments takes ~9-10s to load on my hardware without eager loading
- With the patch it's reduced to ~3-4s (around a 66% speedup for the query)
