### PR TITLE
Fixes #11023 - Pass identity_endpoint to Openstack Fog 1.32.0

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -129,30 +129,27 @@ module Foreman::Model
 
     private
 
+    def fog_credentials
+      { :provider => :openstack,
+        :openstack_api_key  => password,
+        :openstack_username => user,
+        :openstack_auth_url => url,
+        :openstack_tenant   => tenant,
+        :openstack_identity_endpoint => url }
+    end
+
     def client
-      @client ||= ::Fog::Compute.new(:provider           => :openstack,
-                                     :openstack_api_key  => password,
-                                     :openstack_username => user,
-                                     :openstack_auth_url => url,
-                                     :openstack_tenant   => tenant)
+      @client ||= ::Fog::Compute.new(fog_credentials)
     end
 
     def network_client
-      @network_client ||= ::Fog::Network.new(:provider           => :openstack,
-                                             :openstack_api_key  => password,
-                                             :openstack_username => user,
-                                             :openstack_auth_url => url,
-                                             :openstack_tenant   => tenant)
+      @network_client ||= ::Fog::Network.new(fog_credentials)
     rescue
       @network_client = nil
     end
 
     def volume_client
-      @volume_client ||= ::Fog::Volume.new(:provider           => :openstack,
-                                           :openstack_api_key  => password,
-                                           :openstack_username => user,
-                                           :openstack_auth_url => url,
-                                           :openstack_tenant   => tenant)
+      @volume_client ||= ::Fog::Volume.new(fog_credentials)
     end
 
     def setup_key_pair


### PR DESCRIPTION
This change will make our Fog clients use our identity URL (the one we store in Foreman) vs the compute/storage/volume management URL. [This diff](https://github.com/fog/fog/commit/83b61986bd2787dd22dc8967f28d0c78d8752aff#diff-23afcc673dd406dbe5604a62b4670488L478) caused the trouble, the `Excon` object created to authenticate Openstack is around line 478 of compute.rb
