### PR TITLE
refs #9782 - implement @mediapath for SUSE

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -236,6 +236,7 @@ class UnattendedController < ApplicationController
   end
 
   def yast_attributes
+    @mediapath = @host.operatingsystem.mediumpath @host
   end
 
   def coreos_attributes

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -1,6 +1,11 @@
 class Suse < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
+  # Simple output of the media url
+  def mediumpath(host)
+    medium_uri(host).to_s
+  end
+
   def pxe_type
     "yast"
   end


### PR DESCRIPTION
I have no idea, why that doesn't work... I changed media_path to @mediapath in the autoyast PXELinux template, but it's always rendering to `install=`.
