### PR TITLE
Fixes #11284 - clear cache during websocket setting migration

### DIFF
--- a/db/migrate/20150312144232_migrate_websockets_setting.rb
+++ b/db/migrate/20150312144232_migrate_websockets_setting.rb
@@ -31,10 +31,13 @@ class MigrateWebsocketsSetting < ActiveRecord::Migration
     end
     encrypt.default = !!SETTINGS[:require_ssl]
     encrypt.save!
+    Rails.cache.delete(encrypt.name.to_s)
   end
 
   def down
     # delete and reset on next app server start
-    FakeSetting.find_by_name("websockets_encrypt").delete
+    encrypt = FakeSetting.find_by_name("websockets_encrypt")
+    Rails.cache.delete(encrypt.name.to_s)
+    encrypt.delete
   end
 end


### PR DESCRIPTION
I am clearing even after delete, just to be sure.
