### PR TITLE
fixes #11473 - remove re-init of domain select2 on env selection

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -455,7 +455,7 @@ function setPowerState(item, status){
 function reloadOnAjaxComplete(element) {
   $(element).indicator_hide();
   $('[rel="twipsy"]').tooltip();
-  $('select').select2({ allowClear: true });
+  $('select:not(.without_select2)').select2({ allowClear: true });
 }
 
 function set_fullscreen(element){

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -569,6 +569,7 @@ function interface_domain_selected(element) {
         subnet_options.attr('disabled', true);
       }
       reloadOnAjaxComplete(element);
+      subnet_options.filter('select').select2({allowClear: true})
     }
   });
 }

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -46,6 +46,7 @@ function save_interface_modal() {
     $('#interfaceForms .interface_provision:checked').attr("checked", false);
   }
 
+  modal_form.find('select').select2('destroy')
   var interface_hidden = get_interface_hidden(interface_id);
   interface_hidden.html('');
   interface_hidden.append(modal_form);


### PR DESCRIPTION
After an environment was selected, the reloadOnAjaxComplete function
re-initialised every select2, but other dropdowns triggered
onContentLoad which excluded those with the without_select class.

Change reloadOnAjaxComplete to be consistent and also explicitly
re-init the subnet dropdown when the domain dropdown causes it to
change.
