### PR TITLE
fixes #11170 - pass quoted args through foreman-rake

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -63,6 +63,7 @@ BANNER
     end
 
     def run(args)
+      args.shift if args.first == '--'
       parser.parse!(args)
 
       if @key && @key_values.any?

--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -9,9 +9,9 @@ die() {
 
 cd ~foreman || die "Cannot change to foreman home directory"
 [ -f Gemfile ] && BUNDLER_CMD="bundle exec"
-CMD="$BUNDLER_CMD $RAKE_CMD $*"
+CMD="$BUNDLER_CMD $RAKE_CMD"
 if [ $USERNAME = foreman ]; then
-  RAILS_ENV=production $CMD
+  RAILS_ENV=production $CMD "$@"
 else
-  su - foreman -s /bin/bash -c "RAILS_ENV=production $CMD"
+  su - foreman -s /bin/bash -c 'RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
 fi


### PR DESCRIPTION
Use the special "$@" to correctly pass quoted arguments through
foreman-rake, through su and to the underlying rake command.  Ensures
the JSON in this command is unharmed:

```
foreman-rake config -- -k trusted_puppetmaster_hosts -v '["foo.bar.com"]'
```

Also swallows the "--" which gets passed through on some versions of
rake.

---

~~Test this on a Debian-based OS or Fedora, since [a further issue lurks in scl-utils](https://bugzilla.redhat.com/show_bug.cgi?id=1248418).~~  Works on all supported OSes in nightlies now.

Replaces #2562, also avoiding adding sudo as a dependency.
