### PR TITLE
fixes #9795 - check if mail is enabled before sending a notification

### DIFF
--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -5,7 +5,7 @@ class HostMailer < ApplicationMailer
 
   # sends out a summary email of hosts and their metrics (e.g. how many changes failures etc).
   def summary(options = {})
-    raise ::Foreman::Exception.new(N_("Must specify a user with email enabled")) unless (user=User.find(options[:user])) && user.mail_enabled?
+    raise ::Foreman::Exception.new(N_("Must specify a valid user with email enabled")) unless (user=User.find(options[:user]))
     hosts = Host::Managed.authorized_as(user, :view_hosts, Host)
     time = options[:time] || 1.day.ago
     host_data = Report.summarise(time, hosts.all).sort

--- a/app/models/user_mail_notification.rb
+++ b/app/models/user_mail_notification.rb
@@ -12,6 +12,7 @@ class UserMailNotification < ActiveRecord::Base
   scope :monthly, lambda { where(:interval => 'Monthly') }
 
   def deliver(options = {})
+    return unless user.mail_enabled?
     options[:time] = last_sent if last_sent
     mail_notification.deliver(options.merge(:user => user.id))
     update_attribute(:last_sent, Time.zone.now)

--- a/test/unit/mail_notification_test.rb
+++ b/test/unit/mail_notification_test.rb
@@ -7,9 +7,12 @@ class MailNotificationTest < ActiveSupport::TestCase
   end
 
   test "user with mail disabled doesn't get mail" do
-    Setting[:send_welcome_email] = true
+    user = FactoryGirl.create(:user, :with_mail, :mail_enabled => false)
+    user.mail_notifications << MailNotification[:puppet_summary]
+    notification = user.user_mail_notifications.find_by_mail_notification_id(MailNotification[:puppet_summary])
+
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      User.create :auth_source => auth_sources(:internal), :login => "welcome", :mail  => "foo@bar.com", :password => "qux", :mail_enabled => false
+      notification.deliver
     end
   end
 end


### PR DESCRIPTION
Currently, the mailer checks but we can move this up the stack to be DRYer.
