### PR TITLE
refs #10072 - derestrict fog-libvirt per semver

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '~> 0.0.2'
+  gem 'fog-libvirt', '>= 0.0.2', '< 1.0'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
This didn't look like a deliberate change, just updating it to require the min version for the feature, but allow other 0.x releases again.
