### PR TITLE
Fixes #9869 - propagate LDAP errors

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -107,10 +107,6 @@ class AuthSourceLdap < AuthSource
 
   def users_in_group(name)
     ldap_con.user_list(name)
-  rescue
-    # To be fixed after ldap_fluff returns [] for an empty group
-    # instead of raising an exception
-    []
   end
 
   private


### PR DESCRIPTION
Ldap fluff used to raise RuntimeException for usergroups with no members. This was fixed in 0.3.3 which we use for some time so we should remove generic rescue as commented at https://github.com/theforeman/foreman/pull/1744#issuecomment-62200988
