### PR TITLE
Fixes #10854 - config_templates missing from show in taxonomies and os

### DIFF
--- a/app/views/api/v2/operatingsystems/show.json.rabl
+++ b/app/views/api/v2/operatingsystems/show.json.rabl
@@ -14,12 +14,16 @@ child :architectures do
   extends "api/v2/architectures/base"
 end
 
-child :ptables do
+child :ptables => :ptables do
   extends "api/v2/ptables/base"
 end
 
-child :config_templates do
+child :provisioning_templates => :config_templates do
   extends "api/v2/config_templates/base"
+end
+
+child :provisioning_templates => :provisioning_templates do
+  extends "api/v2/provisioning_templates/base"
 end
 
 child :os_default_templates do

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -26,9 +26,14 @@ child :media do
   extends "api/v2/media/base"
 end
 
-child :config_templates do
+child :provisioning_templates => :config_templates do
   extends "api/v2/config_templates/base"
 end
+
+child :provisioning_templates => :provisioning_templates do
+  extends "api/v2/provisioning_templates/base"
+end
+
 
 child :domains do
   extends "api/v2/domains/base"


### PR DESCRIPTION
Changes in provisioning templates broke some rabl templates
