### PR TITLE
Fixes #10382 - Allow lowercase IPMI provider

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -2,6 +2,7 @@ module Nic
   class BMC < Managed
     PROVIDERS = %w(IPMI)
     before_validation :ensure_physical
+    before_validation { |nic| nic.provider.upcase! }
     validates :provider, :presence => true, :inclusion => { :in => PROVIDERS }
     validates :mac, :presence => true, :if => :managed?
 

--- a/test/unit/nics/bmc_test.rb
+++ b/test/unit/nics/bmc_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class BMCTest < ActiveSupport::TestCase
+  test 'lowercase IPMI provider string gets set to uppercase' do
+    host = FactoryGirl.build(:host, :managed)
+    assert FactoryGirl.build(:nic_bmc, :host => host, :provider => 'ipmi').valid?
+  end
+end


### PR DESCRIPTION
This is meant to fix the issue of users trying to create interfaces through the API or hammer, and getting 'provider not in the list' errors when specifying provider=ipmi.
