### PR TITLE
fixes #3145 - host with a lot of parameters quicker

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -24,6 +24,13 @@ module HostsHelper
     javascript_include_tag("compute_resources/#{compute_resource.provider.downcase}/nic_info.js")
   end
 
+  def value_hash_cache(host)
+    @value_hash_cache ||= {}
+    @value_hash_cache[host.id] ||= begin
+      Classification::ClassParam.new(:host=>host).inherited_values.merge(Classification::GlobalParam.new(:host=>host).inherited_values)
+    end
+  end
+
   def host_taxonomy_select(f, taxonomy)
     taxonomy_id = "#{taxonomy.to_s.downcase}_id"
     selected_taxonomy = @host.new_record? ? taxonomy.current.try(:id) : @host.send(taxonomy_id)

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -35,9 +35,9 @@ module Classification
 
     def values_hash(options = {})
       values = Hash.new { |h,k| h[k] = {} }
-      all_lookup_values = LookupValue.where(:match => path2matches).where(:lookup_key_id => class_parameters)
+      all_lookup_values = LookupValue.where(:match => path2matches).where(:lookup_key_id => class_parameters, :use_puppet_default => false).includes(:lookup_key).to_a
       class_parameters.each do |key|
-        lookup_values_for_key = all_lookup_values.where(:lookup_key_id => key.id, :use_puppet_default => false).includes(:lookup_key)
+        lookup_values_for_key = all_lookup_values.select{|i| i.lookup_key_id == key.id}
         sorted_lookup_values = lookup_values_for_key.sort_by do |lv|
           matcher_key = ''
           matcher_value = ''

--- a/app/views/puppetclasses/_class_parameters.html.erb
+++ b/app/views/puppetclasses/_class_parameters.html.erb
@@ -1,5 +1,5 @@
 <% lookup_keys = overridable_lookup_keys(puppetclass, obj) %>
-<% value_hash  = Classification::ClassParam.new(:host=>obj).inherited_values.merge(Classification::GlobalParam.new(:host=>obj).inherited_values) if obj.class.model_name == "Host" %>
+<% value_hash  = value_hash_cache(obj) if obj.class.model_name == "Host" %>
 <% lookup_keys.each_with_index do |key,i| %>
     <tr id="puppetclass_<%= puppetclass.id %>_params[<%= key.id %>]">
       <%= content_tag :td, (i == 0 ? {:rowspan => lookup_keys.size} : {:class => 'hide'}) do


### PR DESCRIPTION
This fixes a bunch of "N+1" queries (not classical N+1, but things which happen more than once in code without a good reason)

Hosts#edit still needs a LOT of work, this is just a first step. On my machine it took about 40% off the load time (11s to 6s), which is a good improvement, but 6s is still WAY too much, so let's keep this issue open after we merge this PR, and add more and more improvements incrementally.
