### PR TITLE
fixes #10397 - parse Windows Local_Area_Connection interface name

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -163,7 +163,7 @@ class FactParser
 
   # these interfaces are ignored when parsing interface facts
   def ignored_interfaces
-    /\A(lo|usb|vnet)/
+    /\A(lo(?!cal_area_connection)|usb|vnet)/
   end
 
   def remove_ignored(interfaces)

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -89,7 +89,7 @@ class PuppetFactParser < FactParser
   def interfaces
     interfaces = super
 
-    underscore_device_regexp = /(.*)_(\d+)/
+    underscore_device_regexp = /\A([^_]*)_(\d+)\z/
     interfaces.clone.each do |identifier, _|
       matches = identifier.match(underscore_device_regexp)
       next unless matches

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -47,14 +47,16 @@ class FactParserTest < ActiveSupport::TestCase
   end
 
   test "#interfaces gets facts hash for desired interfaces, keeping same values it gets from parser" do
-    parser.stub(:get_interfaces, ['eth1', 'lo', 'eth0', 'eth0.0', 'local', 'usb0', 'vnet0', 'br0', 'virbr0']) do
+    parser.stub(:get_interfaces, ['eth1', 'lo', 'eth0', 'eth0.0', 'local', 'usb0', 'vnet0', 'br0', 'virbr0', 'Local_Area_Connection_2']) do
       parser.expects(:get_facts_for_interface).with('eth1').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'custom' => 'value'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0.0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('br0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:ef'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('virbr0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:ab:ef'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('local_area_connection_2').returns({'link' => 'true', 'macaddress' => '00:00:00:00:de:ef'}.with_indifferent_access)
       result = parser.interfaces
       refute_includes result.keys, 'lo'
+      refute_includes result.keys, 'local'
       refute_includes result.keys, 'usb0'
       refute_includes result.keys, 'vnet0'
       assert_includes result.keys, 'br0'
@@ -62,6 +64,7 @@ class FactParserTest < ActiveSupport::TestCase
       assert_includes result.keys, 'eth1'
       assert_includes result.keys, 'eth0'
       assert_includes result.keys, 'eth0.0'
+      assert_includes result.keys, 'local_area_connection_2'
       assert_equal 'true', result['eth0']['link']
       assert_equal 'false', result['eth1']['link']
       assert_equal 'value', result[:eth0]['custom']

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -220,6 +220,19 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     assert_equal '192.168.0.4', parser.interfaces['eth2'][:ipaddress]
   end
 
+  test "#interfaces are mapped case-insensitively and parses Windows LAN name" do
+    parser = get_parser({:interfaces => 'Local_Area_Connection_2',
+                         :ipaddress_local_area_connection_2 => '172.30.43.87',
+                         :macaddress_local_area_connection_2 => '00:50:56:B7:69:F6',
+                         :netmask_local_area_connection_2 => '255.255.255.0',
+                         :network_local_area_connection_2 => '172.30.43.0'})
+    assert_not_nil parser.interfaces['local_area_connection_2']
+    assert_equal '172.30.43.87', parser.interfaces['local_area_connection_2'][:ipaddress]
+    assert_equal '255.255.255.0', parser.interfaces['local_area_connection_2'][:netmask]
+    assert_equal '00:50:56:B7:69:F6', parser.interfaces['local_area_connection_2'][:macaddress]
+    assert_equal '172.30.43.0', parser.interfaces['local_area_connection_2'][:network]
+  end
+
   private
 
   def get_parser(facts)


### PR DESCRIPTION
There's a JSON facts file in the bug report, which you can upload to /api/v2/hosts/facts if you'd like to verify it works.
