### PR TITLE
fixes #10087 - Pass nic_type to vm_clone

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -365,6 +365,7 @@ module Foreman::Model
         "memoryMB" => args[:memory_mb],
         "datastore" => args[:volumes].first[:datastore],
         "network_label" => args[:interfaces].first[:network],
+        "nic_type" => args[:interfaces].first[:type],
         "network_adapter_device_key" => network_adapter_device_key
       }
       client.servers.get(client.vm_clone(opts)['new_vm']['id'])


### PR DESCRIPTION
Fixes issue when deploying Vm from template, nic type is always set to E1000, instead of the desired configuration setting (either E1000 or vmxnet3)
