### PR TITLE
Fixes #9591 - Added support for "inherit" state.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -170,11 +170,11 @@ function mark_params_override(){
     $('#inherited_parameters').find('[id^=name_]').each(function(){
       if (param_name.val() == $(this).text()){
         $(this).addClass('override-param');
-        $(this).closest('tr').find('textarea').addClass('override-param')
+        $(this).closest('tr').find('textarea').addClass('override-param');
         $(this).closest('tr').find('[data-tag=override]').hide();
       }
-    })
-  })
+    });
+  });
   $('#inherited_puppetclasses_parameters .override-param').removeClass('override-param');
   $('#inherited_puppetclasses_parameters [data-tag=override]').show();
   $('#puppetclasses_parameters').find('[data-property=class]:visible').each(function(){
@@ -485,4 +485,34 @@ function exit_fullscreen(){
          .resize();
   $('.exit-fullscreen').remove();
   $(window).scrollTop(element.data('position'));
+}
+
+function disableButtonToggle(item, explicit) {
+  if (explicit === undefined) {
+    explicit = true;
+  }
+  
+  item = $(item);
+  item.data('explicit', explicit);
+  var isActive = item.hasClass("active");
+  var formControl = item.closest('.input-group').find('.form-control');
+  if (!isActive) {
+    var blankValue = formControl.children("option[value='']");
+    if (blankValue.length == 0) {
+      $(item).data('no-blank', true);
+      $(formControl).append("<option value='' />");
+    }
+  } else {
+    var blankAttr = item.data('no-blank');
+    if (blankAttr == 'true') {
+      $(formControl).children("[value='']").remove();
+    }
+  }
+
+  formControl.attr('disabled', !isActive);
+  if (!isActive) {
+    $(formControl).val('');
+  }
+
+  $(item).blur();
 }

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -208,12 +208,34 @@ function hostgroup_changed(element) {
     } else if (host_changed == undefined) { // hostgroup changes parent
       update_form(element);
     } else { // edit host
+      set_inherited_value(element);
       update_puppetclasses(element);
       reload_host_params();
     }
   } else { // a new host
+    set_inherited_value(element);
     update_form(element);
   }
+}
+
+function set_inherited_value(hostgroup_elem) {
+  var had_hostgroup = $(hostgroup_elem).data("had-hostgroup")
+
+  if (had_hostgroup) {
+    return;
+  }
+
+  var hostgroup_selected = hostgroup_elem.value != ""
+  $("[name=is_overridden_btn]").each(function(i, btn) {
+    var item = $(btn)
+    var is_active = item.hasClass("active");
+    var is_explicit = item.data('explicit');
+    if (!is_explicit &&
+        ((hostgroup_selected && !is_active) ||
+        (!hostgroup_selected && is_active))) {
+      disableButtonToggle(item, false);
+    }
+  })
 }
 
 function organization_changed(element) {

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -94,7 +94,7 @@ module Api
       param_group :host
 
       def update
-        @host.attributes = host_attributes(params[:host])
+        @host.attributes = host_attributes(params[:host], @host)
         merge_interfaces(@host)
 
         process_response @host.save
@@ -210,7 +210,7 @@ Return the host's compute attributes that can be used to create a clone of this 
         merge.run(host.interfaces, host.compute_resource.try(:compute_profile_for, host.compute_profile_id))
       end
 
-      def host_attributes(params)
+      def host_attributes(params, host = nil)
         return {} if params.nil?
 
         params = params.deep_clone
@@ -224,6 +224,7 @@ Return the host's compute attributes that can be used to create a clone of this 
             interface_attributes(nic_attr)
           end
         end
+        params = host.apply_inherited_attributes(params) if host
         params
       end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -97,7 +97,9 @@ class HostsController < ApplicationController
   def update
     forward_url_options
     Taxonomy.no_taxonomy_scope do
-      if @host.update_attributes(params[:host])
+      attributes = @host.apply_inherited_attributes(params[:host])
+
+      if @host.update_attributes(attributes)
         process_success :success_redirect => host_path(@host)
       else
         taxonomy_scope
@@ -521,7 +523,7 @@ class HostsController < ApplicationController
     @host = if params[:host][:id]
               host = Host::Base.authorized(:view_hosts, Host).find(params[:host][:id])
               host = host.becomes Host::Managed
-              host.attributes = params[:host]
+              host.attributes = host.apply_inherited_attributes(params[:host])
               host
             else
               Host.new(params[:host])

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -39,6 +39,11 @@ class Host::Managed < Host::Base
   before_save :clear_puppetinfo, :if => :environment_id_changed?
   after_save :update_hostgroups_puppetclasses, :if => :hostgroup_id_changed?
 
+  def initialize(attributes = nil, options = {})
+    attributes = apply_inherited_attributes(attributes, false)
+    super(attributes, options)
+  end
+
   def build_hooks
     return unless respond_to?(:old) && old && (build? != old.build?)
     if build?
@@ -552,13 +557,49 @@ class Host::Managed < Host::Base
     operatingsystem.family == "Solaris" and architecture.name =~/Sparc/i rescue false
   end
 
+  def hostgroup_inherited_attributes
+    %w{puppet_proxy_id puppet_ca_proxy_id environment_id compute_profile_id realm_id}
+  end
+
+  def apply_inherited_attributes(attributes, initialized = true)
+    return nil unless attributes
+    #don't change the source to minimize side effects.
+    attributes = hash_clone(attributes)
+
+    new_hostgroup_id = attributes['hostgroup_id'] || attributes['hostgroup_name']
+    #hostgroup didn't change, no inheritance needs update.
+    return attributes if new_hostgroup_id.blank?
+
+    new_hostgroup = self.hostgroup if initialized
+    unless [new_hostgroup.try(:id), new_hostgroup.try(:friendly_id)].include? new_hostgroup_id
+      new_hostgroup = Hostgroup.find(new_hostgroup_id)
+    end
+    return attributes unless new_hostgroup
+
+    inherited_attributes = hostgroup_inherited_attributes - attributes.keys
+
+    inherited_attributes.each do |attribute|
+      value = new_hostgroup.send("inherited_#{attribute}")
+      attributes[attribute] = value
+    end
+
+    attributes
+  end
+
+  def hash_clone(value)
+    if value.is_a? Hash
+      hash_type = value.class
+      return hash_type[value.map{ |k, v| [k, hash_clone(v)] }]
+    end
+
+    value
+  end
+
   def set_hostgroup_defaults
     return unless hostgroup
-    assign_hostgroup_attributes(%w{environment_id domain_id compute_profile_id})
-    assign_hostgroup_attributes(["puppet_proxy_id"]) if new_record? || (!new_record? && !puppet_proxy_id.blank?)
-    assign_hostgroup_attributes(["puppet_ca_proxy_id"]) if new_record? || (!new_record? && !puppet_ca_proxy_id.blank?)
+    assign_hostgroup_attributes(%w{domain_id compute_profile_id})
     if SETTINGS[:unattended] and (new_record? or managed?)
-      assign_hostgroup_attributes(%w{operatingsystem_id architecture_id realm_id})
+      assign_hostgroup_attributes(%w{operatingsystem_id architecture_id})
       assign_hostgroup_attributes(%w{medium_id ptable_id subnet_id}) if pxe_build?
     end
   end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -40,8 +40,12 @@
 
         <%= select_f f, :hostgroup_id, accessible_hostgroups, :id, :to_label,
           { :include_blank => true},
-          { :onchange => 'hostgroup_changed(this);', :'data-host-id' => @host.id,
-            :'data-url' => (@host.new_record? || @host.type_changed?) ? process_hostgroup_hosts_path : hostgroup_or_environment_selected_hosts_path,
+          { :onchange => 'hostgroup_changed(this);',
+            :data => {
+              :'host-id' => @host.id,
+              :'url' => (@host.new_record? || @host.type_changed?) ? process_hostgroup_hosts_path : hostgroup_or_environment_selected_hosts_path,
+              :'had-hostgroup' => !!@host.hostgroup_id_was
+            },
             :help_inline => :indicator } %>
 
         <%= select_f f, :compute_resource_id, ComputeResource.with_taxonomy_scope_override(@location,@organization).authorized(:view_compute_resources).order(:name), :id, :to_label,
@@ -55,20 +59,27 @@
          be different from the defaults, or the defaults could have changed after the vm was created. %>
         <div id="compute_profile" <%= display?(!@host.compute_resource_id) %> >
           <%= select_f f, :compute_profile_id, ComputeProfile.visibles, :id, :name,
-            { :include_blank => true },
+            { :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
+              :disable_button_enabled => @host.hostgroup && @host.hostgroup_id_was.nil? && !params[:host][:compute_profile_id],
+              :user_set => params[:host] && params[:host][:compute_profile_id]
+            },
             { :label => _("Compute profile"), :'data-url' => compute_resource_selected_hosts_path,
               :onchange => 'computeResourceSelected(this);',
               :help_inline => :indicator } if SETTINGS[:unattended] %>
         </div>
         <% end %>
 
-        <%= select_f f, :environment_id, Environment.with_taxonomy_scope_override(@location,@organization).order(:name), :id, :to_label, { :include_blank => true },
-            {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
+        <%= select_f f, :environment_id, Environment.with_taxonomy_scope_override(@location,@organization).order(:name), :id, :to_label, { :include_blank => true,
+             :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
+             :disable_button_enabled => @host.hostgroup && @host.hostgroup_id_was.nil? && !params[:host][:environment_id],
+             :user_set => params[:host] && params[:host][:environment_id]
+           },
+           {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
             :'data-host-id' => @host.id, :help_inline => :indicator} %>
 
-        <%= puppet_master_fields f %>
+        <%= puppet_master_fields f, true, @host.hostgroup && @host.hostgroup_id_was.nil? %>
 
-        <%= realm_field f %>
+        <%= realm_field f, true, @host.hostgroup && @host.hostgroup_id_was.nil? %>
 
       </div>
 

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -62,6 +62,35 @@ class HostsControllerTest < ActionController::TestCase
     assert_redirected_to host_url(assigns['host'])
   end
 
+  test "should create new host with hostgroup inherited fields" do
+    leftovers = Host.search_for('myotherfullhost').first
+    refute leftovers
+    hostgroup = hostgroups(:common)
+    assert_difference 'Host.count' do
+      post :create, { :commit => "Create",
+        :host => {:name => "myotherfullhost",
+          :mac => "aabbecddee06",
+          :ip => "2.3.4.125",
+          :domain_id => domains(:mydomain).id,
+          :hostgroup_id => hostgroup.id,
+          :operatingsystem_id => operatingsystems(:redhat).id,
+          :architecture_id => architectures(:x86_64).id,
+          :subnet_id => subnets(:one).id,
+          :medium_id => media(:one).id,
+          :realm_id => realms(:myrealm).id,
+          :disk => "empty partition",
+          :root_pass           => "xybxa6JUkz63w",
+          :location_id => taxonomies(:location1).id,
+          :organization_id => taxonomies(:organization1).id
+        }
+      }, set_session_user
+    end
+    new_host = Host.search_for('myotherfullhost').first
+    assert_equal new_host.environment, hostgroup.environment
+    assert_equal new_host.puppet_proxy, hostgroup.puppet_proxy
+    assert_redirected_to host_url(assigns['host'])
+  end
+
   test "should get edit" do
     get :edit, {:id => @host.name}, set_session_user
     assert_response :success

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -724,8 +724,6 @@ class HostTest < ActiveSupport::TestCase
       hostgroup = FactoryGirl.create(:hostgroup, :with_puppet_orchestration)
       h = FactoryGirl.create(:host, :managed, :with_environment, :hostgroup => hostgroup)
       Setting[:manage_puppetca] = true
-      assert h.puppet_proxy.present?
-      assert h.puppetca?
 
       h.puppet_proxy_id = h.puppet_ca_proxy_id = nil
       h.save
@@ -2212,6 +2210,92 @@ class HostTest < ActiveSupport::TestCase
       assert_difference('LookupValue.count', -1) do
         host.save
       end
+    end
+  end
+
+  describe '#apply_inherited_attributes' do
+    test 'should be no-op if no hostgroup selected' do
+      host = FactoryGirl.build(:host, :managed)
+      attributes = { 'environment_id' => 1 }
+
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr, attributes
+    end
+
+    test 'should take new hostgroup if hostgroup_id present' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      new_environment = FactoryGirl.create(:environment)
+      new_hostgroup = FactoryGirl.create(:hostgroup, :environment => new_environment)
+      assert_not_equal new_environment.id, host.hostgroup.environment.try(:id)
+
+      attributes = { 'hostgroup_id' => new_hostgroup.id }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['environment_id'], new_environment.id
+    end
+
+    test 'should take new hostgroup if hostgroup_name present' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      new_environment = FactoryGirl.create(:environment)
+      new_hostgroup = FactoryGirl.create(:hostgroup, :environment => new_environment)
+      assert_not_equal new_environment.id, host.hostgroup.environment.try(:id)
+
+      attributes = { 'hostgroup_name' => new_hostgroup.title }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['environment_id'], new_environment.id
+    end
+
+    test 'should take old hostgroup if hostgroup not updated' do
+      environment = FactoryGirl.create(:environment)
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup, :environment => environment)
+      Hostgroup.expects(:find).never
+
+      attributes = { 'hostgroup_id' => host.hostgroup.id }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['environment_id'], host.hostgroup.environment.id
+    end
+
+    test 'should accept non-existing hostgroup' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      Hostgroup.expects(:find).with(1111).returns(nil)
+
+      attributes = { 'hostgroup_id' => 1111 }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_nil actual_attr['environment_id']
+    end
+
+    test 'should not touch attribute set explicitly' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+
+      attributes = { 'hostgroup_id' => host.hostgroup.id, 'environment_id' => 1111 }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['environment_id'], 1111
+    end
+
+    test 'should inherit attribute value, if not set explicitly' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      environment = FactoryGirl.create(:environment)
+      host.hostgroup.environment = environment
+      host.hostgroup.save!
+
+      attributes = { 'hostgroup_id' => host.hostgroup.id }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['environment_id'], host.hostgroup.environment.id
+    end
+
+    test 'should not touch non-inherited attributes' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+
+      attributes = { 'hostgroup_id' => host.hostgroup.id, 'zzz_id' => 1111 }
+      actual_attr = host.apply_inherited_attributes(attributes)
+
+      assert_equal actual_attr['zzz_id'], 1111
     end
   end
 


### PR DESCRIPTION
Changed the UI so it will possible to create a dropdown with empty value and "inherit" option in the same time.
On the server side, I check for existence of the field in the update to check if I need to inherit the value (if the field does not exists - its value will be inherited).
I did not change the notion of "inherit" in hosts, it is more of a "copy" notion - it copies the value from the hostgroup, but does not change it, if the value is changed. The change will be performed on the first update to the host object.
