### PR TITLE
Fixes #11011 - notifications are removed when window is changed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,10 @@
 $(document).on('ContentLoad', function(){onContentLoad()});
 Turbolinks.enableProgressBar();
 
+$(window).bind('beforeunload', function() {
+  $(".jnotify-container").remove();
+});
+
 $(function() {
   $(document).trigger('ContentLoad');
 });
@@ -208,10 +212,6 @@ $(document).ready(function() {
   $("#uncheck_all_roles").click(function(e) {
       e.preventDefault();
       $(".role_checkbox").prop('checked', false);
-  });
-
-  $('#login-form').submit(function(e){
-      $(".jnotify-container").remove();
   });
 });
 

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -12,23 +12,4 @@ class UserTest < ActionDispatch::IntegrationTest
     assert_submit_button(users_path)
     assert page.has_link? 'user12345'
   end
-
-  context 'javascript test' do
-    def setup
-      Capybara.current_driver = Capybara.javascript_driver
-    end
-
-    test "notice is removed after submit pressed" do
-      visit "/"
-      fill_in "login_login", :with => users(:admin).login
-      fill_in "login_password", :with => "badPass"
-      click_button "Login"
-      assert page.has_selector?('div.jnotify-message'), "notice wasn't on page after login with bad credentials"
-      execute_script("$('#login-form').submit(function(e){return false;});")
-      fill_in "login_login", :with => users(:admin).login
-      fill_in "login_password", :with => "secret"
-      click_button "Login"
-      assert_not page.has_selector?('div.jnotify-message'), "notice wasn't removed after login was clicked"
-    end
-  end
 end


### PR DESCRIPTION
Notifications are now removed immediately before the page changes to avoid confusion.
i have removed the login page spacial notification removal because now the solution is app wide.
