### PR TITLE
Fixes #11010 - removed type and association tabs.

### DIFF
--- a/app/views/ptables/_custom_tab_headers.html.erb
+++ b/app/views/ptables/_custom_tab_headers.html.erb
@@ -1,2 +1,0 @@
-<li><a href="#template_type" data-toggle="tab"><%= _("Type") %></a></li>
-<li><a href="#template_associations" data-toggle="tab"><%= _("Association") %></a></li>

--- a/app/views/ptables/_custom_tabs.html.erb
+++ b/app/views/ptables/_custom_tabs.html.erb
@@ -1,8 +1,6 @@
-<div class="tab-pane" id="template_type">
-  <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
-</div>
+<div class="content">
+<%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
 
-<div class="tab-pane" id="template_associations">
   <p id="snippet_message" class="alert alert-info" <%= display? !@template.snippet %> ><%= _("Not relevant for snippet") %></p>
 
   <div id="association" <%= display? @template.snippet %> >

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -4,8 +4,7 @@
   <%= base_errors_for @template %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a id="primary_tab" href="#primary" data-toggle="tab"><%= _("Template") %></a></li>
-
-    <%= render "#{@type_name_plural}/custom_tab_headers" %>
+    <%= render "#{@type_name_plural}/custom_tab_headers" unless type == 'ptable'%>
 
     <li><a id='history_tab' href="#history" data-toggle="tab"><%= _("History") %></a></li>
     <% if show_location_tab? %>
@@ -24,6 +23,7 @@
         <%= checkbox_f f, :default, :label=>_('Default'), :help_block => default_template_description %>
       <% end -%>
 
+
       <% if @template.locked? -%>
         <%= alert :class => 'alert-warning', :header => '',
                   :text  => icon_text("warning-sign", (_("Warning: This template is locked. You may only change the associations. Please %s it to customize.") %
@@ -34,6 +34,7 @@
                   :text  => icon_text("info-sign", (_('Note: %s ') % link_to(_('Useful template functions and macros'),
                                                                              "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#4.4.3ProvisioningTemplates", :rel => 'external')).html_safe) %>
       <% end -%>
+      <%= render "custom_tabs", :f => f %>
 
       <% if pxe_with_building_hosts?(@template) -%>
         <%= alert :class => 'alert-warning', :header => '',
@@ -89,7 +90,6 @@
     </div>
 
 
-    <%= render "custom_tabs", :f => f %>
 
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @template %>
 


### PR DESCRIPTION
Placed those options in the template tab, removed the headers file because those tabs are no longer needed.
