### PR TITLE
Fixes #8321 - correctly pull Compute Resource image method from compute attrs

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -789,7 +789,7 @@ class Host::Managed < Host::Base
               if images.blank?
                 [TemplateKind.find('finish')]
               else
-                uuid       = self.compute_attributes.cr.image_param_name
+                uuid       = self.compute_attributes[cr.image_param_name]
                 image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
                 [TemplateKind.find(image_kind)]
               end

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -60,4 +60,13 @@ FactoryGirl.define do
     factory :rackspace_cr, :class => Foreman::Model::Rackspace, :traits => [:rackspace]
     factory :vmware_cr, :class => Foreman::Model::Vmware, :traits => [:vmware]
   end
+
+  factory :image do
+    sequence(:name) { |n| "image#{n}" }
+    uuid Foreman.uuid
+    username 'root'
+    compute_resource
+    operatingsystem
+    architecture
+  end
 end

--- a/test/factories/config_template.rb
+++ b/test/factories/config_template.rb
@@ -13,9 +13,9 @@ FactoryGirl.define do
   end
 
   factory :os_default_template do
-    config_template
-    operatingsystem
     template_kind
+    config_template { FactoryGirl.create(:config_template, :template_kind => template_kind) }
+    operatingsystem { FactoryGirl.create(:operatingsystem, :config_templates => [config_template]) }
   end
 
   factory :template_kind do

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -585,6 +585,24 @@ context "location or organizations are not enabled" do
     test "retrieves finish template if associated to the correct environment only" do
       assert_equal ConfigTemplate.find_by_name("MyFinish"), @host.configTemplate({:kind => "finish"})
     end
+
+    test "available_template_kinds finds templates for a PXE host" do
+      os_dt = FactoryGirl.create(:os_default_template, :template_kind=> TemplateKind.find('finish'))
+      host  = FactoryGirl.create(:host, :operatingsystem => os_dt.operatingsystem)
+
+      assert_equal [os_dt.config_template], host.available_template_kinds('build')
+    end
+
+    test "available_template_kinds finds templates for an image host" do
+      os_dt = FactoryGirl.create(:os_default_template, :template_kind=> TemplateKind.find('finish'))
+      host  = FactoryGirl.create(:host, :on_compute_resource,
+                                 :operatingsystem => os_dt.operatingsystem)
+      image = FactoryGirl.create(:image, :uuid => 'abcde',
+                                 :compute_resource => host.compute_resource)
+      host.compute_attributes = {:image_id => 'abcde'}
+
+      assert_equal [os_dt.config_template], host.available_template_kinds('image')
+    end
   end
 
   test "handle_ca must not perform actions when the manage_puppetca setting is false" do


### PR DESCRIPTION
as detailed in #8321, compute_attrs is an ordinary hash, so we need to evaluate cr.image_param_name _first_ and then get the resulting key from the hash. As such, PXE hosts were working fine, but image hosts were not. Added tests to cover this for the future.

Also updated the template factories to work slightly better - os_default_template wasn't creating the associations between the OS and template objects (i.e operatingsystem.config_templates == [] meaning the join entry was useless).
