### PR TITLE
fixes #8735 - enable config drive on Rackspace servers

### DIFF
--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -110,7 +110,8 @@ module Foreman::Model
     def vm_instance_defaults
       #256 server
       super.merge(
-        :flavor_id => 1
+        :flavor_id => 1,
+        :config_drive => true
       )
     end
 


### PR DESCRIPTION
```
171152 #theforeman: < geek876> gwmngilfen: https://github.com/domcleal/foreman/compare/rackspace-cloud-init works.  Thanks
```

Useful tip when testing it.. if you can't get into the VM to check /var/log/cloud-init.log, you can reset the root password via the Rackspace control panel to get a password login.
