### PR TITLE
Refs #4478 - copy in pre-built plugin caches on rake apipie:cache index

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -1,0 +1,19 @@
+desc 'Apipie cache specific tasks'
+namespace :apipie do
+
+  desc 'Generate cache index'
+  task 'cache:index' do |t, args|
+    ENV['cache_part'] = 'index'
+    Rake::Task['apipie:cache'].invoke
+  end
+
+  # when building just the cache index
+  # copy all the prebuilt plugin resources to the cache
+  Rake::Task['apipie:cache'].enhance do
+    if ENV['cache_part'] == 'index'
+      require 'fileutils'
+      cache_path = File.expand_path('./public/apipie-cache')
+      FileUtils.cp_r(Dir.glob(File.join(cache_path, 'plugin/*/*')).sort, cache_path)
+    end
+  end
+end


### PR DESCRIPTION
Due to some issues with copying the prebuilt plugin caches in postinstall script we have to move it to the rake task
- adds apipie:cache:index as a shortcut to apipie:cache cache_part=index 
- it also extends the apipie:cache:index task to copy the prebuilt caches provided by plugins
