### PR TITLE
fixes #9397 - Make usage of @host.operatingsystem consistent

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -181,7 +181,7 @@ class UnattendedController < ApplicationController
 
   def load_template_vars
     # load the os family default variables
-    send "#{@host.os.pxe_type}_attributes"
+    send "#{@host.operatingsystem.pxe_type}_attributes"
 
     @provisioning_type = @host.is_a?(Hostgroup) ? 'hostgroup' : 'host'
 
@@ -195,8 +195,7 @@ class UnattendedController < ApplicationController
   end
 
   def alterator_attributes
-    os           = @host.operatingsystem
-    @mediapath   = os.mediumpath @host
+    @mediapath   = @host.operatingsystem.mediumpath @host
     @mediaserver = URI(@mediapath).host
     @metadata    = params[:metadata].to_s
   end
@@ -205,11 +204,7 @@ class UnattendedController < ApplicationController
     if @host.operatingsystem.supports_image and @host.use_image
       @install_type     = "flash_install"
       # We have an individual override for the host's image file
-      if @host.image_file
-        @archive_location = @host.image_file
-      else
-        @archive_location = @host.default_image_file
-      end
+      @archive_location = @host.image_file ? @host.image_file : @host.default_image_file
     else
       @install_type = "initial_install"
       @system_type  = "standalone"
@@ -223,15 +218,14 @@ class UnattendedController < ApplicationController
   def kickstart_attributes
     @dynamic   = @host.diskLayout =~ /^#Dynamic/
     @arch      = @host.architecture.name
-    os         = @host.operatingsystem
-    @osver     = os.major.to_i
-    @mediapath = os.mediumpath @host
-    @repos     = os.repos @host
+    @osver     = @host.operatingsystem.major.to_i
+    @mediapath = @host.operatingsystem.mediumpath @host
+    @repos     = @host.operatingsystem.repos @host
   end
 
   def preseed_attributes
-    @preseed_path   = @host.os.preseed_path   @host
-    @preseed_server = @host.os.preseed_server @host
+    @preseed_path   = @host.operatingsystem.preseed_path   @host
+    @preseed_server = @host.operatingsystem.preseed_server @host
   end
 
   def yast_attributes
@@ -242,18 +236,15 @@ class UnattendedController < ApplicationController
   end
 
   def aif_attributes
-    os         = @host.operatingsystem
-    @mediapath = os.mediumpath @host
+    @mediapath = @host.operatingsystem.mediumpath @host
   end
 
   def memdisk_attributes
-    os         = @host.operatingsystem
-    @mediapath = os.mediumpath @host
+    @mediapath = @host.operatingsystem.mediumpath @host
   end
 
   def ZTP_attributes
-    os         = @host.operatingsystem
-    @mediapath = os.mediumpath @host
+    @mediapath = @host.operatingsystem.mediumpath @host
   end
 
   def waik_attributes

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -249,7 +249,7 @@ module HostsHelper
       [_("MAC Address"), host.mac],
       [_("Puppet Environment"), (link_to(host.environment, hosts_path(:search => "environment = #{host.environment}")) if host.environment)],
       [_("Host Architecture"), (link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}")) if host.arch)],
-      [_("Operating System"), (link_to(host.os.to_label, hosts_path(:search => "os_description = #{host.os.description}")) if host.os)],
+      [_("Operating System"), (link_to(host.operatingsystem.to_label, hosts_path(:search => "os_description = #{host.operatingsystem.description}")) if host.operatingsystem)],
       [_("Host group"), (link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"})) if host.hostgroup)],
     ]
     fields += [[_("Location"), (link_to(host.location.title, hosts_path(:search => "location = #{host.location}")) if host.location)]] if SETTINGS[:locations_enabled]

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -26,7 +26,7 @@ module Nic
                           })
       # Are we booting SPARC solaris?
       if host.jumpstart?
-        jumpstart_arguments = host.os.jumpstart_params host, host.model.vendor_class
+        jumpstart_arguments = host.operatingsystem.jumpstart_params host, host.model.vendor_class
         attrs.merge! jumpstart_arguments unless jumpstart_arguments.empty?
       end
       attrs

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -108,7 +108,7 @@ class Operatingsystem < ActiveRecord::Base
 
   def medium_uri(host, url = nil)
     url ||= host.medium.path
-    medium_vars_to_uri(url, host.architecture.name, host.os)
+    medium_vars_to_uri(url, host.architecture.name, host.operatingsystem)
   end
 
   def medium_vars_to_uri(url, arch, os)

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -24,7 +24,7 @@
               </td>
               <td><%= name_column(host) %>
               </td>
-              <td class="hidden-xs"><%= (icon(host.os, :size => "18x18") + trunc_with_tooltip(" #{host.os.to_label}",14)).html_safe if host.os %></td>
+              <td class="hidden-xs"><%= (icon(host.operatingsystem, :size => "18x18") + trunc_with_tooltip(" #{host.operatingsystem.to_label}",14)).html_safe if host.operatingsystem %></td>
               <td class="hidden-xs"><%= trunc_with_tooltip(host.try(:environment), 14) %></td>
               <td class="hidden-tablet hidden-xs"><%= model_name host %></td>
               <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 26 %></td>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -21,7 +21,7 @@
         </td>
         <td class='ellipsis'><%= name_column(host) %>
         </td>
-        <td class="hidden-xs"><%= (icon(host.os, :size => "18x18") + trunc_with_tooltip(" #{host.os.to_label}",14)).html_safe if host.os %></td>
+        <td class="hidden-xs"><%= (icon(host.operatingsystem, :size => "18x18") + trunc_with_tooltip(" #{host.operatingsystem.to_label}",14)).html_safe if host.operatingsystem %></td>
         <td class="hidden-xs"><%= trunc_with_tooltip(host.try(:environment), 14) %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= model_name host %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= label_with_link host.hostgroup, 26, @hostgroup_authorizer %></td>

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -1,5 +1,5 @@
 <% javascript 'charts', 'hosts' %>
-<% title @host.to_label, icon(@host.os) + @host.to_label %>
+<% title @host.to_label, icon(@host.operatingsystem) + @host.to_label %>
 <%= host_title_actions(@host) %>
 <% content_for(:search_bar) {reports_show} %>
 <div id="host-show" class="row" data-history-url='<%= host_path(@host)%>'>

--- a/app/views/unattended/snippets/_epel.erb
+++ b/app/views/unattended/snippets/_epel.erb
@@ -19,4 +19,4 @@ name: epel
   ''
   end
 -%>
-su -c 'rpm -Uvh <%= @host.os.medium_uri(@host, epel_url) %>'
+su -c 'rpm -Uvh <%= @host.operatingsystem.medium_uri(@host, epel_url) %>'

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -48,7 +48,7 @@ class MediumTest < ActiveSupport::TestCase
     host = FactoryGirl.create(:host, :with_operatingsystem)
     refute host.build?
     host.medium = medium
-    host.os.media << medium
+    host.operatingsystem.media << medium
     assert host.save!
 
     medium.hosts << host
@@ -65,7 +65,7 @@ class MediumTest < ActiveSupport::TestCase
     host = FactoryGirl.create(:host, :with_operatingsystem)
     host.build = true
     host.medium = medium
-    host.os.media << medium
+    host.operatingsystem.media << medium
     assert host.save!
 
     medium.hosts << host

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -55,7 +55,7 @@ class OperatingsystemTest < ActiveSupport::TestCase
     assert operating_system.save
 
     host = FactoryGirl.create(:host)
-    host.os = operating_system
+    host.operatingsystem = operating_system
     host.save(:validate => false)
 
     assert !operating_system.destroy

--- a/test/unit/operatingsystems/operatingsystems_test.rb
+++ b/test/unit/operatingsystems/operatingsystems_test.rb
@@ -43,7 +43,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :ptables => [ptables(:one)],
                                                                      :media => [FactoryGirl.build(:medium)]),
                                :architecture => arch)
-      assert_equal(config['expected'], host.os.kernel(host.arch))
+      assert_equal(config['expected'], host.operatingsystem.kernel(host.arch))
     end
   end
 
@@ -60,7 +60,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :ptables => [ptables(:one)],
                                                                      :media => [FactoryGirl.build(:medium)]),
                                :architecture => arch)
-      assert_equal(config['expected'], host.os.initrd(host.arch))
+      assert_equal(config['expected'], host.operatingsystem.initrd(host.arch))
     end
   end
 
@@ -77,7 +77,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :ptables => [ptables(:one)],
                                                                      :media => [FactoryGirl.build(:medium)]),
                                :architecture => arch)
-      assert_equal(config['expected'], host.os.pxe_prefix(host.arch))
+      assert_equal(config['expected'], host.operatingsystem.pxe_prefix(host.arch))
     end
   end
 
@@ -107,11 +107,11 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                :architecture    => arch,
                                :medium          => medium)
 
-      host.medium.operatingsystems << host.os
-      host.arch.operatingsystems << host.os
+      host.medium.operatingsystems << host.operatingsystem
+      host.arch.operatingsystems << host.operatingsystem
 
-      prefix = host.os.pxe_prefix(host.arch).to_sym
-      pxe_files = host.os.pxe_files(host.medium, host.arch)
+      prefix = host.operatingsystem.pxe_prefix(host.arch).to_sym
+      pxe_files = host.operatingsystem.pxe_files(host.medium, host.arch)
 
       assert pxe_files.include?({ prefix => config['kernel'] })
       assert pxe_files.include?({ prefix => config['initrd'] })


### PR DESCRIPTION
Make usage of @host.operatingsystem in UnattendedController consistent to looklike "@mediapath = @host.operatingsystem.mediumpath @host" in all definitions. [Issue](http://projects.theforeman.org/issues/9397)
