### PR TITLE
fixes #10627 - apply host taxonomy scope to facts/report joins

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -32,13 +32,14 @@ module Authorizable
     #
     # Or you may simply use authorized for User.current
     #
-    scope :joins_authorized_as, Proc.new { |user, resource, permission|
+    # The default scope of `resource` is NOT applied since it's a join, instead
+    # any extra conditions can be given in `opts[:where]`.
+    #
+    scope :joins_authorized_as, Proc.new { |user, resource, permission, opts = {}|
       if user.nil?
         self.where('1=0')
-      elsif user.admin?
-        self.scoped
       else
-        Authorizer.new(user).find_collection(resource, :permission => permission, :joined_on => self)
+        Authorizer.new(user).find_collection(resource, {:permission => permission, :joined_on => self}.merge(opts) )
       end
     }
 
@@ -65,8 +66,8 @@ module Authorizable
       authorized_as(User.current, permission, resource)
     end
 
-    def joins_authorized(resource, permission = nil)
-      joins_authorized_as(User.current, resource, permission)
+    def joins_authorized(resource, permission = nil, opts = {})
+      joins_authorized_as(User.current, resource, permission, opts)
     end
   end
 end

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -23,8 +23,8 @@ class FactValue < ActiveRecord::Base
     joins(:fact_name).where("fact_names.name = ?",:_timestamp)
   }
   scope :my_facts, lambda {
-    unless User.current.admin? and Organization.current.nil? and Location.current.nil?
-      joins_authorized(Host, :view_hosts)
+    if !User.current.admin? || Organization.expand(Organization.current).present? || Location.expand(Location.current).present?
+      joins_authorized(Host, :view_hosts, :where => Host.taxonomy_conditions)
     end
   }
 

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -37,13 +37,17 @@ module Host
     validate :uniq_interfaces_identifiers
 
     default_scope lambda {
+      where(taxonomy_conditions)
+    }
+
+    def self.taxonomy_conditions
       org = Organization.expand(Organization.current) if SETTINGS[:organizations_enabled]
       loc = Location.expand(Location.current) if SETTINGS[:locations_enabled]
       conditions = {}
       conditions[:organization_id] = Array(org).map { |o| o.subtree_ids }.flatten.uniq if org.present?
       conditions[:location_id] = Array(loc).map { |l| l.subtree_ids }.flatten.uniq if loc.present?
-      where(conditions)
-    }
+      conditions
+    end
 
     scope :no_location, lambda { where(:location_id => nil) }
     scope :no_organization, lambda { where(:organization_id => nil) }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -34,7 +34,7 @@ class Report < ActiveRecord::Base
   # returns reports for hosts in the User's filter set
   scope :my_reports, lambda {
     if !User.current.admin? || Organization.expand(Organization.current).present? || Location.expand(Location.current).present?
-      joins_authorized(Host, :view_hosts)
+      joins_authorized(Host, :view_hosts, :where => Host.taxonomy_conditions)
     end
   }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,7 +112,7 @@ Spork.prefork do
     end
 
     def in_taxonomy(taxonomy)
-      new_taxonomy = taxonomies(taxonomy)
+      new_taxonomy = taxonomy.is_a?(Taxonomy) ? taxonomy : taxonomies(taxonomy)
       saved_taxonomy = new_taxonomy.class.current
       new_taxonomy.class.current = new_taxonomy
       result = yield


### PR DESCRIPTION
Previous changes to perform a join onto hosts with authorisation result
in a query such as Report.joins(:hosts), which ignores any
default_scope on Host::Base.  This commit explicitly passes taxonomy
conditionals into the Authorizer to re-apply it.

---

Taxonomies + default scopes + authorisation = hell.
