### PR TITLE
Fixes #11255 - Fixed checks for explicit input in host cloning

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -60,7 +60,7 @@ module HostsAndHostgroupsHelper
     select_f f, :puppet_ca_proxy_id, proxies, :id, :name,
              { :include_blank => blank_or_inherit_f(f, :puppet_ca_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-               :disable_button_enabled => override && !params[:host][:puppet_ca_proxy_id],
+               :disable_button_enabled => override && !explicit_value?(:puppet_ca_proxy_id),
                :user_set => params[:host] && params[:host][:puppet_ca_proxy_id]
              },
              { :label       => _("Puppet CA"),
@@ -75,7 +75,7 @@ module HostsAndHostgroupsHelper
     select_f f, :puppet_proxy_id, proxies, :id, :name,
              { :include_blank => blank_or_inherit_f(f, :puppet_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-               :disable_button_enabled => override && !params[:host][:puppet_proxy_id],
+               :disable_button_enabled => override && !explicit_value?(:puppet_proxy_id),
                :user_set => params[:host] && params[:host][:puppet_proxy_id]
 
              },
@@ -93,7 +93,7 @@ module HostsAndHostgroupsHelper
                 :id, :to_label,
                 { :include_blank => true,
                   :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-                  :disable_button_enabled => override && !params[:host][:realm_id],
+                  :disable_button_enabled => override && !explicit_value?(:realm_id),
                   :user_set => params[:host] && params[:host][:realm_id]
                 },
                 { :help_inline   => :indicator }
@@ -108,5 +108,11 @@ module HostsAndHostgroupsHelper
     klasses    = (smart_vars + class_vars).uniq
 
     classes.where(:id => klasses)
+  end
+
+  def explicit_value?(field)
+    return true if params[:action] == 'clone'
+    return false unless params[:host]
+    !!params[:host][field]
   end
 end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -443,4 +443,11 @@ module HostsHelper
                               :class => "btn btn-default btn-xs pull-right", :title => _("Edit %s" % type) )
     end
   end
+
+  def inherited_by_default?(field, host)
+    return false unless host.hostgroup && host.hostgroup_id_was.nil?
+    return false if params[:action] == 'clone'
+    return true unless params[:host]
+    !params[:host][field]
+  end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -60,7 +60,7 @@
         <div id="compute_profile" <%= display?(!@host.compute_resource_id) %> >
           <%= select_f f, :compute_profile_id, ComputeProfile.visibles, :id, :name,
             { :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
-              :disable_button_enabled => @host.hostgroup && @host.hostgroup_id_was.nil? && !params[:host][:compute_profile_id],
+              :disable_button_enabled => inherited_by_default?(:compute_profile_id, @host),
               :user_set => params[:host] && params[:host][:compute_profile_id]
             },
             { :label => _("Compute profile"), :'data-url' => compute_resource_selected_hosts_path,
@@ -71,7 +71,7 @@
 
         <%= select_f f, :environment_id, Environment.with_taxonomy_scope_override(@location,@organization).order(:name), :id, :to_label, { :include_blank => true,
              :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
-             :disable_button_enabled => @host.hostgroup && @host.hostgroup_id_was.nil? && !params[:host][:environment_id],
+             :disable_button_enabled => inherited_by_default?(:environment_id, @host),
              :user_set => params[:host] && params[:host][:environment_id]
            },
            {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -211,6 +211,15 @@ class HostsControllerTest < ActionController::TestCase
     refute assigns(:host).mac
   end
 
+  def test_clone_with_hostgroup
+    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({})
+    host = FactoryGirl.create(:host, :with_hostgroup)
+    get :clone, {:id => host.id}, set_session_user
+    assert assigns(:clone_host)
+    assert_template 'clone'
+    assert_response :success
+  end
+
   def setup_user(operation, type = 'hosts', filter = nil)
     super
   end


### PR DESCRIPTION
Now clone action will try to inherit values from the hostgroup, unless the user explicitly unchecked the "inherit" button. Custom errors added to each field that will be overridden by this action. 
