### PR TITLE
refs #8747 - undo pinning google_api_client gem

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,4 +1,4 @@
 group :gce do
-  gem 'google-api-client', '0.7.1', :require => 'google/api_client'
+  gem 'google-api-client', '~> 0.7', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
Reminder for when https://github.com/google/google-api-ruby-client/issues/183 is resolved
