### PR TITLE
Fixes #10002 - Add attribute ancestry to taxonomies (orgs, locations)

### DIFF
--- a/app/views/api/v2/taxonomies/main.json.rabl
+++ b/app/views/api/v2/taxonomies/main.json.rabl
@@ -2,4 +2,4 @@ object @taxonomy
 
 extends "api/v2/taxonomies/base"
 
-attributes :created_at, :updated_at
+attributes :ancestry, :created_at, :updated_at

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -123,7 +123,7 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     response = ActiveSupport::JSON.decode(@response.body)
     assert response.is_a?(Hash)
     assert response['results'].is_a?(Array)
-    assert_equal ['created_at', 'id', 'name', 'title', 'updated_at'], response['results'][0].keys.sort
+    assert_equal ['ancestry', 'created_at', 'id', 'name', 'title', 'updated_at'], response['results'][0].keys.sort
   end
 
   test "object name on show defaults to object class name" do


### PR DESCRIPTION
precedence: this attribute comes back in hostgroups.

When accessing v2 api, hostgroups come back with ancestry.
Taxonomies, which backup Locations and Organizations, are also dependent upon ancestry,
but that attribute does not come back.

thanks
