### PR TITLE
Fixes #11428 - External user groups refresh shouldn't be case sensitive

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -107,10 +107,10 @@ class AuthSourceLdap < AuthSource
 
     logger.debug "Updating user groups for user #{login}"
     internal = User.find(login).external_usergroups.map(&:name)
-    external = ldap_con.group_list(login)
+    external = ldap_con.group_list(login) # this list will return all groups in lowercase
     (internal | external).each do |name|
       begin
-        external_usergroup = external_usergroups.find_by_name(name)
+        external_usergroup = external_usergroups.where('lower(name) = ?', name.downcase).last
         if external_usergroup.present?
           logger.debug "Refreshing external user group #{external_usergroup.name}"
           external_usergroup.refresh


### PR DESCRIPTION
group_list in ldap_fluff returns a list of lowercase LDAP GIDs.
When AuthSourceLdap tries to run update_usergroups to refresh the external
user groups, it will try to match these lowercase gids with external user
group names.

However, we don't enforce external user group names to be lowercase.
If an external user group contains any capital letter, it will not be
synced as it will not match the lowercase GID.

This commit makes sure we search for external groups case insensitive,
so we can match LDAP GIDs with external groups names.
