### PR TITLE
fixes #11149 - foreman-debug to collect two httpd katello.conf files

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -265,6 +265,7 @@ add_files /var/lib/pgsql/data/*.conf
 add_files /var/lib/puppet/ssl/certs/$(hostname -f).pem /var/lib/puppet/ssl/certs/ca.pem
 add_files /etc/{httpd,apache2}/conf/*
 add_files /etc/{httpd,apache2}/conf.d/*
+add_files /etc/{httpd,apache2}/conf.d/*/*
 add_files /var/log/{httpd,apache2}/*error_log*
 add_files /var/log/{httpd,apache2}/foreman-ssl_access_ssl.log*
 add_cmd "echo \"select id,name,value from settings where name not similar to '%(pass|key|secret)'\" | su postgres -c 'psql foreman'" "foreman_settings_table"


### PR DESCRIPTION
in particular:

/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf
/etc/httpd/conf.d/05-foreman.d/katello.conf

Signed-off-by: Pavel Moravec pmoravec@redhat.com
