### PR TITLE
fixes #9108 - parent parameters are now overrideable

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -5,6 +5,7 @@ class HostgroupsController < ApplicationController
   before_filter :find_resource,  :only => [:nest, :clone, :edit, :update, :destroy]
   before_filter :ajax_request,   :only => [:process_hostgroup, :current_parameters, :puppetclass_parameters]
   before_filter :taxonomy_scope, :only => [:new, :edit, :process_hostgroup]
+  before_filter :update_parent_params!, :only => [:update, :create]
 
   def index
     @hostgroups = resource_base.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
@@ -52,9 +53,6 @@ class HostgroupsController < ApplicationController
   end
 
   def update
-    if params[:hostgroup][:group_parameters_attributes].present?
-      params[:hostgroup][:group_parameters_attributes].merge(parse_parent_params(params.select { |k| k.match(/parent.*/) } ))
-    end
     # remove from hash :root_pass if blank?
     params[:hostgroup].except!(:root_pass) if params[:hostgroup][:root_pass].blank?
     if @hostgroup.update_attributes(params[:hostgroup])
@@ -141,16 +139,25 @@ class HostgroupsController < ApplicationController
   end
 
   def parse_parent_params(parameters)
-    parameters.reject! { |k, v| v.empty? }
     parameter_keys   = parameters.select { |p| p.match(/key/) }.values
     parameter_values = parameters.select { |p| p.match(/value/) }.values
     parameters = {}
+    parameters_hash = parameter_keys.zip(parameter_values).reject{|k, v| v.blank?}
 
-    parameter_keys.zip(parameter_values).each do |key, value|
-      id = GroupParameter.last.id + 1
-      parameters[id] = { 'name' => key, 'value' => value }
+    parameters_hash.each_with_index do |val, i|
+      key, value = val[0], val[1]
+      id = GroupParameter.last.id + 1 + i
+      parameters[id] = { 'name' => key, 'value' => value, 'nested' => true } if value.present?
     end
     parameters
+  end
+
+  def update_parent_params!
+    parent_params = parse_parent_params(params.select { |k| k.match(/parent.*/) } )
+    if params[:hostgroup] && (params[:hostgroup][:group_parameters_attributes].present? || parent_params.present?)
+      params[:hostgroup][:group_parameters_attributes] ||= {}
+      params[:hostgroup][:group_parameters_attributes].merge!(parent_params)
+    end
   end
 
   def define_parent

--- a/app/views/common_parameters/_parent_parameter.html.erb
+++ b/app/views/common_parameters/_parent_parameter.html.erb
@@ -10,7 +10,7 @@
       <% next if @hostgroup.group_parameters.map(&:name).include? parameter.name %>
       <tr>
         <td>
-          <%= text_field_tag("parent_parameter_#{i}_key", '', :class => "form-control", :placeholder => parameter.name) %>
+          <%= text_field_tag("parent_parameter_#{i}_key", '', :class => "form-control", :value => parameter.name, :readonly => true) %>
         </td>
         <td>
           <div class="input-group">

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -148,4 +148,36 @@ class HostgroupsControllerTest < ActionController::TestCase
                                                   :environment_id => "" }}, set_session_user
     assert_equal(1, (assigns(:hostgroup).puppetclasses.length))
   end
+
+  describe "parent attributes" do
+    before do
+      @base = FactoryGirl.create(:hostgroup)
+      @base.group_parameters << GroupParameter.create(:name => "x", :value => "original")
+      @base.group_parameters << GroupParameter.create(:name => "y", :value => "originally")
+    end
+
+    it "creates a hostgroup with a parent parameter" do
+      post :create, {"hostgroup" => {"name"=>"test_it", "parent_id" => @base.id, :realm_id => realms(:myrealm).id}, "parent_parameter_0_key"=>"x", "parent_parameter_0_value"=>"overridden"}, set_session_user
+      assert_redirected_to hostgroups_url
+      hostgroup = Hostgroup.where(:name => "test_it").last
+      assert_equal "overridden", hostgroup.parameters["x"]
+    end
+
+    it "updates a hostgroup with a parent parameter" do
+      child = FactoryGirl.create(:hostgroup, :parent => @base)
+      assert_equal "original", child.parameters["x"]
+      post :update, {"id" => child.id, "hostgroup" => {"name" => child.name}, "parent_parameter_0_key"=>"x", "parent_parameter_0_value"=>"overridden" }, set_session_user
+      assert_redirected_to hostgroups_url
+      assert_equal "overridden", child.parameters["x"]
+    end
+
+    it "updates a hostgroup with a parent parameter, ignores empty values" do
+      child = FactoryGirl.create(:hostgroup, :parent => @base)
+      assert_equal "original", child.parameters["x"]
+      post :update, {"id" => child.id, "hostgroup" => {"name" => child.name}, "parent_parameter_0_key"=>"x", "parent_parameter_0_value"=>nil, "parent_parameter_1_key"=>"y", "parent_parameter_1_value"=>"overridden" }, set_session_user
+      assert_redirected_to hostgroups_url
+      assert_equal "overridden", child.parameters["y"]
+      assert_equal "original", child.parameters["x"]
+    end
+  end
 end


### PR DESCRIPTION
don't really understand how this ever worked... probably didn't.
