### PR TITLE
fixes #9877 - Add descriptions to smart_class_parameters in api/v2

### DIFF
--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -33,18 +33,18 @@ module Api
       param :id, :identifier, :required => true
       param :smart_class_parameter, Hash, :required => true do
         # can't update parameter/key name for :parameter, String, :required => true
-        param :override, :bool
-        param :description, String
-        param :default_value, String
-        param :use_puppet_default, :bool
-        param :path, String
-        param :validator_type, String
-        param :validator_rule, String
-        param :override_value_order, String
-        param :parameter_type, String
-        param :required, :bool
-        param :merge_overrides, :bool
-        param :avoid_duplicates, :bool
+        param :override, :bool, :desc => N_("Whether the smart variable value is managed by Foreman")
+        param :description, String, :desc => N_("Description of smart class")
+        param :default_value, String, :desc => N_("Value to use when there is no match")
+        param :use_puppet_default, :bool, :desc => N_("Do not send this parameter via the ENC. Puppet will use the value defined in the Puppet manifest for this parameter")
+        param :path, String, :desc => N_("The order in which values are resolved")
+        param :validator_type, LookupKey::VALIDATOR_TYPES, :desc => N_("Types of validation values")
+        param :validator_rule, String, :desc => N_("Used to enforce certain values for the parameter values")
+        param :override_value_order, String, :desc => N_("The order in which values are resolved")
+        param :parameter_type, LookupKey::KEY_TYPES, :desc => N_("Types of variable values")
+        param :required, :bool, :desc => N_("If true, will raise an error if there is no default value and no matcher provide a value")
+        param :merge_overrides, :bool, :desc => N_("Merge all matching values (only array/hash type)")
+        param :avoid_duplicates, :bool, :desc => N_("Remove duplicate values (only array type)")
       end
 
       def update

--- a/app/controllers/api/v2/smart_variables_controller.rb
+++ b/app/controllers/api/v2/smart_variables_controller.rb
@@ -30,9 +30,9 @@ module Api
           param :default_value, String, :desc => N_("Default value of variable")
           param :override_value_order, String, :desc => N_("The order in which values are resolved")
           param :description, String, :desc => N_("Description of variable")
-          param :validator_type, LookupKey::VALIDATOR_TYPES
+          param :validator_type, LookupKey::VALIDATOR_TYPES, :desc => N_("Types of validation values")
           param :validator_rule, String, :desc => N_("Used to enforce certain values for the parameter values")
-          param :variable_type, LookupKey::KEY_TYPES
+          param :variable_type, LookupKey::KEY_TYPES, :desc => N_("Types of variable values")
           param :merge_overrides, :bool, :desc => N_("Merge all matching values (only array/hash type)")
           param :avoid_duplicates, :bool, :desc => N_("Remove duplicate values (only array type)")
         end


### PR DESCRIPTION
Override values descriptions have been added at: https://github.com/shlomizadok/foreman/blob/fix_9812/app/controllers/api/v2/override_values_controller.rb#L33-L34 in #2255 
