### PR TITLE
fixes #6044 - production.log should have timestamps in it

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,12 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
+#Add timestamps and severity to environment.log
+class Logger
+  def format_message(severity, timestamp, progname, msg)
+    "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} [#{severity[0]}] #{msg}\n"
+  end
+end
+
 # Initialize the rails application
 Foreman::Application.initialize!


### PR DESCRIPTION
This will add timestamps and severity to production.log or whatever is the current environment.

Example log:
2015-02-25 11:31:14 +0100 (INFO)   Rendered home/_user_dropdown.html.erb (1.7ms)
2015-02-25 11:31:14 +0100 (DEBUG)   CACHE (0.0ms)  SELECT COUNT(_) FROM "taxonomies" WHERE "taxonomies"."type" IN ('Organization')
2015-02-25 11:31:14 +0100 (DEBUG)   CACHE (0.0ms)  SELECT "taxonomies"._ FROM "taxonomies" WHERE "taxonomies"."type" IN ('Organization') ORDER BY title
2015-02-25 11:31:14 +0100 (INFO)   Rendered home/_organization_dropdown.html.erb (6.8ms)
