### PR TITLE
fixes #8357 - Set fog gem to version 1.25

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,5 +1,5 @@
 group :fog do
- gem 'fog', '1.24.0'
- gem 'fog-core', '1.24.0'
+ gem 'fog', '1.25.0'
+ gem 'fog-core', '1.25.0'
  gem 'unf', '>= 0.1.3'
 end


### PR DESCRIPTION
Version 1.25, with fixes to redmine issues: 
[Refactor libvirt reset method](http://projects.theforeman.org/issues/8356)
[Cannot select vSphere clusters in folders (foreman-vmware)](http://projects.theforeman.org/issues/5855)
[Better VMWare support for non-clusters setup](http://projects.theforeman.org/issues/1945)
[Unknown region: "eu-central-1"](http://projects.theforeman.org/issues/8429)
