### PR TITLE
fixes #8739 - use global setting when hostgroup root_pass is blank

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -107,8 +107,15 @@ module HostCommon
   end
 
   def crypt_root_pass
-    unless root_pass.empty?
-      unencrypted_pass = root_pass
+    # hosts will always copy and crypt the password from parents when saved, but hostgroups should
+    # only crypt if the attribute is stored, else will stay blank and inherit
+    unencrypted_pass = if kind_of?(Hostgroup)
+                         read_attribute(:root_pass)
+                       else
+                         root_pass
+                       end
+
+    if unencrypted_pass.present?
       self.root_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass :
           (operatingsystem.nil? ? PasswordCrypt.passw_crypt(unencrypted_pass) : PasswordCrypt.passw_crypt(unencrypted_pass, operatingsystem.password_hash))
       self.grub_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -646,7 +646,9 @@ class Host::Managed < Host::Base
 
   # no need to store anything in the db if the password is our default
   def root_pass
-    read_attribute(:root_pass).blank? ? (hostgroup.try(:root_pass) || Setting[:root_pass]) : read_attribute(:root_pass)
+    return read_attribute(:root_pass) if read_attribute(:root_pass).present?
+    return hostgroup.try(:root_pass) if hostgroup.try(:root_pass).present?
+    Setting[:root_pass]
   end
 
   def clone

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -176,7 +176,10 @@ class Hostgroup < ActiveRecord::Base
 
   # no need to store anything in the db if the password is our default
   def root_pass
-    read_attribute(:root_pass) || nested_root_pw || Setting[:root_pass]
+    return read_attribute(:root_pass) if read_attribute(:root_pass).present?
+    npw = nested_root_pw
+    return npw if npw.present?
+    Setting[:root_pass]
   end
 
   # Clone the hostgroup

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -304,6 +304,31 @@ class HostgroupTest < ActiveSupport::TestCase
     assert hostgroup.valid?
   end
 
+  test "root_pass inherited from parent if blank" do
+    parent = FactoryGirl.create(:hostgroup, :root_pass => '12345678')
+    hostgroup = FactoryGirl.build(:hostgroup, :parent => parent, :root_pass => '')
+    assert_equal parent.read_attribute(:root_pass), hostgroup.root_pass
+    hostgroup.save!
+    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+  end
+
+  test "root_pass inherited from settings if blank" do
+    Setting[:root_pass] = '12345678'
+    hostgroup = FactoryGirl.build(:hostgroup, :root_pass => '')
+    assert_equal '12345678', hostgroup.root_pass
+    hostgroup.save!
+    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+  end
+
+  test "root_pass inherited from settings if group and parent are blank" do
+    Setting[:root_pass] = '12345678'
+    parent = FactoryGirl.create(:hostgroup, :root_pass => '')
+    hostgroup = FactoryGirl.build(:hostgroup, :parent => parent, :root_pass => '')
+    assert_equal '12345678', hostgroup.root_pass
+    hostgroup.save!
+    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+  end
+
   test "hostgroup name can't be too big to create lookup value matcher over 255 characters" do
     parent = FactoryGirl.create(:hostgroup)
     min_lookupvalue_length = "hostgroup=".length + parent.title.length + 1


### PR DESCRIPTION
A blank (not nil) root_pass on hostgroups was preventing correct inheritance
from settings in both hosts and nested hostgroups.

root_pass was also being copied from parents/settings to hostgroups when they
were saved, when it should remain blank to continue inheriting.  Only hosts
are meant to copy the password on save.
