### PR TITLE
Fixes #6765 - correct wrong validation on media name

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -16,8 +16,7 @@ class Medium < ActiveRecord::Base
 
   # We need to include $ in this as $arch, $release, can be in this string
   VALID_NFS_PATH=/\A([-\w\d\.]+):(\/[\w\d\/\$\.]+)\Z/
-  validates :name, :uniqueness => true, :presence => true,
-                   :format => { :with => /\A(\S+\s)*\S+\Z/, :message => N_("can't contain trailing white spaces.") }
+  validates :name, :uniqueness => true, :presence => true
   validates :path, :uniqueness => true, :presence => true,
                    :format => { :with => /^(http|https|ftp|nfs):\/\//,
                                 :message => N_("Only URLs with schema http://, https://, ftp:// or nfs:// are allowed (e.g. nfs://server/vol/dir)")

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -12,16 +12,11 @@ class MediumTest < ActiveSupport::TestCase
     assert !medium.save
   end
 
-  test "name can't contain white spaces" do
+  test "name strips leading and trailing white spaces" do
     medium = Medium.new :name => "   Archlinux mirror   thing   ", :path => "http://www.google.com"
-    assert !medium.name.squeeze(" ").empty?
-    assert !medium.save
-
-    medium.name = "Archlinux mirror      thing"
-    assert !medium.save
-
-    medium.name.squeeze!(" ")
-    assert medium.save!
+    assert medium.save
+    assert !medium.name.starts_with?(' ')
+    assert !medium.name.ends_with?(' ')
   end
 
   test "name must be unique" do


### PR DESCRIPTION
Regex used for validation was wrong, raising error on multiple white spaces instead of on trailing white space.
Trailing white space is stripped anyways by StripWhitespace concern before validation.
Original bug was concerning " " passing validation. However, that is not a single white space but rather quotes with a space between them; while not useful, it is a valid name. (The quotes are escaped in the db)
