### PR TITLE
fixes #11016 adds test-unit on ruby 2.2.0

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -13,4 +13,5 @@ group :test do
   gem 'spork', '~> 0.9'
   gem 'factory_girl_rails', '~> 4.5', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.1'
+  gem 'test-unit' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
 end


### PR DESCRIPTION
Signed-off-by: Max Kovgan mvk@redhat.com

Validated in RVM on:

```
for r in 1.9.3-p551 2.0.0-p598 2.1.5 2.2.0; do
    rvm use ruby-"${r}"
    bundle install --without postgresql mysql2 openid vmware
    rake test
done
```

Hope this is enough
