### PR TITLE
Fixes #10134 - Stdout/err in Rails logger now and better CR logging

### DIFF
--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -113,7 +113,12 @@ module Foreman::Model
     end
 
     def client
-      @client ||= ::Fog::Compute.new(:provider => "AWS", :aws_access_key_id => user, :aws_secret_access_key => password, :region => region)
+      @client ||= ::Fog::Compute.new(
+        :provider              => "AWS",
+        :aws_access_key_id     => user,
+        :aws_secret_access_key => password,
+        :region                => region,
+        :connection_options    => { :instrumentor => FogExtensions::Debug::DebugHttpInstrumentor })
     end
 
     # this method creates a new key pair for each new ec2 compute resource

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -103,7 +103,12 @@ module Foreman::Model
     private
 
     def client
-      @client ||= ::Fog::Compute.new(:provider => 'google', :google_project => project, :google_client_email => email, :google_key_location => key_path)
+      @client ||= ::Fog::Compute.new(
+        :provider            => 'google',
+        :google_project      => project,
+        :google_client_email => email,
+        :google_key_location => key_path,
+        :instrumentor        => FogExtensions::Debug::DebugHttpInstrumentor)
     end
 
     def check_google_key_path

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -156,7 +156,10 @@ module Foreman::Model
     def client
       # WARNING potential connection leak
       tries ||= 3
-      Thread.current[url] ||= ::Fog::Compute.new(:provider => "Libvirt", :libvirt_uri => url)
+      Thread.current[url] ||= ::Fog::Compute.new(
+        :provider           => "Libvirt",
+        :libvirt_uri        => url,
+        :connection_options => { :instrumentor => FogExtensions::Debug::DebugHttpInstrumentor })
     rescue ::Libvirt::RetrieveError
       Thread.current[url] = nil
       retry unless (tries -= 1).zero?

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -134,7 +134,8 @@ module Foreman::Model
                                      :openstack_api_key  => password,
                                      :openstack_username => user,
                                      :openstack_auth_url => url,
-                                     :openstack_tenant   => tenant)
+                                     :openstack_tenant   => tenant,
+                                     :instrumentor       => FogExtensions::Debug::DebugHttpInstrumentor)
     end
 
     def network_client
@@ -142,7 +143,8 @@ module Foreman::Model
                                              :openstack_api_key  => password,
                                              :openstack_username => user,
                                              :openstack_auth_url => url,
-                                             :openstack_tenant   => tenant)
+                                             :openstack_tenant   => tenant,
+                                             :instrumentor       => FogExtensions::Debug::DebugHttpInstrumentor)
     rescue
       @network_client = nil
     end
@@ -152,7 +154,8 @@ module Foreman::Model
                                            :openstack_api_key  => password,
                                            :openstack_username => user,
                                            :openstack_auth_url => url,
-                                           :openstack_tenant   => tenant)
+                                           :openstack_tenant   => tenant,
+                                           :instrumentor       => FogExtensions::Debug::DebugHttpInstrumentor)
     end
 
     def setup_key_pair

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -252,7 +252,8 @@ module Foreman::Model
           :ovirt_password   => password,
           :ovirt_url        => url,
           :ovirt_datacenter => uuid,
-          :ovirt_ca_cert_store => ca_cert_store(public_key)
+          :ovirt_ca_cert_store => ca_cert_store(public_key),
+          :instrumentor => FogExtensions::Debug::DebugHttpInstrumentor
       )
       client.datacenters
       @client = client

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -97,12 +97,13 @@ module Foreman::Model
 
     def client
       @client ||= Fog::Compute.new(
-        :provider => "Rackspace",
-        :version => 'v2',
-        :rackspace_api_key => password,
+        :provider           => "Rackspace",
+        :version            => 'v2',
+        :rackspace_api_key  => password,
         :rackspace_username => user,
         :rackspace_auth_url => url,
-        :rackspace_region => region.downcase.to_sym
+        :rackspace_region   => region.downcase.to_sym,
+        :connection_options => { :instrumentor => FogExtensions::Debug::DebugHttpInstrumentor }
       )
     end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -446,8 +446,8 @@ module Foreman::Model
         :vsphere_username             => user,
         :vsphere_password             => password,
         :vsphere_server               => server,
-        :vsphere_expected_pubkey_hash => pubkey_hash
-      )
+        :vsphere_expected_pubkey_hash => pubkey_hash,
+        :vsphere_debug                => ::Foreman::Logging.logger('crs').debug?)
     rescue => e
       if e.message =~ /The remote system presented a public key with hash (\w+) but we're expecting a hash of/
         raise Foreman::FingerprintException.new(

--- a/app/models/concerns/fog_extensions/debug/debug_http_instrumentor.rb
+++ b/app/models/concerns/fog_extensions/debug/debug_http_instrumentor.rb
@@ -1,0 +1,67 @@
+module FogExtensions
+  module Debug
+    class DebugHttpInstrumentor
+      class << self
+        attr_accessor :events
+
+        def instrument(name, params = {}, &block)
+          logger = ::Foreman::Logging.logger('crs')
+          if logger.debug?
+            begin
+              params = params.dup
+              if params.key?(:headers) && params[:headers].key?('Authorization')
+                params[:headers] = params[:headers].dup
+                params[:headers]['Authorization'] = 'FILTERED'
+              end
+              if params.key?(:password)
+                params[:password] = 'FILTERED'
+              end
+              logger.debug("--- #{name} ---")
+              if name.include?('.request')
+                query = ''
+                tmp_query = ''
+                if params.key?(:query) && !params[:query].nil?
+                  params[:query].each do |key, value|
+                    tmp_query += "#{key}=#{value}&"
+                  end
+                  if !tmp_query.nil?
+                    query = "?#{tmp_query}"
+                    query.chomp!('&')
+                  end
+                end
+                logger.debug("#{params[:method]} #{params[:path]}#{query} HTTP/1.1" )
+                logger.debug("User-Agent: #{params[:headers]['User-Agent']}")
+                logger.debug("Host: #{params[:host]} Port: #{params[:port]}")
+                logger.debug("Accept: #{params[:headers]['Accept']}")
+                logger.debug("X-Auth-Token: #{params[:headers]['X-Auth-Token']}")
+                logger.debug("Body: #{params[:body]}")
+              elsif name.include?('.response')
+                logger.debug("HTTP/1.1 #{params[:status]}")
+                logger.debug("Content-Length: #{params[:headers]['Content-Length']}")
+                logger.debug("Content-Type: #{params[:headers]['Content-Type']}")
+                logger.debug("Date: #{params[:headers]['Date']}")
+                params[:headers].each do |key, value|
+                  if !['Content-Length', 'Content-Type', 'Date'].include?(key)
+                    logger.debug("#{key}: #{value}")
+                  end
+                end
+                logger.debug("Date: #{params[:headers]['Date']}\n")
+                logger.debug("Body: #{params[:body]}")
+              elsif name.include?('.retry')
+                logger.debug("#{params.inspect}")
+              elsif name.include?('.error')
+                logger.debug("#{params.inspect}")
+              end
+            rescue => e
+              logger.debug("Error during fog debug instrumentation: #{e}")
+            end
+          end
+
+          if block_given?
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -144,7 +144,11 @@ module Foreman
     )
 
     # Check that the loggers setting exist to configure the app and sql loggers
-    Foreman::Logging.add_loggers(SETTINGS[:loggers] || {:app => {:enabled => true}, :sql => {:enabled => true}})
+    Foreman::Logging.add_loggers(SETTINGS[:loggers] || {
+      :app => {:enabled => true},
+      :sql => {:enabled => true},
+      :crs => {:enabled => true}
+    })
 
     config.logger = Foreman::Logging.logger('app')
     config.active_record.logger = Foreman::Logging.logger('sql')


### PR DESCRIPTION
This is just an idea. When running with Rails DEBUG mode on, we will see
requests/replies from compute resources.

Those fog drivers which leverage `excon` library accepts `connection_options`.
Special ones are libvirt (does not currently accept that) and vmware (it has
it's own debug capabilities - to be merged:
https://github.com/fog/fog/pull/3530)
