### PR TITLE
fixes #6332 - skip taxonomy queries when features are disabled

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -27,8 +27,8 @@ module Taxonomix
     # default inner_method includes children (subtree_ids)
     def with_taxonomy_scope(loc = Location.current, org = Organization.current, inner_method = :subtree_ids)
       self.which_ancestry_method = inner_method
-      self.which_location        = Location.expand(loc)
-      self.which_organization    = Organization.expand(org)
+      self.which_location        = Location.expand(loc) if SETTINGS[:locations_enabled]
+      self.which_organization    = Organization.expand(org) if SETTINGS[:organizations_enabled]
       scope =  block_given? ? yield : where('1=1')
       scope = scope.where(:id => taxable_ids) if taxable_ids
       scope.readonly(false)

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -110,8 +110,10 @@ class Filter < ActiveRecord::Base
   end
 
   def search_condition
-    searches = [self.search, self.taxonomy_search].compact
-    searches = searches.map { |s| parenthesize(s) } if searches.size > 1
+    searches = [self.search]
+    searches << self.taxonomy_search if Taxonomy.enabled_taxonomies.any?
+    searches.compact!
+    searches.map! { |s| parenthesize(s) } if searches.size > 1
     searches.join(' and ')
   end
 

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -37,8 +37,8 @@ module Host
     validate :uniq_interfaces_identifiers
 
     default_scope lambda {
-      org = Organization.expand(Organization.current)
-      loc = Location.expand(Location.current)
+      org = Organization.expand(Organization.current) if SETTINGS[:organizations_enabled]
+      loc = Location.expand(Location.current) if SETTINGS[:locations_enabled]
       conditions = {}
       conditions[:organization_id] = Array(org).map { |o| o.subtree_ids }.flatten.uniq if org.present?
       conditions[:location_id] = Array(loc).map { |l| l.subtree_ids }.flatten.uniq if loc.present?


### PR DESCRIPTION
Most obvious when in non-admin mode, it should remove lots of SQL queries and conditionals on the taxonomy tables, though they're mostly cached after the first.
