### PR TITLE
Allow plugins to update the Rabl view_paths

### DIFF
--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -56,7 +56,8 @@ Rabl.configure do |config|
   # config.include_child_root = true
   # config.enable_json_callbacks = false
   # config.xml_options = { :dasherize  => true, :skip_types => false }
-  config.view_paths = [Rails.root.join('app', 'views')]
+  config.view_paths ||= []
+  config.view_paths << [Rails.root.join('app', 'views')]
   # config.raise_on_missing_attribute = true # Defaults to false
   # config.replace_nil_values_with_empty_strings = true # Defaults to false
   config.use_controller_name_as_json_root = false

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -56,8 +56,7 @@ Rabl.configure do |config|
   # config.include_child_root = true
   # config.enable_json_callbacks = false
   # config.xml_options = { :dasherize  => true, :skip_types => false }
-  config.view_paths ||= []
-  config.view_paths << [Rails.root.join('app', 'views')]
+  config.view_paths << Rails.root.join('app', 'views')
   # config.raise_on_missing_attribute = true # Defaults to false
   # config.replace_nil_values_with_empty_strings = true # Defaults to false
   config.use_controller_name_as_json_root = false


### PR DESCRIPTION
Please look at this issue with foreman_hooks:

https://github.com/theforeman/foreman_hooks/issues/24

I wanted foreman_discovery plugin to be able to update the Rabl view_path. But that's not possible because the foreman overwrites any changes that the plugins make. So I propose this change to make sure it doesn't overwrite.

Please review.

Thanks,
-PP
