### PR TITLE
Fixes #9045 - added reschedule_migrations seed script

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -164,8 +164,8 @@ class User < ActiveRecord::Base
     to_label + " (#{login})"
   end
 
-  def self.anonymous_admin
-    unscoped.find_by_login ANONYMOUS_ADMIN or raise Foreman::Exception.new(N_("Anonymous admin user %s is missing, run foreman-rake db:seed"), ANONYMOUS_ADMIN)
+  def self.anonymous_admin(raise_exception = true)
+    unscoped.find_by_login ANONYMOUS_ADMIN or ((raise_exception and raise Foreman::Exception.new(N_("Anonymous admin user %s is missing, run foreman-rake db:seed"), ANONYMOUS_ADMIN)) or false)
   end
 
   def self.anonymous_api_admin

--- a/db/migrate/20141110084848_fix_puppetclass_total_hosts.rb
+++ b/db/migrate/20141110084848_fix_puppetclass_total_hosts.rb
@@ -1,6 +1,11 @@
-class FixPuppetclassTotalHosts < ActiveRecord::Migration
+class FixPuppetclassTotalHosts < ActiveRecord::Migrati
   def up
-    Rake::Task['puppet:fix_total_hosts'].invoke
+    if User.anonymous_admin(false) && Puppetclass.count > 0
+      User.current = User.anonymous_admin
+      Puppetclass.all.each(&:update_total_hosts)
+    else
+      puts "Migration #{self.class.name} will be rescheduled during db:seed"
+    end
   end
 
   def down

--- a/db/seeds.d/99-reschedule_migrations.rb
+++ b/db/seeds.d/99-reschedule_migrations.rb
@@ -1,0 +1,8 @@
+# Reschedule migrations which were skipped
+
+def reschedule_migration(id)
+  sql = "DELETE FROM schema_migrations WHERE version = '#{id}'"
+  ActiveRecord::Base.connection.execute sql
+end
+
+reschedule_migration('20141110084848') if Puppetclass.count > 0


### PR DESCRIPTION
This fixes the issue, but the drawback is it reschedules the puppetclass
correction after every single seed.

Alternative solution would be to create the anonymous admin if it's not present
directly in the codebase.
