### PR TITLE
Fixes #9049 - Log exceptions when triggering a Puppet run

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -606,6 +606,8 @@ class Host::Managed < Host::Base
     ProxyAPI::Puppet.new({:url => puppet_proxy.url}).run fqdn
   rescue => e
     errors.add(:base, _("failed to execute puppetrun: %s") % e)
+    logger.warn "unable to execute puppet run: " % e
+    logger.debug e.backtrace.join("\n")
     false
   end
 


### PR DESCRIPTION
If an exception occurs during triggering a Puppet run from the UI,
user will be notified of the error in a flash message. If the
exception occurs when running the action non-interactively (e.g. from
a DynFlow task), the exception will get swallowed. This patch makes
sure the exception message is at least logged to allow later
inspection.

The patch is necessary to proceed with debugging of a Staypuft issue:

https://bugzilla.redhat.com/show_bug.cgi?id=1183802
