### PR TITLE
Fixes #5998: add taxonomy in config_templates

### DIFF
--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -6,6 +6,12 @@
       <li><a href="#template_type" data-toggle="tab"><%= _("Type") %></a></li>
       <li><a href="#template_associations" data-toggle="tab"><%= _("Association") %></a></li>
       <li><a id='history_tab' href="#history" data-toggle="tab"><%= _("History") %></a></li>
+      <% if show_location_tab? %>
+        <li><a href="#locations" data-toggle="tab"><%= _("Locations") %></a></li>
+      <% end %>
+      <% if show_organization_tab? %>
+        <li><a href="#organizations" data-toggle="tab"><%= _("Organizations") %></a></li>
+      <% end %>      
     </ul>
 
     <div class="tab-content">
@@ -78,7 +84,7 @@
         <% end %>
       </div>
 
-
+      <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @config_template %>
 
       <div class="tab-pane" id="template_associations">
         <p id="snippet_message" class="alert alert-info" <%= display? !@config_template.snippet %> ><%= _("Not relevant for snippet") %></p>

--- a/db/migrate/20090714132448_create_hosts.rb
+++ b/db/migrate/20090714132448_create_hosts.rb
@@ -51,6 +51,7 @@ class CreateHosts < ActiveRecord::Migration
     add_column :hosts, :sp_subnet_id, :integer
     add_column :hosts, :ptable_id, :integer
     add_column :hosts, :medium_id, :integer
+    add_column :hosts, :config_template_id, :integer
     add_column :hosts, :build, :boolean, :default => true
     add_column :hosts, :comment, :text
     add_column :hosts, :disk, :text


### PR DESCRIPTION
Config templates cannot be assigned to a taxonomy from config_template#edit
http://projects.theforeman.org/issues/5998

Added taxonomy in Provisioning Templates in edit template.