### PR TITLE
Fixes #9879 - fixed host delete dialog

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -316,9 +316,20 @@ module HostsHelper
         ),
         button_group(
             link_to_if_authorized(_("Delete"), hash_for_host_path(:id => host).merge(:auth_object => host, :permission => 'destroy_hosts'),
-                                  :class => "btn btn-danger", :id => "delete-button", :data => { :message => _("Are you sure?") }, :method => :delete)
+                                  :class => "btn btn-danger",
+                                  :id => "delete-button",
+                                  :data => { :message => delete_host_dialog(host) },
+                                  :method => :delete)
         )
     )
+  end
+
+  def delete_host_dialog(host)
+    if host.compute?
+      _("Are you sure you want to delete host %s? This will delete the virtual machine and its disks, and is irreversible.") % host.name
+    else
+      _("Are you sure you want to delete host %s? This action is irreversible.") % host.name
+    end
   end
 
   # we ignore interfaces.conflict because they are always registered in host errors as well

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -30,7 +30,7 @@
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),
                       display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host)),
-                      display_delete_if_authorized(hash_for_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer), :confirm => _("Delete %s?") % host.name, :action => :destroy))%>
+                      display_delete_if_authorized(hash_for_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer), :confirm => delete_host_dialog(host), :action => :destroy))%>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Host delete dialog is now more verbose and shows the name of the host that is going to be deleted.
