### PR TITLE
fixes #11374 - re-initialize select2 on smart vars

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -61,7 +61,6 @@ function add_child_node(item) {
     // Setup
     var assoc   = $(item).attr('data-association');           // Name of child
     var template_class = '.' + assoc + '_fields_template';
-    $(item).parent().find(template_class).find('select').select2('destroy');
     var content = $(item).parent().find(template_class).html(); // Fields template
     if (content == undefined) {content = $(template_class).html()};
 
@@ -87,6 +86,7 @@ function add_child_node(item) {
     $(item).closest("form").trigger({type: 'nested:fieldAdded', field: field});
     $('a[rel="popover"]').popover({html: true});
     $('a[rel="twipsy"]').tooltip();
+    $(field).find('select:not(.matcher_key)').select2()
     return new_id;
 }
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -47,7 +47,7 @@ module LookupKeysHelper
 
   def param_type_selector(f, options = {})
     selectable_f f, :key_type, options_for_select(LookupKey::KEY_TYPES.map { |e| [_(e),e] }, f.object.key_type),{},
-                 options.merge({ :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
+                 options.merge({ :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8", :class=> "without_select2",
                  :help_inline => popover("",_("<dl>" +
                "<dt>String</dt> <dd>Everything is taken as a string.</dd>" +
                "<dt>Boolean</dt> <dd>Common representation of boolean values are accepted.</dd>" +
@@ -62,7 +62,7 @@ module LookupKeysHelper
 
   def validator_type_selector(f)
     selectable_f f, :validator_type, options_for_select(LookupKey::VALIDATOR_TYPES.map { |e| [_(e),e]  }, f.object.validator_type),{:include_blank => _("None")},
-               { :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8",
+               { :disabled => (f.object.is_param && !f.object.override), :size => "col-md-8", :class=> "without_select2",
                  :onchange => 'validatorTypeSelected(this)',
                  :help_inline => popover("",_("<dl>" +
                "<dt>List</dt> <dd>A list of the allowed values, specified in the Validator rule field.</dd>" +

--- a/app/views/lookup_keys/_value.html.erb
+++ b/app/views/lookup_keys/_value.html.erb
@@ -4,7 +4,7 @@
 <tr class="fields matchers form-group <%= 'has-error' if f.object.errors.any? %>">
   <td>
     <%= f.hidden_field :match, :class => 'match' %>
-    <%= select_tag '', nil, :class => 'matcher_key' %>
+    <%= select_tag '', nil, :class => 'matcher_key without_select2' %>
     =
     <%= text_field_tag '', nil, :class => 'matcher_value' %>
   </td>


### PR DESCRIPTION
To be honest, I'd remove select2 from the smart vars and lookup keys and leave only the "without_select2" class
