### PR TITLE
Fixes #9500 - matching uses the whole domain name

### DIFF
--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -69,7 +69,7 @@ module Nic
 
       if domain.nil? and name.match(/\./)
         # try to assign the domain automatically based on our existing domains from the host FQDN
-        self.domain = Domain.all.select{|d| name.match(d.name)}.first rescue nil
+        self.domain = Domain.all.select{|d| name.match(/#{d.name}\Z/)}.first rescue nil
       else
         # if we've just updated the domain name, strip off the old one
         if !new_record? and changed_attributes['domain_id'].present?

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -111,7 +111,7 @@ class HostTest < ActiveSupport::TestCase
     assert_equal "myhost.company.com", host.name
   end
 
-  test "should not append domainname to fqdn" do
+  test "should not append domainname to fqdn for unmanaged host" do
     host = Host.create :name => "myhost.sub.comp.net", :mac => "aabbccddeeff", :ip => "123.01.02.03",
       :domain => Domain.find_or_create_by_name("company.com"),
       :certname => "myhost.sub.comp.net",

--- a/test/unit/nics/managed_test.rb
+++ b/test/unit/nics/managed_test.rb
@@ -18,4 +18,66 @@ class ManagedTest < ActiveSupport::TestCase
     assert_equal 'updated', nic.host.comment
     assert_equal 'original', clone.host.comment
   end
+
+  test "#normalize_hostname returns nil for empty names" do
+    nic = setup_primary_nic_with_name('')
+    assert_nil nic.send(:normalize_name)
+  end
+
+  # all tests that sues " Host..." as a name also checks that it removes whitespace and normalizes the hostname
+  # this is because this method does too many things...
+  test "#normalize_hostname sets a domain based on name that contains its name if it's nil and such domain exists" do
+    domain = FactoryGirl.create(:domain)
+    nic = setup_primary_nic_with_name(" Host.#{domain.name}")
+    nic.domain_id = nil
+    nic.send(:normalize_name)
+    assert_equal "host.#{domain.name}", nic.name
+    assert_equal domain, nic.domain
+  end
+
+  test "#normalize_hostname keeps domain nil if it can't find such domain based on name" do
+    domain = FactoryGirl.create(:domain)
+    nic = setup_primary_nic_with_name(" Host.#{domain.name}.custom", :domain => nil)
+    nic.send(:normalize_name)
+    assert_equal "host.#{domain.name}.custom", nic.name
+    assert_nil nic.domain
+  end
+
+  test "#normalize_hostname keeps domain nil if it can't find such domain based on name" do
+    nic = setup_primary_nic_with_name(" Host", :domain => nil)
+    nic.send(:normalize_name)
+    assert_equal "host", nic.name
+    assert_nil nic.domain
+  end
+
+  test "#normalize_hostname does not touch name if it's different from domain name and it's a new record (leaves inconsistency)" do
+    domain = FactoryGirl.create(:domain)
+    nic = setup_primary_nic_with_name(" Host.#{domain.name}.custom", :domain => domain)
+    nic.send(:normalize_name)
+    assert_equal "host.#{domain.name}.custom", nic.name
+    assert_equal domain, nic.domain
+  end
+
+  test "#normalize_hostname updates name on existing record if domain changed" do
+    domain = FactoryGirl.create(:domain)
+    nic = setup_primary_nic_with_name(" Host.#{domain.name}", :domain => domain)
+    nic.host.save
+    nic.reload
+
+    new_domain = FactoryGirl.create(:domain)
+    nic.domain_id = new_domain.id
+    nic.send(:normalize_name)
+    assert_equal "host.#{new_domain.name}", nic.name
+    assert_equal new_domain, nic.domain
+  end
+
+  private
+
+  def setup_primary_nic_with_name(name, opts = {})
+    h = FactoryGirl.build(:host, :managed, opts) # build host, which also builds primary interface
+    h.name = name                                # setup the desired name on host
+    nic = h.primary_interface
+    nic.valid?                                   # triggers copying hostname from host and normalize_name
+    nic
+  end
 end


### PR DESCRIPTION
I added more tests to cover complex normalize_name method.
