### PR TITLE
Fixes #8405 - Filter :interfaces_attributes when calculating templates_used

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -529,7 +529,7 @@ class HostsController < ApplicationController
 
   def process_taxonomy
     return head(:not_found) unless @location || @organization
-    @host = Host.new(params[:host])
+    @host = Host.new(params[:host].except(:interfaces_attributes))
     # revert compute resource to "Bare Metal" (nil) if selected
     # compute resource is not included taxonomy
     Taxonomy.as_taxonomy @organization, @location do
@@ -540,7 +540,7 @@ class HostsController < ApplicationController
   end
 
   def template_used
-    host      = Host.new(params[:host])
+    host      = Host.new(params[:host].except(:interfaces_attributes))
     templates = host.available_template_kinds(params[:provisioning])
     return not_found if templates.empty?
     render :partial => 'provisioning', :locals => { :templates => templates }

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -833,6 +833,25 @@ class HostsControllerTest < ActionController::TestCase
     assert_template 'review_before_build'
   end
 
+  test 'template_used returns templates' do
+    @host.setBuild
+    nic=FactoryGirl.create(:nic_managed, :host => @host)
+    attrs = @host.attributes
+    attrs[:interfaces_attributes] = nic.attributes
+    xhr :put, :template_used, {:provisioning => 'build', :host => attrs }, set_session_user
+    assert_response :success
+    assert_template :partial => '_provisioning'
+  end
+
+  test 'process_taxonomy renders a host from the params correctly' do
+    nic=FactoryGirl.create(:nic_managed, :host => @host)
+    attrs = @host.attributes
+    attrs[:interfaces_attributes] = nic.attributes
+    xhr :put, :process_taxonomy, { :host => attrs }, set_session_user
+    assert_response :success
+    assert_template :partial => '_form'
+  end
+
   private
   def initialize_host
     User.current = users(:admin)


### PR DESCRIPTION
This _might_ also affect the Host.new in #process_taxonomy too, but I've not tested that.
