### PR TITLE
fixes #11274 - Unable to get resourcePool

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -57,7 +57,7 @@ module Foreman::Model
         Rails.logger.info "Datacenter #{dc.try(:name)} returned zero clusters"
         return []
       end
-      dc.clusters.map(&:name).sort
+      dc.clusters.map(&:full_path).sort
     end
 
     def datastores(opts = {})


### PR DESCRIPTION
Cluster attribute full_path makes sense when there are intermediate folders (both between vCenter/datacenter and datacenter/cluster). There was a bug/typo in fog (https://github.com/fog/fog/pull/3645) and after it is merged into fog this should work for foreman.
