### PR TITLE
fixes #8711 - password should not disappear on connection test.

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -30,7 +30,7 @@ function providerSelected(item)
 
 function testConnection(item) {
   var cr_id = $("form").data('id');
-  var password = $("input[id$='password']").val();
+  var password = $("input[id$='_password']").val();
   $('.tab-error').removeClass('tab-error');
   $('#test_connection_indicator').show();
   $.ajax({


### PR DESCRIPTION
there are two fields with "password" in their ID - one is what we need, the other is fakepassword. adding underscore in the initial value fetcher returns the correct password input (rails' way of defining ids is model_name_password, thus, adding the underscore fixes this)
