### PR TITLE
Fixes #10186 - Provisioning fails when vsphere using Network Distributed...

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -39,8 +39,6 @@ module FogExtensions
         selected_nic =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
         selected_nic ||= if service.get_network(nic_attrs['network'], datacenter).key?(:id)
                            fog_nics.detect { |fn| fn.network  == service.get_network(nic_attrs['network'], datacenter)[:id]  } # no network? try the portgroup
-                         else
-                           nil
                          end
         selected_nic
       end

--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -36,9 +36,13 @@ module FogExtensions
 
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
-        match =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
-        match ||= fog_nics.detect { |fn| fn.network  == service.get_network(nic_attrs['network'], datacenter)[:id]  } # no network? try the portgroup
-        match
+        selected_nic =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
+        selected_nic ||= if service.get_network(nic_attrs['network'], datacenter).key?(:id)
+                           fog_nics.detect { |fn| fn.network  == service.get_network(nic_attrs['network'], datacenter)[:id]  } # no network? try the portgroup
+                         else
+                           nil
+                         end
+        selected_nic
       end
     end
   end

--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -37,9 +37,12 @@ module FogExtensions
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
         selected_nic =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
-        selected_nic ||= if service.get_network(nic_attrs['network'], datacenter).key?(:id)
-                           fog_nics.detect { |fn| fn.network  == service.get_network(nic_attrs['network'], datacenter)[:id]  } # no network? try the portgroup
-                         end
+        unless selected_nic
+          vm_network = service.get_network(nic_attrs['network'], datacenter)
+          if vm_network && vm_network.key?(:id)
+            selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:id] } # try and match on portgroup
+          end
+        end
         selected_nic
       end
     end

--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -35,7 +35,10 @@ module FogExtensions
       end
 
       def select_nic(fog_nics, nic)
-        fog_nics.detect {|fn| fn.network == nic.compute_attributes['network']} # grab any nic on the same network
+        nic_attrs = nic.compute_attributes
+        match =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
+        match ||= fog_nics.detect { |fn| fn.network  == service.get_network(nic_attrs['network'], datacenter)[:id]  } # no network? try the portgroup
+        match
       end
     end
   end


### PR DESCRIPTION
Try and match on portgroup if match on network name fails. Since Vsphere can use port groups, the portgroup name is returned from Fog instead of the network name so we need to try and match on portgroup as well.
