### PR TITLE
Fixes #9497 - Require MAC for managed BMC

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -19,8 +19,10 @@ module Nic
     after_validation :set_validated
     before_destroy :not_required_interface
 
-    validates :mac, :uniqueness => {:scope => :virtual}, :if => Proc.new { |nic| nic.host && nic.host.managed? && !nic.host.compute? && !nic.virtual? }
-    validates :mac, :presence => true, :if => Proc.new { |nic| nic.host && nic.host.managed? && !nic.host.compute? &&!nic.virtual? }
+    validates :mac, :uniqueness => {:scope => :virtual},
+              :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? && !nic.virtual? }, :allow_blank => true
+    validates :mac, :presence => true,
+              :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? &&!nic.virtual? }
     validates :mac, :mac_address => true, :allow_blank => true
 
     # TODO uniq on primary per host

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -1,7 +1,14 @@
 module Nic
   class BMC < Managed
     PROVIDERS = %w(IPMI)
+    before_validation :ensure_physical
     validates :provider, :presence => true, :inclusion => { :in => PROVIDERS }
+    validates :mac, :presence => true, :if => :managed?
+
+    def virtual
+      false
+    end
+    alias_method :virtual?, :virtual
 
     register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
 
@@ -22,6 +29,11 @@ module Nic
     end
 
     private
+
+    def ensure_physical
+      self.virtual = false
+      true # don't stop validation chain
+    end
 
     def enc_attributes
       @enc_attributes ||= (super + %w(username password provider))

--- a/app/models/nic/bond.rb
+++ b/app/models/nic/bond.rb
@@ -5,7 +5,7 @@ module Nic
     validates :mode, :presence => true, :inclusion => { :in => MODES }
     validates :attached_devices, :format => { :with => /\A[a-z0-9#{SEPARATOR}.:_-]+\Z/ }, :allow_blank => true
 
-    before_save :ensure_virtual
+    before_validation :ensure_virtual
 
     register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
 

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -144,6 +144,18 @@ class NicTest < ActiveSupport::TestCase
       end
     end
 
+    test "bmc requires MAC address if managed" do
+      bmc = FactoryGirl.build(:nic_bmc, :managed => true, :mac => '')
+      refute bmc.valid?
+      assert_includes bmc.errors.keys, :mac
+    end
+
+    test "bmc does not require MAC address if unmanaged" do
+      bmc = FactoryGirl.build(:nic_bmc, :managed => false, :mac => '')
+      bmc.valid?
+      refute_includes bmc.errors.keys, :mac
+    end
+
     context "on managed host" do
       setup do
         @host = FactoryGirl.create(:host, :managed, :ip => '127.0.0.1')


### PR DESCRIPTION
Other related minor changes:
- perform uniqueness and presence of MAC only on managed interfaces (otherwise we'd get not unique on empty MAC on unmanaged etc)
- move `ensure_virtual` in bond to before_validation to keep consistency and have this information available during validations
