### PR TITLE
fixes #11170 broken parameter passing in foreman-rake

### DIFF
--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -9,9 +9,8 @@ die() {
 
 cd ~foreman || die "Cannot change to foreman home directory"
 [ -f Gemfile ] && BUNDLER_CMD="bundle exec"
-CMD="$BUNDLER_CMD $RAKE_CMD $*"
 if [ $USERNAME = foreman ]; then
-  RAILS_ENV=production $CMD
+  RAILS_ENV=production $BUNDLER_CMD $RAKE_CMD "$@"
 else
-  su - foreman -s /bin/bash -c "RAILS_ENV=production $CMD"
+  sudo -u foreman RAILS_ENV=production -- $BUNDLER_CMD $RAKE_CMD "$@"
 fi


### PR DESCRIPTION
By putting the command to run in $CMD, arguments containing whitespaces
and/or quotes will not correctly get passed to rake. Using "$@" and
switching from su to sudo, this is now done correctly.

(see also http://unix.stackexchange.com/questions/156343/pass-arguments-to-a-command-run-by-another-user)
