### PR TITLE
Fixes #6454 - Display error message when user_data is needed but not set

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -84,6 +84,15 @@ module Orchestration::Compute
     @host      = self
     # For some reason this renders as 'built' in spoof view but 'provision' when
     # actually used. For now, use foreman_url('built') in the template
+    if template.nil?
+      failure((_("%{image} needs user data, but %{os_link} is not associated to any provisioning template of the kind user_data. Please associate it with a suitable template or uncheck 'User data' for %{compute_resource_image_link}.") %
+      { :image => image.name,
+        :os_link => "<a target='_blank' href='#{url_for(edit_operatingsystem_path(operatingsystem))}'>#{operatingsystem.title}</a>",
+        :compute_resource_image_link =>
+          "<a target='_blank' href='#{url_for(edit_compute_resource_image_path(:compute_resource_id => compute_resource.id, :id => image.id))}'>#{image.name}</a>"}).html_safe)
+      return false
+    end
+
     self.compute_attributes[:user_data] = unattended_render(template.template)
     self.handle_ca
     return false if errors.any?

--- a/test/unit/orchestration/user_data_test.rb
+++ b/test/unit/orchestration/user_data_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ComputeOrchestrationTest < ActiveSupport::TestCase
+  test "a helpful error message shows up if no user_data is provided and it's necessary" do
+    image = images(:one)
+    host = FactoryGirl.build(:host, :operatingsystem => image.operatingsystem, :image => image,
+                                    :compute_resource => image.compute_resource)
+    host.send(:setUserData)
+    assert host.errors.full_messages.first =~ /associate it/
+  end
+end


### PR DESCRIPTION
Currently if the selected operating system doesn't have a user_data template associated to it, and the image requires it, creating a host fails with the message:

 `Render user data template for aaaa.138.17.5 task failed with the following error: undefined method`template' for nil:NilClass`

This fixes that problem by displaying a more meaningful message with instruction and links to the solution.
