### PR TITLE
fixes #8463 - remove i18n bundler group as it isn't optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,8 @@ gem 'friendly_id', '~> 4.0'
 gem 'secure_headers', '~> 1.3'
 gem 'safemode', '~> 1.2'
 gem 'ruby_parser', '3.1.1'
-
+gem 'fast_gettext', '~> 0.8'
+gem 'gettext_i18n_rails', '~> 1.0'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -10,8 +10,9 @@ group :assets do
   gem 'flot-rails', '0.0.3'
   gem 'quiet_assets', '~> 1.0'
   gem 'gettext_i18n_rails_js', '~> 0.0', '>= 0.0.8'
+  # unspecified dep of gettext_i18n_rails_js
+  #   https://github.com/nubis/gettext_i18n_rails_js/pull/23
   gem 'gettext', '~> 3.1', :require => false
-  gem 'locale', '~> 2.0'
   gem 'multi-select-rails', '~> 0.9'
   gem 'gridster-rails', '~> 0.1'
   gem 'jquery_pwstrength_bootstrap', '~> 1.2'

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -5,7 +5,6 @@ group :development do
 
   # for generating i18n files
   gem 'gettext', '~> 3.1', :require => false
-  gem 'locale', '~> 2.0'
 
   # for generating foreign key migrations
   gem 'immigrant', '~> 0.1'

--- a/bundler.d/i18n.rb
+++ b/bundler.d/i18n.rb
@@ -1,5 +1,0 @@
-group :i18n do
-  gem 'fast_gettext', '~> 0.8'
-  gem 'gettext_i18n_rails', '~> 1.0'
-  gem 'gettext_i18n_rails_js', '~> 0.0', '>= 0.0.8'
-end


### PR DESCRIPTION
fast_gettext/gettext_i18n_rails are both runtime dependencies, not optional.
gettext_i18n_rails_js moved to assets as it provides no runtime functionality.
