### PR TITLE
Fixes #10307 - editing host with 'unattended: false' no longer results in error

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -10,7 +10,7 @@ module Orchestration::DHCP
   def dhcp?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
-    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && mac_available? && !subnet.nil? && subnet.dhcp?
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && mac_available? && !subnet.nil? && subnet.dhcp? && SETTINGS[:unattended]
   end
 
   def dhcp_record

--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -9,13 +9,13 @@ module Orchestration::DNS
   def dns?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
-    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !domain.nil? && !domain.proxy.nil?
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !domain.nil? && !domain.proxy.nil? && SETTINGS[:unattended]
   end
 
   def reverse_dns?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
-    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !subnet.nil? && subnet.dns?
+    (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && !subnet.nil? && subnet.dns? && SETTINGS[:unattended]
   end
 
   def dns_a_record

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -12,7 +12,7 @@ module Orchestration::TFTP
   def tftp?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
-    (host.nil? || host.managed?) && managed && provision? && !!(subnet && subnet.tftp?) && (host && host.operatingsystem && host.operatingsystem.pxe_variant) && pxe_build?
+    (host.nil? || host.managed?) && managed && provision? && !!(subnet && subnet.tftp?) && (host && host.operatingsystem && host.operatingsystem.pxe_variant) && pxe_build? && SETTINGS[:unattended]
   end
 
   def tftp

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -168,6 +168,18 @@ class Host::Managed < Host::Base
     validate :short_name_periods
     before_validation :set_compute_attributes, :on => :create
     validate :check_if_provision_method_changed, :on => :update, :if => Proc.new { |host| host.managed }
+  else
+    def fqdn
+      facts['fqdn'] || name
+    end
+
+    def compute?
+      false
+    end
+
+    def compute_provides?(attr)
+      false
+    end
   end
 
   before_validation :set_hostgroup_defaults, :set_ip_address

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -22,7 +22,7 @@ module Nic
     validates :mac, :uniqueness => {:scope => :virtual},
               :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? && !nic.virtual? }, :allow_blank => true
     validates :mac, :presence => true,
-              :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? &&!nic.virtual? }
+              :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? && !nic.virtual? && SETTINGS[:unattended] }
     validates :mac, :mac_address => true, :allow_blank => true
 
     # TODO uniq on primary per host
@@ -32,9 +32,9 @@ module Nic
 
     validate :exclusive_primary_interface
     validate :exclusive_provision_interface
-    validates :domain, :presence => true, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.primary? }
-    validate :valid_domain, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.primary? }
-    validates :ip, :presence => true, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.require_ip_validation? }
+    validates :domain, :presence => true, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.primary? && SETTINGS[:unattended] }
+    validate :valid_domain, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.primary? && SETTINGS[:unattended] }
+    validates :ip, :presence => true, :if => Proc.new { |nic| nic.host && nic.host.managed? && nic.require_ip_validation? && SETTINGS[:unattended] }
 
     scope :bootable, lambda { where(:type => "Nic::Bootable") }
     scope :bmc, lambda { where(:type => "Nic::BMC") }


### PR DESCRIPTION
Editing host with 'unattended: false' no longer results in an error. I also made a small change in puppetrun to avoid 'undefined method'.
