### PR TITLE
Fixes #9362 - corrected mediapath

### DIFF
--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -5,9 +5,8 @@ class Coreos < Operatingsystem
     'coreos'
   end
 
-  # Simple output of the media url
   def mediumpath(host)
-    medium_uri(host, "#{host.medium.path}/#{pxedir}").to_s
+    medium_uri(host, "#{host.medium.path}/#{host.architecture.name}-usr").to_s.gsub('x86_64','amd64')
   end
 
   def url_for_boot(file)
@@ -15,7 +14,11 @@ class Coreos < Operatingsystem
   end
 
   def pxedir
-    'amd64-usr/$version'
+    '$arch/$version'
+  end
+
+  def boot_files_uri(medium, architecture, host = nil)
+    super(medium, architecture, host).each{ |img_uri| img_uri.path = img_uri.path.gsub('x86_64','amd64-usr') }
   end
 
   def display_family

--- a/test/unit/operatingsystems/operatingsystems_test.rb
+++ b/test/unit/operatingsystems/operatingsystems_test.rb
@@ -15,7 +15,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'expected' => 'amd64-usr/$version' },
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'expected' => '$arch/$version' },
     :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/debian-installer/$arch' },
     :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/ubuntu-installer/$arch' },
     :suse        => { 'os' => :suse,        'arch' => :x86_64, 'expected' => 'boot/$arch/loader' } }.


### PR DESCRIPTION
Changed `medium_uri(host, "#{host.medium.path}/#{pxedir}").to_s` to `medium_uri(host, "#{host.medium.path}/amd64-usr").to_s` because the coreos-install script adds the version automatically.
