### PR TITLE
fixes #10441 - sort time and count-based columns in descending order

### DIFF
--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -9,7 +9,7 @@
       <th class="hidden-xs"><%= sort :environment, :as => _('Environment') %></th>
       <th class="hidden-tablet hidden-xs"><%= sort :model, :as => _('Model') %></th>
       <th class="hidden-tablet hidden-xs"><%= sort :hostgroup, :as => _("Host group") %></th>
-      <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _('Last report') %></th>
+      <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -6,7 +6,7 @@
   <thead>
     <tr>
       <th><%= sort :name, :as => s_("Realm|Name") %></th>
-      <th><%= sort :hosts_count, :as => _("Hosts") %></th>
+      <th><%= sort :hosts_count, :as => _("Hosts"), :default => 'DESC' %></th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
       <th><%= sort :lastname, :as => s_("User|Lastname") %></th>
       <th><%= sort :mail, :as => s_("User|Mail") %></th>
       <th><%= sort :admin, :as => s_("User|Admin") %></th>
-      <th><%= sort :last_login_on, :as => s_("User|Last login on") %></th>
+      <th><%= sort :last_login_on, :as => s_("User|Last login on"), :default => 'DESC' %></th>
       <th><%= _("Authorized by") %></th>
       <th></th>
     </tr>


### PR DESCRIPTION
Small usability tweak IMHO. On the hosts page, for example, if you're sorting by last reported, you're interested in the most recent.
