### PR TITLE
fixes #10937 - Exposes VM interfaces through API

### DIFF
--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -3,7 +3,7 @@ object @interface
 extends "api/v2/interfaces/base"
 
 attributes :subnet_id, :subnet_name, :domain_id, :domain_name, :created_at, :updated_at,
-           :managed, :identifier
+           :managed, :identifier, :compute_attributes
 
 node do |interface|
   partial("api/v2/interfaces/types/#{interface.type_name.downcase}.json", :object => interface)

--- a/test/functional/api/v2/interfaces_controller_test.rb
+++ b/test/functional/api/v2/interfaces_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::V2::InterfacesControllerTest < ActionController::TestCase
   valid_attrs = { 'name' => "test.foreman.com", 'ip' => "10.0.1.1", 'mac' => "AA:AA:AA:AA:AA:AA",
                   'username' => "foo", 'password' => "bar", 'provider' => "IPMI",
-                  'type' => "bmc" }
+                  'type' => "bmc", 'compute_attributes' => { 'test' => "yes" } }
 
   def setup
     @host = FactoryGirl.create(:host)
@@ -24,6 +24,7 @@ class Api::V2::InterfacesControllerTest < ActionController::TestCase
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
     assert "bmc", show_response["type"]
+    assert "yes", show_response["compute_attributes"]["test"]
   end
 
   test "create interface" do


### PR DESCRIPTION
`Host.vm_compute_attributes` calls out to Fog's `Server.attributes`, which omits the network `interfaces` and storage `controllers` data. This will check for those values and add them in to the response.
