### PR TITLE
Fixes #11665 - Fixed select_f to support 'to_s' and blank_value combination.

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -122,6 +122,10 @@ module LayoutHelper
     if include_blank
       blank_value = include_blank.is_a?(TrueClass) ? nil : include_blank
       blank_option = OpenStruct.new({id => '', method => blank_value })
+      # if the method is to_s, OpenStruct will respond with its own version.
+      # in this case, I need to undefine its own alias to to_s, and use the attribute
+      # that was defined in the struct.
+      blank_option.instance_eval('undef to_s') if method.to_s == 'to_s' || id.to_s == 'to_s'
       array.insert(0, blank_option)
     end
 

--- a/test/unit/helpers/layout_helper_test.rb
+++ b/test/unit/helpers/layout_helper_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class LayoutHelperTest < ActionView::TestCase
+  include LayoutHelper
   test "alert should be closable" do
     result = alert(:close => true)
     assert_include result, 'alert-dismissable'
@@ -30,5 +31,20 @@ class LayoutHelperTest < ActionView::TestCase
 
   test "table css classes should return the regular classes for table plus the added classes" do
     assert_equal table_css_classes("test-class"),"table table-bordered table-striped table-condensed test-class"
+  end
+
+  context '#select_f' do
+    test 'include_blank works with #to_s as retreival method' do
+      form_for User.new do |f|
+        fields_for :user_mail_notifications do |notifications|
+          #f = ActionView::Helpers::FormBuilder.new(:mail_notification, MailNotification.new, @mail_notification, {}, {})
+          values = ['one', :two]
+
+          html = select_f(notifications, :interval, values, :to_s, :to_sym, { :include_blank => _('No emails') }, {})
+          assert_match /one/, html
+          assert_no_match /to_s/, html
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Added workaround to override OpenStruct's to_s function with custom value from the dictionary.
Basically I removed the to_s alias, since OpenStruct checks if the object already implements the function before looking into its internal hash.
