### PR TITLE
fixes #9982 - update fog to 1.29.0

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,4 +1,4 @@
 group :fog do
-  gem 'fog', '1.28.0', :require => false
+  gem 'fog', '1.29.0', :require => false
   gem 'fog-core', '1.29.0'
 end


### PR DESCRIPTION
RPMs are a trivial update, don't worry about waiting for those.
