### PR TITLE
Fixes #11440 - Network bonding is not working properly when provision…

### DIFF
--- a/app/views/unattended/snippets/_kickstart_networking_setup.erb
+++ b/app/views/unattended/snippets/_kickstart_networking_setup.erb
@@ -50,7 +50,6 @@ DEVICE="$real"
 ONBOOT=yes
 PEERDNS=no
 PEERROUTES=no
-DEFROUTE=no
 TYPE=Bond
 BONDING_OPTS="<%= bond.bond_options -%> mode=<%= bond.mode -%>"
 BONDING_MASTER=yes


### PR DESCRIPTION
Removing "DEFROUTE=no" which prevents CentOS/RHEL server to properly set default gw when on the bonded interface.

Issue is described here: http://projects.theforeman.org/issues/11440
