### PR TITLE
fixes #8581 - [vmware] use cluster full path to create vm

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -50,7 +50,7 @@ module Foreman::Model
     end
 
     def clusters
-      name_sort(dc.clusters)
+      dc.clusters.map(&:full_path).sort
     end
 
     def datastores(opts = {})


### PR DESCRIPTION
**To be merged only when fog/fog#3341 is merged and new fog version is out.**
