### PR TITLE
Refs #3809 - Stabby lambda syntax for oneliners

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_from:
 
 AllCops:
   RunRailsCops: true # always run the rails cops
+  Include:
+    - 'app/views/api/**/*.rabl'
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -205,10 +205,6 @@ Style/FormatString:
 Style/GuardClause:
   Enabled: false
 
-# Offense count: 91
-Style/Lambda:
-  Enabled: false
-
 # Offense count: 183
 # Cop supports --auto-correct.
 Style/LeadingCommentSpace:
@@ -233,11 +229,6 @@ Style/MethodDefParentheses:
 # Offense count: 50
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 Style/MethodName:
-  Enabled: false
-
-# Offense count: 11
-# Cop supports --auto-correct.
-Style/MultilineBlockLayout:
   Enabled: false
 
 # Offense count: 121

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -26,8 +26,8 @@ class AuthSource < ActiveRecord::Base
 
   validates :name, :presence => true, :uniqueness => true, :length => { :maximum => 60 }
 
-  scope :non_internal, lambda { where("type NOT IN (?)", ['AuthSourceInternal', 'AuthSourceHidden']) }
-  scope :except_hidden, lambda { where('type <> ?', 'AuthSourceHidden') }
+  scope :non_internal, -> { where("type NOT IN (?)", ['AuthSourceInternal', 'AuthSourceHidden']) }
+  scope :except_hidden, -> { where('type <> ?', 'AuthSourceHidden') }
 
   def authenticate(login, password)
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -16,7 +16,7 @@ class Bookmark < ActiveRecord::Base
                          :inclusion => {
                            :in => ["dashboard"] + ActiveRecord::Base.connection.tables.map(&:to_s),
                            :message => _("%{value} is not a valid controller") }
-  default_scope lambda { order(:name) }
+  default_scope -> { order(:name) }
   before_validation :set_default_user
 
   scope :my_bookmarks, lambda {
@@ -28,7 +28,7 @@ class Bookmark < ActiveRecord::Base
     where(conditions)
   }
 
-  scope :controller, lambda { |*args| where("controller = ?", (args.first || '')) }
+  scope :controller, ->(*args) { where("controller = ?", (args.first || '')) }
 
   def set_default_user
     self.owner ||= User.current

--- a/app/models/compute_profile.rb
+++ b/app/models/compute_profile.rb
@@ -18,7 +18,7 @@ class ComputeProfile < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
 
   scoped_search :on => :name, :complete_value => true
-  default_scope lambda { order('compute_profiles.name') }
+  default_scope -> { order('compute_profiles.name') }
 
-  scope :visibles, lambda { includes(:compute_attributes).where('compute_attributes.id > 0') }
+  scope :visibles, -> { includes(:compute_attributes).where('compute_attributes.id > 0') }
 end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -39,7 +39,7 @@ class ComputeResource < ActiveRecord::Base
   has_many :compute_profiles, :through => :compute_attributes
 
   # The DB may contain compute resource from disabled plugins - filter them out here
-  scope :live_descendants, lambda { where(:type => self.descendants.map(&:to_s)) unless Rails.env.development? }
+  scope :live_descendants, -> { where(:type => self.descendants.map(&:to_s)) unless Rails.env.development? }
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/concerns/report_common.rb
+++ b/app/models/concerns/report_common.rb
@@ -10,9 +10,7 @@ module ReportCommon
     # search for a metric - e.g.:
     # Report.with("failed") --> all reports which have a failed counter > 0
     # Report.with("failed",20) --> all reports which have a failed counter > 20
-    scope :with, lambda { |*arg| {
-      :conditions => "(#{report_status} >> #{BIT_NUM*METRIC.index(arg[0])} & #{MAX}) > #{arg[1] || 0}"}
-    }
+    scope :with, ->(*arg) { { :conditions => "(#{report_status} >> #{BIT_NUM*METRIC.index(arg[0])} & #{MAX}) > #{arg[1] || 0}"} }
   end
 
   # generate dynamically methods for all metrics

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -20,7 +20,7 @@ class ConfigGroup < ActiveRecord::Base
   scoped_search :on => :hostgroups_count
   scoped_search :on => :config_group_classes_count
 
-  default_scope lambda { order('config_groups.name') }
+  default_scope -> { order('config_groups.name') }
 
   # the following methods are required for app/views/puppetclasses/_class_selection.html.erb
   alias_method :classes, :puppetclasses

--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -7,8 +7,8 @@ class FactName < ActiveRecord::Base
   has_many :fact_values, :dependent => :destroy
   has_many_hosts :through => :fact_values
 
-  scope :no_timestamp_fact, lambda { where("fact_names.name <> ?",:_timestamp) }
-  scope :timestamp_facts,  lambda { where(:name => :_timestamp) }
+  scope :no_timestamp_fact, -> { where("fact_names.name <> ?",:_timestamp) }
+  scope :timestamp_facts, -> { where(:name => :_timestamp) }
   scope :with_parent_id, lambda { |find_ids|
     conds, binds = [], []
     [find_ids].flatten.each do |find_id|
@@ -18,7 +18,7 @@ class FactName < ActiveRecord::Base
     where(conds.join(' OR '), *binds)
   }
 
-  default_scope lambda { order('fact_names.name') }
+  default_scope -> { order('fact_names.name') }
 
   validates :name, :uniqueness => { :scope => :type }
 

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -28,12 +28,12 @@ class FactValue < ActiveRecord::Base
     end
   }
 
-  scope :distinct, lambda { select('DISTINCT fact_values.value') }
-  scope :required_fields, lambda { includes(:host, :fact_name) }
-  scope :facts_counter, lambda {|value, name_id| where(:value => value, :fact_name_id => name_id) }
-  scope :with_fact_parent_id, lambda {|find_ids| joins(:fact_name).merge FactName.with_parent_id(find_ids) }
-  scope :with_roots, lambda { includes(:fact_name) }
-  scope :root_only, lambda { with_roots.where(:fact_names => {:ancestry => nil}) }
+  scope :distinct, -> { select('DISTINCT fact_values.value') }
+  scope :required_fields, -> { includes(:host, :fact_name) }
+  scope :facts_counter, ->(value, name_id) { where(:value => value, :fact_name_id => name_id) }
+  scope :with_fact_parent_id, ->(find_ids) { joins(:fact_name).merge FactName.with_parent_id(find_ids) }
+  scope :with_roots, -> { includes(:fact_name) }
+  scope :root_only, -> { with_roots.where(:fact_names => {:ancestry => nil}) }
 
   validates :fact_name_id, :uniqueness => { :scope => :host_id }
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -31,9 +31,9 @@ class Filter < ActiveRecord::Base
 
   validates_lengths_from_database
 
-  default_scope lambda { order(['role_id', "#{self.table_name}.id"]) }
-  scope :unlimited, lambda { where(:search => nil, :taxonomy_search => nil) }
-  scope :limited, lambda { where("search IS NOT NULL OR taxonomy_search IS NOT NULL") }
+  default_scope -> { order(['role_id', "#{self.table_name}.id"]) }
+  scope :unlimited, -> { where(:search => nil, :taxonomy_search => nil) }
+  scope :limited, -> { where("search IS NOT NULL OR taxonomy_search IS NOT NULL") }
 
   scoped_search :on => :search, :complete_value => true
   scoped_search :on => :limited, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_limited, :only_explicit => true

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -36,9 +36,7 @@ module Host
     validate :host_has_required_interfaces
     validate :uniq_interfaces_identifiers
 
-    default_scope lambda {
-      where(taxonomy_conditions)
-    }
+    default_scope -> { where(taxonomy_conditions) }
 
     def self.taxonomy_conditions
       org = Organization.expand(Organization.current) if SETTINGS[:organizations_enabled]
@@ -49,8 +47,8 @@ module Host
       conditions
     end
 
-    scope :no_location, lambda { where(:location_id => nil) }
-    scope :no_organization, lambda { where(:organization_id => nil) }
+    scope :no_location,     -> { where(:location_id => nil) }
+    scope :no_organization, -> { where(:organization_id => nil) }
 
     # primary interface is mandatory because of delegated methods so we build it if it's missing
     # similar for provision interface

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -4,9 +4,7 @@ class Log < ActiveRecord::Base
   belongs_to :report
   validates :message_id, :source_id, :report_id, :level_id, :presence => true
 
-  default_scope do
-    order('logs.id')
-  end
+  default_scope -> { order('logs.id') }
 
   LEVELS = [:debug, :info, :notice, :warning, :err, :alert, :emerg, :crit]
 

--- a/app/models/lookup_key.rb
+++ b/app/models/lookup_key.rb
@@ -54,24 +54,24 @@ class LookupKey < ActiveRecord::Base
   scoped_search :in => :param_classes, :on => :name, :rename => :puppetclass, :complete_value => true
   scoped_search :in => :lookup_values, :on => :value, :rename => :value, :complete_value => true
 
-  default_scope lambda { order('lookup_keys.key') }
+  default_scope -> { order('lookup_keys.key') }
 
-  scope :override, lambda { where(:override => true) }
+  scope :override, -> { where(:override => true) }
 
-  scope :smart_class_parameters_for_class, lambda {|puppetclass_ids, environment_id|
+  scope :smart_class_parameters_for_class, lambda { |puppetclass_ids, environment_id|
     joins(:environment_classes).where(:environment_classes => {:puppetclass_id => puppetclass_ids, :environment_id => environment_id})
   }
 
-  scope :parameters_for_class, lambda {|puppetclass_ids, environment_id|
+  scope :parameters_for_class, lambda { |puppetclass_ids, environment_id|
     override.smart_class_parameters_for_class(puppetclass_ids,environment_id)
   }
 
-  scope :global_parameters_for_class, lambda {|puppetclass_ids|
+  scope :global_parameters_for_class, lambda { |puppetclass_ids|
     where(:puppetclass_id => puppetclass_ids)
   }
 
-  scope :smart_variables, lambda { where('lookup_keys.puppetclass_id > 0').readonly(false) }
-  scope :smart_class_parameters, lambda { where(:is_param => true).joins(:environment_classes).readonly(false) }
+  scope :smart_variables, -> { where('lookup_keys.puppetclass_id > 0').readonly(false) }
+  scope :smart_class_parameters, -> { where(:is_param => true).joins(:environment_classes).readonly(false) }
 
   # new methods for API instead of revealing db names
   alias_attribute :parameter, :key

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -19,7 +19,7 @@ class LookupValue < ActiveRecord::Base
   serialize :value
   attr_name :match
 
-  scope :default, lambda { where(:match => "default").limit(1) }
+  scope :default, -> { where(:match => "default").limit(1) }
 
   scoped_search :on => :value, :complete_value => true, :default_order => true
   scoped_search :on => :match, :complete_value => true

--- a/app/models/mail_notification.rb
+++ b/app/models/mail_notification.rb
@@ -13,7 +13,7 @@ class MailNotification < ActiveRecord::Base
   scoped_search :on => :description, :complete_value => true
   scoped_search :in => :users, :on => :login, :complete_value => true, :rename => :user
 
-  scope :subscriptable, lambda { where(:subscriptable => true) }
+  scope :subscriptable, -> { where(:subscriptable => true) }
 
   validates :name, :presence => true, :uniqueness => true
   validates :subscription_type, :inclusion => { :in => SUBSCRIPTION_TYPES }, :allow_blank => true
@@ -21,9 +21,7 @@ class MailNotification < ActiveRecord::Base
   validates :method, :presence => true
   alias_attribute :mailer_method, :method
 
-  default_scope lambda {
-    order("mail_notifications.name")
-  }
+  default_scope -> { order("mail_notifications.name") }
 
   # Easy way to reference the notification to support something like:
   #   MailNotification[:some_error_notification].deliver(options)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -9,7 +9,7 @@ class Model < ActiveRecord::Base
   validates_lengths_from_database
   validates :name, :uniqueness => true, :presence => true
 
-  default_scope lambda { order('models.name') }
+  default_scope -> { order('models.name') }
 
   scoped_search :on => :name, :complete_value => :true, :default_order => true
   scoped_search :on => :info

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -39,18 +39,18 @@ module Nic
     validate :validate_host_location, :if => Proc.new { |nic| SETTINGS[:locations_enabled] && nic.subnet.present? }
     validate :validate_host_organization, :if => Proc.new { |nic| SETTINGS[:organizations_enabled] && nic.subnet.present? }
 
-    scope :bootable, lambda { where(:type => "Nic::Bootable") }
-    scope :bmc, lambda { where(:type => "Nic::BMC") }
-    scope :bonds, lambda { where(:type => "Nic::Bond") }
-    scope :interfaces, lambda { where(:type => "Nic::Interface") }
-    scope :managed, lambda { where(:type => "Nic::Managed") }
+    scope :bootable, -> { where(:type => "Nic::Bootable") }
+    scope :bmc, -> { where(:type => "Nic::BMC") }
+    scope :bonds, -> { where(:type => "Nic::Bond") }
+    scope :interfaces, -> { where(:type => "Nic::Interface") }
+    scope :managed, -> { where(:type => "Nic::Managed") }
 
-    scope :virtual, lambda { where(:virtual => true) }
-    scope :physical, lambda { where(:virtual => false) }
-    scope :is_managed, lambda { where(:managed => true) }
+    scope :virtual, -> { where(:virtual => true) }
+    scope :physical, -> { where(:virtual => false) }
+    scope :is_managed, -> { where(:managed => true) }
 
-    scope :primary, lambda { { :conditions => { :primary => true } } }
-    scope :provision, lambda { { :conditions => { :provision => true } } }
+    scope :primary, -> { { :conditions => { :primary => true } } }
+    scope :provision, -> { { :conditions => { :provision => true } } }
 
     belongs_to :subnet
     belongs_to :domain, :counter_cache => 'hosts_count'

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -12,7 +12,7 @@ module Nic
     end
     alias_method :virtual?, :virtual
 
-    register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
+    register_to_enc_transformation :type, ->(type) { type.constantize.humanized_name }
 
     def proxy
       proxy = bmc_proxy

--- a/app/models/nic/bond.rb
+++ b/app/models/nic/bond.rb
@@ -8,7 +8,7 @@ module Nic
 
     before_validation :ensure_virtual
 
-    register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
+    register_to_enc_transformation :type, ->(type) { type.constantize.humanized_name }
 
     def virtual
       true

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -6,7 +6,7 @@ module Nic
     # ensure that we can only have one bootable interface
     validates :type, :uniqueness => {:scope => :host_id, :message => N_("Only one bootable interface is allowed")}
 
-    register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
+    register_to_enc_transformation :type, ->(type) { type.constantize.humanized_name }
 
     def initialize(*args)
       Foreman::Deprecation.deprecation_warning("1.11", "Use Nic::Managed setting provision: true")

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -19,7 +19,7 @@ module Nic
     delegate :operatingsystem_id, :hostgroup_id, :environment_id,
              :overwrite?, :to => :host, :allow_nil => true
 
-    register_to_enc_transformation :type, lambda { |type| type.constantize.humanized_name }
+    register_to_enc_transformation :type, ->(type) { type.constantize.humanized_name }
 
     # this ensures we can create an interface even when there is no host queue
     # e.g. outside to Host nested attributes

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -39,7 +39,7 @@ class Operatingsystem < ActiveRecord::Base
   before_save :set_family
 
   audited :allow_mass_assignment => true, :except => [:hosts_count, :hostgroups_count]
-  default_scope lambda { order(:title) }
+  default_scope -> { order(:title) }
 
   scoped_search :on => :name,        :complete_value => :true
   scoped_search :on => :major,       :complete_value => :true

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -12,7 +12,7 @@ class Parameter < ActiveRecord::Base
 
   scoped_search :on => :name, :complete_value => true
 
-  default_scope lambda { order("parameters.name") }
+  default_scope -> { order("parameters.name") }
 
   attr_accessor :nested
   before_validation :strip_whitespaces

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -16,7 +16,8 @@ class ProvisioningTemplate < Template
   has_many :environments, :through => :template_combinations
   has_many :template_combinations, :dependent => :destroy
   belongs_to :template_kind
-  accepts_nested_attributes_for :template_combinations, :allow_destroy => true, :reject_if => lambda {|tc| tc[:environment_id].blank? and tc[:hostgroup_id].blank? }
+  accepts_nested_attributes_for :template_combinations, :allow_destroy => true,
+    :reject_if => ->(tc) { tc[:environment_id].blank? and tc[:hostgroup_id].blank? }
   has_and_belongs_to_many :operatingsystems
   has_many :os_default_templates
   before_save :check_for_snippet_assoications

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -18,11 +18,11 @@ class Puppetclass < ActiveRecord::Base
   has_many :config_groups, :through => :config_group_classes, :dependent => :destroy
 
   has_many :lookup_keys, :inverse_of => :puppetclass, :dependent => :destroy
-  accepts_nested_attributes_for :lookup_keys, :reject_if => lambda { |a| a[:key].blank? }, :allow_destroy => true
+  accepts_nested_attributes_for :lookup_keys, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
   # param classes
   has_many :class_params, :through => :environment_classes, :uniq => true,
     :source => :lookup_key, :conditions => 'environment_classes.lookup_key_id is NOT NULL'
-  accepts_nested_attributes_for :class_params, :reject_if => lambda { |a| a[:key].blank? }, :allow_destroy => true
+  accepts_nested_attributes_for :class_params, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
   validates :name, :uniqueness => true, :presence => true, :no_whitespace => true
   audited :allow_mass_assignment => true, :except => [:total_hosts, :lookup_keys_count, :global_class_params_count]
 
@@ -31,7 +31,7 @@ class Puppetclass < ActiveRecord::Base
   alias_attribute :smart_class_parameters, :class_params
   alias_attribute :smart_class_parameter_ids, :class_param_ids
 
-  default_scope lambda { order('puppetclasses.name') }
+  default_scope -> { order('puppetclasses.name') }
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :total_hosts
@@ -43,7 +43,7 @@ class Puppetclass < ActiveRecord::Base
   scoped_search :in => :hosts, :on => :name, :complete_value => :true, :rename => "host", :ext_method => :search_by_host, :only_explicit => true
   scoped_search :in => :class_params, :on => :key, :complete_value => :true, :only_explicit => true
 
-  scope :not_in_any_environment, lambda { includes(:environment_classes).where(:environment_classes => {:environment_id => nil}) }
+  scope :not_in_any_environment, -> { includes(:environment_classes).where(:environment_classes => {:environment_id => nil}) }
 
   # returns a hash containing modules and associated classes
   def self.classes2hash(classes)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -39,10 +39,10 @@ class Report < ActiveRecord::Base
   }
 
   # returns recent reports
-  scope :recent, lambda { |*args| where("reported_at > ?", (args.first || 1.day.ago)).order(:reported_at) }
+  scope :recent, ->(*args) { where("reported_at > ?", (args.first || 1.day.ago)).order(:reported_at) }
 
   # with_changes
-  scope :interesting, lambda { where("status <> 0") }
+  scope :interesting, -> { where("status <> 0") }
 
   # a method that save the report values (e.g. values from METRIC)
   # it is not supported to edit status values after it has been written once.

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -27,8 +27,8 @@ class Role < ActiveRecord::Base
   BUILTIN_ANONYMOUS     = 2
   audited :allow_mass_assignment => true
 
-  scope :givable, lambda { where(:builtin => 0).order(:name) }
-  scope :for_current_user, lambda { User.current.admin? ? {} : where(:id => User.current.role_ids) }
+  scope :givable, -> { where(:builtin => 0).order(:name) }
+  scope :for_current_user, -> { User.current.admin? ? {} : where(:id => User.current.role_ids) }
   scope :builtin, lambda { |*args|
     compare = 'not' if args.first
     where("#{compare} builtin = 0")

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -46,10 +46,10 @@ class Setting < ActiveRecord::Base
   before_save :clear_cache
   validate :validate_frozen_attributes
   after_find :readonly_when_overridden_in_SETTINGS
-  default_scope lambda { order(:name) }
+  default_scope -> { order(:name) }
 
   # The DB may contain settings from disabled plugins - filter them out here
-  scope :live_descendants, lambda { where(:category => self.descendants.map(&:to_s)) unless Rails.env.development? }
+  scope :live_descendants, -> { where(:category => self.descendants.map(&:to_s)) unless Rails.env.development? }
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :description, :complete_value => :true

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -39,7 +39,7 @@ class SmartProxy < ActiveRecord::Base
     end
   }
 
-  scope :with_features, lambda {|*feature_names| where(:features => { :name => feature_names }).joins(:features) if feature_names.any? }
+  scope :with_features, ->(*feature_names) { where(:features => { :name => feature_names }).joins(:features) if feature_names.any? }
 
   def hostname
     # This will always match as it is validated

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -12,7 +12,7 @@ class Location < Taxonomy
   accepts_nested_attributes_for :location_parameters, :allow_destroy => true
   include ParameterValidators
 
-  scope :completer_scope, lambda { |opts| my_locations }
+  scope :completer_scope, ->(opts) { my_locations }
 
   scope :my_locations, lambda {
     conditions = User.current.admin? ? {} : sanitize_sql_for_conditions([" (taxonomies.id in (?))", User.current.location_and_child_ids])

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -12,7 +12,7 @@ class Organization < Taxonomy
   accepts_nested_attributes_for :organization_parameters, :allow_destroy => true
   include ParameterValidators
 
-  scope :completer_scope, lambda { |opts| my_organizations }
+  scope :completer_scope, ->(opts) { my_organizations }
 
   scope :my_organizations, lambda {
     conditions = User.current.admin? ? {} : sanitize_sql_for_conditions([" (taxonomies.id in (?))", User.current.organization_and_child_ids])

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -36,7 +36,7 @@ class Taxonomy < ActiveRecord::Base
   delegate :import_missing_ids, :inherited_ids, :used_and_selected_or_inherited_ids, :selected_or_inherited_ids,
            :non_inherited_ids, :used_or_inherited_ids, :used_ids, :to => :tax_host
 
-  default_scope lambda { order(:title) }
+  default_scope -> { order(:title) }
 
   scope :completer_scope, lambda{|opts|
     if opts[:controller] == 'organizations'

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -6,7 +6,7 @@ class Template < ActiveRecord::Base
   validates :name, :presence => true
   validates :template, :presence => true
   validates :audit_comment, :length => {:maximum => 255}
-  validate :template_changes, :if => lambda { |template| (template.locked? || template.locked_changed?) && template.persisted? && !Foreman.in_rake? }
+  validate :template_changes, :if => ->(template) { (template.locked? || template.locked_changed?) && template.persisted? && !Foreman.in_rake? }
 
   before_destroy :check_if_template_is_locked
 

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,13 +1,13 @@
 class Trend < ActiveRecord::Base
   validates_lengths_from_database
-  after_save :create_values, :if => lambda{ |o|  o.fact_value.nil? }
-  after_destroy :destroy_values, :if => lambda{ |o|  o.fact_value.nil? }
+  after_save :create_values, :if => ->(o) { o.fact_value.nil? }
+  after_destroy :destroy_values, :if => ->(o) { o.fact_value.nil? }
 
   belongs_to :trendable, :polymorphic => true
   has_many :trend_counters, :dependent => :destroy
 
-  scope :has_value, lambda { where('fact_value IS NOT NULL').order("fact_value") }
-  scope :types, lambda { where(:fact_value => nil) }
+  scope :has_value, -> { where('fact_value IS NOT NULL').order("fact_value") }
+  scope :types, -> { where(:fact_value => nil) }
 
   def to_param
     Parameterizable.parameterize("#{id}-#{to_label}")

--- a/app/models/trend_counter.rb
+++ b/app/models/trend_counter.rb
@@ -2,6 +2,6 @@ class TrendCounter < ActiveRecord::Base
   belongs_to :trend
   validates :count, :numericality => {:greater_than_or_equal_to => 0}
   validates :created_at, :uniqueness => {:scope => :trend_id}
-  default_scope lambda { order(:created_at) }
-  scope :recent, lambda { |*args| where("created_at > ?", (args.first || 30.day.ago) ).order(:created_at) }
+  default_scope -> { order(:created_at) }
+  scope :recent, ->(*args) { where("created_at > ?", (args.first || 30.day.ago) ).order(:created_at) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,8 +59,8 @@ class User < ActiveRecord::Base
       where("#{self.table_name}.auth_source_id <> ?", hidden)
     end
   }
-  scope :visible,         lambda { except_hidden }
-  scope :completer_scope, lambda { |opts| visible }
+  scope :visible,         -> { except_hidden }
+  scope :completer_scope, ->(opts) { visible }
 
   validates :mail, :format => { :with => /\A(([\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~]+((\.\"[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+(\.[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+)*\")*\.[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~]+)*)|(\"[\w !#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+(\.[\w !#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+)*\"))
                                           @[a-z0-9]+((\.[a-z0-9]+)*|(\-[a-z0-9]+)*)*\z/ix },

--- a/app/models/user_mail_notification.rb
+++ b/app/models/user_mail_notification.rb
@@ -7,9 +7,9 @@ class UserMailNotification < ActiveRecord::Base
   validates :user_id, :presence => true
   validates :mail_notification, :presence => true
 
-  scope :daily, lambda { where(:interval => 'Daily') }
-  scope :weekly,  lambda { where(:interval => 'Weekly') }
-  scope :monthly, lambda { where(:interval => 'Monthly') }
+  scope :daily, -> { where(:interval => 'Daily') }
+  scope :weekly, -> { where(:interval => 'Weekly') }
+  scope :monthly, -> { where(:interval => 'Monthly') }
 
   def deliver(options = {})
     return unless user.mail_enabled?

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -26,12 +26,12 @@ class Usergroup < ActiveRecord::Base
 
   # The text item to see in a select dropdown menu
   alias_attribute :select_title, :to_s
-  default_scope lambda { order('usergroups.name') }
-  scope :visible, lambda { }
+  default_scope -> { order('usergroups.name') }
+  scope :visible, -> { }
   scoped_search :on => :name, :complete_value => :true
   validate :ensure_uniq_name, :ensure_last_admin_remains_admin
 
-  accepts_nested_attributes_for :external_usergroups, :reject_if => lambda { |a| a[:name].blank? }, :allow_destroy => true
+  accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
 
   # This methods retrieves all user addresses in a usergroup
   # Returns: Array of strings representing the user's email addresses

--- a/app/models/usergroup_member.rb
+++ b/app/models/usergroup_member.rb
@@ -7,8 +7,8 @@ class UsergroupMember < ActiveRecord::Base
   after_save :add_new_cache
   after_destroy :remove_old_cache
 
-  scope :user_memberships, lambda { where("member_type = 'User'") }
-  scope :usergroup_memberships, lambda { where("member_type = 'Usergroup'") }
+  scope :user_memberships, -> { where("member_type = 'User'") }
+  scope :usergroup_memberships, -> { where("member_type = 'Usergroup'") }
 
   private
 

--- a/app/views/api/v1/home/index.json.rabl
+++ b/app/views/api/v1/home/index.json.rabl
@@ -1,8 +1,8 @@
 object false
 child(:links => "links") do
-
   # gather index methods of resources
-  index_method_description_apis = Apipie.app.resource_descriptions[Apipie.configuration.default_version].map do |name, resource_description|
+  index_method_description_apis = Apipie.app.resource_descriptions[Apipie.configuration.default_version]
+    .map do |name, resource_description|
     if (description = Apipie.app["#{name}#index"])
       description.method_apis_to_json.first
     end

--- a/app/views/api/v1/hosts/show.json.rabl
+++ b/app/views/api/v1/hosts/show.json.rabl
@@ -8,13 +8,8 @@ attributes :name, :id, :ip, :environment_id, :last_report, :updated_at, :created
            :puppet_proxy_id, :certname, :image_id, :created_at, :updated_at,
            :last_compile, :puppet_status, :root_pass
 
-if SETTINGS[:organizations_enabled]
-  attribute :organization_id
-end
-
-if SETTINGS[:locations_enabled]
-  attribute :location_id
-end
+attribute :organization_id if SETTINGS[:organizations_enabled]
+attribute :location_id if SETTINGS[:locations_enabled]
 
 node :environment do |host|
   {:environment => {:id => host.environment_id, :name => host.environment_name}}
@@ -25,5 +20,5 @@ child :host_parameters do
 end
 
 node do |host|
-   { :interfaces => partial("api/v1/interfaces/show", :object => host.interfaces) }
+  { :interfaces => partial("api/v1/interfaces/show", :object => host.interfaces) }
 end

--- a/app/views/api/v1/images/show.json.rabl
+++ b/app/views/api/v1/images/show.json.rabl
@@ -1,4 +1,4 @@
 object @image
 
 attributes :id, :operatingsystem_id, :compute_resource_id, :architecture_id, :uuid, :username, :name, :created_at, :updated_at
-attribute :iam_role, :if => lambda { |img| img.compute_resource.kind_of? Foreman::Model::EC2 }
+attribute :iam_role, :if => ->(img) { img.compute_resource.is_a? Foreman::Model::EC2 }

--- a/app/views/api/v1/import_puppetclasses/show.json.rabl
+++ b/app/views/api/v1/import_puppetclasses/show.json.rabl
@@ -3,25 +3,25 @@ object @environment => nil
 attributes :name
 
 node(:actions) do |environment|
- actions = []
- actions << 'new' if @changed['new'][environment.name].present?
- actions << 'updated' if @changed['updated'][environment.name].present?
- actions << 'obsolete' if @changed['obsolete'][environment.name].present?
- actions.as_json
+  actions = []
+  actions << 'new' if @changed['new'][environment.name].present?
+  actions << 'updated' if @changed['updated'][environment.name].present?
+  actions << 'obsolete' if @changed['obsolete'][environment.name].present?
+  actions.as_json
 end
 
-node(:new_puppetclasses, :if => lambda { |environment| @changed['new'][environment.name].present? }) do |environment|
+node(:new_puppetclasses, :if => ->(environment) { @changed['new'][environment.name].present? }) do |environment|
   JSON.parse(@changed['new'][environment.name]).keys
 end
 
-node(:updated_puppetclasses, :if => lambda { |environment| @changed['updated'][environment.name].present? }) do |environment|
+node(:updated_puppetclasses, :if => ->(environment) { @changed['updated'][environment.name].present? }) do |environment|
   JSON.parse(@changed['updated'][environment.name]).keys
 end
 
-node(:obsolete_puppetclasses, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && !@changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+node(:obsolete_puppetclasses, :if => ->(environment) { @changed['obsolete'][environment.name].present? && !@changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
   JSON.parse(@changed['obsolete'][environment.name])
 end
 
-node(:removed_environment, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+node(:removed_environment, :if => ->(environment) { @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
   environment.name
 end

--- a/app/views/api/v1/reports/show.json.rabl
+++ b/app/views/api/v1/reports/show.json.rabl
@@ -13,5 +13,5 @@ child :logs do
 end
 
 node :summary do |report|
-	report.summaryStatus
+  report.summaryStatus
 end

--- a/app/views/api/v1/smart_proxies/show.json.rabl
+++ b/app/views/api/v1/smart_proxies/show.json.rabl
@@ -3,7 +3,5 @@ object @smart_proxy
 attributes :name, :id, :url, :created_at, :updated_at
 
 child :features do
-	attributes :name, :id, :url
+  attributes :name, :id, :url
 end
-
-

--- a/app/views/api/v2/filters/main.json.rabl
+++ b/app/views/api/v2/filters/main.json.rabl
@@ -4,7 +4,6 @@ extends "api/v2/filters/base"
 
 attributes :search, :resource_type, :unlimited?, :created_at, :updated_at
 
-
 child :role do
   extends "api/v2/roles/base"
 end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -10,11 +10,5 @@ attributes :ip, :environment_id, :environment_name, :last_report, :mac, :realm_i
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
            :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
            :last_compile, :puppet_status
-
-if SETTINGS[:organizations_enabled]
-  attributes :organization_id, :organization_name
-end
-
-if SETTINGS[:locations_enabled]
-  attributes :location_id, :location_name
-end
+attributes :organization_id, :organization_name if SETTINGS[:organizations_enabled]
+attributes :location_id, :location_name         if SETTINGS[:locations_enabled]

--- a/app/views/api/v2/images/main.json.rabl
+++ b/app/views/api/v2/images/main.json.rabl
@@ -5,6 +5,6 @@ extends "api/v2/images/base"
 attributes :operatingsystem_id, :operatingsystem_name, :compute_resource_id, :compute_resource_name,
            :architecture_id, :architecture_name, :uuid, :username, :created_at, :updated_at
 
-attribute :user_data, :if => lambda { |img| img.compute_resource.user_data_supported? }
+attribute :user_data, :if => ->(img) { img.compute_resource.user_data_supported? }
 
-attribute :iam_role, :if => lambda { |img| img.compute_resource.kind_of? Foreman::Model::EC2 }
+attribute :iam_role, :if => ->(img) { img.compute_resource.is_a? Foreman::Model::EC2 }

--- a/app/views/api/v2/import_puppetclasses/show.json.rabl
+++ b/app/views/api/v2/import_puppetclasses/show.json.rabl
@@ -3,25 +3,25 @@ object @environment => nil
 attributes :name
 
 node(:actions) do |environment|
- actions = []
- actions << 'new' if @changed['new'][environment.name].present?
- actions << 'updated' if @changed['updated'][environment.name].present?
- actions << 'obsolete' if @changed['obsolete'][environment.name].present?
- actions.as_json
+  actions = []
+  actions << 'new' if @changed['new'][environment.name].present?
+  actions << 'updated' if @changed['updated'][environment.name].present?
+  actions << 'obsolete' if @changed['obsolete'][environment.name].present?
+  actions.as_json
 end
 
-node(:new_puppetclasses, :if => lambda { |environment| @changed['new'][environment.name].present? }) do |environment|
+node(:new_puppetclasses, :if => ->(environment) { @changed['new'][environment.name].present? }) do |environment|
   JSON.parse(@changed['new'][environment.name]).keys
 end
 
-node(:updated_puppetclasses, :if => lambda { |environment| @changed['updated'][environment.name].present? }) do |environment|
+node(:updated_puppetclasses, :if => ->(environment) { @changed['updated'][environment.name].present? }) do |environment|
   JSON.parse(@changed['updated'][environment.name]).keys
 end
 
-node(:obsolete_puppetclasses, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && !@changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+node(:obsolete_puppetclasses, :if => ->(environment) { @changed['obsolete'][environment.name].present? && !@changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
   JSON.parse(@changed['obsolete'][environment.name])
 end
 
-node(:removed_environment, :if => lambda { |environment| @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+node(:removed_environment, :if => ->(environment) { @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
   environment.name
 end

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -50,18 +50,18 @@ child :hostgroups do
   extends "api/v2/hostgroups/base"
 end
 
-if @taxonomy.kind_of?(Location)
+if @taxonomy.is_a?(Location)
   child :organizations => :organizations  do
     extends "api/v2/taxonomies/base"
   end
 end
 
-if @taxonomy.kind_of?(Organization)
+if @taxonomy.is_a?(Organization)
   child :locations => :locations do
     extends "api/v2/taxonomies/base"
   end
 end
 
 node do |taxonomy|
-   { :parameters => partial("api/v2/parameters/base", :object => taxonomy.parameters) }
+  { :parameters => partial("api/v2/parameters/base", :object => taxonomy.parameters) }
 end

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -13,7 +13,7 @@ Apipie.configure do |config|
   # config.languages = [] # turn off localized API docs and CLI, useful for development
   config.languages = ENV['FOREMAN_APIPIE_LANGS'].try(:split, ' ') || FastGettext.available_locales
   config.default_locale = FastGettext.default_locale
-  config.locale = lambda { |loc| loc ? FastGettext.set_locale(loc) : FastGettext.locale }
+  config.locale = ->(loc) { loc ? FastGettext.set_locale(loc) : FastGettext.locale }
 
   substitutions = {
     :operatingsystem_families => Operatingsystem.families.join(", "),

--- a/test/unit/enc_output_test.rb
+++ b/test/unit/enc_output_test.rb
@@ -4,7 +4,7 @@ class EncOutputTest < ActiveSupport::TestCase
   class SampleModel
     attr_accessor :name, :attrs, :subnet, :mac, :password, :subnet
     include EncOutput
-    register_to_enc_transformation :mac, lambda { |v| v.upcase }
+    register_to_enc_transformation :mac, ->(v) { v.upcase }
 
     def attributes
       {

--- a/test/unit/helpers/filters_helper_test.rb
+++ b/test/unit/helpers/filters_helper_test.rb
@@ -26,7 +26,7 @@ class FiltersHelperTest < ActionView::TestCase
   end
 
   def test_engine_search_path_is_used_when_engine_override_available
-    FiltersHelperOverrides.override_search_path("TestOverride", lambda { |resource| "test_override/auto_complete_search" })
+    FiltersHelperOverrides.override_search_path("TestOverride", ->(resource) { 'test_override/auto_complete_search' } )
     assert_equal "test_override/auto_complete_search", search_path('TestOverride::Resource')
   end
 end


### PR DESCRIPTION
I started by spotting log.rb which didn't have a lambda wrapping it's
default scope, as needed by Rails 4. Since the style guide and most
Rails 4 documents used the stabby lambda, I turned on the cop so that we
use it everywhere there's a oneliner lambda.
