### PR TITLE
Refs #3860 - add Kernel.rand to safemode functions

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -6,7 +6,8 @@ module Foreman
     ALLOWED_HELPERS = [ :foreman_url, :grub_pass, :snippet, :snippets,
                         :snippet_if_exists, :ks_console, :root_pass,
                         :multiboot, :jumpstart_path, :install_path, :miniroot,
-                        :media_path, :param_true?, :param_false?, :match, :indent ]
+                        :media_path, :param_true?, :param_false?, :match, :indent,
+                        :rand]
 
     ALLOWED_VARIABLES = [ :arch, :host, :osver, :mediapath, :mediaserver, :static,
                           :repos, :dynamic, :kernel, :initrd,


### PR DESCRIPTION
This is handy function that is needed for auto-provisioning of discovered
hosts: https://github.com/theforeman/foreman_discovery/pull/98
