### PR TITLE
Fixes #11187 - explicitly pass resource_type and permission to check

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -347,6 +347,18 @@ module LayoutHelper
   private
 
   def authorized_associations(associations)
-    associations.included_modules.include?(Authorizable) ? associations.authorized : associations
+    if associations.included_modules.include?(Authorizable)
+      if associations.respond_to?(:klass)
+        associations.authorized(authorized_associations_permission_name(associations.klass), associations.klass)
+      else
+        associations.authorized(authorized_associations_permission_name(associations), associations)
+      end
+    else
+      associations
+    end
+  end
+
+  def authorized_associations_permission_name(klass)
+    Permission.find_by_name("view_#{klass.to_s.underscore.pluralize}").try(:name)
   end
 end

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -181,7 +181,7 @@ module Taxonomix
 
       next if (User.current.nil? || User.current.send("#{assoc}").empty?) || (!new_record? && !self.send("#{key}_changed?"))
 
-      allowed = taxonomy.authorized("assign_#{assoc}", taxonomy).pluck(:id).to_set
+      allowed = taxonomy.authorized("assign_#{assoc}", taxonomy).pluck(:id).to_set.union(self.send("#{key}_was"))
       tried = self.send(key).to_set
 
       if tried.empty? || !tried.subset?(allowed)


### PR DESCRIPTION
A slightly safer way of fixing redmine issue [11187](http://projects.theforeman.org/issues/11187) for Foreman 1.9. See #2564 for more information.
