### PR TITLE
Fixes #11693 - removed 'destroy' for smart class parameter from API c…

### DIFF
--- a/app/controllers/api/v1/lookup_keys_controller.rb
+++ b/app/controllers/api/v1/lookup_keys_controller.rb
@@ -57,7 +57,11 @@ module Api
       param :id, :identifier, :required => true
 
       def destroy
-        process_response @lookup_key.destroy
+        if @lookup_key.type == "PuppetclassLookupKey"
+          render_error 'unprocessable_entity', :status => :unprocessable_entity
+        else
+          process_response @lookup_key.destroy
+        end
       end
     end
   end

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -54,11 +54,6 @@ module Api
         render 'api/v2/smart_class_parameters/show'
       end
 
-      def destroy
-        @smart_class_parameter.destroy
-        render 'api/v2/smart_class_parameters/destroy'
-      end
-
       # overwrite Api::BaseController
       def resource_class
         LookupKey

--- a/app/views/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/puppetclass_lookup_keys/index.html.erb
@@ -7,7 +7,6 @@
       <th><%= sort :key, :as => _("Parameter") %></th>
       <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
       <th><%= sort :values_count, :as => _('Number of values'), :default => "DESC" %></th>
-      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -17,8 +16,6 @@
         <% puppet_class = lookup_key.param_class %>
         <td><%= link_to_if_authorized trunc_with_tooltip(puppet_class), hash_for_edit_puppetclass_path(:id => puppet_class).merge(:auth_object => puppet_class, :authorizer => @puppetclass_authorizer) if puppet_class %></td>
         <td><%=h lookup_key.lookup_values_count %></td>
-        <td><%= display_delete_if_authorized hash_for_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'destroy_external_variables', :authorizer => authorizer),
-          :data => { :confirm => _("Delete %s?") % lookup_key.key } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -62,7 +62,7 @@ Foreman::Application.routes.draw do
         end
         resources :puppetclasses, :except => [:new, :edit] do
           resources :smart_class_parameters, :except => [:new, :edit, :create] do
-            resources :override_values, :except => [:new, :edit]
+            resources :override_values, :except => [:new, :edit, :destroy]
           end
         end
         resources :hosts, :except => [:new, :edit]
@@ -132,11 +132,11 @@ Foreman::Application.routes.draw do
           resources :override_values, :except => [:new, :edit]
         end
         resources :smart_class_parameters, :except => [:new, :edit, :create] do
-          resources :override_values, :except => [:new, :edit]
+          resources :override_values, :except => [:new, :edit, :destroy]
         end
         resources :environments, :only => [] do
           resources :smart_class_parameters, :except => [:new, :edit, :create] do
-            resources :override_values, :except => [:new, :edit]
+            resources :override_values, :except => [:new, :edit, :destroy]
           end
         end
         resources :hostgroups, :only => [:index, :show]
@@ -182,7 +182,7 @@ Foreman::Application.routes.draw do
         resources :override_values, :except => [:new, :edit]
       end
 
-      resources :smart_class_parameters, :except => [:new, :edit, :create] do
+      resources :smart_class_parameters, :except => [:new, :edit, :create, :destroy] do
         resources :override_values, :except => [:new, :edit]
       end
 

--- a/test/functional/api/v1/lookup_keys_controller_test.rb
+++ b/test/functional/api/v1/lookup_keys_controller_test.rb
@@ -30,9 +30,16 @@ class Api::V1::LookupKeysControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should destroy lookup_keys" do
-    assert_difference('LookupKey.count', -1) do
+  test "should not destroy PuppetclassLookupKey" do
+    assert_difference('LookupKey.count', 0) do
       delete :destroy, { :id => lookup_keys(:one).to_param }
+    end
+    assert_response 422
+  end
+
+  test "should destroy VariableLookupKey" do
+    assert_difference('LookupKey.count', -1) do
+      delete :destroy, { :id => lookup_keys(:two).to_param }
     end
     assert_response :success
   end

--- a/test/functional/api/v2/smart_class_parameters_controller_test.rb
+++ b/test/functional/api/v2/smart_class_parameters_controller_test.rb
@@ -124,13 +124,6 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     refute_equal orig_value, new_value
   end
 
-  test "should destroy smart class parameter" do
-    assert_difference('LookupKey.count', -1) do
-      delete :destroy, { :id => lookup_keys(:five).to_param }
-    end
-    assert_response :success
-  end
-
   test "should return error if smart class parameter if it does not belong to specified puppetclass" do
     get :show, {:id => lookup_keys(:five).id, :puppetclass_id => puppetclasses(:one).id}
     assert_response 404


### PR DESCRIPTION
…ontrollers

I deleted the `destroy` method in api/v2/smart_class_parameters_controller and changed the api/v1/lookup_keys_controller - it checks for smart class parameter before deletion.
I also found out that smart class parameters could be deleted in UI under /puppetclass_lookup_keys, so I made a change there as well. With all the nested resources I am not completely sure if I my route changes are correct and the way we want them to, just let me know and I will change them.
