### PR TITLE
fixes #10298 - handle destroyed but present interfaces

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -387,7 +387,7 @@ module Host
           # we can't use SQL, we need to get even unsaved objects
           interface = self.interfaces.detect(&flag)
 
-          interface.host = self if interface # inverse_of does not help (STI), but ignore this on deletion (interface is not found)
+          interface.host = self if interface && !interface.destroyed? # inverse_of does not help (STI), but ignore this on deletion
           instance_variable_set(cache, interface)
         end
       end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1884,6 +1884,13 @@ class HostTest < ActiveSupport::TestCase
     assert_equal original_mac, clone.provision_interface.mac
   end
 
+  test '#primary_interface works during deletion' do
+    host = FactoryGirl.create(:host, :managed)
+    iface = host.interfaces.first
+    assert iface.delete
+    assert_equal iface, host.primary_interface
+  end
+
   test '#primary_interface is never cached for new record' do
     host = FactoryGirl.build(:host, :managed)
     refute_nil host.primary_interface


### PR DESCRIPTION
When deleting a host and DHCP orchestration is removing reservations for NICs,
it generates a dhcp_record that contains next-server data.  Determining the
next-server IP causes the primary interface to be fetched for DNS resolution,
to resolve the next-server hostname:

```
app/models/host/base.rb:390:in `get_interface_by_flag'
app/models/host/base.rb:253:in `primary_interface'
app/models/host/managed.rb:130:in `dns_ptr_record'
app/models/host/managed.rb:838:in `to_ip_address'
app/models/nic/managed.rb:16:in `to_ip_address'
app/models/concerns/orchestration/dhcp.rb:49:in `boot_server'
app/models/concerns/orchestration/dhcp.rb:72:in `dhcp_attrs'
app/models/concerns/orchestration/dhcp.rb:18:in `dhcp_record'
app/models/concerns/orchestration/dhcp.rb:32:in `del_dhcp'
```

get_interface_by_flag no longer attempts to modify the interface when it is
being deleted.

---

Bit of a pain to reproduce the stack trace above.  You need a) DHCP orchestration, b) reverse DNS orchestration, c) TFTP orchestration with either the proxy's :tftp_servername set to a hostname or the smart proxy added to Foreman with a hostname (using an IP here will not reproduce it).
