### PR TITLE
fixes #8402 - Reports from the last xx Days not displaying day filter option

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -165,7 +165,7 @@ module HostsHelper
     return unless @host.reports.size > 0
     form_tag @host, :id => 'days_filter', :method => :get, :class => "form form-inline" do
       content_tag(:span, (_("Reports from the last %{days} days - %{count} reports found") %
-        { :days  => select(nil, 'range', 1..days_ago(@host.reports.first.reported_at),
+        { :days  => select(nil, 'range', 1..days_ago(@host.reports.order(:reported_at).first.reported_at),
                     {:selected => @range}, {:class=>"col-md-1 form-control", :style=>"float:none;", :onchange =>"$('#days_filter').submit();$(this).disabled();"}),
           :count => @host.reports.recent(@range.days.ago).count }).html_safe)
     end


### PR DESCRIPTION
...tion

The query for the latest report was returning a random report
Add in order by, so we are always getting the oldest report
