### PR TITLE
Fixes #8620 - Remove useless back to host index link in multiple hosts action

### DIFF
--- a/app/views/hosts/multiple_parameters.html.erb
+++ b/app/views/hosts/multiple_parameters.html.erb
@@ -2,7 +2,6 @@
 
 <% if @parameters.empty? %>
   <%= _('Sorry, these hosts do not have parameters assigned to them, you must add them first.') %>
-  <p><%= link_to _("Back to host list"), hosts_path %></p>
 <% else %>
   <%= form_tag update_multiple_parameters_hosts_path({:host_ids => params[:host_ids]}) do %>
     <% for param in @parameters %>


### PR DESCRIPTION
The 'Cancel' button on the modal does the same thing, this is likely a really old leftover.
