### PR TITLE
Fixes #10740 - ignore auditing of Host and Hostgroup in migrations

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -5,7 +5,6 @@ class ProvisioningTemplate < Template
   include Parameterizable::ByIdName
 
   audited :allow_mass_assignment => true
-  self.auditing_enabled = !Foreman.in_rake?('db:migrate')
 
   attr_accessible :template_kind, :template_kind_id, :template_combinations_attributes,
                   :operatingsystems, :operatingsystem_ids, :vendor

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -10,7 +10,6 @@ class Ptable < Template
   include ValidateOsFamily
 
   audited :allow_mass_assignment => true
-  self.auditing_enabled = !Foreman.in_rake?('db:migrate')
   has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
 
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ActiveRecord::Base
   include Taxonomix
   include DirtyAssociations
   audited :except => [:last_login_on, :password, :password_hash, :password_salt, :password_confirmation], :allow_mass_assignment => true
-  self.auditing_enabled = !Foreman.in_rake?('db:migrate')
 
   ANONYMOUS_ADMIN = 'foreman_admin'
   ANONYMOUS_API_ADMIN = 'foreman_api_admin'

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -5,3 +5,18 @@ require 'audit_extensions'
 
 Audit = Audited.audit_class
 Audit.send(:include, AuditExtensions)
+
+module Foreman
+  module DisableAudited
+    extend ActiveSupport::Concern
+
+    included do
+      def self.audited(*args)
+        super
+        self.auditing_enabled = false if Foreman.in_rake?('db:migrate')
+      end
+    end
+  end
+end
+
+::ActiveRecord::Base.send :include, Foreman::DisableAudited

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -14,7 +14,7 @@ module Foreman
 
   def self.in_rake?(rake_task = nil)
     defined?(Rake) && Rake.application.top_level_tasks.any? do |running_rake_task|
-      rake_task.nil? || running_rake_task == rake_task
+      rake_task.nil? || running_rake_task.start_with?(rake_task)
     end
   end
 


### PR DESCRIPTION
fixing also `in_rake?` to work for db:migrate:down and db:migrate:up tasks (and similarly to other namespaced rake tasks)
