### PR TITLE
fixes #11121 - initialise websockets_encrypt after dependencies

### DIFF
--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -24,9 +24,10 @@ class Setting::Auth < Setting
         self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ssl_priv_key),
         self.set('ssl_client_dn_env', N_('Environment variable containing the subject DN from a client SSL certificate'), 'SSL_CLIENT_S_DN'),
         self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY'),
-        self.set('websockets_encrypt', N_("VNC/SPICE websocket proxy console access encryption (websockets_ssl_key/cert setting required)"), SETTINGS[:require_ssl]),
         self.set('websockets_ssl_key', N_("Private key that Foreman will use to encrypt websockets "), nil),
         self.set('websockets_ssl_cert', N_("Certificate that Foreman will use to encrypt websockets "), nil),
+        # websockets_encrypt depends on key/cert when true, so initialize it last
+        self.set('websockets_encrypt', N_("VNC/SPICE websocket proxy console access encryption (websockets_ssl_key/cert setting required)"), SETTINGS[:require_ssl]),
         self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), nil),
         self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'), nil),
         self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"), false),


### PR DESCRIPTION
When settings.yaml (SETTINGS) is used to set websockets_encrypt to true,
the key and cert need to be initialised first for its key/cert
validation to pass.
