### PR TITLE
Fixes #10402: add to_bool function for converting to boolean.

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -130,11 +130,11 @@ module HostCommon
   end
 
   def param_true?(name)
-    params.has_key?(name) && LookupKey::TRUE_VALUES.include?(params[name])
+    params.has_key?(name) && Foreman::Cast.to_bool(value)
   end
 
   def param_false?(name)
-    params.has_key?(name) && LookupKey::FALSE_VALUES.include?(params[name])
+    params.has_key?(name) && Foreman::Cast.to_bool(value) == false
   end
 
   def cg_class_ids

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -5,9 +5,6 @@ class LookupKey < ActiveRecord::Base
   KEY_TYPES = [N_("string"), N_("boolean"), N_("integer"), N_("real"), N_("array"), N_("hash"), N_("yaml"), N_("json")]
   VALIDATOR_TYPES = [N_("regexp"), N_("list") ]
 
-  TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON', 'yes', 'YES', 'y', 'Y'].to_set
-  FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO', 'n', 'N'].to_set
-
   KEY_DELM = ","
   EQ_DELM  = "="
 
@@ -226,9 +223,9 @@ class LookupKey < ActiveRecord::Base
   end
 
   def cast_value_boolean(value)
-    return true if TRUE_VALUES.include? value
-    return false if FALSE_VALUES.include? value
-    raise TypeError
+    casted = Foreman::Cast.to_bool(value)
+    raise TypeError if casted.nil?
+    casted
   end
 
   def cast_value_integer(value)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -106,15 +106,14 @@ class Setting < ActiveRecord::Base
   def parse_string_value(val)
     case settings_type
     when "boolean"
-      val = val.downcase
-      if val == "true"
-        self.value = true
-      elsif val == "false"
-        self.value = false
-      else
+      boolean = Foreman::Cast.to_bool(val)
+
+      if boolean.nil?
         invalid_value_error _("must be boolean")
         return false
       end
+
+      self.value = boolean
 
     when "integer"
       if val =~ /\A\d+\Z/

--- a/lib/foreman/cast.rb
+++ b/lib/foreman/cast.rb
@@ -1,0 +1,26 @@
+module Foreman
+  module Cast
+    def self.to_bool(value)
+      case value
+
+      when String
+        return true if value =~ (/\A(true|t|yes|y|on|1)\z/i)
+        return false if value.blank? || value =~ (/\A(false|f|no|n|off|0)\z/i)
+        return nil
+
+      when Fixnum
+        return true if value == 1
+        return false if value == 0
+
+      when NilClass
+        return false
+
+      when TrueClass, FalseClass
+        return value
+
+      else
+        return nil
+      end
+    end
+  end
+end

--- a/test/lib/foreman/cast_test.rb
+++ b/test/lib/foreman/cast_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'foreman/cast'
+
+class CastTest < ActiveSupport::TestCase
+  include Foreman::Cast
+
+  test "should convert strings to booleans" do
+    true_strings = %w(true t yes y on 1)
+    false_strings = %w(false f no n off 0)
+
+    true_strings.each do |true_string|
+      assert_equal true, Foreman::Cast.to_bool(true_string)
+    end
+
+    false_strings.each do |false_string|
+      assert_equal false, Foreman::Cast.to_bool(false_string)
+    end
+  end
+
+  test "should convert FixNums to booleans" do
+    assert_equal true, Foreman::Cast.to_bool(1)
+    assert_equal false, Foreman::Cast.to_bool(0)
+  end
+
+  test "should convert Nil to boolean" do
+    assert_equal false, Foreman::Cast.to_bool(nil)
+  end
+
+  test "should return TrueClass if TrueClass" do
+    assert_equal true, Foreman::Cast.to_bool(true)
+  end
+
+  test "should return FalseClass if FalseClass" do
+    assert_equal false, Foreman::Cast.to_bool(false)
+  end
+end
+

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -259,8 +259,8 @@ class SettingTest < ActiveSupport::TestCase
     check_parsed_value "boolean", false, "false"
     check_parsed_value "boolean", true, "True"
     check_parsed_value "boolean", false, "False"
-    check_parsed_value_failure "boolean", "1"
-    check_parsed_value_failure "boolean", "0"
+    check_parsed_value "boolean", true, "1"
+    check_parsed_value "boolean", false, "0"
     check_parsed_value_failure "boolean", "unknown"
   end
 


### PR DESCRIPTION
This commit adds a to_bool function for casting values to boolean
as well as an example usage.

http://projects.theforeman.org/issues/10402
