### PR TITLE
Fixes #11350 - Duplicate parameters can be created within subtype

### DIFF
--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -7,7 +7,8 @@ class Parameter < ActiveRecord::Base
 
   belongs_to_host :foreign_key => :reference_id
   include Authorizable
-  validates :name, :presence => true, :no_whitespace => true
+  validates :name, :presence => true, :no_whitespace => true,
+                   :uniqueness => { :scope => [:reference_id, :type] }
   validates :reference_id, :presence => {:message => N_("parameters require an associated domain, operating system, host or host group")}, :unless => Proc.new {|p| p.nested or p.is_a? CommonParameter}
 
   scoped_search :on => :name, :complete_value => true

--- a/app/models/parameters/domain_parameter.rb
+++ b/app/models/parameters/domain_parameter.rb
@@ -1,5 +1,4 @@
 class DomainParameter < Parameter
   belongs_to :domain, :foreign_key => :reference_id, :inverse_of => :domain_parameters
   audited :except => [:priority], :associated_with => :domain, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 end

--- a/app/models/parameters/group_parameter.rb
+++ b/app/models/parameters/group_parameter.rb
@@ -1,5 +1,4 @@
 class GroupParameter < Parameter
   belongs_to :hostgroup, :foreign_key => :reference_id, :inverse_of => :group_parameters
   audited :except => [:priority], :associated_with => :hostgroup, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 end

--- a/app/models/parameters/host_parameter.rb
+++ b/app/models/parameters/host_parameter.rb
@@ -1,7 +1,6 @@
 class HostParameter < Parameter
   belongs_to_host :foreign_key => :reference_id, :inverse_of => :host_parameters
   audited :except => [:priority], :associated_with => :host, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 
   def to_s
     "#{host.id ? host.name : "unassociated"}: #{name} = #{value}"

--- a/app/models/parameters/location_parameter.rb
+++ b/app/models/parameters/location_parameter.rb
@@ -1,7 +1,6 @@
 class LocationParameter < Parameter
   belongs_to :location, :foreign_key => :reference_id, :inverse_of => :location_parameters
   audited :except => [:priority], :associated_with => :location, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 
   private
 

--- a/app/models/parameters/organization_parameter.rb
+++ b/app/models/parameters/organization_parameter.rb
@@ -1,7 +1,6 @@
 class OrganizationParameter < Parameter
   belongs_to :organization, :foreign_key => :reference_id, :inverse_of => :organization_parameters
   audited :except => [:priority], :associated_with => :organization, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 
   private
 

--- a/app/models/parameters/os_parameter.rb
+++ b/app/models/parameters/os_parameter.rb
@@ -1,5 +1,4 @@
 class OsParameter < Parameter
   belongs_to :operatingsystem, :foreign_key => :reference_id, :inverse_of => :os_parameters
   audited :except => [:priority], :associated_with => :operatingsystem, :allow_mass_assignment => true
-  validates :name, :uniqueness => {:scope => :reference_id}
 end

--- a/test/unit/parameter_test.rb
+++ b/test/unit/parameter_test.rb
@@ -4,6 +4,7 @@ class ParameterTest < ActiveSupport::TestCase
   setup do
     User.current = users :admin
   end
+
   test  "names may be reused in different parameter groups" do
     host = FactoryGirl.create(:host)
     p1 = HostParameter.new   :name => "param", :value => "value1", :reference_id => host.id
@@ -51,5 +52,21 @@ class ParameterTest < ActiveSupport::TestCase
     host.host_parameters << HostParameter.create(:name => "animal", :value => "pig")
     host.clear_host_parameters_cache!
     assert_equal "pig", host.host_params["animal"]
+  end
+
+  test 'parameters are unique scoped by reference_id and type' do
+    assert_difference('Parameter.count', 1) do
+      2.times do |time|
+        foo = Parameter.new(:name => 'foo', :reference_id => 2)
+        foo.type = 'DomainParameter'
+
+        assert foo.save if time == 0
+        refute foo.save if time == 1
+      end
+    end
+
+    foo = Parameter.new(:name => 'foo', :reference_id => 2)
+    foo.type = 'GroupParameter'
+    assert foo.valid?
   end
 end


### PR DESCRIPTION
Parameter class leaves its :name uniqueness validation to subtypes such as
CommonParameter, GroupParameter, and so forth. This means that one can
trivially create duplicate parameters by calling Parameter.new, then changing
the type attribute of the newly created object.

To avoid this situation (and remove some duplicated validations) we can simply
declare a default validation on all Parameter names scoped by reference_id, and
override it for CommonParameter which doesn't have a reference_id.
