### PR TITLE
fixes #8331 - provide some tools for filtering mail

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,16 @@
+require 'uri'
+
 class ApplicationMailer < ActionMailer::Base
 
   default :from => Setting[:email_reply_address] || "noreply@foreman.example.org"
+
+  def mail(headers = {}, &block)
+    if headers.present?
+      headers[:subject] = "#{Setting[:email_subject_prefix]} #{headers[:subject]}" if (headers[:subject] && !Setting[:email_subject_prefix].blank?)
+      headers['X-Foreman-Server'] = URI.parse(Setting[:foreman_url]).host unless Setting[:foreman_url].blank?
+    end
+    super
+  end
 
   private
 

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -13,7 +13,7 @@ class HostMailer < ApplicationMailer
     total_metrics = load_metrics(host_data)
     total = 0; total_metrics.values.each { |v| total += v }
 
-    subject = _("Summary Puppet report from Foreman - F:%{failed} R:%{restarted} S:%{skipped} A:%{applied} FR:%{failed_restarts} T:%{total}") % {
+    subject = _("Puppet Summary Report - F:%{failed} R:%{restarted} S:%{skipped} A:%{applied} FR:%{failed_restarts} T:%{total}") % {
       :failed => total_metrics["failed"],
       :restarted => total_metrics["restarted"],
       :skipped => total_metrics["skipped"],

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -15,6 +15,7 @@ class Setting::General < Setting
         self.set('administrator', N_("The default administrator email address"), administrator),
         self.set('foreman_url', N_("URL where your Foreman instance is reachable (see also Provisioning > unattended_url)"), foreman_url),
         self.set('email_reply_address', N_("Email reply address for emails that Foreman is sending"), email_reply_address),
+        self.set('email_subject_prefix', N_("Prefix to add to all outgoing email"), '[foreman]'),
         self.set('send_welcome_email', N_("Send a welcome mail including username and URL to new users"), false),
         self.set('entries_per_page', N_("Number of records shown per page in Foreman"), 20),
         self.set('fix_db_cache', N_('Fix DB cache on next Foreman restart'), false),

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -250,3 +250,8 @@ attributes53:
   category: Setting::General
   default: "false"
   description: "Send a welcome mail including initial username and password to new users"
+attributes54:
+  name: email_subject_prefix
+  category: Setting::General
+  default: "[foreman]"
+  description: "Prefix to add to all outgoing email"

--- a/test/lib/tasks/reports_test.rb
+++ b/test/lib/tasks/reports_test.rb
@@ -18,7 +18,7 @@ class ReportsTest < ActiveSupport::TestCase
 
   test 'reports:daily sends mail' do
     Rake.application.invoke_task 'reports:daily'
-    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Summary Puppet report/ }
+    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Puppet Summary/ }
     assert mail
     assert_match /Summary from/, mail.body.encoded
   end
@@ -33,7 +33,7 @@ class ReportsTest < ActiveSupport::TestCase
     end
 
     Rake.application.invoke_task 'reports:daily'
-    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Summary Puppet report/ }
+    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Puppet Summary/ }
     assert mail
     assert_match /#{@host.name}/, mail.body.encoded
   end

--- a/test/unit/application_mailer_test.rb
+++ b/test/unit/application_mailer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ApplicationMailerTest < ActiveSupport::TestCase
+
+  setup do
+    ActionMailer::Base.deliveries = []
+    Setting[:email_subject_prefix] = '[foreman-production]'
+
+    ApplicationMailer.mail(:to => 'nobody@example.com', :subject => 'Danger, Will Robinson!') do |mail|
+      format.text "This is a test mail."
+    end.deliver
+
+    @mail = ActionMailer::Base.deliveries.first
+  end
+
+  test "foreman server header is set" do
+    assert_equal @mail.header['X-Foreman-Server'].to_s, 'foreman.some.host.fqdn'
+  end
+
+  test "foreman subject prefix is attached" do
+    assert_match /^\[foreman-production\]/, @mail.subject
+  end
+end


### PR DESCRIPTION
- Adds a header `X-Foreman-Server`
- Add a prefix to subjects (e..g [foreman])
