### PR TITLE
Fixes #10849 - remove hidden template fields on submit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -120,6 +120,9 @@ function onContentLoad(){
   $('select').select2();
   $("#new_lookup_keys_ select").select2('destroy');
 
+  $('input.remove_form_templates').closest('form').submit(function(event) {
+    $(this).find('.form_template').remove()
+  })
 }
 
 function preserve_selected_options(elem) {

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -220,7 +220,8 @@ module LayoutHelper
     content_tag(:div, :class => "clearfix") do
       content_tag(:div, :class => "form-actions") do
         text    = overwrite ? _("Overwrite") : _("Submit")
-        options = overwrite ? {:class => "btn btn-danger"} : {:class => "btn btn-primary"}
+        options = {}
+        options[:class] = "btn btn-#{overwrite ? 'danger' : 'primary'} remove_form_templates"
         options.merge! :'data-id' => form_to_submit_id(f) unless options.has_key?(:'data-id')
         link_to(_("Cancel"), args[:cancel_path], :class => "btn btn-default") + " " +
             f.submit(text, options)

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -21,7 +21,7 @@ module LookupKeysHelper
     options[:form_builder_local] ||= :f
     options[:form_builder_attrs] ||= {}
 
-    content_tag(:div, :class => "#{association}_fields_template", :style => "display: none;") do
+    content_tag(:div, :class => "#{association}_fields_template form_template", :style => "display: none;") do
       form_builder.fields_for(association, options[:object], :child_index => "new_#{association}") do |f|
         render(:partial => options[:partial],
                :layout => options[:layout],

--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -37,10 +37,6 @@ class ComputeAttribute < ActiveRecord::Base
 
   def attribute_values(attr_name)
     attr_key = "#{attr_name}_attributes"
-    if vm_attrs[attr_key]
-      vm_attrs[attr_key].select { |k,v| k.to_s != "new_#{attr_name}" }.values
-    else
-      []
-    end
+    vm_attrs[attr_key].try(:values) || []
   end
 end


### PR DESCRIPTION
For potential tester, one can test it for example with compute profiles (network/compute attributes) or lookup values and their matchers. Just compare parameters with and without the patch. I tested all forms and removed hacks that are no longer necessary (where it make sense). Usually :reject_if workaround is used but it has other impact as well so I couldn't remove these.
