### PR TITLE
Fixes #10988 - Remove 1.11 deprecations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::Base
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
   rescue_from Exception, :with => :generic_exception if Rails.env.production?
   rescue_from ActiveRecord::RecordNotFound, :with => :not_found
-  rescue_from ActionView::MissingTemplate, :with => :api_deprecation_error
   rescue_from ProxyAPI::ProxyException, :with => :smart_proxy_exception
 
   # standard layout to all controllers
@@ -90,17 +89,6 @@ class ApplicationController < ActionController::Base
       format.any { head :status => :not_found}
     end
     true
-  end
-
-  def api_deprecation_error(exception = nil)
-    if request.format.try(:json?) && !request.env['REQUEST_URI'].match(/\/api\//i)
-      msg = "/api/ prefix must now be used to access API URLs, e.g. #{request.env['HTTP_HOST']}/api#{request.env['REQUEST_URI']}"
-      Foreman::Deprecation.deprecation_warning("1.11", msg)
-      Foreman::Logging.exception(msg, exception, :level => :debug)
-      render :json => {:message => msg}, :status => :bad_request
-    else
-      raise exception
-    end
   end
 
   def smart_proxy_exception(exception = nil)

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -82,7 +82,7 @@ module Api::V2::TaxonomiesController
   def rename_config_template
     if params[taxonomy_single] && params[taxonomy_single][:config_template_ids].present?
       params[taxonomy_single][:provisioning_template_ids] = params[taxonomy_single].delete(:config_template_ids)
-      Foreman::Deprecation.deprecation_warning('1.11', 'Config templates were renamed to provisioning templates')
+      Foreman::Deprecation.api_deprecation_warning('Config templates were renamed to provisioning templates')
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -13,34 +13,6 @@ class ApplicationMailer < ActionMailer::Base
 
   private
 
-  class GroupMail
-    def initialize(emails)
-      Foreman::Deprecation.deprecation_warning("1.11", "GroupMail will be removed as mailers should not generate multiple messages, use MailNotification.deliver")
-      @emails = emails
-    end
-
-    def deliver
-      @emails.each do |email|
-        begin
-          email.deliver
-        rescue => e
-          Foreman::Logging.exception("Unable to send email notification", e)
-        end
-      end
-    end
-  end
-
-  def group_mail(users, options)
-    Foreman::Deprecation.deprecation_warning("1.11", "group_mail is replaced by MailNotification.deliver with :users in the options hash")
-    mails = users.map do |user|
-      @user = user
-      set_locale_for user
-      mail(options.merge(:to => user.mail)) unless user.mail.blank?
-    end
-
-    GroupMail.new(mails.compact)
-  end
-
   def set_locale_for(user)
     old_loc = FastGettext.locale
     begin

--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -47,22 +47,16 @@ module Orchestration
     raise ActiveRecord::Rollback
   end
 
-  # log and add to errors
-  def failure(msg, exception_or_backtrace = nil, dest = :base)
-    if exception_or_backtrace
-      if exception_or_backtrace.is_a? Exception
-        exception = exception_or_backtrace
-      else
-        exception = StandardError.new(msg)
-        exception.set_backtrace(exception_or_backtrace)
-        Foreman::Deprecation.deprecation_warning("1.11", "Passing backtrace to failure method is deprecated, pass the exception instead")
-      end
-      Foreman::Logging.exception(msg, exception)
-    else
-      logger.warn(msg)
-    end
-    errors.add dest, msg
+  # Log and add error to model
+  def failure(message, exception = nil, dest = :base)
+    log_failure(message, exception)
+    errors.add(dest, message)
     false
+  end
+
+  def log_failure(message, exception)
+    return Foreman::Logging.exception(message, exception) if exception.present?
+    logger.warn(message)
   end
 
   public

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -274,16 +274,6 @@ module Host
       @provision_interface = nil
     end
 
-    def self.find_by_ip(ip)
-      Foreman::Deprecation.deprecation_warning("1.11", "Host#find_by_ip has been deprecated, you should search for primary interfaces")
-      Nic::Base.primary.find_by_ip(ip).try(:host)
-    end
-
-    def self.find_by_mac(mac)
-      Foreman::Deprecation.deprecation_warning("1.11", "Host#find_by_mac has been deprecated, you should search for provision interfaces")
-      Nic::Base.provision.find_by_mac(mac).try(:host)
-    end
-
     def matching?
       missing_ids.empty?
     end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -329,11 +329,6 @@ class Host::Managed < Host::Base
     pxe_render(template.tr("\r", ''))
   end
 
-  def configTemplate(args = {})
-    Foreman::Deprecation.deprecation_warning("1.11", 'configTemplate was renamed to provisioning_template')
-    self.provisioning_template(args)
-  end
-
   # returns a configuration template (such as kickstart) to a given host
   def provisioning_template(opts = {})
     opts[:kind]               ||= "provision"

--- a/app/models/nic/bootable.rb
+++ b/app/models/nic/bootable.rb
@@ -8,11 +8,6 @@ module Nic
 
     register_to_enc_transformation :type, ->(type) { type.constantize.humanized_name }
 
-    def initialize(*args)
-      Foreman::Deprecation.deprecation_warning("1.11", "Use Nic::Managed setting provision: true")
-      super(*args)
-    end
-
     def self.human_name
       N_('Bootable')
     end

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -13,11 +13,6 @@ class FactParser
     @parsers ||= { :puppet => PuppetFactParser }.with_indifferent_access
   end
 
-  def self.register_fact_importer(key, klass)
-    Foreman::Deprecation.deprecation_warning("1.11", "Use factParser.register_fact_parser instead")
-    register_fact_parser(key, klass)
-  end
-
   def self.register_fact_parser(key, klass)
     parsers[key.to_sym] = klass
   end

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,9 +1,0 @@
-module Deprecations
-  def const_missing(const_name)
-    return(super) unless const_name.to_s == 'ConfigTemplate'
-    Foreman::Deprecation.deprecation_warning('1.11', 'Config templates were renamed to provisioning templates')
-    ::ProvisioningTemplate
-  end
-end
-
-Object.extend(Deprecations)

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -52,9 +52,8 @@ module Foreman
       fail "Trying to use logger #{name} which has not been configured."
     end
 
-    # standard way for logging exceptions to get the most data to
-    # the log.
-    # The behehaviour can be influenced by this options:
+    # Standard way for logging exceptions to get the most data in the log.
+    # The behaviour can be influenced by this options:
     #   * :logger - the name of the logger to put the exception in ('app' by default)
     #   * :level - the logging level (:warn by default)
     def exception(context_message, exception, options = {})

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -169,7 +169,7 @@ class UnattendedControllerTest < ActionController::TestCase
     @request.env["REMOTE_ADDR"] = @ub_host.ip
     get :built
     assert_response :created
-    host = Host.find_by_ip(@ub_host.ip)
+    host = Nic::Base.primary.find_by_ip(@ub_host.ip)
     assert_equal host.build,false
   end
 


### PR DESCRIPTION
Not sure what to do with api_deprecation_warning, or if we even should have them. We kind of have an implicit contract API v1 & v2 won't change so in reality we're not deprecating paths like `api/v2/config_templates`.
