### PR TITLE
Fixes #11056: Configure base SETTINGS for test environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 # foreman plugins import this file therefore __FILE__ cannot be used
 FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
-require File.expand_path('../config/settings', FOREMAN_GEMFILE)
 require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
 
 source 'https://rubygems.org'

--- a/bundler.d/jsonp.rb
+++ b/bundler.d/jsonp.rb
@@ -1,3 +1,3 @@
 group :jsonp do
   gem 'rack-jsonp', :require => 'rack/jsonp'
-end if SETTINGS[:support_jsonp]
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,8 @@ require 'apipie/middleware/checksum_in_headers'
 
 require 'rails/all'
 
+require File.expand_path('../../config/settings', __FILE__)
+
 if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
   # If there is a Gemfile.in file, we will not use Bundler but BundlerExt
   # gem which parses this file and loads all dependencies from the system

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,4 @@
 require 'rubygems'
-require 'yaml'
-require File.expand_path('../../config/settings', __FILE__)
 
 unless File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
   ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -2,7 +2,9 @@ root = File.expand_path(File.dirname(__FILE__) + "/..")
 require 'yaml'
 require "#{root}/app/services/foreman/version"
 
-SETTINGS = YAML.load_file("#{root}/config/settings.yaml")
+settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
+
+SETTINGS = YAML.load_file("#{root}/#{settings_file}")
 SETTINGS[:version] = Foreman::Version.new
 SETTINGS[:unattended] = SETTINGS[:unattended].nil? || SETTINGS[:unattended]
 SETTINGS[:login]    ||= SETTINGS[:ldap]

--- a/config/settings.yaml.test
+++ b/config/settings.yaml.test
@@ -1,0 +1,6 @@
+---
+:unattended: true
+:login: true
+:require_ssl: false
+:locations_enabled: true
+:organizations_enabled: true


### PR DESCRIPTION
This change introduces the idea of having a base configuration for
SETTINGS within the test environment. This is captured in the
settings.yaml.test file. To be able to detect the Rails environment
in settings.rb, the ordering had to be changed whereby the Gemfile
is loaded up via boot.rb and then Rails is required so that the
Rails environment is available by the time settings.rb is processed.
