### PR TITLE
Fixes #10111 - Use a dummy primary interface for unmanaged hosts

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -26,6 +26,7 @@ class HostsController < ApplicationController
   before_filter :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_filter :set_host_type, :only => [:update]
   before_filter :find_multiple, :only => MULTIPLE_ACTIONS
+  before_filter :cleanup_passwords, :only => :update
   helper :hosts, :reports, :interfaces
 
   def index(title = nil)
@@ -96,13 +97,6 @@ class HostsController < ApplicationController
   def update
     forward_url_options
     Taxonomy.no_taxonomy_scope do
-      # remove from hash :root_pass and bmc :password if blank?
-      params[:host].except!(:root_pass) if params[:host][:root_pass].blank?
-      if @host.type == "Host::Managed" && params[:host][:interfaces_attributes]
-        params[:host][:interfaces_attributes].each do |k, v|
-          params[:host][:interfaces_attributes]["#{k}"].except!(:password) if params[:host][:interfaces_attributes]["#{k}"][:password].blank?
-        end
-      end
       if @host.update_attributes(params[:host])
         process_success :success_redirect => host_path(@host)
       else
@@ -721,5 +715,16 @@ class HostsController < ApplicationController
   # is rendered differently and the next save operation will be forced
   def offer_to_overwrite_conflicts
     @host.overwrite = "true" if @host.errors.any? and @host.errors.are_all_conflicts?
+  end
+
+  # :root_pass and bmc :password should not update the Host and Nic passwords when blank
+  # This method removes them from the params hash to avoid any processing of these attributes.
+  def cleanup_passwords
+    params[:host].except!(:root_pass) if params[:host][:root_pass].blank?
+    if @host.type == "Host::Managed" && params[:host][:interfaces_attributes]
+      params[:host][:interfaces_attributes].each do |k, v|
+        params[:host][:interfaces_attributes]["#{k}"].except!(:password) if params[:host][:interfaces_attributes]["#{k}"][:password].blank?
+      end
+    end
   end
 end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -246,6 +246,10 @@ module Host
     end
 
     def primary_interface
+      # Build a dummy object if host is unmanaged and without interfaces.
+      # Unmanaged hosts still have the interface requirement due to delegations and certain validations.
+      # A refactoring that allows unmanaged hosts to exist without interfaces is sorely needed.
+      build_required_interfaces unless managed? || interfaces.detect(&:primary)
       get_interface_by_flag(:primary)
     end
 
@@ -323,8 +327,8 @@ module Host
     end
 
     def build_required_interfaces(attrs = {})
-      self.interfaces.build(attrs.merge(:primary => true, :type => 'Nic::Managed')) if self.primary_interface.nil?
-      self.primary_interface.provision = true if self.provision_interface.nil?
+      self.interfaces.build(attrs.merge(:primary => true, :type => 'Nic::Managed')) if get_interface_by_flag(:primary).nil?
+      get_interface_by_flag(:primary).provision = true if self.provision_interface.nil?
     end
 
     def set_interface(attributes, name, iface)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2000,6 +2000,15 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test 'unmanaged hosts name does not rely on primary interface' do
+    host = FactoryGirl.build(:host, :managed)
+    host.managed = false
+    host.interfaces = []
+    # A dummy primary interface is created here
+    host.update_attributes(:name => 'foounmanaged')
+    assert_equal 'foounmanaged', host.name
+  end
+
   test 'updating host domain should validate domain exists' do
     host = FactoryGirl.create(:host, :managed)
     last_domain_id = Domain.order(:id).last.id


### PR DESCRIPTION
Unmanaged hosts require a host interface due to delegation of networking
attributes, and some others like 'name'. Since unmanaged hosts do not
necessarily have an interface associated (unless created through puppet
facts importer), we provide a dummy interface to prevent errors.

Ideally this should go away as soon as unmanaged hosts are a different
class or Host::Base, moving validations and other particularities
to Host::Managed.
