### PR TITLE
Fixes #6884 - Installation media without $minor generate broken $version

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -121,8 +121,8 @@ class Operatingsystem < ActiveRecord::Base
     path.gsub('$arch',  arch).
          gsub('$major',  os.major).
          gsub('$minor',  os.minor).
-         gsub('$version', [os.major, os.minor ].compact.join('.')).
-         gsub('$release', os.release_name ? os.release_name : "" )
+         gsub('$version', os.minor.blank? ? os.major : [os.major, os.minor].compact.join('.')).
+         gsub('$release', os.release_name.blank? ? '' : os.release_name)
   end
 
   # The OS is usually represented as the concatenation of the OS and the revision

--- a/db/seeds.d/10-installation_media.rb
+++ b/db/seeds.d/10-installation_media.rb
@@ -3,11 +3,11 @@ os_suse = Operatingsystem.find_all_by_type "Suse" || Operatingsystem.where("name
 # Installation media: default mirrors
 Medium.without_auditing do
   [
-    { :name => "CentOS mirror", :os_family => "Redhat", :path => "http://mirror.centos.org/centos/$major.$minor/os/$arch" },
+    { :name => "CentOS mirror", :os_family => "Redhat", :path => "http://mirror.centos.org/centos/$version/os/$arch" },
     { :name => "Debian mirror", :os_family => "Debian", :path => "http://ftp.debian.org/debian" },
     { :name => "Fedora mirror", :os_family => "Redhat", :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Fedora/$arch/os/" },
-    { :name => "FreeBSD mirror", :os_family => "Freebsd", :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$major.$minor-RELEASE/" },
-    { :name => "OpenSUSE mirror", :os_family => "Suse", :path => "http://download.opensuse.org/distribution/$major.$minor/repo/oss", :operatingsystems => os_suse },
+    { :name => "FreeBSD mirror", :os_family => "Freebsd", :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$version-RELEASE/" },
+    { :name => "OpenSUSE mirror", :os_family => "Suse", :path => "http://download.opensuse.org/distribution/$version/repo/oss", :operatingsystems => os_suse },
     { :name => "Ubuntu mirror", :os_family => "Debian", :path => "http://archive.ubuntu.com/ubuntu" },
     { :name => "CoreOS mirror", :os_family => "Coreos", :path => "http://$release.release.core-os.net" }
   ].each do |input|

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -345,4 +345,10 @@ class OperatingsystemTest < ActiveSupport::TestCase
     assert_equal("#{operatingsystem.id}-applet-מערכתההפעלהשלי 4", operatingsystem.to_param)
   end
 
+  test 'interpolated $version does not include dots if only major is specified' do
+    operatingsystem = FactoryGirl.build(:operatingsystem, :name => 'foo', :major => '4')
+    result_path = operatingsystem.interpolate_medium_vars('http://foo.org/$version',
+                                                          'x64', operatingsystem)
+    assert result_path, 'http://foo.org/4'
+  end
 end


### PR DESCRIPTION
$version is generated with the major version and a dot, producing paths
like foo.bar/x64/7. which don't exist. For CentOS at least we want to generate
a path without the dot. The default values for these media have been changed too in the seed file.
