### PR TITLE
fixes #11719 - mysql2 dep must match ActiveRecord's runtime dep

### DIFF
--- a/bundler.d/mysql2.rb
+++ b/bundler.d/mysql2.rb
@@ -1,3 +1,3 @@
 group :mysql2 do
-  gem 'mysql2', '> 0.3.0'
+  gem 'mysql2', '~> 0.3.10'
 end


### PR DESCRIPTION
When AR loads the mysql2 adapter, [it calls 'gem' with a version spec](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3).
For our bundle to include a compatible version of mysql2 and not the
latest version, the spec needs to match AR's.

Tests running: http://ci.theforeman.org/job/test_develop_pull_request/12549/ (upgrade tests from 1.7/1.8 will fail until this is merged back to those branches anyway, ignore them.)
