### PR TITLE
Fixes #9424 - orchestration progress no longer triggers twice

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -142,10 +142,12 @@ function animate_progress(){
   if (stop_pooling == true) return;
   setTimeout(function() {
     var url = $('#host_progress_report_id').data('url');
-    $.get(url, function (response){
-       update_progress(response);
-       animate_progress();
-    })
+    if (typeof url !== 'undefined') {
+      $.get(url, function (response) {
+        update_progress(response);
+        animate_progress();
+      })
+    }
   }, 1600);
 }
 


### PR DESCRIPTION
This is reproducible through discovery and is the cause of http://projects.theforeman.org/issues/9424.
The progress animation is triggered twice when provisioning a discovered host and the second time it can't find a url since the host has been successfully saved. This creates another call to discovered_host edit but there is no discovered host to edit and a 500 error appears in the log.
