### PR TITLE
Fixes #10826 - Adds unique constraint to the title in operatingsystem…

### DIFF
--- a/db/migrate/20150713143226_add_unique_to_operatingsystems_title.rb
+++ b/db/migrate/20150713143226_add_unique_to_operatingsystems_title.rb
@@ -1,0 +1,30 @@
+class AddUniqueToOperatingsystemsTitle < ActiveRecord::Migration
+  def up
+    dups = Operatingsystem.all.group_by(&:fullname).values.keep_if { |ary| ary.length > 1}
+    dups.each do |systems|
+      systems.sort! { |a, b| b.hosts_count <=> a.hosts_count }.shift
+      systems.each_with_index do |os, index|
+        os.name = os.name + "-#{index + 1}"
+        os.save!
+      end
+    end
+
+    duplicities = Operatingsystem.all.group_by(&:title).values.keep_if { |ary| ary.length > 1}
+    duplicities.each do |systems|
+      systems.each do |os|
+        os.description = os.fullname
+        os.save!
+      end
+    end
+
+    add_index :operatingsystems, :title, :unique => true
+    change_column_null :operatingsystems, :name, false
+    add_index :operatingsystems, [:name, :major, :minor], :unique => true
+  end
+
+  def down
+    remove_index :operatingsystems, :title
+    change_column_null :operatingsystems, :name, true
+    remove_index :operatingsystems, [:name, :major, :minor]
+  end
+end


### PR DESCRIPTION
… table

It also generates a new description for systems with duplicate title based on fullname since description is set as a title in before_validation. This assumes constraints on name and version are not violated.
