### PR TITLE
Fixes #8289 - complete handling for cloudinit in ovirt feature

### DIFF
--- a/app/views/images/form/_ovirt.html.erb
+++ b/app/views/images/form/_ovirt.html.erb
@@ -1,3 +1,4 @@
 <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
 <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
 <%= image_field(f) %>


### PR DESCRIPTION
found a  way to move all the logic into ovirt compute resource code (by means of using the comment field of the vm to temporarily hold the rendered user_data)
opening PR 
and another small depending one at rbovirt to expose comment field ( description was available but only 255 chars long ) 
