### PR TITLE
Fixes #10887 - Removed annoying 'removed setting from cache' debug statement

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -224,7 +224,6 @@ class Setting < ActiveRecord::Base
 
   def clear_cache
     # ensures we don't have cache left overs in settings
-    Rails.logger.debug "removing #{name} from cache"
     if Setting.cache.delete(name.to_s) == false
       Rails.logger.warn "Failed to remove #{name} from cache"
     end


### PR DESCRIPTION
Ok this is annoying me with introduction of the new logger. I don't think it's
that useful anyway.
