### PR TITLE
Fixes #7488 - correctly display hostgroups with / in their names

### DIFF
--- a/app/helpers/ancestry_helper.rb
+++ b/app/helpers/ancestry_helper.rb
@@ -4,7 +4,7 @@ module AncestryHelper
   def label_with_link(obj, max_length = 1000, authorizer = nil)
     return if obj.blank?
     options = (obj.title.to_s.size > max_length) ? { :'data-original-title' => obj.title, :rel => 'twipsy' } : {}
-    nesting = obj.title.to_s.gsub(/[^\/]+\/?$/, '')
+    nesting = obj.title.chomp(obj.name)
     nesting = truncate(nesting, :length => max_length - obj.name.to_s.size) if nesting.to_s.size > 0
     name    = truncate(obj.name, :length => max_length - nesting.to_s.size)
     link_to_if_authorized(


### PR DESCRIPTION
Original bug was about hostgroup names containing html closing tags.
This was actually a bug affecting all objects with ancestry (hostgroups, locations, organizations) containing the `/` character in their names.
