### PR TITLE
Fixes #10072: Support for user-data during image-based provisioning with libvirt (used for creating of Atomic libvirt VM)

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -73,9 +73,13 @@ module Orchestration::Compute
   def setCompute
     logger.info "Adding Compute instance for #{name}"
     add_interfaces_to_compute_attrs
-    self.vm = compute_resource.create_vm compute_attributes.merge(:name => Setting[:use_shortname_for_vms] ? shortname : name)
+    self.vm = compute_resource.create_vm compute_attributes.merge(:name => vm_name)
   rescue => e
     failure _("Failed to create a compute %{compute_resource} instance %{name}: %{message}\n ") % { :compute_resource => compute_resource, :name => name, :message => e.message }, e.backtrace
+  end
+
+  def vm_name
+    Setting[:use_shortname_for_vms] ? shortname : name
   end
 
   def setUserData
@@ -95,6 +99,7 @@ module Orchestration::Compute
 
     self.compute_attributes[:user_data] = unattended_render(template.template)
     self.handle_ca
+
     return false if errors.any?
     logger.info "Revoked old certificates and enabled autosign for UserData"
   end

--- a/app/views/images/form/_libvirt.html.erb
+++ b/app/views/images/form/_libvirt.html.erb
@@ -1,3 +1,4 @@
 <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
 <%= password_f f, :password, :help_inline => _("Password to authenticate with - used for SSH finish step.") %>
+<%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
 <%= image_field(f, :label => _("Image path"), :help_inline => _("Full path to backing image used to create new volumes.")) %>

--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '~> 0.0'
-  gem 'ruby-libvirt', '~> 0.4', :require => 'libvirt'
+  gem 'fog-libvirt', '~> 0.0.2'
+  gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
Depends on https://github.com/fog/fog-libvirt/pull/2

Open questions:
- I updated `app/views/unattended/cloudinit/userdata_cloudinit.erb` to create a default user, as modifying built-in user (`centos` and `fedora` for atomic centos and atomic fedora respectively) would expose their password in clear-text. Should this change stay in this template, or go into a completely new template?
- We do not require password for image-based provisioning. I feel that we should if user_data is available.
