### PR TITLE
Fixes #5701 - fixed DHCP validation when OS was not set

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -57,9 +57,9 @@ module Orchestration::DHCP
   # returns a hash of dhcp record settings
   def dhcp_attrs
     return unless dhcp?
-    dhcp_attr = { :name => name, :filename => operatingsystem.boot_filename(self),
-                  :ip => ip, :mac => mac, :hostname => hostname, :proxy => subnet.dhcp_proxy,
-                  :network => subnet.network, :nextServer => boot_server }
+    dhcp_attr = { :name => name, :filename => operatingsystem.try(:boot_filename, self),
+                  :ip => ip, :mac => mac, :hostname => hostname, :proxy => subnet.try(:dhcp_proxy),
+                  :network => subnet.try(:network), :nextServer => boot_server }
 
     if jumpstart?
       jumpstart_arguments = os.jumpstart_params self, model.vendor_class


### PR DESCRIPTION
When OS is not set, Rails adds some errors into validation array, but we
continue with DHCP orchestration which fails because OS is not set (nil error).

This is an easy way to fix this because when OS is not set, we cannot create
full DHCP record. It does not hurt, because for validations we only care about
hostname/mac/ip tuples.

Other way to fix this would be to skip DHCP validations if there are some
entries in the errors array. I don't like this approach because it opens doors
to possible bugs. In the worst case for solution A we could create a DHCP
record without filename when OS was not set. But this is more or less expected
behavior, Rails form should prevent this.

The same applies for subnet, so I am adding checks there as well.
