### PR TITLE
Fixes #8424 - Controller concerns are loaded twice

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,6 @@ module Foreman
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
     config.autoload_paths += Dir[ Rails.root.join('app', 'models', 'power_manager') ]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
-    config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/services"]
     config.autoload_paths += Dir["#{config.root}/app/observers"]
     config.autoload_paths += Dir["#{config.root}/app/mailers"]


### PR DESCRIPTION
In config/application.rb, we are adding the controller concerns folder twice to autoload_paths
