### PR TITLE
Fixes #10248 - cloning volume information for virtual machines

### DIFF
--- a/app/assets/javascripts/compute_resources/ovirt/nic_info.js
+++ b/app/assets/javascripts/compute_resources/ovirt/nic_info.js
@@ -1,3 +1,3 @@
 providerSpecificNICInfo = function(form) {
-  return form.find('.ovirt_name').val() + ' @ ' + form.find('.ovirt_network').val();
+  return form.find('.ovirt_name').val() + ' @ ' + form.find('.ovirt_network').text();
 }

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -253,6 +253,7 @@ class ComputeResource < ActiveRecord::Base
     end
     vm_attrs
   rescue ActiveRecord::RecordNotFound
+    logger.debug("vm with uuid '#{uuid}' not found")
     {}
   end
 

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -253,7 +253,7 @@ class ComputeResource < ActiveRecord::Base
     end
     vm_attrs
   rescue ActiveRecord::RecordNotFound
-    logger.debug("vm with uuid '#{uuid}' not found")
+    logger.warn("vm with uuid '#{uuid}' not found on #{self}")
     {}
   end
 

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -244,12 +244,16 @@ class ComputeResource < ActiveRecord::Base
 
   def vm_compute_attributes_for(uuid)
     vm = find_vm_by_uuid(uuid)
-    vm_attrs = vm.attributes.reject{|k,v| k == :id }
+    vm_attrs = vm.attributes rescue {}
+    vm_attrs = vm_attrs.reject{|k,v| k == :id }
+
     if vm.respond_to?(:volumes)
       volumes = vm.volumes || []
       vm_attrs[:volumes_attributes] = Hash[volumes.each_with_index.map { |volume, idx| [idx.to_s, volume.attributes] }]
     end
     vm_attrs
+  rescue ActiveRecord::RecordNotFound
+    {}
   end
 
   def user_data_supported?

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -244,7 +244,12 @@ class ComputeResource < ActiveRecord::Base
 
   def vm_compute_attributes_for(uuid)
     vm = find_vm_by_uuid(uuid)
-    vm.attributes.reject{|k,v| k == :id }
+    vm_attrs = vm.attributes.reject{|k,v| k == :id }
+    if vm.respond_to?(:volumes)
+      volumes = vm.volumes || []
+      vm_attrs[:volumes_attributes] = Hash[volumes.each_with_index.map { |volume, idx| [idx.to_s, volume.attributes] }]
+    end
+    vm_attrs
   end
 
   def user_data_supported?

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -28,7 +28,7 @@ module Foreman::Model
     end
 
     def find_vm_by_uuid(uuid)
-      client.servers.get(uuid)
+      super
     rescue Fog::Compute::AWS::Error
       raise(ActiveRecord::RecordNotFound)
     end

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -152,7 +152,12 @@ module Foreman::Model
 
     def vm_compute_attributes_for(uuid)
       vm_attrs = super
-      vm_attrs[:memory] = vm_attrs[:memory_size]*1024 rescue nil # value is returned in megabytes, we need bytes
+      if vm_attrs[:memory_size].nil?
+        vm_attrs[:memory] = nil
+        logger.debug("compute attributes for vm '#{uuid}' didin't contain :memory_size")
+      else
+        vm_attrs[:memory] = vm_attrs[:memory_size]*1024 # value is returned in megabytes, we need bytes
+      end
       vm_attrs
     end
 

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -26,7 +26,7 @@ module Foreman::Model
     end
 
     def find_vm_by_uuid(uuid)
-      client.servers.get(uuid)
+      super
     rescue ::Libvirt::RetrieveError => e
       Foreman::Logging.exception("Failed retrieving libvirt vm by uuid #{ uuid }", e)
       raise ActiveRecord::RecordNotFound

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -150,6 +150,12 @@ module Foreman::Model
       associate_by("mac", vm.mac)
     end
 
+    def vm_compute_attributes_for(uuid)
+      vm_attrs = super
+      vm_attrs[:memory] = vm_attrs[:memory_size]*1024 rescue nil # value is returned in megabytes, we need bytes
+      vm_attrs
+    end
+
     protected
 
     def client

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -17,6 +17,12 @@ module Foreman::Model
       [:build, :image]
     end
 
+    def find_vm_by_uuid(uuid)
+      super
+    rescue OVIRT::OvirtException
+      raise(ActiveRecord::RecordNotFound)
+    end
+
     def supports_update?
       true
     end

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -16,7 +16,7 @@ module Foreman::Model
     end
 
     def find_vm_by_uuid(uuid)
-      client.servers.get(uuid)
+      super
     rescue Fog::Compute::Rackspace::Error
       raise(ActiveRecord::RecordNotFound)
     end

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -260,7 +260,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     get :vm_compute_attributes, { :id => host.to_param }
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal data, "cpus" => 4
+    assert_equal data, "cpus" => 4, "memory" => nil
     ComputeResource.any_instance.unstub(:vm_compute_attributes_for)
   end
 

--- a/test/unit/compute_resources/compute_resource_test_helpers.rb
+++ b/test/unit/compute_resources/compute_resource_test_helpers.rb
@@ -1,4 +1,4 @@
-module CRTestHelpers
+module ComputeResourceTestHelpers
   def empty_servers
     servers = mock()
     servers.stubs(:get).returns(nil)

--- a/test/unit/compute_resources/cr_test_helpers.rb
+++ b/test/unit/compute_resources/cr_test_helpers.rb
@@ -1,0 +1,27 @@
+module CRTestHelpers
+  def empty_servers
+    servers = mock()
+    servers.stubs(:get).returns(nil)
+    servers
+  end
+
+  def servers_raising_exception(ex)
+    servers = mock()
+    servers.stubs(:get).raises(ex)
+    servers
+  end
+
+  def mock_cr_servers(cr, servers)
+    client = mock()
+    client.stubs(:servers).returns(servers)
+
+    cr.stubs(:client).returns(client)
+    cr
+  end
+
+  def assert_find_by_uuid_raises(ex_class, cr)
+    assert_raises(ex_class) do
+      cr.find_vm_by_uuid('abc')
+    end
+  end
+end

--- a/test/unit/compute_resources/ec2_test.rb
+++ b/test/unit/compute_resources/ec2_test.rb
@@ -7,4 +7,30 @@ class EC2Test < ActiveSupport::TestCase
     iface = mock('iface1', :public_ip_address => '10.0.0.154', :private_ip_address => "10.1.1.1")
     assert_equal host, as_admin { cr.associated_host(iface) }
   end
+
+  describe "find_vm_by_uuid" do
+    before do
+      @servers = mock()
+      @servers.stubs(:get).returns(nil)
+
+      client = mock()
+      client.stubs(:servers).returns(@servers)
+
+      @cr = Foreman::Model::EC2.new
+      @cr.stubs(:client).returns(client)
+    end
+
+    it "raises RecordNotFound when the vm does not exist" do
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+
+    it "raises RecordNotFound when the compute raises rackspace error" do
+      @servers.stubs(:get).raises(Fog::Compute::AWS::Error)
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+  end
 end

--- a/test/unit/compute_resources/ec2_test.rb
+++ b/test/unit/compute_resources/ec2_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-require 'unit/compute_resources/cr_test_helpers'
+require 'unit/compute_resources/compute_resource_test_helpers'
 
 class EC2Test < ActiveSupport::TestCase
-  include CRTestHelpers
+  include ComputeResourceTestHelpers
 
   test "#associated_host matches any NIC" do
     host = FactoryGirl.create(:host, :ip => '10.0.0.154')

--- a/test/unit/compute_resources/libvirt_test.rb
+++ b/test/unit/compute_resources/libvirt_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'unit/compute_resources/cr_test_helpers'
 
 class LibvirtTest < ActiveSupport::TestCase
+  include CRTestHelpers
+
   test "#associated_host matches any NIC" do
     host = FactoryGirl.create(:host, :mac => 'ca:d0:e6:32:16:97')
     cr = FactoryGirl.build(:libvirt_cr)
@@ -9,28 +12,14 @@ class LibvirtTest < ActiveSupport::TestCase
   end
 
   describe "find_vm_by_uuid" do
-    before do
-      @servers = mock()
-      @servers.stubs(:get).returns(nil)
-
-      client = mock()
-      client.stubs(:servers).returns(@servers)
-
-      @cr = Foreman::Model::Libvirt.new
-      @cr.stubs(:client).returns(client)
-    end
-
     it "raises RecordNotFound when the vm does not exist" do
-      assert_raises ActiveRecord::RecordNotFound do
-        @cr.find_vm_by_uuid('abc')
-      end
+      cr = mock_cr_servers(Foreman::Model::Libvirt.new, empty_servers)
+      assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
     end
 
     it "raises RecordNotFound when the compute raises retrieve error" do
-      @servers.stubs(:get).raises(Libvirt::RetrieveError)
-      assert_raises ActiveRecord::RecordNotFound do
-        @cr.find_vm_by_uuid('abc')
-      end
+      cr = mock_cr_servers(Foreman::Model::Libvirt.new, servers_raising_exception(Libvirt::RetrieveError))
+      assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
     end
   end
 

--- a/test/unit/compute_resources/libvirt_test.rb
+++ b/test/unit/compute_resources/libvirt_test.rb
@@ -8,6 +8,32 @@ class LibvirtTest < ActiveSupport::TestCase
     assert_equal host, as_admin { cr.associated_host(iface) }
   end
 
+  describe "find_vm_by_uuid" do
+    before do
+      @servers = mock()
+      @servers.stubs(:get).returns(nil)
+
+      client = mock()
+      client.stubs(:servers).returns(@servers)
+
+      @cr = Foreman::Model::Libvirt.new
+      @cr.stubs(:client).returns(client)
+    end
+
+    it "raises RecordNotFound when the vm does not exist" do
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+
+    it "raises RecordNotFound when the compute raises retrieve error" do
+      @servers.stubs(:get).raises(Libvirt::RetrieveError)
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+  end
+
   describe "compute_attributes_for" do
     test "returns memory in bytes" do
       vm = mock()

--- a/test/unit/compute_resources/libvirt_test.rb
+++ b/test/unit/compute_resources/libvirt_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-require 'unit/compute_resources/cr_test_helpers'
+require 'unit/compute_resources/compute_resource_test_helpers'
 
 class LibvirtTest < ActiveSupport::TestCase
-  include CRTestHelpers
+  include ComputeResourceTestHelpers
 
   test "#associated_host matches any NIC" do
     host = FactoryGirl.create(:host, :mac => 'ca:d0:e6:32:16:97')

--- a/test/unit/compute_resources/libvirt_test.rb
+++ b/test/unit/compute_resources/libvirt_test.rb
@@ -7,4 +7,28 @@ class LibvirtTest < ActiveSupport::TestCase
     iface = mock('iface1', :mac => 'ca:d0:e6:32:16:97')
     assert_equal host, as_admin { cr.associated_host(iface) }
   end
+
+  describe "compute_attributes_for" do
+    test "returns memory in bytes" do
+      vm = mock()
+      vm.stubs(:attributes).returns({ :memory_size => 6 })
+
+      cr = FactoryGirl.build(:libvirt_cr)
+      cr.stubs(:find_vm_by_uuid).returns(vm)
+
+      attrs = cr.vm_compute_attributes_for('abc')
+      assert_equal 6*1024, attrs[:memory]
+    end
+
+    test "returns nil memory when :memory_size is not provided" do
+      vm = mock()
+      vm.stubs(:attributes).returns({})
+
+      cr = FactoryGirl.build(:libvirt_cr)
+      cr.stubs(:find_vm_by_uuid).returns(vm)
+
+      attrs = cr.vm_compute_attributes_for('abc')
+      assert_equal nil, attrs[:memory]
+    end
+  end
 end

--- a/test/unit/compute_resources/openstack_test.rb
+++ b/test/unit/compute_resources/openstack_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'unit/compute_resources/compute_resource_test_helpers'
 
 class OpenstackTest < ActiveSupport::TestCase
+  include ComputeResourceTestHelpers
+
   setup do
     @compute_resource = FactoryGirl.build(:openstack_cr)
   end
@@ -21,6 +24,13 @@ class OpenstackTest < ActiveSupport::TestCase
     @compute_resource.expects(:boot_from_volume).never
     @compute_resource.create_vm(:boot_from_volume => 'false', :nics => [""],
                                 :flavor_ref => 'foo_flavor', :image_ref => 'foo_image')
+  end
+
+  describe "find_vm_by_uuid" do
+    it "raises RecordNotFound when the vm does not exist" do
+      cr = mock_cr_servers(Foreman::Model::Openstack.new, empty_servers)
+      assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
+    end
   end
 
   private

--- a/test/unit/compute_resources/ovirt_test.rb
+++ b/test/unit/compute_resources/ovirt_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'unit/compute_resources/compute_resource_test_helpers'
 
 class OvirtTest < ActiveSupport::TestCase
+  include ComputeResourceTestHelpers
+
   test "#associated_host matches any NIC" do
     host = FactoryGirl.create(:host, :mac => 'ca:d0:e6:32:16:97')
     cr = FactoryGirl.build(:ovirt_cr)
@@ -8,5 +11,17 @@ class OvirtTest < ActiveSupport::TestCase
     iface2 = mock('iface2', :mac => 'ca:d0:e6:32:16:97')
     vm = mock('vm', :interfaces => [iface1, iface2])
     assert_equal host, as_admin { cr.associated_host(vm) }
+  end
+
+  describe "find_vm_by_uuid" do
+    it "raises RecordNotFound when the vm does not exist" do
+      cr = mock_cr_servers(Foreman::Model::Ovirt.new, empty_servers)
+      assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
+    end
+
+    it "raises RecordNotFound when the compute raises retrieve error" do
+      cr = mock_cr_servers(Foreman::Model::Ovirt.new, servers_raising_exception(OVIRT::OvirtException.new('VM not found')))
+      assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
+    end
   end
 end

--- a/test/unit/compute_resources/rackspace_test.rb
+++ b/test/unit/compute_resources/rackspace_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-require 'unit/compute_resources/cr_test_helpers'
+require 'unit/compute_resources/compute_resource_test_helpers'
 
 class RackspaceTest < ActiveSupport::TestCase
-  include CRTestHelpers
+  include ComputeResourceTestHelpers
 
   test "#associated_host matches any NIC" do
     host = FactoryGirl.create(:host, :ip => '10.0.0.154')

--- a/test/unit/compute_resources/rackspace_test.rb
+++ b/test/unit/compute_resources/rackspace_test.rb
@@ -7,4 +7,30 @@ class RackspaceTest < ActiveSupport::TestCase
     iface = mock('iface1', :public_ip_address => '10.0.0.154', :private_ip_address => "10.1.1.1")
     assert_equal host, as_admin { cr.associated_host(iface) }
   end
+
+  describe "find_vm_by_uuid" do
+    before do
+      @servers = mock()
+      @servers.stubs(:get).returns(nil)
+
+      client = mock()
+      client.stubs(:servers).returns(@servers)
+
+      @cr = Foreman::Model::Rackspace.new
+      @cr.stubs(:client).returns(client)
+    end
+
+    it "raises RecordNotFound when the vm does not exist" do
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+
+    it "raises RecordNotFound when the compute raises rackspace error" do
+      @servers.stubs(:get).raises(Fog::Compute::Rackspace::Error)
+      assert_raises ActiveRecord::RecordNotFound do
+        @cr.find_vm_by_uuid('abc')
+      end
+    end
+  end
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -148,7 +148,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "can fetch vm compute attributes" do
-    host = FactoryGirl.create(:host, :compute_resource => compute_resources(:one))
+    host = FactoryGirl.create(:host, :compute_resource => compute_resources(:ec2))
     ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:cpus => 4})
     assert_equal host.vm_compute_attributes, :cpus => 4
   end


### PR DESCRIPTION
`vm.attributes` (Fog) returns volumes and nics info as objects under keys `:volumes` and `:interfaces`. This PR places the volume attributes into `:volumes_attributes` where the Rails' form helper can find it.

NICs are no longer a problem since we save the original compute attributes with them now.

Tested providers checklist:
- [x] libvirt
- [x] oVirt
- [x] VMWare
