### PR TITLE
Fixes #8267 - accept template_url in call to foreman from proxy

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -186,6 +186,12 @@ class UnattendedController < ApplicationController
 
     # force static network configuration if static http parameter is defined, in the future this needs to go into the GUI
     @static = !params[:static].empty?
+
+    # this is sent by the proxy when the templates feature is enabled
+    # and is needed to direct the host to the correct url. without it, we increase
+    # latency by requesting the correct url directly from the proxy.
+    @template_url = params['url']
+
   end
 
   def alterator_attributes

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -36,12 +36,22 @@ module HostTemplateHelpers
     @host ||= self
     proxy = @host.try(:subnet).try(:tftp)
 
-    if proxy.present? && proxy.try(:features).map(&:name).include?('Templates') && @host.try(:token).present?
-      url = ProxyAPI::Template.new(:url => proxy.url).template_url
-      if url.nil?
-        logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
-        url = proxy.url
-      end
+    # use template_url from the request if set, but otherwise look for a Template
+    # feature proxy, as PXE templates are written without an incoming request.
+    url = if @template_url && @host.try(:token).present?
+            @template_url
+          elsif proxy.present? && proxy.try(:features).map(&:name).include?('Templates') && @host.try(:token).present?
+            temp_url = ProxyAPI::Template.new(:url => proxy.url).template_url
+            if temp_url.nil?
+              logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
+              temp_url = proxy.url
+            end
+            temp_url
+          else
+            nil
+          end
+
+    if url.present?
       uri      = URI.parse(url)
       host     = uri.host
       port     = uri.port

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -34,12 +34,22 @@ module Foreman
 
       proxy = @host.try(:subnet).try(:tftp)
 
-      if proxy.present? && proxy.try(:features).map(&:name).include?('Templates') && @host.try(:token).present?
-        url = ProxyAPI::Template.new(:url => proxy.url).template_url
-        if url.nil?
-          logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
-          url = proxy.url
-        end
+      # use template_url from the request if set, but otherwise look for a Template
+      # feature proxy, as PXE templates are written without an incoming request.
+      url = if @template_url && @host.try(:token).present?
+              @template_url
+            elsif proxy.present? && proxy.try(:features).map(&:name).include?('Templates') && @host.try(:token).present?
+              temp_url = ProxyAPI::Template.new(:url => proxy.url).template_url
+              if temp_url.nil?
+                logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
+                temp_url = proxy.url
+              end
+              temp_url
+            else
+              nil
+            end
+
+      if url.present?
         uri      = URI.parse(url)
         host     = uri.host
         port     = uri.port


### PR DESCRIPTION
Also passes the ?static parameter on correctly.

@witlessbird @dustints could you comment and/or test? This will cut down on calls to /templateServer.

See also https://github.com/theforeman/smart-proxy/pull/232
