### PR TITLE
POC - title_actions_for_path plugin initializer block

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -5,7 +5,8 @@ module LayoutHelper
   end
 
   def title_actions(*elements)
-    content_for(:title_actions) { elements.join(" ").html_safe }
+    plugins_html = Foreman::Plugin.call_title_actions_for_path(self, request.path)
+    content_for(:title_actions) { elements.join(" ").html_safe + plugins_html }
   end
 
   def button_group(*elements)


### PR DESCRIPTION
This is a small POC patch that introduces new kind of plugin initializer block.
It can be used to add buttons on index pages per request path:

```
    initializer 'foreman_bootdisk.register_plugin', :after=> :finisher_hook do |app|
      Foreman::Plugin.register :foreman_bootdisk do
        # ...

        title_actions_for_path("/subnets") do
          # this_code_is_executed_in_a_controller_context
          display_my_link_if_authorized(_("Some link"), {:controller => 'blah/blah', :action => 'foo'}, :class=>'btn')
        end
      end
    end
```

This will work with most our index pages that use `title_actions` helper method.

My idea is to use this for Bootdisk and move subnet image generation to
Subnets page (opening up a confirmation dialog box to select a subnet
to generate for).
