### PR TITLE
fixes #8510 - ignore gettext load failures in production without it

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -1,44 +1,50 @@
-require "fast_gettext"
-require "gettext_i18n_rails"
-require "gettext_i18n_rails/tasks"
-require "gettext_i18n_rails_js/tasks"
-require File.expand_path("../../../lib/foreman/gettext/support.rb", __FILE__)
-
-namespace :gettext do
-
-  # redefine locale path to be taken from current directory (for plugins)
-  def locale_path
-    path = FastGettext.translation_repositories[text_domain].instance_variable_get(:@options)[:path] rescue nil
-    path || "locale"
-  end
-
-  # redefine file globs for Foreman
-  def files_to_translate
-    Dir.glob("{app,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js,rabl}")
-  end
-end
-
-desc 'Extract plugin strings - called via rake plugin:gettext[plugin_name]'
-task 'plugin:gettext', :engine do |t, args|
-
-  @engine = "#{args[:engine].camelize}::Engine".constantize
-  @engine_root = @engine.root
+begin
+  require "fast_gettext"
+  require "gettext_i18n_rails"
+  require "gettext_i18n_rails/tasks"
+  require "gettext_i18n_rails_js/tasks"
+  require File.expand_path("../../../lib/foreman/gettext/support.rb", __FILE__)
 
   namespace :gettext do
 
+    # redefine locale path to be taken from current directory (for plugins)
     def locale_path
-      "#{@engine_root}/locale"
+      path = FastGettext.translation_repositories[text_domain].instance_variable_get(:@options)[:path] rescue nil
+      path || "locale"
     end
 
+    # redefine file globs for Foreman
     def files_to_translate
-      Dir.glob("#{@engine.root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
+      Dir.glob("{app,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js,rabl}")
     end
-
   end
 
-  Foreman::Gettext::Support.add_text_domain args[:engine], "#{@engine_root}/locale"
-  ENV['TEXTDOMAIN'] = args[:engine]
+  desc 'Extract plugin strings - called via rake plugin:gettext[plugin_name]'
+  task 'plugin:gettext', :engine do |t, args|
 
-  Rake::Task['gettext:find'].invoke
+    @engine = "#{args[:engine].camelize}::Engine".constantize
+    @engine_root = @engine.root
 
+    namespace :gettext do
+
+      def locale_path
+        "#{@engine_root}/locale"
+      end
+
+      def files_to_translate
+        Dir.glob("#{@engine.root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
+      end
+
+    end
+
+    Foreman::Gettext::Support.add_text_domain args[:engine], "#{@engine_root}/locale"
+    ENV['TEXTDOMAIN'] = args[:engine]
+
+    Rake::Task['gettext:find'].invoke
+
+  end
+rescue LoadError
+  # gettext unavailable
+  # this can happen as gettext is a development-only dependency used in
+  # gettext_i18n_rails*/tasks for extraction, but not generally runtime
 end


### PR DESCRIPTION
gettext is only used when loading gettext_i18n_rails 1.x rake tasks, so it's
only marked as a development dependency.  In production we won't have it, but
still ship this .rake file, so permit loading to fail.
