### PR TITLE
Fixes #10542: correct path for auto complete search on filters page.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -205,8 +205,9 @@ module ApplicationHelper
   end
 
   def auto_complete_search(name, val, options = {})
-    path = options[:path] || send("#{controller_name}_path")
-    options.merge!(:class => "autocomplete-input form-control", :'data-url' => "#{path}/auto_complete_#{name}" )
+    path = options[:full_path]
+    path ||= (options[:path] || send("#{controller_name}_path")) + "/auto_complete_#{name}"
+    options.merge!(:class => "autocomplete-input form-control", :'data-url' => path )
     text_field_tag(name, val, options)
   end
 

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -143,13 +143,13 @@ module LayoutHelper
 
   def autocomplete_f(f, attr, options = {})
     field(f, attr, options) do
-      path = options.delete(:path) || send("#{f.object.class.pluralize.underscore}_path")
+      path = options.delete(:path) || send("#{f.object.class.pluralize.underscore}_path") if options[:full_path].nil?
       auto_complete_search(attr,
                            f.object.send(attr).try(:squeeze, " "),
                            options.merge(
                                :placeholder => _("Filter") + ' ...',
                                :path        => path,
-                               :name       => "#{f.object_name}[#{attr}]"
+                               :name        => "#{f.object_name}[#{attr}]"
                            )
       ).html_safe
     end

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -48,7 +48,7 @@
 
         <%= autocomplete_f f, :search,
                            :disabled => f.object.unlimited?,
-                           :path => resource_path(f.object.resource_type) || "",
+                           :full_path => search_path(f.object.resource_type),
                            :control_group_id => 'search_group' %>
       </div>
     </div>


### PR DESCRIPTION
The filters page was using an incorrect path for the autocomplete search
which caused it to not work on initial page load with non-core resources.
This commit updates the autocomplete search path to use the correct URL.

http://projects.theforeman.org/issues/10542
