### PR TITLE
fixes #6098 - ec2 compute resources now check image validity.

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -243,6 +243,10 @@ class ComputeResource < ActiveRecord::Base
     false
   end
 
+  def image_exists?(image)
+    true
+  end
+
   protected
 
   def client

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -102,6 +102,10 @@ module Foreman::Model
       true
     end
 
+    def image_exists?(image)
+      client.images.get(image).present?
+    end
+
     private
 
     def subnet_implies_is_vpc? args

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,11 +12,19 @@ class Image < ActiveRecord::Base
   validates_lengths_from_database
   validates :username, :name, :operatingsystem_id, :compute_resource_id, :architecture_id, :presence => true
   validates :uuid, :presence => true, :uniqueness => {:scope => :compute_resource_id}
+  validate :uuid_exists?
 
   scoped_search :on => [:name, :username], :complete_value => true
   scoped_search :in => :compute_resources, :on => :name, :complete_value => :true, :rename => "compute_resource"
   scoped_search :in => :architecture, :on => :id, :rename => "architecture", :complete_enabled => false, :only_explicit => true
   scoped_search :in => :operatingsystem, :on => :id, :rename => "operatingsystem", :complete_enabled => false, :only_explicit => true
   scoped_search :on => :user_data, :complete_value => {:true => true, :false => false}
+
+  private
+
+  def uuid_exists?
+    return true if compute_resource.blank?
+    errors.add(:uuid, _("could not be found in %s") % compute_resource.name) if !compute_resource.image_exists?(uuid)
+  end
 
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -5,6 +5,7 @@ class HostTest < ActiveSupport::TestCase
     disable_orchestration
     User.current = users :admin
     Setting[:token_duration] = 0
+    Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
   end
 
   test "should not save without a hostname" do

--- a/test/unit/image_test.rb
+++ b/test/unit/image_test.rb
@@ -14,4 +14,12 @@ class ImageTest < ActiveSupport::TestCase
     assert_nil host.image_id
   end
 
+  test "image is invalid if uuid invalid" do
+    resource = compute_resources(:one)
+    image = resource.images.build(:name => "foo", :uuid => "bar")
+    ComputeResource.any_instance.stubs(:image_exists?).returns(false)
+    image.valid? #trigger validations
+    assert image.errors.messages.keys.include?(:uuid)
+  end
+
 end


### PR DESCRIPTION
allowing other compute resources to do the same (default behaviour is returning true)
