### PR TITLE
8498 Add the ability to access root_pass (hashed root password) for finish scripts

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -27,7 +27,7 @@ class UnattendedController < ApplicationController
   before_filter :handle_ca, :only => PROVISION_URLS
   before_filter :handle_realm, :only => PROVISION_URLS
   # load "helper" variables to be available in the templates
-  before_filter :load_template_vars, :only => PROVISION_URLS
+  before_filter :load_template_vars, :only => [PROVISION_URLS, FINISH_URLS]
   before_filter :pxe_config, :only => CONFIG_URLS
   # all of our requests should be returned in text/plain
   after_filter :set_content_type
@@ -49,6 +49,7 @@ class UnattendedController < ApplicationController
     return head(:not_found) unless template and @host
 
     load_template_vars if template.template_kind.name == 'provision'
+    load_template_vars if template.template_kind.name == 'finish'
     safe_render template.template
   end
 

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -109,9 +109,9 @@ module HostCommon
   def crypt_root_pass
     unless root_pass.empty?
       unencrypted_pass = root_pass
-      self.root_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass :
+      self.root_pass = !!(unencrypted_pass.match('^\$\d+\$.+\$.+')) ? unencrypted_pass :
           (operatingsystem.nil? ? PasswordCrypt.passw_crypt(unencrypted_pass) : PasswordCrypt.passw_crypt(unencrypted_pass, operatingsystem.password_hash))
-      self.grub_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)
+      self.grub_pass = !!(unencrypted_pass.match('^\$\d+\$.+\$.+')) ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)
     end
   end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -60,7 +60,7 @@ class Host::Managed < Host::Base
       :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
       :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :primary_interface, :interfaces,
-      :has_primary_interface?, :bond_interfaces, :interfaces_with_identifier, :managed_interfaces
+      :has_primary_interface?, :bond_interfaces, :interfaces_with_identifier, :managed_interfaces, :root_pass
   end
 
   attr_reader :cached_host_params

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -81,7 +81,7 @@ class Hostgroup < ActiveRecord::Base
     allow :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
       :environment, :ptable, :url_for_boot, :params, :puppetproxy, :param_true?,
       :param_false?, :puppet_ca_server, :indent, :os, :arch, :domain, :subnet,
-      :realm
+      :realm, :root_pass
   end
 
   #TODO: add a method that returns the valid os for a hostgroup

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -24,11 +24,13 @@
 
   <%= textarea_f f, :disk, :size => "col-md-8", :rows => "4",
            :help_block => _("What ever text(or ERB template) you use in here, would be used as your OS disk layout options If you want to use the partition table option, delete all of the text from this field") %>
-  <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more"), :required => true %>
 </div>
 
 <div id='image_provisioning' <%= display? !@host.image_build? %> >
 
+</div>
+<div id='root_password'>
+  <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more"), :required => true %>
 </div>
 <!-- this section is used for displaying the provisioning scripts-->
 <div class="form-group">

--- a/app/views/unattended/kickstart/finish.erb
+++ b/app/views/unattended/kickstart/finish.erb
@@ -1,3 +1,4 @@
+#!/bin/bash
 <%#
 kind: finish
 name: Kickstart default finish
@@ -18,6 +19,11 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
 %>
+
+<% if @host.provision_method == 'image' &&  ! root_pass.blank? -%>
+# Install the root password
+echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
+<% end -%>
 
 <% if rhel_compatible -%>
 <%= snippet "epel" -%>


### PR DESCRIPTION
This fixes the ability to access the root_pass attribute, and ensures that its loaded. It also includes an updated default kickstart template that actually _sets_ the root password on a "image" based install. (with the assumption that the root password will be set by the provision script otherwise so setting it again would be unnecessary).

Since the "finish" script will not get loaded automatically, in order to test this, add the following to a finish script for a centos/rhel/fedora based install.. I am not sure if it works on debian or gentoo based images.

```
<% if @host.provision_method == 'image' &&  ! root_pass.blank? -%>
# Install the root password
echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
<% end -%>
```
