### PR TITLE
Fixes #9044 - fixes invalid mac in tests

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -94,7 +94,11 @@ module Host
 
     def set_interfaces(parser)
       parser.interfaces.each do |name, attributes|
-        macaddress = Net::Validations.normalize_mac(attributes[:macaddress])
+        begin
+          macaddress = Net::Validations.normalize_mac(attributes[:macaddress])
+        rescue ArgumentError
+          logger.debug "invalid mac during parsing: #{attributes[:macaddress]}"
+        end
         base = self.interfaces.where(:mac => macaddress)
 
         if attributes[:virtual]

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -935,7 +935,11 @@ class Host::Managed < Host::Base
   end
 
   def normalize_addresses
-    self.mac = Net::Validations.normalize_mac(mac)
+    begin
+      self.mac = Net::Validations.normalize_mac(mac)
+    rescue ArgumentError => e
+      self.errors.add(:mac, e.message)
+    end
     self.ip  = Net::Validations.normalize_ip(ip)
   end
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -92,6 +92,8 @@ module Nic
 
     def normalize_mac
       self.mac = Net::Validations.normalize_mac(mac)
+    rescue ArgumentError => e
+      self.errors.add(:mac, e.message)
     end
 
     # do we require a host object associate to the interface? defaults to true

--- a/lib/net/validations.rb
+++ b/lib/net/validations.rb
@@ -79,6 +79,8 @@ module Net
           m.split("-").map { |nibble| "%02x" % ("0x" + nibble) }.join(":")
         when /\A([a-f0-9]{1,2}-){5}[a-f0-9]{1,2}\z/
           m.split("-").map { |nibble| "%02x" % ("0x" + nibble) }.join(":")
+        else
+          raise ArgumentError, "'#{mac}' is not a valid MAC address"
       end
     end
 

--- a/test/lib/net/validations_test.rb
+++ b/test/lib/net/validations_test.rb
@@ -106,11 +106,15 @@ class ValidationsTest < ActiveSupport::TestCase
 
     context "when invalid MAC address" do
       test "should handle invalid MAC address length" do
-        assert_nil Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:gg:11")
+        assert_raise ArgumentError do
+          Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:gg:11")
+        end
       end
 
       test "should handle invalid MAC address characters" do
-        assert_nil Net::Validations.normalize_mac("aa:bb:cc:dd:ee:zz")
+        assert_raise ArgumentError do
+          assert_nil Net::Validations.normalize_mac("aa:bb:cc:dd:ee:zz")
+        end
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -209,6 +209,10 @@ Spork.prefork do
       ENV.update old_values
       result
     end
+
+    def next_mac(mac)
+      mac.tr(':','').to_i(16).succ.to_s(16).rjust(12, '0').scan(/../).join(':')
+    end
   end
 
   # Transactional fixtures do not work with Selenium tests, because Capybara

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -362,7 +362,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "update a host's location" do
-    host = Host.create :name => "host 1", :mac => "aabbccddee", :ip => "5.5.5.5", :hostgroup => hostgroups(:common), :managed => false
+    host = Host.create :name => "host 1", :mac => "aabbccddeeff", :ip => "5.5.5.5", :hostgroup => hostgroups(:common), :managed => false
     original_location = Location.create :name => "New York"
 
     host.location_id = original_location.id

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -122,7 +122,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
 
   test "when an existing host change its mac address, its dhcp record should be updated" do
     h = FactoryGirl.create(:host, :with_dhcp_orchestration)
-    h.mac = h.mac.succ
+    h.mac = next_mac(h.mac)
     assert h.valid?
     assert_equal 2, h.queue.items.select {|x| x.action == [ h,     :set_dhcp ] }.size
     assert_equal 1, h.queue.items.select {|x| x.action == [ h.old, :del_dhcp ] }.size
@@ -136,7 +136,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     end
     h.reload
     bmc = h.interfaces.bmc.first
-    bmc.mac = bmc.mac.succ
+    bmc.mac = next_mac(bmc.mac)
     assert h.valid?
     assert bmc.valid?
     assert_equal 1, bmc.queue.items.select {|x| x.action == [ bmc,     :set_dhcp ] }.size
@@ -150,10 +150,10 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
                        :name => "bmc-it", :provider => 'IPMI', :ip => h.ip.succ)
     end
     h.reload
-    h.mac = h.mac.succ
+    h.mac = next_mac(h.mac)
     bmc = h.interfaces.bmc.first
     assert !bmc.new_record?
-    bmc.mac = bmc.mac.succ
+    bmc.mac = next_mac(bmc.mac)
     assert h.valid?
     assert bmc.valid?
     assert_equal 2, h.queue.items.select {|x| x.action == [ h,     :set_dhcp ] }.size


### PR DESCRIPTION
Also do not reset invalid mac address to nil so we can propagate proper
validation error.
