### PR TITLE
Fixes #4551 - GCE provisioning support

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -114,7 +114,7 @@ class ComputeResource < ActiveRecord::Base
   end
 
   def interfaces_attrs_name
-    "interfaces"
+    :interfaces
   end
 
   # returns a new fog server instance

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -18,7 +18,7 @@ module Foreman::Model
     end
 
     def interfaces_attrs_name
-      "nics"
+      :nics
     end
 
     def capabilities

--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -12,11 +12,21 @@ module FogExtensions
       end
 
       def image_id
-        image_name unless disks.nil?
+        image_name unless disks.blank?
       end
 
       def vm_description
         pretty_machine_type
+      end
+
+      def volumes_attributes=(attrs); end
+
+      def volumes
+        disks
+      end
+
+      def vm_ip_address
+        external_ip ? public_ip_address : private_ip_address
       end
     end
   end

--- a/app/views/compute_resources_vms/form/gce/_base.html.erb
+++ b/app/views/compute_resources_vms/form/gce/_base.html.erb
@@ -1,4 +1,4 @@
-<%= select_f f, :machine_type, compute_resource.flavors, :id, :name, {}, :label => _('Machine type') %>
+<%= select_f f, :machine_type, compute_resource.flavors, :name, :name, {}, :label => _('Machine type') %>
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)

--- a/app/views/compute_resources_vms/form/gce/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/gce/_volume.html.erb
@@ -1,0 +1,1 @@
+<%= text_f f, :size_gb, :class => "col-md-2", :label => _("Size (GB)"), :onchange => 'capacity_edit(this)' %>

--- a/app/views/compute_resources_vms/show/_gce.html.erb
+++ b/app/views/compute_resources_vms/show/_gce.html.erb
@@ -15,7 +15,7 @@
       </tr>
       <tr>
         <td>Zone</td>
-        <td><%= @vm.zone %></td>
+        <td><%= @vm.zone_name %></td>
       </tr>
       <tr>
         <td>Private IP</td>


### PR DESCRIPTION
Enable provisioning of VMs through Google Compute Engine. Volume-wise,
this is currently limited to creating a VM with an attached disk that
contains the image specified. Future enhancements should include
choosing any available disks to auto-attach the VM and not force the
user to create a new one through Foreman.

I thought about removing disks when removing the VM as well, since disks are created at the same time as the VM. However users might attach their own disks through the GCE console and we don't want to destroy these.
