### PR TITLE
Fixes #10803: Return nil if no resource_type when creating a filter.

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -61,7 +61,12 @@ class Filter < ActiveRecord::Base
     { :conditions => conditions }
   end
 
+  # This method attempts to return an existing class that is derived from the resource_type.
+  # In some instances, this may not be a real class (e.g. a typo) or may be nil in the case
+  # of a filter not having been saved yet and thus the permissions objects not being currently
+  # accessible.
   def self.get_resource_class(resource_type)
+    return nil if resource_type.nil?
     resource_type.constantize
   rescue NameError => e
     Foreman::Logging.exception("unknown class #{resource_type}, ignoring", e)

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -50,6 +50,10 @@ class FilterTest < ActiveSupport::TestCase
     assert_nil Filter.get_resource_class('BookmarkThatDoesNotExist')
   end
 
+  test ".get_resource_class nil" do
+    assert_nil Filter.get_resource_class(nil)
+  end
+
   test "#resource_class" do
     f = FactoryGirl.build(:filter, :resource_type => 'Bookmark')
     Filter.stub :get_resource_class, Architecture do


### PR DESCRIPTION
In some instances, such as during DB seed, when a filter is being
created for the first time the before_validation callback to
build_taxonomy_search is triggered. Since, the filter hasn't been
saved, there are no permissions connected to the filter yet when
the 'permissions.first.try(:resource_type)' call is made generating
the resource_type. This in turn leads get_resource_class to call
constantize on 'nil' and throw an exception which then appears
throughout the db:seed log.
