### PR TITLE
Fixes #10635 - Formalize deprecation warning

### DIFF
--- a/app/controllers/api/v1/config_templates_controller.rb
+++ b/app/controllers/api/v1/config_templates_controller.rb
@@ -95,7 +95,7 @@ module Api
       end
 
       def deprecated
-        ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+        Foreman::Deprecation.api_deprecation_warning("Config templates were renamed to provisioning templates")
       end
     end
   end

--- a/app/controllers/api/v1/operatingsystems_controller.rb
+++ b/app/controllers/api/v1/operatingsystems_controller.rb
@@ -88,7 +88,7 @@ module Api
       def rename_config_templates
         if params[:operatingsystem] && params[:operatingsystem][:config_template_ids].present?
           params[:operatingsystem][:provisioning_template_ids] = params[:operatingsystem].delete(:config_template_ids)
-          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+          Foreman::Deprecation.api_deprecation_warning('Config templates were renamed to provisioning templates')
         end
       end
     end

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -82,7 +82,7 @@ module Api
       api :POST, "/config_templates/build_pxe_default", N_("Update the default PXE menu on all configured TFTP servers")
 
       def build_pxe_default
-        ::ActiveSupport::Deprecation.warn('GET method for build pxe default is deprecated. Please use POST instead.') if request.method == "GET"
+        Foreman::Deprecation.api_deprecation_warning("GET method for build pxe default is deprecated. Please use POST instead") if request.method == "GET"
         status, msg = ProvisioningTemplate.authorized(:deploy_provisioning_templates).build_pxe_default(self)
         render_message(msg, :status => status)
       end
@@ -115,7 +115,7 @@ module Api
       end
 
       def deprecated
-        ::ActiveSupport::Deprecation.warn('The resources /config_templates were moved to /provisioning_templates. Please use the new path instead.')
+        Foreman::Deprecation.api_deprecation_warning("The resources /config_templates were moved to /provisioning_templates. Please use the new path instead")
       end
 
       def resource_class

--- a/app/controllers/api/v2/os_default_templates_controller.rb
+++ b/app/controllers/api/v2/os_default_templates_controller.rb
@@ -65,7 +65,7 @@ module Api
       def rename_config_template
         if !params[:config_template_id].nil?
           params[:provisioning_template_id] = params.delete(:config_template_id)
-          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+          Foreman::Deprecation.api_deprecation_warning("Config templates were renamed to provisioning templates")
         end
       end
 

--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -79,7 +79,7 @@ module Api
       def rename_config_template
         if !params[:config_template_id].nil?
           params[:provisioning_template_id] = params.delete(:config_template_id)
-          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+          Foreman::Deprecation.api_deprecation_warning("Config templates were renamed to provisioning templates")
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,7 +96,7 @@ class ApplicationController < ActionController::Base
   def api_deprecation_error(exception = nil)
     if request.format.try(:json?) && !request.env['REQUEST_URI'].match(/\/api\//i)
       msg = "/api/ prefix must now be used to access API URLs, e.g. #{request.env['HTTP_HOST']}/api#{request.env['REQUEST_URI']}"
-      logger.error "DEPRECATION: #{msg}."
+      Foreman::Deprecation.deprecation_warning("1.11", msg)
       Foreman::Logging.exception(msg, exception, :level => :debug)
       render :json => {:message => msg}, :status => :bad_request
     else

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -81,7 +81,7 @@ module Api::V2::TaxonomiesController
   def rename_config_template
     if params[taxonomy_single] && params[taxonomy_single][:config_template_ids].present?
       params[taxonomy_single][:provisioning_template_ids] = params[taxonomy_single].delete(:config_template_ids)
-      ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+      Foreman::Deprecation.deprecation_warning('1,11', 'Config templates were renamed to provisioning templates')
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,7 +15,7 @@ class ApplicationMailer < ActionMailer::Base
 
   class GroupMail
     def initialize(emails)
-      ActiveSupport::Deprecation.warn 'GroupMail will be removed as mailers should not generate multiple messages, use MailNotification#deliver'
+      Foreman::Deprecation.deprecation_warning("1.11", "GroupMail will be removed as mailers should not generate multiple messages, use MailNotification.deliver")
       @emails = emails
     end
 
@@ -31,8 +31,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def group_mail(users, options)
-    ActiveSupport::Deprecation.warn '#group_mail is replaced by MailNotification#deliver with :users in the options hash, this does not function properly'
-
+    Foreman::Deprecation.deprecation_warning("1.11", "group_mail is replaced by MailNotification.deliver with :users in the options hash")
     mails = users.map do |user|
       @user = user
       set_locale_for user

--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -39,7 +39,7 @@ module Orchestration
       else
         exception = StandardError.new(msg)
         exception.set_backtrace(exception_or_backtrace)
-        logger.warn("DEPRECATION: passing backtrace to failure method is deprecated, pass the exception instead")
+        Foreman::Deprecation.deprecation_warning("1.11", "Passing backtrace to failure method is deprecated, pass the exception instead")
       end
       Foreman::Logging.exception(msg, exception)
     else

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -277,12 +277,12 @@ module Host
     end
 
     def self.find_by_ip(ip)
-      logger.warn 'DEPRECATION WARNING: Host#find_by_ip has been deprecated, you should search for primary interfaces'
+      Foreman::Deprecation.deprecation_warning("1.11", "Host#find_by_ip has been deprecated, you should search for primary interfaces")
       Nic::Base.primary.find_by_ip(ip).try(:host)
     end
 
     def self.find_by_mac(mac)
-      logger.warn 'DEPRECATION WARNING: Host#find_by_mac has been deprecated, you should search for provision interfaces'
+      Foreman::Deprecation.deprecation_warning("1.11", "Host#find_by_mac has been deprecated, you should search for provision interfaces")
       Nic::Base.provision.find_by_mac(mac).try(:host)
     end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -288,7 +288,7 @@ class Host::Managed < Host::Base
   end
 
   def configTemplate(args = {})
-    ::ActiveSupport::Deprecation.warn 'configTemplate was renamed to provisioning_template'
+    Foreman::Deprecation.deprecation_warning("1.11", 'configTemplate was renamed to provisioning_template')
     self.provisioning_template(args)
   end
 

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -9,7 +9,7 @@ module Nic
     register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
 
     def initialize(*args)
-      ActiveSupport::Deprecation.warn 'Nic::Bootable is replaced by Nic::Managed with provision: true, this class will be removed'
+      Foreman::Deprecation.deprecation_warning("1.11", "Use Nic::Managed setting provision: true")
       super(*args)
     end
 

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -14,7 +14,7 @@ class FactParser
   end
 
   def self.register_fact_importer(key, klass)
-    ActiveSupport::Deprecation.warn('FactParser#register_fact_importer was renamed to FactParser#register_fact_parser, please update your code')
+    Foreman::Deprecation.deprecation_warning("1.11", "Use factParser.register_fact_parser instead")
     register_fact_parser(key, klass)
   end
 

--- a/app/services/foreman/deprecation.rb
+++ b/app/services/foreman/deprecation.rb
@@ -1,0 +1,13 @@
+module Foreman
+  class Deprecation
+    #deadline_version - is the version the deprecation is going to be deleted, the format must be a major release e.g "1.8"
+    def self.deprecation_warning(foreman_version_deadline, info)
+      raise Foreman::Exception.new(N_("Invalid version format, please enter in x.y (only major version).")) unless foreman_version_deadline.to_s.match(/\A\d[.]\d+\z/)
+      ActiveSupport::Deprecation.warn("You are using a deprecated behavior, it will be removed in version #{foreman_version_deadline}, #{info}", caller(2))
+    end
+
+    def self.api_deprecation_warning(info)
+      ActiveSupport::Deprecation.warn("Your API call uses deprecated behavior, #{info}", caller)
+    end
+  end
+end

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,7 +1,7 @@
 module Deprecations
   def const_missing(const_name)
     return(super) unless const_name.to_s == 'ConfigTemplate'
-    warn '`ConfigTemplate` has been deprecated. Use `ProvisioningTemplate` instead.'
+    Foreman::Deprecation.deprecation_warning('1.11', 'Config templates were renamed to provisioning templates')
     ::ProvisioningTemplate
   end
 end

--- a/test/unit/foreman_deprecation_test.rb
+++ b/test/unit/foreman_deprecation_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ForemanDeprecationTest < ActiveSupport::TestCase
+  test "deadline version is higher than current version and version name in right format" do
+    assert_nothing_raised do
+      Foreman::Deprecation.deprecation_warning("1.9", "More info")
+    end
+  end
+  test "version name in wrong format, should raise exception" do
+    assert_raises Foreman::Exception do
+      Foreman::Deprecation.deprecation_warning("1.1.3", "More info")
+    end
+    assert_raises Foreman::Exception do
+      Foreman::Deprecation.deprecation_warning("1.1r", "More info")
+    end
+  end
+  test "calling API deprecation" do
+    assert_nothing_raised do
+      Foreman::Deprecation.api_deprecation_warning("More info")
+    end
+  end
+end
+


### PR DESCRIPTION
I have added Foreman::Deprecation service which wraps ActiveSupport::Deprecation that we are currently using, formalizing the messages and enforces deprecation.
I have changed all the deprecations calls on the core to the new format and placed a default
two versions up (1.10.0) as a deadline(all deprecations with 1.10.0 will be deleted on it's release).
