### PR TITLE
Fine tune test logging defaults

### DIFF
--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -60,5 +60,8 @@
   :filename: "development.log"
 
 :test:
-  :level: debug
+  :colorize: false
+  :console_inline: true
+  :level: error
+  :log_trace: true
   :filename: "test.log"


### PR DESCRIPTION
I don't think the default logging for test environment is right.

Currently we log everything (debug level) into log/test.log file. This creates
enormous entries usually SQL debug lines and hides stacktraces which are much
more interesting that millions of SQL statements during testing.

This patch defaults to error level to filter out uninteresting stuff and also
doubles it on the stdout so errors are more transparent. This can break up the
dotted "progress bars" indeed, but I find this more useful than what we have
now.

@ehelms ?
