### PR TITLE
Fixes #11200: Add plugin test tasks for local and Jenkins.

### DIFF
--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -92,7 +92,7 @@ module Foreman #:nodoc:
     end
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
-    attr_reader :id, :logging, :default_roles
+    attr_reader :id, :logging, :default_roles, :test_task_name
 
     def initialize(id)
       @id = id.to_sym
@@ -269,6 +269,11 @@ module Foreman #:nodoc:
         Apipie.configuration.ignored.concat(controllers)
       end
       @apipie_ignored_controllers
+    end
+
+    def test_task(task=nil)
+      return @test_task_name unless task
+      @test_task_name = task
     end
   end
 end

--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -8,10 +8,19 @@ begin
   end
 
   namespace :jenkins do
+    desc "CI test task for the full test suite"
     task :unit => ["jenkins:setup:minitest", 'rake:test:units', 'rake:test:lib', 'rake:test:functionals']
+    
+    desc "CI test task for the integration test suite"
     task :integration => ["jenkins:setup:minitest", 'rake:test:integration']
+    
+    desc "CI test task for the lib test suite"
     task :lib => ["jenkins:setup:minitest", 'rake:test:lib']
+    
+    desc "CI test task for the functionals test suite"
     task :functionals => ["jenkins:setup:minitest", 'rake:test:functionals']
+    
+    desc "CI test task for the unit test suite"
     task :units => ["jenkins:setup:minitest", 'rake:test:units']
 
     namespace :setup do

--- a/lib/tasks/plugin_test.rake
+++ b/lib/tasks/plugin_test.rake
@@ -1,0 +1,99 @@
+require File.expand_path('../../config/environment', File.dirname(__FILE__))
+
+desc 'Run a single or multiple plugins tests - called via rake plugin:test[plugin_name,plugin_name]'
+task 'plugin:test' => [:environment] do |t, args|
+  plugin_names = args.extras
+    
+  puts "You must specify the name of at least one plugin (e.g. rake plugin:test['my_plugin'])" if plugin_names.empty?
+
+  plugins = plugin_names.collect do |plugin_name|
+    plugin = Foreman::Plugin.find(plugin_name)
+    unless plugin
+      puts "No plugin found for #{plugin_name}. Available plugins are:"
+      Rake::Task['plugin:list'].invoke
+      exit 1
+    end
+    plugin
+  end
+
+  plugins.each do |plugin|
+    test_task = plugin.test_task.nil? ? "plugin:test:#{plugin.name}" : plugin.test_task
+    Rake::Task["test"].enhance [test_task]
+  end
+
+  Rake::Task['test'].invoke
+end
+
+Foreman::Plugin.all.each do |plugin|
+  namespace 'plugin:test' do
+    desc "Run the #{plugin.name} plugin test suite"
+    task plugin.name => ['db:test:prepare'] do
+      if plugin.test_task
+        test_task = plugin.test_task
+      else
+        test_task = Rake::TestTask.new("#{plugin.name}_test_task") do |t|
+          t.libs.concat(["#{Rails.root}/test", "#{plugin.path}/test"])
+          t.test_files = [
+            "#{plugin.path}/test/**/*_test.rb"
+          ]
+          t.verbose = true
+        end
+        test_task = test_task.name
+      end
+      
+      Rake::Task[test_task].invoke
+    end
+  end
+
+  namespace 'plugin:rubocop' do
+    desc "Run Rubocop on #{plugin.name}"
+    task plugin.name do
+      begin
+        require 'rubocop/rake_task'
+        rubocop_task = RuboCop::RakeTask.new("#{plugin.name}_docker") do |task|
+          task.patterns = ["#{plugin.path}/app/**/*.rb",
+                           "#{plugin.path}/lib/**/*.rb",
+                           "#{plugin.path}/test/**/*.rb"]
+        end
+      rescue
+        puts "Rubocop not loaded."
+      end
+
+      Rake::Task[rubocop_task.name].invoke
+    end
+  end
+end
+
+begin
+  desc 'CI plugin test task for running a single or multiple plugins tests - called via rake plugin:jenkins[plugin_name,plugin_name]'
+  task 'plugin:jenkins' => [:environment] do |t, args|
+    plugin_names = args.extras
+      
+    puts "You must specify the name of at least one plugin (e.g. rake plugin:jenkins['my_plugin'])" if plugin_names.empty?
+
+    # Reset to the base Jenkins unit test in case plugins are enhancing it
+    Rake::Task['jenkins:unit'].clear
+    load 'lib/tasks/jenkins.rake'
+
+    plugins = plugin_names.collect do |plugin_name|
+      plugin = Foreman::Plugin.find(plugin_name)
+      unless plugin
+        puts "No plugin found for #{plugin_name}. Available plugins are:"
+        Rake::Task['plugin:list'].invoke
+        exit 1
+      end
+      plugin
+    end
+
+    plugins.each do |plugin|
+      test_task = plugin.test_task.nil? ? "plugin:test:#{plugin.name}" : plugin.test_task
+      rubocop_task = "plugin:rubocop:#{plugin.name}"
+      Rake::Task["jenkins:unit"].enhance [rubocop_task]
+      Rake::Task["jenkins:unit"].enhance [test_task]
+    end
+
+    Rake::Task['jenkins:unit'].invoke
+  end
+rescue LoadError
+  # ci/reporter/rake/rspec not present, skipping this definition
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -251,4 +251,11 @@ class PluginTest < ActiveSupport::TestCase
     plugin.logging.expects(:add_logger).with(:test_logger, {:enabled => true})
     plugin.logger(:test_logger, {:enabled => true})
   end
+
+  def test_test_task
+    plugin = Foreman::Plugin.find(:foo)
+    plugin.test_task('test')
+
+    assert_equal 'test', plugin.test_task
+  end
 end


### PR DESCRIPTION
This adds a set of plugin test tasks that can be utilized by any
plugin. The first task is so that any number of available plugin's
tests can be run singularly or in combination alongside the Foreman
core test suite. The second task does the same but for use on Jenkins.
The last set of tasks generates a test task automatically for every
plugin currently known for running just that plugins test suite.

The rake tasks assume that plugins will have a simple test/ directory,
but if a plugin needs some customization they can specify their test
task entry point via the plugin registration.
