### PR TITLE
Fixes #8812 - Pass model type so search_for is called on Host

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -204,7 +204,7 @@ module Api
           if allowed_nested_id.include?(param)
             model = md[1].classify.constantize
             controller = md[1].pluralize
-            authorized_scope = model.authorized("#{action_permission}_#{controller}")
+            authorized_scope = model.authorized("#{action_permission}_#{controller}", model)
             @nested_obj = begin
               authorized_scope.find(params[param])
             rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -245,7 +245,7 @@ Return value may either be one of the following:
 
       def permissions_check
         permission = "#{params[:action]}_hosts".to_sym
-        deny_access unless Host.authorized(permission).find(@host.id)
+        deny_access unless Host.authorized(permission, Host).find(@host.id)
       end
 
       def resource_class

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -152,7 +152,7 @@ class Api::TestableControllerTest < ActionController::TestCase
       scope = mock('scope')
       obj = mock('domain')
       scope.expects(:find).with(1).returns(obj)
-      Domain.expects(:authorized).with('view_domains').returns(scope)
+      Domain.expects(:authorized).with('view_domains', Domain).returns(scope)
       assert_equal obj, ctrl.send(:find_required_nested_object)
     end
   end


### PR DESCRIPTION
At least on version 1.6.1, the absence of this second parameter leads to a
runtime crash when it's time to validate if the current user (non-admin) is
allowed to perform a power operation on given a host via the APIv2.

The root cause of the crash is basically that search_for is called on
Host::Base by app/services/authorizer.rb:50.
