### PR TITLE
fixes #8874 - rework POT/PO updates for gettext 3's edit.po

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ doc/apidoc*
 .ruby-version*
 .ruby-gemset*
 locale/*.mo
+locale/*/*.edit.po
+locale/*/*.po.time_stamp
 locale/*/*.pox
 locale/*/LC_MESSAGES
 coverage/

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [foreman.foreman]
-file_filter = locale/<lang>/foreman.po
+file_filter = locale/<lang>/foreman.edit.po
 source_file = locale/foreman.pot
 source_lang = en
 type = PO

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -3,7 +3,7 @@ group :development do
   gem 'rubocop', '0.35.1'
 
   # for generating i18n files
-  gem 'gettext', '~> 3.1', :require => false
+  gem 'gettext', '>= 3.2.1', '< 4.0.0', :require => false
 
   # for generating foreign key migrations
   gem 'immigrant', '~> 0.1'

--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -18,6 +18,11 @@ Foreman::Gettext::Support.register_human_localenames
 # work in all domains context by default (for plugins)
 include FastGettext::TranslationMultidomain
 
+# Keep TRANSLATORS comments
+Rails.application.config.gettext_i18n_rails.xgettext = %w[--add-comments=TRANSLATORS:]
+# Disable fuzzy .po merging
+Rails.application.config.gettext_i18n_rails.msgmerge = %w[--no-fuzzy-matching]
+
 # When mark_translated setting is set, we will wrap all translated strings
 # which is useful when translating code base.
 if SETTINGS[:mark_translated] and not Rails.env.test?

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -20,7 +20,8 @@ begin
 
   desc 'Extract plugin strings - called via rake plugin:gettext[plugin_name]'
   task 'plugin:gettext', :engine do |t, args|
-    @engine = "#{args[:engine].camelize}::Engine".constantize
+    @domain = args[:engine]
+    @engine = "#{@domain.camelize}::Engine".constantize
     @engine_root = @engine.root
 
     namespace :gettext do
@@ -31,10 +32,13 @@ begin
       def files_to_translate
         Dir.glob("#{@engine.root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
       end
+
+      def text_domain
+        @domain
+      end
     end
 
-    Foreman::Gettext::Support.add_text_domain args[:engine], "#{@engine_root}/locale"
-    ENV['TEXTDOMAIN'] = args[:engine]
+    Foreman::Gettext::Support.add_text_domain @domain, "#{@engine_root}/locale"
 
     Rake::Task['gettext:find'].invoke
   end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -33,9 +33,6 @@ namespace :locale do
   find_dependencies = [:find_model, :find_code]
   find_dependencies.shift if ENV['SKIP_MODEL']
   task :find => find_dependencies do
-    # do not commit PO string merge into git (we are using transifex.com)
-    `git checkout -- locale/*/*.po`
-
     # find malformed strings
     errors = File.open("locale/#{DOMAIN}.pot") {|f| f.grep /(%s.*%s|#\{)/}
     if errors.count > 0
@@ -46,7 +43,7 @@ namespace :locale do
   end
 
   desc 'Alias for gettext:po_to_json'
-  task :po_to_json => "gettext:po_to_json"
+  task :po_to_json => Dir['locale/*/foreman.po'].push("gettext:po_to_json")
 
   desc 'Alias for gettext:pack'
   task :pack => "gettext:pack"

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -9,9 +9,10 @@
 DOMAIN = foreman
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
-POFILES = $(shell find . -name '*.po')
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
 	mkdir -p $(shell dirname $@)/LC_MESSAGES
@@ -29,13 +30,6 @@ all-mo: $(MOFILES)
 	! grep -q msgid $@
 
 check: $(POXFILES)
-	msgfmt -c ${POTFILE}
-
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
 
 # Unify duplicate translations
 uniq-po:
@@ -43,17 +37,19 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-tx-pull:
+tx-pull: $(EDITFILES)
 	tx pull -f
-	-git commit -a -m "i18n - extracting new, pulling from tx"
 
+# Extract strings and update the .pot, prepare .edit.po files
 extract-strings:
-	bundle exec rake locale:po_to_json locale:find DOMAIN=$(DOMAIN) SKIP_MODEL=1
+	bundle exec rake locale:find DOMAIN=$(DOMAIN) SKIP_MODEL=1
 
-tx-update: tx-pull extract-strings
-	# merging po files is unnecessary when using transifex.com (amend that)
-	git checkout -- ../locale/*/*po
-	git commit -a --amend -m "i18n - extracting new, pulling from tx"
+# Merge .edit.po into .po
+update-po:
+	bundle exec rake locale:find locale:po_to_json DOMAIN=$(DOMAIN) SKIP_MODEL=1
+
+tx-update: extract-strings tx-pull update-po
+	git commit -m "i18n - extracting new, pulling from tx" . ../app/assets/javascripts/locale
 	-echo Changes commited!
 
 # Remove all MO files


### PR DESCRIPTION
3.1.13 adds an intermediate .edit.po file alongside each .po, which is meant
to be kept outside of SCM and updated by users, whereupon it's merged back into
the .po on the next rake gettext:find execution.

Previously we overwrote all gettext .po file changes with files directly from
Transifex, but now these are downloaded to .edit.po and gettext merges them
back in.  Fuzzy merges have been disabled as they were inaccurate.

---

Reminder, use `make -C locale tx-update` to trigger it all.

Note there are a couple of style changes in the POT file, but I think they're good.  1) "TRANSLATORS" is now showing up in the comments, 2) source locations are enabled, 3) the header is in template form.

More details on the ticket comments too.
