### PR TITLE
Fixes #8821 - Images form fails for unnamed Openstack images

### DIFF
--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -3,7 +3,9 @@ module ImagesHelper
     return unless @compute_resource.capabilities.include?(:image)
     images = @compute_resource.available_images
     if images.any?
-      return select_f(f, :uuid, images.to_a.sort! { |a, b| a.name.downcase <=> b.name.downcase }, :id, :name, {}, :label => _('Image'))
+      images.each { |image| image.name = image.id if image.name.nil? }
+      select_f f, :uuid, images.to_a.sort_by { |image| image.name.downcase },
+                  :id, :name, {}, :label => _('Image')
     else
       text_f f, :uuid, :label => opts[:label] || _("Image ID"), :help_inline => opts[:help_inline] || _("Image ID as provided by the compute resource, e.g. ami-..")
     end

--- a/test/unit/helpers/images_helper_test.rb
+++ b/test/unit/helpers/images_helper_test.rb
@@ -1,4 +1,0 @@
-require 'test_helper'
-
-class ImagesHelperTest < ActionView::TestCase
-end


### PR DESCRIPTION
With this fix is now possible to associate images with Openstack (or other Compute Resource) images that lack a name, by falling back to the ID.

I removed that url_for stub I removed in that helper test because it doesn't do anything. 
I wrote a test for the images helper but I cannot get it to work, error is `RuntimeError: In order to use #url_for, you must include routing helpers explicitly. For instance, 'include Rails.application.routes.url_helpers`

``` ruby
class ImagesHelperTest < ActionView::TestCase
  test "id is used to order images from compute resource without a name" do
    f = ActionView::Helpers::FormBuilder.new(:image, Image.new, @image, {}, {}) 
    @compute_resource = FactoryGirl.build(:compute_resource, :openstack)
    @compute_resource.stubs(:capabilities).returns([:image])
    @compute_resource.stubs(:available_images)
                     .returns([Fog::Compute::OpenStack::Image.new(:name => 'aaa', :id => '1a'),
                               Fog::Compute::OpenStack::Image.new(:name => nil,   :id => '2a')])
    image_field(f)
  end
end
```
