### PR TITLE
Fixes #9427 - Return meaningful errors from subnets/freeip 

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -600,6 +600,10 @@ function interface_subnet_selected(element) {
       interface_ip.val(result['ip']);
       update_interface_table();
     },
+    error: function(request, status, error) {
+      interface_ip.addClass('tab-error');
+      interface_ip.val(Jed.sprintf(__("Error generating IP: %s"), error))
+    },
     complete:function () {
       $(element).indicator_hide();
       interface_ip.attr('disabled', false);

--- a/test/functional/subnets_controller_test.rb
+++ b/test/functional/subnets_controller_test.rb
@@ -56,4 +56,60 @@ class SubnetsControllerTest < ActionController::TestCase
     assert_redirected_to subnets_url
     assert !Subnet.exists?(subnet.id)
   end
+
+  def test_freeip_fails_no_subnet
+    get :freeip, {}, set_session_user
+
+    assert_response :bad_request
+  end
+
+  def test_freeip_fails_subnet_not_authorized
+    subnet_id = setup_subnet nil
+
+    get :freeip, {subnet_id: subnet_id}, set_session_user
+
+    assert_response :not_found
+  end
+
+  def test_freeip_not_found
+    subnet = mock('subnet')
+    subnet.stubs(:unused_ip).returns(nil)
+    subnet_id = setup_subnet subnet
+
+    get :freeip, {subnet_id: subnet_id}, set_session_user
+
+    assert_response :not_found
+  end
+
+  def test_freeip_fails_on_error
+    subnet = mock('subnet')
+    subnet.stubs(:unused_ip).raises(StandardError, 'Exception message')
+    subnet_id = setup_subnet subnet
+
+    get :freeip, {subnet_id: subnet_id}, set_session_user
+
+    assert_response :internal_server_error
+  end
+
+  def test_freeip_returns_json_on_success
+    ip = '1.2.3.4'
+    subnet = mock('subnet')
+    subnet.stubs(:unused_ip).returns(ip)
+    subnet_id = setup_subnet subnet
+
+    get :freeip, {subnet_id: subnet_id}, set_session_user
+
+    assert_response :success
+    assert_equal ip, JSON.parse(response.body)['ip']
+  end
+
+  private
+
+  def setup_subnet(subnet)
+    subnet_id = 10
+    scope = mock('scope')
+    scope.expects(:find).with(subnet_id).returns(subnet)
+    Subnet.stubs(:authorized).with(:view_subnets).returns(scope)
+    subnet_id
+  end
 end


### PR DESCRIPTION
and parse the error response to the UI
