### PR TITLE
Refs #6518 - Use #find instead of #select #first to choose a BMC proxy for the subnet

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -15,7 +15,7 @@ module Nic
 
     def proxy
       if subnet.present?
-        proxy = subnet.proxies.select { |subnet_proxy| subnet_proxy.has_feature?('BMC') }.first
+        proxy = subnet.proxies.find { |subnet_proxy| subnet_proxy.has_feature?('BMC') }
       end
       proxy ||= SmartProxy.with_features("BMC").first
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?


### PR DESCRIPTION
Drive-by syntax patch - Enumerable#find stops at the first matching entry instead of going through the entire array. ~~I can do the redmine tickets later today.~~ _Referencing the original Redmine from the commit that introduced the #select #first usage._
