### PR TITLE
Fixes #11093 - Cockpit journal and console if available

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -307,6 +307,12 @@ module HostsHelper
               link_to(_("Loading power state ..."), '#', :disabled => true, :id => :loading_power_state)
           )
         end,
+        if host.cockpit_enabled?
+          button_group(
+              link_to_if_authorized(_('Console'), hash_for_console_host_path(:id => host), :id => :cockpit_console),
+              link_to_if_authorized(_('Journal'), hash_for_journal_host_path(:id => host), :id => :cockpit_journal)
+          )
+        end,
         button_group(
           if host.try(:puppet_proxy)
             link_to_if_authorized(_("Run puppet"), hash_for_puppetrun_host_path(:id => host).merge(:auth_object => host, :permission => 'puppetrun_hosts'),

--- a/app/models/concerns/cockpit.rb
+++ b/app/models/concerns/cockpit.rb
@@ -1,0 +1,17 @@
+module Cockpit
+  extend ActiveSupport::Concern
+
+  included do
+    def cockpit_enabled?
+      return false unless primary_interface.fqdn.present? ||
+        %w(Fedora Redhat Archlinux).include?(operatingsystem.type)
+      Timeout::timeout(5) do
+        'cockpit' == JSON.parse(RestClient.get("#{primary_interface.fqdn}:9090/ping"))['service']
+      end
+    rescue => e
+      logger.warn "Tried to contact Cockpit for host #{name} but failed: #{e}"
+      logger.debug e.backtrace.join("\n")
+      false
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,6 +1,7 @@
 class Host::Managed < Host::Base
   include ReportCommon
   include Hostext::Search
+  include Cockpit
   PROVISION_METHODS = %w[build image]
 
   has_many :host_classes, :foreign_key => :host_id

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -367,7 +367,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :"api/v2/tasks" => [:index] }
     map.permission :power_hosts,   {:hosts          => [:power],
                                     :"api/v2/hosts" => [:power] }
-    map.permission :console_hosts, {:hosts => [:console] }
+    map.permission :console_hosts, {:hosts => [:console, :journal] }
     map.permission :ipmi_boot, { :hosts          => [:ipmi_boot],
                                  :"api/v2/hosts" => [:boot] }
     map.permission :puppetrun_hosts, {:hosts => [:puppetrun, :multiple_puppetrun, :update_multiple_puppetrun],

--- a/app/views/hosts/console/cockpit.html.erb
+++ b/app/views/hosts/console/cockpit.html.erb
@@ -1,0 +1,3 @@
+<% title "Cockpit console: #{@console[:name]}".html_safe %>
+<iframe width="700px" height="420px" frameBorder="0"
+  src="http://<%= @console[:fqdn] %>:9090/cockpit/@localhost/system/terminal.html"/>

--- a/app/views/hosts/journal.html.erb
+++ b/app/views/hosts/journal.html.erb
@@ -1,0 +1,3 @@
+<% title "Cockpit journal: #{@console[:name]}".html_safe %>
+<iframe width="700px" height="420px" frameBorder="0"
+  src="http://<%= @console[:fqdn] %>:9090/cockpit/@localhost/system/log.html"/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Foreman::Application.routes.draw do
         post 'environment_selected'
         put 'power'
         get 'console'
+        get 'journal'
         get 'overview'
         get 'bmc'
         get 'vm'

--- a/test/unit/concerns/cockpit_test.rb
+++ b/test/unit/concerns/cockpit_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class DummyCockpit
+  include Cockpit
+end
+
+class CockpitTest < ActiveSupport::TestCase
+  test 'cockpit is enabled if cockpit ping is successful' do
+    dummy_cockpit = DummyCockpit.new
+    dummy_cockpit.stubs(:operatingsystem).returns(OpenStruct.new(:type => 'Fedora'))
+    dummy_cockpit.stubs(:primary_interface).returns(OpenStruct.new(:fqdn => 'http://foo.bar'))
+    RestClient.expects(:get).with("#{dummy_cockpit.primary_interface.fqdn}:9090/ping").
+      returns('{"service": "cockpit"}')
+    assert dummy_cockpit.cockpit_enabled?
+  end
+end


### PR DESCRIPTION
This should allow us to see a button Console/Journal if cockpit is enabled in some host, and that host is contactable by Foreman. 

![screenshot](http://i.imgur.com/GTUWT5c.png)
