### PR TITLE
Avoid duplicates interfaces

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -25,6 +25,8 @@ module Nic
               :if => Proc.new { |nic| nic.managed? && nic.host_managed? && !nic.host.compute? && !nic.virtual? }
     validates :mac, :mac_address => true, :allow_blank => true
 
+    validates :name, :uniqueness => {:scope => :host_id}
+
     # TODO uniq on primary per host
     # validate :uniq_with_hosts
 


### PR DESCRIPTION
This commit should prevent any NIC creation when another NIC already exists. This is meanly to prevent facter to  create duplicate NIC's.
