### PR TITLE
fixes #8597 - friendly ID should escape slashes for URL parameters

### DIFF
--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -4,8 +4,7 @@
 # modified version of one of these in textual form
 class Ptable < ActiveRecord::Base
   include Authorizable
-  extend FriendlyId
-  friendly_id :name
+  include Parameterizable::ByIdName
   include ValidateOsFamily
   audited :allow_mass_assignment => true
 

--- a/test/integration/ptable_test.rb
+++ b/test/integration/ptable_test.rb
@@ -22,4 +22,16 @@ class PtableTest < ActionDispatch::IntegrationTest
     assert_submit_button(ptables_path)
     assert page.has_link? 'debian default'
   end
+
+  test "make sure that ptable names with slashes work" do
+    visit ptables_path
+    click_link "ubuntu default"
+    fill_in "ptable_name", :with => "debian default /dev/sda"
+    fill_in "ptable_layout", :with => "d-i partman-auto/disk string /dev/sda\nd-i"
+    assert_submit_button(ptables_path)
+
+    assert page.has_link? 'debian default /dev/sda'
+    click_link "debian default /dev/sda"
+    assert page.has_field?("ptable_name") #not 404
+  end
 end


### PR DESCRIPTION
just a short explanation - there was a similar PR on friendly id, to which they answered - hey, why not use sluggable? (which means another table in the DB, just for fetching the ID)
there's also an option to sanitise names, which means we don't let slashes in the name (feels intrusive to me, and doesn't solve current broken items)

I think that this monkey patch fixes it in the best possible way - we are able to both keep current (broken) data and have it working, we don't need to add a database table which might break current friendly ids, and this seems like the most performant option of the ones I see.
