### PR TITLE
refs #3809 - exclude auto-generated schema.rb from rubocop checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_from:
 
 AllCops:
   RunRailsCops: true # always run the rails cops
+  Exclude:
+    - 'db/schema.rb'
 
 # Don't enforce documentation
 Style/Documentation:
@@ -18,4 +20,4 @@ Style/HashSyntax:
 
 Metrics/ClassLength:
   Exclude:
-   - 'test/**/*'
+    - 'test/**/*'


### PR DESCRIPTION
Mine shows...

<pre>
Offenses:
 
db/schema.rb:15:1: C: Extra empty line detected at block body beginning.
db/schema.rb:833:1: C: Extra empty line detected at block body end.
</pre>
