### PR TITLE
fixes #8527 - pin rest-client to version compatible with current rbovirt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.21'
 gem 'json', '~> 1.5'
-gem 'rest-client', '~> 1.6', :require => 'rest_client'
+gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord', '3.0.0'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '~> 2.0'

--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem 'rbovirt', '>= 0.0.24'
+  gem 'rbovirt', '~> 0.0.24'
 end


### PR DESCRIPTION
Pin rbovirt a bit in preparation for a jump in versions.
