### PR TITLE
fixes #7764 - add quirks mode to JSON.dump

### DIFF
--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,0 +1,24 @@
+require 'json/version'
+module JSON
+  class << self
+    def dump_in_quirks_mode(obj, anIO = nil, limit = nil)
+      if anIO && limit.nil?
+        an_io_obj = anIO.to_io if anIO.respond_to?(:to_io)
+        unless anIO.respond_to?(:write)
+          limit = anIO
+          an_io_obj = nil
+        end
+      end
+      limit ||= 0
+      result = generate(obj, :allow_nan => true, :max_nesting => limit, :quirks_mode => true)
+      if an_io_obj
+        an_io_obj.write result
+        an_io_obj
+      else
+        result
+      end
+    rescue JSON::NestingError
+      raise ArgumentError, "exceed depth limit"
+    end
+  end
+end


### PR DESCRIPTION
Copied dump method from JSON (version 1.5.5.) from https://github.com/flori/json/blob/v1.5.5/lib/json/common.rb#L343

Added the option `quirks_mode => true`.

The quirks_mode is added in later versions of JSON (https://github.com/flori/json/blob/master/lib/json/common.rb#L363)
the difference in the options between 1.5.5 and later is the addition of quirks_mode

This solves issue #7764, and openscap with json-1.5.5 
