### PR TITLE
fixes #10158 - use full column name to avoid ambiguity on Rails 3.2.8

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -87,7 +87,7 @@ module HostsAndHostgroupsHelper
 
   def interesting_klasses(obj)
     classes    = obj.all_puppetclasses
-    classes_ids = classes.reorder('').pluck(:id)
+    classes_ids = classes.reorder('').pluck('puppetclasses.id')
     smart_vars = LookupKey.reorder('').where(:puppetclass_id => classes_ids).uniq.pluck(:puppetclass_id)
     class_vars = LookupKey.reorder('').joins(:environment_classes).where(:environment_classes => { :puppetclass_id => classes_ids }).uniq.pluck('environment_classes.puppetclass_id')
     klasses    = (smart_vars + class_vars).uniq


### PR DESCRIPTION
Host editing will currently fail entirely on an RPM installation.
