### PR TITLE
fixes #8885 - pin google-api-client to retain Ruby 1.9 support

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,4 +1,4 @@
 group :gce do
-  gem 'google-api-client', '~> 0.7', :require => 'google/api_client'
+  gem 'google-api-client', '>= 0.7', '< 0.9', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
Being proactive :)
