### PR TITLE
Fixes #9198 - migration sets type explicitly

### DIFF
--- a/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
+++ b/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
@@ -36,6 +36,7 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
       nic.managed = true
       nic.primary = true
       nic.provision = true
+      nic.type = 'Nic::Managed'
       nic.save!
 
       say "  Migrated #{nic.name}-#{nic.identifier} to nics"


### PR DESCRIPTION
This fixes existing migration. There's no way to safely fix from new migration (see below) so we should merge this ASAP. For users with already broken DB, this snippet executed from foreman console will help

``` ruby
Nic::Base.where(:type => nil).all.each {|n| n.type = 'Nic::Managed'; n.save!}
```

I would rather avoid adding new migration changing all Nics with unspecified type to `Nic::Managed` because we have no idea where they come from. Comments to this welcome.
