### PR TITLE
Fixes #8747 - Temporary pin for google_api_client gem

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,4 +1,4 @@
 group :gce do
-  gem 'google-api-client', '~> 0.7', :require => 'google/api_client'
+  gem 'google-api-client', '0.7.1', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
Creating this PR now because of Katello 2.1 RC: https://groups.google.com/forum/#!topic/foreman-dev/QluZRa5W2aU.
If there is a way to avoid this for now please do not merge until next week and see if there is a fix for the gem.
