### PR TITLE
fixes #9084 - catch net-ldap 0.11's specific invalid filter exception

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -163,7 +163,7 @@ class AuthSourceLdap < AuthSource
 
   def validate_ldap_filter
     Net::LDAP::Filter.construct(ldap_filter)
-  rescue Net::LDAP::LdapError => e
+  rescue Net::LDAP::LdapError, Net::LDAP::FilterSyntaxInvalidError => e
     logger.error e.message
     logger.error e.backtrace.join("\n")
     errors.add(:ldap_filter, _("invalid LDAP filter syntax"))


### PR DESCRIPTION
See the exceptions at https://github.com/ruby-ldap/ruby-net-ldap/blob/v0.11/lib/net/ldap/error.rb

PR test running manually as test_develop is down: http://ci.theforeman.org/job/test_develop_pull_request/10120/ :white_check_mark: 
