### PR TITLE
Refs #9391 - Fix NIC taxonomies validation tests

### DIFF
--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -629,7 +629,7 @@ class HostTest < ActiveSupport::TestCase
       assert_equal 'xybxa6JUkz63w', parameters['root_pw']
       assert_includes parameters.keys, 'foreman_subnets'
       assert_includes parameters.keys, 'foreman_interfaces'
-      assert_equal '2.3.4.12', parameters['foreman_interfaces'].first['ip']
+      assert_equal '3.3.4.12', parameters['foreman_interfaces'].first['ip']
     end
 
     test "show be enabled by default" do

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -146,6 +146,7 @@ class NicTest < ActiveSupport::TestCase
 
   test "Alias subnet can only use static boot mode if it's managed" do
     nic = FactoryGirl.build(:nic_managed, :virtual => true, :attached_to => 'eth0', :managed => true, :identifier => 'eth0:0')
+    nic.host = FactoryGirl.build(:host)
     nic.subnet = FactoryGirl.build(:subnet, :boot_mode => Subnet::BOOT_MODES[:dhcp])
     refute nic.valid?
     assert_includes nic.errors.keys, :subnet_id


### PR DESCRIPTION
Some of the tests in #9391 changed the way subnets should work regarding
taxonomies and some test data, this commit fixes that so tests are green
once again.
