### PR TITLE
Fixes #10850 - handled errors when missing template when rendering widget

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -15,6 +15,8 @@ module DashboardHelper
 
   def render_widget(widget)
     render(:partial => widget.template, :locals => widget.data)
+  rescue ActionView::MissingTemplate
+    ::Foreman::Exception.new(N_("Missing template '%{template}' for widget '%{widget}'."), :widget => _(widget.name), :template => widget.template)
   end
 
   def widget_data(widget)


### PR DESCRIPTION
How to reproduce:
- install a plugin with a widget (such as foreman discovery),
- configure the widget from the plugin to be displayed
- uninstall the plugin
