### PR TITLE
refs #4521 - Openstack Compute Resource: Boot from Volume on new Host Creation

### DIFF
--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -6,6 +6,7 @@ module FogExtensions
       included do
         alias_method_chain :security_groups, :no_id
         attr_reader :nics
+	attr_accessor :boot_from_volume, :size_gb
         attr_writer :security_group, :network # floating IP
       end
 
@@ -46,6 +47,14 @@ module FogExtensions
         return [] if id.nil?
 
         security_groups_without_no_id
+      end
+
+      def boot_from_volume
+        attr[:boot_from_volume]
+      end
+
+      def size_gb
+        attr[:size_gb]
       end
 
       def network

--- a/app/views/compute_resources_vms/form/openstack/_base.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_base.html.erb
@@ -15,4 +15,5 @@
 <%= select_f f, :nics, compute_resource.internal_networks, :id, :name,
              {}, { :label => _('Internal network'), :multiple => true } %>
 <%= selectable_f f, :network, compute_resource.address_pools, { :prompt => "None" }, { :label => _("Floating IP network") } %>
-
+<%= checkbox_f f, :boot_from_volume, {:label => "Boot from Volume", :help_inline => _("Create new boot volume from image")}, "true", "false" %>
+<%= text_f f, :size_gb, { :label => _("New Boot Volume Size (GB)"), :help_inline => _("Defaults to image size if left blank") } %>


### PR DESCRIPTION
At my company we use all Ceph storage volumes for VM storage. This required the ability to boot from these volumes which is not currently available with any Foreman version.

The code changes allow creating a boot volume from specified image and attaching to host via the block_device_mapping v2 api call in the latest fog commits: 

https://github.com/fog/fog/commit/a1eb38d1b980d983ce94ac18b1592183df92571d

Please let me know if you see any glaring mistakes...I'm just getting familiar with Ruby on rails.
