### PR TITLE
Fixes #5568 - Improves performance of trends:clean rake task

### DIFF
--- a/lib/tasks/trends.rake
+++ b/lib/tasks/trends.rake
@@ -10,10 +10,8 @@ namespace :trends do
     # Note this can take a few minutes to run as the table is huge
 
     # Get a hash of all TrendCounter pairs and how many records of each pair
-    counts = TrendCounter.group([:trend_id, :created_at]).count
-
     # Keep only those pairs that have more than one record
-    dupes = counts.select{|attrs, count| count > 1}
+    dupes = TrendCounter.having('count(*) > 1').group([:trend_id, :created_at]).count
 
     # Map objects by the attributes
     object_groups = dupes.map do |attrs, count|

--- a/test/lib/tasks/trends_test.rb
+++ b/test/lib/tasks/trends_test.rb
@@ -104,6 +104,25 @@ class TrendsTest < ActiveSupport::TestCase
     end
   end
 
+  test 'trends:clean' do
+    trend = FactoryGirl.create(:foreman_trends, :operating_system)
+    created_at = Time.now
+    args = [:trend_counter, :trend => trend, :created_at => created_at, :updated_at => created_at, :count => 1]
+    # create a legit counter
+    FactoryGirl.create(*args)
+
+    # now create some dupes (skipping validations)
+    2.times do
+      FactoryGirl.build(*args).save(validate: false)
+    end
+
+    assert_equal 3, TrendCounter.where(trend_id: trend.id).length
+
+    Rake.application.invoke_task 'trends:clean'
+
+    assert_equal 1, TrendCounter.where(trend_id: trend.id).length
+  end
+
   private
 
   def create_trend_line(trend, values_line)


### PR DESCRIPTION
Perform trend counter dupe counting within the database rather than in the Ruby code.
