### PR TITLE
Fixes #9113 - api docs for users miss locale and timestamp params

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -44,7 +44,8 @@ module Api
           param :default_location_id, Integer if SETTINGS[:locations_enabled]
           param :default_organization_id, Integer if SETTINGS[:organizations_enabled]
           param :auth_source_id, Integer, :required => true
-          param :timezone, String, :required => false
+          param :timezone, ActiveSupport::TimeZone.zones_map.keys, :required => false, :desc => N_("User's timezone")
+          param :locale, FastGettext.available_locales, :required => false, :desc => N_("User's preferred locale")
           param_group :taxonomies, ::Api::V2::BaseController
         end
       end

--- a/app/views/api/v2/users/main.json.rabl
+++ b/app/views/api/v2/users/main.json.rabl
@@ -2,7 +2,7 @@ object @user
 
 extends "api/v2/users/base"
 
-attributes :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :timezone, :last_login_on, :created_at, :updated_at
+attributes :firstname, :lastname, :mail, :admin, :auth_source_id, :auth_source_name, :timezone, :locale, :last_login_on, :created_at, :updated_at
 
 if SETTINGS[:locations_enabled]
   child :default_location => :default_location do


### PR DESCRIPTION
Locale was missing also in the server responses.
