### PR TITLE
Fixes #7462 - new UI for network interfaces

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -533,8 +533,11 @@ $(document).on('change', '.interface_type', function () {
 });
 
 function interface_domain_selected(element) {
+  // mark the selected value to preserve it for form hiding
+  $(element).find('option:selected').attr('selected', 'selected')
+
   var domain_id = element.value;
-  var subnet_options = $(element).parentsUntil('.fields').parent().find('[id$=_subnet_id]').empty();
+  var subnet_options = $(element).closest('fieldset').find('[id$=_subnet_id]').empty();
 
   subnet_options.attr('disabled', true);
 
@@ -571,9 +574,12 @@ function interface_domain_selected(element) {
 }
 
 function interface_subnet_selected(element) {
+  // mark the selected value to preserve it for form hiding
+  $(element).find('option:selected').attr('selected', 'selected')
+
   var subnet_id = $(element).val();
   if (subnet_id == '') return;
-  var interface_ip = $(element).parentsUntil('.fields').parent().find('input[id$=_ip]')
+  var interface_ip = $(element).closest('fieldset').find('input[id$=_ip]');
 
   interface_ip.attr('disabled', true);
   $(element).indicator_show();

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -1,0 +1,105 @@
+
+
+function remove_interface(interface_id) {
+  $('#interface'+interface_id).remove();
+  $('#interfaceHidden'+interface_id+' .destroyFlag').val(1);
+}
+
+function edit_interface(interface_id) {
+  if (interface_id == null)
+    form = get_interface_template_clone();
+  else
+    form = $('#interfaces #interfaceHidden'+interface_id).clone(true);
+
+  show_interface_modal(form);
+}
+
+function show_interface_modal(modal_content) {
+  var modal_window = $('#interfaceModal');
+  var interface_id = modal_content.data('interface-id');
+
+  modal_window.data('current-id', interface_id);
+
+  var identifier = modal_content.find('.interface_identifier').val();
+
+
+  modal_window.find('.modal-body').html('');
+  modal_window.find('.modal-body').append(modal_content.contents());
+  modal_window.find('.modal-title').html(__('Interface') + ' ' + String(identifier));
+  modal_window.modal({'show': true});
+}
+
+function close_interface_modal() {
+  var modal_window = $('#interfaceModal');
+  var interface_id = modal_window.data('current-id');
+
+  var interface_row = get_interface_row(interface_id);
+  update_interface_row(interface_row, modal_window);
+
+  modal_window.modal('hide');
+  modal_window.removeData('current-id');
+
+  var interface_hidden = get_interface_hidden(interface_id);
+  interface_hidden.html('');
+  interface_hidden.append(modal_window.find('.modal-body').contents());
+}
+
+function get_interface_template_clone() {
+  var content = $('.interfaces_fields_template').html();
+  var interface_id = new Date().getTime();
+
+  content = fix_template_names(content, 'interfaces', interface_id);
+
+  var hidden = $(content);
+
+  $('#interfaceForms').closest("form").trigger({type: 'nested:fieldAdded', field: hidden});
+  $('a[rel="popover"]').popover({html: true});
+  $('a[rel="twipsy"]').tooltip();
+
+  hidden.attr('id', 'interfaceHidden'+interface_id);
+  hidden.data('interface-id', interface_id);
+
+  return hidden;
+}
+
+function get_interface_row(interface_id) {
+  var interface_row = $('#interface'+interface_id);
+  if ( interface_row.length == 0) {
+    interface_row = $('#interfaceTemplate').clone(true);
+    interface_row.attr('id', 'interface'+interface_id);
+
+    interface_row.find('.showModal').click( function(){
+      edit_interface(interface_id);
+      return false;
+    });
+
+    interface_row.find('.removeInterface').click( function(){
+      remove_interface(interface_id);
+      return false;
+    });
+
+    interface_row.show();
+    interface_row.insertBefore('#interfaceTemplate');
+  }
+  return interface_row;
+}
+
+function get_interface_hidden(interface_id) {
+  var interface_hidden = $('#interfaceHidden'+interface_id);
+  if ( interface_hidden.length == 0) {
+
+    interface_hidden = $('<div></div>');
+    interface_hidden.attr('style', 'display: none');
+    interface_hidden.attr('id', 'interfaceHidden'+interface_id);
+    interface_hidden.data('interface-id', interface_id);
+
+    $('#interfaceForms').append(interface_hidden);
+  }
+  return interface_hidden;
+}
+
+function update_interface_row(row, modal_window) {
+  row.find('.type').html(modal_window.find('.interface_type option:selected').text());
+  row.find('.identifier').html(modal_window.find('.interface_identifier').val());
+  row.find('.mac').html(modal_window.find('.interface_mac').val());
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -371,3 +371,50 @@ table tr td:last-child {
   vertical-align: bottom;
   float: none;
 }
+
+#interfaceModal .modal-dialog {
+  min-width: 1000px
+}
+
+#addInterface {
+  margin-left: 10px;
+  margin-bottom: 5px;
+}
+
+.interface-down {
+  color: #808080;
+}
+
+#interfaceList.table {
+
+  border-collapse: separate;
+  border-width: 0 0 1px 0;
+
+  tr {
+    th:first-child,
+    td:first-child {
+      border-width: 1px 1px 0 1px;
+    }
+
+    th, td {
+      border-width: 1px 1px 0 0;
+    }
+  }
+
+  tr.has-error {
+    td:first-child {
+      border-left: 1px solid #a94442;
+    }
+
+    td:last-child {
+      border-right: 1px solid #a94442;
+    }
+
+    td {
+      color: #333333;
+      border-top: 1px solid #a94442;
+      border-bottom: 1px solid #a94442;
+    }
+  }
+
+}

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -186,3 +186,11 @@ span.btn a{ text-decoration: none; color: #333333}
 .tooltip {
   word-wrap: break-word;
 }
+
+.has-error {
+  color: #a94442
+}
+
+body.modal-open {
+  overflow: visible;
+}

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -331,9 +331,15 @@ module HostsHelper
                                :class => 'fr label label-danger'})
   end
 
-  def link_status(f)
-    return '' if f.object.new_record?
-    '(' + (f.object.link ? _('Up') : _('Down')) + ')'
+  def link_status(nic)
+    return '' if nic.new_record?
+
+    if nic.link
+      status = '<i class="glyphicon glyphicon glyphicon-arrow-up interface-up" title="'+ _('Up') +'"></i>'
+    else
+      status = '<i class="glyphicon glyphicon glyphicon-arrow-down interface-down" title="'+ _('Down') +'"></i>'
+    end
+    status.html_safe
   end
 
   def build_state(build)

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= javascript 'host_edit', 'class_edit', 'compute_resource', 'lookup_keys'%>
+<%= javascript 'host_edit', 'host_edit_interfaces', 'class_edit', 'compute_resource', 'lookup_keys'%>
 <%= render "hosts/dhcp_lease_errors" if has_dhcp_lease_errors?(@host.errors) %>
 <%= render "hosts/conflicts" if (!has_dhcp_lease_errors?(@host.errors) && has_conflicts?(@host.errors)) %>
 <%= render "hosts/progress" %>

--- a/app/views/hosts/_interfaces.html.erb
+++ b/app/views/hosts/_interfaces.html.erb
@@ -1,0 +1,86 @@
+
+<% interfaces_invalid = @host.interfaces.any?{ |i| !i.valid? } %>
+
+<fieldset id="interfaces" data-url="<%= new_interface_path %>">
+  <legend>
+    <span <%= interfaces_invalid ? 'class="has-error"'.html_safe : '' %>>
+    <%= _("Interfaces") %>
+    </span>
+    <a onclick="edit_interface();return false;"
+      href="#"
+      class="info add_nested_fields btn btn-success"
+      id = "addInterface"
+      title="add new network interface">+ <%= _('Add Interface') %></a>
+  </legend>
+
+  <% if interfaces_invalid %>
+  <p class="alert alert-danger">
+    <%= _("Some of the interfaces are invalid. Please check the table below.") %>
+  </p>
+  <% end %>
+
+  <!-- interface list -->
+  <table class="table table-bordered table-striped table-condensed" id="interfaceList">
+    <tr>
+      <th class="hidden-xs" width="3%"></th>
+      <th class="ellipsis"><%= _('Identifier') %></th>
+      <th class="hidden-xs"><%= _('Type') %></th>
+      <th class="hidden-xs"><%= _("MAC address") %></th>
+      <th></th>
+    </tr>
+    <% @host.interfaces.each do |interface| %>
+      <tr class="<%= 'has-error' unless interface.valid? %>" id="interface<%= interface.object_id %>" data-interface-id="<%= interface.object_id %>">
+        <td class="status hidden-xs" align="center"><%= link_status(interface) %></td>
+        <td class="identifier ellipsis"><%= interface.identifier %></td>
+        <td class="type hidden-xs"><%= _(interface.class.humanized_name) %></td>
+        <td class="mac hidden-xs"><%= interface.mac %></td>
+        <td>
+          <button class="btn btn-default showModal" onclick="edit_interface(<%= interface.object_id %>); return false;"><%= _('Edit') %></button>
+          <button class="btn btn-danger removeInterface" onclick="remove_interface(<%= interface.object_id %>); return false;"><%= _('Delete') %></button>
+        </td>
+      </tr>
+    <% end %>
+    <tr id="interfaceTemplate" style="display: none">
+      <td class="status hidden-xs" align="center"></td>
+      <td class="identifier ellipsis"></td>
+      <td class="type hidden-xs"></td>
+      <td class="mac hidden-xs"></td>
+      <td>
+        <button class="btn btn-default showModal" data-toggle="modal" data-target="#interfaceModal"><%= _('Edit') %></button>
+        <button class="btn btn-danger removeInterface"><%= _('Delete') %></button>
+      </td>
+    </tr>
+
+  </table>
+
+
+  <!-- hidden interface forms -->
+  <div id="interfaceForms">
+    <%= f.fields_for :interfaces do |interface| %>
+      <%= render :partial => interface.object, :locals => {:f => interface, :id => interface.object.object_id}, :layout => 'nic/hidden_layout' %>
+    <% end %>
+  </div>
+
+  <!-- modal window -->
+  <div class="modal fade" id="interfaceModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
+          <h4 class="modal-title"></h4>
+        </div>
+        <div class="modal-body">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn btn-default" data-dismiss="modal"><%= _('Cancel') %></button>
+          <button class="btn btn-primary" onclick="close_interface_modal(); return false;"><%= _('Ok') %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</fieldset>
+
+
+<%= new_child_fields_template(f, :interfaces, {:partial => Nic::Managed.new, :layout => 'nic/hidden_layout'}) %>
+

--- a/app/views/hosts/_unattended.html.erb
+++ b/app/views/hosts/_unattended.html.erb
@@ -27,11 +27,9 @@
         </span>
         <%= text_f f, :ip, :autocomplete => 'off', :help_block => link_to(_("Suggest new"), '#', :id => 'suggest_new_ip'),
           :help_inline => popover(_("IP address auto-suggest"), _("An IP address will be auto-suggested if you have a DHCP-enabled Smart Proxy on the subnet selected above.<br/><br/>The IP address can be left blank when:<br/><ul><li>provisioning tokens are enabled</li><li>the domain does not manage DNS</li><li>the subnet does not manage reverse DNS</li><li>and the subnet does not manage DHCP reservations</li></ul>"), :title => _("IP address for this host")).html_safe %>
-        <%= f.fields_for :interfaces do |interfaces| %>
-          <%= render :partial => interfaces.object, :layout => 'nic/interface_layout', :locals => {:f => interfaces} %>
-        <% end %>
-        <%= new_child_fields_template(f, :interfaces, {:partial => Nic::Managed.new, :layout => 'nic/interface_layout'}) %>
-        <%= add_child_link "+ " + _("Add Interface"), :interfaces, { :class => "info", :title => _('add new network interface') } %>
+
+        <%= render 'hosts/interfaces', :host => @host, :f => f %>
+
       </div>
     <% end %>
   <% end %>

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -1,8 +1,10 @@
 <%= selectable_f f, :type, interfaces_types, {},
                  :class => 'interface_type', :disabled => !f.object.new_record? %>
 
-<%= text_f f, :mac %>
-<%= text_f f, :identifier, :disabled => !f.object.new_record?, :help_inline => _("Device identifier, i.e.: eth0 or eth1.1") %>
+<%= text_f f, :mac, :class => :interface_mac %>
+<%= text_f f, :identifier, :disabled => !f.object.new_record?,
+              :help_inline => _("Device identifier, i.e.: eth0 or eth1.1"),
+              :class => :interface_identifier %>
 <%= text_f f, :name, :label => _("DNS name") %>
 <%= select_f f, :domain_id, accessible_domains, :id, :to_label,
              { :include_blank => accessible_domains.any? ? true : _("No domains")},

--- a/app/views/nic/_hidden_layout.html.erb
+++ b/app/views/nic/_hidden_layout.html.erb
@@ -1,0 +1,7 @@
+
+<div class="hidden" id="interfaceHidden<%= local_assigns[:id] %>" data-interface-id="<%= local_assigns[:id] %>">
+  <%= field_set_tag "", :id => "interface", :'data-url' => new_interface_path do %>
+    <%= f.hidden_field(:_destroy, :class => :destroyFlag) %>
+    <%= yield %>
+  <% end %>
+</div>

--- a/app/views/nic/_interface_layout.html.erb
+++ b/app/views/nic/_interface_layout.html.erb
@@ -1,7 +1,0 @@
-<div class="fields">
-  <%= field_set_tag "#{_("Interface")} #{link_status(f)} #{remove_interface_link(f)}".html_safe,
-                    :id => "interface",
-                    :'data-url' => new_interface_path do %>
-    <%= yield %>
-  <% end %>
-</div>

--- a/app/views/nic/new.js.erb
+++ b/app/views/nic/new.js.erb
@@ -1,8 +1,8 @@
 <% if @interface.present? %>
   <%= fields_for :host, Host::Base.new do |host| %>
     <%= host.fields_for :interfaces, @interface, :child_index => @key do |interfaces| %>
-      $("#host_interfaces_attributes_<%= @key %>_type").closest('fieldset').html(
-        '<%=j render :partial => @interface, :layout => 'nic/interface_layout', :locals => {:f => interfaces} %>'
+      $("#interfaceModal #host_interfaces_attributes_<%= @key %>_type").closest('fieldset').html(
+        '<%=j render :partial => @interface, :locals => {:f => interfaces} %>'
       );
     <% end %>
   <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,7 @@ Foreman::Application.configure do |app|
                   ace/keybinding-emacs
                   diff
                   host_edit
+                  host_edit_interfaces
                   hosts
                   jquery.cookie
                   host_checkbox


### PR DESCRIPTION
Editing network interfaces moved into a modal window. Some screenshots of the new UI are at:
https://tstrachota.fedorapeople.org/screenshots/nics_ui/

Bits of host form related to NICs are initially hidden and copied into a modal window on edit button click. This allows reusing validation error notices rendered by rails.
