### PR TITLE
Fixes #8922 - authorized_smart_proxy_features should not fail if not imp...

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -20,7 +20,8 @@ class FactImporter
 
   def self.authorized_smart_proxy_features
     # When writing your own Fact importer, provide feature(s) of authorized Smart Proxies
-    raise NotImplementedError
+    Rails.logger.debug("Importer #{self} does not implement authorized_smart_proxy_features.")
+    []
   end
 
   def initialize(host, facts = {})

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class FactImporterTest < ActiveSupport::TestCase
+  class CustomImporter < FactImporter; end
 
   test "default importers" do
     assert_includes FactImporter.importers.keys, 'puppet'
@@ -10,10 +11,18 @@ class FactImporterTest < ActiveSupport::TestCase
     assert_equal PuppetFactImporter, FactImporter.importer_for('whatever')
   end
 
-  test ".register_custom_importer" do
-    chef_importer = Struct.new(:my_method)
-    FactImporter.register_fact_importer :chef, chef_importer
+  context 'when using a custom importer' do
+    setup do
+      FactImporter.register_fact_importer :custom_importer, CustomImporter
+    end
 
-    assert_equal chef_importer, FactImporter.importer_for(:chef)
+    test ".register_custom_importer" do
+      assert_equal CustomImporter, FactImporter.importer_for(:custom_importer)
+    end
+
+    test 'importers without authorized_smart_proxy_features return empty set of features' do
+      assert_equal [], FactImporter.importer_for(:custom_importer).authorized_smart_proxy_features
+    end
   end
+
 end


### PR DESCRIPTION
Installations where a plugin is not updated and doesn't implement this method should not fail right away Instead just returning an empty set of features and leaving a debug message will not break other importers.
