### PR TITLE
fixes #8521 - fix classes accessors, copy overrides on host clone

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -159,7 +159,7 @@ module HostCommon
   end
 
   def host_class_ids
-    is_a?(Host::Base) ? host_classes.pluck(:puppetclass_id) : []
+    (is_a?(Host::Base) ? host_classes : hostgroup_classes).map(&:puppetclass_id)
   end
 
   def all_puppetclass_ids
@@ -189,7 +189,12 @@ module HostCommon
   end
 
   def individual_puppetclasses
-    puppetclasses - classes_in_groups
+    conditions = {:id => host_class_ids - cg_class_ids}
+    if environment
+      environment.puppetclasses.where(conditions)
+    else
+      Puppetclass.where(conditions)
+    end
   end
 
   def available_puppetclasses
@@ -224,6 +229,7 @@ module HostCommon
   end
 
   def update_config_group_counters(record)
+    return unless persisted?
     record.update_attribute(:hostgroups_count, cnt_hostgroups(record))
     record.update_attribute(:hosts_count, cnt_hosts(record))
 

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -11,7 +11,8 @@ class ConfigGroup < ActiveRecord::Base
   has_many :config_group_classes
   has_many :puppetclasses, :through => :config_group_classes, :dependent => :destroy
   has_many :host_config_groups
-  has_many_hosts :through => :host_config_groups
+  has_many_hosts :through => :host_config_groups, :source => :host, :source_type => 'Host::Managed'
+  has_many :hostgroups, :through => :host_config_groups, :source => :host, :source_type => 'Hostgroup'
 
   validates :name, :presence => true, :uniqueness => true
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -709,7 +709,7 @@ class Host::Managed < Host::Base
 
   def clone
     # do not copy system specific attributes
-    host = self.deep_clone(:include => [:host_config_groups, :host_classes, :host_parameters],
+    host = self.deep_clone(:include => [:config_groups, :host_config_groups, :host_classes, :host_parameters, :lookup_values],
                            :except  => [:name, :mac, :ip, :uuid, :certname, :last_report])
     self.interfaces.each do |nic|
       host.interfaces << nic.clone

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -266,7 +266,7 @@ class HostgroupTest < ActiveSupport::TestCase
     # nagios puppetclasses(:five) is also in config_groups(:one) Monitoring
     hostgroup.puppetclasses << puppetclasses(:five)
     assert_equal ['git', 'nagios'].sort, hostgroup.puppetclasses.map(&:name).sort
-    assert_equal ['git'], hostgroup.individual_puppetclasses.map(&:name)
+    assert_equal [], hostgroup.individual_puppetclasses.map(&:name)
   end
 
   test "available_puppetclasses should return all if no environment" do


### PR DESCRIPTION
This PR should make host and host group cloning properly copy all class and config group associations, parameters and overrides.

It's wrapping up #2563, which itself was pretty much ready to go.  I noticed that it now wasn't cloning Puppet class associations since the deep_clone change, and realised that this was the same bug as http://projects.theforeman.org/issues/8521.  I fixed that general issue, added the commit from #2563 to fix host group cloning, and then fixed the last bit of host group + class cloning in the third commit (I suggest that this last one can be squashed into @cfouant's).
