### PR TITLE
fixes #10168 - delegate fqdn/shortname to primary interface

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -136,7 +136,7 @@ class Host::Managed < Host::Base
     include Orchestration::SSHProvision
     include Orchestration::Realm
     include HostTemplateHelpers
-    delegate :fqdn, :fqdn_changed?, :fqdn_was, :shortname, :to => :provision_interface,
+    delegate :fqdn, :fqdn_changed?, :fqdn_was, :shortname, :to => :primary_interface,
              :allow_nil => true
     delegate :require_ip_validation?, :to => :provision_interface
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2031,6 +2031,18 @@ class HostTest < ActiveSupport::TestCase
     assert host.jumpstart?
   end
 
+  test '#fqdn returns the FQDN from the primary interface' do
+    primary = FactoryGirl.build(:nic_managed, :primary => true, :name => 'foo', :domain => FactoryGirl.build(:domain))
+    host = FactoryGirl.create(:host, :managed, :interfaces => [primary, FactoryGirl.build(:nic_managed, :provision => true)])
+    assert_equal "foo.#{primary.domain.name}", host.fqdn
+  end
+
+  test '#shortname returns the name from the primary interface' do
+    primary = FactoryGirl.build(:nic_managed, :primary => true, :name => 'foo')
+    host = FactoryGirl.create(:host, :managed, :interfaces => [primary, FactoryGirl.build(:nic_managed, :provision => true)])
+    assert_equal 'foo', host.shortname
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
As noted in the [ticket comment](http://projects.theforeman.org/issues/10168), this affects a few things, most notably adding lookup values/overrides when primary/provisioning interfaces differ.
