### PR TITLE
Fixes #10099 - pin execjs gem for Ruby 1.9 compatibility

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,7 +1,7 @@
 group :assets do
   gem 'sass-rails', '~> 3.2'
   gem 'uglifier', '>= 1.0.3'
-  gem 'execjs', '>= 1.4.0'
+  gem 'execjs', '>= 1.4.0', '<2.5.0'
   gem 'jquery-rails', '2.0.3'
   gem 'jquery-ui-rails', '< 5.0.0'
   gem 'therubyracer', '0.11.3', :require => 'v8'


### PR DESCRIPTION
Technically only 2.5.1 has `>= 2.0.0` in the gemspec (only change to 2.5.0), but better safe than sorry. 
