### PR TITLE
Fixes #9357 - Making description db types consistent across Foreman

### DIFF
--- a/db/migrate/20150212161904_move_description_fields_to_text.rb
+++ b/db/migrate/20150212161904_move_description_fields_to_text.rb
@@ -1,0 +1,8 @@
+class MoveDescriptionFieldsToText < ActiveRecord::Migration
+  def change
+    change_column :compute_resources, :description, :text
+    change_column :operatingsystems, :description, :text
+    change_column :lookup_keys, :description, :text
+    change_column :mail_notifications, :description, :text
+  end
+end

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -146,4 +146,14 @@ class ComputeResourceTest < ActiveSupport::TestCase
     refute_valid cr, :provider, "cannot be changed"
   end
 
+  test "description supports more than 255 characters" do
+    unless ActiveRecord::Base.connection.instance_values["config"][:adapter] == 'sqlite3'
+      # rails uses text(255) with sqlite
+      description = "a" * 300
+      assert (description.length > 255)
+      cr = compute_resources(:mycompute)
+      cr.description = description
+      assert_valid cr
+    end
+  end
 end


### PR DESCRIPTION
Some db fields are text fields (taxonomies, settings, etc) that accept more than 255 characters while others are string fields. This makes all description fields text.
