### PR TITLE
WIP - Fixes #11188 - EnsureNotUsedBy checks for unscoped associations before destroying

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
   attr_protected :password_hash, :password_salt, :admin
   attr_accessor :password, :password_confirmation
   after_save :ensure_default_role
-  before_destroy EnsureNotUsedBy.new(:direct_hosts), :ensure_hidden_users_are_not_deleted, :ensure_last_admin_is_not_deleted
+  before_destroy EnsureNotUsedBy.new([:direct_hosts, :owner_id]), :ensure_hidden_users_are_not_deleted, :ensure_last_admin_is_not_deleted
 
   belongs_to :auth_source
   belongs_to :default_organization, :class_name => 'Organization'

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -6,7 +6,7 @@ class Usergroup < ActiveRecord::Base
   include Parameterizable::ByIdName
 
   validates_lengths_from_database
-  before_destroy EnsureNotUsedBy.new(:hosts), :ensure_last_admin_group_is_not_deleted
+  before_destroy EnsureNotUsedBy.new([:hosts, :owner_id]), :ensure_last_admin_group_is_not_deleted
 
   has_many :user_roles, :dependent => :destroy, :foreign_key => 'owner_id', :conditions => {:owner_type => self.to_s}
   has_many :roles, :through => :user_roles, :dependent => :destroy


### PR DESCRIPTION
I'm having some problems with polymorphic associations and has_many through.
Adding this PR to discuss possibilities.
Tests will fail for now.

Edit - example for background: hostgroup A connected to org A and org B, host A: connected to hg A and org A.
If someone has permissions to org B only they can try to delete hg A, `before_destroy` in EnsureNotUsedBy will run and check if there are hosts connected to hg A before deleting it. Since we are in the scope of org B and the search is currently scoped we will not find host A and try to delete. As a result there will be a fk violation error since host A does exist. To avoid this error `before_destroy` needs to do an unscoped search finding all hosts connected to hg A.
