### PR TITLE
Fixes #8736 - confirmation before host delete for freshly created hosts

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -110,16 +110,11 @@ function submit_host(){
     url: url,
     data: $('form').serialize(),
     success: function(response){
-      if(response.redirect){
-        window.location.replace(response.redirect);
-      }
-      else{
-        $("#host-progress").hide();
-        $('#content').replaceWith($("#content", response));
-        $(document.body).trigger('ContentLoad');
-        if($("[data-history-url]").exists()){
-            history.pushState({}, "Host show", $("[data-history-url]").data('history-url'));
-        }
+      $("#host-progress").hide();
+      $('#content').replaceWith($("#content", response));
+      $(document.body).trigger('ContentLoad');
+      if($("[data-history-url]").exists()){
+          history.pushState({}, "Host show", $("[data-history-url]").data('history-url'));
       }
     },
     error: function(response){

--- a/app/assets/javascripts/hosts.js
+++ b/app/assets/javascripts/hosts.js
@@ -1,4 +1,5 @@
-$(function () {
+$(document).on('ContentLoad', function () {
+
   var dialog = $("#review_before_build");
   $("#build-review").click(function () {
     dialog.find(".modal-body #build_status").html('');

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -81,7 +81,7 @@ class HostsController < ApplicationController
     @host.managed = true if (params[:host] && params[:host][:managed].nil?)
     forward_url_options
     if @host.save
-      process_success :success_redirect => host_path(@host), :redirect_xhr => request.xhr?
+      process_success :success_redirect => host_path(@host)
     else
       load_vars_for_ajax
       offer_to_overwrite_conflicts
@@ -104,7 +104,7 @@ class HostsController < ApplicationController
         end
       end
       if @host.update_attributes(params[:host])
-        process_success :success_redirect => host_path(@host), :redirect_xhr => request.xhr?
+        process_success :success_redirect => host_path(@host)
       else
         taxonomy_scope
         load_vars_for_ajax

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= javascript 'host_edit', 'host_edit_interfaces', 'class_edit', 'compute_resource', 'lookup_keys'%>
+<%= javascript 'hosts', 'host_edit', 'host_edit_interfaces', 'class_edit', 'compute_resource', 'lookup_keys'%>
 <%= render "hosts/dhcp_lease_errors" if has_dhcp_lease_errors?(@host.errors) %>
 <%= render "hosts/conflicts" if (!has_dhcp_lease_errors?(@host.errors) && has_conflicts?(@host.errors)) %>
 <%= render "hosts/progress" %>


### PR DESCRIPTION
The js code that adds confirmation callbacks was not executed after ajax content change.
This PR also removes some dead code.
