### PR TITLE
fixes #4769 - fix deprecation warning while syncing LDAP attrs

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -154,7 +154,7 @@ class AuthSourceLdap < AuthSource
         value = entry[value].is_a?(Array) ? entry[value].first : entry[value]
         [name, value.to_s]
       end
-    end]
+    end.compact]
   end
 
   def store_avatar(avatar)


### PR DESCRIPTION
Can be seen when running test/unit/auth_sources/auth_source_ldap_test.rb under Ruby 2.0.0 on develop.
