### PR TITLE
Fixes #9147 - move managed checks to the start of the DHCP/DNS/TFTP orchestration checks

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -8,7 +8,9 @@ module Orchestration::DHCP
   end
 
   def dhcp?
-    hostname.present? && ip_available? && mac_available? && !subnet.nil? && subnet.dhcp? && host.managed? && managed?
+    # host.managed? and managed? should always come first so that orchestration doesn't
+    # even get tested for such objects
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && mac_available? && !subnet.nil? && subnet.dhcp?
   end
 
   def dhcp_record

--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -7,11 +7,15 @@ module Orchestration::DNS
   end
 
   def dns?
-    hostname.present? && ip_available? && !domain.nil? && !domain.proxy.nil? && host.managed? && managed?
+    # host.managed? and managed? should always come first so that orchestration doesn't
+    # even get tested for such objects
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !domain.nil? && !domain.proxy.nil?
   end
 
   def reverse_dns?
-    hostname.present? && ip_available? && !subnet.nil? && subnet.dns? && host.managed? && managed?
+    # host.managed? and managed? should always come first so that orchestration doesn't
+    # even get tested for such objects
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !subnet.nil? && subnet.dns?
   end
 
   def dns_a_record

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -10,7 +10,9 @@ module Orchestration::TFTP
   end
 
   def tftp?
-    provision? && !!(subnet && subnet.tftp?) && host.managed? && (host.operatingsystem && host.operatingsystem.pxe_variant) && managed? && pxe_build?
+    # host.managed? and managed? should always come first so that orchestration doesn't
+    # even get tested for such objects
+    (host.nil? || host.managed?) && managed && provision? && !!(subnet && subnet.tftp?) && (host && host.operatingsystem && host.operatingsystem.pxe_variant) && pxe_build?
   end
 
   def tftp

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -70,11 +70,11 @@ module Nic
 
     # Copied from compute orchestraion
     def ip_available?
-      ip.present? || host.compute_provides?(:ip) # TODO revist this for VMs
+      ip.present? || (host.present? && host.compute_provides?(:ip)) # TODO revist this for VMs
     end
 
     def mac_available?
-      mac.present? || host.compute_provides?(:mac) # TODO revist this for VMs
+      mac.present? || (host.present? && host.compute_provides?(:mac)) # TODO revist this for VMs
     end
 
     protected

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -46,6 +46,14 @@ class HostTest < ActiveSupport::TestCase
     refute host.save
     assert_includes host.errors.keys, :interfaces
 
+    host.interfaces = [ FactoryGirl.build(:nic_managed, :primary => true, :host => host,
+                                           :domain => FactoryGirl.create(:domain)) ]
+    assert host.save
+  end
+
+  test "existing interface can be assigned as host primary interface" do
+    host = FactoryGirl.build(:host, :managed)
+    host.interfaces = [] # remove existing primary interface
     host.interfaces = [ FactoryGirl.create(:nic_managed, :primary => true, :host => host,
                                            :domain => FactoryGirl.create(:domain)) ]
     assert host.save

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -31,6 +31,15 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     end
   end
 
+  test 'unmanaged should not call methods after managed?' do
+    if unattended?
+      h = FactoryGirl.create(:host)
+      Nic::Managed.any_instance.expects(:ip_available?).never
+      assert h.valid?
+      assert_equal false, h.dhcp?
+    end
+  end
+
   test 'bmc_should_have_valid_dhcp_record' do
     if unattended?
       h = FactoryGirl.create(:host, :with_dhcp_orchestration)

--- a/test/unit/orchestration/dns_test.rb
+++ b/test/unit/orchestration/dns_test.rb
@@ -72,4 +72,14 @@ class DnsOrchestrationTest < ActiveSupport::TestCase
       assert_equal "#{b.ip}/#{b.shortname}.#{b.domain.name}", b.dns_ptr_record.to_s
     end
   end
+
+  test 'unmanaged should not call methods after managed?' do
+    if unattended?
+      h = FactoryGirl.create(:host)
+      Nic::Managed.any_instance.expects(:ip_available?).never
+      assert h.valid?
+      assert_equal false, h.dns?
+      assert_equal false, h.reverse_dns?
+    end
+  end
 end

--- a/test/unit/orchestration/tftp_test.rb
+++ b/test/unit/orchestration/tftp_test.rb
@@ -19,6 +19,15 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     end
   end
 
+  test 'unmanaged should not call methods after managed?' do
+    if unattended?
+      h = FactoryGirl.create(:host)
+      Nic::Managed.any_instance.expects(:provision?).never
+      assert h.valid?
+      assert_equal false, h.tftp?
+    end
+  end
+
   def test_generate_pxe_template_for_build
     if unattended?
       h = FactoryGirl.create(:host, :build => true,


### PR DESCRIPTION
Replaces #2116, there was last missing check but @GregSutcliffe won't get to it anytime soon so I took his commit, fixed https://github.com/theforeman/foreman/pull/2116#discussion-diff-24655127 and amended (that's the only change I did).
