### PR TITLE
Fixes #7954 - When creating a host cant is spelled wrong under partition...

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -151,7 +151,7 @@ class Host::Managed < Host::Base
                           :presence => {:message => N_('should not be blank - consider setting a global or host group default')},
                           :if => Proc.new { |host| host.managed && host.pxe_build? }
     validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :if => Proc.new { |host| host.require_ip_validation? }
-    validates :ptable_id, :presence => {:message => N_("cant be blank unless a custom partition has been defined")},
+    validates :ptable_id, :presence => {:message => N_("can't be blank unless a custom partition has been defined")},
                           :if => Proc.new { |host| host.managed and host.disk.empty? and not Foreman.in_rake? and host.pxe_build? }
     validates :serial, :format => {:with => /[01],\d{3,}n\d/, :message => N_("should follow this format: 0,9600n8")},
                        :allow_blank => true, :allow_nil => true


### PR DESCRIPTION
Description of problem:
all of the other side notes say "can't"

partition table shows "cant"

It's the validation message when a partition table is left blank. To reproduce, attempt to create a new host but don't set a partition table.

"cant be blank unless a custom partition has been defined"
