### PR TITLE
refs #11738 - fix incorrect capitalisation and host group wording

### DIFF
--- a/app/views/provisioning_templates/_custom_tabs.html.erb
+++ b/app/views/provisioning_templates/_custom_tabs.html.erb
@@ -16,7 +16,7 @@
 
       <h3><%= _("How templates are determined") %><br></h3>
 
-      <p><%= _("When editing a Template, you must assign a list of Operating Systems which this Template can be used with. Optionally, you can restrict a template to a list of Hostgroups and/or Environments.") %></p>
+      <p><%= _("When editing a template, you must assign a list of operating systems which this template can be used with. Optionally, you can restrict a template to a list of host groups and/or environments.") %></p>
 
       <p><%= _("When a Host requests a template (e.g. during provisioning), Foreman will select the best match from the available templates of that type, in the following order:") %></p>
       <ul>


### PR DESCRIPTION
If we're going to retranslate a string, might as well fix all the other errors in it at the same time.
