### PR TITLE
refs #11449 - move therubyracer to its own bundler group

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -4,7 +4,6 @@ group :assets do
   gem 'execjs', '>= 1.4.0', '<2.5.0'
   gem 'jquery-rails', '2.0.3'
   gem 'jquery-ui-rails', '< 5.0.0'
-  gem 'therubyracer', '0.11.3', :require => 'v8'
   gem 'bootstrap-sass', '3.0.3.0'
   gem 'spice-html5-rails', '~> 0.1.4'
   gem 'flot-rails', '0.0.3'

--- a/bundler.d/therubyracer.rb
+++ b/bundler.d/therubyracer.rb
@@ -1,0 +1,3 @@
+group :therubyracer do
+  gem 'therubyracer', '0.11.3', :require => 'v8'
+end


### PR DESCRIPTION
The defaults don't change, but therubyracer can be disabled while doing bundler install. I tested `rake assets:precompile` without therubyracer but with nodejs installed and it works as expected.
