### PR TITLE
fixes #8377 - Nic::Base.uniq_with_hosts fails if host is nil

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -78,7 +78,7 @@ module Nic
       uniq_fields_with_hosts.each do |attr|
         value = self.send(attr)
         unless value.blank?
-          if host.send(attr) == value
+          if host && host.send(attr) == value
             errors.add(attr, _("can't use the same value as the primary interface"))
             failed = true
           elsif Host.where(attr => value).limit(1).pluck(attr).any?


### PR DESCRIPTION
This commit considers a nil host reference equivalent to a non-conflicting
one for the purposes of uniq_with_hosts validation.
