### PR TITLE
fixes #9124 - fixes detection of hashed root passwords

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -116,9 +116,9 @@ module HostCommon
                        end
 
     if unencrypted_pass.present?
-      self.root_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass :
+      self.root_pass = !!(unencrypted_pass.match('^\$\d+\$.+\$.+')) ? unencrypted_pass :
           (operatingsystem.nil? ? PasswordCrypt.passw_crypt(unencrypted_pass) : PasswordCrypt.passw_crypt(unencrypted_pass, operatingsystem.password_hash))
-      self.grub_pass = unencrypted_pass.starts_with?('$') ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)
+      self.grub_pass = !!(unencrypted_pass.match('^\$\d+\$.+\$.+')) ? unencrypted_pass : PasswordCrypt.grub2_passw_crypt(unencrypted_pass)
     end
   end
 


### PR DESCRIPTION
A root password that started with "$" would not be hashed, and therefore
would end up being stored in clear text and inserted in clear text to the
/etc/shadow file, which just won't work. This adds a bit more to the match
to ensure it starts with a $, then has a number, then another $, then
any characters (salt), then another $, then some more characters. It has
been tested both ways and seems to work well.

~tommy
