### PR TITLE
fixes #8348 - expose user variable to templates in group mail

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -21,10 +21,13 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def group_mail(users, options)
-    GroupMail.new(users.map do |user|
-      set_locale_for(user)
+    mails = users.map do |user|
+      @user = user
+      set_locale_for user
       mail(options.merge(:to => user.mail)) unless user.mail.blank?
-    end.compact)
+    end
+
+    GroupMail.new(mails.compact)
   end
 
   def set_locale_for(user)


### PR DESCRIPTION
It is useful to know which user the mail is going to inside the template when working with group mail
