### PR TITLE
fixes #10994 - remove new_* data from compute profile attributes

### DIFF
--- a/db/migrate/20150714140850_remove_new_from_compute_attributes.rb
+++ b/db/migrate/20150714140850_remove_new_from_compute_attributes.rb
@@ -1,0 +1,21 @@
+class FakeComputeAttribute < ActiveRecord::Base
+  set_table_name 'compute_attributes'
+  serialize :vm_attrs, Hash
+end
+
+class RemoveNewFromComputeAttributes < ActiveRecord::Migration
+  def up
+    FakeComputeAttribute.all.each do |comp_attr|
+      attrs_name = ['nics', 'interfaces'].find do |name|
+        comp_attr.vm_attrs["#{name}_attributes"].present?
+      end
+      comp_attr.vm_attrs["#{attrs_name}_attributes"].delete("new_#{attrs_name}") if attrs_name
+      comp_attr.vm_attrs['volumes_attributes'].try(:delete, 'new_volumes')
+      comp_attr.save!
+    end
+  end
+
+  def down
+    # Cannot restore data
+  end
+end


### PR DESCRIPTION
77c68e4 stopped new_\* data hashes from being stored in compute profiles
and elsewhere, and removed the filtering of it too.  This filters
existing attributes in the DB to prevent InterfaceMerge trying to use
the data.

---

@ares would you mind checking this too please?
