### PR TITLE
Fixes #8400: Remove eager loading of puppetclass in lookup_keys index

### DIFF
--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -4,7 +4,9 @@ class LookupKeysController < ApplicationController
   before_filter :find_resource, :only => [:edit, :update, :destroy], :if => Proc.new { params[:id] }
 
   def index
-    @lookup_keys = resource_base.search_for(params[:search], :order => params[:order]).includes(:param_classes, :puppetclass).paginate(:page => params[:page])
+    @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])
+                                .includes(:param_classes)
+                                .paginate(:page => params[:page])
     @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map(&:puppetclass_id).compact.uniq)
   end
 


### PR DESCRIPTION
No need for the `includes :puppetclass`, it is not used in the view for anything and makes the query heavier needlessly.
