### PR TITLE
Fixes #11009 - removed type and association tabs.

### DIFF
--- a/app/views/ptables/_custom_tab_headers.html.erb
+++ b/app/views/ptables/_custom_tab_headers.html.erb
@@ -1,2 +1,0 @@
-<li><a href="#template_type" data-toggle="tab"><%= _("Type") %></a></li>
-<li><a href="#template_associations" data-toggle="tab"><%= _("Association") %></a></li>

--- a/app/views/ptables/_custom_tabs.html.erb
+++ b/app/views/ptables/_custom_tabs.html.erb
@@ -1,11 +1,7 @@
-<div class="tab-pane" id="template_type">
   <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
-</div>
 
-<div class="tab-pane" id="template_associations">
   <p id="snippet_message" class="alert alert-info" <%= display? !@template.snippet %> ><%= _("Not relevant for snippet") %></p>
 
   <div id="association" <%= display? @template.snippet %> >
     <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family")  }, { :label => _("Operating system family") } %>
   </div>
-</div>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -4,8 +4,7 @@
   <%= base_errors_for @template %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a id="primary_tab" href="#primary" data-toggle="tab"><%= _("Template") %></a></li>
-
-    <%= render "#{@type_name_plural}/custom_tab_headers" %>
+    <%= render "#{@type_name_plural}/custom_tab_headers" if type == 'provisioning_template'%>
 
     <li><a id='history_tab' href="#history" data-toggle="tab"><%= _("History") %></a></li>
     <% if show_location_tab? %>


### PR DESCRIPTION
Placed those options in the template tab, removed the headers file because those tabs are no longer needed.
