### PR TITLE
fixes #10695 - don't seed initial taxonomies if there are any already

### DIFF
--- a/db/seeds.d/05-taxonomies.rb
+++ b/db/seeds.d/05-taxonomies.rb
@@ -1,5 +1,5 @@
 # Create an initial organization if specified
-if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION']
+if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION'] && !Organization.any?
   Organization.without_auditing do
     User.current = User.anonymous_admin
     Organization.find_or_create_by_name!(:name => ENV['SEED_ORGANIZATION'])
@@ -8,7 +8,7 @@ if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION']
 end
 
 # Create an initial location if specified
-if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION']
+if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION'] && !Location.any?
   Location.without_auditing do
     User.current = User.anonymous_admin
     Location.find_or_create_by_name!(:name => ENV['SEED_LOCATION'])

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -134,27 +134,35 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "seed organization when environment SEED_ORGANIZATION specified" do
+    Organization.stubs(:any?).returns(false)
     with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed
     end
     assert Organization.find_by_name('seed_test')
+  end
 
-    with_env('SEED_ORGANIZATION' => 'seed_test2') do
+  test "don't seed organization when an org already exists" do
+    Organization.stubs(:any?).returns(true)
+    with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed
     end
-    assert Organization.find_by_name('seed_test2')
+    refute Organization.find_by_name('seed_test')
   end
 
   test "seed location when environment SEED_LOCATION specified" do
+    Location.stubs(:any?).returns(false)
     with_env('SEED_LOCATION' => 'seed_test') do
       seed
     end
     assert Location.find_by_name('seed_test')
+  end
 
-    with_env('SEED_LOCATION' => 'seed_test_a') do
+  test "don't seed location when a location already exists" do
+    Location.stubs(:any?).returns(true)
+    with_env('SEED_LOCATION' => 'seed_test') do
       seed
     end
-    assert Location.find_by_name('seed_test_a')
+    refute Location.find_by_name('seed_test')
   end
 
   test "all access permissions are created by permissions seed" do


### PR DESCRIPTION
Initial taxonomies shouldn't get seeded if there are any already.  Early Katello 2.0 users end up with 2 sets of default orgs, as they were created differently back then.
