### PR TITLE
Fixes #8898 - Caps lock warning in password fields

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -108,6 +108,8 @@ function onContentLoad(){
     $("#fakepassword").remove();
   });
 
+  password_caps_lock_hint();
+
   var tz = jstz.determine();
   $.cookie('timezone', tz.name(), { path: '/' });
 }
@@ -116,6 +118,25 @@ function preserve_selected_options(elem) {
   // mark the selected values to preserve them for form hiding
   elem.find('option:not(:selected)').removeAttr('selected');
   elem.find('option:selected').attr('selected', 'selected');
+}
+
+function password_caps_lock_hint() {
+  $('[type=password]').keypress(function(e) {
+    var $addon         = $(this).parent().children('.input-addon'),
+        key            = String.fromCharCode(e.which);
+
+    if (check_caps_lock(key, e)){
+      if (!$addon.is(':visible'))
+        $addon.show();
+    } else if ($addon.is(':visible')) {
+      $addon.hide();
+    }
+  });
+}
+
+//Tests if letter is upper case and the shift key is NOT pressed.
+function check_caps_lock(key, e) {
+  return key.toUpperCase() === key && key.toLowerCase() !== key && !e.shiftKey
 }
 
 function remove_fields(link) {

--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -25,7 +25,9 @@ function providerSelected(item)
   var url = $(item).attr('data-url');
   var data = 'provider=' + provider;
   compute_connection.show();
-  compute_connection.load(url + ' div#compute_connection', data);
+  compute_connection.load(url + ' div#compute_connection', data, function () {
+    password_caps_lock_hint()
+  });
 }
 
 function testConnection(item) {

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -617,11 +617,15 @@ function interface_type_selected(element) {
     value: $('#host_compute_resource_id').val()
   })
 
-  $.ajax({
-    data: data,
-    type: 'GET',
-    url: fieldset.attr('data-url'),
-    dataType: 'script'
+  request = $.ajax({
+              data: data,
+              type: 'GET',
+              url: fieldset.attr('data-url'),
+              dataType: 'script'
+            });
+
+  request.done(function() {
+    password_caps_lock_hint();
   });
 }
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -194,3 +194,20 @@ span.btn a{ text-decoration: none; color: #333333}
 body.modal-open {
   overflow: visible;
 }
+
+// The following block can be safely replaced by form-control-feedback on Bootstrap 3.1+
+// form-control-feedback backport from Bootstrap 3.1+
+.form-control {
+  padding-right: 30px;
+}
+
+.form-control + .glyphicon {
+  position: absolute;
+  right: 0;
+  padding: 9px 37px;
+}
+
+.input-addon {
+  color: black;
+}
+// eof form-control-feedback

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -51,12 +51,13 @@ module LayoutHelper
 
   def password_f(f, attr, options = {})
     password_field_tag(:fakepassword, nil, :style => 'display: none') +
-    # The actual field.
     field(f, attr, options) do
-      options[:autocomplete] ||= "off"
-      options[:placeholder] ||= password_placeholder(f.object)
-      addClass options, "form-control"
-      f.password_field attr, options
+      options[:autocomplete]   ||= 'off'
+      options[:placeholder]    ||= password_placeholder(f.object)
+      addClass options, 'form-control'
+      f.password_field(attr, options) +
+      '<span class="glyphicon glyphicon-warning-sign input-addon"
+             title="' + _('Caps lock ON') + '" style="display:none"></span>'.html_safe
     end
   end
 
@@ -151,7 +152,6 @@ module LayoutHelper
   def field(f, attr, options = {})
     error = f.object.errors[attr] if f && f.object.respond_to?(:errors)
     help_inline = help_inline(options.delete(:help_inline), error)
-
     help_block  = content_tag(:span, options.delete(:help_block), :class => "help-block")
     size_class = options.delete(:size) || "col-md-4"
     content_tag(:div, :class=> "clearfix") do

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -18,7 +18,9 @@
           <div class="form-group">
             <%= label_tag "login[password]", _("Password"), :class=>"col-sm-2 control-label" %>
             <div class="col-sm-10">
-              <%= password_field_tag "login[password]",nil, :class=>"form-control" %>
+              <%= password_field_tag 'login[password]', nil, :class => 'form-control' %>
+              <span class="glyphicon glyphicon-warning-sign input-addon"
+                title="<%= _('Caps lock ON') %>" style="display:none"></span>
             </div>
           </div>
           <div class="form-group">


### PR DESCRIPTION
![](http://i.imgur.com/fWf4ZRt.gif)

The password fields should show a warning (glyphicon with a popover on hover) when the user is typing the password with caps lock on.

I've tested it everywhere I could in the application, it works on compute resource image, login, host, change password, hostgroup root pass, ~~but for some reason it doesn't work on BMC, new compute resource passwords (edit compute resource password works). I think it's due to the fact these are loaded _after_ the page is loaded. Any help?~~ Now it loads everywhere
