### PR TITLE
Bugfix: broken rake-config command

### DIFF
--- a/script/foreman-config
+++ b/script/foreman-config
@@ -44,5 +44,5 @@ end
 
 Dir.chdir(options[:foreman_path]) do
   ENV['RAILS_ENV'] = options[:environment]
-  exec('rake', 'config', '--', *rake_args)
+  exec('rake', '--', 'config', *rake_args)
 end


### PR DESCRIPTION
This change was made to correct an issue on
Foreman 1.7.1, Ubuntu 14.04 LTS, Ruby 1.9.3

Where
`/usr/share/foreman/script/foreman-config` failed to modify Foreman config values.
