### PR TITLE
Fixes #9657 - merge NICs from compute profile in host create API

### DIFF
--- a/app/models/concerns/foreman/sti.rb
+++ b/app/models/concerns/foreman/sti.rb
@@ -12,7 +12,7 @@ module Foreman
     module ClassMethods
       # ensures that the correct STI object is created when :type is passed.
       def new_with_cast(*attributes, &block)
-        if (h = attributes.first).is_a?(Hash) && (type = h.delete(:type)) && type.length > 0
+        if (h = attributes.first).is_a?(Hash) && (type = h.with_indifferent_access.delete(:type)) && type.length > 0
           if (klass = type.constantize) != self
             raise "Invalid type #{type}" unless klass <= self
             return klass.new(*attributes, &block)

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -8,7 +8,7 @@ module Nic
 
     validates_lengths_from_database
     attr_accessible :host_id, :host,
-                    :mac, :name,
+                    :mac, :name, :type,
                     :provider, :username, :password,
                     :identifier, :virtual, :link, :tag, :attached_to,
                     :managed, :bond_options, :attached_devices, :mode,

--- a/app/services/interface_type_mapper.rb
+++ b/app/services/interface_type_mapper.rb
@@ -1,0 +1,21 @@
+class InterfaceTypeMapper
+  class UnknownTypeExeption < Foreman::Exception; end
+
+  DEFAULT_TYPE = Nic::Managed
+  ALLOWED_TYPE_NAMES = Nic::Base.allowed_types.map{ |t| t.humanized_name.downcase }
+  LEGACY_TYPE_NAMES = Nic::Base.allowed_types.map{ |t| t.name }
+
+  def self.map(nic_type)
+    return DEFAULT_TYPE.name if nic_type.nil?
+
+    if ALLOWED_TYPE_NAMES.include? nic_type
+      # convert human readable name to the NIC's class name
+      Nic::Base.type_by_name(nic_type).to_s
+    elsif LEGACY_TYPE_NAMES.include? nic_type
+      # enable sending class names directly to keep backward compatibility
+      nic_type
+    else
+      raise UnknownTypeExeption.new(N_("Unknown interface type, must be one of [%s]") % ALLOWED_TYPE_NAMES.join(', '))
+    end
+  end
+end

--- a/app/views/api/v2/hosts/update.json.rabl
+++ b/app/views/api/v2/hosts/update.json.rabl
@@ -1,0 +1,3 @@
+object @host
+
+extends "api/v2/hosts/show"

--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,6 +1,6 @@
 object @interface
 
-attributes :id, :name, :ip, :mac
+attributes :id, :name, :ip, :mac, :identifier, :primary, :provision
 node :type do |i|
   i.class.humanized_name.downcase
 end

--- a/test/fixtures/compute_attributes.yml
+++ b/test/fixtures/compute_attributes.yml
@@ -29,7 +29,7 @@ four:
     memory: 4294967296
 
 with_interfaces:
-  compute_profile: two
+  compute_profile: four
   compute_resource: one
   vm_attrs:
     nics_attributes:

--- a/test/fixtures/compute_profiles.yml
+++ b/test/fixtures/compute_profiles.yml
@@ -8,3 +8,6 @@ two:
 
 three:
   name: 3-Large
+
+four:
+  name: 4-Networking

--- a/test/unit/compute_profile_test.rb
+++ b/test/unit/compute_profile_test.rb
@@ -31,13 +31,13 @@ class ComputeProfileTest < ActiveSupport::TestCase
   end
 
   test "shoud show visible hw profiles only" do
-    assert_equal 3, ComputeProfile.count
+    assert_equal 4, ComputeProfile.count
     #3-Large does not have any data in compute_attributes.yml
-    assert_equal 2, ComputeProfile.visibles.count
+    assert_equal 3, ComputeProfile.visibles.count
   end
 
   test "compute profile with associated attributes can be destroyed" do
-    assert_difference('ComputeAttribute.count', -3) do
+    assert_difference('ComputeAttribute.count', -2) do
       assert compute_attributes(:three).compute_profile.destroy
     end
   end

--- a/test/unit/interface_type_mapper_test.rb
+++ b/test/unit/interface_type_mapper_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class InterfaceTypeMapperTest < ActiveSupport::TestCase
+  def setup
+    @mapper = InterfaceTypeMapper
+  end
+
+  test "it maps name to interface class name" do
+    assert_equal Nic::Managed.name, @mapper.map("interface")
+    assert_equal Nic::BMC.name, @mapper.map("bmc")
+    assert_equal Nic::Bond.name, @mapper.map("bond")
+  end
+
+  test "it accepts class names for legacy reasons" do
+    assert_equal Nic::Managed.name, @mapper.map("Nic::Managed")
+    assert_equal Nic::BMC.name, @mapper.map("Nic::BMC")
+    assert_equal Nic::Bond.name, @mapper.map("Nic::Bond")
+  end
+
+  test "it returns Managed as default for nil input" do
+    assert_equal Nic::Managed.name, @mapper.map(nil)
+  end
+
+  test "it raises exception on unknown name" do
+    assert_raises InterfaceTypeMapper::UnknownTypeExeption do
+      @mapper.map("unknown")
+    end
+  end
+end


### PR DESCRIPTION
- updated api docs for hosts and interfaces
- host create/update api actions now merge interfaces from compute
  profiles
- NIC type mapping extracted into a separate class
- return full host detail after host update
