### PR TITLE
fixes #10493, #10509 - disable usergroup sync on login with $login and toggle

### DIFF
--- a/app/controllers/api/v1/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v1/auth_source_ldaps_controller.rb
@@ -31,6 +31,7 @@ module Api
         param :attr_mail, String, :desc => "required if onthefly_register is true"
         param :attr_photo, String
         param :onthefly_register, :bool
+        param :usergroup_sync, :bool, :desc => N_("sync external user groups on login")
         param :tls, :bool
       end
 
@@ -54,6 +55,7 @@ module Api
         param :attr_mail, String, :desc => "required if onthefly_register is true"
         param :attr_photo, String
         param :onthefly_register, :bool
+        param :usergroup_sync, :bool, :desc => N_("sync external user groups on login")
         param :tls, :bool
       end
 

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -30,6 +30,7 @@ module Api
           param :attr_mail, String, :desc => N_("required if onthefly_register is true")
           param :attr_photo, String
           param :onthefly_register, :bool
+          param :usergroup_sync, :bool, :desc => N_("sync external user groups on login")
           param :tls, :bool
         end
       end

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -100,6 +100,11 @@ class AuthSourceLdap < AuthSource
       return
     end
 
+    unless usergroup_sync?
+      logger.info "Skipping user group update for user #{login} as usergroup_sync is disabled"
+      return
+    end
+
     logger.debug "Updating user groups for user #{login}"
     internal = User.find(login).external_usergroups.map(&:name)
     external = ldap_con.group_list(login)

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -95,9 +95,14 @@ class AuthSourceLdap < AuthSource
   end
 
   def update_usergroups(login)
+    if use_user_login_for_service?
+      logger.info "Skipping user group update for user #{login} as $login is in use, group sync is unsupported"
+      return
+    end
+
     logger.debug "Updating user groups for user #{login}"
     internal = User.find(login).external_usergroups.map(&:name)
-    external = ldap_con(account, account_password).group_list(login)
+    external = ldap_con.group_list(login)
     (internal | external).each do |name|
       begin
         external_usergroup = external_usergroups.find_by_name(name)

--- a/app/views/api/v2/auth_source_ldaps/main.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/main.json.rabl
@@ -2,4 +2,4 @@ object @auth_source_ldap
 
 extends "api/v2/auth_source_ldaps/base"
 
-attributes :host, :port, :account, :base_dn, :ldap_filter, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :attr_photo, :onthefly_register, :tls, :created_at, :updated_at
+attributes :host, :port, :account, :base_dn, :ldap_filter, :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :attr_photo, :onthefly_register, :usergroup_sync, :tls, :created_at, :updated_at

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -27,6 +27,8 @@
       <%= text_f f, :ldap_filter, :label => _("LDAP filter"), :help_inline => _("Custom LDAP search filter, <i>optional</i>").html_safe, :size => "col-md-8" %>
       <%= checkbox_f f, :onthefly_register,
                         :help_inline => _("LDAP users will have their Foreman account automatically created the first time they log into Foreman") %>
+      <%= checkbox_f f, :usergroup_sync,
+                        :help_inline => _("External user groups will be synced on login, else relies on periodic cronjob to check group membership") %>
     </div>
     <div class="tab-pane" id="attributes">
       <%= text_f f, :attr_login, :help_inline => _("e.g. uid") %>

--- a/db/migrate/20150514121649_add_usergroup_sync_to_auth_sources.rb
+++ b/db/migrate/20150514121649_add_usergroup_sync_to_auth_sources.rb
@@ -1,0 +1,5 @@
+class AddUsergroupSyncToAuthSources < ActiveRecord::Migration
+  def change
+    add_column :auth_sources, :usergroup_sync, :boolean, :null => false, :default => true
+  end
+end

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2013-08-15 10:46+0100\n"
+"PO-Revision-Date: 2015-05-14 13:31+0100\n"
 "Last-Translator: Lukas Zapletal <lzap+git@redhat.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language: en\n"
@@ -7378,6 +7378,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "AuthSource|Tls"
 msgstr "TLS"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "AuthSource|Usergroup sync"
+msgstr "User group syncing"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Bookmark"

--- a/test/unit/auth_sources/auth_source_ldap_test.rb
+++ b/test/unit/auth_sources/auth_source_ldap_test.rb
@@ -186,6 +186,13 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     ldap.send(:update_usergroups, 'test')
   end
 
+  test 'update_usergroups is no-op with usergroup_sync=false' do
+    ldap = FactoryGirl.build(:auth_source_ldap, :usergroup_sync => false)
+    User.any_instance.expects(:external_usergroups).never
+    ExternalUsergroup.any_instance.expects(:refresh).never
+    ldap.send(:update_usergroups, 'test')
+  end
+
   test '#to_config with dedicated service account returns hash' do
     conf = FactoryGirl.build(:auth_source_ldap, :service_account).to_config
     assert_kind_of Hash, conf

--- a/test/unit/auth_sources/auth_source_ldap_test.rb
+++ b/test/unit/auth_sources/auth_source_ldap_test.rb
@@ -179,6 +179,13 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     end
   end
 
+  test 'update_usergroups is no-op with $login service account' do
+    ldap = FactoryGirl.build(:auth_source_ldap, :account => 'DOMAIN/$login')
+    User.any_instance.expects(:external_usergroups).never
+    ExternalUsergroup.any_instance.expects(:refresh).never
+    ldap.send(:update_usergroups, 'test')
+  end
+
   test '#to_config with dedicated service account returns hash' do
     conf = FactoryGirl.build(:auth_source_ldap, :service_account).to_config
     assert_kind_of Hash, conf


### PR DESCRIPTION
Login behaviour now matches the user group management page, which doesn't permit these two features to be used together.  Passing account\* into ldap_con had hidden the proper error message, but really it should be a no-op.
