### PR TITLE
Fixes #9194 - add ability to copy fact value to clipboard

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require settings
 //= require jquery.gridster
 //= require hidden_values
+//= require select_on_click
 
 $(document).on('ContentLoad', function(){onContentLoad()});
 Turbolinks.enableProgressBar();
@@ -112,6 +113,8 @@ function onContentLoad(){
 
   var tz = jstz.determine();
   $.cookie('timezone', tz.name(), { path: '/', secure: location.protocol === 'https:' });
+
+  $('.full-value').SelectOnClick();
 }
 
 function preserve_selected_options(elem) {

--- a/app/assets/javascripts/hidden_values.js
+++ b/app/assets/javascripts/hidden_values.js
@@ -28,6 +28,13 @@ function hidden_value_control(){
   });
 }
 
+function replace_value_control(link) {
+  var link = $(link);
+  link.find("i").toggleClass("glyphicon-plus").toggleClass("glyphicon-minus");
+  link.parent().find(".full-value").toggleClass("unhide pull-left");
+  link.parent().parent().find('a.pull-left').toggleClass("hide");
+}
+
 // normal page load trigger
 $(document).ready(turn_textarea_switch);
 

--- a/app/assets/javascripts/select_on_click.js
+++ b/app/assets/javascripts/select_on_click.js
@@ -1,0 +1,18 @@
+$.fn.SelectOnClick = function () {
+  return $(this).on('click', function () {
+    // In here, "this" is the element
+    var range, selection;
+
+    if (window.getSelection) {
+      selection = window.getSelection();
+      range = document.createRange();
+      range.selectNodeContents(this);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    } else if (document.body.createTextRange) {
+      range = document.body.createTextRange();
+      range.moveToElementText(this);
+      range.select();
+    }
+  });
+};

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -482,6 +482,17 @@ table {
   }
 }
 
+.replace-hidden-value {
+  .full-value {
+    display: none;
+    &.unhide {
+      display: inline;
+      width: 90%;
+      word-break: break-all;
+    }
+  }
+}
+
 .puppetclass_group, .config_group_group {
   li {
     a {

--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -37,4 +37,15 @@ module FactValuesHelper
       name
     end
   end
+
+  def show_full_fact_value(fact_value)
+    content_tag(:div, :class => 'replace-hidden-value') do
+      link_to_function(icon_text('plus', '', :class => 'small'), 'replace_value_control(this)',
+               :title => _('Show full value'),
+               :class => 'replace-hidden-value pull-right') +
+      content_tag(:span, :class => 'full-value') do
+        fact_value
+      end
+    end.html_safe
+  end
 end

--- a/app/views/fact_values/_fact.html.erb
+++ b/app/views/fact_values/_fact.html.erb
@@ -13,9 +13,11 @@
   </td>
   <td>
     <% unless fact.compose %>
-        <%= link_to trunc_with_tooltip(fact.value, 40),
-                    fact_values_path("search" => "facts.#{fact.name} = \"#{fact.value}\""),
-                    :title => _("Show all %{name} facts where they are equal to %{value}") % { :name => fact.name, :value => fact.value } %>
+      <%= link_to trunc_with_tooltip(fact.value, 40),
+                  fact_values_path("search" => "facts.#{fact.name} = \"#{fact.value}\""),
+                  :title => _("Show all %{name} facts where they are equal to %{value}") % { :name => fact.name, :value => fact.value },
+                  :class => 'pull-left' %>
+      <%= show_full_fact_value(fact.value) if fact.value.length > 40 %>
     <% end %>
   </td>
   <td><%= fact_from fact %></td>


### PR DESCRIPTION
Add ability to copy a fact value to clipboard.
Sadly, our bootstrap version does not support "copy" or "copy to clipboard" glyphicons so I've used the "paperclip" icon.
