### PR TITLE
Pass model type so search_for is called on Host

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -234,7 +234,7 @@ module Api
               find_method = "find_by_#{key}"
               model = md[1].classify.constantize
               controller = md[1].pluralize
-              authorized_scope = model.authorized("#{action_permission}_#{controller}")
+              authorized_scope = model.authorized("#{action_permission}_#{controller}", model)
               @nested_obj ||= authorized_scope.send(find_method, params[param])
             end
           else

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -194,7 +194,7 @@ Return value may either be one of the following:
 
       def permissions_check
         permission = "#{params[:action]}_hosts".to_sym
-        deny_access unless Host.authorized(permission).find(@host.id)
+        deny_access unless Host.authorized(permission, Host).find(@host.id)
       end
 
     end


### PR DESCRIPTION
At least on version 1.6.1, the absence of this second parameter leads to a
runtime crash when it's time to validate if the current user (non-admin) is
allowed to perform a power operation on given a host via the APIv2.

The root cause of the crash is basically that search_for is called on
Host::Base by app/services/authorizer.rb:50.

Not sure this is necessary in newer versions, up to the developers to figure
it out :)
