### PR TITLE
fixes #6362 - correct menu dividers if user isn't auth for some actions

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -8,17 +8,28 @@ module HomeHelper
   end
 
   def authorized_menu_actions(choices)
-    last_item = Menu::Divider.new(:first_div)
-    choices   = choices.map do |item|
-      last_item = case item
-                    when Menu::Divider
-                      item unless last_item.is_a?(Menu::Divider) #prevent adjacent dividers
-                    when Menu::Item
-                      item if item.authorized?
-                    when Menu::Toggle
-                      item if item.authorized_children.size > 0
-                  end
+    last_shown_item_was_divider = true
+
+    choices = choices.map do |item|
+      case item
+      when Menu::Divider
+        unless last_shown_item_was_divider
+          last_shown_item_was_divider = true
+          item
+        end
+      when Menu::Item
+        if item.authorized?
+          last_shown_item_was_divider = false
+          item
+        end
+      when Menu::Toggle
+        if item.authorized_children.size > 0
+          last_shown_item_was_divider = false
+          item
+        end
+      end
     end.compact
+
     choices.shift if choices.first.is_a?(Menu::Divider)
     choices.pop if choices.last.is_a?(Menu::Divider)
     choices


### PR DESCRIPTION
This fixes the issue of Katello showing a blank "Content" menu when a user has no right to items in that menu.

This was kind of subtle, but we need to evaluate the last **shown** item, not just the last item in order to correctly determine whether the last shown item was a divider or not.  

For all of the native Foreman menus, you don't ever see this problem because they only ever have at most 2 dividers and the "divider chomping" (L33, 34) prevents the menus being displayed for any user without privs.  But, in Katello, "Content" has 3 of them -  the first and last divider are removed but the middle one remains, so the `items.any?` is true, and the empty menu is rendered. :tada:
