### PR TITLE
fixes #10720 - Adds API to get host vm attributes

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -660,6 +660,10 @@ class Host::Managed < Host::Base
     bmc_nic.try(:name)
   end
 
+  def vm_compute_attributes
+    compute_resource ? compute_resource.vm_compute_attributes_for(uuid) : nil
+  end
+
   def host_status
     if build
       N_("Pending Installation")

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -319,7 +319,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :dashboard => [:OutOfSync, :errors, :active],
                                     :unattended => [:template, :provision],
                                      :"api/v1/hosts" => [:index, :show, :status],
-                                     :"api/v2/hosts" => [:index, :show, :status],
+                                     :"api/v2/hosts" => [:index, :show, :status, :vm_compute_attributes],
                                      :"api/v2/interfaces" => [:index, :show],
                                      :locations =>  [:mismatches],
                                      :organizations =>  [:mismatches]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -268,6 +268,7 @@ Foreman::Application.routes.draw do
         end
         resources :hosts, :except => [:new, :edit] do
           get :status, :on => :member
+          get :vm_compute_attributes, :on => :member
           put :puppetrun, :on => :member
           put :disassociate, :on => :member
           put :boot, :on => :member

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -252,6 +252,16 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "should show hosts vm attributes" do
+    host = FactoryGirl.create(:host, :compute_resource => compute_resources(:one))
+    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns( :cpus => 4 )
+    get :vm_compute_attributes, { :id => host.to_param }
+    assert_response :success
+    data = JSON.parse(@response.body)
+    assert_equal data, "compute_attributes" => { "cpus" => 4 }
+    ComputeResource.any_instance.unstub(:vm_compute_attributes_for)
+  end
+
   def set_remote_user_to(user)
     @request.env['REMOTE_USER'] = user.login
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -147,6 +147,17 @@ class HostTest < ActiveSupport::TestCase
     host.update_attributes!(:mac => "52:54:00:dd:ee:ff")
   end
 
+  test "can fetch vm compute attributes" do
+    host = FactoryGirl.create(:host, :compute_resource => compute_resources(:one))
+    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:cpus => 4})
+    assert_equal host.vm_compute_attributes, :cpus => 4
+  end
+
+  test "fetches nil vm compute attributes for bare metal" do
+    host = FactoryGirl.create(:host)
+    assert_equal host.vm_compute_attributes, nil
+  end
+
   context "when unattended is false" do
     def setup
       SETTINGS[:unattended] = false


### PR DESCRIPTION
This exposes an API to fetch a host's vm_compute_attributes, such as vmware cpus and memory. It lives at a separate endpoint because it involves a fetch for data from the compute resource, and may have different performance characteristics than the database.
