### PR TITLE
fixes #10510 - move secure flag to existing session configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -146,12 +146,6 @@ module Foreman
         child.helper helpers
       end
     end
-
-    # Secure cookies if the connection is via SSL
-    if !!SETTINGS[:require_ssl]
-      config.session_options[:secure] = !!SETTINGS[:require_ssl]
-      middleware.use config.session_store, config.session_options
-    end
   end
 
   def self.setup_console

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,4 +5,4 @@
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
-Foreman::Application.config.session_store :active_record_store
+Foreman::Application.config.session_store :active_record_store, :secure => !!SETTINGS[:require_ssl]


### PR DESCRIPTION
On a source installation with SSL, the session store is properly configured
now and no longer continually resets user sessions.
