### PR TITLE
Fixes #11206 - plugin API now expose default role permissions

### DIFF
--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -92,11 +92,12 @@ module Foreman #:nodoc:
     end
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
-    attr_reader :id, :logging
+    attr_reader :id, :logging, :default_roles
 
     def initialize(id)
       @id = id.to_sym
       @logging = Plugin::Logging.new(@id)
+      @default_roles = {}
     end
 
     def after_initialize
@@ -207,7 +208,8 @@ module Foreman #:nodoc:
 
     # Add a new role if it doesn't exist
     def role(name, permissions)
-      return false if pending_migrations
+      @default_roles[name] = permissions
+      return false if pending_migrations || Rails.env.test?
 
       Role.transaction do
         role = Role.find_or_create_by_name(name)

--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -1,5 +1,18 @@
-desc "List Installed plugins"
-task :plugins => :environment do
-  puts 'Collecting plugin information'
-  Foreman::Plugin.all.map{ |p| puts p.to_s }
+namespace :plugin do
+  desc "List Installed plugins"
+  task :list => :environment do
+    puts 'Collecting plugin information'
+    Foreman::Plugin.all.map{ |p| puts p.to_s }
+  end
+
+  desc 'Validate permissions for built-in roles'
+  task :validate_roles => :environment do
+    Foreman::Plugin.all.each do |plugin|
+      plugin.default_roles.each do |role, expected_perms|
+        actual_perms = Role.find_by_name(role).permissions.collect(&:name).collect(&:to_sym)
+        missing = actual_perms - expected_perms
+        puts "Role '#{role}' is missing permissions #{missing.inspect}" unless missing.empty?
+      end
+    end
+  end
 end


### PR DESCRIPTION
If we were able to list default roles and it's permissions we can use this in
unit/functional tests to verify permissions and filters. More than that, this
gives us possibility to create a mechanism for comparing expected permissions
with existing ones. This might be useful after upgrades when users want to
check if some important permissions were not added in the new version.

This patch that adds this, it's simple. It also adds a simple rake task that
does the check. I would like to have this for 1.9 because we would like to
merge a big permission review for Discovery 4.0 together with bunch of new
tests covering this area which greatly improves the quality.
