### PR TITLE
fixes #8356 - refactor reset method for libvirt

### DIFF
--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -25,8 +25,8 @@ module FogExtensions
       end
 
       def reset
-        # @TODO: change to poweroff && start upon fix for LibVirt on Fog gem.
-        service.vm_action(uuid, :reset)
+        poweroff
+        start
       end
 
       def vm_description


### PR DESCRIPTION
Uses libvirts methods to restart
