### PR TITLE
fixes #8477 - usability improvements to template locking/defaults

### DIFF
--- a/app/helpers/config_templates_helper.rb
+++ b/app/helpers/config_templates_helper.rb
@@ -14,15 +14,46 @@ module ConfigTemplatesHelper
               'ace/mode-diff', 'diff', 'ace/mode-ruby', 'ace/keybinding-vim', 'ace/keybinding-emacs'
   end
 
+  def show_default?
+    rights = Taxonomy.enabled_taxonomies.select { |taxonomy| User.current.can?("create_#{taxonomy}".to_sym) }
+    rights.all? && !rights.blank?
+  end
+
+  def default_template_description
+    if locations_only?
+      _("Default templates are automatically added to new locations")
+    elsif organizations_only?
+      _("Default templates are automatically added to new organizations")
+    elsif locations_and_organizations?
+      _("Default templates are automatically added to new organizations and locations")
+    end
+  end
+
   def permitted_actions(config_template)
     actions = [display_link_if_authorized(_('Clone'), hash_for_clone_config_template_path(:id => config_template))]
 
     if config_template.locked?
-      # Default templates aren't actually unlockable - show the link as gray and no confirm dialog.
-      opts = config_template.default ? {:style => "color: gray"} : {:confirm =>  _("You are about to unlock a locked " \
-        "template -- this is for every organization and location that uses it. Continue?"), :style => "color: red"}
+      confirm = [
+        _("You are about to unlock a locked template."),
 
-      actions << display_link_if_authorized(_('Unlock'), hash_for_unlock_config_template_path(:id => config_template), opts)
+        if locations_only?
+          _("This is for every location that uses it.")
+        elsif organizations_only?
+          _("This is for every organization that uses it.")
+        elsif locations_and_organizations?
+          _("This is for every location and organization that uses it.")
+        end,
+
+        if config_template.vendor
+          _("It is not reccomended to unlock this template, as it is provided by %{vendor} and may be overwritten. Please consider cloning it instead." %
+            {:vendor => config_template.vendor})
+        end,
+
+        _("Continue?")
+      ].compact
+
+      actions << display_link_if_authorized(_('Unlock'), hash_for_unlock_config_template_path(:id => config_template),
+                                            {:confirm => confirm.join(" "), :style => 'color: red'})
 
     else
       actions << display_link_if_authorized(_('Lock'), hash_for_lock_config_template_path(:id => config_template))
@@ -30,6 +61,20 @@ module ConfigTemplatesHelper
          merge(:auth_object => config_template, :authorizer => authorizer, :permission => 'destroy_templates'),
          :confirm => _("Delete %s?") % config_template)
     end
+  end
+
+  private
+
+  def locations_only?
+    SETTINGS[:locations_enabled] && !SETTINGS[:organizations_enabled]
+  end
+
+  def organizations_only?
+    SETTINGS[:organizations_enabled] && !SETTINGS[:locations_enabled]
+  end
+
+  def locations_and_organizations?
+    SETTINGS[:locations_enabled] && SETTINGS[:organizations_enabled]
   end
 end
 

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -72,6 +72,10 @@ class Taxonomy < ActiveRecord::Base
     end
   end
 
+  def self.enabled_taxonomies
+    %w(locations organizations).select { |taxonomy| SETTINGS["#{taxonomy}_enabled".to_sym] }
+  end
+
   def self.ignore?(taxable_type)
     Array.wrap(self.current).each{ |current|
       return true if current.ignore?(taxable_type)

--- a/app/views/config_templates/_form.html.erb
+++ b/app/views/config_templates/_form.html.erb
@@ -12,6 +12,10 @@
       <div class="tab-pane active" id="primary">
         <%= text_f f, :name, :disabled => @config_template.locked? %>
 
+        <% if show_default? %>
+          <%= checkbox_f f, :default, :label=>_('Default'), :help_block => default_template_description %>
+        <% end -%>
+
         <% if @config_template.locked? -%>
         <%= alert :class => 'alert-warning', :header => '',
             :text  => icon_text("warning-sign", (_("Warning: This template is locked. You may only change the associations. Please %s it to customize.") %

--- a/db/migrate/20141203082104_make_templates_default.rb
+++ b/db/migrate/20141203082104_make_templates_default.rb
@@ -1,0 +1,28 @@
+class MakeTemplatesDefault < ActiveRecord::Migration
+  def up
+    update_templates_default_to true
+  end
+
+  def down
+    update_templates_default_to false
+  end
+
+  private
+
+  def update_templates_default_to(flag)
+    templates = ["PXELinux global default", "PXELinux default local boot", "PXELinux default memdisk", "PXEGrub default local boot",
+      "Alterator default", "Alterator default finish", "Alterator default PXELinux", "AutoYaST default",
+      "AutoYaST SLES default", "AutoYaST default PXELinux", "FreeBSD (mfsBSD) finish", "FreeBSD (mfsBSD) provision",
+      "FreeBSD (mfsBSD) PXELinux", "Grubby default", "Jumpstart default", "Jumpstart default finish", "Jumpstart default PXEGrub",
+      "Kickstart default", "Kickstart RHEL default", "Kickstart default finish", "Kickstart default PXELinux", "Kickstart default iPXE",
+      "Kickstart default user data", "Preseed default", "Preseed default finish", "Preseed default PXELinux", "Preseed default iPXE",
+      "Preseed default user data", "UserData default", "WAIK default PXELinux", "Junos default SLAX", "Junos default ZTP config"]
+
+    templates.each do |template|
+      if (template = ConfigTemplate.find_by_name(template))
+        template.update_attribute(:default, flag)
+      end
+    end
+  end
+
+end

--- a/db/seeds.d/07-config_templates.rb
+++ b/db/seeds.d/07-config_templates.rb
@@ -62,6 +62,9 @@ ConfigTemplate.without_auditing do
   ].each do |input|
     next if ConfigTemplate.find_by_name(input[:name])
     next if audit_modified? ConfigTemplate, input[:name]
+
+    input.merge!(:default => true)
+
     t = ConfigTemplate.create({
       :snippet  => false,
       :template => File.read(File.join("#{Rails.root}/app/views/unattended", input.delete(:source)))

--- a/test/unit/config_template_test.rb
+++ b/test/unit/config_template_test.rb
@@ -103,13 +103,14 @@ class ConfigTemplateTest < ActiveSupport::TestCase
     refute_with_errors tmplt.destroy, tmplt, :base, /locked/
   end
 
-  test "should not unlock a vendor-provided default template" do
+  test "should not unlock a template if not allowed" do
     tmplt = ConfigTemplate.create :name => "Vendor Template", :template => "provision test",
                                   :template_kind => template_kinds(:provision), :default => true,
                                   :vendor => "Katello"
     tmplt.update_attribute(:locked, true)
+    User.current = FactoryGirl.create(:user)
     tmplt.locked = false
-    refute_valid tmplt, :base, /Katello/
+    refute_valid tmplt, :base, /not authorized/
   end
 
   test "should change a locked template while in rake" do


### PR DESCRIPTION
- In practice, locking templates without the ability to unlock them doesn't seem to work (see the foreman_discovery issue that would be fixed by #7480).
- Provide a warning for templates that are shipped by default by plugins
- Exposes the 'default' option to users so they can mark templates to be automatically seeded or not
- Mark foreman templates as default on new installs

If this or something like this is taken, I can remove the code from Katello seeds that touches Foreman templates.
