### PR TITLE
refs #746 - hosts stylesheet is part of app.css, not standalone

### DIFF
--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -1,4 +1,3 @@
-<% stylesheet 'hosts' %>
 <% javascript 'charts', 'hosts' %>
 <% title @host.to_label, icon(@host.os) + @host.to_label %>
 


### PR DESCRIPTION
Causes a sass error on a production Debian installation otherwise, as it can't be compiled on the fly.
