### PR TITLE
Fixes #9267 - overridden smart class parameters large names are truncated with tool tip

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -177,8 +177,8 @@ function mark_params_override(){
   $('#inherited_puppetclasses_parameters .override-param').removeClass('override-param');
   $('#inherited_puppetclasses_parameters [data-tag=override]').show();
   $('#puppetclasses_parameters').find('[data-property=class]:visible').each(function(){
-    var klass = $(this).val();
-    var name = $(this).closest('tr').find('[data-property=name]').val();
+    var klass = $(this).text();
+    var name = $(this).closest('tr').find('[data-property=name]').text();
     $('#inherited_puppetclasses_parameters [id^="puppetclass_"][id*="_params\\["][id$="\\]"]').each(function(){
       var param = $(this);
       if (param.find('[data-property=class]').text() == klass && param.find('[data-property=name]').text() == name) {

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -410,19 +410,24 @@ function override_param(item){
 
 function override_class_param(item){
   var param = $(item).closest('tr[id^="puppetclass_"][id*="_params\\["][id$="\\]"]');
-  var id = param.attr('id').replace(/puppetclass_\d+_params\[(\d+)\]/, '$1')
-  var c = param.find('[data-property=class]').text();
-  var n = param.find('[data-property=name]').text();
-  var v = param.find('[data-property=value]').val();
-  var t = param.find('[data-property=type]').text();
-
+  var id = param.attr('id').replace(/puppetclass_\d+_params\[(\d+)\]/, '$1');
+  var class_name = param.find('[data-property=class]').text();
+  var name = param.find('[data-property=name]').text();
+  var value = param.find('[data-property=value]').val();
+  var type = param.find('[data-property=type]').text();
+  var class_tooltip = param.find('[data-property=class]').children('span').attr('data-original-title');
+  var name_tooltip = param.find('[data-property=name]').children('span').attr('data-original-title');
   $('#puppetclasses_parameters').find('.btn-success').click();
-  var new_param = param.closest('.tab-pane').find('[id*=_lookup_values]:visible').last().parents('.form-group');
+  var new_param = param.closest('.tab-pane').find('[id*=_lookup_values]:visible').last().parents('tr');
   new_param.find('[data-property=lookup_key_id]').val(id);
-  new_param.find('[data-property=class]').val(c);
-  new_param.find('[data-property=name]').val(n);
-  new_param.find('[data-property=value]').val(v);
-  new_param.find('[data-property=type]').val(t);
+  new_param.find('[data-property=class]').text(class_name);
+  new_param.find('[data-property=name]').text(name);
+  new_param.find('[data-property=value]').val(value);
+  new_param.find('[data-property=type]').val(type);
+  if (name_tooltip != undefined)
+    new_param.find('[data-property=name]')[0].setAttribute("title", name_tooltip);
+  if (class_tooltip !=undefined)
+    new_param.find('[data-property=class]')[0].setAttribute("title", class_tooltip);
   mark_params_override();
 }
 

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -11,7 +11,7 @@
       <% keys = inherited_parameters.keys.sort %>
       <% keys.each do |name| %>
         <tr class="<%="override-param" if @host.host_parameters.map(&:name).include?(name)%>">
-          <td><%= content_tag :span, name, :id => "name_#{name}"%>
+          <td><%= content_tag :span, trunc_with_tooltip(name), :id => "name_#{name}"%>
           </td>
           <td><%= parameter_value_field inherited_parameters[name] %></td>
           <td>

--- a/app/views/common_parameters/_puppetclass_parameter.html.erb
+++ b/app/views/common_parameters/_puppetclass_parameter.html.erb
@@ -1,14 +1,14 @@
 <div class="fields">
-  <table class="row">
+  <table>
     <tbody>
-      <tr class="form-group <%= 'error' if f.object.errors.any? %>">
+      <tr class="<%= 'error' if f.object.errors.any? %>">
         <td class="col-md-3">
           <%= f.hidden_field :lookup_key_id, :'data-property' => 'lookup_key_id' %>
           <% puppetclass = f.object.lookup_key ? f.object.lookup_key.param_class : nil %>
-          <%= text_field_tag '', (puppetclass.name rescue ''), :class => 'form-control', :'data-property' => 'class', :disabled => true, :title => _('Puppetclass') %>
+          <%= content_tag :span, (trunc_with_tooltip(puppetclass.name, 20) rescue ''), :'data-property' => 'class' %>
         </td>
         <td class="col-md-2">
-          <%= text_field_tag '', (f.object.lookup_key.key rescue ''), :class => 'form-control', :'data-property' => 'name', :disabled => true, :title => _('Parameter name') %>
+          <%= content_tag :span, (trunc_with_tooltip(f.object.lookup_key.key,20) rescue ''), :'data-property' => 'name' %>
         </td>
         <td class="col-md-5">
           <div class="input-group">

--- a/app/views/puppetclasses/_class_parameters.html.erb
+++ b/app/views/puppetclasses/_class_parameters.html.erb
@@ -5,10 +5,10 @@
       <%= content_tag :td, (i == 0 ? {:rowspan => lookup_keys.size} : {:class => 'hide'}) do
         # In order to use the class .hide-first-col, we must have an extra, invisible cell.
         # Plus, we make the class name available from javascript without having to look at any previous row.
-        content_tag :span, trunc_with_tooltip(puppetclass.name), :'data-property' => 'class'
+        content_tag :span, trunc_with_tooltip(puppetclass.name, 20), :'data-property' => 'class'
       end %>
       <td>
-        <%= content_tag :span, trunc_with_tooltip(key.key), :class => "#{"override-param" if key.overridden?(obj)}", :'data-property' => 'name' %></td>
+        <%= content_tag :span, trunc_with_tooltip(key.key, 20), :class => "#{"override-param" if key.overridden?(obj)}", :'data-property' => 'name' %></td>
       <td><%= obj.class.model_name == "Host" ? host_key_with_diagnostic(obj, value_hash, key) : hostgroup_key_with_diagnostic(obj, key)%></td>
       <td>
           <%= link_to_function(_("override"), "override_class_param(this)", :title => _("Override this value"),


### PR DESCRIPTION
In host group parameters, overridded parameter names textfield are too short. 
 large names are truncated and tool tip added
