### PR TITLE
Fixes #9815 - Use dup instead of clone for hostgroup params

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -196,7 +196,7 @@ class Hostgroup < ActiveRecord::Base
     new.locations     = locations
     new.organizations = organizations
     # Clone any parameters as well
-    self.group_parameters.each{|param| new.group_parameters << param.clone}
+    self.group_parameters.each{|param| new.group_parameters << param.dup}
     self.config_groups.each{|group| new.config_groups << group}
     new
   end


### PR DESCRIPTION
This changes the params from a clone to a dup, which doesn't copy the ID, which was found in:

https://gist.github.com/ericsaboia/994614
