### PR TITLE
fixes #11619 - only check template changes when persisted

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -6,7 +6,7 @@ class Template < ActiveRecord::Base
   validates :name, :presence => true
   validates :template, :presence => true
   validates :audit_comment, :length => {:maximum => 255}
-  validate :template_changes, :if => lambda { |template| (template.locked? || template.locked_changed?) && !Foreman.in_rake? }
+  validate :template_changes, :if => lambda { |template| (template.locked? || template.locked_changed?) && template.persisted? && !Foreman.in_rake? }
 
   before_destroy :check_if_template_is_locked
 

--- a/test/unit/provisioning_template_test.rb
+++ b/test/unit/provisioning_template_test.rb
@@ -81,6 +81,10 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     assert_equal clone.template, tmplt.template
   end
 
+  test "can instantiate a locked template" do
+    assert FactoryGirl.create(:provisioning_template, :locked => true)
+  end
+
   test "should not edit a locked template" do
     tmplt = templates(:locked)
     tmplt.name = "something else"


### PR DESCRIPTION
Something like `ProvisioningTemplate.create(...some stuff..., :locked => true)` doesn't work, you have to create it and change the locked value later.

```
ActiveRecord::RecordInvalid: Validation failed: This template is locked. Please clone it to a new template to customize.
```

The validation should only validate if the record is persisted.
