### PR TITLE
Fixes #10917 - Update API docs for template combinations

### DIFF
--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -12,7 +12,7 @@ module Api
         param :environment_id, String, :desc => N_("ID of environment")
       end
 
-      api :GET, "/config_templates/:config_template_id/template_combinations", N_("List template combination")
+      api :GET, "/config_templates/:config_template_id/template_combinations", N_("List template combination"), :deprecated => true
       api :GET, "/provisioning_templates/:provisioning_template_id/template_combinations", N_("List template combination")
       api :GET, "/hostgroups/:hostgroup_id/template_combinations", N_("List template combination")
       api :GET, "/environments/:environment_id/template_combinations", N_("List template combination")
@@ -29,7 +29,8 @@ module Api
         end
       end
 
-      api :POST, "/config_templates/:config_template_id/template_combinations", N_("Add a template combination")
+      api :POST, "/config_templates/:config_template_id/template_combinations", N_("Add a template combination"), :deprecated => true
+      api :POST, "/provisioning_templates/:provisioning_template_id/template_combinations", N_("Add a template combination")
       api :POST, "/hostgroups/:hostgroup_id/template_combinations", N_("Add a template combination")
       api :POST, "/environments/:environment_id/template_combinations", N_("Add a template combination")
       param_group :template_combination_identifiers
@@ -41,11 +42,17 @@ module Api
       end
 
       api :GET, "/template_combinations/:id", N_("Show template combination")
+      api :GET, "/config_templates/:config_template_id/template_combinations/:id", N_("Show template combination"), :deprecated => true
+      api :GET, "/provisioning_templates/:provisioning_template_id/template_combinations/:id", N_("Show template combination")
+      api :GET, "/hostgroups/:hostgroup_id/template_combinations/:id", N_("Show template combination")
+      api :GET, "/environments/:environment_id/template_combinations/:id", N_("Show template combination")
+      param_group :template_combination_identifiers
       param :id, :identifier, :required => true
       def show
       end
 
-      api :PUT, "/config_templates/:config_template_id/template_combinations/:id", N_("Update template combination")
+      api :PUT, "/provisioning_templates/:provisioning_template_id/template_combinations/:id", N_("Update template combination")
+      api :PUT, "/config_templates/:config_template_id/template_combinations/:id", N_("Update template combination"), :deprecated => true
       api :PUT, "/hostgroups/:hostgroup_id/template_combinations/:id", N_("Update template combination")
       api :PUT, "/environments/:environment_id/template_combinations/:id", N_("Update template combination")
       param :id, :identifier, :required => true

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -44,7 +44,7 @@ Foreman::Application.routes.draw do
           post 'build_pxe_default'
           get 'revision'
         end
-        resources :template_combinations, :only => [:index, :create]
+        resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]
         resources :os_default_templates, :except => [:new, :edit]
       end


### PR DESCRIPTION
- fixed copy-paste error in routes
- updated API doc for available routes according to `rake routes`
- set `config_template` routes as deprecated
