### PR TITLE
Fixes #10815 - introduced FOREMAN_APIPIE_LANGS env variable

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -11,7 +11,7 @@ Apipie.configure do |config|
   config.doc_base_url = "/apidoc"
   config.use_cache = Rails.env.production? || File.directory?(config.cache_dir)
   # config.languages = [] # turn off localized API docs and CLI, useful for development
-  config.languages = FastGettext.available_locales # generate API docs for all available locales
+  config.languages = ENV['FOREMAN_APIPIE_LANGS'].try(:split, ' ') || FastGettext.available_locales
   config.default_locale = FastGettext.default_locale
   config.locale = lambda { |loc| loc ? FastGettext.set_locale(loc) : FastGettext.locale }
 

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -1,6 +1,6 @@
 desc 'Apipie cache specific tasks'
 namespace :apipie do
-  desc 'Generate cache index'
+  desc 'Generate cache index for all langs (override with FOREMAN_APIPIE_LANGS envvar)'
   task 'cache:index' do |t, args|
     ENV['cache_part'] = 'index'
     Rake::Task['apipie:cache'].invoke


### PR DESCRIPTION
Tired of generating all the languages for development. Since this is not meant
for production, I use environment variable. Not a good fit for settings.yaml I
think.

Dramatically speeds up apipie generation with this setting:

```
FOREMAN_APIPIE_LANGS=en be rake apipie:cache
```
