### PR TITLE
Refs #3917 - Enable strong_params (Puppetclass and generic)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'i18n', '~> 0.6.4'
 gem 'rails-i18n', '~> 3.0.0'
 gem 'turbolinks', '~> 2.5'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
+gem 'strong_parameters', '~> 0.2'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -37,7 +37,7 @@ module Api
       end
 
       def create
-        @image = @compute_resource.images.new(params[:image])
+        @image = @compute_resource.images.new(safe_params)
         process_response @image.save, @compute_resource
       end
 
@@ -54,7 +54,7 @@ module Api
       end
 
       def update
-        process_response @image.update_attributes(params[:image])
+        process_response @image.update_attributes(safe_params)
       end
 
       api :DELETE, "/compute_resources/:compute_resource_id/images/:id/", "Delete an image."

--- a/app/controllers/api/v1/puppetclasses_controller.rb
+++ b/app/controllers/api/v1/puppetclasses_controller.rb
@@ -32,7 +32,7 @@ module Api
       end
 
       def create
-        @puppetclass = Puppetclass.new(params[:puppetclass])
+        @puppetclass = Puppetclass.new(safe_params)
         process_response @puppetclass.save
       end
 
@@ -43,7 +43,7 @@ module Api
       end
 
       def update
-        process_response @puppetclass.update_attributes(params[:puppetclass])
+        process_response @puppetclass.update_attributes(safe_params)
       end
 
       api :DELETE, "/puppetclasses/:id/", "Delete a puppetclass."

--- a/app/controllers/api/v2/images_controller.rb
+++ b/app/controllers/api/v2/images_controller.rb
@@ -43,7 +43,7 @@ module Api
       param_group :image, :as => :create
 
       def create
-        @image = nested_obj.images.new(params[:image])
+        @image = nested_obj.images.new(safe_params)
         process_response @image.save, nested_obj
       end
 
@@ -53,7 +53,7 @@ module Api
       param_group :image
 
       def update
-        process_response @image.update_attributes(params[:image])
+        process_response @image.update_attributes(safe_params)
       end
 
       api :DELETE, "/compute_resources/:compute_resource_id/images/:id/", N_("Delete an image")

--- a/app/controllers/api/v2/puppetclasses_controller.rb
+++ b/app/controllers/api/v2/puppetclasses_controller.rb
@@ -63,7 +63,7 @@ module Api
       param_group :puppetclass, :as => :create
 
       def create
-        @puppetclass = Puppetclass.new(params[:puppetclass])
+        @puppetclass = Puppetclass.new(safe_params)
         process_response @puppetclass.save
       end
 
@@ -72,7 +72,7 @@ module Api
       param_group :puppetclass
 
       def update
-        class_params = params[:puppetclass].merge!(:smart_class_parameter_ids => @puppetclass.smart_class_parameters.map(&:id))
+        class_params = safe_params.merge!(:smart_class_parameter_ids => @puppetclass.smart_class_parameters.map(&:id))
         process_response @puppetclass.update_attributes(class_params)
       end
 

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -15,4 +15,42 @@ module ApplicationShared
     # Reset timezone for the next thread
     Time.zone = default_timezone
   end
+
+  private
+
+  # Get the allowed parameters from the Apipie documentation in the API controllers.
+  def safe_params
+    model_api_description = apipie_params.find { |param| param[:name] == controller_name.singularize }
+    params.require(controller_name.singularize.to_sym).
+      permit(*safe_attributes_from_api_description(model_api_description))
+  end
+
+  def safe_attributes_from_api_description(model_api_description)
+    model_api_description[:params].map do |apipie_param|
+      if param_group?(apipie_param)
+        { apipie_param[:name].to_sym => build_safe_params(apipie_param[:params]) }
+      else
+        case apipie_param[:expected_type]
+        when "array"
+          { apipie_param[:name] => [] }
+        when "hash"
+          { apipie_param[:name] => {} }
+        else
+          apipie_param[:name].to_sym
+        end
+      end
+    end
+  end
+
+  def param_group?(apipie_param)
+    apipie_param[:params].present?
+  end
+
+  def apipie_params
+    Apipie.app.get_method_description(apipie_class, action_name).to_json[:params]
+  end
+
+  def apipie_class
+    "v2##{controller_name}"
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -16,7 +16,7 @@ class ImagesController < ApplicationController
   end
 
   def create
-    @image = Image.new(params[:image])
+    @image = Image.new(safe_params)
     if @image.save
       process_success :success_redirect => compute_resource_path(@compute_resource)
     else
@@ -28,8 +28,8 @@ class ImagesController < ApplicationController
   end
 
   def update
-    params[:image].except!(:password) if params[:image][:password].blank?
-    if @image.update_attributes(params[:image])
+    safe_params.except!(:password) if safe_params[:password].blank?
+    if @image.update_attributes(safe_params)
       process_success :success_redirect => compute_resource_path(@compute_resource)
     else
       process_error

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -13,7 +13,7 @@ class PuppetclassesController < ApplicationController
   end
 
   def update
-    if @puppetclass.update_attributes(params[:puppetclass])
+    if @puppetclass.update_attributes(safe_params)
       process_success
     else
       process_error

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,6 @@
 class Image < ActiveRecord::Base
   include Authorizable
+  include ActiveModel::ForbiddenAttributesProtection
 
   audited :allow_mass_assignment => true
 

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -4,6 +4,7 @@ class Puppetclass < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName
+  include ActiveModel::ForbiddenAttributesProtection
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -110,3 +110,5 @@ class IdentifierDottableValidator < Apipie::Validator::BaseValidator
         "dot(.), space, underscore(_), hypen(-) with no leading or trailing space."
   end
 end
+
+Apipie.reload_documentation

--- a/test/functional/api/v2/images_controller_test.rb
+++ b/test/functional/api/v2/images_controller_test.rb
@@ -32,7 +32,8 @@ class Api::V2::ImagesControllerTest < ActionController::TestCase
   end
 
   test "should update image" do
-    put :update, { :compute_resource_id => images(:two).compute_resource_id, :id => images(:one).to_param, :image => { } }
+    put :update, { :compute_resource_id => images(:two).compute_resource_id, :id => images(:one).to_param,
+                   :image => { :name => 'foo' } }
     assert_response :success
   end
 

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -10,12 +10,4 @@ class PuppetclassIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_link? 'vim'
     assert page.has_link? 'Common'
   end
-
-  # PENDING
-  # test "smart variables" do
-  # end
-
-  # PENDING
-  # test "smart class parameters" do
-  # end
 end


### PR DESCRIPTION
The idea of this PR is to start enabling strong_params in one class, and provide a minimal avenue, `method_missing`, to allow any class to define it's permitted attributes in the model. We could possibly even just read the Apipie docs and permit these attributes.

If I'm not wrong, this should allow us to follow this path:
1. Enable this in as many classes as we can without breaking plugins. I started with Puppetclass as it has almost no `belongs_to` relations and I don't know any plugin that uses it.
2. When the only classes remaining are the ones that plugins utilize (Host, Hostgroup, etc..) we can work together with plugins to improve this. 
3. It allows plugin owners to start making their own controllers Rails 4 ready before the migration.
4. When we migrate to Rails 4, at a bare minimum we would have done all our homework regarding params if steps 1,2,3 have been completed.

We can also move in almost all testing changes from the [Rails 4 big PR](https://github.com/theforeman/foreman/pull/2055) as a trivial next step as well.

Basically @shlomizadok 's [PR](https://github.com/theforeman/foreman/pull/1819/files) but I'm trying to keep permitted attributes in their own classes rather than a central file.

@unorthodoxgeek thoughts?
