### PR TITLE
Fixes #10713 - keep more information in the backtrace in production environment

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,7 +18,7 @@ module Api
     after_filter :log_response_body
 
     rescue_from StandardError, :with => lambda { |error|
-      logger.error "#{error.message} (#{error.class})\n#{error.backtrace.join("\n")}"
+      Foreman::Logging.exception("Action failed", error)
       render_error 'standard_error', :status => :internal_server_error, :locals => { :exception => error }
     }
 

--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -8,8 +8,7 @@ class ComputeResourcesVmsController < ApplicationController
       format.json { render :json => @vms }
     end
   rescue => e
-    logger.warn "Error has occurred while listing VMs on #{@compute_resource}: #{e}"
-    logger.debug e.backtrace.join("\n")
+    Foreman::Logging.exception("Error has occurred while listing VMs on #{@compute_resource}", e)
     render :partial => 'compute_resources_vms/error', :locals => { :errors => e.message }
   end
 

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -69,6 +69,7 @@ module Api::ImportPuppetclassesCommonController
       if e.message =~ /puppet feature/i
         msg = _('No proxy found to import classes from, ensure that the smart proxy has the Puppet feature enabled.')
       else
+        Foreman::Logging.exception("Error while importing Puppet classes", e)
         msg = e.message
       end
       render_message(msg, :status => :internal_server_error) and return false
@@ -114,8 +115,7 @@ module Api::ImportPuppetclassesCommonController
   def find_optional_environment
     @environment = Environment.authorized(:view_environments).find(@env_id)
   rescue ActiveRecord::RecordNotFound => e
-    logger.debug e.message
-    logger.debug e.backtrace.join("\n")
+    Foreman::Logging.exception("Resource not found", e, :level => :debug)
     nil
   end
 end

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -8,7 +8,7 @@ module Foreman::Controller::Session
       expire_session
     end
   rescue => e
-    logger.warn "failed to determine if user sessions needs to be expired, expiring anyway: #{e}"
+    Foreman::Logging.exception("failed to determine if user sessions needs to be expired, expiring anyway", e)
     expire_session
   end
 

--- a/app/controllers/lookup_values_controller.rb
+++ b/app/controllers/lookup_values_controller.rb
@@ -8,6 +8,7 @@ class LookupValuesController < ApplicationController
       values = LookupValue.search_for(params[:search], :order => params[:order])
     rescue => e
       error e.to_s
+      Foreman::Logging.exception("Failed loading lookup values", e)
       values = LookupValue.search_for ""
     end
     @lookup_values = values.paginate(:page => params[:page])

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -142,7 +142,7 @@ class UnattendedController < ApplicationController
           mac_list << request.env[header].split[1].strip.downcase if header =~ /^HTTP_X_RHN_PROVISIONING_MAC_/
         end
       rescue => e
-        logger.info "unknown RHN_PROVISIONING header #{e}"
+        Foreman::Logging.exception("unknown RHN_PROVISIONING header", e)
         mac_list = []
       end
     end
@@ -294,9 +294,10 @@ class UnattendedController < ApplicationController
 
     begin
       render :inline => "<%= unattended_render(@unsafe_template, @template_name).html_safe %>" and return
-    rescue => exc
+    rescue => error
       msg = _("There was an error rendering the %s template: ") % (@template_name)
-      render :text => msg + exc.message, :status => :internal_server_error and return
+      Foreman::Logging.exception(msg, error)
+      render :text => msg + error.message, :status => :internal_server_error and return
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,8 +19,7 @@ module ApplicationHelper
             id = 'not_defined'
           end
         rescue => e
-          logger.error e.message
-          logger.error e.backtrace.join("\n")
+          Foreman::Logging.exception("Failed generating link using #{ args.inspect }", e)
           id = 'not_parseable'
         end
         html_options.merge!(:'data-id' => "aid_#{id}")

--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -53,7 +53,8 @@ module ComputeResourcesHelper
   rescue Foreman::FingerprintException => e
     compute.errors[:pubkey_hash] = e
     []
-  rescue
+  rescue => e
+    Foreman::Logging.exception("Failed listing datacenters", e)
     []
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -24,7 +24,7 @@ class ApplicationMailer < ActionMailer::Base
         begin
           email.deliver
         rescue => e
-          Rails.logger.info("Unable to send email notification: #{e}")
+          Foreman::Logging.exception("Unable to send email notification", e)
         end
       end
     end

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -70,7 +70,7 @@ class AuthSource < ActiveRecord::Base
           attrs[:auth_source_id] = source.id
         end
       rescue => e
-        logger.error "Error during authentication against '#{source}': #{e.message}"
+        Foreman::Logging.exception("Error during authentication against '#{source}'", e)
         attrs = nil
       end
       return attrs if attrs

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -181,9 +181,9 @@ class AuthSourceLdap < AuthSource
   def validate_ldap_filter
     Net::LDAP::Filter.construct(ldap_filter)
   rescue Net::LDAP::LdapError, Net::LDAP::FilterSyntaxInvalidError => e
-    logger.error e.message
-    logger.error e.backtrace.join("\n")
-    errors.add(:ldap_filter, _("invalid LDAP filter syntax"))
+    message = _("invalid LDAP filter syntax")
+    Foreman::Logging.exception(message, e)
+    errors.add(:ldap_filter, message)
   end
 
   def use_user_login_for_service?

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -48,7 +48,7 @@ module Foreman::Model
       args[:associate_public_ip] = subnet_implies_is_vpc?(args) && args[:managed_ip] == 'public'
       super(args)
     rescue Fog::Errors::Error => e
-      logger.error "Unhandled EC2 error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      Foreman::Logging.exception("Unhandled EC2 error", e)
       raise e
     end
 
@@ -122,9 +122,7 @@ module Foreman::Model
       key = client.key_pairs.create :name => "foreman-#{id}#{Foreman.uuid}"
       KeyPair.create! :name => key.name, :compute_resource_id => self.id, :secret => key.private_key
     rescue => e
-      logger.warn "failed to generate key pair"
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
+      Foreman::Logging.exception("Failed to generate key pair", e)
       destroy_key_pair
       raise
     end

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -70,7 +70,7 @@ module Foreman::Model
       ssh      = { :username => username, :public_key => key_pair.public }
       super(args.merge(ssh))
     rescue Fog::Errors::Error => e
-      logger.error "Unhandled GCE error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      Foreman::Logging.exception("Unhandled GCE error", e)
       raise e
     end
 
@@ -112,8 +112,7 @@ module Foreman::Model
         errors.add(:key_path, _('Unable to access key'))
       end
     rescue => e
-      logger.warn("failed to access gce key path: #{e}")
-      logger.debug(e.backtrace)
+      Foreman::Logging.exception("Failed to access gce key path", e)
       errors.add(:key_path, e.message.to_s)
     end
 

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -28,8 +28,7 @@ module Foreman::Model
     def find_vm_by_uuid(uuid)
       client.servers.get(uuid)
     rescue ::Libvirt::RetrieveError => e
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
+      Foreman::Logging.exception("Failed retrieving libvirt vm by uuid #{ uuid }", e)
       raise ActiveRecord::RecordNotFound
     end
 
@@ -121,7 +120,7 @@ module Foreman::Model
       create_volumes :prefix => vm.name, :volumes => vm.volumes, :backing_id => args[:image_id]
       vm.save
     rescue Fog::Errors::Error => e
-      logger.error "Unhandled LibVirt error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      Foreman::Logging.exception("Unhandled Libvirt error", e)
       destroy_vm vm.id if vm
       raise e
     end

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -159,9 +159,7 @@ module Foreman::Model
       key = client.key_pairs.create :name => "foreman-#{id}#{Foreman.uuid}"
       KeyPair.create! :name => key.name, :compute_resource_id => self.id, :secret => key.private_key
     rescue => e
-      logger.warn "failed to generate key pair"
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
+      Foreman::Logging.exception("Failed to generate key pair", e)
       destroy_key_pair
       raise
     end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -240,6 +240,7 @@ module Foreman::Model
     def bootstrap(args)
       client.servers.bootstrap vm_instance_defaults.merge(args.to_hash)
     rescue Fog::Errors::Error => e
+      Foreman::Logging.exception("Failed to bootstrap vm", e)
       errors.add(:base, e.to_s)
       false
     end

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -24,7 +24,7 @@ module Foreman::Model
     def create_vm(args = { })
       super(args)
     rescue Fog::Errors::Error => e
-      logger.error "Unhandled Rackspace error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      Foreman::Logging.exception("Unhandled Rackspace error", e)
       raise e
     end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -326,7 +326,7 @@ module Foreman::Model
         vm.save
       end
     rescue Fog::Errors::Error => e
-      logger.error "Unhandled VMware error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
+      Foreman::Logging.exception("Unhandled VMware error", e)
       destroy_vm vm.id if vm
       raise e
     end

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -54,6 +54,5 @@ begin
 rescue LoadError
   Rails.logger.info "Fog is not installed - unable to manage compute resources"
 rescue => exception
-  Rails.logger.warn "Fog initialization failed - #{exception}"
-  Rails.logger.debug exception.backtrace.join("\n")
+  Foreman::Logging.exception("Fog initialization failed", exception)
 end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -75,7 +75,7 @@ module Orchestration::Compute
     add_interfaces_to_compute_attrs
     self.vm = compute_resource.create_vm compute_attributes.merge(:name => Setting[:use_shortname_for_vms] ? shortname : name)
   rescue => e
-    failure _("Failed to create a compute %{compute_resource} instance %{name}: %{message}\n ") % { :compute_resource => compute_resource, :name => name, :message => e.message }, e.backtrace
+    failure _("Failed to create a compute %{compute_resource} instance %{name}: %{message}\n ") % { :compute_resource => compute_resource, :name => name, :message => e.message }, e
   end
 
   def setUserData
@@ -107,7 +107,7 @@ module Orchestration::Compute
       respond_to?(:initialize_puppetca,true) && initialize_puppetca && delCertificate && delAutosign
     end
   rescue => e
-    failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e.backtrace
+    failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def setComputeDetails
@@ -149,7 +149,7 @@ module Orchestration::Compute
       end
     end
   rescue => e
-    failure _("Failed to get IP for %{name}: %{e}") % { :name => name, :e => e }, e.backtrace
+    failure _("Failed to get IP for %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def delComputeIP; end
@@ -158,35 +158,35 @@ module Orchestration::Compute
     logger.info "Removing Compute instance for #{name}"
     compute_resource.destroy_vm uuid
   rescue => e
-    failure _("Failed to destroy a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e.backtrace
+    failure _("Failed to destroy a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e
   end
 
   def setComputePowerUp
     logger.info "Powering up Compute instance for #{name}"
     compute_resource.start_vm uuid
   rescue => e
-    failure _("Failed to power up a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e.backtrace
+    failure _("Failed to power up a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e
   end
 
   def delComputePowerUp
     logger.info "Powering down Compute instance for #{name}"
     compute_resource.stop_vm uuid
   rescue => e
-    failure _("Failed to stop compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e.backtrace
+    failure _("Failed to stop compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e
   end
 
   def setComputeUpdate
     logger.info "Update Compute instance for #{name}"
     compute_resource.save_vm uuid, compute_attributes
   rescue => e
-    failure _("Failed to update a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e.backtrace
+    failure _("Failed to update a compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e
   end
 
   def delComputeUpdate
     logger.info "Undo Update Compute instance for #{name}"
     compute_resource.save_vm uuid, old.compute_attributes
   rescue => e
-    failure _("Failed to undo update compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e.backtrace
+    failure _("Failed to undo update compute %{compute_resource} instance %{name}: %{e}") % { :compute_resource => compute_resource, :name => name, :e => e }, e
   end
 
   private

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -52,7 +52,7 @@ module Orchestration::DHCP
 
     failure _("Unable to determine the host's boot server. The DHCP smart proxy failed to provide this information and this subnet is not provided with TFTP services.")
   rescue => e
-    failure _("failed to detect boot server: %s") % e
+    failure _("failed to detect boot server: %s") % e, e
   end
 
   private

--- a/app/models/concerns/orchestration/puppetca.rb
+++ b/app/models/concerns/orchestration/puppetca.rb
@@ -15,7 +15,7 @@ module Orchestration::Puppetca
     @puppetca = ProxyAPI::Puppetca.new :url => puppet_ca_proxy.url
     true
   rescue => e
-    failure _("Failed to initialize the PuppetCA proxy: %s") % e
+    failure _("Failed to initialize the PuppetCA proxy: %s") % e, e
   end
 
   # Removes the host's puppet certificate from the puppetmaster's CA

--- a/app/models/concerns/orchestration/realm.rb
+++ b/app/models/concerns/orchestration/realm.rb
@@ -14,7 +14,7 @@ module Orchestration::Realm
     return unless realm?
     @realm_api = ProxyAPI::Realm.new :url => realm.realm_proxy.url, :realm_name => realm.name
   rescue => e
-    failure _("Failed to initialize the realm proxy: %s") % e
+    failure _("Failed to initialize the realm proxy: %s") % e, e
   end
 
   # Removes the host from the realm
@@ -35,7 +35,7 @@ module Orchestration::Realm
     self.otp = result["randompassword"]
     result
   rescue => e
-    failure _("Failed to create %{name}'s realm entry: %{e}") % { :name => name, :e => e }
+    failure _("Failed to create %{name}'s realm entry: %{e}") % { :name => name, :e => e }, e
   end
 
   def update_realm

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -55,7 +55,7 @@ module Orchestration::SSHProvision
     self.client = Foreman::Provision::SSH.new provision_ip, image.username, { :template => template_file.path, :uuid => uuid }.merge(credentials)
 
   rescue => e
-    failure _("Failed to login via SSH to %{name}: %{e}") % { :name => name, :e => e }, e.backtrace
+    failure _("Failed to login via SSH to %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def delSSHWaitForResponse; end
@@ -72,7 +72,7 @@ module Orchestration::SSHProvision
       respond_to?(:initialize_puppetca,true) && initialize_puppetca && delCertificate && delAutosign
     end
   rescue => e
-    failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e.backtrace
+    failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def setSSHProvision
@@ -86,7 +86,7 @@ module Orchestration::SSHProvision
     end
 
   rescue => e
-    failure _("Failed to launch script on %{name}: %{e}") % { :name => name, :e => e }, e.backtrace
+    failure _("Failed to launch script on %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def delSSHProvision; end
@@ -98,8 +98,7 @@ module Orchestration::SSHProvision
     begin
       template = provisioning_template(:kind => "finish")
     rescue => e
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
+      Foreman::Logging.exception("Error while validating ssh provisioning", e)
       status = false
     end
     status = false if template.nil?

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -80,7 +80,7 @@ module Orchestration::TFTP
       end
     end
   rescue => e
-    failure _("Failed to generate %{template_kind} template: %{e}") % { :template_kind => host.operatingsystem.template_kind, :e => e }
+    failure _("Failed to generate %{template_kind} template: %{e}") % { :template_kind => host.operatingsystem.template_kind, :e => e }, e
   end
 
   def queue_tftp

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -64,9 +64,7 @@ class Filter < ActiveRecord::Base
   def self.get_resource_class(resource_type)
     resource_type.constantize
   rescue NameError => e
-    logger.error "unknown klass #{resource_type}, ignoring"
-    logger.error e.message
-    logger.error e.backtrace.join("\n")
+    Foreman::Logging.exception("unknown class #{resource_type}, ignoring", e)
     return nil
   end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -595,8 +595,7 @@ class Host::Managed < Host::Base
     ProxyAPI::Puppet.new({:url => puppet_proxy.url}).run fqdn
   rescue => e
     errors.add(:base, _("failed to execute puppetrun: %s") % e)
-    logger.warn "unable to execute puppet run: #{e}"
-    logger.debug e.backtrace.join("\n")
+    Foreman::Logging.exception("Unable to execute puppet run", e)
     false
   end
 

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -62,8 +62,7 @@ class LookupValue < ActiveRecord::Base
       end
       true
     rescue StandardError, SyntaxError => e
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
+      Foreman::Logging.exception("Error while parsing #{ lookup_key }", e)
       errors.add(:value, _("is invalid %s") % lookup_key.key_type)
       false
     end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -102,7 +102,7 @@ module Nic
 
     # log errors to host object since we can't read it later (even if host.destroy fails host.interfaces is
     # always set to [] so we lose interfaces errors)
-    def failure(msg, backtrace = nil, dest = :base)
+    def failure(msg, exception_or_backtrace = nil, dest = :base)
       result = super
       host.errors.add(dest, msg)
       result

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -97,7 +97,7 @@ class Foreman::Provision::SSH
       rescue Timeout::Error
         retry
       rescue => e
-        logger.debug "SSH error: #{e.message}\n " + e.backtrace.join("\n ")
+        Foreman::Logging.exception("SSH error", e)
       end
     end
   end

--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -37,7 +37,7 @@ module Menu
     def authorized?
       User.current.allowed_to?(url_hash.slice(:controller, :action, :id))
     rescue => error
-      Rails.logger.error "#{error.message} (#{error.class})\n#{error.backtrace.join("\n")}"
+      Foreman::Logging.exception("Error while evaluating permissions", error)
       false
     end
 

--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -9,8 +9,7 @@ module PowerManager
       rescue Timeout::Error
         raise Foreman::Exception.new(N_("Timeout has occurred while communicating with %s"), host.compute_resource)
       rescue => e
-        logger.warn "Error has occurred while communicating to #{host.compute_resource}: #{e}"
-        logger.debug e.backtrace
+        Foreman::Logging.exception("Error has occurred while communicating to #{host.compute_resource}", e)
         raise Foreman::Exception.new(N_("Error has occurred while communicating with %{cr}: %{e}"), { :cr => host.compute_resource, :e => e })
       end
     end

--- a/app/views/common/500.html.erb
+++ b/app/views/common/500.html.erb
@@ -12,6 +12,6 @@
 <div id="backtrace" class="alert alert-block alert-danger base in fade hide">
   <em><%= exception.class %></em><br>
   <strong><%= exception.message %></strong><br>
-  <%= Rails.backtrace_cleaner.clean(exception.backtrace).join("<br>").html_safe %>
+  <%= exception.backtrace.join("<br>").html_safe %>
 </div>
 <p><%= link_to _("Back"), main_app.root_path %></p>

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,6 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+
+# keep the lines from plugins in the backtrace
+Rails.backtrace_cleaner.remove_silencers!
+Rails.backtrace_cleaner.add_silencer do |line|
+  line !~ Rails::BacktraceCleaner::APP_DIRS_PATTERN &&
+      !(Foreman::Plugin.all.any? { |plugin| line.include?(plugin.name) })
+end
+
 Rails.backtrace_cleaner.add_silencer { |line| line =~ /passenger/ }
 
 # You can also remove all the silencers if you're trying do debug a problem that might steem from framework code.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,8 +55,7 @@ Foreman::Plugin.registered_plugins.each do |name, plugin|
     engine = (name.to_s.tr('-', '_').camelize + '::Engine').constantize
     foreman_seeds += Dir.glob(engine.root + 'db/seeds.d/*.rb')
   rescue NameError => e
-    Rails.logger.error e.message
-    Rails.logger.error e.backtrace.join("\n")
+    Foreman::Logging.exception("Failed to register plugin #{ name }", e)
   end
 end
 

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -52,6 +52,23 @@ module Foreman
       fail "Trying to use logger #{name} which has not been configured."
     end
 
+    # standard way for logging exceptions to get the most data to
+    # the log.
+    # The behehaviour can be influenced by this options:
+    #   * :logger - the name of the logger to put the exception in ('app' by default)
+    #   * :level - the logging level (:warn by default)
+    def exception(context_message, exception, options = {})
+      options.assert_valid_keys :level, :logger
+      logger_name = options[:logger] || 'app'
+      level       = options[:level] || :warn
+      unless ::Logging::LEVELS.keys.include?(level.to_s)
+        raise "Unexpected log level #{level}, expected one of #{ ::Logging::LEVELS.keys }"
+      end
+      self.logger(logger_name).public_send(level) do
+        ([context_message, "#{exception.class}: #{exception.message}"] + exception.backtrace).join("\n")
+      end
+    end
+
     private
 
     def load_config(environment, overrides = {})

--- a/lib/proxy_api/template.rb
+++ b/lib/proxy_api/template.rb
@@ -13,10 +13,7 @@ module ProxyAPI
     rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
       EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
       Net::ProtocolError, RestClient::ResourceNotFound => e
-      logger.error("Failed to obtain template server from smart-proxy #{@url}")
-      logger.error e.message
-      logger.error e.backtrace.join("\n")
-
+      Foreman::Logging.exception("Failed to obtain template server from smart-proxy #{@url}", e)
       nil
     end
   end


### PR DESCRIPTION
1. in the full trace in UI, keep the backtrace from plugins, otherwise, the
   errors from the plugin pages are without useful inforamtion
2. in the production.log, log the backtrace at error level: asking the user to
   switch to the debug first is not very user friendly: we should try to get as much
   needed info as possible from the beginning.
