### PR TITLE
Fixes #11168 - Provisioning templates form is showing corrrect tabs

### DIFF
--- a/app/views/ptables/_custom_tabs.html.erb
+++ b/app/views/ptables/_custom_tabs.html.erb
@@ -1,9 +1,10 @@
-<div class="content">
-<%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
-
-  <p id="snippet_message" class="alert alert-info" <%= display? !@template.snippet %> ><%= _("Not relevant for snippet") %></p>
-
-  <div id="association" <%= display? @template.snippet %> >
-    <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family")  }, { :label => _("Operating system family") } %>
+<div class="panel">
+  <div class="panel-body">
+    <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
+     <p id="snippet_message" class="alert alert-info" <%= display? !@template.snippet %> ><%= _("Not relevant for snippet") %></p>
+     <div id="association" <%= display? @template.snippet %> >
+      <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family")  }, { :label => _("Operating system family") } %>
+     </div>
   </div>
 </div>
+

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -23,6 +23,7 @@
         <%= checkbox_f f, :default, :label=>_('Default'), :help_block => default_template_description %>
       <% end -%>
 
+      <%= render "custom_tabs", :f => f if type == 'ptable' %>
 
       <% if @template.locked? -%>
         <%= alert :class => 'alert-warning', :header => '',
@@ -34,7 +35,7 @@
                   :text  => icon_text("info-sign", (_('Note: %s ') % link_to(_('Useful template functions and macros'),
                                                                              "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#4.4.3ProvisioningTemplates", :rel => 'external')).html_safe) %>
       <% end -%>
-      <%= render "custom_tabs", :f => f %>
+
 
       <% if pxe_with_building_hosts?(@template) -%>
         <%= alert :class => 'alert-warning', :header => '',
@@ -99,7 +100,7 @@
     </div>
 
 
-
+    <%= render "custom_tabs", :f => f unless type == 'ptable'%>
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @template %>
 
     <%= submit_or_cancel f, false, :cancel_path => template_path_for(@template.class) %>


### PR DESCRIPTION
Fixed the problems there were in PR 11010.
