### PR TITLE
fixes #5630 - VmWare clone from template fails with interface label in foreign language

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -353,10 +353,10 @@ module Foreman::Model
     # because it has no children.
     def clone_vm(args)
       args = parse_args args
-      path_replace = %r{/Datacenters/#{datacenter}/vm(/|)}
+      path_replace = %r{/[^/]+/#{datacenter}/vm(/|)}
 
       interfaces = client.list_vm_interfaces(args[:image_id])
-      interface = interfaces.detect{|i| i[:name] == "Network adapter 1" }
+      interface = interfaces.detect{|i| i[:name].end_with?('1') }
       network_adapter_device_key = interface[:key]
 
       opts = {


### PR DESCRIPTION
This PR fixes http://projects.theforeman.org/issues/5630 .

When cloning a VMware template, foreman throws an error if the network adapter of the template is in a foreign language:
Failed to create a compute [...] instance [...]: undefined method `[]' for nil:NilClass

After this fix, this works with "Netzwerkinterface 1", German for "Network adapter 1".
