### PR TITLE
fixes #8302 - only return active images for openstack compute resources

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -42,7 +42,7 @@ module Foreman::Model
     end
 
     def available_images
-      client.images
+      client.images.select { |image| image.status.downcase == 'active' }
     end
 
     def address_pools


### PR DESCRIPTION
It seems possible to have an image in a 'SAVING' state without a name:

```
    id="3c018863-ed63-45f7-af15-870840905836",
    name=nil,
    created_at="2014-10-23T03:48:18Z",
    updated_at="2014-10-23T03:48:18Z",
    progress=25,
    status="SAVING"
```

This is causing the reported error, when we try to sort by downcased names.  "available_images" should only return ACTIVE images.
