### PR TITLE
fixes #10507 - wait for completion of update env request

### DIFF
--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -293,6 +293,7 @@ class HostTest < ActionDispatch::IntegrationTest
       # remove hosts cookie on submit
       index_modal.find('.btn-primary').trigger('click')
       assert_empty(page.driver.cookies['_ForemanSelectedhosts'])
+      assert has_selector?("div", :text => "Updated hosts: changed environment")
     end
   end
 end


### PR DESCRIPTION
When testing the multiple host environment update, the integration test
submits the modal popup form and then the test ends.  The server thread
takes some time to update all host envs, add audit entries etc, but in
the meantime, the test thread begins to clean up fixtures and so can hit
a deadlock with the server thread which is still processing.

As seen in http://ci.theforeman.org/job/test_develop_pr_core/4818/ and especially on the Rails 4 PR.
