### PR TITLE
fixes #10403 - resync names of unmanaged hosts to their primary NIC

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -246,10 +246,6 @@ module Host
     end
 
     def primary_interface
-      # Build a dummy object if host is unmanaged and without interfaces.
-      # Unmanaged hosts still have the interface requirement due to delegations and certain validations.
-      # A refactoring that allows unmanaged hosts to exist without interfaces is sorely needed.
-      build_required_interfaces unless managed? || interfaces.detect(&:primary)
       get_interface_by_flag(:primary)
     end
 
@@ -327,8 +323,8 @@ module Host
     end
 
     def build_required_interfaces(attrs = {})
-      self.interfaces.build(attrs.merge(:primary => true, :type => 'Nic::Managed')) if get_interface_by_flag(:primary).nil?
-      get_interface_by_flag(:primary).provision = true if self.provision_interface.nil?
+      self.interfaces.build(attrs.merge(:primary => true, :type => 'Nic::Managed')) if self.primary_interface.nil?
+      self.primary_interface.provision = true if self.provision_interface.nil?
     end
 
     def set_interface(attributes, name, iface)

--- a/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
+++ b/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
@@ -23,7 +23,6 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
     say "Migrating Host interfaces to standalone Interfaces"
 
     Host::Managed.all.each do |host|
-      next unless host.managed?
       nic = FakeNic.new
       nic.host_id = host.id
       nic.name = host.name
@@ -33,7 +32,7 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
       nic.domain_id = host.attributes.with_indifferent_access[:domain_id]
       nic.virtual = false
       nic.identifier = host.primary_interface || "eth0"
-      nic.managed = true
+      nic.managed = host.attributes.with_indifferent_access[:managed]
       nic.primary = true
       nic.provision = true
       nic.type = 'Nic::Managed'
@@ -63,7 +62,6 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
     say "Migrating Interfaces to Host interfaces"
     FakeHost.reset_column_information
     FakeHost.all.each do |host|
-      next unless host.managed?
       host = host.becomes(FakeHost)
       raise ActiveRecord::IrreversibleMigration if FakeNic.where(:primary => true, :provision => false).any?
       raise ActiveRecord::IrreversibleMigration if FakeNic.where(:primary => false, :provision => true).any?

--- a/db/migrate/20150508124600_copy_unmanaged_hosts_to_interfaces.rb
+++ b/db/migrate/20150508124600_copy_unmanaged_hosts_to_interfaces.rb
@@ -1,0 +1,44 @@
+class FakeNic < ActiveRecord::Base
+  self.table_name = 'nics'
+
+  def type
+    Nic::Managed
+  end
+end
+
+class FakeHost < ActiveRecord::Base
+  self.table_name = 'hosts'
+
+  def type
+    Host::Managed
+  end
+end
+
+class CopyUnmanagedHostsToInterfaces < ActiveRecord::Migration
+  def up
+    say "Migrating Unmanaged Host interfaces to standalone Interfaces"
+
+    FakeHost.where(:managed => false).each do |host|
+      nic = FakeNic.where(:host_id => host.id, :primary => true, :provision => true).first
+      if nic.present?
+        nic.name = host.name if nic.name.blank?
+      else
+        nic = FakeNic.new
+        nic.host_id = host.id
+        nic.name = host.name
+        nic.virtual = false
+        nic.identifier = host.primary_interface || "eth0"
+        nic.managed = host.managed?
+        nic.primary = true
+        nic.provision = true
+        nic.type = 'Nic::Managed'
+      end
+      nic.save!
+
+      say "  Migrated #{nic.name}-#{nic.identifier} to nics"
+    end
+  end
+
+  def down
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2014,15 +2014,6 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
-  test 'unmanaged hosts name does not rely on primary interface' do
-    host = FactoryGirl.build(:host, :managed)
-    host.managed = false
-    host.interfaces = []
-    # A dummy primary interface is created here
-    host.update_attributes(:name => 'foounmanaged')
-    assert_equal 'foounmanaged', host.name
-  end
-
   test 'updating host domain should validate domain exists' do
     host = FactoryGirl.create(:host, :managed)
     last_domain_id = Domain.order(:id).last.id


### PR DESCRIPTION
MoveHostNicsToInterfaces previously ignored unmanaged hosts, but they
need migrating too.  Updated the existing migration to migrate both,
then for existing hosts, add a new migration to ensure all primary NIC
names are set from the host's name, and to add new NICs where they are
missing.

---

Should I also revert a5dc3e2, if this migration now ensures an interface exists in the DB?  Assuming all code paths like creation through fact upload generate an interface too.
