### PR TITLE
fixes #8817 - look up reports with all joins from host scoped_search

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -22,9 +22,25 @@ module Authorizable
       end
     }
 
-    def self.authorized(permission = nil, resource = nil)
-      self.authorized_as(User.current, permission, resource)
-    end
+    # joins to another class, on which the authorization is applied
+    #
+    # permission can be nil (therefore we use Proc instead of lambda)
+    #
+    # e.g.
+    #   Report.joins_authorized_as(user, Host, :view_hosts)
+    #   Host.joins_authorized_as(user, Domain, :view_domains)
+    #
+    # Or you may simply use authorized for User.current
+    #
+    scope :joins_authorized_as, Proc.new { |user, resource, permission|
+      if user.nil?
+        self.where('1=0')
+      elsif user.admin?
+        self.scoped
+      else
+        Authorizer.new(user).find_collection(resource, :permission => permission, :joined_on => self)
+      end
+    }
 
     def authorized?(permission)
       return false if User.current.nil?
@@ -43,6 +59,14 @@ module Authorizable
 
     def allows_location_filtering?
       allows_taxonomy_filtering?(:location_id)
+    end
+
+    def authorized(permission = nil, resource = nil)
+      authorized_as(User.current, permission, resource)
+    end
+
+    def joins_authorized(resource, permission = nil)
+      joins_authorized_as(User.current, resource, permission)
     end
   end
 end

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -24,8 +24,7 @@ class FactValue < ActiveRecord::Base
   }
   scope :my_facts, lambda {
     unless User.current.admin? and Organization.current.nil? and Location.current.nil?
-      host_ids = Host.authorized(:view_hosts, Host).select('hosts.id').all
-      where(:fact_values => {:host_id => host_ids})
+      joins_authorized(Host, :view_hosts)
     end
   }
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -34,7 +34,7 @@ class Report < ActiveRecord::Base
   # returns reports for hosts in the User's filter set
   scope :my_reports, lambda {
     if !User.current.admin? || Organization.expand(Organization.current).present? || Location.expand(Location.current).present?
-      where(:reports => {:host_id => Host.authorized(:view_hosts, Host)})
+      joins_authorized(Host, :view_hosts)
     end
   }
 

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -77,4 +77,34 @@ class ReportTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe '.my_reports' do
+    setup do
+      @target_host = FactoryGirl.create(:host, :with_hostgroup)
+      @target_reports = FactoryGirl.create_pair(:report, host: @target_host)
+      @other_host = FactoryGirl.create(:host, :with_hostgroup)
+      @other_reports = FactoryGirl.create_pair(:report, host: @other_host)
+    end
+
+    test 'returns all reports for admin' do
+      as_admin do
+        assert_empty (@target_reports + @other_reports).map(&:id) - Report.my_reports.map(&:id)
+      end
+    end
+
+    test 'returns visible reports for unlimited user' do
+      user_role = FactoryGirl.create(:user_user_role)
+      FactoryGirl.create(:filter, :role => user_role.role, :permissions => Permission.where(:name => 'view_hosts'), :unlimited => true)
+      collection = as_user(user_role.owner) { Report.my_reports }
+      assert_empty (@target_reports + @other_reports).map(&:id) - collection.map(&:id)
+    end
+
+    test 'returns visible reports for filtered user' do
+      user_role = FactoryGirl.create(:user_user_role)
+      FactoryGirl.create(:filter, :role => user_role.role, :permissions => Permission.where(:name => 'view_hosts'), :search => "hostgroup_id = #{@target_host.hostgroup_id}")
+      as_user user_role.owner do
+        assert_equal @target_reports.map(&:id).sort, Report.my_reports.map(&:id).sort
+      end
+    end
+  end
 end


### PR DESCRIPTION
This changes the optimisation in d50c799 which caused errors for users with
host filters referencing tables other than hosts.

When retrieving all reports joined with authorised hosts, the nested joins need
to be passed into AR via .joins on the main scope (reports) rather than what
happened with scoped_search, which only specifies the joins on the inner scope.
In that case, they're ignored and not included in the table list.

Retrieving the conditionals and tables from scoped_search directly allows us to
build up a more correct authorisation AR query with joins.
