### PR TITLE
refactor #8661 - compute resource form partials

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -142,4 +142,8 @@ module ComputeResourcesVmsHelper
     controller_name != 'hosts' && controller_name != 'compute_attributes'
   end
 
+  def new_host?(host)
+    host.try(:new_record?)
+  end
+
 end

--- a/app/views/compute_resources_vms/form/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/form/_libvirt.html.erb
@@ -1,7 +1,7 @@
-<% new = f.object && f.object.try(:new_record?) %>
-<%= text_f f, :name, :disabled => !new if show_vm_name? %>
-<%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :disabled => !new, :label => _('CPUs') %>
-<%= selectable_f f, :memory, memory_options(compute_resource.max_memory), { }, :class => "col-md-2", :disabled => !new, :label => _('Memory') %>
+<% new_host = new_host?(f.object) %>
+<%= text_f f, :name, :disabled => !new_host if show_vm_name? %>
+<%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :disabled => !new_host, :label => _('CPUs') %>
+<%= selectable_f f, :memory, memory_options(compute_resource.max_memory), { }, :class => "col-md-2", :disabled => !new_host, :label => _('Memory') %>
 
 <!--NICS-->
 <div class="children_fields">
@@ -30,7 +30,7 @@
 </div>
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
-<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start')} if new && controller_name != "compute_attributes" %>
+<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start')} if new_host && controller_name != "compute_attributes" %>
 
 <%
    arch ||= nil ; os ||= nil

--- a/app/views/compute_resources_vms/form/_openstack.html.erb
+++ b/app/views/compute_resources_vms/form/_openstack.html.erb
@@ -1,5 +1,5 @@
-<% new = f.object && f.object.id.blank? %>
-<%= text_f f, :name, :disabled => !new if show_vm_name? %>
+<% new_host = new_host?(f.object) %>
+<%= text_f f, :name, :disabled => !new_host if show_vm_name? %>
 <%= select_f f, :flavor_ref, compute_resource.flavors, :id, :name, {}, :label => _('Flavor') %>
 <%
    arch ||= nil ; os ||= nil

--- a/app/views/compute_resources_vms/form/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/form/_ovirt.html.erb
@@ -1,20 +1,20 @@
 <% javascript 'compute_resource', 'lookup_keys' %>
 <%= text_f f, :name if show_vm_name? %>
-<% new = @host.nil? || @host.try(:new_record?) %>
+<% new_host = new_host?(@host) %>
 <% clusters = compute_resource.clusters %>
 <%= select_f f, :cluster, clusters, :id, :name, { },
-             { :disabled    => !new, :'data-url' => cluster_selected_compute_resource_path(compute_resource),
+             { :disabled    => !new_host, :'data-url' => cluster_selected_compute_resource_path(compute_resource),
                :onchange    => 'ovirt_clusterSelected(this);',
                :help_inline => :indicator,
                :label      => _('Cluster') } %>
-<%= f.hidden_field :cluster if !new %>
+<%= f.hidden_field :cluster if !new_host %>
 <%= select_f f, :template, compute_resource.templates, :id, :name, {:include_blank => _("Select template")},
-             { :disabled    => !new, :'data-url' => template_selected_compute_resource_path(compute_resource),
+             { :disabled    => !new_host, :'data-url' => template_selected_compute_resource_path(compute_resource),
                :onchange    => 'ovirt_templateSelected(this);',
                :help_inline => :indicator,
                :help_block  => _("oVirt/RHEV template to use"),
                :label       => _('Template') } %>
-<%= f.hidden_field :template if !new %>
+<%= f.hidden_field :template if !new_host %>
 
 <% selected_cluster ||= params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
 
@@ -44,7 +44,7 @@
   </div>
 </div>
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
-<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new && controller_name != "compute_attributes" %>
+<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new_host && controller_name != "compute_attributes" %>
 
 <%
    arch ||= nil ; os ||= nil

--- a/app/views/compute_resources_vms/form/_vmware.html.erb
+++ b/app/views/compute_resources_vms/form/_vmware.html.erb
@@ -1,24 +1,24 @@
-<% new = @host ? @host.created_at.nil? : true %>
-<%= text_f f, :name, :disabled => !new if show_vm_name? %>
-<%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :class => "col-md-2", :disabled => !new, :label => _('CPUs') %>
-<%= selectable_f f, :corespersocket, 1..compute_resource.max_cpu_count, { }, :class => "col-md-2", :disabled => !new, :label => _('Cores per socket') %>
-<%= text_f f, :memory_mb, :class => "col-md-2", :disabled => !new, :label => _("Memory (MB)") %>
-<%= selectable_f f, :cluster, compute_resource.clusters, { }, :class => "col-md-2", :disabled => !new, :label => _('Cluster') %>
-<%# selectable_f f, :resource_pool, compute_resource.resource_pools, { }, :class => "col-md-2", :disabled => !new %>
-<%= select_f f, :path, compute_resource.folders, :path, :to_label , {}, { :label => _("Folder"), :class => "col-md-2", :disabled => !new } %>
-<%= select_f f, :guest_id, compute_resource.guest_types, :first, :last, {}, { :label => _("Guest OS"), :class => "col-md-2", :disabled => !new } %>
-<%= select_f f, :hardware_version, compute_resource.vm_hw_versions, :first, :last, {}, { :label => _("Virtual H/W version"), :class => "col-md-2", :disabled => !new } %>
+<% new_host = new_host?(@host) %>
+<%= text_f f, :name, :disabled => !new_host if show_vm_name? %>
+<%= selectable_f f, :cpus, 1..compute_resource.max_cpu_count, { }, :class => "col-md-2", :disabled => !new_host, :label => _('CPUs') %>
+<%= selectable_f f, :corespersocket, 1..compute_resource.max_cpu_count, { }, :class => "col-md-2", :disabled => !new_host, :label => _('Cores per socket') %>
+<%= text_f f, :memory_mb, :class => "col-md-2", :disabled => !new_host, :label => _("Memory (MB)") %>
+<%= selectable_f f, :cluster, compute_resource.clusters, { }, :class => "col-md-2", :disabled => !new_host, :label => _('Cluster') %>
+<%# selectable_f f, :resource_pool, compute_resource.resource_pools, { }, :class => "col-md-2", :disabled => !new_host %>
+<%= select_f f, :path, compute_resource.folders, :path, :to_label , {}, { :label => _("Folder"), :class => "col-md-2", :disabled => !new_host } %>
+<%= select_f f, :guest_id, compute_resource.guest_types, :first, :last, {}, { :label => _("Guest OS"), :class => "col-md-2", :disabled => !new_host } %>
+<%= select_f f, :hardware_version, compute_resource.vm_hw_versions, :first, :last, {}, { :label => _("Virtual H/W version"), :class => "col-md-2", :disabled => !new_host } %>
 
 <!--interfaces-->
 <div class="children_fields">
   <%= new_child_fields_template(f, :interfaces, {
       :object  => compute_resource.new_interface,
-      :partial => 'compute_resources_vms/form/vmware/network', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
+      :partial => 'compute_resources_vms/form/vmware/network', :form_builder_attrs => { :compute_resource => compute_resource, :new => new_host } }) %>
   <%= field_set_tag _("Network interfaces"), :id => "network_interfaces" do %>
     <%= f.fields_for :interfaces do |i| %>
-      <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource, :new => new %>
+      <%= render 'compute_resources_vms/form/vmware/network', :f => i, :compute_resource => compute_resource, :new => new_host %>
     <% end %>
-    <% if new %>
+    <% if new_host %>
       <%= add_child_link '+ ' + _("Add Interface"), :interfaces, { :class => "info disable-unsupported", :title => _('add new network interface') } %>
     <% end %>
   <% end %>
@@ -28,13 +28,13 @@
 <div class="children_fields">
   <%= new_child_fields_template(f, :volumes, {
       :object  => compute_resource.new_volume,
-      :partial => 'compute_resources_vms/form/vmware/volume', :form_builder_attrs => { :compute_resource => compute_resource, :new => new } }) %>
+      :partial => 'compute_resources_vms/form/vmware/volume', :form_builder_attrs => { :compute_resource => compute_resource, :new => new_host } }) %>
   <%= field_set_tag _("Storage"), :id => "storage_volumes" do %>
-    <%= select_f f, :scsi_controller_type, compute_resource.scsi_controller_types, :first, :last, {}, { :label => _("SCSI controller"), :class => "col-md-2", :disabled => !new } %>
+    <%= select_f f, :scsi_controller_type, compute_resource.scsi_controller_types, :first, :last, {}, { :label => _("SCSI controller"), :class => "col-md-2", :disabled => !new_host } %>
     <%= f.fields_for :volumes do |i| %>
-      <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource, :new => new %>
+      <%= render 'compute_resources_vms/form/vmware/volume', :f => i, :compute_resource => compute_resource, :new => new_host %>
     <% end %>
-    <% if new %>
+    <% if new_host %>
       <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info disable-unsupported", :title => _('add new storage volume') } %>
     <% end %>
   <% end %>
@@ -42,7 +42,7 @@
 
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
-<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new and controller_name != 'compute_attributes' %>
+<%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start') } if new_host and controller_name != 'compute_attributes' %>
 
 <%
   arch ||= nil ; os ||= nil


### PR DESCRIPTION
removing pointless try methods (try is send for everything except nil, for which it returns nil, so there's no point in something like foo && foo.try(:bar)
renaming the "new" variable to "new_host" to remove possible name confusion, as new can be used as a method call to the Class#new method if the current self is a class (not relevant here, but using reserved names for variable names is very bad for the next developer's mental health :smile: 
