### PR TITLE
fixes #10151 - Unable to get resourcePool

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -57,7 +57,7 @@ module Foreman::Model
         Rails.logger.info "Datacenter #{dc.try(:name)} returned zero clusters"
         return []
       end
-      dc.clusters.map(&:full_path).sort
+      dc.clusters.map(&:name).sort
     end
 
     def datastores(opts = {})


### PR DESCRIPTION
Fog gets all cluster resources using the cluster name not the cluster full_path.
