### PR TITLE
Fixes #8919 - extract the model-specific resource names into the models

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -243,6 +243,11 @@ class ComputeResource < ActiveRecord::Base
     false
   end
 
+  def self.authorized_resource_name
+    # We don't want STI subclasses to have separate permissions
+    ComputeResource.name
+  end
+
   protected
 
   def client

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -195,6 +195,11 @@ module Host
       self.interfaces.is_managed.where(:identifier => identifiers).all
     end
 
+    def self.authorized_resource_name
+      # We don't want STI subclasses to have separate permissions
+      'Host'
+    end
+
     private
 
     def set_interface(attributes, name, iface)

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -238,6 +238,11 @@ class Operatingsystem < ActiveRecord::Base
     end
   end
 
+  def self.authorized_resource_name
+    # We don't want STI subclasses to have separate permissions
+    Operatingsystem.name
+  end
+
   private
   def set_family
     self.family ||= self.deduce_family

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -113,14 +113,13 @@ class Authorizer
 
   # sometimes we need exceptions however we don't want to just split namespaces
   def resource_name(klass)
-    return 'Operatingsystem' if klass <= Operatingsystem
-    return 'ComputeResource' if klass <= ComputeResource
+    if klass.respond_to?(:authorized_resource_name)
+      return klass.authorized_resource_name
+    end
 
     case name = klass.to_s
       when 'Audited::Adapters::ActiveRecord::Audit'
         'Audit'
-      when /\AHost::.*\Z/
-        'Host'
       else
         name
       end


### PR DESCRIPTION
This allows plugins also to specify non-default resource name, and prevent
things like STI to mess with the resource type.

In foreman-tasks, the task has STI and although there is 
ForemanTasks::DynflowTask, in permissions we don't want to have it separated,
similarly as we don't want different permissions for all types of operating
systems.
