### PR TITLE
Fixes #10275 -Use secure cookies when SSL

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -111,7 +111,7 @@ function onContentLoad(){
   password_caps_lock_hint();
 
   var tz = jstz.determine();
-  $.cookie('timezone', tz.name(), { path: '/' });
+  $.cookie('timezone', tz.name(), { path: '/', secure: location.protocol === 'https:' });
 }
 
 function preserve_selected_options(elem) {

--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -9,7 +9,7 @@ function hostChecked(box) {
     addHostId(cid);
   else
     rmHostId(cid);
-  $.cookie($.cookieName, JSON.stringify($.foremanSelectedHosts));
+  $.cookie($.cookieName, JSON.stringify($.foremanSelectedHosts), { secure: location.protocol === 'https:' });
   toggle_actions();
   update_counter();
   return false;

--- a/config/application.rb
+++ b/config/application.rb
@@ -146,6 +146,12 @@ module Foreman
         child.helper helpers
       end
     end
+
+    # Secure cookies if the connection is via SSL
+    if !!SETTINGS[:require_ssl]
+      config.session_options[:secure] = !!SETTINGS[:require_ssl]
+      middleware.use config.session_store, config.session_options
+    end
   end
 
   def self.setup_console


### PR DESCRIPTION
In production, we must enforce ssl, so cookies will be secured :)
Tried on a local foreman (Satellite machine):
![secure](https://cloud.githubusercontent.com/assets/433583/7368299/5cee4b22-edaf-11e4-9b49-c810620c0f3a.png)

This should be backported to 1.7 and 1.8
