### PR TITLE
Fixes #10228 - adding index to source_id in logs table

### DIFF
--- a/db/migrate/20150428070436_add_index_to_logs_source_id.rb
+++ b/db/migrate/20150428070436_add_index_to_logs_source_id.rb
@@ -1,0 +1,9 @@
+class AddIndexToLogsSourceId < ActiveRecord::Migration
+  def up
+    add_index :logs, :source_id
+  end
+
+  def down
+    remove_index :logs, :source_id
+  end
+end


### PR DESCRIPTION
Migration that adds index to source_id in logs table
