### PR TITLE
Fixes #10915 - Deleting a host removes all host specific overrides

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -820,7 +820,7 @@ class Host::Managed < Host::Base
   end
 
   def lookup_value_match
-    "fqdn=#{fqdn}"
+    "fqdn=#{fqdn || name}"
   end
 
   def lookup_keys_params

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2174,6 +2174,14 @@ class HostTest < ActiveSupport::TestCase
     assert_equal 'foo', host.shortname
   end
 
+  test 'lookup_value_match returns host name instead of fqdn when there is no primary interface' do
+    host = FactoryGirl.build(:host, :managed)
+    host_name = host.name
+    host.interfaces.delete_all
+    assert_nil host.primary_interface
+    assert_equal host.send(:lookup_value_match), "fqdn=#{host_name}"
+  end
+
   test 'check operatingsystem and architecture association' do
     host = FactoryGirl.build(:host, :interfaces => [FactoryGirl.build(:nic_primary_and_provision)])
     assert_nil Operatingsystem.find_by_name('RedHat-test'), "operatingsystem already exist"


### PR DESCRIPTION
fqdn is delegated to primary_interface so when the host is deleted and the interfaces are deleted fqdn returns as nil.
When searching for lookup_values connected to the host to delete them 'lookup_value_match' is called but with no fqdn we end up with `LookupValue.where(:match => "match=")`.
Trying to add before_destroy to save the fqdn somehow failed because the interfaces were still destroyed first.
