### PR TITLE
fixes #9362 - Add mediapath support to CoreOS

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -240,6 +240,7 @@ class UnattendedController < ApplicationController
   end
 
   def coreos_attributes
+    @mediapath = @host.operatingsystem.mediumpath @host
   end
 
   def aif_attributes

--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -5,6 +5,11 @@ class Coreos < Operatingsystem
     'coreos'
   end
 
+  # Simple output of the media url
+  def mediumpath(host)
+    medium_uri(host, "#{host.medium.path}/#{pxedir}").to_s
+  end
+
   def url_for_boot(file)
     PXEFILES[file]
   end


### PR DESCRIPTION
Add mediapath support to CoreOS. Support base-url in coreos-install script see https://github.com/theforeman/community-templates/pull/139
