### PR TITLE
fixes #9031 - Add routes to view template_combinations per hostgroup / env

### DIFF
--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -1,31 +1,56 @@
 module Api
   module V2
     class TemplateCombinationsController < V2::BaseController
-      before_filter :find_resource, :only => [:show, :destroy]
-      before_filter :find_parent_config_template, :only => [:index, :create]
+      before_filter :find_required_nested_object
+      before_filter :find_resource, :only => [:show, :update, :destroy]
+
+      def_param_group :template_combination_identifiers do
+        param :config_template_id, String, :desc => N_("ID of config template")
+        param :hostgroup_id, String, :desc => N_("ID of host group")
+        param :environment_id, String, :desc => N_("ID of environment")
+      end
 
       api :GET, "/config_templates/:config_template_id/template_combinations", N_("List template combination")
-      param :config_template_id, :identifier, :required => true
+      api :GET, "/hostgroups/:hostgroup_id/template_combinations", N_("List template combination")
+      api :GET, "/environments/:environment_id/template_combinations", N_("List template combination")
+      param_group :template_combination_identifiers
       def index
-        @template_combinations = @config_template.template_combinations
+        @template_combinations = nested_obj.template_combinations
         @total = @template_combinations.count
       end
 
-      api :POST, "/config_templates/:config_template_id/template_combinations", N_("Add a template combination")
-      param :config_template_id, :identifier, :required => true
-      param :template_combination, Hash, :required => true do
-        param :environment_id, :number, :allow_nil => true, :desc => N_("environment id")
-        param :hostgroup_id, :number, :allow_nil => true, :desc => N_("host group id")
+      def_param_group :template_combination do
+        param :template_combination, Hash, :required => true, :action_aware => true do
+          param :environment_id, :number, :allow_nil => true, :desc => N_("environment id")
+          param :hostgroup_id, :number, :allow_nil => true, :desc => N_("host group id")
+        end
       end
 
+      api :POST, "/config_templates/:config_template_id/template_combinations", N_("Add a template combination")
+      api :POST, "/hostgroups/:hostgroup_id/template_combinations", N_("Add a template combination")
+      api :POST, "/environments/:environment_id/template_combinations", N_("Add a template combination")
+      param_group :template_combination_identifiers
+      param_group :template_combination, :as => :create
+
       def create
-        @template_combination = @config_template.template_combinations.build(params[:template_combination])
+        @template_combination = nested_obj.template_combinations.build(params[:template_combination])
         process_response @template_combination.save
       end
 
       api :GET, "/template_combinations/:id", N_("Show template combination")
       param :id, :identifier, :required => true
       def show
+      end
+
+      api :PUT, "/config_templates/:config_template_id/template_combinations/:id", N_("Update template combination")
+      api :PUT, "/hostgroups/:hostgroup_id/template_combinations/:id", N_("Update template combination")
+      api :PUT, "/environments/:environment_id/template_combinations/:id", N_("Update template combination")
+      param :id, :identifier, :required => true
+      param_group :template_combination_identifiers
+      param_group :template_combination
+
+      def update
+        process_response @template_combination.update_attributes!(params[:template_combination])
       end
 
       api :DELETE, "/template_combinations/:id", N_("Delete a template combination")
@@ -35,10 +60,10 @@ module Api
         process_response @template_combination.destroy
       end
 
-      def find_parent_config_template
-        @config_template = ConfigTemplate.authorized(:view_templates).find(params[:config_template_id])
-        not_found unless @config_template
-        @config_template
+      private
+
+      def allowed_nested_id
+        %w(environment_id hostgroup_id config_template_id)
       end
     end
   end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -31,7 +31,7 @@ Foreman::Application.routes.draw do
           get 'build_pxe_default'
           get 'revision'
         end
-        resources :template_combinations, :only => [:index, :create]
+        resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]
         resources :os_default_templates, :except => [:new, :edit]
       end
@@ -53,6 +53,7 @@ Foreman::Application.routes.draw do
           end
         end
         resources :hosts, :except => [:new, :edit]
+        resources :template_combinations, :only => [:index, :show, :create, :update]
       end
 
       resources :fact_values, :only => [:index]
@@ -75,6 +76,7 @@ Foreman::Application.routes.draw do
         resources :puppetclasses, :except => [:new, :edit]
         resources :hostgroup_classes, :path => :puppetclass_ids, :only => [:index, :create, :destroy]
         resources :hosts, :except => [:new, :edit]
+        resources :template_combinations, :only => [:show, :index, :create, :update]
       end
 
       resources :media, :except => [:new, :edit] do

--- a/test/functional/api/v2/template_combinations_controller_test.rb
+++ b/test/functional/api/v2/template_combinations_controller_test.rb
@@ -23,10 +23,20 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
         :config_template_id => config_templates(:mystring2).id }
     end
     template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert template_combination["environment_id"] == environments(:production).id
-    assert template_combination["hostgroup_id"] == hostgroups(:unusual).id
-    assert template_combination["config_template_id"] == config_templates(:mystring2).id
+    assert_equal(template_combination["environment_id"], environments(:production).id)
+    assert_equal(template_combination["hostgroup_id"], hostgroups(:unusual).id)
+    assert_equal(template_combination["config_template_id"], config_templates(:mystring2).id)
     assert_response 200
+  end
+
+  test "should update template combination" do
+    put :update, { :template_combination => { :environment_id => environments(:testing).id, :hostgroup_id => hostgroups(:common).id },
+                   :config_template_id => config_templates(:mystring2).id, :id => template_combinations(:two).id }
+
+    template_combination = ActiveSupport::JSON.decode(@response.body)
+    assert_equal(template_combination["environment_id"], environments(:testing).id)
+    assert_equal(template_combination["hostgroup_id"], hostgroups(:common).id)
+    assert_response :success
   end
 
   test "should destroy" do


### PR DESCRIPTION
Created under `/api/v2/hostgroups/:id/template_combinations` and `/api/v2/environments/:id/template_combinations`, as it seems more reasonable.

I have also added the option to update template combinations.
