### PR TITLE
Refs #8364 - removed javascript N+1 alerts

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,6 @@ Foreman::Application.configure do
 
   config.after_initialize do
     Bullet.enable = true
-    Bullet.alert = true
     Bullet.bullet_logger = true
     Bullet.console = true
     Bullet.rails_logger = true


### PR DESCRIPTION
The N+1 is a nifty plugin but these javascript alerts are _killing_ me and will
definitely ruin my today's demo which must be done in 2 minutes and 30 seconds
:-)

I beg for a quick merge. There is still the log and the footer box (which is
quite obvious and big). These are both non-modal but still useful.
