### PR TITLE
Fixes #7908 - normalize mac before host get saved

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -80,6 +80,9 @@ module Host
       parser = FactParser.parser_for(type).new(facts)
 
       set_non_empty_values(parser, attributes_to_import_from_facts)
+      # descendents may add mac address to attributes_to_import_from_facts and
+      # facter sometimes return mac upcase so we have to normalize it ASAP (before host gets saved)
+      normalize_addresses
       set_interfaces(parser)
 
       parser

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -456,7 +456,6 @@ class Host::Managed < Host::Base
 
   def populate_fields_from_facts(facts = self.facts_hash, type = 'puppet')
     importer = super
-    normalize_addresses
     if Setting[:update_environment_from_facts]
       set_non_empty_values importer, [:environment]
     else


### PR DESCRIPTION
For some reason we save host without running valdiations when we import
attributes from facts. Therefore we have to take care of mac
normalization by ourselves. We have to normalize it just after setting
new value because save can occure anytime.
