### PR TITLE
fixes #11408 - allow plugin to define own permission for layout helper

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -434,7 +434,12 @@ module LayoutHelper
   end
 
   def authorized_associations_permission_name(klass)
-    permission = "view_#{klass.to_s.underscore.pluralize}"
+    permission = if klass.respond_to?(:permission_name)
+                   klass.permission_name :view
+                 else
+                   "view_#{klass.to_s.underscore.pluralize}"
+                 end
+
     unless Permission.where(:name => permission).present?
       raise Foreman::Exception.new(N_('unknown permission %s'), permission)
     end


### PR DESCRIPTION
Plugin example https://github.com/theforeman/foreman_salt/pull/46
