### PR TITLE
Fixes #10487: Add custom logging support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'fast_gettext', '~> 0.8'
 gem 'gettext_i18n_rails', '~> 1.0'
 gem 'i18n', '~> 0.6.4'
 gem 'turbolinks', '~> 2.5'
+gem 'logging', '>= 1.8.0', '< 3.0.0'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -143,7 +143,11 @@ class Subnet < ActiveRecord::Base
   end
 
   def unused_ip(mac = nil, excluded_ips = [])
-    logger.debug "Not suggesting IP Address for #{self} as IPAM is disabled" and return unless ipam?
+    unless ipam?
+      logger.debug "Not suggesting IP Address for #{self} as IPAM is disabled"
+      return
+    end
+
     if self.ipam == IPAM_MODES[:dhcp] && dhcp?
       # we have DHCP proxy so asking it for free IP
       logger.debug "Asking #{dhcp.url} for free IP"
@@ -163,7 +167,8 @@ class Subnet < ActiveRecord::Base
           return(ip)
         end
       end
-      logger.debug("Not suggesting IP Address for #{self} as no free IP found in our DB") and return
+      logger.debug("Not suggesting IP Address for #{self} as no free IP found in our DB")
+      return
     end
   rescue => e
     logger.warn "Failed to fetch a free IP from our proxy: #{e}"

--- a/app/services/foreman/plugin/logging.rb
+++ b/app/services/foreman/plugin/logging.rb
@@ -1,0 +1,66 @@
+module Foreman
+  class Plugin
+    # Configures logging for plugins and creates loggers per defined logger as well as
+    # creates a default logger based on the name of the plugin. Note that even though
+    # these loggers are created, the plugin must still use them directly within the code
+    # base.
+    #
+    # For a plugin named 'foreman_docker', a default logger will be created that can be
+    # accessed via:
+    #
+    #   Foreman::Logging.logger['foreman_docker']
+    #
+    # A plugin can specify other custom loggers and specify them using the same syntax as
+    # the Foreman default loggers. For example, the foreman_docker plugin could specify
+    # a REST logger for Docker commands:
+    #
+    #   {:loggers => :rest => {:enabled => true}}
+    #
+    # This will in turn create both the default logger and a logger named 'foreman_docker/rest'
+    # which will output the same way in the logs. Note that all plugin loggers are name spaced
+    # based upon the ID of the plugin specified in the plugin definition. This is to prevent
+    # potential name clashes when viewing the logs. In other words, instead of just seeing:
+    #
+    # 2015-05-13 13:28:22 [rest] [D] Debugging message for Docker REST call /docker
+    # 2015-05-13 13:28:22 [rest] [D] Pulp REST call made to /pulp/api
+    #
+    # The logs will show:
+    #
+    # 2015-05-13 13:28:22 [foreman_docker/rest] [D] Debugging message for Docker REST call /docker
+    # 2015-05-13 13:28:22 [katello/rest] [D] Pulp REST call made to /pulp/api
+    #
+    class Logging
+      attr_reader :config, :plugin_id
+
+      def initialize(plugin_id)
+        @plugin_id = plugin_id
+        @config = {:loggers => {}}
+      end
+
+      def configure(config)
+        warn "Foreman::Logging is undefined and no plugin loggers have been defined" unless defined?(Foreman::Logging)
+        @config = config if config
+
+        loggers.each do |name, logger_config|
+          add_logger(name, logger_config)
+        end
+      end
+
+      def add_logger(name, logger_config)
+        @config[:loggers] = {"#{name}" => logger_config}
+        Foreman::Logging.add_logger(namespace(name), logger_config)
+      end
+
+      def loggers
+        config = @config[:loggers] || {}
+        config[@plugin_id] = {:enabled => true} unless config.key?(@plugin_id)
+        config
+      end
+
+      def namespace(name)
+        return name.to_s if @plugin_id.to_s == name.to_s
+        "#{@plugin_id}/#{name}"
+      end
+    end
+  end
+end

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -99,7 +99,11 @@ class ReportImporter
     if report.error?
       # found a report with errors
       # notify via email IF enabled is set to true
-      logger.warn "#{name} is disabled - skipping alert" and return if host.disabled?
+
+      if host.disabled?
+        logger.warn "#{name} is disabled - skipping alert"
+        return
+      end
 
       owners = host.owner.present? ? host.owner.recipients_for(:puppet_error_state) : []
       if owners.present?

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,12 +1,5 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
-#Add timestamps and severity to environment.log
-class Logger
-  def format_message(severity, timestamp, progname, msg)
-    "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} [#{severity[0]}] #{msg}\n"
-  end
-end
-
 # Initialize the rails application
 Foreman::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Foreman::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
 
   # Should ANSI color codes be used when logging information
-  config.colorize_logging = true
+  config.colorize_logging = Foreman::Logging.config[:colorize]
 
   # Do not compress assets
   config.assets.compress = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Foreman::Application.configure do |app|
   # config.assets.manifest = YOUR_PATH
 
   # Should ANSI color codes be used when logging information
-  config.colorize_logging = SETTINGS[:colorize_logging]
+  config.colorize_logging = Foreman::Logging.config[:colorize]
 
   # Add the fonts path
   config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,7 @@ Foreman::Application.configure do
   # config.active_record.schema_format = :sql
 
   # Should ANSI color codes be used when logging information
-  config.colorize_logging = false
+  config.colorize_logging = Foreman::Logging.config[:colorize]
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,64 @@
+# Configuration values can be set per environment and apply to the root logger that
+# all other loggers inherit from. Additional loggers can be configured in settings.yaml
+# The valid options are:
+#
+# :colorize:
+#   Colorize log including level token based on severity
+#   values: true, false
+#
+# :console_inline:
+#   Enable logging output inline in rails console
+#   values: true, false
+#
+# :level: 
+#   Only messages with severity >= this level from all loggers will be logged
+#   values: debug, info, warn, error, fatal, unknown
+#
+# :type:
+#   Type of logging, for file variant you can specify other options below like filename
+#   values: file, syslog
+#
+# :filename:
+#   Log filename for this environment, it will be placed into #{Rails.root}/log directory
+#   note when you log outside of standard rails path you won't see log output in WEBrick
+#   STDOUT (usually not wanted in development), to use Rails default path, don't set path
+#
+# :log_trace:
+#   Include caller tracing information in generated log events (this
+#   includes filename and line number of the log message)
+#   values: true, false
+#
+# :pattern:
+#   Logger line pattern, you can use the following macros
+#     [%c] name of the logger that generate the log event
+#     [%d] datestamp
+#     [%m] the user supplied log message
+#     [%p] PID of the current process
+#     [%r] the time in milliseconds since the program started
+#     [%T] the name of the thread Thread.current[:name]
+#     [%t] object_id of the thread
+#     [%F] filename where the logging request was issued
+#     [%L] line number where the logging request was issued
+#     [%M] method name where the logging request was issued
+#     [%X{string}] variable set using ::Logging.mdc['string'] =
+
+:default:
+  :colorize: false
+  :console_inline: false
+  :log_trace: false
+  :level: info
+  :type: file
+  :pattern: "%d [%c] [%.1l] %m\n"
+
+:production:
+  :filename: "production.log"
+
+:development:
+  :colorize: true
+  :console_inline: true
+  :level: debug
+  :filename: "development.log"
+
+:test:
+  :level: debug
+  :filename: "test.log"

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -23,5 +23,13 @@
 :domain: 'localdomain.net'
 :fqdn: 'localhost.localdomain.net'
 
-# Should ANSI color codes be used in logs
-:colorize_logging: false
+# Log settings for the current environment can be adjusted by adding them
+# here. For example, if you want to increase the log level.
+#:logging:
+#  :level: debug
+
+:loggers:
+  :app:
+    :enabled: true
+  :sql:
+    :enabled: true

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -1,0 +1,173 @@
+require 'logging'
+require 'fileutils'
+
+module Foreman
+  class LoggingImpl
+    private_class_method :new
+
+    attr_reader :config, :log_directory
+
+    def configure(options = {})
+      fail 'logging can be configured only once' if @configured
+      @configured = true
+
+      @log_directory = options.fetch(:log_directory, './log')
+      ensure_log_directory(@log_directory)
+
+      load_config(options.fetch(:environment), options.fetch(:config_overrides, {}))
+
+      configure_color_scheme
+      configure_root_logger(options)
+
+      build_console_appender
+    end
+
+    def add_loggers(loggers = {})
+      return unless loggers.is_a?(Hash)
+
+      loggers.each do |name, config|
+        add_logger(name, config)
+      end
+    end
+
+    def add_logger(logger_name, logger_config)
+      logger          = ::Logging.logger[logger_name]
+      logger.level    = logger_config[:level] if logger_config.key?(:level)
+      logger.additive = logger_config[:enabled] if logger_config.key?(:enabled)
+
+      # TODO: Remove once only Logging 2.0 is supported
+      if logger.respond_to?(:caller_tracing)
+        logger.caller_tracing = logger_config[:log_trace] || @config[:log_trace]
+      else
+        logger.trace = logger_config[:log_trace] || @config[:log_trace]
+      end
+    end
+
+    def loggers
+      ::Logging::Repository.instance.children('root').map(&:name)
+    end
+
+    def logger(name)
+      return ::Logging.logger[name] if ::Logging::Repository.instance.has_logger?(name)
+      fail "Trying to use logger #{name} which has not been configured."
+    end
+
+    private
+
+    def load_config(environment, overrides = {})
+      fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?('config/logging.yaml')
+      overrides ||= {}
+      @config = YAML.load_file('config/logging.yaml')
+      @config = @config[:default].deep_merge(@config[environment.to_sym]).deep_merge(overrides)
+    end
+
+    def ensure_log_directory(log_directory)
+      return true if File.directory?(log_directory)
+
+      begin
+        FileUtils.mkdir_p(log_directory)
+      rescue Errno::EACCES
+        warn "Insufficient privileges for #{log_directory}"
+      end
+    end
+
+    # we also set fallback appender to STDOUT in case a developer asks for unusable appender
+    def configure_root_logger(options)
+      ::Logging.logger.root.level     = @config[:level]
+      ::Logging.logger.root.appenders = build_root_appender(options)
+
+      # TODO: Remove once only Logging 2.0 is supported
+      if ::Logging.logger.root.respond_to?(:caller_tracing)
+        ::Logging.logger.root.caller_tracing = @config[:log_trace]
+      else
+        ::Logging.logger.root.trace = @config[:log_trace]
+      end
+
+      # fallback to log to STDOUT if there is any @config problem
+      if ::Logging.logger.root.appenders.empty?
+        ::Logging.logger.root.appenders = ::Logging.appenders.stdout
+        ::Logging.logger.root.warn 'No appender set, logging to STDOUT'
+      end
+    end
+
+    def build_console_appender
+      return unless @config[:console_inline]
+
+      ::Logging.logger.root.add_appenders(
+        ::Logging.appenders.stdout(:layout => build_layout(@config[:pattern], @config[:colorize]))
+      )
+    end
+
+    # currently we support two types of appenders, rolling file and syslog
+    # note that syslog ignores pattern and logs only messages
+    def build_root_appender(options)
+      name = "foreman"
+
+      case @config[:type]
+      when 'syslog'
+        build_syslog_appender(name, options)
+      when 'file'
+        build_file_appender(name, options)
+      else
+        fail 'unsupported logger type, please choose syslog or file'
+      end
+    end
+
+    def build_syslog_appender(name, options)
+      ::Logging.appenders.syslog(name, options.reverse_merge(:facility => ::Syslog::Constants::LOG_DAEMON))
+    end
+
+    def build_file_appender(name, options)
+      log_filename = "#{@log_directory}/#{@config[:filename]}"
+      begin
+        ::Logging.appenders.file(
+          name,
+          options.reverse_merge(:filename => log_filename,
+                                :layout   => build_layout(@config[:pattern], @config[:colorize]))
+        )
+      rescue ArgumentError
+        warn "Log file #{log_filename} cannot be opened. Falling back to STDOUT"
+        nil
+      end
+    end
+
+    def build_layout(pattern, colorize)
+      pattern += "  Log trace: %F:%L method: %M\n" if @config[:log_trace]
+      MultilinePatternLayout.new(:pattern => pattern, :color_scheme => colorize ? 'bright' : nil)
+    end
+
+    def configure_color_scheme
+      ::Logging.color_scheme(
+        'bright',
+        :levels => {
+          :info  => :green,
+          :warn  => :yellow,
+          :error => :red,
+          :fatal => [:white, :on_red]
+        },
+        :date   => :green,
+        :logger => :cyan,
+        :line   => :yellow,
+        :file   => :yellow,
+        :method => :yellow
+      )
+    end
+
+    # Custom pattern layout that indents multiline strings and adds | symbol to beginning of each
+    # following line hence you can see what belongs to the same message
+    class MultilinePatternLayout < ::Logging::Layouts::Pattern
+      def format_obj(obj)
+        obj.is_a?(String) ? indent_lines(obj) : super
+      end
+
+      private
+
+      # all new lines will be indented
+      def indent_lines(string)
+        string.gsub("\n", "\n | ")
+      end
+    end
+  end
+
+  Logging = LoggingImpl.send :new
+end

--- a/test/lib/foreman/logging_test.rb
+++ b/test/lib/foreman/logging_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ForemanLoggingTest < ActiveSupport::TestCase
+  def test_configure_once
+    assert_raises RuntimeError do
+      Foreman::Logging.configure({})
+    end
+  end
+
+  def test_default_loggers_exist
+    assert Foreman::Logging.logger('app')
+    assert Foreman::Logging.logger('sql')
+  end
+
+  def test_prevents_nonexistent_logger
+    assert_raises RuntimeError do
+      Foreman::Logging.logger('nonexistent_logger')
+    end
+  end
+
+  def test_add_loggers
+    Foreman::Logging.add_loggers({:fake_logger => {:enabled => true}})
+    assert Foreman::Logging.logger('fake_logger')
+  end
+
+  def test_add_logger
+    Foreman::Logging.add_logger('test_logger', {:enabled => true, :level => :debug})
+    assert Foreman::Logging.logger('test_logger')
+  end
+
+  def test_error_config_missing
+    File.expects(:exist?).returns(false)
+
+    assert_raises RuntimeError do
+      Foreman::Logging.send(:load_config, 'development')
+    end
+  end
+end

--- a/test/unit/plugin_logging_test.rb
+++ b/test/unit/plugin_logging_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class PluginLoggingTest < ActiveSupport::TestCase
+  def setup
+    @plugin_config = {:loggers => {:foreman_test_plugin => {:enabled => true}}}
+    @logging = Foreman::Plugin::Logging.new("foreman_test_plugin")
+    @logging.configure(@plugin_config)
+  end
+
+  def assert_logger_exists(name)
+    assert ::Logging::Repository.instance.has_logger?(name), "Failed assertion, logger #{name} does not exist"
+  end
+
+  def refute_logger_exists(name)
+    refute ::Logging::Repository.instance.has_logger?(name), "Failed assertion, logger #{name} exists"
+  end
+
+  def test_configure
+    @logging.configure(@plugin_config)
+
+    assert_logger_exists 'foreman_test_plugin'
+  end
+
+  def test_missing_config
+    @logging.configure({})
+
+    assert_logger_exists 'foreman_test_plugin'
+  end
+
+  def test_multiple_loggers
+    @plugin_config[:loggers][:backend_logger] = {:enabled => true}
+    @logging.configure(@plugin_config)
+
+    assert_logger_exists 'foreman_test_plugin/backend_logger'
+    refute_logger_exists 'backend_logger'
+  end
+
+  def test_namespace
+    assert_equal "foreman_test_plugin", @logging.namespace(:foreman_test_plugin)
+    assert_equal "foreman_test_plugin/backend_logger", @logging.namespace(:backend_logger)
+  end
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -235,4 +235,20 @@ class PluginTest < ActiveSupport::TestCase
     end
     assert_equal [ "test1", "test2", "test3", "test4" ], @klass.tests_to_skip["FooTest"]
   end
+
+  def test_configure_logging
+    Foreman::Plugin::Logging.any_instance.expects(:configure).with(nil)
+    @klass.register(:foo) {}
+
+    assert Foreman::Plugin.find(:foo).logging
+  end
+
+  def test_logger
+    Foreman::Plugin::Logging.any_instance.expects(:configure).with(nil)
+    @klass.register(:foo) {}
+    plugin = Foreman::Plugin.find(:foo)
+
+    plugin.logging.expects(:add_logger).with(:test_logger, {:enabled => true})
+    plugin.logger(:test_logger, {:enabled => true})
+  end
 end


### PR DESCRIPTION
This change moves away from the Rails logger to the 'logging' gem
to support more configurability of logging. Further, this allows for
the creation of custom loggers that plugins can then register through
settings.

For example, the plugin katello could define within its settings file
(settings.plugins.d/katello.yaml) the following:

```
:katello:
  :loggers:
    :pulp_rest:
      :enabled: false
    :cp_rest:
      :enabled: true
```

Which would define 2 loggers, pulp_rest and cp_rest where the latter
is turned on be default, but the former can be enabled such that
the log file isn't continuously filled with messages from that particular
layer.
