### PR TITLE
[TEST] fixes #8539 - refactoring a test to work for both GNU libc and Darwin libc

### DIFF
--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -754,21 +754,21 @@ context "location or organizations are not enabled" do
     assert_equal h.root_pass, Setting.root_pass
   end
 
-  test "should generate a random salt when saving root pw" do
-    h = FactoryGirl.create(:host, :managed)
-    h.hostgroup = nil
-    h.root_pass = "xybxa6JUkz63w"
-    assert h.save!
-    first = h.root_pass
+  test "should crypt the password and update it in the database" do
+    unencrypted_password = "xybxa6JUkz63w"
+    host = FactoryGirl.create(:host, :managed)
+    host.hostgroup = nil
+    host.root_pass = unencrypted_password
+    assert host.save!
+    first_password = host.root_pass
 
-    # Check it's a $.$....$...... enhanced style password
-    assert_equal 4, first.split('$').count
-    assert first.split('$')[2].size >= 8
+    # Make sure that the password gets encrypted in the DB, we don't care how it does that
+    refute first_password.include?(unencrypted_password)
 
     # Check it changes
-    h.root_pass = "12345678"
-    assert h.save
-    assert_not_equal first.split('$')[2], h.root_pass.split('$')[2]
+    host.root_pass = "12345678"
+    assert host.save
+    assert_not_equal first_password, host.root_pass
   end
 
   test "should pass through existing salt when saving root pw" do


### PR DESCRIPTION
Ruby's String#crypt method relies on the libc implementation of crypt. Mac OS does it differently, thus the output hashed string has a different structure.
see http://apidock.com/ruby/String/crypt#1075-String-crypt-uses-your-platform-s-native-implementation for an example.

The workaround for this is relatively simple - if we're on a mac, expect 2 parts, otherwise, stick with the original 4. The same logic goes towards the place in the array which should be tested for updated password
