### PR TITLE
fixes #9775 - always load Encryptable when key's missing, log runtime warning

### DIFF
--- a/app/models/concerns/encryptable.rb
+++ b/app/models/concerns/encryptable.rb
@@ -1,115 +1,120 @@
 module Encryptable
   extend ActiveSupport::Concern
-  include EncryptionKey if defined?(EncryptionKey)
-  # Set encryption key for tests only if case it's not set
-  ENCRYPTION_KEY = '25d224dd383e92a7e0c82b8bf7c985e815f34cf5' if Rails.env.test?
 
-  if const_defined?(:ENCRYPTION_KEY)
+  included do
+    ENCRYPTION_PREFIX = "encrypted-"
+    before_save :encrypt_setters
+  end
 
-    included do
-      ENCRYPTION_PREFIX = "encrypted-"
-      before_save :encrypt_setters
+  module ClassMethods
+    def encrypts(*fields)
+      class_attribute :encryptable_fields
+      self.encryptable_fields = fields.map(&:to_sym)
+      define_getter_in_db(fields.map(&:to_sym))
+      define_auto_decrypt_getter(fields.map(&:to_sym))
     end
 
-    def encrypt_setters
-      self.encryptable_fields.each do |field|
-        if send("#{field}_changed?")
-          self.send("#{field}=", encrypt_field(read_attribute(field.to_sym)))
+    def encrypts?(field)
+      encryptable_fields.include?(field.to_sym)
+    end
+
+    private
+
+    def define_getter_in_db(fields)
+      fields.each do |field|
+        define_method "#{field}_in_db" do
+          read_attribute(field.to_sym)
         end
       end
     end
 
-    def matches_prefix?(str)
-      ENCRYPTION_PREFIX == str.to_s[0..(ENCRYPTION_PREFIX.length - 1)]
-    end
-
-    def puts_and_logs(msg)
-      logger.info msg
-      puts msg if Foreman.in_rake? && !Rails.env.test?
-    end
-
-    def is_encryptable?(str)
-      return true if !matches_prefix?(str) && str.present?
-      if str.blank?
-        puts_and_logs "String is empty', so #{self.class.name} #{name} was not encrypted"
-      else
-        puts_and_logs "String starts with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not encrypted again"
+    def define_auto_decrypt_getter(fields)
+      fields.each do |field|
+        define_method field do
+          decrypt_field(send("#{field}_in_db".to_sym))
+        end
       end
+    end
+  end
+
+  def encrypt_setters
+    self.encryptable_fields.each do |field|
+      if send("#{field}_changed?")
+        self.send("#{field}=", encrypt_field(read_attribute(field.to_sym)))
+      end
+    end
+  end
+
+  def matches_prefix?(str)
+    ENCRYPTION_PREFIX == str.to_s[0..(ENCRYPTION_PREFIX.length - 1)]
+  end
+
+  def encryption_key
+    return ENV['ENCRYPTION_KEY'] if ENV['ENCRYPTION_KEY'].present?
+    return EncryptionKey::ENCRYPTION_KEY if defined? EncryptionKey::ENCRYPTION_KEY
+    nil
+  end
+
+  def is_encryptable?(str)
+    if !encryption_key.present?
+      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be encrypted", Logger::WARN
       false
-    end
-
-    def is_decryptable?(str)
-      return true if matches_prefix?(str)
-      puts_and_logs "String does not start with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not decrypted"
+    elsif str.blank?
+      puts_and_logs "String is blank', so #{self.class.name} #{name} was not encrypted", Logger::DEBUG
       false
+    elsif matches_prefix?(str)
+      puts_and_logs "String starts with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not encrypted again", Logger::DEBUG
+      false
+    else
+      true
     end
+  end
 
-    def encrypt_field(str)
-      return str.to_s unless is_encryptable?(str)
-      encryptor = ActiveSupport::MessageEncryptor.new(ENCRYPTION_KEY)
-      begin
-        # add prefix to encrypted string
-        str_encrypted = "#{ENCRYPTION_PREFIX}#{encryptor.encrypt_and_sign(str)}"
-        puts_and_logs "Successfully encrypted field for #{self.class.name} #{name}"
-        str = str_encrypted
-      rescue
-        puts_and_logs "WARNING: Encryption failed for string. Please check that the ENCRYPTION_KEY has not changed."
-      end
-      str
+  def is_decryptable?(str)
+    if !matches_prefix?(str)
+      puts_and_logs "String does not start with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not decrypted", Logger::DEBUG
+      false
+    elsif !encryption_key.present?
+      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be decrypted", Logger::WARN
+      false
+    else
+      true
     end
+  end
 
-    def decrypt_field(str)
-      return str unless is_decryptable?(str)
-      encryptor = ActiveSupport::MessageEncryptor.new(ENCRYPTION_KEY)
-      begin
-        # remove prefix before decrypting string
-        str_no_prefix = str.gsub(/^#{ENCRYPTION_PREFIX}/, "")
-        str_decrypted = encryptor.decrypt_and_verify(str_no_prefix)
-        puts_and_logs "Successfully decrypted field for #{self.class.name} #{name}"
-        str = str_decrypted
-      rescue ActiveSupport::MessageVerifier::InvalidSignature
-        puts_and_logs "WARNING: Decryption failed for string. Please check that the ENCRYPTION_KEY has not changed."
-      end
-      str
+  def encrypt_field(str)
+    return str unless is_encryptable?(str)
+    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+    begin
+      # add prefix to encrypted string
+      str_encrypted = "#{ENCRYPTION_PREFIX}#{encryptor.encrypt_and_sign(str)}"
+      puts_and_logs "Successfully encrypted field for #{self.class.name} #{name}"
+      str = str_encrypted
+    rescue
+      puts_and_logs "WARNING: Encryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
     end
+    str
+  end
 
-    module ClassMethods
-      def encrypts(*fields)
-        class_attribute :encryptable_fields
-        self.encryptable_fields = fields.map(&:to_sym)
-        define_getter_in_db(fields.map(&:to_sym))
-        define_auto_decrypt_getter(fields.map(&:to_sym))
-      end
-
-      def encrypts?(field)
-        encryptable_fields.include?(field.to_sym)
-      end
-
-      def define_getter_in_db(fields)
-        fields.each do |field|
-          define_method "#{field}_in_db" do
-            read_attribute(field.to_sym)
-          end
-        end
-      end
-
-      def define_auto_decrypt_getter(fields)
-        fields.each do |field|
-          define_method field do
-            decrypt_field(send("#{field}_in_db".to_sym))
-          end
-        end
-      end
+  def decrypt_field(str)
+    return str unless is_decryptable?(str)
+    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+    begin
+      # remove prefix before decrypting string
+      str_no_prefix = str.gsub(/^#{ENCRYPTION_PREFIX}/, "")
+      str_decrypted = encryptor.decrypt_and_verify(str_no_prefix)
+      puts_and_logs "Successfully decrypted field for #{self.class.name} #{name}"
+      str = str_decrypted
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      puts_and_logs "WARNING: Decryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
     end
+    str
+  end
 
-  else
-    included do
-      logger.info "ENCRYPTION_KEY is not defined, so encryption is turned off for #{model_name}."
-    end
+  private
 
-    module ClassMethods
-      def encrypts(*fields)
-      end
-    end
+  def puts_and_logs(msg, level = Logger::INFO)
+    logger.add level, msg
+    puts msg if Foreman.in_rake? && !Rails.env.test? && level >= Logger::INFO
   end
 end

--- a/config/initializers/encryption_key.rb.example
+++ b/config/initializers/encryption_key.rb.example
@@ -7,5 +7,5 @@
 # You can use `rake security:generate_encryption_key` to regenerate this file.
 
 #module EncryptionKey
-#  ENCRYPTION_KEY = ENV['ENCRYPTION_KEY'] || 'uncomment and insert encryption key here'
+#  ENCRYPTION_KEY = 'uncomment and insert encryption key here'
 #end

--- a/lib/tasks/encrypt.rake
+++ b/lib/tasks/encrypt.rake
@@ -14,7 +14,7 @@ namespace :security do
 # You can use `rake security:generate_encryption_key` to regenerate this file.
 
 module EncryptionKey
-  ENCRYPTION_KEY = ENV['ENCRYPTION_KEY'] || '#{secure_encryption_key}'
+  ENCRYPTION_KEY = '#{secure_encryption_key}'
 end
 ")
       puts "Encryption key generated in file config/initializers/encryption_key.rb"

--- a/test/lib/encryptable_test.rb
+++ b/test/lib/encryptable_test.rb
@@ -1,13 +1,18 @@
 require 'test_helper'
 
 class EncryptableTest < ActiveSupport::TestCase
-  # use ComputeResource as class to test Encryptable module
-  # class ComputeResource < ActiveRecord::Base
-  #   include Encryptable
-  #   encrypts :password
-  # end
-  def setup
-    User.current = users(:admin)
+  setup do
+    # default test behaviour should be no encryption
+    ComputeResource.any_instance.stubs(:encryption_key).returns(nil)
+  end
+
+  def cr_with_encryption_key
+    stub_encryption_key(FactoryGirl.build(:ec2_cr, password: 'encrypted-NEN1YVJtdWdaaTdlOHdiUXRHd29nWUZsOHc1UjdMb3p1MFZLenlLekFEbz0tLVA0MGVzUEorUDlJZHVUV2F6azUzUEE9PQ==--9f45d5c88ec582eeb48ebb906ae0a66345ded0fa'))
+  end
+
+  def stub_encryption_key(model)
+    model.stubs(:encryption_key).returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+    model
   end
 
   test "encrypts?(:password) is true" do
@@ -18,27 +23,41 @@ class EncryptableTest < ActiveSupport::TestCase
     assert ComputeResource.encryptable_fields.include?(:password)
   end
 
+  test "is_encryptable? is false when key is empty" do
+    cr = FactoryGirl.build(:ec2_cr)
+    cr.stubs(:encryption_key).returns(nil)
+    cr.expects(:puts_and_logs)
+    refute cr.is_encryptable?('foo')
+  end
+
+  test "is_decryptable? is false when key is empty" do
+    cr = FactoryGirl.build(:ec2_cr)
+    cr.stubs(:encryption_key).returns(nil)
+    cr.expects(:puts_and_logs)
+    refute cr.is_decryptable?('encrypted-WkQyR0xMVXZCT2hRTmVGaTNIWlY3RkoxM1M4')
+  end
+
   test "this string IS encryptable and NOT decryptable" do
     str = "abcd1234"
-    compute_resource = compute_resources(:one)
+    compute_resource = cr_with_encryption_key
     assert compute_resource.is_encryptable?(str)
     refute compute_resource.is_decryptable?(str)
   end
 
   test "this string is NOT encryptable and IS decryptable" do
     str = "encrypted-WkQyR0xMVXZCT2hRTmVGaTNIWlY3RkoxM1M4"
-    compute_resource = compute_resources(:one)
+    compute_resource = cr_with_encryption_key
     refute compute_resource.is_encryptable?(str)
     assert compute_resource.is_decryptable?(str)
   end
 
   test "string is NOT encrypted AGAIN upon save if it is not changed" do
-    compute_resource = compute_resources(:one)
+    compute_resource = cr_with_encryption_key
     orig_pass = compute_resource.password
     orig_pass_in_db = compute_resource.password_in_db
     refute compute_resource.is_decryptable?(orig_pass)
     assert compute_resource.is_decryptable?(orig_pass_in_db)
-    assert compute_resource.save
+    assert compute_resource.save!
     compute_resource.reload
     new_pass = compute_resource.password
     new_pass_in_db = compute_resource.password_in_db
@@ -48,12 +67,11 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   test "string is re-encrypted upon save if password changed" do
-    # :one fixture password is saved encrypted
-    compute_resource = compute_resources(:one)
+    compute_resource = cr_with_encryption_key
     orig_pass = compute_resource.password
     orig_pass_in_db = compute_resource.password_in_db
     compute_resource.password = "3333333"
-    assert compute_resource.save
+    assert compute_resource.save!
     compute_resource.reload
     new_pass = compute_resource.password
     new_pass_in_db = compute_resource.password_in_db
@@ -62,8 +80,7 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   test "does not decrypt if string is not decryptable and returns database value" do
-    # :yourcompute fixture password is not saved encrypted (1234567)
-    compute_resource = compute_resources(:yourcompute)
+    compute_resource = stub_encryption_key(FactoryGirl.build(:compute_resource, password: '1234567'))
     orig_pass = compute_resource.password
     orig_pass_in_db = compute_resource.password_in_db
     refute compute_resource.is_decryptable?(orig_pass_in_db)
@@ -72,7 +89,7 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   test "encrypt successfully" do
-    compute_resource = ComputeResource.new
+    compute_resource = cr_with_encryption_key
     plain_str = "secretpassword"
     encrypted_str = compute_resource.encrypt_field(plain_str)
     refute_equal plain_str, encrypted_str
@@ -81,7 +98,7 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   test "decrypt successfully" do
-    compute_resource = ComputeResource.new
+    compute_resource = cr_with_encryption_key
     plain_str = "secretpassword"
     encrypted_str = compute_resource.encrypt_field(plain_str)
     decrypted_str = compute_resource.decrypt_field(encrypted_str)
@@ -89,10 +106,10 @@ class EncryptableTest < ActiveSupport::TestCase
     assert_equal plain_str, decrypted_str
   end
 
-  test "returns blank string '' if password is nil" do
-    compute_resource = ComputeResource.new
+  test "encrypt_field returns nil if password is nil" do
+    compute_resource = cr_with_encryption_key
     encrypted_str = compute_resource.encrypt_field(nil)
-    assert encrypted_str == ''
+    assert_nil encrypted_str
   end
 end
 

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -9,6 +9,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
 
   test "password is saved encrypted when updated" do
     compute_resource = compute_resources(:one)
+    compute_resource.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
     compute_resource.password = "123456"
     as_admin do
       assert compute_resource.save
@@ -19,6 +20,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
 
   test "password is saved encrypted when created" do
     Fog.mock!
+    ComputeResource.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
     compute_resource = ComputeResource.new_provider(:name => "new12345", :provider => "EC2", :url => "eu-west-1",
                                                     :user => "username", :password => "abcdef")
     as_admin do


### PR DESCRIPTION
a59972c3 causes Encryptable to be loaded before the encryption_key.rb
initialiser and the majority of the class was skipped as the key was undefined.

Now Encryptable always loads, but logs at runtime if the key is unavailable,
allowing it to be defined a bit later.

---

Sorry it's a bit hard to read, easier with `?w=1`.  I gave the tests a little modernisation while I was in there, and reduced the day to day logging as that's a frequent confusion.

This seems a bit better than renaming files to change the initialisation order, as it also fixes the weirdness [that is undefined methods when there's no key](http://projects.theforeman.org/issues/9771), replacing it with proper logging of the error condition.
