### PR TITLE
Fixes #10194 - token_duration > 0, updated help text

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -24,7 +24,7 @@ class Setting::Provisioning < Setting
         self.set('ignore_puppet_facts_for_provisioning', N_("Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"), false),
         self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false),
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1"),
-        self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable"), 60 * 6),
+        self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6),
         self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0"),
         self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false),
         self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false),


### PR DESCRIPTION
token generation cannot be disabled, token_duration setting must be greater than 0
