### PR TITLE
Fixes #10568 - Show release field when OS family is CoreOS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -308,7 +308,7 @@ function auth_source_selected(){
 
 function show_release(element){
   var os_family = $(element).val();
-  if (os_family == 'Debian' || os_family == 'Solaris') {
+  if ($.inArray(os_family, ['Debian', 'Solaris', 'Coreos']) != -1) {
     $("#release_name").show();
   } else {
     $("#release_name").hide();


### PR DESCRIPTION
$release is necessary for CoreOS installation media, however the new Operating
System form doesn't show it when you change family to CoreOS, only after it's
submitted.
