### PR TITLE
Fixes #8052 - allows erb in array and hash params

### DIFF
--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -28,7 +28,7 @@ class LookupValue < ActiveRecord::Base
   end
 
   def value_before_type_cast
-    return self.value if lookup_key.nil?
+    return self.value if lookup_key.nil? || lookup_key.contains_erb?(self.value)
     lookup_key.value_before_type_cast self.value
   end
 
@@ -42,7 +42,9 @@ class LookupValue < ActiveRecord::Base
   def validate_and_cast_value
     return true if self.marked_for_destruction? or !self.value.is_a? String
     begin
-      self.value = lookup_key.cast_validate_value self.value
+      unless self.lookup_key.contains_erb?(value)
+        self.value = lookup_key.cast_validate_value self.value
+      end
       true
     rescue StandardError, SyntaxError => e
       logger.error e.message
@@ -53,13 +55,17 @@ class LookupValue < ActiveRecord::Base
   end
 
   def validate_regexp
-    return true unless (lookup_key.validator_type == 'regexp')
-    errors.add(:value, _("is invalid")) and return false unless (value =~ /#{lookup_key.validator_rule}/)
+    return true if (lookup_key.validator_type != 'regexp' || (lookup_key.contains_erb?(value) && Setting[:interpolate_erb_in_parameters]))
+    valid = (value =~ /#{lookup_key.validator_rule}/)
+    errors.add(:value, _("is invalid")) unless valid
+    valid
   end
 
   def validate_list
-    return true unless (lookup_key.validator_type == 'list')
-    errors.add(:value, _("%{value} is not one of %{rules}") % { :value => value, :rules => lookup_key.validator_rule }) and return false unless lookup_key.validator_rule.split(LookupKey::KEY_DELM).map(&:strip).include?(value)
+    return true if (lookup_key.validator_type != 'list' || (lookup_key.contains_erb?(value) && Setting[:interpolate_erb_in_parameters]))
+    valid = lookup_key.validator_rule.split(LookupKey::KEY_DELM).map(&:strip).include?(value)
+    errors.add(:value, _("%{value} is not one of %{rules}") % { :value => value, :rules => lookup_key.validator_rule }) unless valid
+    valid
   end
 
   def ensure_fqdn_exists

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -23,6 +23,9 @@
                     :disabled => (f.object.is_param && !f.object.override)) if is_param%>
   <div <%= "id=#{(f.object.key || 'new_lookup_keys').to_s.gsub(' ','_')}_lookup_key_override_value" %> style=<%= "display:none;" if (f.object.is_param && !f.object.override) %>>
     <legend><%= _("Optional input validator") %></legend>
+    <p class="help-block">
+      <%= _('Note that if you use ERB as a value of parameter, value will be validated during ENC evaluation. If value is invalid, ENC evaluation will fail.') %>
+    </p>
     <%= checkbox_f(f, :required, :size => "col-md-8", :disabled => !f.object.override,
                    :help_block => _("If checked, will raise an error if there is no default value and no matcher provide a value.")
         ) if is_param %>

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class ClassificationTest < ActiveSupport::TestCase
 
-  #TODO: add more tests here
   def setup
     host = FactoryGirl.create(:host,
                               :location => taxonomies(:location1),
@@ -556,6 +555,72 @@ class ClassificationTest < ActiveSupport::TestCase
     enc = classification.enc
 
     assert_equal 'child', enc["apache"][key.key]
+  end
+
+  test 'smart class parameter should accept string with erb for arrays and evaluate it properly' do
+    key = FactoryGirl.create(:lookup_key, :as_smart_class_param,
+                             :override => true, :key_type => 'array', :merge_overrides => false,
+                             :default_value => '<%= [1,2] %>', :path => "organization\nos\nlocation",
+                             :puppetclass => puppetclasses(:one))
+    assert_equal [1,2], classification.enc['base'][key.key]
+
+    as_admin do
+      LookupValue.create! :lookup_key_id => key.id,
+                          :match => "location=#{taxonomies(:location1)}",
+                          :value => '<%= [2,3] %>',
+                          :use_puppet_default => false
+    end
+    as_admin do
+      LookupValue.create! :lookup_key_id => key.id,
+                          :match => "organization=#{taxonomies(:organization1)}",
+                          :value => '<%= [3,4] %>',
+                          :use_puppet_default => false
+    end
+    as_admin do
+      LookupValue.create! :lookup_key_id => key.id,
+                          :match => "os=#{operatingsystems(:redhat)}",
+                          :value => '<%= [4,5] %>',
+                          :use_puppet_default => false
+    end
+
+    key.reload
+    @classification = Classification::ClassParam.new(:host => classification.send(:host))
+
+    assert_equal({key.id => {key.key => {:value => '<%= [3,4] %>',
+                                         :element => 'organization',
+                                         :element_name => 'Organization 1'}}},
+                 classification.send(:values_hash))
+    assert_equal [3,4], classification.enc['base'][key.key]
+  end
+
+  test 'smart class parameter with erb values is validated after erb is evaluated' do
+    key = FactoryGirl.create(:lookup_key, :as_smart_class_param,
+                             :override => true, :key_type => 'string', :merge_overrides => false,
+                             :default_value => '<%= "a" %>', :path => "organization\nos\nlocation",
+                             :puppetclass => puppetclasses(:one),
+                             :validator_type => 'list', :validator_rule => 'b')
+
+    assert_raise RuntimeError do
+      classification.enc['base'][key.key]
+    end
+
+    key.update_attribute :default_value, '<%= "b" %>'
+    @classification = Classification::ClassParam.new(:host => classification.send(:host))
+    assert_equal 'b', classification.enc['base'][key.key]
+
+    as_admin do
+      LookupValue.create! :lookup_key_id => key.id,
+                          :match => "location=#{taxonomies(:location1)}",
+                          :value => '<%= "c" %>',
+                          :use_puppet_default => false
+    end
+
+    key.reload
+    @classification = Classification::ClassParam.new(:host => classification.send(:host))
+
+    assert_raise RuntimeError do
+      classification.enc['base'][key.key]
+    end
   end
 
   private

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -95,12 +95,12 @@ class LookupValueTest < ActiveSupport::TestCase
     lk1 = LookupValue.new(:value => "---\n  foo: bar", :match => "hostgroup=Common", :lookup_key => lookup_keys(:six))
     assert lk1.save!
     assert lk1.value.is_a? Hash
-    assert_equal lk1.value_before_type_cast, "foo: bar\n"
+    assert_include lk1.value_before_type_cast, "foo: bar"
 
     lk2 = LookupValue.new(:value => "{'foo': 'bar'}", :match => "environment=Production", :lookup_key => lookup_keys(:six))
     assert lk2.save!
     assert lk2.value.is_a? Hash
-    assert_equal lk2.value_before_type_cast, "foo: bar\n"
+    assert_include lk2.value_before_type_cast, "foo: bar"
   end
 
   test "should cast and uncast string containing an Array" do
@@ -131,5 +131,18 @@ class LookupValueTest < ActiveSupport::TestCase
       lvalue.save!
     end
     assert_equal "#{pc.name}::#{key.key}", lvalue.audits.last.associated_name
+  end
+
+  test "shuld not cast string with erb" do
+    key = FactoryGirl.create(:lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'array', :merge_overrides => true, :avoid_duplicates => true,
+                            :default_value => [1,2,3], :puppetclass => puppetclasses(:one))
+
+    lv = LookupValue.new(:value => "<%= [4,5,6] %>", :match => "hostgroup=Common", :lookup_key => key)
+    # does not cast on save (validate_and_cast_value)
+    assert lv.save!
+    # does not cast on load (value_before_type_cast)
+    assert_equal lv.value_before_type_cast, "<%= [4,5,6] %>"
+    assert_equal lv.value, "<%= [4,5,6] %>"
   end
 end


### PR DESCRIPTION
I also removed useless TODO comment in classification test and fixed two lookup_value tests to be independent on json provider. Let me know if I should split it, it seems as "small enough" changes to me.
