### PR TITLE
fixes #6655 - remove _ForemanSelectedhosts cookie on action submit

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -63,7 +63,7 @@ $(function() {
 });
 
 function removeForemanHostsCookie() {
-  $.cookie($.cookieName, null);
+  $.removeCookie($.cookieName);
 }
 
 function resetSelection() {
@@ -103,10 +103,20 @@ function toggle_multiple_ok_button(elem){
 
 // updates the form URL based on the action selection
 $(function() {
-  $('#submit_multiple a').click(function(){
-    if ($.foremanSelectedHosts.length == 0 || $(this).hasClass('dropdown-toggle')) { return false }
-    var title = $(this).attr('data-dialog-title');
-    var url = $(this).attr('href') + "?" + $.param({host_ids: $.foremanSelectedHosts});
+  $('#confirmation-modal .secondary').click(function(){
+    $('#confirmation-modal').modal('hide');
+  });
+});
+
+function submit_modal_form() {
+  removeForemanHostsCookie();
+  $("#confirmation-modal form").submit();
+  $('#confirmation-modal').modal('hide');
+}
+
+function build_modal(element, url) {
+  var url = url + "?" + $.param({host_ids: $.foremanSelectedHosts});
+  var title = $(element).attr('data-dialog-title');
     $('#confirmation-modal .modal-header h4').text(title);
     $('#confirmation-modal .modal-body').empty().append("<img class='modal-loading' src='/assets/spinner.gif'>");
     $('#confirmation-modal').modal();
@@ -121,18 +131,8 @@ $(function() {
             b.removeClass("disabled").attr("disabled", false);
           });
     return false;
-  });
 
-  $('#confirmation-modal .btn-primary').click(function(){
-    $("#confirmation-modal form").submit();
-    $('#confirmation-modal').modal('hide');
-  });
-
-  $('#confirmation-modal .secondary').click(function(){
-    $('#confirmation-modal').modal('hide');
-  });
-
-});
+}
 
 function update_counter() {
   var item = $("#check_all");

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -141,7 +141,7 @@ module HostsHelper
   def multiple_actions_select
     select_action_button( _("Select Action"), {:id => 'submit_multiple'},
       multiple_actions.map do |action|
-        link_to(action[0], action[1], :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0])
+        link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0])
       end.flatten
     )
   end

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -47,7 +47,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= _('Cancel') %></button>
-        <button type="button" class="btn btn-primary"><%= _('Submit') %></button>
+        <button type="button" class="btn btn-primary" onclick="submit_modal_form()"><%= _('Submit') %></button>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->


### PR DESCRIPTION
1) remove the cookie completely on RemoveForemanHostCookie, instead of setting it to null
2) Upon submitting the action on the modal box, remove also the cookie.
