### PR TITLE
Fixes #9603 - fixed websockets_* set of settings

### DIFF
--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -78,14 +78,7 @@ class ComputeResourcesVmsController < ApplicationController
     @compute_resource = find_compute_resource(:console_compute_resources_vms)
     @vm = find_vm
     @console = @compute_resource.console @vm.identity
-    @encrypt = case Setting[:websockets_encrypt]
-               when 'on'
-                 true
-               when 'off'
-                 false
-               else
-                 request.ssl? and not Setting[:websockets_ssl_key].blank? and not Setting[:websockets_ssl_cert].blank?
-               end
+    @encrypt = Setting[:websockets_encrypt]
     render case @console[:type]
              when 'spice'
                "hosts/console/spice"

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -288,14 +288,7 @@ class HostsController < ApplicationController
   def console
     return unless @host.compute_resource
     @console = @host.compute_resource.console @host.uuid
-    @encrypt = case Setting[:websockets_encrypt]
-               when 'on'
-                 true
-               when 'off'
-                 false
-               else
-                 request.ssl? and not Setting[:websockets_ssl_key].blank? and not Setting[:websockets_ssl_cert].blank?
-               end
+    @encrypt = Setting[:websockets_encrypt]
     render case @console[:type]
              when 'spice'
                "hosts/console/spice"

--- a/db/migrate/20150312144232_migrate_websockets_setting.rb
+++ b/db/migrate/20150312144232_migrate_websockets_setting.rb
@@ -1,0 +1,19 @@
+class MigrateWebsocketsSetting < ActiveRecord::Migration
+  def up
+    return unless encrypt = Setting.find_by_name("websockets_encrypt")
+    encrypt.settings_type = "boolean"
+    if encrypt.value == "auto"
+      encrypt.value = (Setting[:websockets_ssl_key].blank? ||
+                       Setting[:websockets_ssl_cert].blank?) ? false : true
+    else
+      encrypt.value = Foreman::Cast.to_bool(encrypt.value)
+    end
+    encrypt.default = false
+    encrypt.save(:validate => false)
+  end
+
+  def down
+    # delete and reset on next app server start
+    Setting.delete_by_name("websockets_encrypt")
+  end
+end

--- a/lib/ws_proxy.rb
+++ b/lib/ws_proxy.rb
@@ -43,8 +43,10 @@ class WsProxy
     begin
       cmd  = "#{ws_proxy} --daemon --idle-timeout=#{idle_timeout} --timeout=#{timeout} #{port} #{host}:#{host_port}"
       cmd += " --ssl-target" if ssl_target
-      cmd += " --cert #{Setting[:websockets_ssl_cert]}" if Setting[:websockets_ssl_cert]
-      cmd += " --key #{Setting[:websockets_ssl_key]}" if Setting[:websockets_ssl_key]
+      if Setting[:websockets_encrypt]
+        cmd += " --cert #{Setting[:websockets_ssl_cert]}" if Setting[:websockets_ssl_cert]
+        cmd += " --key #{Setting[:websockets_ssl_key]}" if Setting[:websockets_ssl_key]
+      end
       execute(cmd)
     rescue PortInUse
       # fallback just in case of race condition


### PR DESCRIPTION
Basically `websockets_encrypt` setting did not work at all. Initially I thought
the only change is not to use certificates when websockets_encrypt is set to
false, but it looks the whole setting handling is incorrect. There are "on" and
"off" switch/case statements which are (no longer?) correct. The setting is
read-only, defined in the settings.yaml and type of boolean.

This fixes it completely.
