### PR TITLE
fixes #9025 - reflect on association for _name(s) methods

### DIFF
--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -2,7 +2,7 @@ module HasManyCommon
   extend ActiveSupport::Concern
 
   def assoc_klass(association)
-    association.to_s.classify.constantize
+    self.class.reflect_on_association(association).klass
   end
 
   # calls method :name or whatever is defined in attr_name :title

--- a/test/lib/has_many_common_test.rb
+++ b/test/lib/has_many_common_test.rb
@@ -52,12 +52,12 @@ class HasManyCommonTest < ActiveSupport::TestCase
   #
   # Test default AR extenstion *_name where method is :name by default
   test "should return domain name using method #domain_name" do
-    host = FactoryGirl.create(:host, :domain => FactoryGirl.create(:domain, :name => "common.net"))
+    host = FactoryGirl.build(:host, :domain => FactoryGirl.create(:domain, :name => "common.net"))
     assert_equal "common.net", host.domain_name
   end
 
   test "should update domain_id by passing existing domain name" do
-    host = FactoryGirl.create(:host, :domain => FactoryGirl.create(:domain, :name => "common.net"))
+    host = FactoryGirl.build(:host, :domain => FactoryGirl.create(:domain, :name => "common.net"))
     orig_id = host.domain_id
     host.domain_name = "yourdomain.net"
     host.save!
@@ -67,13 +67,13 @@ class HasManyCommonTest < ActiveSupport::TestCase
 
   # Test non-default AR extenstion *_nam where method is :label for belongs_to :hostgroup
   test "should return hostgroup label using method #hostgroup_name" do
-    host = FactoryGirl.create(:host)
+    host = FactoryGirl.build(:host)
     host.update_attribute(:hostgroup, hostgroups(:inherited))
     assert_equal "Parent/inherited", host.hostgroup_name
   end
 
   test "should update hostgroup_id by passing existing hostgroup label" do
-    host = FactoryGirl.create(:host)
+    host = FactoryGirl.build(:host)
     orig_id = host.hostgroup_id
     host.hostgroup_name = "Parent/inherited"
     host.save!
@@ -81,5 +81,14 @@ class HasManyCommonTest < ActiveSupport::TestCase
     refute_equal orig_id, new_id
   end
 
+  ## Test name methods resolve for Plugin AR objects
+  class ::FakePlugin; end
+  class ::FakePlugin::FakeModel; end
 
+  test "should return plugin associations" do
+    Host::Managed.class_eval do
+      belongs_to :fake_model, :class_name => '::FakePlugin::FakeModel'
+    end
+    assert_equal FactoryGirl.build(:host).assoc_klass(:fake_model), FakePlugin::FakeModel
+  end
 end


### PR DESCRIPTION
The current method doesn't work for associations in another module (like in plugins).  

In the Salt plugin, some_host.salt_environment_name resolves to `SaltEnvironment` instead of `ForemanSalt::SaltEnvironment`.  This PR changes how the class is resolved, by instead relying on active record reflection.
