### PR TITLE
Fixes #9097 - Fix typo in value_to_sql method

### DIFF
--- a/app/models/concerns/scoped_search_extensions.rb
+++ b/app/models/concerns/scoped_search_extensions.rb
@@ -4,7 +4,7 @@ module ScopedSearchExtensions
   module ClassMethods
     def value_to_sql(operator, value)
       return value                 if operator !~ /LIKE/i
-      return value.tr_s('%*', '%') if (value ~ /%|\*/)
+      return value.tr_s('%*', '%') if (value =~ /%|\*/)
       "%#{value}%"
     end
   end

--- a/test/unit/concerns/scoped_search_extensions_test.rb
+++ b/test/unit/concerns/scoped_search_extensions_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ScopedSearchExtensionsTest < ActiveSupport::TestCase
+
+  def setup
+    @search_class = Class.new { include ScopedSearchExtensions }
+  end
+
+  test "should change * to %" do
+    input = "test*"
+    assert_equal "test%", @search_class.value_to_sql("like", input)
+  end
+end


### PR DESCRIPTION
To test, go to the hosts page and filter by `user.firstname ~ fjdkslfjdsklfjsdkldsjlk`. You should get no hosts (unless you have a user with first name containing fjdkslfjdsklfjsdkldsjlk) but you'll probably see all your hosts as the filter is not being applied.
