### PR TITLE
Refs #9049 - fix log message formatting

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -607,7 +607,7 @@ class Host::Managed < Host::Base
     ProxyAPI::Puppet.new({:url => puppet_proxy.url}).run fqdn
   rescue => e
     errors.add(:base, _("failed to execute puppetrun: %s") % e)
-    logger.warn "unable to execute puppet run: " % e
+    logger.warn "unable to execute puppet run: %s" % e
     logger.debug e.backtrace.join("\n")
     false
   end


### PR DESCRIPTION
Missing "%s" in the commit that was supposed to fix #9049 caused the
exception message not to be printed into the log.
