### PR TITLE
Fixes #11089 - Adapt tests to Rails 4

### DIFF
--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -4,7 +4,7 @@
   host: one
   metrics: "--- \n  time: \n    schedule: 0.00083\n    service: 0.149739\n    mailalias: 0.000283\n    cron: 0.000419\n    config_retrieval: 16.3637869358063\n    package: 0.003989\n    filebucket: 0.000171\n    file: 0.007025\n    exec: 0.000299\n  resources: \n    total: 33\n  changes: {}\n  events: \n    total: 0"
   status: 0
-  reported_at: <%= 1.week.ago %>
+  reported_at: <%= Time.at 1.week.ago.to_i %>
 # 
 # one:
 #   column: value

--- a/test/fixtures/taxable_taxonomies.yml
+++ b/test/fixtures/taxable_taxonomies.yml
@@ -123,3 +123,13 @@ twentyfour:
   taxonomy: organization1
   taxable: myrealm
   taxable_type: Realm
+
+twentyfive:
+  taxonomy: organization1
+  taxable: Location 1
+  taxable_type: Taxonomy
+
+twentysix:
+  taxonomy: organization2
+  taxable: Location 2
+  taxable_type: Taxonomy

--- a/test/fixtures/taxonomies.yml
+++ b/test/fixtures/taxonomies.yml
@@ -1,13 +1,11 @@
 location1:
   name: "Location 1"
   type: "Location"
-  organizations: organization1
   title: "Location 1"
 
 location2:
   name: "Location 2"
   type: "Location"
-  organizations: organization2
   title: "Location 2"
 
 organization1:

--- a/test/functional/api/v1/architectures_controller_test.rb
+++ b/test/functional/api/v1/architectures_controller_test.rb
@@ -34,7 +34,7 @@ class Api::V1::ArchitecturesControllerTest < ActionController::TestCase
   end
 
   test "should update architecture" do
-    put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+    put :update, { :id => architectures(:x86_64).to_param, :architecture => arch_i386 }
     assert_response :success
   end
 
@@ -55,7 +55,7 @@ class Api::V1::ArchitecturesControllerTest < ActionController::TestCase
   test "user with viewer rights should fail to update an architecture" do
     user_one_as_anonymous_viewer
     as_user :one do
-      put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+      put :update, { :id => architectures(:x86_64).to_param, :architecture => arch_i386 }
     end
     assert_response :forbidden
   end
@@ -63,7 +63,7 @@ class Api::V1::ArchitecturesControllerTest < ActionController::TestCase
   test "user with manager rights should success to update an architecture" do
     user_one_as_manager
     as_user :one do
-      put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+      put :update, { :id => architectures(:x86_64).to_param, :architecture => arch_i386 }
     end
     assert_response :success
   end

--- a/test/functional/api/v1/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v1/auth_source_ldaps_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::AuthSourceLdapsControllerTest < ActionController::TestCase
   end
 
   test "should update auth_source_ldap" do
-    put :update, { :id => auth_sources(:one).to_param, :auth_source_ldap => { } }
+    put :update, { :id => auth_sources(:one).to_param, :auth_source_ldap => { :host => "ldap3" } }
     assert_response :success
   end
 

--- a/test/functional/api/v1/bookmarks_controller_test.rb
+++ b/test/functional/api/v1/bookmarks_controller_test.rb
@@ -44,7 +44,7 @@ class Api::V1::BookmarksControllerTest < ActionController::TestCase
   end
 
   test "should update bookmark" do
-    put :update, { :id => bookmarks(:one).to_param, :bookmark => { } }
+    put :update, { :id => bookmarks(:one).to_param, :bookmark => bookmark_base }
     assert_response :success
   end
 

--- a/test/functional/api/v1/common_parameters_controller_test.rb
+++ b/test/functional/api/v1/common_parameters_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::CommonParametersControllerTest < ActionController::TestCase
   end
 
   test "should update common_parameter" do
-    put :update, { :id => parameters(:common).to_param, :common_parameter => { } }
+    put :update, { :id => parameters(:common).to_param, :common_parameter => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/config_templates_controller_test.rb
+++ b/test/functional/api/v1/config_templates_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::ConfigTemplatesControllerTest < ActionController::TestCase
   end
 
   test "should not create invalid" do
-    post :create
+    post :create, {:config_template => {:name => ""}}
     assert_response :unprocessable_entity
   end
 

--- a/test/functional/api/v1/environments_controller_test.rb
+++ b/test/functional/api/v1/environments_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should update environment" do
-    put :update, { :id => environments(:production).to_param, :environment => { } }
+    put :update, { :id => environments(:production).to_param, :environment => development_environment }
     assert_response :success
   end
 

--- a/test/functional/api/v1/hostgroups_controller_test.rb
+++ b/test/functional/api/v1/hostgroups_controller_test.rb
@@ -26,13 +26,14 @@ class Api::V1::HostgroupsControllerTest < ActionController::TestCase
   end
 
   test "should update hostgroup" do
-    put :update, { :id => hostgroups(:common).to_param, :hostgroup => { } }
+    put :update, { :id => hostgroups(:common).to_param, :hostgroup => valid_attrs }
     assert_response :success
   end
 
   test "should destroy hostgroups" do
+    hostgroup = FactoryGirl.create(:hostgroup)
     assert_difference('Hostgroup.count', -1) do
-      delete :destroy, { :id => hostgroups(:unusual).to_param }
+      delete :destroy, :id => hostgroup
     end
     assert_response :success
   end

--- a/test/functional/api/v1/hosts_controller_test.rb
+++ b/test/functional/api/v1/hosts_controller_test.rb
@@ -57,7 +57,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
   end
 
   test "should update host" do
-    put :update, { :id => @host.to_param, :host => { } }
+    put :update, { :id => @host.to_param, :host => { :name => 'testhost1435' } }
     assert_response :success
   end
 
@@ -92,7 +92,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
     disable_orchestration
     host = FactoryGirl.create(:host, :owner => users(:restricted))
     setup_user 'edit', 'hosts', "owner_type = User and owner_id = #{users(:restricted).id}", :restricted
-    put :update, { :id => host.to_param, :host => {} }
+    put :update, { :id => host.to_param, :host => {:name => 'testhost1435'} }
     assert_response :success
   end
 

--- a/test/functional/api/v1/images_controller_test.rb
+++ b/test/functional/api/v1/images_controller_test.rb
@@ -32,7 +32,7 @@ class Api::V1::ImagesControllerTest < ActionController::TestCase
   end
 
   test "should update image" do
-    put :update, { :compute_resource_id => images(:two).compute_resource_id, :id => images(:one).to_param, :image => { } }
+    put :update, { :compute_resource_id => images(:two).compute_resource_id, :id => images(:one).to_param, :image => { :name => "testimagegergt"} }
     assert_response :success
   end
 

--- a/test/functional/api/v1/ptables_controller_test.rb
+++ b/test/functional/api/v1/ptables_controller_test.rb
@@ -30,7 +30,7 @@ class Api::V1::PtablesControllerTest < ActionController::TestCase
   end
 
   test "should update ptable" do
-    put :update, { :id => @ptable.to_param, :ptable => { } }
+    put :update, { :id => @ptable.to_param, :ptable => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/puppetclasses_controller_test.rb
+++ b/test/functional/api/v1/puppetclasses_controller_test.rb
@@ -18,7 +18,7 @@ class Api::V1::PuppetclassesControllerTest < ActionController::TestCase
   end
 
   test "should update puppetclass" do
-    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => { } }
+    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/roles_controller_test.rb
+++ b/test/functional/api/v1/roles_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V1::RolesControllerTest < ActionController::TestCase
   end
 
   test "should update role" do
-    put :update, { :id => roles(:manager).to_param, :role => { } }
+    put :update, { :id => roles(:manager).to_param, :role => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/smart_proxies_controller_test.rb
+++ b/test/functional/api/v1/smart_proxies_controller_test.rb
@@ -47,7 +47,7 @@ class Api::V1::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should update smart_proxy" do
-    put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => { } }
+    put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/subnets_controller_test.rb
+++ b/test/functional/api/v1/subnets_controller_test.rb
@@ -31,7 +31,7 @@ class Api::V1::SubnetsControllerTest < ActionController::TestCase
   end
 
   test "should update subnet" do
-    put :update, { :id => subnets(:one).to_param, :subnet => { } }
+    put :update, { :id => subnets(:one).to_param, :subnet => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v1/usergroups_controller_test.rb
+++ b/test/functional/api/v1/usergroups_controller_test.rb
@@ -30,7 +30,7 @@ class Api::V1::UsergroupsControllerTest < ActionController::TestCase
   end
 
   test "should update usergroup" do
-    put :update, { :id => @usergroup.to_param, :usergroup => { } }
+    put :update, { :id => @usergroup.to_param, :usergroup => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/architectures_controller_test.rb
+++ b/test/functional/api/v2/architectures_controller_test.rb
@@ -34,7 +34,7 @@ class Api::V2::ArchitecturesControllerTest < ActionController::TestCase
   end
 
   test "should update architecture" do
-    put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+    put :update, { :id => architectures(:x86_64).to_param, :architecture => {:name => 'newx86_64'} }
     assert_response :success
   end
 
@@ -55,7 +55,7 @@ class Api::V2::ArchitecturesControllerTest < ActionController::TestCase
   test "user with viewer rights should fail to update an architecture" do
     user_one_as_anonymous_viewer
     as_user :one do
-      put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+      put :update, { :id => architectures(:x86_64).to_param, :architecture => {:name => 'newx86_64'} }
     end
     assert_response :forbidden
   end
@@ -63,7 +63,7 @@ class Api::V2::ArchitecturesControllerTest < ActionController::TestCase
   test "user with manager rights should success to update an architecture" do
     user_one_as_manager
     as_user :one do
-      put :update, { :id => architectures(:x86_64).to_param, :architecture => { } }
+      put :update, { :id => architectures(:x86_64).to_param, :architecture => {:name => 'newx86_64'} }
     end
     assert_response :success
   end

--- a/test/functional/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v2/auth_source_ldaps_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
   end
 
   test "should update auth_source_ldap" do
-    put :update, { :id => auth_sources(:one).to_param, :auth_source_ldap => { } }
+    put :update, { :id => auth_sources(:one).to_param, :auth_source_ldap => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/bookmarks_controller_test.rb
+++ b/test/functional/api/v2/bookmarks_controller_test.rb
@@ -44,7 +44,7 @@ class Api::V2::BookmarksControllerTest < ActionController::TestCase
   end
 
   test "should update bookmark" do
-    put :update, { :id => bookmarks(:one).to_param, :bookmark => { } }
+    put :update, { :id => bookmarks(:one).to_param, :bookmark => dot_bookmark }
     assert_response :success
   end
 

--- a/test/functional/api/v2/common_parameters_controller_test.rb
+++ b/test/functional/api/v2/common_parameters_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::CommonParametersControllerTest < ActionController::TestCase
   end
 
   test "should update common_parameter" do
-    put :update, { :id => parameters(:common).to_param, :common_parameter => { } }
+    put :update, { :id => parameters(:common).to_param, :common_parameter => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/environments_controller_test.rb
+++ b/test/functional/api/v2/environments_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::EnvironmentsControllerTest < ActionController::TestCase
   end
 
   test "should update environment" do
-    put :update, { :id => environments(:production).to_param, :environment => { } }
+    put :update, { :id => environments(:production).to_param, :environment => development_environment }
     assert_response :success
   end
 

--- a/test/functional/api/v2/fact_values_controller_test.rb
+++ b/test/functional/api/v2/fact_values_controller_test.rb
@@ -18,7 +18,7 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
     get :index, {:host_id => @host.name }
     assert_response :success
     fact_values   = ActiveSupport::JSON.decode(@response.body)['results']
-    expected_hash = FactValue.build_facts_hash(FactValue.find_all_by_host_id(@host.id))
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
     assert_equal expected_hash, fact_values
   end
 
@@ -26,7 +26,7 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
     get :index, {:host_id => @host.id }
     assert_response :success
     fact_values   = ActiveSupport::JSON.decode(@response.body)['results']
-    expected_hash = FactValue.build_facts_hash(FactValue.find_all_by_host_id(@host.id))
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
     assert_equal expected_hash, fact_values
   end
 end

--- a/test/functional/api/v2/filters_controller_test.rb
+++ b/test/functional/api/v2/filters_controller_test.rb
@@ -25,7 +25,8 @@ class Api::V2::FiltersControllerTest < ActionController::TestCase
   end
 
   test "should update filter" do
-    put :update, { :id => filters(:manager_1).to_param, :filter => { } }
+    valid_attrs = { :role_id => roles(:manager).id, :permission_ids => [permissions(:view_architectures).id]  }
+    put :update, { :id => filters(:manager_1).to_param, :filter => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
   end
 
   test "should update hostgroup" do
-    put :update, { :id => hostgroups(:common).to_param, :hostgroup => { } }
+    put :update, { :id => hostgroups(:common).to_param, :hostgroup => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -142,7 +142,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test "should update host" do
-    put :update, { :id => @host.to_param, :host => { } }
+    put :update, { :id => @host.to_param, :host => valid_attrs }
     assert_response :success
   end
 
@@ -199,7 +199,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     disable_orchestration
     host = FactoryGirl.create(:host, :owner => users(:restricted))
     setup_user 'edit', 'hosts', "owner_type = User and owner_id = #{users(:restricted).id}", :restricted
-    put :update, { :id => host.to_param, :host => {} }
+    put :update, { :id => host.to_param, :host => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/provisioning_templates_controller_test.rb
+++ b/test/functional/api/v2/provisioning_templates_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
   end
 
   test "should not create invalid" do
-    post :create
+    post :create, {:provisioning_template => {:name => "no"}}
     assert_response 422
   end
 

--- a/test/functional/api/v2/ptables_controller_test.rb
+++ b/test/functional/api/v2/ptables_controller_test.rb
@@ -30,7 +30,7 @@ class Api::V2::PtablesControllerTest < ActionController::TestCase
   end
 
   test "should update ptable" do
-    put :update, { :id => @ptable.to_param, :ptable => { } }
+    put :update, { :id => @ptable.to_param, :ptable => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/puppetclasses_controller_test.rb
+++ b/test/functional/api/v2/puppetclasses_controller_test.rb
@@ -27,7 +27,7 @@ class Api::V2::PuppetclassesControllerTest < ActionController::TestCase
   end
 
   test "should update puppetclass" do
-    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => { } }
+    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => valid_attrs }
     assert_response :success
   end
 
@@ -125,7 +125,7 @@ class Api::V2::PuppetclassesControllerTest < ActionController::TestCase
   end
 
   test "should update puppetclass" do
-    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => { } }
+    put :update, { :id => puppetclasses(:one).to_param, :puppetclass => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/roles_controller_test.rb
+++ b/test/functional/api/v2/roles_controller_test.rb
@@ -26,7 +26,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
   end
 
   test "should update role" do
-    put :update, { :id => roles(:manager).to_param, :role => { } }
+    put :update, { :id => roles(:manager).to_param, :role => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/smart_proxies_controller_test.rb
+++ b/test/functional/api/v2/smart_proxies_controller_test.rb
@@ -50,7 +50,7 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should update smart_proxy" do
-    put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => { } }
+    put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/subnets_controller_test.rb
+++ b/test/functional/api/v2/subnets_controller_test.rb
@@ -31,7 +31,7 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
   end
 
   test "should update subnet" do
-    put :update, { :id => subnets(:one).to_param, :subnet => { } }
+    put :update, { :id => subnets(:one).to_param, :subnet => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/api/v2/usergroups_controller_test.rb
+++ b/test/functional/api/v2/usergroups_controller_test.rb
@@ -30,7 +30,7 @@ class Api::V2::UsergroupsControllerTest < ActionController::TestCase
   end
 
   test "should update usergroup" do
-    put :update, { :id => @usergroup.to_param, :usergroup => { } }
+    put :update, { :id => @usergroup.to_param, :usergroup => valid_attrs }
     assert_response :success
   end
 

--- a/test/functional/architectures_controller_test.rb
+++ b/test/functional/architectures_controller_test.rb
@@ -23,7 +23,7 @@ class ArchitecturesControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Architecture.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:architecture => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
@@ -45,13 +45,13 @@ class ArchitecturesControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Architecture.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Architecture.first}, set_session_user
+    put :update, {:id => Architecture.first.to_param, :architecture => {:name => "3243"}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Architecture.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Architecture.first}, set_session_user
+    put :update, {:id => Architecture.first.to_param, :architecture => {:name => Architecture.first.name}}, set_session_user
     assert_redirected_to architectures_url
   end
 

--- a/test/functional/auth_source_ldaps_controller_test.rb
+++ b/test/functional/auth_source_ldaps_controller_test.rb
@@ -13,13 +13,13 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:auth_source_ldap => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:auth_source_ldap => {:name => AuthSourceLdap.first.name}}, set_session_user
     assert_redirected_to auth_source_ldaps_url
   end
 
@@ -30,27 +30,27 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => AuthSourceLdap.first, :auth_source_ldap => {} }, set_session_user
+    put :update, {:id => AuthSourceLdap.first, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_template 'edit'
   end
 
   def test_formats_valid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => AuthSourceLdap.first.id, :format => "weird", :auth_source_ldap => {} }, set_session_user
+    put :update, {:id => AuthSourceLdap.first.id, :format => "weird", :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_response :success
 
     wierd_id = "#{AuthSourceLdap.first.id}.weird"
-    put :update, {:id => wierd_id, :auth_source_ldap => {} }, set_session_user
+    put :update, {:id => wierd_id, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_response :success
 
     parameterized_id = "#{AuthSourceLdap.first.id}-#{AuthSourceLdap.first.name.parameterize}"
-    put :update, {:id => parameterized_id, :auth_source_ldap => {} }, set_session_user
+    put :update, {:id => parameterized_id, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_response :success
   end
 
   def test_update_valid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => AuthSourceLdap.first, :auth_source_ldap => {} }, set_session_user
+    put :update, {:id => AuthSourceLdap.first, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_redirected_to auth_source_ldaps_url
   end
 
@@ -83,7 +83,7 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     auth_source_ldap = AuthSourceLdap.first
     old_pass = auth_source_ldap.account_password
     as_admin do
-      put :update, {:commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:account_password => '', :name => auth_source_ldap.name} }, set_session_user
+      put :update, {:commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:account_password => nil, :name => auth_source_ldap.name} }, set_session_user
     end
     auth_source_ldap = AuthSourceLdap.find(auth_source_ldap.id)
     assert_equal old_pass, auth_source_ldap.account_password

--- a/test/functional/bookmarks_controller_test.rb
+++ b/test/functional/bookmarks_controller_test.rb
@@ -36,7 +36,7 @@ class BookmarksControllerTest < ActionController::TestCase
   end
 
   test "should update bookmark" do
-    put :update, {:id => bookmarks(:one).to_param, :bookmark => { }}, set_session_user
+    put :update, {:id => bookmarks(:one).to_param, :bookmark => { :name => 'bar' }}, set_session_user
     assert_redirected_to bookmarks_path
   end
 
@@ -44,7 +44,6 @@ class BookmarksControllerTest < ActionController::TestCase
     assert_difference('Bookmark.count', -1) do
       delete :destroy, {:id => bookmarks(:one).to_param}, set_session_user
     end
-
     assert_redirected_to bookmarks_path
   end
 end

--- a/test/functional/common_parameters_controller_test.rb
+++ b/test/functional/common_parameters_controller_test.rb
@@ -13,13 +13,13 @@ class CommonParametersControllerTest < ActionController::TestCase
 
   def test_create_invalid
     CommonParameter.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:common_parameter => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     CommonParameter.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:common_parameter => {:name => CommonParameter.first.name}}, set_session_user
     assert_redirected_to common_parameters_url
   end
 
@@ -30,13 +30,13 @@ class CommonParametersControllerTest < ActionController::TestCase
 
   def test_update_invalid
     CommonParameter.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => CommonParameter.first}, set_session_user
+    put :update, {:id => CommonParameter.first, :common_parameter => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     CommonParameter.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => CommonParameter.first}, set_session_user
+    put :update, {:id => CommonParameter.first, :common_parameter => {:name => "Reference", :value => "foreman"}}, set_session_user
     assert_redirected_to common_parameters_url
   end
 

--- a/test/functional/compute_resources_vms_controller_test.rb
+++ b/test/functional/compute_resources_vms_controller_test.rb
@@ -2,14 +2,9 @@ require 'test_helper'
 
 class ComputeResourcesVmsControllerTest < ActionController::TestCase
   setup do
-#    Fog.mock!
     @compute_resource = compute_resources(:mycompute)
     @your_compute_resource = compute_resources(:yourcompute)
     get_test_vm
-  end
-
-  teardown do
-#    Fog.unmock!
   end
 
   def setup_user(operation, type = 'compute_resources_vms')

--- a/test/functional/domains_controller_test.rb
+++ b/test/functional/domains_controller_test.rb
@@ -13,13 +13,13 @@ class DomainsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Domain.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:domain => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     Domain.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:domain => {:name => "MyDomain"}}, set_session_user
     assert_redirected_to domains_url
   end
 
@@ -30,13 +30,13 @@ class DomainsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Domain.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Domain.first}, set_session_user
+    put :update, {:id => Domain.first.to_param, :domain => {:name => Domain.first.name }}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Domain.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Domain.first}, set_session_user
+    put :update, {:id => Domain.first.to_param, :domain => {:name => Domain.first.name }}, set_session_user
     assert_redirected_to domains_url
   end
 

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -85,7 +85,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
 #    db_tree   of {"env1" => ["b", "c"],     "env2" => ["a", "b", "c"]}
 #    disk_tree of {"env1" => ["a", "b", "c"],"env2" => ["a", "b", "c"]}
     get :import_environments, {:proxy => smart_proxies(:puppetmaster)}, set_session_user
-    assert_template "puppetclasses_or_envs_changed"
+    assert_template "common/_puppetclasses_or_envs_changed"
     assert_select 'input#changed_new_env1'
     post :obsolete_and_new,
       {"changed" =>
@@ -104,7 +104,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
     #db_tree   of {"env1" => ["a", "b", "c", "d"], "env2" => ["a", "b", "c"]}
     #disk_tree of {"env1" => ["a", "b", "c"],      "env2" => ["a", "b", "c"]}
     get :import_environments, {:proxy => smart_proxies(:puppetmaster)}, set_session_user
-    assert_template "puppetclasses_or_envs_changed"
+    assert_template "common/_puppetclasses_or_envs_changed"
     assert_select 'input#changed_obsolete_env1[value*="d"]'
     post :obsolete_and_new,
       {"changed" =>
@@ -123,7 +123,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
     #db_tree   of {"env1" => ["a", "b", "c"], "env2" => ["a", "b", "c"], "env3" => []}
     #disk_tree of {"env1" => ["a", "b", "c"], "env2" => ["a", "b", "c"]}
     get :import_environments, {:proxy => smart_proxies(:puppetmaster).id}, set_session_user
-    assert_template "puppetclasses_or_envs_changed"
+    assert_template "common/_puppetclasses_or_envs_changed"
     assert_select 'input#changed_obsolete_env3'
     post :obsolete_and_new,
       {"changed" =>

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -18,15 +18,15 @@ class HostgroupsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Hostgroup.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:hostgroup => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     Hostgroup.any_instance.stubs(:valid?).returns(true)
     pc = Puppetclass.first
-    post :create, {"hostgroup" => {"name"=>"test_it", "group_parameters_attributes"=>{"1272344174448"=>{"name"=>"x", "value"=>"y", "_destroy"=>""}},
-                   "puppetclass_ids"=>["", pc.id.to_s], :realm_id => realms(:myrealm).id}}, set_session_user
+    post :create, {:hostgroup => {:name=>"test_it", :group_parameters_attributes=>{"1272344174448"=>{:name => "x", :value =>"y", :_destroy => ""}},
+                   :puppetclass_ids=>["", pc.id.to_s], :realm_id => realms(:myrealm).id}}, set_session_user
     assert_redirected_to hostgroups_url
   end
 
@@ -41,14 +41,12 @@ class HostgroupsControllerTest < ActionController::TestCase
   end
 
   def test_update_invalid
-    Hostgroup.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Hostgroup.first, :hostgroup => {}}, set_session_user
+    put :update, {:id => Hostgroup.first, :hostgroup => { :name => '' }}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
-    Hostgroup.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Hostgroup.first, :hostgroup => {}}, set_session_user
+    put :update, {:id => Hostgroup.first, :hostgroup => { :name => Hostgroup.first.name }}, set_session_user
     assert_redirected_to hostgroups_url
   end
 
@@ -79,7 +77,7 @@ class HostgroupsControllerTest < ActionController::TestCase
     hostgroup = hostgroups(:common)
     old_root_pass = hostgroup.root_pass
     as_admin do
-      put :update, {:commit => "Update", :id => hostgroup.id, :hostgroup => {:root_pass => ''} }, set_session_user
+      put :update, {:commit => "Update", :id => hostgroup.id, :hostgroup => {:root_pass => '', :name => hostgroup.name} }, set_session_user
     end
     hostgroup = Hostgroup.find(hostgroup.id)
     assert_equal old_root_pass, hostgroup.root_pass

--- a/test/functional/images_controller_test.rb
+++ b/test/functional/images_controller_test.rb
@@ -19,10 +19,8 @@ class ImagesControllerTest < ActionController::TestCase
 
   test "should create image" do
     assert_difference('Image.count') do
-      @image.name     = "gold"
-      @image.username = "ec2-user"
-      @image.uuid     = Foreman.uuid.to_s
-      post :create, { :image => @image.attributes, :compute_resource_id => @image.compute_resource_id }, set_session_user
+      image_attributes = {:name => 'gold', :username => 'ec2-user', :uuid => Foreman.uuid.to_s, :operatingsystem_id => Operatingsystem.first.id, :architecture_id => Architecture.first.id, :compute_resource_id => @image.compute_resource_id}
+      post :create, { :image => image_attributes, :compute_resource_id => @image.compute_resource_id }, set_session_user
     end
 
     assert_redirected_to compute_resource_path(@image.compute_resource)
@@ -34,9 +32,7 @@ class ImagesControllerTest < ActionController::TestCase
   end
 
   test "should update image" do
-    @image.username = "ec2-user"
-    @image.name     = "lala"
-    put :update, { :id => @image.to_param, :image => @image.attributes, :compute_resource_id => @image.compute_resource_id }, set_session_user
+    put :update, { :id => @image.to_param, :image => {:name => 'lala', :username => 'ec2-user'}, :compute_resource_id => @image.compute_resource_id }, set_session_user
     assert_redirected_to compute_resource_path(@image.compute_resource)
   end
 

--- a/test/functional/media_controller_test.rb
+++ b/test/functional/media_controller_test.rb
@@ -13,13 +13,13 @@ class MediaControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Medium.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:medium => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     Medium.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:medium => {:name => "MyMedia"}}, set_session_user
     assert_redirected_to media_url
   end
 
@@ -30,13 +30,13 @@ class MediaControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Medium.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Medium.first}, set_session_user
+    put :update, {:id => Medium.first, :medium => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Medium.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Medium.first}, set_session_user
+    put :update, {:id => Medium.first, :medium => {:name => "MyUpdatedMedia"}}, set_session_user
     assert_redirected_to media_url
   end
 

--- a/test/functional/models_controller_test.rb
+++ b/test/functional/models_controller_test.rb
@@ -13,7 +13,7 @@ class ModelsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Model.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:model => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
@@ -30,13 +30,13 @@ class ModelsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Model.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Model.first}, set_session_user
+    put :update, {:id => Model.first, :model => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Model.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Model.first}, set_session_user
+    put :update, {:id => Model.first, :model => {:name => "updated test"}}, set_session_user
     assert_redirected_to models_url
   end
 

--- a/test/functional/operatingsystems_controller_test.rb
+++ b/test/functional/operatingsystems_controller_test.rb
@@ -18,7 +18,7 @@ class OperatingsystemsControllerTest < ActionController::TestCase
 
     test 'create invalid' do
       Operatingsystem.any_instance.stubs(:valid?).returns(false)
-      post :create, {}, set_session_user
+      post :create, {:operatingsystem => {:name => nil}}, set_session_user
       assert_template 'new'
     end
 
@@ -30,7 +30,7 @@ class OperatingsystemsControllerTest < ActionController::TestCase
     test 'update invalid' do
       Operatingsystem.any_instance.stubs(:valid?).returns(false)
       Redhat.any_instance.stubs(:valid?).returns(false)
-      put :update, {:id => Operatingsystem.first}, set_session_user
+      put :update, {:id => Operatingsystem.first, :operatingsystem => {:name => Operatingsystem.first.name}}, set_session_user
       assert_template 'edit'
     end
   end
@@ -38,14 +38,14 @@ class OperatingsystemsControllerTest < ActionController::TestCase
   context 'redirects' do
     test 'create valid' do
       Operatingsystem.any_instance.stubs(:valid?).returns(true)
-      post :create, {}, set_session_user
+      post :create, {:operatingsystem => {:name => "MyOS"}}, set_session_user
       assert_redirected_to operatingsystems_url
     end
 
     test 'update valid' do
       Operatingsystem.any_instance.stubs(:valid?).returns(true)
       Redhat.any_instance.stubs(:valid?).returns(true)
-      put :update, {:id => Operatingsystem.first}, set_session_user
+      put :update, {:id => Operatingsystem.first, :operatingsystem => {:name => "MyOS"}}, set_session_user
       assert_redirected_to operatingsystems_url
     end
 
@@ -117,7 +117,7 @@ class OperatingsystemsControllerTest < ActionController::TestCase
       assert_difference 'OsDefaultTemplate.count', -1 do
         os_default_template_id = operatingsystem.os_default_templates.first.id
         put :update, {:id => operatingsystem.id,
-                      :operatingsystem => {:os_default_templates_attributes => {0 => { :id => os_default_template_id, :provisioning_template_id => '', :template_kind_id => @template_kind.id }}}}, set_session_user
+                      :operatingsystem => {:os_default_templates_attributes => [{ :id => os_default_template_id, :provisioning_template_id => '', :template_kind_id => @template_kind.id }]}}, set_session_user
       end
     end
   end

--- a/test/functional/provisioning_templates_controller_test.rb
+++ b/test/functional/provisioning_templates_controller_test.rb
@@ -13,13 +13,13 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
 
   test "create invalid" do
     ProvisioningTemplate.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:provisioning_template => {:name => "123"}}, set_session_user
     assert_template 'new'
   end
 
   test "create valid" do
     ProvisioningTemplate.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:provisioning_template => {:name => "123"}}, set_session_user
     assert_redirected_to provisioning_templates_url
   end
 
@@ -49,13 +49,13 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
 
   test "update invalid" do
     ProvisioningTemplate.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => templates(:pxekickstart).to_param }, set_session_user
+    put :update, {:id => templates(:pxekickstart).to_param, :provisioning_template => {:name => "123"} }, set_session_user
     assert_template 'edit'
   end
 
   test "update valid" do
     ProvisioningTemplate.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => templates(:pxekickstart).to_param }, set_session_user
+    put :update, {:id => templates(:pxekickstart).to_param, :provisioning_template => {:name => "123"} }, set_session_user
     assert_redirected_to provisioning_templates_url
   end
 

--- a/test/functional/ptables_controller_test.rb
+++ b/test/functional/ptables_controller_test.rb
@@ -17,7 +17,7 @@ class PtablesControllerTest < ActionController::TestCase
 
   test 'create_invalid' do
     Ptable.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:ptable => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
@@ -34,13 +34,13 @@ class PtablesControllerTest < ActionController::TestCase
 
   test 'update_invalid' do
     Ptable.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Ptable.first.id}, set_session_user
+    put :update, {:id => Ptable.first.id, :ptable => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   test 'update_valid' do
     Ptable.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Ptable.first.id}, set_session_user
+    put :update, {:id => Ptable.first.id, :ptable => {:name => "UpdatedDummy", :layout => "dummy_layout"}}, set_session_user
     assert_redirected_to ptables_url
   end
 

--- a/test/functional/puppetclasses_controller_test.rb
+++ b/test/functional/puppetclasses_controller_test.rb
@@ -14,13 +14,15 @@ class PuppetclassesControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Puppetclass.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Puppetclass.first.to_param}, set_session_user
+    put :update, {:id => Puppetclass.first.to_param, :puppetclass => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Puppetclass.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Puppetclass.first.to_param}, set_session_user
+    updated_puppetclass_id = Puppetclass.first.id
+    put :update, {:id => updated_puppetclass_id, :puppetclass => {:name => 'foo'}}, set_session_user
+    assert_equal 'foo', Puppetclass.find(updated_puppetclass_id).name
     assert_redirected_to puppetclasses_url
   end
 

--- a/test/functional/realms_controller_test.rb
+++ b/test/functional/realms_controller_test.rb
@@ -13,13 +13,13 @@ class RealmsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Realm.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:realm => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     Realm.any_instance.stubs(:valid?).returns(true)
-    post :create, {}, set_session_user
+    post :create, {:realm => {:name => "MyRealm"}}, set_session_user
     assert_redirected_to realms_url
   end
 
@@ -30,13 +30,15 @@ class RealmsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Realm.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Realm.first}, set_session_user
+    put :update, {:id => Realm.first.name, :realm => {:name => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Realm.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Realm.first}, set_session_user
+    put :update, {:id => Realm.first.name,
+                  :realm => { :realm_proxy_id => SmartProxy.first.id } }, set_session_user
+    assert_equal SmartProxy.first.id, Realm.first.realm_proxy_id
     assert_redirected_to realms_url
   end
 

--- a/test/functional/settings_controller_test.rb
+++ b/test/functional/settings_controller_test.rb
@@ -24,7 +24,8 @@ class SettingsControllerTest < ActionController::TestCase
   end
 
   test "does not render an old sti type setting" do
-    assert Setting.create(:name => "foo", :default => "bar", :description => "test foo", :category => "Setting::Invalid")
+    assert setting = Setting.create(:name => "foo", :default => "bar", :description => "test foo")
+    setting.send(:write_attribute, :category, "Setting::Invalid")
     get :index, {}, set_session_user
     assert_no_match /id='Invalid'/, @response.body
   end

--- a/test/functional/smart_proxies_controller_test.rb
+++ b/test/functional/smart_proxies_controller_test.rb
@@ -13,14 +13,14 @@ class SmartProxiesControllerTest < ActionController::TestCase
 
   def test_create_invalid
     SmartProxy.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:smart_proxy => {:name => nil}}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     SmartProxy.any_instance.stubs(:valid?).returns(true)
     SmartProxy.any_instance.stubs(:to_s).returns("puppet")
-    post :create, {}, set_session_user
+    post :create, {:smart_proxy => {:name => "MySmartProxy", :url => "http://nowhere.net:8000"}}, set_session_user
     assert_redirected_to smart_proxies_url
   end
 
@@ -31,13 +31,14 @@ class SmartProxiesControllerTest < ActionController::TestCase
 
   def test_update_invalid
     SmartProxy.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => SmartProxy.first}, set_session_user
+    put :update, {:id => SmartProxy.first.to_param, :smart_proxy => {:url => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     SmartProxy.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => SmartProxy.first}, set_session_user
+    put :update, {:id => SmartProxy.first,:smart_proxy => {:url => "http://elsewhere.com:8443"}}, set_session_user
+    assert_equal "http://elsewhere.com:8443", SmartProxy.first.url
     assert_redirected_to smart_proxies_url
   end
 

--- a/test/functional/subnets_controller_test.rb
+++ b/test/functional/subnets_controller_test.rb
@@ -13,7 +13,7 @@ class SubnetsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Subnet.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:subnet => {:network => nil}}, set_session_user
     assert_template 'new'
   end
 
@@ -30,13 +30,14 @@ class SubnetsControllerTest < ActionController::TestCase
 
   def test_update_invalid
     Subnet.any_instance.stubs(:valid?).returns(false)
-    put :update, {:id => Subnet.first}, set_session_user
+    put :update, {:id => Subnet.first, :subnet => {:network => nil}}, set_session_user
     assert_template 'edit'
   end
 
   def test_update_valid
     Subnet.any_instance.stubs(:valid?).returns(true)
-    put :update, {:id => Subnet.first}, set_session_user
+    put :update, {:id => Subnet.first, :subnet => {:network => '192.168.100.10'}}, set_session_user
+    assert_equal '192.168.100.10', Subnet.first.network
     assert_redirected_to subnets_url
   end
 

--- a/test/functional/usergroups_controller_test.rb
+++ b/test/functional/usergroups_controller_test.rb
@@ -17,13 +17,13 @@ class UsergroupsControllerTest < ActionController::TestCase
 
   def test_create_invalid
     Usergroup.any_instance.stubs(:valid?).returns(false)
-    post :create, {}, set_session_user
+    post :create, {:usergroup => { :name => nil }}, set_session_user
     assert_template 'new'
   end
 
   def test_create_valid
     Usergroup.any_instance.stubs(:valid?).returns(true)
-    post :create, { :usergroup => { :name => 'usergroup' } }, set_session_user
+    post :create, { :usergroup => { :name => 'Managing users' }}, set_session_user
     assert_redirected_to usergroups_url
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -78,7 +78,7 @@ class UsersControllerTest < ActionController::TestCase
   test "user changes should expire topbar cache" do
     user = FactoryGirl.create(:user, :with_mail)
     User.any_instance.expects(:expire_topbar_cache).once
-    put :update, { :id => user.id, :user => {:admin => true} }, set_session_user
+    put :update, { :id => user.id, :user => {:admin => true, :mail => user.mail} }, set_session_user
   end
 
   test "role changes should expire topbar cache" do
@@ -233,6 +233,7 @@ class UsersControllerTest < ActionController::TestCase
   test "should create and login external user" do
     Setting['authorize_login_delegation'] = true
     Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache_mod'
+    @request.session = nil
     @request.env['REMOTE_USER'] = 'ares'
     get :extlogin, {}, {}
     assert_redirected_to edit_user_path(User.find_by_login('ares'))
@@ -306,7 +307,7 @@ class UsersControllerTest < ActionController::TestCase
     User.expects(:try_to_login).with(u.login, 'password').returns(nil)
     post :login, {:login => {'login' => u.login, 'password' => 'password'}}
     assert_redirected_to login_users_path
-    assert_present flash[:error]
+    assert flash[:error].present?
   end
 
   test "#login retains taxonomy session attributes in new session" do

--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AboutTest < ActionDispatch::IntegrationTest
+class AboutIntegrationTest < ActionDispatch::IntegrationTest
   test "about page" do
     visit about_index_path
     assert_index_page(about_index_path,"About", nil, false, false)

--- a/test/integration/api_routing_test.rb
+++ b/test/integration/api_routing_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RoutingTest < ActionDispatch::IntegrationTest
+class RoutingIntegrationTest < ActionDispatch::IntegrationTest
   test "should go to v1 controller for /v1/ passed in URL" do
     assert_recognizes({:controller => "api/v1/domains", :action => "index", :apiv => "v1", :format => "json"}, "/api/v1/domains")
   end

--- a/test/integration/architecture_test.rb
+++ b/test/integration/architecture_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ArchitectureTest < ActionDispatch::IntegrationTest
+class ArchitectureIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(architectures_path,"Architectures","New Architecture")
   end

--- a/test/integration/audit_test.rb
+++ b/test/integration/audit_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AuditTest < ActionDispatch::IntegrationTest
+class AuditIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(audits_path,"Audits",nil,true)
   end

--- a/test/integration/auth_source_ldap_test.rb
+++ b/test/integration/auth_source_ldap_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AuthSourceLdapTest < ActionDispatch::IntegrationTest
+class AuthSourceLdapIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(auth_source_ldaps_path,"LDAP Authentication","New LDAP Source",false,false)
   end

--- a/test/integration/bookmark_test.rb
+++ b/test/integration/bookmark_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BookmarkTest < ActionDispatch::IntegrationTest
+class BookmarkIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(bookmarks_path,"Manage Bookmarks",false,false,true)
   end

--- a/test/integration/common_parameter_test.rb
+++ b/test/integration/common_parameter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CommonParameterTest < ActionDispatch::IntegrationTest
+class CommonParameterIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(common_parameters_path,"Global Parameters","New Parameter")
   end

--- a/test/integration/compute_profile_test.rb
+++ b/test/integration/compute_profile_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ComputeProfileTest < ActionDispatch::IntegrationTest
+class ComputeProfileIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     Fog.mock!
   end

--- a/test/integration/compute_resource_test.rb
+++ b/test/integration/compute_resource_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ComputeResourceTest < ActionDispatch::IntegrationTest
+class ComputeResourceIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(compute_resources_path,"Compute Resources","New Compute Resource")
   end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class DashboardTest < ActionDispatch::IntegrationTest
+class DashboardIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     FactoryGirl.create(:host)
     Dashboard::Manager.reset_user_to_default(users(:admin))

--- a/test/integration/domain_test.rb
+++ b/test/integration/domain_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class DomainTest < ActionDispatch::IntegrationTest
+class DomainIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(domains_path,"Domains","New Domain")
   end

--- a/test/integration/environment_test.rb
+++ b/test/integration/environment_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EnvironmentTest < ActionDispatch::IntegrationTest
+class EnvironmentIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(environments_path,"Environments","New Puppet Environment")
   end

--- a/test/integration/fact_value_test.rb
+++ b/test/integration/fact_value_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
-class FactValueTest < ActionDispatch::IntegrationTest
+class FactValueIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     @host = FactoryGirl.create(:host)
-    FactoryGirl.create(:fact_value, :value => '2.6.9',:host => @host,
-                       :fact_name => FactoryGirl.create(:fact_name, :name => 'kernelversion'))
+    @fact_name = FactoryGirl.create(:fact_name)
+    @value = FactoryGirl.create(:fact_value, :host => @host, :fact_name => @fact_name)
   end
 
   test "index page" do
@@ -13,7 +13,7 @@ class FactValueTest < ActionDispatch::IntegrationTest
 
   test "host fact links" do
     visit fact_values_path
-    within(:xpath, "//tr[contains(.,'kernelversion')]") do
+    within(:xpath, "//tr[contains(.,'#{@fact_name.name}')]") do
       click_link(@host.fqdn)
     end
     assert_equal "host = #{@host.fqdn}", find_field('search').value
@@ -21,15 +21,15 @@ class FactValueTest < ActionDispatch::IntegrationTest
 
   test "fact_name fact links" do
     visit fact_values_path
-    within(:xpath, "//tr[contains(.,'kernelversion')]") do
+    within(:xpath, "//tr[contains(.,'#{@fact_name.name}')]") do
       first(:xpath, "//td[2]/a").click
     end
-    assert_equal 'name = kernelversion', find_field('search').value
+    assert_equal "name = #{@fact_name.name}", find_field('search').value
   end
 
   test "value fact links" do
     visit fact_values_path
-    click_link("2.6.9")
-    assert_equal 'facts.kernelversion = "2.6.9"', find_field('search').value
+    click_link(@value.value)
+    assert_equal "facts.#{@fact_name.name} = \"#{@value.value}\"", find_field('search').value
   end
 end

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class HostgroupTest < ActionDispatch::IntegrationTest
+class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(hostgroups_path,"Host Groups","New Host Group")
   end

--- a/test/integration/location_test.rb
+++ b/test/integration/location_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LocationTest < ActionDispatch::IntegrationTest
+class LocationIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     FactoryGirl.create(:host)
   end

--- a/test/integration/lookup_key_test.rb
+++ b/test/integration/lookup_key_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LookupKeyTest < ActionDispatch::IntegrationTest
+class LookupKeyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(lookup_keys_path,"Smart variables",false)
   end

--- a/test/integration/media_test.rb
+++ b/test/integration/media_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class MediaTest < ActionDispatch::IntegrationTest
+class MediaIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(media_path,"Media","New Medium")
   end

--- a/test/integration/model_test.rb
+++ b/test/integration/model_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ModelTest < ActionDispatch::IntegrationTest
+class ModelIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(models_path,"Hardware Models","New Model")
   end

--- a/test/integration/operatingsystem_test.rb
+++ b/test/integration/operatingsystem_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class OperatingsystemTest < ActionDispatch::IntegrationTest
+class OperatingsystemIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(operatingsystems_path,"Operating systems","New Operating system")
   end

--- a/test/integration/organization_test.rb
+++ b/test/integration/organization_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class OrganizationTest < ActionDispatch::IntegrationTest
+class OrganizationIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     FactoryGirl.create(:host)
   end

--- a/test/integration/provisioning_template_test.rb
+++ b/test/integration/provisioning_template_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ProvisioningTemplateTest < ActionDispatch::IntegrationTest
+class ProvisioningTemplateIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(provisioning_templates_path,"Provisioning Templates","New Template")
   end

--- a/test/integration/ptable_test.rb
+++ b/test/integration/ptable_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PtableTest < ActionDispatch::IntegrationTest
+class PtableIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     @ptable = FactoryGirl.create(:ptable, :ubuntu, :name => 'ubuntu default')
   end

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PuppetclassTest < ActionDispatch::IntegrationTest
+class PuppetclassIntegrationTest < ActionDispatch::IntegrationTest
   test "edit page" do
     visit puppetclasses_path
     click_link "vim"

--- a/test/integration/realm_test.rb
+++ b/test/integration/realm_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RealmTest < ActionDispatch::IntegrationTest
+class RealmIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(realms_path,"Realms","New Realm")
   end

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ReportTest < ActionDispatch::IntegrationTest
+class ReportIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     @report = FactoryGirl.create(:report, :old_report)
   end

--- a/test/integration/role_test.rb
+++ b/test/integration/role_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RoleTest < ActionDispatch::IntegrationTest
+class RoleIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(roles_path,"Roles","New role")
   end

--- a/test/integration/setting_test.rb
+++ b/test/integration/setting_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SettingTest < ActionDispatch::IntegrationTest
+class SettingIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(settings_path,"Settings",false,true,false)
     assert page.has_link?("General", :href => "#General")

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SmartProxyTest < ActionDispatch::IntegrationTest
+class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(smart_proxies_path,"Smart Proxies","New Smart Proxy",false)
   end

--- a/test/integration/statistic_test.rb
+++ b/test/integration/statistic_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class StatisticTest < ActionDispatch::IntegrationTest
+class StatisticIntegrationTest < ActionDispatch::IntegrationTest
   test "statistics page" do
     visit statistics_path
     assert page.has_selector?('h4', :text => "OS Distribution")

--- a/test/integration/subnet_test.rb
+++ b/test/integration/subnet_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SubnetTest < ActionDispatch::IntegrationTest
+class SubnetIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(subnets_path,"Subnets","New Subnet")
   end

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
-class TopBarTest < ActionDispatch::IntegrationTest
+class TopBarIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     FactoryGirl.create(:fact_value, :value => '2.6.9',:host => FactoryGirl.create(:host),
-                       :fact_name => FactoryGirl.create(:fact_name, :name => 'kernelversion'))
+                       :fact_name => FactoryGirl.create(:fact_name) )
   end
 
   test "top bar links" do

--- a/test/integration/trend_test.rb
+++ b/test/integration/trend_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TrendTest < ActionDispatch::IntegrationTest
+class TrendIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     visit trends_path
     assert page.has_selector?('h1', :text => "Trends"), "Trends was expected in the <h1> tag, but was not found"

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UserTest < ActionDispatch::IntegrationTest
+class UserIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(users_path,"Users","New User")
   end

--- a/test/integration/usergroup_test.rb
+++ b/test/integration/usergroup_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class UsergroupTest < ActionDispatch::IntegrationTest
+class UsergroupIntegrationTest < ActionDispatch::IntegrationTest
   def setup
-    as_admin { FactoryGirl.create(:usergroup, :name => "Admins") }
+    as_admin { @usergroup = FactoryGirl.create(:usergroup) }
   end
 
   test "index page" do
@@ -18,7 +18,7 @@ class UsergroupTest < ActionDispatch::IntegrationTest
 
   test "edit page" do
     visit usergroups_path
-    click_link "Admins"
+    click_link @usergroup.name
     fill_in "usergroup_name", :with => "SuperAdmins"
     assert_submit_button(usergroups_path)
     assert page.has_link? 'SuperAdmins'

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -48,7 +48,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     domain     = FactoryGirl.create(:domain)
     auth       = Authorizer.new(@user)
 
-    assert_include auth.find_collection(Domain, :permission => :view_domains), domain
+    assert_includes auth.find_collection(Domain, :permission => :view_domains), domain
     assert auth.can?(:view_domains, domain)
   end
 
@@ -59,7 +59,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     domain     = FactoryGirl.create(:domain)
     auth       = Authorizer.new(@user)
 
-    assert_include auth.find_collection(Domain, :permission => :view_domains), domain
+    assert_includes auth.find_collection(Domain, :permission => :view_domains), domain
     assert auth.can?(:view_domains, domain)
   end
 
@@ -72,7 +72,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     domain              = FactoryGirl.create(:domain)
     auth                = Authorizer.new(@user)
 
-    assert_include auth.find_collection(Domain, :permission => :view_domains), domain
+    assert_includes auth.find_collection(Domain, :permission => :view_domains), domain
     assert auth.can?(:view_domains, domain)
   end
 
@@ -83,7 +83,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     domain     = FactoryGirl.create(:domain)
     auth       = Authorizer.new(@user)
 
-    assert_not_include auth.find_collection(Domain, :permission => :view_domains), domain
+    assert_not_includes auth.find_collection(Domain, :permission => :view_domains), domain
     refute auth.can?(:view_domains, domain)
   end
 
@@ -96,8 +96,8 @@ class AuthorizerTest < ActiveSupport::TestCase
     auth       = Authorizer.new(@user)
 
     collection = auth.find_collection(Domain, :permission => :view_domains)
-    assert_not_include collection, domain1
-    assert_include collection, domain2
+    assert_not_includes collection, domain1
+    assert_includes collection, domain2
     refute auth.can?(:view_domains, domain1)
     assert auth.can?(:view_domains, domain2)
   end
@@ -136,10 +136,10 @@ class AuthorizerTest < ActiveSupport::TestCase
     # unlimited filter on Domain permission does add the domain
     FactoryGirl.create(:filter, :role => @role, :permissions => [permission1])
     collection = auth.find_collection(Domain)
-    assert_include collection, domain1
-    assert_include collection, domain2
-    assert_include collection, domain3
-    assert_include collection, domain4
+    assert_includes collection, domain1
+    assert_includes collection, domain2
+    assert_includes collection, domain3
+    assert_includes collection, domain4
   end
 
   test "#can?(:view_domains, @host) for user without filter" do
@@ -149,7 +149,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     auth       = Authorizer.new(FactoryGirl.create(:user))
 
     result = auth.find_collection(Domain, :permission => :view_domains)
-    assert_not_include result, domain
+    assert_not_includes result, domain
     assert_kind_of ActiveRecord::Relation, result
     refute auth.can?(:view_domains, domain)
   end

--- a/test/unit/host_build_status_test.rb
+++ b/test/unit/host_build_status_test.rb
@@ -7,7 +7,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
     User.current = users(:admin)
     @host = Host.new(:name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03", :ptable => FactoryGirl.create(:ptable), :medium => media(:one),
                     :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
-                    :subnet => subnets(:one), :architecture => architectures(:x86_64), :environment => environments(:production), :managed => true,
+                    :architecture => architectures(:x86_64), :environment => environments(:production), :managed => true,
                     :owner_type => "User", :root_pass => "xybxa6JUkz63w")
     @build = @host.build_status
     # bypass host.valid?
@@ -15,7 +15,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
   end
 
   test "should be able to render a template" do
-    assert_blank build.errors[:templates]
+    assert build.errors[:templates].blank?
   end
 
   test "should fail rendering a template" do

--- a/test/unit/host_mailer_test.rb
+++ b/test/unit/host_mailer_test.rb
@@ -58,6 +58,6 @@ class HostMailerTest < ActionMailer::TestCase
     assert_includes mail.from, Setting["email_reply_address"]
     assert_includes mail.to, user.mail
     assert_includes mail.subject, report.host.name
-    assert_present mail.body
+    assert mail.body.present?
   end
 end

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -272,18 +272,18 @@ class HostgroupTest < ActiveSupport::TestCase
   test "available_puppetclasses should return all if no environment" do
     hostgroup = hostgroups(:common)
     hostgroup.update_attribute(:environment_id, nil)
-    assert_equal Puppetclass.scoped, hostgroup.available_puppetclasses
+    assert_equal Puppetclass.all, hostgroup.available_puppetclasses
   end
 
   test "available_puppetclasses should return environment-specific classes" do
     hostgroup = hostgroups(:common)
-    refute_equal Puppetclass.scoped, hostgroup.available_puppetclasses
+    refute_equal Puppetclass.all, hostgroup.available_puppetclasses
     assert_equal hostgroup.environment.puppetclasses.sort, hostgroup.available_puppetclasses.sort
   end
 
   test "available_puppetclasses should return environment-specific classes (and that are NOT already inherited by parent)" do
     hostgroup = hostgroups(:inherited)
-    refute_equal Puppetclass.scoped, hostgroup.available_puppetclasses
+    refute_equal Puppetclass.all, hostgroup.available_puppetclasses
     refute_equal hostgroup.environment.puppetclasses.sort, hostgroup.available_puppetclasses.sort
     assert_equal (hostgroup.environment.puppetclasses - hostgroup.parent_classes).sort, hostgroup.available_puppetclasses.sort
   end
@@ -309,7 +309,7 @@ class HostgroupTest < ActiveSupport::TestCase
     hostgroup = FactoryGirl.build(:hostgroup, :parent => parent, :root_pass => '')
     assert_equal parent.read_attribute(:root_pass), hostgroup.root_pass
     hostgroup.save!
-    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+    assert hostgroup.read_attribute(:root_pass).blank?, 'root_pass should not be copied and stored on child'
   end
 
   test "root_pass inherited from settings if blank" do
@@ -317,7 +317,7 @@ class HostgroupTest < ActiveSupport::TestCase
     hostgroup = FactoryGirl.build(:hostgroup, :root_pass => '')
     assert_equal '12345678', hostgroup.root_pass
     hostgroup.save!
-    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+    assert hostgroup.read_attribute(:root_pass).blank?, 'root_pass should not be copied and stored on child'
   end
 
   test "root_pass inherited from settings if group and parent are blank" do
@@ -326,7 +326,7 @@ class HostgroupTest < ActiveSupport::TestCase
     hostgroup = FactoryGirl.build(:hostgroup, :parent => parent, :root_pass => '')
     assert_equal '12345678', hostgroup.root_pass
     hostgroup.save!
-    assert_blank hostgroup.read_attribute(:root_pass), 'root_pass should not be copied and stored on child'
+    assert hostgroup.read_attribute(:root_pass).blank?, 'root_pass should not be copied and stored on child'
   end
 
   test "hostgroup name can't be too big to create lookup value matcher over 255 characters" do

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -96,12 +96,12 @@ class LookupValueTest < ActiveSupport::TestCase
     lk1 = LookupValue.new(:value => "---\n  foo: bar", :match => "hostgroup=Common", :lookup_key => lookup_keys(:six))
     assert lk1.save!
     assert lk1.value.is_a? Hash
-    assert_include lk1.value_before_type_cast, "foo: bar"
+    assert_includes lk1.value_before_type_cast, 'foo: bar'
 
     lk2 = LookupValue.new(:value => "{'foo': 'bar'}", :match => "environment=Production", :lookup_key => lookup_keys(:six))
     assert lk2.save!
     assert lk2.value.is_a? Hash
-    assert_include lk2.value_before_type_cast, "foo: bar"
+    assert_includes lk2.value_before_type_cast, 'foo: bar'
   end
 
   test "should cast and uncast string containing an Array" do

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -116,9 +116,9 @@ class NicTest < ActiveSupport::TestCase
 
   test "Nic::Managed#hostname should return blank for blank hostnames" do
     i = Nic::Managed.new :mac => "babbccddeeff00112233445566778899aabbccdd", :host => FactoryGirl.create(:host), :subnet => subnets(:one), :domain => subnets(:one).domains.first, :name => ""
-    assert_blank i.name
-    assert_present i.domain
-    assert_blank i.hostname
+    assert i.name.blank?
+    assert i.domain.present?
+    assert i.hostname.blank?
   end
 
   test "Mac address uniqueness validation is skipped for virtual NICs and unmanaged hosts" do
@@ -349,14 +349,15 @@ class NicTest < ActiveSupport::TestCase
       class DisallowedTestNic < Nic::Base
       end
 
-      Nic::Base.allowed_types.clear
       Nic::Base.register_type(DefaultTestNic)
       Nic::Base.register_type(HumanizedTestNic)
     end
 
     test "base registers allowed nic types" do
       expected_types = [DefaultTestNic, HumanizedTestNic]
-      assert_equal expected_types.map(&:name), Nic::Base.allowed_types.map(&:name)
+      expected_types.map(&:name).each do |type|
+        assert Nic::Base.allowed_types.map(&:name).include? type
+      end
     end
 
     test "type_by_name returns nil for an unknown name" do

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -211,7 +211,7 @@ class OperatingsystemTest < ActiveSupport::TestCase
     host = FactoryGirl.create(:host)
     os = operatingsystems(:ubuntu1010)
     assert_difference "os.hosts_count" do
-      host.update_attribute(:operatingsystem, os)
+      host.update_attributes(:operatingsystem => os)
       os.reload
     end
   end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -81,7 +81,7 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
   test "should not alter description field if already set" do
     # Need to instantiate @importer once with normal facts
-    assert_present @importer.operatingsystem
+    assert @importer.operatingsystem.present?
     # Now re-import with a different description
     facts_with_desc = facts.merge({:lsbdistdescription => "A different string"})
     @importer = PuppetFactParser.new facts_with_desc

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -114,6 +114,7 @@ class ReportTest < ActiveSupport::TestCase
       orgs = FactoryGirl.create_pair(:organization)
       locs = FactoryGirl.create_pair(:location)
       @target_host.update_attributes(:location => locs.last, :organization => orgs.last)
+      @target_host.hostgroup.update_attributes(:locations => [locs.last], :organizations => [orgs.last])
 
       user_role.owner.update_attributes(:locations => [locs.first], :organizations => [orgs.first])
       as_user user_role.owner do

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -129,7 +129,7 @@ class RoleTest < ActiveSupport::TestCase
         User.current.roles<< first
       end
 
-      subject { Role.for_current_user.all }
+      subject { Role.for_current_user.to_a }
       it { subject.must_include(first) }
       it { subject.wont_include(second) }
     end

--- a/test/unit/sso.rb
+++ b/test/unit/sso.rb
@@ -21,6 +21,6 @@ class SSOTest < ActiveSupport::TestCase
   def test_get_available_should_find_first_available_method
     stub(SSO).all { [ DummyFalseMethod, DummyTrueMethod, DummyFalseMethod ] }
     available = SSO.get_available(Object.new)
-    assert_present available
+    assert available.present?
   end
 end

--- a/test/unit/user_role_test.rb
+++ b/test/unit/user_role_test.rb
@@ -18,7 +18,7 @@ class UserRoleTest < ActiveSupport::TestCase
     cached_user_roles = user.cached_user_roles.map(&:role)
 
     user.roles.each do |role|
-      assert_include cached_user_roles, role
+      assert_includes cached_user_roles, role
     end
   end
 
@@ -28,8 +28,8 @@ class UserRoleTest < ActiveSupport::TestCase
     users = @semiadmin_users + [@admin_user] + [@superadmin_user]
     users.each do |user|
       cached_user_roles = user.cached_user_roles
-      assert_include cached_user_roles.map(&:role), user_role.role
-      assert_include cached_user_roles.map(&:user_role), user_role
+      assert_includes cached_user_roles.map(&:role), user_role.role
+      assert_includes cached_user_roles.map(&:user_role), user_role
     end
   end
 
@@ -41,7 +41,7 @@ class UserRoleTest < ActiveSupport::TestCase
 
     users = @semiadmin_users + [@admin_user] + [@superadmin_user]
     users.each  do |user|
-      assert_include user.cached_user_roles.map(&:role), new_role
+      assert_includes user.cached_user_roles.map(&:role), new_role
     end
   end
 
@@ -52,7 +52,7 @@ class UserRoleTest < ActiveSupport::TestCase
 
     users = [@admin_user, @superadmin_user]
     users.each do |user|
-      assert_include user.cached_user_roles.map(&:role), user_role.role
+      assert_includes user.cached_user_roles.map(&:role), user_role.role
     end
 
     users = @semiadmin_users

--- a/test/unit/usergroup_member_test.rb
+++ b/test/unit/usergroup_member_test.rb
@@ -5,13 +5,13 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     setup_admins_scenario
     assert_includes @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
 
-    @superadmins.users.clear
+    @superadmins.users.destroy_all
 
-    assert_not_include @superadmin_user.reload.cached_user_roles.map(&:role), @semiadmin_role
+    assert_not_includes @superadmin_user.reload.cached_user_roles.map(&:role), @semiadmin_role
     cached_usergroups = @superadmin_user.cached_usergroups
-    assert_not_include cached_usergroups, @superadmins
-    assert_not_include cached_usergroups, @admins
-    assert_not_include cached_usergroups, @semiadmins
+    assert_not_includes cached_usergroups, @superadmins
+    assert_not_includes cached_usergroups, @admins
+    assert_not_includes cached_usergroups, @semiadmins
   end
 
   test "searching for user roles" do
@@ -32,7 +32,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     found = @admins.usergroup_members.first.send :find_all_usergroups
     assert_includes found, @semiadmins
     assert_includes found, @admins
-    assert_not_include found, @superadmins
+    assert_not_includes found, @superadmins
   end
 
   test "searching for affected users memberships" do
@@ -52,10 +52,10 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "remove root member in tree" do
     setup_admins_scenario
 
-    assert_include @admin_user.cached_user_roles.map(&:role), @semiadmin_role
-    assert_include @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @admin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
 
-    @semiadmins.usergroups.clear
+    @semiadmins.usergroups.destroy_all
     [@semiadmin_user, @admin_user, @superadmin_user].map(&:reload)
 
     assert_includes @semiadmin_user.cached_user_roles.map(&:role), @semiadmin_role
@@ -63,8 +63,8 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     assert_includes @superadmin_user.cached_user_roles.map(&:role), @admin_role
     assert_includes @superadmin_user.cached_user_roles.map(&:role), @superadmin_role
 
-    assert_not_include @admin_user.cached_user_roles.map(&:role), @semiadmin_role
-    assert_not_include @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_not_includes @admin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_not_includes @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
 
     assert_includes @semiadmin_user.cached_usergroups, @semiadmins
     assert_not_includes @admin_user.cached_usergroups, @semiadmins
@@ -77,19 +77,19 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "remove leaf member in tree" do
     setup_admins_scenario
 
-    assert_include @semiadmin_user.cached_user_roles.map(&:role), @semiadmin_role
-    assert_include @admin_user.cached_user_roles.map(&:role), @semiadmin_role
-    assert_include @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @semiadmin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @admin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
 
-    @admins.usergroups.clear
+    @admins.usergroups.destroy_all
     [@semiadmin_user, @admin_user, @superadmin_user].map(&:reload)
 
     assert_includes @semiadmin_user.cached_user_roles.map(&:role), @semiadmin_role
     assert_includes @admin_user.cached_user_roles.map(&:role), @admin_role
     assert_includes @superadmin_user.cached_user_roles.map(&:role), @superadmin_role
-    assert_include @admin_user.cached_user_roles.map(&:role), @semiadmin_role
-    assert_not_include @superadmin_user.cached_user_roles.map(&:role), @admin_role
-    assert_not_include @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_includes @admin_user.cached_user_roles.map(&:role), @semiadmin_role
+    assert_not_includes @superadmin_user.cached_user_roles.map(&:role), @admin_role
+    assert_not_includes @superadmin_user.cached_user_roles.map(&:role), @semiadmin_role
 
     assert_includes @semiadmin_user.cached_usergroups, @semiadmins
     assert_includes @admin_user.cached_usergroups, @semiadmins
@@ -126,11 +126,11 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     basic.usergroups<< @admins
     [@semiadmin_user, @admin_user, @superadmin_user].map(&:reload)
 
-    assert_not_include @semiadmin_user.cached_user_roles.map(&:role), basic_role
+    assert_not_includes @semiadmin_user.cached_user_roles.map(&:role), basic_role
     assert_includes @admin_user.cached_user_roles.map(&:role), basic_role
     assert_includes @superadmin_user.cached_user_roles.map(&:role), basic_role
 
-    assert_not_include @semiadmin_user.cached_usergroups, basic
+    assert_not_includes @semiadmin_user.cached_usergroups, basic
     assert_includes @admin_user.cached_usergroups, basic
     assert_includes @superadmin_user.cached_usergroups, basic
   end
@@ -148,8 +148,8 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     assert_not_includes @admin_user.cached_user_roles.map(&:role), basic_role
     assert_includes @superadmin_user.cached_user_roles.map(&:role), basic_role
 
-    assert_not_include @semiadmin_user.cached_usergroups, basic
-    assert_not_include @admin_user.cached_usergroups, basic
+    assert_not_includes @semiadmin_user.cached_usergroups, basic
+    assert_not_includes @admin_user.cached_usergroups, basic
     assert_includes @superadmin_user.cached_usergroups, basic
   end
 
@@ -170,9 +170,9 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     assert_includes @superadmin_user.cached_usergroups, @semiadmins
     assert_includes @superadmin_user.cached_usergroups, @admins
     assert_includes @superadmin_user.cached_usergroups, @superadmins
-    assert_not_include @admin_user.cached_usergroups, @semiadmins
-    assert_include @admin_user.cached_usergroups, @admins
-    assert_include @semiadmin_user.cached_usergroups, @semiadmins
+    assert_not_includes @admin_user.cached_usergroups, @semiadmins
+    assert_includes @admin_user.cached_usergroups, @admins
+    assert_includes @semiadmin_user.cached_usergroups, @semiadmins
   end
 
   test "change membership (hostgroup) in the middle of chain" do
@@ -192,7 +192,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
 
     assert_includes @superadmin_user.cached_usergroups, @superadmins
     assert_includes @superadmin_user.cached_usergroups, @semiadmins
-    assert_not_include @superadmin_user.cached_usergroups, @admins
+    assert_not_includes @superadmin_user.cached_usergroups, @admins
     assert_includes @admin_user.cached_usergroups, @semiadmins
     assert_includes @admin_user.cached_usergroups, @admins
     assert_includes @semiadmin_user.cached_usergroups, @semiadmins
@@ -202,7 +202,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     setup_redundant_scenario
 
     @admins.users = []
-    assert_not_include @semiadmin_user.cached_user_roles.map(&:role), @admin_role
+    assert_not_includes @semiadmin_user.cached_user_roles.map(&:role), @admin_role
   end
 
   test "user is in three two joined groups, middle membership is removed" do


### PR DESCRIPTION
This commit contains all changes to tests in branch
https://github.com/theforeman/foreman/pull/2055 that I found to be
retrocompatible with Rails 3. The more of these we can get in, the less
code we will have to review for Rails 4, and the more relevant it will
be, as it'll be all completly Rails 4 specific.
