### PR TITLE
Fixes #8727 - DHCP validation does not fail on discovered leases

### DIFF
--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -39,7 +39,7 @@ module Net::DHCP
 
     # Returns an array of record objects which are conflicting with our own
     def conflicts
-      conflicts = [proxy.record(network, mac), proxy.record(network, ip)].delete_if { |c| c == self }.compact
+      conflicts = [proxy.record(network, ip)].delete_if { |c| c == self }.compact
       @conflicts ||= conflicts.uniq {|c| c.attrs}
     end
 


### PR DESCRIPTION
For description read the conversation on the ticket.

DO NOT MERGE.

Greg it looks like this does not work. I might have a mistake in my tests tho,
but I still see `127.0.0.1` as a conflict in the test.
