### PR TITLE
Fixes #9921 - wrong requirements on apidoc params for NICs

### DIFF
--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -32,12 +32,12 @@ module Api
 
       def_param_group :interface_attributes do
         #common parameters
-        param :mac, String, :required => true, :desc => N_("MAC address of interface")
-        param :ip, String, :required => true, :desc => N_("IP address of interface")
-        param :type, InterfaceTypeMapper::ALLOWED_TYPE_NAMES, :required => true, :desc => N_("Interface type, e.g: bmc")
-        param :name, String, :required => true, :desc => N_("Interface's DNS name")
+        param :mac, String, :desc => N_("MAC address of interface. Required for managed interfaces on bare metal.")
+        param :ip, String, :desc => N_("IP address of interface")
+        param :type, InterfaceTypeMapper::ALLOWED_TYPE_NAMES, :desc => N_("Interface type, e.g. bmc. Default is %{default_nic_type}")
+        param :name, String, :desc => N_("Interface's DNS name")
         param :subnet_id, Fixnum, :desc => N_("Foreman subnet ID of interface")
-        param :domain_id, Fixnum, :desc => N_("Foreman domain ID of interface")
+        param :domain_id, Fixnum, :desc => N_("Foreman domain ID of interface. Required for primary interfaces on managed hosts.")
         param :identifier, String, :desc => N_("Device identifier, e.g. eth0 or eth1.1")
         param :managed, :bool, :desc => N_("Should this interface be managed via DHCP and DNS smart proxy and should it be configured during provisioning?")
         param :primary, :bool, :desc => N_("Should this interface be used for constructing the FQDN of the host? Each managed hosts needs to have one primary interface.")

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -17,7 +17,8 @@ Apipie.configure do |config|
 
   substitutions = {
     'operatingsystem_families' => Operatingsystem.families.join(", "),
-    'providers' => ComputeResource.providers.join(', ')
+    'providers' => ComputeResource.providers.join(', '),
+    :default_nic_type => InterfaceTypeMapper::DEFAULT_TYPE.humanized_name.downcase
   }
 
   config.translate = lambda do |str, loc|


### PR DESCRIPTION
NIC's parameters mac, ip, type and name are wrongly marked as required in the API docs. They are required only at certain circumstances. Combination with a bug in apipie-bindings 0.0.11 that always evaluates required parameters of type "array of hash" as missing makes it impossible to use apipie-bindings (and hammer) for creating hosts with interfaces.

Issue on apipie-bindings will follow.
