### PR TITLE
Fixes #11303: Allow scoped search by name for permissions.

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -7,6 +7,9 @@ class Permission < ActiveRecord::Base
   has_many :filterings, :dependent => :destroy
   has_many :filters, :through => :filterings
 
+  scoped_search :on => :name, :complete_value => true
+  scoped_search :on => :resource_type
+
   def self.resources
     @all_resources ||= Permission.uniq.order(:resource_type).pluck(:resource_type).compact
   end

--- a/test/unit/permission_test.rb
+++ b/test/unit/permission_test.rb
@@ -14,4 +14,20 @@ class PermissionTest < ActiveSupport::TestCase
     Permission.stubs(:with_translations).returns([['Z', 'z'], ['A', 'b'], ['H', 'a']])
     assert_equal [['A', 'b'], ['H', 'a'], ['Z', 'z']], Permission.resources_with_translations
   end
+
+  test "can search permissions by name" do
+    permission = FactoryGirl.create :permission, :domain, :name => 'view_all_domains'
+    as_admin do
+      permissions = Permission.search_for('name = view_all_domains')
+      assert_includes permissions, permission
+    end
+  end
+
+  test "can search permissions by resource_type" do
+    permission = FactoryGirl.create :permission, :domain, :name => 'view_all_domains'
+    as_admin do
+      permissions = Permission.search_for('resource_type = Domain')
+      assert_includes permissions, permission
+    end
+  end
 end


### PR DESCRIPTION
This both provides this functionality and fixes an issue with creating
filters using hammer. Hammer attempts to search for a permission by
name using scoped search syntax when creating a filter with the
--permission=view_domains style syntax. However, this was defaulting to
returning all permissions instead of scoped permissions.
