### PR TITLE
Fixes #8414 - extracts validators from models

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -11,8 +11,7 @@ class Architecture < ActiveRecord::Base
   has_many :hostgroups
   has_many :images, :dependent => :destroy
   has_and_belongs_to_many :operatingsystems
-  validates :name, :presence => true, :uniqueness => true,
-                   :format => { :with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.") }
+  validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
   audited :allow_mass_assignment => true
 
   scoped_search :on => :name, :complete_value => :true

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -12,8 +12,7 @@ class Bookmark < ActiveRecord::Base
 
   validates :name, :uniqueness => true, :unless => Proc.new{|b| Bookmark.my_bookmarks.where(:name => b.name).empty?}
   validates :name, :query, :presence => true
-  validates :controller, :presence => true,
-                         :format => { :with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.") },
+  validates :controller, :presence => true, :no_whitespace => true,
                          :inclusion => {
                            :in => ["dashboard"] + ActiveRecord::Base.connection.tables.map(&:to_s),
                            :message => _("%{value} is not a valid controller") }

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -24,8 +24,7 @@ class ComputeResource < ActiveRecord::Base
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
 
   before_destroy EnsureNotUsedBy.new(:hosts)
-  validates :name, :presence => true, :uniqueness => true,
-            :format => { :with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.") }
+  validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
   validate :ensure_provider_not_changed, :on => :update
   validates :provider, :presence => true, :inclusion => { :in => proc { self.providers } }
   validates :url, :presence => true

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -14,7 +14,7 @@ class Environment < ActiveRecord::Base
   has_many :hostgroups
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
 
-  validates :name, :uniqueness => true, :presence => true, :format => { :with => /\A[\w\d]+\Z/, :message => N_("is alphanumeric and cannot contain spaces") }
+  validates :name, :uniqueness => true, :presence => true, :alphanumeric => true
   has_many :template_combinations, :dependent => :destroy
   has_many :config_templates, :through => :template_combinations
 

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -12,7 +12,7 @@ class Hostgroup < ActiveRecord::Base
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many :hostgroup_classes
   has_many :puppetclasses, :through => :hostgroup_classes, :dependent => :destroy
-  validates :name, :format => { :with => /\A(\S+\s?)+\Z/, :message => N_("can't contain trailing white spaces.")}
+  validates :name, :presence => true
   validates :root_pass, :allow_blank => true, :length => {:minimum => 8, :message => _('should be 8 characters or more')}
   has_many :group_parameters, :dependent => :destroy, :foreign_key => :reference_id, :inverse_of => :hostgroup
   accepts_nested_attributes_for :group_parameters, :allow_destroy => true

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -29,7 +29,7 @@ class Operatingsystem < ActiveRecord::Base
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
   attr_name :to_label
   validates :minor, :numericality => {:greater_than_or_equal_to => 0}, :allow_nil => true, :allow_blank => true
-  validates :name, :presence => true, :format => {:with => /\A(\S+)\Z/, :message => N_("can't contain white spaces.")}
+  validates :name, :presence => true, :no_whitespace => true
   validates :description, :uniqueness => true, :allow_blank => true
   validates :password_hash, :inclusion => { :in => PasswordCrypt::ALGORITHMS }
   before_validation :downcase_release_name, :set_title

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -6,7 +6,7 @@ class Parameter < ActiveRecord::Base
 
   belongs_to_host :foreign_key => :reference_id
   include Authorizable
-  validates :name, :presence => true, :format => {:with => /\A\S*\Z/, :message => N_("can't contain white spaces")}
+  validates :name, :presence => true, :no_whitespace => true
   validates :reference_id, :presence => {:message => N_("parameters require an associated domain, operating system, host or host group")}, :unless => Proc.new {|p| p.nested or p.is_a? CommonParameter}
 
   scoped_search :on => :name, :complete_value => true

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -15,8 +15,7 @@ class Ptable < ActiveRecord::Base
   has_many :hostgroups
   has_and_belongs_to_many :operatingsystems
   validates :layout, :presence => true
-  validates :name, :presence => true, :uniqueness => true,
-            :format => {:with => /\A(\S+\s?)+\S\Z/, :message => N_("can't contain trailing white spaces.")}
+  validates :name, :presence => true, :uniqueness => true
   default_scope lambda { order('ptables.name') }
   validate_inclusion_in_families :os_family
 

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -23,7 +23,7 @@ class Puppetclass < ActiveRecord::Base
   has_many :class_params, :through => :environment_classes, :uniq => true,
     :source => :lookup_key, :conditions => 'environment_classes.lookup_key_id is NOT NULL'
   accepts_nested_attributes_for :class_params, :reject_if => lambda { |a| a[:key].blank? }, :allow_destroy => true
-  validates :name, :uniqueness => true, :presence => true, :format => {:with => /\A(\S+\s?)+\Z/, :message => N_("can't contain white spaces.") }
+  validates :name, :uniqueness => true, :presence => true, :no_whitespace => true
   audited :allow_mass_assignment => true
 
   alias_attribute :smart_variables, :lookup_keys

--- a/app/validators/alphanumeric_validator.rb
+++ b/app/validators/alphanumeric_validator.rb
@@ -1,0 +1,5 @@
+class AlphanumericValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, _("is alphanumeric and cannot contain spaces")) unless value =~ /\A\w+\Z/
+  end
+end

--- a/app/validators/no_whitespace_validator.rb
+++ b/app/validators/no_whitespace_validator.rb
@@ -1,0 +1,5 @@
+class NoWhitespaceValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, _("can't contain white spaces.")) if value =~ /\s/
+  end
+end

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -20,15 +20,6 @@ class ArchitectureTest < ActiveSupport::TestCase
     assert_not architecture.save
   end
 
-  test "name should not contain white spaces" do
-    architecture = Architecture.new :name => " i38  6 "
-    assert_not_empty architecture.name.squeeze(" ").tr(' ', '')
-    assert_not architecture.save
-
-    architecture.name.squeeze!(" ").tr!(' ', '')
-    assert architecture.save
-  end
-
   test "name should be unique" do
     architecture = Architecture.new :name => "i386"
     assert architecture.save

--- a/test/unit/environment_test.rb
+++ b/test/unit/environment_test.rb
@@ -21,16 +21,6 @@ class EnvironmentTest < ActiveSupport::TestCase
     end
   end
 
-  test "name should have no spaces" do
-    env = Environment.new :name => "f o o"
-    assert !env.valid?
-  end
-
-  test "name should be alphanumeric" do
-    env = Environment.new :name => "test&fail"
-    assert !env.valid?
-  end
-
   test "to_label should print name" do
     env = Environment.new :name => "foo"
     assert_equal env.to_label, env.name

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -10,13 +10,11 @@ class HostgroupTest < ActiveSupport::TestCase
     assert !host_group.save
   end
 
-  test "name can't contain trailing white spaces" do
+  test "name strips leading and trailing white spaces" do
     host_group = Hostgroup.new :name => " all    hosts in the     world    "
-    assert !host_group.name.squeeze(" ").empty?
-    assert !host_group.save
-
-    host_group.name.squeeze!(" ")
     assert host_group.save
+    assert !host_group.name.ends_with?(' ')
+    assert !host_group.name.starts_with?(' ')
   end
 
   test "name must be unique" do

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -21,16 +21,6 @@ class OperatingsystemTest < ActiveSupport::TestCase
     assert !operating_system.save
   end
 
-  test "name shouldn't contain white spaces" do
-    operating_system = Operatingsystem.new :name => " U bun     tu ", :major => "9"
-    assert !operating_system.name.squeeze(" ").tr(' ', '').empty?
-    assert !operating_system.save
-
-    operating_system.name.squeeze!(" ").tr!(' ', '')
-    assert !operating_system.name.include?(' ')
-    assert operating_system.save
-  end
-
   test "major should be numeric" do
     operating_system = Operatingsystem.new :name => "Ubuntu", :major => "9"
     assert operating_system.major.to_i != 0 if operating_system.major != "0"

--- a/test/unit/ptable_test.rb
+++ b/test/unit/ptable_test.rb
@@ -11,13 +11,12 @@ class PtableTest < ActiveSupport::TestCase
     assert !partition_table.save
   end
 
-  test "name can't contain trailing white spaces" do
+  test "name strips leading and trailing white spaces" do
     partition_table = Ptable.new :name => "   Archlinux        default  ", :layout => "any layout"
-    assert !partition_table.name.squeeze(" ").empty?
-    assert !partition_table.save
-
-    partition_table.name.squeeze!(" ")
     assert partition_table.save
+
+    assert !partition_table.name.ends_with?(' ')
+    assert !partition_table.name.starts_with?(' ')
   end
 
   test "layout can't be blank" do

--- a/test/unit/puppetclass_test.rb
+++ b/test/unit/puppetclass_test.rb
@@ -10,20 +10,18 @@ class PuppetclassTest < ActiveSupport::TestCase
     assert !puppet_class.save
   end
 
-  test "name can't contain trailing white spaces" do
-    puppet_class = Puppetclass.new :name => "   test     class   "
-    assert !puppet_class.name.squeeze(" ").empty?
-    assert !puppet_class.save
-
-    puppet_class.name.squeeze!(" ")
+  test "name strips leading and trailing white spaces" do
+    puppet_class = Puppetclass.new :name => "   testclass   "
     assert puppet_class.save
+    assert !puppet_class.name.ends_with?(' ')
+    assert !puppet_class.name.starts_with?(' ')
   end
 
   test "name must be unique" do
-    puppet_class = Puppetclass.new :name => "test class"
+    puppet_class = Puppetclass.new :name => "testclass"
     assert puppet_class.save
 
-    other_puppet_class = Puppetclass.new :name => "test class"
+    other_puppet_class = Puppetclass.new :name => "testclass"
     assert !other_puppet_class.save
   end
 

--- a/test/unit/validators/alphanumeric_validator_test.rb
+++ b/test/unit/validators/alphanumeric_validator_test.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+require 'test_helper'
+
+class AlphanumericValidatorTest < ActiveSupport::TestCase
+  setup do
+    class Validatable
+      include ActiveModel::Validations
+      validates :name, :alphanumeric => true
+      attr_accessor :name
+    end
+    @item = Validatable.new
+  end
+
+  test "validation passes on alphanumeric input" do
+    @item.name = "AlphaNumeric123"
+    assert @item.valid?
+  end
+
+  test "validation fails on whitespace in input" do
+    @item.name = "AlphaNumeric 123"
+    refute @item.valid?
+  end
+
+  test "validation fails on symbol in input" do
+    @item.name = "AlphaNumeric@123"
+    refute @item.valid?
+  end
+
+  test "validation fails on non-english character in input" do
+    @item.name = "AlphaNuméric123"
+    refute @item.valid?
+  end
+end

--- a/test/unit/validators/no_whitespace_validator_test.rb
+++ b/test/unit/validators/no_whitespace_validator_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class NoWhitespaceValidatorTest < ActiveSupport::TestCase
+  setup do
+    class Validatable
+      include ActiveModel::Validations
+      validates :name, :no_whitespace => true
+      attr_accessor :name
+    end
+    @item = Validatable.new
+    @item.name = "nowhitespace"
+  end
+
+  test "validation passes when no whitespace is present" do
+    assert @item.valid?
+  end
+
+  test "validation fails when whitespace is present" do
+    @item.name.insert(rand(@item.name.length),' ')
+    refute @item.valid?
+  end
+
+end


### PR DESCRIPTION
Also cleans up some unused validators looking for trailing whitespace
that is stripped by the StripWhitespaces concern.
Tried to make some sense from unmatching regexps and validation error
messages. Some validations might need a different regexp to check for what
they are actually supposed to validate - but atleast now messages fit
the actual validation.
