### PR TITLE
fixes #8822 - append target=_blank to all links with rel-external

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -82,10 +82,7 @@ function onContentLoad(){
   });
 
   // allow opening new window for selected links
-  $('a[rel="external"]').click( function() {
-    window.open( $(this).attr('href') );
-    return false;
-  });
+  $('a[rel="external"]').attr("target","_blank");
 
   $('*[data-ajax-url]').each(function() {
     var url = $(this).data('ajax-url');


### PR DESCRIPTION
Tested with Chrome & Firefox in Fedora. Can anyone please test with Mac / windows?
