### PR TITLE
Fixes #9589 - Add documentation button to various models

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -385,6 +385,12 @@ module ApplicationHelper
     (obj.new_record? && obj.class.count > 0) || (!obj.new_record? && obj.class.count > 1)
   end
 
+  def documentation_button(section)
+    link_to(icon_text('question-sign', _('Documentation'), :class => 'icon-white'),
+            "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html##{section}",
+            :rel => 'external', :class => 'btn btn-info', :target => '_blank')
+  end
+
   private
 
   def edit_inline(object, property, options = {})

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Audits") %>
-
+<% title_actions documentation_button('4.1.4Auditing') %>
 <%= render :partial => 'list', :locals =>{:audits => @audits}%>
 
 <%= will_paginate_with_info @audits %>

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -1,7 +1,5 @@
 <% javascript 'auth_source_ldap' %>
 
-<% title_actions link_to(icon_text("question-sign", _("Documentation"), :class => "icon-white"), "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#4.1.2LDAPAuthentication", :rel => "external", :class => "btn btn-info") %>
-
 <%= form_for @auth_source_ldap do |f| %>
   <%= base_errors_for @auth_source_ldap %>
   <ul class="nav nav-tabs" data-tabs="tabs">

--- a/app/views/auth_source_ldaps/index.html.erb
+++ b/app/views/auth_source_ldaps/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title _("LDAP Authentication") %>
 
-<% title_actions display_link_if_authorized(_("New LDAP Source"), hash_for_new_auth_source_ldap_path), help_path %>
+<% title_actions(display_link_if_authorized(_("New LDAP Source"), hash_for_new_auth_source_ldap_path), documentation_button('4.1.1LDAPAuthentication')) %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,4 +1,5 @@
 <% title _("Manage Bookmarks") %>
+<% title_actions documentation_button('4.1.5Bookmarks') %>
 <div class="title_action"></div>
 
 <table class="table table-bordered table-striped table-two-pane">

--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -15,7 +15,11 @@
         <% end %>
         <li class="divider"></li>
         <li><%= link_to_function _('Bookmark this search'), "$('#bookmarks-modal').modal();",
-                                 {:id => "bookmark", :"data-url"=> main_app.new_bookmark_path(:kontroller => controller_name)}%></li>
+                                 {:id => "bookmark", :"data-url"=> main_app.new_bookmark_path(:kontroller => controller_name)} %></li>
+        <li><%= link_to(icon_text('question-sign', _('Documentation'), :class => 'icon-black'),
+            "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#4.1.5Searching",
+            :rel => 'external', :target => '_blank')
+  %></li>
       </ul>
     </span>
   </div>

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Global Parameters") %>
 
-<% title_actions display_link_if_authorized(_("New Parameter"), hash_for_new_common_parameter_path) %>
+<% title_actions display_link_if_authorized(_("New Parameter"), hash_for_new_common_parameter_path),
+                 documentation_button('4.2.3Parameters') %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -1,6 +1,7 @@
 <% title _('Compute profiles') %>
 
-<% title_actions display_link_if_authorized(_('New Compute Profile'), hash_for_new_compute_profile_path), help_path %>
+<% title_actions display_link_if_authorized(_('New Compute Profile'), hash_for_new_compute_profile_path),
+                 documentation_button('5.2.2UsingComputeProfiles') %>
 <table class="table table-bordered table-striped table-two-pane">
   <thead>
     <tr>

--- a/app/views/compute_resources/form/_ec2.html.erb
+++ b/app/views/compute_resources/form/_ec2.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :user, :label => _("Access Key") %>
+<%= text_f f, :user, :label => _("Access Key"), :help_inline => documentation_button('5.2.3EC2Notes') %>
 <%= password_f f, :password, :label => _("Secret Key") %>
 
 <% regions = f.object.regions rescue [] %>

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :project, :label => _("Google Project ID") %>
+<%= text_f f, :project, :label => _("Google Project ID"), :help_inline => documentation_button('5.2.4GoogleComputeEngineNotes') %>
 <%= text_f f, :email, :label => _("Client Email"), :class => 'col-md-8' %>
 <%= text_f f, :key_path, :label => _("Certificate path"), :help_inline => _('The file path where your p12 file is located'), :class => 'col-md-8' %>
 

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system") %>
+<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
 
 <%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display type") %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens") %>
+<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens"), :help_inline => documentation_button('5.2.6OpenStackNotes') %>
 <%= text_f f, :user %>
 <%= password_f f, :password %>
 

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://ovirt.example.com/api") %>
+<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://ovirt.example.com/api"), :help_inline => documentation_button('5.2.7oVirt/RHEVNotes') %>
 <%= text_f f, :user, :help_block => _("e.g. admin@internal") %>
 <%= password_f f, :password %>
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0") %>
+<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0"), :help_inline => documentation_button('5.2.8RackspaceNotes') %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :label => _("API Key") %>
 <% flavors = f.object.flavors rescue [] %>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -1,9 +1,9 @@
-<%= text_f f, :server, :label => _("VCenter/Server"), :size => "col-md-8" %>
+<%= text_f f, :server, :label => _("VCenter/Server"), :size => "col-md-8", :help_inline => documentation_button('5.2.9VMwareNotes') %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :placeholder => password_placeholder(f.object) %>
 <% datacenters = list_datacenters f.object%>
 <%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'),
-                 :help_block => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)",
+                 :help_inline => link_to_function(datacenters.empty? ? "Load Datacenters" : "Test Connection", "testConnection(this)",
                  :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>

--- a/app/views/compute_resources/index.html.erb
+++ b/app/views/compute_resources/index.html.erb
@@ -1,5 +1,6 @@
 <% title _("Compute Resources") %>
-<% title_actions display_link_if_authorized(_("New Compute Resource"), hash_for_new_compute_resource_path), help_path %>
+<% title_actions display_link_if_authorized(_("New Compute Resource"), hash_for_new_compute_resource_path),
+                 documentation_button('5.2ComputeResources') %>
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/app/views/config_templates/index.html.erb
+++ b/app/views/config_templates/index.html.erb
@@ -3,9 +3,10 @@
 <% title _("Provisioning Templates") %>
 
 <% title_actions display_link_if_authorized(_("New Template"), hash_for_new_config_template_path),
-  display_link_if_authorized(_("Build PXE Default"), {:action => :build_pxe_default},{
-    :confirm => _("You Are about to change the default PXE menu on all configured TFTP servers - continue ?"),
-    :class => "btn btn-info"})
+                 display_link_if_authorized(_("Build PXE Default"), {:action => :build_pxe_default},{
+                   :confirm => _("You Are about to change the default PXE menu on all configured TFTP servers - continue ?"),
+                   :class => "btn btn-info"}),
+                documentation_button('4.4.3ProvisioningTemplates')
 %>
 
 <table class="table table-bordered table-striped table-two-pane">

--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -1,4 +1,5 @@
 <% title _("Fact Values") %>
+<% title_actions documentation_button('3.5.5FactsandtheENC') %>
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Filters") %>
 
-<% title_actions link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role)) %>
+<% title_actions link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role)),
+                 documentation_button('4.1.2RolesandPermissions') %>
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -20,7 +20,8 @@
   <%= checkbox_f(f, :use_puppet_default, :label => _('Use Puppet default'), :size => "col-md-8",
                     :help_block => _('Do not send this parameter via the ENC. Puppet will use the value defined in the Puppet manifest for this parameter.'),
                     :onchange=>'toggleUsePuppetDefaultValue(this, "default_value")',
-                    :disabled => (f.object.is_param && !f.object.override)) if is_param%>
+                    :disabled => (f.object.is_param && !f.object.override)) if is_param %>
+ </br>
   <div <%= "id=#{(f.object.key || 'new_lookup_keys').to_s.gsub(' ','_')}_lookup_key_override_value" %> style=<%= "display:none;" if (f.object.is_param && !f.object.override) %>>
     <legend><%= _("Optional input validator") %></legend>
     <p class="help-block">
@@ -49,6 +50,7 @@
         <%= render 'lookup_keys/value', :f => lookup_values, :is_param => is_param %>
       <% end %>
       <%= add_child_link '+ ' + _("Add Matcher-Value"), :lookup_values, { :title => _('add a new matcher-value pair')} %>
+      <%= documentation_button('4.2.6SmartMatchers') %>
     </div>
   </div>
 </div>

--- a/app/views/lookup_keys/index.html.erb
+++ b/app/views/lookup_keys/index.html.erb
@@ -1,5 +1,6 @@
 <%= javascript "lookup_keys" %>
 <% title _("Smart variables") %>
+<% title_actions documentation_button('4.2.4SmartVariables') %>
 <table class="table table-bordered table-striped table-two-pane">
   <thead>
     <tr>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -1,7 +1,8 @@
 <%= javascript "nfs_visibility" %>
 <% title _("Installation Media") %>
-
-<% title_actions display_link_if_authorized(_("New Medium"), hash_for_new_medium_path), help_path %>
+<% title_actions display_link_if_authorized(_("New Medium"), hash_for_new_medium_path),
+                 documentation_button('4.4.2InstallationMedia'),
+                 help_path %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -1,5 +1,6 @@
 <% title _("Operating systems") %>
-<% title_actions display_link_if_authorized(_("New Operating system"), hash_for_new_operatingsystem_path) %>
+<% title_actions display_link_if_authorized(_("New Operating system"), hash_for_new_operatingsystem_path),
+                 documentation_button('4.4.1OperatingSystems') %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -1,5 +1,7 @@
 <% title _("Partition Tables") %>
-<% title_actions display_link_if_authorized(_("New Partition Table"), hash_for_new_ptable_path), help_path %>
+<% title_actions display_link_if_authorized(_("New Partition Table"), hash_for_new_ptable_path),
+                 documentation_button('4.4.4PartitionTables'),
+                 help_path %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -37,6 +37,9 @@
                              :include_blank => "All Environments - (Not filtered)",:class=>'form-control', :onchange=>'filterByEnvironment(this)'%>
             </div>
           </div>
+          <div class='col-md-6 text-right'>
+            <%= documentation_button('4.2.5ParameterizedClasses') %>
+          </div>
         </div>
         <div class="smart-var-left col-md-3">
           <ul class="nav nav-pills nav-stacked smart-var-tabs" data-tabs="pills">
@@ -58,16 +61,13 @@
       <% end %>
     </div>
     <div class="tab-pane lookup-keys-container" id="smart_vars">
-      <% if @puppetclass.lookup_keys.empty? %>
-        <div class="alert alert-warning alert-dismissable">
-          <%= alert_close %>
-          <p><strong><%= _('Help!') %></strong>
-            <%= (_('What is a <a href="%s" rel="external">Smart variable</a>?') % "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#4.2.4SmartVariables").html_safe %>
-          </p>
-        </div>
-      <% end %>
       <div class="undo-smart-vars alert alert-info hide">
         <%= _('Undo remove') %>
+      </div>
+      <div class='row'>
+        <div class='form-group col-md-12 text-right'>
+          <%= documentation_button('4.2.4SmartVariables') %>
+        </div>
       </div>
       <div class="smart-var-left col-md-3">
         <ul class="nav nav-pills nav-stacked smart-var-tabs" data-tabs="pills">

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Puppet classes") %>
 
-<% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path) %>
+<% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path),
+                 documentation_button('4.2.2Classes') %>
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -1,6 +1,6 @@
-<% title _("Realms") %>
-
-<% title_actions display_link_if_authorized(_("New Realm"), hash_for_new_realm_path), help_path %>
+<% title _('Realms') %>
+<% title_actions(display_link_if_authorized(_("New Realm"), hash_for_new_realm_path),
+                 documentation_button('4.3.9Realm')) %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/realms/welcome.html.erb
+++ b/app/views/realms/welcome.html.erb
@@ -1,5 +1,6 @@
-<% title_actions link_to(_("New Realm"), new_realm_path) %>
-<% title _("Realm Configuration") %>
+<% title _('Realms') %>
+<% title_actions(display_link_if_authorized(_("New Realm"), hash_for_new_realm_path),
+                 documentation_button('4.3.9Realm')) %>
 <div id="welcome">
   <p>
   <%= _("Foreman supports automatically creating realm entries for new hosts.  When a realm is selected for a host, Foreman contacts the relevant realm smart proxy to create an entry for the host and retrieve it's one-time registration password.").html_safe %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,3 +1,3 @@
 <% title _("Reports") %>
-
+<% title_actions documentation_button('3.5.4PuppetReports') %>
 <%= render :partial => 'list' %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,5 +1,6 @@
 <% title _("Roles") %>
-<% title_actions link_to_if_authorized(_("New role"), hash_for_new_role_path) %>
+<% title_actions link_to_if_authorized(_("New role"), hash_for_new_role_path),
+                 documentation_button('4.1.2RolesandPermissions') %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,4 +1,5 @@
 <% title _("Settings") %>
+<% title_actions documentation_button('3.5.2ConfigurationOptions') %>
 <ul class="nav nav-tabs" data-tabs="tabs">
   <% @settings.group_by(&:category).each do |category, setting| %>
     <li class='<%= category == @settings.first.category ? "active" : ""%>'>

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Smart Proxies") %>
 
-<% title_actions display_link_if_authorized(_("New Smart Proxy"), hash_for_new_smart_proxy_path) %>
+<% title_actions display_link_if_authorized(_("New Smart Proxy"), hash_for_new_smart_proxy_path),
+                 documentation_button('4.3SmartProxies') %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,5 +1,6 @@
 <% title _("Trends") %>
-<% title_actions display_link_if_authorized(_("Add Trend Counter"), hash_for_new_trend_path) %>
+<% title_actions display_link_if_authorized(_("Add Trend Counter"), hash_for_new_trend_path),
+                 documentation_button('4.1.3Trends') %>
 
 <% if @trends.empty? %>
   <div class="alert alert-info">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -40,6 +40,12 @@
     </div>
 
     <div class='tab-pane' id='mail_preferences'>
+      <div class='row'>
+        <div class='col-md-4'>
+          <%= documentation_button('4.6.1EmailPreferences') %>
+        </div>
+      </div>
+      </br>
       <%= field_set_tag _("General") do %>
         <%= checkbox_f f, :mail_enabled %>
       <% end %>


### PR DESCRIPTION
My attempt to reduce user reliance on other support channels like IRC and mailing lists. Google often returns outdated results, or points to outdated parts of the wiki, these buttons are supposed to both explain the concepts to new users and to give 'official' answers to their questions. 
Installation media and Partition tables have their own help page already so that's why they don't have a documentation button.
