### PR TITLE
Fixes #10935 - FreeIPA client registration with --server enabled fails.

### DIFF
--- a/app/views/unattended/snippets/_freeipa_register.erb
+++ b/app/views/unattended/snippets/_freeipa_register.erb
@@ -40,7 +40,11 @@ name: freeipa_register
 ## IPA Client Installation
 ##
 
-<% if @host.params['freeipa_server'] -%>
+<% if @host.params['freeipa_domain'] -%>
+freeipa_domain="--domain <%= @host.params['freeipa_domain'] %>"
+<% end -%>
+
+<% if @host.params['freeipa_server'] && @host.params['freeipa_domain'] -%>
 freeipa_server="--server <%= @host.params['freeipa_server'] %>"
 <% end -%>
 
@@ -56,7 +60,7 @@ freeipa_ssh="--no-ssh"
 freeipa_opts="<%= @host.params['freeipa_opts'] %>"
 <% end -%>
 
-/usr/sbin/ipa-client-install -w '<%= @host.otp %>' --realm=<%= @host.realm %> -U $freeipa_mkhomedir $freeipa_opts $freeipa_server $freeipa_ssh
+/usr/sbin/ipa-client-install -w '<%= @host.otp %>' --realm=<%= @host.realm %> -U $freeipa_mkhomedir $freeipa_opts $freeipa_domain $freeipa_server $freeipa_ssh
 
 ##
 ## Automounter


### PR DESCRIPTION
I encountered errors while testing the FreeIPA integration module. The hosts were added to IPA, but never registered locally. I tracked it down to enabled --server option, which was supplied without the required --domain one, ending with ipa-client-install returning an error. 

This patch adds freeipa_domain host parameter for --domain option, and adds --server only if it's present.
