### PR TITLE
refs #11719 - change pg/sqlite3 deps to match ActiveRecord

### DIFF
--- a/bundler.d/postgresql.rb
+++ b/bundler.d/postgresql.rb
@@ -1,3 +1,3 @@
 group :postgresql do
-  gem 'pg'
+  gem 'pg', '~> 0.11'
 end

--- a/bundler.d/sqlite.rb
+++ b/bundler.d/sqlite.rb
@@ -1,3 +1,3 @@
 group :sqlite do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.5'
 end


### PR DESCRIPTION
Follow-on from #2683 to pin the other two adapters, in case new versions cause it to break.

AR sqlite3: https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L3
AR pg: https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L7
