### PR TITLE
Fixes #10230 - Host clone uses create_hosts permission

### DIFF
--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -29,7 +29,7 @@
         <td>
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),
-                      display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),
+                      display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host)),
                       display_delete_if_authorized(hash_for_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer), :confirm => _("Delete %s?") % host.name, :action => :destroy))%>
         </td>
       </tr>


### PR DESCRIPTION
Non-admin users are not able to clone hosts. This is a regression, in
the past the create_hosts permission has been used for this, but it no
longer works. Passing the permission directly fixes the regression.
