### PR TITLE
fixes #6408 - dismiss org/loc context menu when mouse leaves it

### DIFF
--- a/app/assets/javascripts/topbar.js
+++ b/app/assets/javascripts/topbar.js
@@ -43,6 +43,14 @@ $(document).on('mouseleave','.loc-submenu', function(){
     $('.loc-submenu').hide();
 });
 
+$(document).on('mouseleave','.dropdown-menu', function(){
+    if($(this).parent().hasClass('org-switcher')) {
+        $('.org-submenu').hide();
+        $('.loc-submenu').hide();
+        $(this).find('.dropdown-toggle:first').click();
+    }
+});
+
 function mark_active_menu() {
   var menus = $('.menu_tab_dropdown'),
       path = window.location.pathname + window.location.search,


### PR DESCRIPTION
Not perfect but much better. The one case that is slightly off is mouse over org name in menubar, move mouse down into menu as it is displayed, then move mouse back into menubar. The dropdown will dismiss instead of remaining. Overall, though, the experience is good.
