### PR TITLE
Fixes #10916 - convert config_template_ids in operatingsystems

### DIFF
--- a/app/controllers/api/v1/operatingsystems_controller.rb
+++ b/app/controllers/api/v1/operatingsystems_controller.rb
@@ -5,6 +5,7 @@ module Api
         name 'Operating systems'
       end
 
+      before_filter :rename_config_templates, :only => %w{update create}
       before_filter :find_resource, :only => %w{show edit update destroy bootfiles}
 
       api :GET, "/operatingsystems/", "List all operating systems."
@@ -35,6 +36,8 @@ module Api
         param :family, String
         param :release_name, String
         param :password_hash, String, :desc => 'Root password hash function to use, one of MD5, SHA256, SHA512, Base64'
+        param :config_template_ids, Array, :desc => "IDs of associated provisioning templates" # FIXME: deprecated
+        param :provisioning_template_ids, Array, :desc => "IDs of associated provisioning templates"
       end
 
       def create
@@ -52,6 +55,8 @@ module Api
         param :family, String
         param :release_name, String
         param :password_hash, String, :desc => 'Root password hash function to use, one of MD5, SHA256, SHA512, Base64'
+        param :config_template_ids, Array, :desc => "IDs of associated provisioning templates" # FIXME: deprecated
+        param :provisioning_template_ids, Array, :desc => "IDs of associated provisioning templates"
       end
 
       def update
@@ -77,6 +82,16 @@ module Api
       rescue => e
         render :json => e.to_s, :status => :unprocessable_entity
       end
+
+      private
+
+      def rename_config_templates
+        if params[:operatingsystem] && params[:operatingsystem][:config_template_ids].present?
+          params[:operatingsystem][:provisioning_template_ids] = params[:operatingsystem].delete(:config_template_ids)
+          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+        end
+      end
+
     end
   end
 end

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -5,6 +5,8 @@ module Api
         name 'Operating systems'
       end
 
+      before_filter :rename_config_templates, :only => %w{update create}
+      before_filter :rename_config_template, :only => %w{index}
       before_filter :find_optional_nested_object
       before_filter :find_resource, :only => %w{show edit update destroy bootfiles}
 
@@ -13,10 +15,12 @@ module Api
       api :GET, "/media/:medium_id/operatingsystems", N_("List all operating systems for nested medium")
       api :GET, "/ptables/:ptable_id/operatingsystems", N_("List all operating systems for nested partition table")
       api :GET, "/config_templates/:config_template_id/operatingsystems", N_("List all operating systems for nested provisioning template")
+      api :GET, "/provisioning_templates/:provisioning_template_id/operatingsystems", N_("List all operating systems for nested provisioning template")
       param :architecture_id, String, :desc => N_("ID of architecture")
       param :medium_id, String, :desc => N_("ID of medium")
       param :ptable_id, String, :desc => N_("ID of partition table")
       param :config_template_id, String, :desc => N_("ID of template")
+      param :provisioning_template_id, String, :desc => N_("ID of template")
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
@@ -39,7 +43,8 @@ module Api
           param :release_name, String
           param :password_hash, String, :desc => N_('Root password hash function to use, one of MD5, SHA256, SHA512, Base64')
           param :architecture_ids, Array, :desc => N_("IDs of associated architectures")
-          param :config_template_ids, Array, :desc => N_("IDs of associated provisioning templates")
+          param :config_template_ids, Array, :desc => N_("IDs of associated provisioning templates") # FIXME: deprecated
+          param :provisioning_template_ids, Array, :desc => N_("IDs of associated provisioning templates")
           param :medium_ids, Array, :desc => N_("IDs of associated media")
           param :ptable_ids, Array, :desc => N_("IDs of associated partition tables")
         end
@@ -83,8 +88,22 @@ module Api
 
       private
 
+      def rename_config_templates
+        if params[:operatingsystem] && params[:operatingsystem][:config_template_ids].present?
+          params[:operatingsystem][:provisioning_template_ids] = params[:operatingsystem].delete(:config_template_ids)
+          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+        end
+      end
+
+      def rename_config_template
+        if params[:config_template_id].present?
+          params[:provisioning_template_id] = params.delete(:config_template_id)
+          ::ActiveSupport::Deprecation.warn('Config templates were renamed to provisioning templates')
+        end
+      end
+
       def allowed_nested_id
-        %w(architecture_id medium_id ptable_id config_template_id)
+        %w(architecture_id medium_id ptable_id provisioning_template_id)
       end
     end
   end

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,6 +1,6 @@
 module Deprecations
   def const_missing(const_name)
-    return(super) unless const_name == :ConfigTemplate
+    return(super) unless const_name.to_s == 'ConfigTemplate'
     warn '`ConfigTemplate` has been deprecated. Use `ProvisioningTemplate` instead.'
     ::ProvisioningTemplate
   end


### PR DESCRIPTION
`config_templates` are no longer part of the model and we have to rename the params.
API docs fixed accordingly.

reproduce with

```
hammer os add-config-template --id 5 --config-template-id 4
```
