### PR TITLE
Bug #7547 - Cannot log out of WebUI from mobile device

### DIFF
--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -8,6 +8,9 @@
         <%= link_to "Foreman", main_app.root_path %>
       </div>
       <% if User.current %>
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-header-menu">
+          <span class="glyphicon glyphicon-user"></span>
+        </button>
         <div>
           <ul class="nav navbar-nav navbar-right navbar-header-menu navbar-collapse collapse" id="menu4">
             <%= render_menu :header_menu %>

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -8,9 +8,6 @@
         <%= link_to "Foreman", main_app.root_path %>
       </div>
       <% if User.current %>
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-header-menu">
-          <span class="glyphicon glyphicon-user"></span>
-        </button>
         <div>
           <ul class="nav navbar-nav navbar-right navbar-header-menu navbar-collapse collapse" id="menu4">
             <%= render_menu :header_menu %>
@@ -22,6 +19,9 @@
   </div>
 </div>
 <div class="navbar navbar-default navbar-inner navbar-fixed-top persist-header">
+  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-header-menu">
+    <span class="glyphicon glyphicon-user"></span>
+  </button>
   <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-menu">
     <span class="icon-bar"></span>
     <span class="icon-bar"></span>


### PR DESCRIPTION
When accessing the Sat6 WebUI from Firefox on Android, no log out link appears, so there's no easy way to log out or sign in as a different user.

Add a user button to fix this.
