### PR TITLE
fixes #8676 - tar foreman-debug results including the parent directory

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -292,7 +292,7 @@ qprintf "\n\n"
 
 if [ "$NOTAR" -eq 0 ]; then
   pushd "$DIR" >/dev/null
-  tar -c * 2>/dev/null | $COMPRESS > "$TARBALL"
+  tar -c ../$(basename $DIR) 2>/dev/null | $COMPRESS > "$TARBALL"
   popd >/dev/null
   qprintf "%s: %s\n\n" "A debug file has been created" "$TARBALL ($(stat -c %s "$TARBALL") bytes)"
 else


### PR DESCRIPTION
Is there a reason this wasn't done? I was thinking maybe it's something mandated by sosreport or something, but this is a pet peeve of mine when I forget and it dumps everything in $PWD.
