### PR TITLE
Fixes #9615 - Adds inheriting_mac method

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -70,7 +70,7 @@ module Nic
     class Jail < ::Safemode::Jail
       allow :managed?, :subnet, :virtual?, :mac, :ip, :identifier, :attached_to,
             :link, :tag, :domain, :vlanid, :bond_options, :attached_devices, :mode,
-            :attached_devices_identifiers, :primary, :provision
+            :attached_devices_identifiers, :primary, :provision, :inheriting_mac
     end
 
     def type_name
@@ -119,6 +119,16 @@ module Nic
     def clone
       # do not copy system specific attributes
       self.deep_clone(:except  => [:name, :mac, :ip])
+    end
+
+    # if this interface does not have MAC and is attached to other interface,
+    # we can fetch mac from this other interface
+    def inheriting_mac
+      if self.mac.nil? || self.mac.empty?
+        self.host.interfaces.detect { |i| i.identifier == self.attached_to }.try(:mac)
+      else
+        self.mac
+      end
     end
 
     protected

--- a/test/unit/nics/managed_test.rb
+++ b/test/unit/nics/managed_test.rb
@@ -71,6 +71,36 @@ class ManagedTest < ActiveSupport::TestCase
     assert_equal new_domain, nic.domain
   end
 
+  test "#inheriting_mac respects interface mac" do
+    h = FactoryGirl.build(:host, :managed)
+    h.primary_interface.mac = '11:22:33:44:55:66'
+    assert_equal '11:22:33:44:55:66', h.primary_interface.inheriting_mac
+  end
+
+  test "#inheriting_mac respects interface mac even if attached_to is specified" do
+    h = FactoryGirl.build(:host, :managed)
+    h.primary_interface.mac = '11:22:33:44:55:66'
+    h.primary_interface.identifier = 'eth0'
+    n = h.interfaces.build :mac => '66:55:44:33:22:11', :attached_to => 'eth0'
+    assert_equal '66:55:44:33:22:11', n.inheriting_mac
+  end
+
+  test "#inheriting_mac inherits mac if own mac is nil" do
+    h = FactoryGirl.build(:host, :managed)
+    h.primary_interface.mac = '11:22:33:44:55:66'
+    h.primary_interface.identifier = 'eth0'
+    n = h.interfaces.build :mac => nil, :attached_to => 'eth0'
+    assert_equal '11:22:33:44:55:66', n.inheriting_mac
+  end
+
+  test "#inheriting_mac inherits mac if own mac is empty" do
+    h = FactoryGirl.build(:host, :managed)
+    h.primary_interface.mac = '11:22:33:44:55:66'
+    h.primary_interface.identifier = 'eth0'
+    n = h.interfaces.build :mac => '', :attached_to => 'eth0'
+    assert_equal '11:22:33:44:55:66', n.inheriting_mac
+  end
+
   private
 
   def setup_primary_nic_with_name(name, opts = {})


### PR DESCRIPTION
Using this method we can find out the MAC of interface to which this
interface is attached to. This can be used in provisioning template when
we check for real interface name.
