### PR TITLE
Fixes #10785 - force encoding for encrypted fields

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -5,7 +5,9 @@ class PasswordCrypt
 
   def self.passw_crypt(passwd, hash_alg = 'SHA256')
     raise Foreman::Exception.new(N_("Unsupported password hash function '%s'"), hash_alg) unless ALGORITHMS.has_key?(hash_alg)
-    hash_alg == 'Base64' ? Base64.strict_encode64(passwd) : passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")
+    result = (hash_alg == 'Base64') ? Base64.strict_encode64(passwd) : passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")
+    result.force_encoding(Encoding::UTF_8) if result.encoding != Encoding::UTF_8
+    result
   end
 
   def self.grub2_passw_crypt(passw)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -923,6 +923,8 @@ class HostTest < ActiveSupport::TestCase
       host.root_pass = "12345678"
       assert host.save
       assert_not_equal first_password, host.root_pass
+      # Encrypted passwords should have UTF-8 encoding
+      assert_equal Encoding::UTF_8, host.root_pass.encoding
     end
 
     test "should pass through existing salt when saving root pw" do
@@ -942,6 +944,8 @@ class HostTest < ActiveSupport::TestCase
       host.root_pass = unencrypted_password
       assert host.save!
       assert_equal host.root_pass, 'eHlieGE2SlVrejYzdw=='
+      # Encrypted passwords should have UTF-8 encoding
+      assert_equal Encoding::UTF_8, host.root_pass.encoding
     end
 
     test "should use hostgroup root password" do


### PR DESCRIPTION
Some info in the ticket and
https://github.com/sparklemotion/sqlite3-ruby/issues/45

The error only appears on sqlite3.
