### PR TITLE
fixes #11649 - taxonomies api - add description to base.json.rabl

### DIFF
--- a/app/views/api/v2/taxonomies/base.json.rabl
+++ b/app/views/api/v2/taxonomies/base.json.rabl
@@ -1,3 +1,3 @@
 object @taxonomy
 
-attributes :id, :name, :title
+attributes :id, :name, :title, :description

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -123,7 +123,7 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     response = ActiveSupport::JSON.decode(@response.body)
     assert response.is_a?(Hash)
     assert response['results'].is_a?(Array)
-    assert_equal ['ancestry', 'created_at', 'id', 'name', 'title', 'updated_at'], response['results'][0].keys.sort
+    assert_equal ['ancestry', 'created_at', 'description', 'id', 'name', 'title', 'updated_at'], response['results'][0].keys.sort
   end
 
   test "object name on show defaults to object class name" do


### PR DESCRIPTION
Adding the 'description' to the base.json.rabl so that it is displayed
when a user performs commands like 'organization list' from hammer-cli-katello.

E.g.

hammer> organization list
----|-------------------------------|--------------------------------|---------------
ID | NAME                     | LABEL                    | DESCRIPTION
----|-------------------------------|--------------------------------|---------------
1  | Default Organization | Default_Organization |
12 | org3                       | org3-label                 | this is an org
----|-------------------------------|--------------------------------|---------------
