### PR TITLE
Fixes #10715 - api build_pxe_default returns non-JSON message

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -110,6 +110,11 @@ module Api
       end
     end
 
+    def render_message(msg, render_options = {})
+      render_options[:json] = { :message => msg }
+      render render_options
+    end
+
     def log_resource_errors(resource)
       logger.error "Unprocessable entity #{resource.class.name} (id: #{resource.try(:id) || "new"}):\n  #{resource.errors.full_messages.join("\n  ")}\n"
     end

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -81,7 +81,7 @@ module Api
 
       def build_pxe_default
         status, msg = ConfigTemplate.authorized(:deploy_templates).build_pxe_default(self)
-        render :json => msg, :status => status
+        render_message(msg, :status => status)
       end
 
       def_param_group :config_template_clone do

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -64,7 +64,7 @@ module Api
 
       def destroy
         if @hostgroup.has_children?
-          render :json => {'message'=> _("Cannot delete group %{current} because it has nested host groups.") % { :current => @hostgroup.title } }, :status => :conflict
+          render_message(_("Cannot delete group %{current} because it has nested host groups.") % { :current => @hostgroup.title }, :status => :conflict)
         else
           process_response @hostgroup.destroy
         end

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -177,7 +177,7 @@ Return value may either be one of the following:
         @host, state = detect_host_type.import_host_and_facts params[:name], params[:facts], params[:certname], detected_proxy.try(:id)
         process_response state
       rescue ::Foreman::Exception => e
-        render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
+        render_message(e.to_s, :status => :unprocessable_entity)
       end
 
       private

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -78,7 +78,7 @@ module Api
         arch   = Architecture.authorized(:view_architectures).find(params[:architecture])
         render :json => @operatingsystem.pxe_files(medium, arch)
       rescue => e
-        render :json => e.to_s, :status => :unprocessable_entity
+        render_message(e.to_s, :status => :unprocessable_entity)
       end
 
       private

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -40,7 +40,7 @@ module Api
         @report = Report.import(params[:report], detected_proxy.try(:id))
         process_response @report.errors.empty?
       rescue ::Foreman::Exception => e
-        render :json => {'message'=>e.to_s}, :status => :unprocessable_entity
+        render_message(e.to_s, :status => :unprocessable_entity)
       end
 
       api :DELETE, "/reports/:id/", N_("Delete a report")

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -71,7 +71,7 @@ module Api::ImportPuppetclassesCommonController
       else
         msg = e.message
       end
-      render :json => {:message => msg}, :status => :internal_server_error and return false
+      render_message(msg, :status => :internal_server_error) and return false
     end
 
     # PuppetClassImporter expects [kind][env] to be in json format
@@ -89,7 +89,7 @@ module Api::ImportPuppetclassesCommonController
       OpenStruct.new(:name => name)
     end
 
-    render :json => {:message => _("No changes to your environments detected")} and return false unless @environments.any?
+    render_message(_("No changes to your environments detected")) and return false unless @environments.any?
     @environments.any?
   end
 

--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -62,7 +62,10 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     ProxyAPI::TFTP.any_instance.stubs(:create_default).returns(true)
     ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
     get :build_pxe_default
+    response_body = ActiveSupport::JSON.decode(@response.body)
     assert_response 200
+    assert response_body.is_a?(Hash)
+    refute response_body['message'].nil?
   end
 
   test "should add audit comment" do


### PR DESCRIPTION
The fix adds a new method `render_message` for responding with a status
text.
