### PR TITLE
refs #11250 - Remove uniqueness check from network address validator in subnet.rb

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -25,8 +25,7 @@ class Subnet < ActiveRecord::Base
   has_many :primary_hosts, :through => :primary_interfaces, :source => :host
   validates :network, :mask, :name, :presence => true
   validates_associated    :subnet_domains
-  validates :network, :uniqueness => true,
-                      :format => {:with => Net::Validations::IP_REGEXP}
+  validates :network, :format => {:with => Net::Validations::IP_REGEXP}
   validates :gateway, :dns_primary, :dns_secondary,
                       :allow_blank => true,
                       :allow_nil => true,


### PR DESCRIPTION
implements Feature #11250 Remove uniqueness check from network address validator in subnet.rb

This is for redmine project: http://projects.theforeman.org/issues/11250
