### PR TITLE
fixes #10959 - gravatar should be opt-in not opt-out

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -19,7 +19,7 @@ class Setting::General < Setting
         self.set('entries_per_page', N_("Number of records shown per page in Foreman"), 20),
         self.set('fix_db_cache', N_('Fix DB cache on next Foreman restart'), false),
         self.set('max_trend', N_("Max days for Trends graphs"), 30),
-        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), true),
+        self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), false),
         self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true),
         self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true),
         self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60)


### PR DESCRIPTION
See the reasoning behind this in the issue, http://projects.theforeman.org/issues/10959.  Feel free to reject this if you really want to keep it as an opt-out feature, I don't know many people complain a lot about it.  But I do know many who turn it off as step 2 or 3 in installing a new Foreman.
