### PR TITLE
fixes #10020 - add next-server/filename attrs to provision NIC DHCP record

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -15,7 +15,7 @@ module Orchestration::DHCP
 
   def dhcp_record
     return unless dhcp? or @dhcp_record
-    @dhcp_record ||= jumpstart? ? Net::DHCP::SparcRecord.new(dhcp_attrs) : Net::DHCP::Record.new(dhcp_attrs)
+    @dhcp_record ||= (provision? && jumpstart?) ? Net::DHCP::SparcRecord.new(dhcp_attrs) : Net::DHCP::Record.new(dhcp_attrs)
   end
 
   protected
@@ -58,15 +58,24 @@ module Orchestration::DHCP
 
   # returns a hash of dhcp record settings
   def dhcp_attrs
-    return unless dhcp?
-    dhcp_attr = { :name => name, :filename => operatingsystem.boot_filename(self),
-                  :ip => ip, :mac => mac, :hostname => hostname, :proxy => subnet.dhcp_proxy,
-                  :network => subnet.network, :nextServer => boot_server }
+    raise ::Foreman::Exception.new(N_("DHCP not supported for this NIC")) unless dhcp?
+    dhcp_attr = {
+      :name => name,
+      :hostname => hostname,
+      :ip => ip,
+      :mac => mac,
+      :proxy => subnet.dhcp_proxy,
+      :network => subnet.network,
+    }
 
-    if jumpstart?
-      jumpstart_arguments = os.jumpstart_params self, model.vendor_class
-      dhcp_attr.merge! jumpstart_arguments unless jumpstart_arguments.empty?
+    if provision?
+      dhcp_attr.merge!({:filename => operatingsystem.boot_filename(self), :nextServer => boot_server})
+      if jumpstart?
+        jumpstart_arguments = os.jumpstart_params self, model.vendor_class
+        dhcp_attr.merge! jumpstart_arguments unless jumpstart_arguments.empty?
+      end
     end
+
     dhcp_attr
   end
 

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -8,28 +8,13 @@ module Nic
 
     register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
 
-    def dhcp_record
-      return unless dhcp? or @dhcp_record
-      @dhcp_record ||= host.jumpstart? ? Net::DHCP::SparcRecord.new(dhcp_attrs) : Net::DHCP::Record.new(dhcp_attrs)
+    def initialize(*args)
+      ActiveSupport::Deprecation.warn 'Nic::Bootable is replaced by Nic::Managed with provision: true, this class will be removed'
+      super(*args)
     end
 
     def self.human_name
       N_('Bootable')
-    end
-
-    protected
-
-    def dhcp_attrs
-      attrs = super.merge({
-                            :filename   => host.operatingsystem.boot_filename(host),
-                            :nextServer => boot_server
-                          })
-      # Are we booting SPARC solaris?
-      if host.jumpstart?
-        jumpstart_arguments = host.operatingsystem.jumpstart_params host, host.model.vendor_class
-        attrs.merge! jumpstart_arguments unless jumpstart_arguments.empty?
-      end
-      attrs
     end
   end
 end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -15,7 +15,7 @@ module Nic
     # this ensures our orchestration works on both a host and a managed interface
     delegate :progress_report_id, :capabilities, :compute_resource,
              :operatingsystem, :configTemplate, :jumpstart?, :build, :build?, :os, :arch,
-             :image_build?, :pxe_build?, :pxe_build?, :token, :to => :host
+             :image_build?, :pxe_build?, :pxe_build?, :token, :to_ip_address, :model, :to => :host
     delegate :operatingsystem_id, :hostgroup_id, :environment_id,
              :overwrite?, :to => :host, :allow_nil => true
 
@@ -33,12 +33,6 @@ module Nic
       end
     end
     alias_method_chain :queue, :host
-
-    # returns a DHCP reservation object
-    def dhcp_record
-      return unless dhcp? or @dhcp_record
-      @dhcp_record ||= Net::DHCP::Record.new(dhcp_attrs)
-    end
 
     def hostname
       if domain.present? && name.present?
@@ -81,18 +75,6 @@ module Nic
 
     def uniq_fields_with_hosts
       super + [:name]
-    end
-
-    # returns a hash of dhcp record attributes
-    def dhcp_attrs
-      raise ::Foreman::Exception.new(N_("DHCP not supported for this NIC")) unless dhcp?
-      {
-        :hostname => hostname,
-        :ip       => ip,
-        :mac      => mac,
-        :proxy    => subnet.dhcp_proxy,
-        :network  => network
-      }
     end
 
     def copy_hostname_from_host

--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -23,6 +23,7 @@ module Net::DHCP
     # Create a DHCP entry
     def create
       logger.info "Create DHCP reservation for #{self}"
+      logger.debug "DHCP reservation on net #{network} with attrs: #{attrs.inspect}"
       begin
         raise "Must define a hostname" if hostname.blank?
         proxy.set network, attrs

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -68,6 +68,10 @@ FactoryGirl.define do
     sequence(:ip) { |n| IPAddr.new(n, Socket::AF_INET).to_s }
   end
 
+  factory :model do
+    sequence(:name) { |n| "hal900#{n}" }
+  end
+
   factory :host do
     sequence(:name) { |n| "host#{n}" }
     sequence(:hostname) { |n| "host#{n}" }

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -73,5 +73,13 @@ FactoryGirl.define do
       type 'Suse'
       title 'OpenSuse 11.4'
     end
+
+    factory :solaris, class: Solaris do
+      sequence(:name) { 'Solaris' }
+      major '10'
+      minor '8'
+      type 'Solaris'
+      title 'Solaris 10.8'
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -178,6 +178,7 @@ Spork.prefork do
       Net::DHCP::Record.any_instance.stubs(:conflicting?).returns(false)
       ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["production"])
       ProxyAPI::DHCP.any_instance.stubs(:unused_ip).returns('127.0.0.1')
+      ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns('127.0.0.1')
     end
 
     def disable_orchestration

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1976,6 +1976,13 @@ class HostTest < ActiveSupport::TestCase
     assert(host.valid?)
   end
 
+  test '#jumpstart? should return true for Solaris and SPARC hosts' do
+    host = FactoryGirl.create(:host,
+                              :operatingsystem => FactoryGirl.create(:solaris),
+                              :architecture => FactoryGirl.create(:architecture, :name => 'SPARC-T2'))
+    assert host.jumpstart?
+  end
+
   private
 
   def parse_json_fixture(relative_path)

--- a/test/unit/operatingsystems/solaris_test.rb
+++ b/test/unit/operatingsystems/solaris_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class SolarisTest < ActiveSupport::TestCase
+  setup { disable_orchestration }
+
+  test "jumpstart parameter generation" do
+    h = FactoryGirl.create(:host, :managed, :domain => domains(:yourdomain),
+          :interfaces => [ FactoryGirl.build(:nic_primary_and_provision,
+                                             :ip => '2.3.4.10')  ],
+          :architecture => architectures(:sparc),
+          :operatingsystem => operatingsystems(:solaris10),
+          :compute_resource => compute_resources(:one),
+          :model => models(:V210),
+          :medium => media(:solaris10),
+          :puppet_proxy => smart_proxies(:puppetmaster),
+          :ptable => ptables(:one)
+        )
+    Resolv::DNS.any_instance.stubs(:getaddress).with("brsla01").returns("2.3.4.5").once
+    Resolv::DNS.any_instance.stubs(:getaddress).with("brsla01.yourdomain.net").returns("2.3.4.5").once
+    result = h.os.jumpstart_params h, h.model.vendor_class
+    assert_equal({
+                   :vendor => "<Sun-Fire-V210>",
+                   :install_path => "/vol/solgi_5.10/sol10_hw0910_sparc",
+                   :install_server_ip => "2.3.4.5",
+                   :install_server_name => "brsla01",
+                   :jumpstart_server_path => "2.3.4.5:/vol/jumpstart",
+                   :root_path_name => "/vol/solgi_5.10/sol10_hw0910_sparc/Solaris_10/Tools/Boot",
+                   :root_server_hostname => "brsla01",
+                   :root_server_ip => "2.3.4.5",
+                   :sysid_server_path => "2.3.4.5:/vol/jumpstart/sysidcfg/sysidcfg_primary"
+                 }, result)
+  end
+end


### PR DESCRIPTION
A host's DHCP record used to be constructed with PXE attributes in
Orchestration::DHCP, but moved to Nic::Managed during 43c4bd7.  Nic::Managed
didn't add PXE attributes, so this commit adds these when provision? is set.

Nic::Bootable could add PXE attributes but was unused, so it is now deprecated.
PXE bootable interfaces should be of type Nic::Managed with provision: true.

I also isolated some of the Jumpstart related DHCP tests while modifying the code that checked for it.
