### PR TITLE
Fixes #9674 - Handle ProxyAPI exceptions on PuppetCA controller

### DIFF
--- a/app/controllers/puppetca_controller.rb
+++ b/app/controllers/puppetca_controller.rb
@@ -3,13 +3,7 @@ class PuppetcaController < ApplicationController
     @proxy = find_proxy
     # expire cache if forced
     Rails.cache.delete("ca_#{@proxy.id}") if params[:expire_cache] == "true"
-    certs = if params[:state].blank?
-              SmartProxies::PuppetCA.find_by_state(@proxy, "valid") + SmartProxies::PuppetCA.find_by_state(@proxy, "pending")
-            elsif params[:state] == "all"
-              SmartProxies::PuppetCA.all @proxy
-            else
-              SmartProxies::PuppetCA.find_by_state @proxy, params[:state]
-            end
+    certs = find_certs
     @certificates = certs.sort.paginate :page => params[:page], :per_page => Setting::General.entries_per_page
   end
 
@@ -17,9 +11,10 @@ class PuppetcaController < ApplicationController
     @proxy = find_proxy(:edit_smart_proxies_puppetca)
     cert = SmartProxies::PuppetCA.find(@proxy, params[:id])
     if cert.sign
-      process_success({ :success_redirect => smart_proxy_puppetca_index_path(@proxy, :state => params[:state]), :object_name => cert.to_s })
+      process_success(:success_redirect => smart_proxy_puppetca_index_path(@proxy, :state => params[:state]),
+                      :object_name => cert.to_s)
     else
-      process_error({ :redirect => smart_proxy_puppetca_index_path(@proxy) })
+      process_error(:redirect => smart_proxy_puppetca_index_path(@proxy))
     end
   end
 
@@ -37,5 +32,16 @@ class PuppetcaController < ApplicationController
 
   def find_proxy(permission = :view_smart_proxies_puppetca)
     SmartProxy.authorized(permission).find(params[:smart_proxy_id])
+  end
+
+  def find_certs
+    if params[:state].blank?
+      SmartProxies::PuppetCA.find_by_state(@proxy, "valid") +
+        SmartProxies::PuppetCA.find_by_state(@proxy, "pending")
+    elsif params[:state] == "all"
+      SmartProxies::PuppetCA.all @proxy
+    else
+      SmartProxies::PuppetCA.find_by_state @proxy, params[:state]
+    end
   end
 end

--- a/test/functional/puppetca_controller_test.rb
+++ b/test/functional/puppetca_controller_test.rb
@@ -1,8 +1,13 @@
 require 'test_helper'
 
 class PuppetcaControllerTest < ActionController::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
+  test 'problems when signing certificate redirect to back' do
+    proxy = smart_proxies(:puppetmaster)
+    # Try set any random path in the referer to ensure redirect_to :back
+    @request.env['HTTP_REFERER'] = hosts_path
+    # This will try to find the certificate to no avail and will raise a ProxyException
+    post :update, { :smart_proxy_id => proxy.id, :id => 1 }, set_session_user
+    assert_redirected_to @request.env['HTTP_REFERER']
+    assert_match /ProxyAPI::ProxyException/, flash[:error]
   end
 end


### PR DESCRIPTION
Currently if any error happens when signing a certificate request, Foreman will throw a 500 error page.

See the following example for a error of a client sending a broken cert request (incompatible digest algorithm):

`ERF12-9815 [ProxyAPI::ProxyException]: Unable to sign PuppetCA certificate for samplehost ([RestClient::NotAcceptable]: 406 Not Acceptable) for proxy https://mydomain:9090/puppet/ca`

We can handle this through an alert and return back to the smart proxy PuppetCA index page.

Same goes for any other `ProxyAPI::ProxyException` that happens within the PuppetCA controller, they all throw a nasty 500 as they are not rescued at all.
