### PR TITLE
fixes #11577 - Add additional volume to Openstack

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -91,13 +91,9 @@ module Foreman::Model
       }
     end
 
-    def create_vm(args = {})
+   def create_vm(args = {})
       boot_from_volume(args) if Foreman::Cast.to_bool(args[:boot_from_volume])
-<<<<<<< HEAD
       create_additional_volume(args) if args[:volumes][:size].to_i > 0 and Foreman::Cast.to_bool(args[:boot_from_volume])
-=======
-      create_additional_volume(args) if args[:volumes][:size].to_i > 0
->>>>>>> 7819e2875cb071367ab1840d952a176563b44741
       network = args.delete(:network)
       # fix internal network format for fog.
       args[:nics].delete_if(&:blank?)
@@ -113,11 +109,7 @@ module Foreman::Model
       logger.warn "failed to create vm: #{message}"
       destroy_vm vm.id if vm
       volume_client.volumes.delete(@boot_vol_id) if args[:boot_from_volume]
-<<<<<<< HEAD
       volume_client.volumes.delete(@add_vol_id) if args[:volumes][:size].to_i > 0 and Foreman::Cast.to_bool(args[:boot_from_volume])
-=======
-      volume_client.volumes.delete(@add_vol_id) if args[:volumes][:size].to_i > 0
->>>>>>> 7819e2875cb071367ab1840d952a176563b44741
       raise message
     end
 

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -73,8 +73,27 @@ module Foreman::Model
       } ]
     end
 
+    def new_volume(attr = { })
+      volume_client.volumes.new attr.merge(:size => 0)
+    end
+
+    def create_additional_volume(args)
+      vm_name = args[:name]
+      add_vol = volume_client.volumes.create( { :display_name => "#{vm_name}-vol1", :volumeType => "Volume", :size => args[:volumes][:size].to_i } )
+      @add_vol_id = add_vol.id.tr('"', '')
+      add_vol.wait_for { status == 'available'  }
+      args[:block_device_mapping_v2] << {
+        :boot_index       => 1,
+        :uuid => @add_vol_id,
+        :source_type => "volume",
+        :destination_type => "volume",
+        :delete_on_termination => true
+      }
+    end
+
     def create_vm(args = {})
       boot_from_volume(args) if Foreman::Cast.to_bool(args[:boot_from_volume])
+      create_additional_volume(args) if args[:volumes][:size].to_i > 0
       network = args.delete(:network)
       # fix internal network format for fog.
       args[:nics].delete_if(&:blank?)
@@ -90,6 +109,7 @@ module Foreman::Model
       logger.warn "failed to create vm: #{message}"
       destroy_vm vm.id if vm
       volume_client.volumes.delete(@boot_vol_id) if args[:boot_from_volume]
+      volume_client.volumes.delete(@add_vol_id) if args[:volumes][:size].to_i > 0
       raise message
     end
 

--- a/app/views/compute_resources_vms/form/openstack/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_volume.html.erb
@@ -1,0 +1,1 @@
+<%= text_f f, :size, { :label => _("Additional volume size (GB)"), :help_inline => _(""), :value => 0 } %>


### PR DESCRIPTION
When creating a new virtual machine using OpenStack compute resource we wanted to be able to add a second volume to it "/dev/vdb" in addition to the boot volume. The second volume will only be created in case the size value is > 0.
