### PR TITLE
Fixes #8425 - n+1 query on audits index

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,7 +4,7 @@ class AuditsController < ApplicationController
   before_filter :setup_search_options, :only => :index
 
   def index
-    Audit.unscoped { @audits = resource_base.search_for(params[:search], :order => params[:order]).paginate :page => params[:page] }
+    Audit.unscoped { @audits = resource_base.includes(:user).search_for(params[:search], :order => params[:order]).paginate :page => params[:page] }
   end
 
   def show


### PR DESCRIPTION
Audits index include users who performed actions, and these are being
called with n+1 queries. Fix should be as simple as providing the
users through the controller with an includes.
