### PR TITLE
Fixes #9827 - compute resource info in API doesn't send provider type

### DIFF
--- a/app/views/api/v2/compute_resources/base.json.rabl
+++ b/app/views/api/v2/compute_resources/base.json.rabl
@@ -1,4 +1,3 @@
 object @compute_resource
 
-attributes :id, :name
-attribute :provider_friendly_name => 'provider'
+attributes :id, :name, :provider, :provider_friendly_name


### PR DESCRIPTION
Both values are useful. The problem with only using the friendly name is that it can differ accross instances. E.g. oVIrt vs. RHEV.
