### PR TITLE
Fixes #9192 - Bad org id now throws 404

### DIFF
--- a/app/controllers/concerns/api/taxonomy_scope.rb
+++ b/app/controllers/concerns/api/taxonomy_scope.rb
@@ -11,9 +11,10 @@ module Api
         Location.current ||= @location = Location.find_by_id(params[:location_id])
       end
       if SETTINGS[:organizations_enabled]
-        Organization.current ||= @organization = Organization.find_by_id(params[:organization_id])
+        if params[:organization_id]
+          Organization.current ||= @organization = Organization.find(params[:organization_id])
+        end
       end
     end
-
   end
 end


### PR DESCRIPTION
Bad organization id in api calls previously would get ignored as nil
and treated as any context. With this update they 'd get treated as
org not found 404 error.
