### PR TITLE
fixes #9773 - correctly render template URL

### DIFF
--- a/app/controllers/concerns/foreman/controller/config_templates.rb
+++ b/app/controllers/concerns/foreman/controller/config_templates.rb
@@ -13,8 +13,14 @@ module Foreman::Controller::ConfigTemplates
   private
 
   def default_template_url(template, hostgroup)
-    url_for(:host => Setting[:unattended_url], :action => :template, :controller => '/unattended',
-            :id => template.name, :hostgroup => hostgroup.name)
+    uri      = URI.parse(Setting[:unattended_url])
+    host     = uri.host
+    port     = uri.port
+    protocol = uri.scheme
+
+    url_for(:only_path => false, :action => :template, :controller => '/unattended',
+            :id => template.name, :hostgroup => hostgroup.name, :protocol => protocol,
+            :host => host, :port => port)
   end
 
   # convert the file upload into a simple string to save in our db.

--- a/test/functional/config_templates_controller_test.rb
+++ b/test/functional/config_templates_controller_test.rb
@@ -75,16 +75,16 @@ class ConfigTemplatesControllerTest < ActionController::TestCase
   end
 
   test "build menu" do
-    ConfigTemplate.find_by_name('PXELinux global default').update_attribute(:template,
-      File.read(File.expand_path(File.dirname(__FILE__) + "/../../app/views/unattended/pxe/PXELinux_default.erb")))
-    Setting[:unattended_url] = "http://foreman.unattended.url"
+    template = File.read(File.expand_path(File.dirname(__FILE__) + "/../../app/views/unattended/pxe/PXELinux_default.erb"))
+    ConfigTemplate.find_by_name('PXELinux global default').update_attribute(:template, template)
 
-    ProxyAPI::TFTP.any_instance.expects(:create_default).with(has_entry(:menu, regexp_matches(/http:\/\/foreman.unattended.url/))).returns(true)
     ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
-
+    Setting[:unattended_url] = "http://foreman.unattended.url"
     @request.env['HTTP_REFERER'] = config_templates_path
-    get :build_pxe_default, {}, set_session_user
 
+    ProxyAPI::TFTP.any_instance.expects(:create_default).with(has_entry(:menu, regexp_matches(/ks=http:\/\/foreman.unattended.url:80\/unattended\/template/))).returns(true)
+
+    get :build_pxe_default, {}, set_session_user
     assert_redirected_to config_templates_path
   end
 


### PR DESCRIPTION
This fixes the URL rendering incorrectly as `https://http://foo.bar.baz` and also ensures the test would catch such a failure in the future.
