### PR TITLE
fixes #8465 - Add Digital Ocean Support

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -15,6 +15,7 @@ class ComputeResource < ActiveRecord::Base
     'Openstack' => 'Foreman::Model::Openstack',
     'Rackspace' => 'Foreman::Model::Rackspace',
     'GCE'       => 'Foreman::Model::GCE',
+    'Digitalocean'       => 'Foreman::Model::Digitalocean',
   }
 
   validates_lengths_from_database

--- a/app/models/compute_resources/foreman/model/digitalocean.rb
+++ b/app/models/compute_resources/foreman/model/digitalocean.rb
@@ -2,9 +2,9 @@ module Foreman::Model
   class Digitalocean < ComputeResource
     has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy
     delegate :flavors, :to => :client
-    delegate :regions, :to => :client
 
     validates :user, :password, :presence => true
+    #before_create :test_connection
 
     # Not sure why it would need a url, but OK (copied from ec2)
     alias_attribute :region, :url
@@ -42,9 +42,18 @@ module Foreman::Model
       client.images
     end
 
+    def regions
+      return [] if user.blank? or password.blank?
+      client.regions
+    end
+
     def test_connection(options = {})
       super
-      errors[:user].empty? and errors[:password].empty? and regions
+      errors[:user].empty? and errors[:password].empty? and regions.count
+#    rescue StandardError => e
+#      errors[:base] << e
+#    rescue Excon::Error => e
+#      errors[:base] << e.response.body
     rescue Excon::Errors::Unauthorized => e
       errors[:base] << e.response.body
     rescue Fog::Compute::DigitalOcean::Error => e

--- a/app/models/compute_resources/foreman/model/digitalocean.rb
+++ b/app/models/compute_resources/foreman/model/digitalocean.rb
@@ -1,0 +1,98 @@
+module Foreman::Model
+  class Digitalocean < ComputeResource
+    has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy
+    delegate :flavors, :to => :client
+    delegate :regions, :to => :client
+
+    validates :user, :password, :presence => true
+
+    # Not sure why it would need a url, but OK (copied from ec2)
+    alias_attribute :region, :url
+
+    def to_label
+      "#{name} (#{provider_friendly_name})"
+    end
+
+    def provided_attributes
+      super.merge({ :ip => :public_ip_address })
+    end
+
+    def self.model_name
+      ComputeResource.model_name
+    end
+
+    def capabilities
+      [:image]
+    end
+
+    def find_vm_by_uuid(uuid)
+      client.servers.get(uuid)
+    rescue Fog::Compute::DigitalOcean::Error
+      raise(ActiveRecord::RecordNotFound)
+    end
+
+    def create_vm(args = { })
+      super(args)
+    rescue Fog::Errors::Error => e
+      logger.error "Unhandled DigitalOcean error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      raise e
+    end
+
+    def available_images
+      client.images
+    end
+
+    def test_connection(options = {})
+      super
+      errors[:user].empty? and errors[:password].empty? and regions
+    rescue Excon::Errors::Unauthorized => e
+      errors[:base] << e.response.body
+    rescue Fog::Compute::DigitalOcean::Error => e
+      errors[:base] << e.message
+    end
+
+    def destroy_vm(uuid)
+      vm = find_vm_by_uuid(uuid)
+      vm.destroy if vm
+      true
+    end
+
+    # not supporting update at the moment
+    def update_required?(old_attrs, new_attrs)
+      false
+    end
+
+    def self.provider_friendly_name
+      "Digital Ocean"
+    end
+
+    def associated_host(vm)
+      Host.authorized(:view_hosts, Host).where(:ip => [vm.public_ip_address, vm.private_ip_address]).first
+    end
+
+    def user_data_supported?
+      true
+    end
+
+    def default_region_name
+      @default_region_name ||= client.regions.get(region.to_i).try(:name)
+    end
+
+    private
+
+    def client
+      @client ||= Fog::Compute.new(
+        :provider => "DigitalOcean",
+        :digitalocean_client_id => user,
+        :digitalocean_api_key => password,
+      )
+    end
+
+    def vm_instance_defaults
+      super.merge(
+        :flavor_id => client.flavors.first.id
+      )
+    end
+
+  end
+end

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -49,6 +49,12 @@ begin
   require 'fog/rackspace/models/compute_v2/server'
   Fog::Compute::RackspaceV2::Server.send(:include, FogExtensions::RackspaceV2::Server)
 
+  require 'fog/digitalocean'
+  require 'fog/digitalocean/models/compute/image'
+  Fog::Compute::DigitalOcean::Image.send(:include, FogExtensions::DigitalOcean::Image)
+  require 'fog/digitalocean/models/compute/server'
+  Fog::Compute::DigitalOcean::Server.send(:include, FogExtensions::DigitalOcean::Server)
+
 rescue LoadError
   Rails.logger.info "Fog is not installed - unable to manage compute resources"
 rescue => exception

--- a/app/models/concerns/fog_extensions/digital_ocean/image.rb
+++ b/app/models/concerns/fog_extensions/digital_ocean/image.rb
@@ -1,0 +1,10 @@
+module FogExtensions
+  module DigitalOcean
+    module Image
+      extend ActiveSupport::Concern
+      def to_label
+        "#{distribution} #{name}"
+      end
+    end
+  end
+end

--- a/app/models/concerns/fog_extensions/digital_ocean/image.rb
+++ b/app/models/concerns/fog_extensions/digital_ocean/image.rb
@@ -2,9 +2,30 @@ module FogExtensions
   module DigitalOcean
     module Image
       extend ActiveSupport::Concern
-      def to_label
-        "#{distribution} #{name}"
+      
+      attr_accessor :os_version
+
+      # Override attribute :name
+      included do
+        define_method :name, instance_method(:full_name)
+        define_method :name=, instance_method(:full_name=)
       end
+
+      def full_name= value
+        self.os_version = value
+      end
+
+      def full_name
+        requires :distribution, :os_version
+        "#{distribution} #{os_version}"
+      end
+
+      # Attempt guessing arch based on the name from digital ocean
+      def arch
+        requires :os_version
+        os_version.end_with?("x64") ? "x86_64" : ( os_version.end_with?("x32") ? "i386" : nil )
+      end
+
     end
   end
 end

--- a/app/models/concerns/fog_extensions/digital_ocean/server.rb
+++ b/app/models/concerns/fog_extensions/digital_ocean/server.rb
@@ -1,0 +1,35 @@
+module FogExtensions
+  module DigitalOcean
+    module Server
+      extend ActiveSupport::Concern
+
+      def vm_description
+        flavor.try(:name)
+      end
+
+      def flavor
+        requires :flavor_id
+        @flavor ||= service.flavors.get(flavor_id.to_i)
+      end
+
+      def image
+        requires :image_id
+        @image ||= service.images.get(image_id)
+      end
+
+      def region
+        requires :region_id
+        @region ||= service.regions.get(region_id)
+      end
+
+      def imageName
+        "#{image.distribution} #{image.name}"
+      end
+
+      def ip_addresses
+        mage[public_ip_address, private_ip_address].flatten.select(&:present?)
+      end
+
+    end
+  end
+end

--- a/app/models/concerns/fog_extensions/digital_ocean/server.rb
+++ b/app/models/concerns/fog_extensions/digital_ocean/server.rb
@@ -22,10 +22,6 @@ module FogExtensions
         @region ||= service.regions.get(region_id)
       end
 
-      def imageName
-        "#{image.distribution} #{image.name}"
-      end
-
       def ip_addresses
         mage[public_ip_address, private_ip_address].flatten.select(&:present?)
       end

--- a/app/models/concerns/fog_extensions/digital_ocean/server.rb
+++ b/app/models/concerns/fog_extensions/digital_ocean/server.rb
@@ -14,16 +14,16 @@ module FogExtensions
 
       def image
         requires :image_id
-        @image ||= service.images.get(image_id)
+        @image ||= service.images.get(image_id.to_i)
       end
 
       def region
         requires :region_id
-        @region ||= service.regions.get(region_id)
+        @region ||= service.regions.get(region_id.to_i)
       end
 
       def ip_addresses
-        mage[public_ip_address, private_ip_address].flatten.select(&:present?)
+        [public_ip_address, private_ip_address].flatten.select(&:present?)
       end
 
     end

--- a/app/views/compute_resources/form/_digitalocean.html.erb
+++ b/app/views/compute_resources/form/_digitalocean.html.erb
@@ -1,0 +1,12 @@
+<%= text_f f, :user, :label => _("Client ID") %>
+<%= password_f f, :password, :label => _("API Key") %>
+
+<% regions = f.object.regions rescue [] %>
+
+<div id='region_selection'>
+<%= select_f(f, :region, regions, :id, :name, {}, {:label => _('Default Region'), :disabled => regions.empty?,
+                 :help_inline => link_to_function(regions.empty? ? _("Load Regions") : _("Test Connection"), "testConnection(this)",
+                 :class => "btn + #{regions.empty? ? "btn-default" : "btn-success"}",
+                 :'data-url' => test_connection_compute_resources_path) + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
+</div>
+

--- a/app/views/compute_resources/show/_digitalocean.html.erb
+++ b/app/views/compute_resources/show/_digitalocean.html.erb
@@ -1,0 +1,4 @@
+<tr>
+  <td><%= _("Default Region") %></td>
+  <td><%= @compute_resource.default_region_name %></td>
+</tr>

--- a/app/views/compute_resources_vms/form/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/form/_digitalocean.html.erb
@@ -1,0 +1,11 @@
+<%= select_f f, :flavor_id, compute_resource.flavors, :id, :name, {}, {:label => _('Flavor')}  %>
+<%
+   arch ||= nil ; os ||= nil
+   images = possible_images(compute_resource, arch, os)
+   images = compute_resource.available_images if images.empty?
+   regions = compute_resource.regions
+   f.object.region_id = compute_resource.region
+%>
+
+<div id='image_selection'><%= select_f f, :image_id, images, :id, :to_label, { :include_blank => (images.empty? || images.size == 1) ? false : _('Please Select an Image') }, { :label => ('Image'), :disabled => images.empty? } %></div>
+<div id='region_selection'><%= select_f f, :region_id, regions, :id, :name, {}, { :label => ('Region'), :disabled => images.empty?} %></div>

--- a/app/views/compute_resources_vms/index/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/index/_digitalocean.html.erb
@@ -12,7 +12,7 @@
   <% @vms.each do |vm| %>
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer) %></td>
-      <td><%= vm.imageName %></td>
+      <td><%= vm.image.name %></td>
       <td><%= vm.flavor.name %></td>
       <td><%= vm.region.name %></td>
       <td> <span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %></span> </td>

--- a/app/views/compute_resources_vms/index/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/index/_digitalocean.html.erb
@@ -1,0 +1,26 @@
+<table class="table table-bordered" data-table='inline'>
+  <thead>
+    <tr>
+      <th><%= _('Name') %></th>
+      <th><%= _('Image') %></th>
+      <th><%= _('Type') %></th>
+      <th><%= _('Region') %></th>
+      <th><%= _('State') %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <% @vms.each do |vm| %>
+    <tr>
+      <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer) %></td>
+      <td><%= vm.imageName %></td>
+      <td><%= vm.flavor.name %></td>
+      <td><%= vm.region.name %></td>
+      <td> <span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %></span> </td>
+      <td>
+        <%= action_buttons(
+                vm_power_action(vm, authorizer),
+                display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.id).merge(:auth_object => @compute_resource, :authorizer => authorizer))) %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/compute_resources_vms/show/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/show/_digitalocean.html.erb
@@ -7,7 +7,7 @@
     <%= prop :state %>
     <%= prop :created_at, 'Created' %>
     <%= prop :image_id, 'Image ID' %>
-    <%= prop :imageName, 'Image' %>
+    <%= prop @vm.image.name, 'Image' %>
     <%= prop :flavor_id, 'Flavor ID' %>
     <%= prop :vm_description, "Type (flavor)" %>
   </table>

--- a/app/views/compute_resources_vms/show/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/show/_digitalocean.html.erb
@@ -1,0 +1,14 @@
+<% title @vm.name %>
+<div class='col-md-12'>
+  <table class="table table-bordered table-striped">
+    <tr><th colspan="2">Properties</th></tr>
+    <%= prop :public_ip_address %>
+    <%= prop :private_ip_address %>
+    <%= prop :state %>
+    <%= prop :created_at, 'Created' %>
+    <%= prop :image_id, 'Image ID' %>
+    <%= prop :imageName, 'Image' %>
+    <%= prop :flavor_id, 'Flavor ID' %>
+    <%= prop :vm_description, "Type (flavor)" %>
+  </table>
+</div>

--- a/app/views/images/form/_digitalocean.html.erb
+++ b/app/views/images/form/_digitalocean.html.erb
@@ -1,0 +1,3 @@
+<%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= image_field(f) %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ SETTINGS[:libvirt] = defined?(::Fog) && defined?(::Libvirt)
 SETTINGS[:ovirt] = defined?(::Fog) && defined?(::OVIRT)
 SETTINGS[:vmware] = defined?(::Fog) && defined?(::RbVmomi)
 SETTINGS[:gce] = defined?(::Fog) && defined?(::Google::APIClient::VERSION)
-SETTINGS[:openstack] = SETTINGS[:rackspace] = SETTINGS[:ec2] = !!defined?(::Fog)
+SETTINGS[:openstack] = SETTINGS[:rackspace] = SETTINGS[:ec2] = SETTINGS[:digitalocean] = !!defined?(::Fog)
 
 require File.expand_path('../../lib/foreman.rb', __FILE__)
 require File.expand_path('../../lib/timed_cached_store.rb', __FILE__)

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -43,6 +43,12 @@ FactoryGirl.define do
       region 'IAD'
     end
 
+    trait :digitalocean do
+      provider 'Digitalocean'
+      user 'rsuser'
+      password 'rspassword'
+    end
+
     trait :vmware do
       provider 'Vmware'
       user 'vuser'


### PR DESCRIPTION
Adds the necessary shims to support Digital Ocean as a Compute Resource. This also _properly_ supports regions at the VM level instead of the compute resource level.

This should fix my bug #8465 to add support.

I am not sure what the next steps are.

~tommy
