### PR TITLE
Fixes #8011 - When displaying Reports for a host, eventful=true should b...

### DIFF
--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -11,7 +11,17 @@
       <ul class="dropdown-menu pull-right">
         <% bookmarks = Bookmark.my_bookmarks.controller(controller_name) %>
         <% bookmarks.each do |bookmark| %>
-          <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
+          <% if bookmark.name == "eventful = false" or bookmark.name == "eventful = true" %>
+            <% if (params[:search].try(:squeeze," ").include? "eventful") == true %>
+              <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => params[:search].try(:squeeze," ").gsub(/eventful.=.(false|true)/,bookmark.query)) %></li>
+            <% elsif params[:search].lstrip != "" %>
+              <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => params[:search].try(:squeeze," ") + " and " + bookmark.query) %></li>
+            <% else %>
+              <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
+            <% end %>
+          <% else %>
+            <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
+          <% end %>
         <% end %>
         <li class="divider"></li>
         <li><%= link_to_function _('Bookmark this search'), "$('#bookmarks-modal').modal();",

--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -11,7 +11,7 @@
       <ul class="dropdown-menu pull-right">
         <% bookmarks = Bookmark.my_bookmarks.controller(controller_name) %>
         <% bookmarks.each do |bookmark| %>
-          <% if bookmark.name == "eventful = false" or bookmark.name == "eventful = true" %>
+          <% if bookmark.name == "eventful" or bookmark.name == "eventless" %>
             <% if (params[:search].try(:squeeze," ").include? "eventful") == true %>
               <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => params[:search].try(:squeeze," ").gsub(/eventful.=.(false|true)/,bookmark.query)) %></li>
             <% elsif params[:search].lstrip != "" %>

--- a/db/seeds.d/15-bookmarks.rb
+++ b/db/seeds.d/15-bookmarks.rb
@@ -2,8 +2,7 @@
 Bookmark.without_auditing do
   [
     { :name => "eventful", :query => "eventful = true", :controller=> "reports" },
-    { :name => "eventful = true", :query => "eventful = true", :controller=> "reports" },
-    { :name => "eventful = false", :query => "eventful = false", :controller=> "reports" },
+    { :name => "eventless", :query => "eventful = false", :controller=> "reports" },
     { :name => "active", :query => 'last_report > "35 minutes ago" and (status.applied > 0 or status.restarted > 0)', :controller=> "hosts" },
     { :name => "out of sync", :query => 'last_report < "30 minutes ago" and status.enabled = true', :controller=> "hosts" },
     { :name => "error", :query => 'last_report > "35 minutes ago" and (status.failed > 0 or status.failed_restarts > 0 or status.skipped > 0)', :controller=> "hosts" },

--- a/db/seeds.d/15-bookmarks.rb
+++ b/db/seeds.d/15-bookmarks.rb
@@ -2,6 +2,8 @@
 Bookmark.without_auditing do
   [
     { :name => "eventful", :query => "eventful = true", :controller=> "reports" },
+    { :name => "eventful = true", :query => "eventful = true", :controller=> "reports" },
+    { :name => "eventful = false", :query => "eventful = false", :controller=> "reports" },
     { :name => "active", :query => 'last_report > "35 minutes ago" and (status.applied > 0 or status.restarted > 0)', :controller=> "hosts" },
     { :name => "out of sync", :query => 'last_report < "30 minutes ago" and status.enabled = true', :controller=> "hosts" },
     { :name => "error", :query => 'last_report > "35 minutes ago" and (status.failed > 0 or status.failed_restarts > 0 or status.skipped > 0)', :controller=> "hosts" },


### PR DESCRIPTION
Description of problem:
When accessing a hosts report (via Dashboard-> Select hostname), the user is presented with a great deal of reports, many of which have no eventful information. This RFE requests setting 'eventful=true' so that the end user doesn't have to wade through a large number of reports to get to the information they desire.

Version-Release number of selected component (if applicable):
foreman-1.6.0.46-1.el6sat.noarch

 Dominic wrote,"Bit of a matter of opinion really, given there's a filter already there. I think when I'm using it, I'm perfectly happy to see non-eventful reports. Maybe a one-click way to add/remove eventful = true to the search would be very useful."

So I add two bookmarks, "eventful = true" and "eventful = false". If the input is "host = test" and "eventful = true" is clicked, the search condition will be set as "host = test and eventful = true". And if the input is "host = test" and "eventful = false" is clicked, the search condition will be set as "host = test and eventful = false".
