### PR TITLE
Fixes #10701 - foreman-debug config file support

### DIFF
--- a/config/foreman-debug.conf
+++ b/config/foreman-debug.conf
@@ -1,0 +1,37 @@
+# Configuration file for foreman-debug utility
+
+# Directory to place the tarball in (string)
+#DIR=
+
+# Skip generic info (0 or 1)
+#NOGENERIC=0
+
+# Do not create tarballs (0 or 1)
+#NOTAR=0
+
+# Maximum lines to keep for files (integer)
+#MAXLINES=8000
+
+# Compress program to pipe the tarball through (string)
+#COMPRESS=
+
+# Print passwords which are filtered out on stdout (0 or 1)
+#PRINTPASS=0
+
+# Quiet mode (0 or 1)
+#QUIET=0
+
+# Verbose mode (0 or 1)
+#VERBOSE=0
+
+# Debug mode (0 or 1)
+#DEBUG=0
+
+# Upload tarball after each run (0 or 1)
+#UPLOAD=0
+
+# Permanently disable upload feature (0 or 1)
+#UPLOAD_DISABLED=0
+
+# Tokens that are fileted out (shell array)
+#FILTER_WORDS=(pass password token key)

--- a/man/foreman-debug.8.asciidoc
+++ b/man/foreman-debug.8.asciidoc
@@ -47,8 +47,32 @@ The following options are available:
   -p      Additionally print all passwords which are being filtered
   -q      Quiet mode
   -v      Verbose mode
+  -u      Upload tarball
   -h      Shows this message
 
+CONFIGURATION
+-------------
+
+Additional configuration can be provided via configuration file that must be
+stored as /etc/foreman/foreman-debug.conf. The file has shell syntax and the
+following environmental variables can be defined:
+
+ - DIR: Directory to place the tarball in (string)
+ - NOGENERIC:  Skip generic info (0 or 1)
+ - NOTAR:  Do not create tarballs (0 or 1)
+ - MAXLINES: Maximum lines to keep for files (integer)
+ - COMPRESS: Compress program to pipe the tarball through (string)
+ - PRINTPASS: Print passwords which are filtered out on stdout (0 or 1)
+ - QUIET: Quiet mode (0 or 1)
+ - VERBOSE: Verbose mode (0 or 1)
+ - DEBUG: Debug mode (0 or 1)
+ - UPLOAD: Upload tarbal after each run (0 or 1)
+ - UPLOAD_DISABLED: Permanently disable upload feature (0 or 1)
+ - FILTER_WORDS: Tokens that are fileted out (shell array)
+
+Most of the configured options are default values and can be overriden by
+command line options, others are unique and can only be set via the
+configuraiton file.
 
 SEE ALSO
 --------

--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -5,6 +5,7 @@ export LC_ALL=C
 export SCLNAME=ruby193
 
 usage() {
+[[ $UPLOAD_DISABLED -ne 0 ]] && UPLOAD_INFO=" (feature disabled by configuration)"
 cat <<USAGE
 $0 - configuration and log data collector
 
@@ -13,10 +14,6 @@ USAGE: $0 [options]
 Collects configuration and log data for Foreman, Smart Proxies, backend
 services and system information while removing security information like
 passwords, tokens and keys.
-
-You may want to upload the tarball (with -u) to our public server via rsync.
-This is a write-only directory (readable only by Foreman core developers)
-Please note that the rsync transmission is UNENCRYPTED.
 
 This program can be used on Foreman instances, Smart Proxy instances or
 backend services separately.
@@ -30,10 +27,16 @@ OPTIONS:
   -p      Additionally print password patterns being filtered out
   -q      Quiet mode
   -v      Verbose mode
-  -u      Upload tarball (default: false)
+  -u      Upload tarball$UPLOAD_INFO
   -h      Shows this message
 
 USAGE
+[[ $UPLOAD_DISABLED -eq 0 ]] && cat <<UPLOADUSAGE
+You may want to upload the tarball (with -u) to our public server via rsync.
+This is a write-only directory (readable only by Foreman core developers)
+Please note that the rsync transmission is UNENCRYPTED.
+
+UPLOADUSAGE
 }
 
 # filter for patterns like password=XYZ or secret: abc!@#$123
@@ -89,11 +92,7 @@ add_files() {
   done
 }
 
-# when running via sosreport close STDIN - http://projects.theforeman.org/issues/4200
-if ps -p $PPID | grep -q sosreport; then
-  exec 0</dev/null
-fi
-
+# default values
 DIR=""
 NOGENERIC=0
 NOTAR=0
@@ -104,6 +103,7 @@ QUIET=0
 VERBOSE=0
 DEBUG=0
 UPLOAD=0
+UPLOAD_DISABLED=0
 
 if type -p xz >/dev/null; then
   COMPRESS="xz -9"
@@ -118,6 +118,10 @@ else
   COMPRESS="cat"
   EXTENSION=""
 fi
+
+# read optional configuration file with user-defined defaults
+CONF_FILE=/usr/share/foreman/config/foreman-debug.conf
+test -f $CONF_FILE && source $CONF_FILE
 
 while getopts "d:gam:j:uqpvhx" opt; do
   case $opt in
@@ -301,12 +305,12 @@ else
 fi
 
 # upload if -u was passed in
-if [ $UPLOAD -eq 1 ]; then
+if [ $UPLOAD_DISABLED -eq 0 -a $UPLOAD -eq 1 ]; then
   qprintf "Uploading...\n"
   rsync $TARBALL rsync://theforeman.org/debug-incoming
   qprintf "The tarball has been uploaded, please contact us on our mailing list or IRC\n"
-  qprintf "referencing the following URL:\n"
-  qprintf "    http://debugs.theforeman.org/$(basename $TARBALL)\n"
+  qprintf "referencing the following URL:\n\n"
+  qprintf "    http://debugs.theforeman.org/$(basename $TARBALL)\n\n"
 else
-  qprintf "To upload a tarball to our secure site, please use the -u option.\n"
+  [[ $UPLOAD_DISABLED -eq 0 ]] && qprintf "To upload a tarball to our secure site, please use the -u option.\n"
 fi


### PR DESCRIPTION
This patch adds configuration file reading for foreman-debug. It allows to
redefine default values for all configuration options plus to configure some
advanced stuff like words to filter out or to temporarily disable upload
feature (e.g. for security policy reasons).
