### PR TITLE
Fixes #9197 - Highlight non-default settings and add reset option

### DIFF
--- a/app/assets/javascripts/settings.js
+++ b/app/assets/javascripts/settings.js
@@ -1,4 +1,21 @@
 $(document).ready(function() {
+  //commented, does not work yet
+  //var reset_settings = {
+  //  method      : 'DELETE',
+  //  indicator   : spinner_placeholder(),
+  //  tooltip     : __('Reset to default value'),
+  //  submitdata  : {authenticity_token: AUTH_TOKEN, format : "json"},
+  //  onsuccess   : function(data) {
+  //    $(this).closest('tr').removeClass('modified');
+  //    $(this).removeClass('resetable');
+  //  },
+  //  onerror     : function(settings, original, xhr) {
+  //    original.reset();
+  //    var error = $.parseJSON(xhr.responseText)["errors"];
+  //    $.jnotify(error, { type: "error", sticky: true });
+  //  }
+  //};
+
   var common_settings = {
     method      : 'PUT',
     indicator   : spinner_placeholder(),
@@ -25,6 +42,14 @@ $(document).ready(function() {
         editable_value = "[ "+editable_value.join(", ")+" ]";
       else
         editable_value = String(editable_value);
+
+      if (parsed.setting['is_default?']){
+          $(this).closest('tr').removeClass('modified');
+          $(this).removeClass('resetable');
+      }else{
+          $(this).closest('tr').addClass('modified');
+          $(this).addClass('resetable');
+      }
 
       $(this).html(editable_value);
     },

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -165,6 +165,16 @@ select {
   margin: 0 !important;
 }
 
+.resetable {
+  background: url("switch.png") no-repeat scroll 98% 6px transparent;
+  cursor: pointer;
+  padding: 4px 8px 4px 0;
+}
+
+tr.modified {
+  font-weight: bold;
+}
+
 .ignore-subnet {
   margin-right: 10px;
   margin-top: -25px;

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class SettingsController < V2::BaseController
       before_filter :require_admin
-      before_filter :find_resource, :only => %w{show update}
+      before_filter :find_resource, :only => %w{show update destroy}
 
       api :GET, "/settings/", N_("List all settings")
       param_group :search_and_pagination, ::Api::V2::BaseController
@@ -25,6 +25,13 @@ module Api
 
       def update
         process_response (@setting.parse_string_value(params[:setting][:value]) && @setting.save)
+      end
+
+      api :DELETE, "/settings/:id/", N_("Reset a setting to default")
+      param :id, String, :required => true
+
+      def destroy
+        process_response (@setting.reset_to_default)
       end
 
     end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -23,4 +23,16 @@ class SettingsController < ApplicationController
     end
   end
 
+  def destroy
+    # Not a real destroy, just delete the value and revert to default
+    @setting = Setting.find(params[:id])
+    if @setting.reset_to_default
+      render :json => @setting
+    else
+      error_msg = @setting.errors.full_messages
+      logger.error "Unprocessable entity Setting (id: #{@setting.id}):\n #{error_msg.join("\n  ")}\n"
+      render :json => {"errors" => error_msg}, :status => :unprocessable_entity
+    end
+  end
+
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -103,6 +103,13 @@ class Setting < ActiveRecord::Base
   end
   alias_method :default_before_type_cast, :default
 
+  def is_default?
+    value == default
+  end
+
+  def reset_to_default
+    write_attribute :value, nil
+  end
 
   def parse_string_value(val)
     case settings_type
@@ -166,6 +173,10 @@ class Setting < ActiveRecord::Base
     else
       create_existing(s, opts)
     end
+  end
+
+  def as_json(options={})
+    super(:methods => [:is_default?])
   end
 
   private

--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -2,4 +2,4 @@ object @setting
 
 extends "api/v2/settings/base"
 
-attributes :value, :description, :category, :settings_type, :default, :created_at, :updated_at
+attributes :value, :description, :category, :settings_type, :default, :created_at, :updated_at, :is_default?

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -19,9 +19,9 @@
         </thead>
         <tbody>
           <% setting.each do |item| %>
-            <tr>
+            <tr class="<%= 'modified' unless item.is_default? %>">
               <td><%=h item.name %></td>
-              <td class="setting_value"><%= value(item) %></td>
+              <td class="setting_value <%= 'resetable' unless item.is_default? %>"><%= value(item) %></td>
               <td><%=h _(item.description) %></td>
             </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :settings, :only => [:index, :update] do
+  resources :settings, :only => [:index, :update, :destroy] do
     collection do
       get 'auto_complete_search'
     end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -156,7 +156,7 @@ Foreman::Application.routes.draw do
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
       end
 
-      resources :settings, :only => [:index, :show, :update]
+      resources :settings, :only => [:index, :show, :update, :destroy]
 
       resources :smart_variables, :except => [:new, :edit] do
         resources :override_values, :except => [:new, :edit]


### PR DESCRIPTION
Ok, this is about 80% done, but I need a little JS/CSS help ;)

Highlighting of non-default rows is done, but there's probably a nicer way than using `font-weight:bold`. The APIv2 call to reset a default works great, but I'm not sure how to add a nice small button (like the existing edit button) to the non-default settings which calls the new action.

Also, bonus points if someone helps me figure out how to reset the bold highlighting appropriately when you save an edit ;)
