### PR TITLE
Fixes #2948 - added sp_* host attributes to safe mode

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -136,6 +136,7 @@ module Host
       end
       hash
     end
+    alias_method :facts, :facts_hash
 
     def ==(comparison_object)
       super ||

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -56,11 +56,12 @@ class Host::Managed < Host::Base
   include HostCommon
 
   class Jail < ::Safemode::Jail
-    allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup, :location,
+    allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
       :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method,
       :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :primary_interface, :interfaces,
-      :has_primary_interface?, :bond_interfaces, :interfaces_with_identifier, :managed_interfaces
+      :has_primary_interface?, :bond_interfaces, :interfaces_with_identifier, :managed_interfaces, :facts, :facts_hash,
+      :sp_name, :sp_ip, :sp_mac, :sp_subnet
   end
 
   attr_reader :cached_host_params


### PR DESCRIPTION
Also few related changes:
- added `facts` alias for `facts_hash`
- exported `facts` attribute via safemode
- removed extra attribute (was there twice: `location`)

I would like to backport this into 1.7 for Discovery 2.0.
