### PR TITLE
fixes #8457 - auto complete search clear btn is now positioned correctly

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -417,5 +417,8 @@ table tr td:last-child {
       border-bottom: 1px solid #a94442;
     }
   }
+}
 
+.autocomplete-input {
+  display:inline-block !important;
 }


### PR DESCRIPTION
in non index pages which uses auto complete (e.g. filters) the clear button
was not inside the input field.
