### PR TITLE
Fixes #10305 - complete handling for cloudinit-like in vsphere feature

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -364,6 +364,7 @@ module Foreman::Model
         "network_label" => args[:interfaces].first[:network],
         "network_adapter_device_key" => network_adapter_device_key
       }
+      opts["customization_spec"] = client.cloudinit_to_customspec(args[:user_data]) if args[:user_data]
       client.servers.get(client.vm_clone(opts)['new_vm']['id'])
     end
 


### PR DESCRIPTION
add the fix from Francois Herbert (kudos to him ) to actually transform the cloudinit to customisation template in vsphere compute ressource 
