### PR TITLE
fixes #8503 - remove ruby_parser pin to allow safemode update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'validates_lengths_from_database',  '~> 0.2'
 gem 'friendly_id', '~> 4.0'
 gem 'secure_headers', '~> 1.3'
 gem 'safemode', '~> 1.2'
-gem 'ruby_parser', '3.1.1'
 gem 'fast_gettext', '~> 0.8'
 gem 'gettext_i18n_rails', '~> 1.0'
 


### PR DESCRIPTION
This should now install safemode 1.2.2 with ruby_parser 3.6.x.
