### PR TITLE
fixes #8601 - cloudinitlike for vsphere

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -13,6 +13,10 @@ module Foreman::Model
       ComputeResource.model_name
     end
 
+    def user_data_supported?
+      true
+    end
+
     def capabilities
       [:build, :image]
     end

--- a/app/views/images/form/_vmware.html.erb
+++ b/app/views/images/form/_vmware.html.erb
@@ -1,3 +1,4 @@
 <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
 <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
 <%= image_field(f, :label => _("Image path"), :help_inline => _("Path to template, relative to datacenter (e.g. My templates/RHEL 6)")) %>


### PR DESCRIPTION
this is a proposed patch to enable user_data type like cloudinit for vsphere
there is an associated pull request on fog side https://github.com/fog/fog/pull/3317
as the idea is to convert user_data string to a hash parsed later as a customisationspec template (vsphere specific)
