### PR TITLE
fixes #10586 - make the 401 status comparison actually match.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,7 +79,7 @@ class UsersController < ApplicationController
         login_user(user)
       end
     else
-      if params[:status] && params[:status] == 401
+      if params[:status] && params[:status] == "401"
         render :layout => 'login', :status => params[:status]
       else
         render :layout => 'login'

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -319,6 +319,16 @@ class UsersControllerTest < ActionController::TestCase
     refute session[:foo], "session contains 'foo', but should have been reset"
   end
 
+  test "#login renders login page" do
+    get :login
+    assert_response :success
+  end
+
+  test "#login renders login page with 401 status from parameter" do
+    get :login, :status => '401'
+    assert_response 401
+  end
+
   context 'default taxonomies' do
     test 'logging in loads default taxonomies' do
       users(:one).update_attributes(:default_location_id     => taxonomies(:location1).id,


### PR DESCRIPTION
In https://github.com/theforeman/foreman/pull/1253, we've settled for

```
if params[:status] && params[:status] == 401
```

which does not seem to work -- running

```
curl -Lksi https://$(hostname)/users/login?status=401
```

will not force the status 401 because the `params[:status]` is presumably a string.
