### PR TITLE
fixes #9654 - assign organization and location to puppet-reported hosts

### DIFF
--- a/db/seeds.d/05-taxonomies.rb
+++ b/db/seeds.d/05-taxonomies.rb
@@ -2,7 +2,8 @@
 if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION'] && !Organization.any?
   Organization.without_auditing do
     User.current = User.anonymous_admin
-    Organization.find_or_create_by_name!(:name => ENV['SEED_ORGANIZATION'])
+    org = Organization.find_or_create_by_name!(:name => ENV['SEED_ORGANIZATION'])
+    Setting[:default_organization] = org.title if Setting[:default_organization].blank?
     User.current = nil
   end
 end
@@ -11,7 +12,8 @@ end
 if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION'] && !Location.any?
   Location.without_auditing do
     User.current = User.anonymous_admin
-    Location.find_or_create_by_name!(:name => ENV['SEED_LOCATION'])
+    loc = Location.find_or_create_by_name!(:name => ENV['SEED_LOCATION'])
+    Setting[:default_location] = loc.title if Setting[:default_location].blank?
     User.current = nil
   end
 end

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -9,6 +9,8 @@ class SeedsTest < ActiveSupport::TestCase
     DatabaseCleaner.clean_with :truncation
     Setting.stubs(:[]).with(:administrator).returns("root@localhost")
     Setting.stubs(:[]).with(:send_welcome_email).returns(false)
+    Setting.stubs(:[]).with(:default_organization).returns('seed_test')
+    Setting.stubs(:[]).with(:default_location).returns('seed_test')
   end
 
   def seed
@@ -112,14 +114,14 @@ class SeedsTest < ActiveSupport::TestCase
     seed
   end
 
-  test "doesn't add a template back that was deleted" do
+  test 'does not add a template back that was deleted' do
     seed
     assert_equal 1, ProvisioningTemplate.destroy_all(:name => 'Kickstart default').size
     seed
     refute ProvisioningTemplate.find_by_name('Kickstart default')
   end
 
-  test "doesn't add a template back that was renamed" do
+  test 'does not add a template back that was renamed' do
     seed
     tmpl = ProvisioningTemplate.find_by_name('Kickstart default')
     tmpl.name = 'test'
@@ -128,12 +130,12 @@ class SeedsTest < ActiveSupport::TestCase
     refute ProvisioningTemplate.find_by_name('Kickstart default')
   end
 
-  test "no audits are recorded" do
+  test 'no audits are recorded' do
     seed
     assert_equal [], Audit.all
   end
 
-  test "seed organization when environment SEED_ORGANIZATION specified" do
+  test 'seed organization when environment SEED_ORGANIZATION specified' do
     Organization.stubs(:any?).returns(false)
     with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed
@@ -141,7 +143,16 @@ class SeedsTest < ActiveSupport::TestCase
     assert Organization.find_by_name('seed_test')
   end
 
-  test "don't seed organization when an org already exists" do
+  test 'seeded organization is set as default' do
+    Organization.stubs(:any?).returns(false)
+    Setting.stubs(:[]).with(:default_organization).returns('')
+    Setting.expects(:[]=).with(:default_organization, 'seed_test')
+    with_env('SEED_ORGANIZATION' => 'seed_test') do
+      seed
+    end
+  end
+
+  test 'do not seed organization when an org already exists' do
     Organization.stubs(:any?).returns(true)
     with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed
@@ -149,7 +160,7 @@ class SeedsTest < ActiveSupport::TestCase
     refute Organization.find_by_name('seed_test')
   end
 
-  test "seed location when environment SEED_LOCATION specified" do
+  test 'seed location when environment SEED_LOCATION specified' do
     Location.stubs(:any?).returns(false)
     with_env('SEED_LOCATION' => 'seed_test') do
       seed
@@ -157,7 +168,16 @@ class SeedsTest < ActiveSupport::TestCase
     assert Location.find_by_name('seed_test')
   end
 
-  test "don't seed location when a location already exists" do
+  test 'seeded location is set as default' do
+    Location.stubs(:any?).returns(false)
+    Setting.stubs(:[]).with(:default_location).returns('')
+    Setting.expects(:[]=).with(:default_location, 'seed_test')
+    with_env('SEED_LOCATION' => 'seed_test') do
+      seed
+    end
+  end
+
+  test 'do not seed location when a location already exists' do
     Location.stubs(:any?).returns(true)
     with_env('SEED_LOCATION' => 'seed_test') do
       seed
@@ -165,7 +185,7 @@ class SeedsTest < ActiveSupport::TestCase
     refute Location.find_by_name('seed_test')
   end
 
-  test "all access permissions are created by permissions seed" do
+  test 'all access permissions are created by permissions seed' do
     seed
     access_permissions = Foreman::AccessControl.permissions.reject(&:public?).reject(&:plugin?).map(&:name).map(&:to_s)
     seeded_permissions = Permission.pluck('permissions.name')
@@ -175,7 +195,7 @@ class SeedsTest < ActiveSupport::TestCase
     assert_equal [], seeded_permissions - access_permissions
   end
 
-  test "viewer role contains all view permissions" do
+  test 'viewer role contains all view permissions' do
     seed
     view_permissions = Permission.all.select { |permission| permission.name.match(/view/) }
     assert_equal [], view_permissions - Role.find_by_name('Viewer').permissions


### PR DESCRIPTION
Hosts must have an organization/location if enabled. It makes sense to give them one by default if organizations are seeded.

This is especially a problem in Katello, where the admin is given a default organzation, so they don't see the Katello host itself in "All Hosts" unless they switch to "Any Context", which isn't obvious to new users.
