### PR TITLE
Fixes #9388 - Adding cname support in foreman.

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -38,6 +38,7 @@ module Api
       def_param_group :host do
         param :host, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
+          param :aliases, String, :desc => N_("DNS aliases of the host.")
           param :location_id, :number, :required => true, :desc => N_("required if locations are enabled") if SETTINGS[:locations_enabled]
           param :organization_id, :number, :required => true, :desc => N_("required if organizations are enabled") if SETTINGS[:organizations_enabled]
           param :environment_id, String, :desc => N_("required if host is managed and value is not inherited from host group")

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -206,10 +206,15 @@ class Host::Managed < Host::Base
     FactValue.where("host_id = #{id}").delete_all
   end
 
+  def defaultValues
+    self.aliases ||= ""
+  end
+
   def clear_data_on_build
     return unless respond_to?(:old) && old && build? && !old.build?
     clearFacts
     clearReports
+    defaultValues
   end
 
   def set_token

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -118,6 +118,10 @@ module Nic
       self.deep_clone(:except  => [:name, :mac, :ip])
     end
 
+    def alias_list
+      return []
+    end
+
     protected
 
     def uniq_fields_with_hosts

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -52,6 +52,10 @@ module Nic
       N_('Interface')
     end
 
+    def alias_list
+      return []
+    end
+
     private
 
     def enc_attributes

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -30,6 +30,8 @@
         <%= text_f f, :name, :size => "col-md-5", :value => name_field(@host),
             :help_inline => _("This value is used also as the host's primary interface name.") %>
 
+        <%= text_f f, _('Name aliases'), :id=> "alias_list", :size => "col-md-4", :value => @host.aliases, 
+          :help_inline => popover(_("DNS alias list format"), _("This field contains a comma seperated list of DNS aliases.<br/><br/>You can fill this with using either the following formats:<ul><li>alias1, alias2, alias2</li><li>alias1 alias2 alias3</li><li>alias1,alias2,alias3</li></ul></br>The list will be automatically formatted to the suitable internal format."), :title => _("DNS alias list format")).html_safe %>
         <% if show_organization_tab?  %>
           <%= host_taxonomy_select(f, Organization) %>
         <% end %>

--- a/db/migrate/20141211143227_add_aliases_to_hosts.rb
+++ b/db/migrate/20141211143227_add_aliases_to_hosts.rb
@@ -1,0 +1,5 @@
+class AddAliasesToHosts < ActiveRecord::Migration
+  def change
+    add_column :hosts, :aliases, :string, :default => ""
+  end
+end

--- a/lib/net/dns.rb
+++ b/lib/net/dns.rb
@@ -5,6 +5,7 @@ module Net
   module DNS
     autoload :ARecord,   "net/dns/a_record.rb"
     autoload :PTRRecord, "net/dns/ptr_record.rb"
+    autoload :CNAMERecord, "net/dns/cname_record.rb"
 
     # Looks up the IP or MAC address. Handles the conversion of a DNS miss
     # exception into nil
@@ -37,11 +38,11 @@ module Net
     end
 
     class Record < Net::Record
-      attr_accessor :ip, :resolver, :type
+      attr_accessor :ip, :resolver, :type, :value
 
       def initialize(opts = { })
         super(opts)
-        self.ip = validate_ip self.ip
+        self.ip = validate_ip self.ip unless self.ip.nil?
         self.resolver ||= Resolv::DNS.new
       end
 

--- a/lib/net/dns/cname_record.rb
+++ b/lib/net/dns/cname_record.rb
@@ -1,0 +1,45 @@
+module Net
+  module DNS
+    class CNAMERecord < DNS::Record
+      def initialize(opts = { })
+        super opts
+        @type = "CNAME"
+      end
+
+      def to_s
+        "#{value}/#{hostname}"
+      end
+
+      def destroy
+        super
+        proxy.delete(hostname)
+      end
+
+      def create
+        super
+        proxy.set attrs
+      rescue RestClient::Conflict
+        raise generate_conflict_error
+      end
+
+      # Returns an array of record objects which are conflicting with our own
+      def conflicts
+        @conflicts ||= [dns_lookup(hostname)].delete_if{|c| c == self}.compact
+      end
+
+      # Verifies that a record already exists on the dns server
+      def valid?
+        logger.debug "Fetching DNS reservation for #{to_s}"
+        dns_lookup(hostname).valid?
+      end
+
+      def a
+        dns_lookup(hostname)
+      end
+
+      def attrs
+        { :fqdn => hostname, :value => value, :type => type }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello, sorry I am redoing my pull request since I screwed up the previous one (#2158, you can delete it) 

I have added a cname support in foreman UI and in the V2 API.

This consists in a field in the host tab, this field splits a comma separated list of aliases.

Theses aliases are automatically formatted using javascript if the aliases are only separated by spaces of only by a comma or by a comma + spaces.

This new issue is related to the tracking issue: http://projects.theforeman.org/issues/5409
