### PR TITLE
Fixes #5701 - removed extra id/name HTML attributes

### DIFF
--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -1,8 +1,7 @@
 <%= fields_for item do |f| %>
   <%= select_f f, :operatingsystem_id, arch_oss, :id, :to_label,
     {:selected => item.operatingsystem_id, :include_blank => blank_or_inherit_f(f, :operatingsystem)},
-    {:id => type + "_operatingsystem_id", :name => type + "[operatingsystem_id]",
-      :label => _("Operating system"),
+    { :label => _("Operating system"),
       :disabled => arch_oss.empty? ? true : false,
       :help_inline => :indicator,
       :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :required => true}

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -1,14 +1,13 @@
 <%= fields_for item do |f| %>
   <%= select_f f, :medium_id, os_media, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
-    {:id => type + "_medium_id", :name => type + "[medium_id]", :label => _("Media"), :disabled => os_media.empty?,
+    {:label => _("Media"), :disabled => os_media.empty?,
      :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' =>  method_path('medium_selected'),
      :'data-type' => controller_name, :required => true }
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},
-    {:id => type + "_ptable_id", :name => type + "[ptable_id]", :label => _("Partition table"), :disabled => os_ptable.empty?,
-     :required => true}
+    {:label => _("Partition table"), :disabled => os_ptable.empty?, :required => true}
   %>
 
   <% if @operatingsystem and @operatingsystem.supports_image %>


### PR DESCRIPTION
It turns out these are causing issues for discovery, because for
operatingsystem, ptable and architecture the name is rendered as
"discovered_host_resource_id" while all the other fields are rendered normally
as "host_resource_id". This is causing issues.

Haven't seen any regression so far, help me to test.

Replaces https://github.com/theforeman/foreman/pull/2026
