### PR TITLE
Fixes #9886 - Caps on password warning is not html safe

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -57,7 +57,8 @@ module LayoutHelper
       addClass options, 'form-control'
       f.password_field(attr, options) +
       '<span class="glyphicon glyphicon-warning-sign input-addon"
-             title="' + _('Caps lock ON') + '" style="display:none"></span>'.html_safe
+             title="'.html_safe + _('Caps lock ON') +
+             '" style="display:none"></span>'.html_safe
     end
   end
 


### PR DESCRIPTION
Applying .html_safe in both strings seems to solve the issue.
