### PR TITLE
Fixes #4613 - Remove duplicate scoped search from taxonomies

### DIFF
--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -19,12 +19,6 @@ class Location < Taxonomy
     where(conditions)
   }
 
-  # This scoped search definition intentionally duplicates app/models/concerns/nested_ancestry_common.rb
-  # It's a temporary fix for scoped_search's issue with completing search strings for inherited attributes
-  # See http://projects.theforeman.org/issues/4613 for details
-  scoped_search :on => :title, :complete_value => :true, :default_order => true
-  scoped_search :on => :name, :complete_value => :true
-
   # returns self and parent parameters as a hash
   def parameters(include_source = false)
     hash = {}

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -19,12 +19,6 @@ class Organization < Taxonomy
     where(conditions)
   }
 
-  # This scoped search definition intentionally duplicates app/models/concerns/nested_ancestry_common.rb
-  # It's a temporary fix for scoped_search's issue with completing search strings for inherited attributes
-  # See http://projects.theforeman.org/issues/4613 for details
-  scoped_search :on => :title, :complete_value => :true, :default_order => true
-  scoped_search :on => :name, :complete_value => :true
-
   # returns self and parent parameters as a hash
   def parameters(include_source = false)
     hash = {}


### PR DESCRIPTION
We've been running on 2.7+ scoped_search for a while, this should be safe to remove.
