### PR TITLE
fixes #9617 - rescue from empty vmware clusters

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -53,6 +53,10 @@ module Foreman::Model
     end
 
     def clusters
+      if dc.clusters.nil?
+        Rails.logger.info "Datacenter #{dc.try(:name)} returned zero clusters"
+        return []
+      end
       dc.clusters.map(&:full_path).sort
     end
 


### PR DESCRIPTION
When there are no clusters or when Foreman / Fog can't fetch clusters from a datacenter.
