### PR TITLE
refs #10168 - fix test that created a duplicate primary interface

### DIFF
--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -315,10 +315,10 @@ class NicTest < ActiveSupport::TestCase
       test "provision flag is set for primary interface automatically" do
         primary = FactoryGirl.build(:nic_managed, :primary => true, :provision => false,
                                     :domain => FactoryGirl.build(:domain))
-        @host.interfaces = [primary]
-        assert @host.save
+        host = FactoryGirl.create(:host, :interfaces => [primary])
+        assert host.save!
         primary.reload
-        assert_equal primary, @host.provision_interface
+        assert_equal primary, host.provision_interface
       end
     end
   end


### PR DESCRIPTION
Subtle interaction between 4d5b979 and a5dc3e2, resulting in the test
that tried to add an interface to an unmanaged host duplicating the one
that was automatically added.

http://ci.theforeman.org/job/test_develop_pull_request/10927/ is running.
