### PR TITLE
fixes #9981 - making sure lookup_keys with errors get displayed if they're broken

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -85,4 +85,8 @@ class PuppetclassesController < ApplicationController
         super
     end
   end
+
+  def resource_scope
+    super.includes(:lookup_keys => [:lookup_values])
+  end
 end

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -70,7 +70,7 @@
       </div>
       <div class="smart-var-left col-md-3">
         <ul class="nav nav-pills nav-stacked smart-var-tabs" data-tabs="pills">
-          <% @puppetclass.lookup_keys.includes(:lookup_values).each do |key| %>
+          <% @puppetclass.lookup_keys.each do |key| %>
             <li>
               <a data-toggle="tab" id="pill_<%= key.to_s.gsub(' ','_') + '_' + key.id.to_s %>" href="#<%= key.to_s.gsub(' ','_') + '_' + key.id.to_s %>" title="<%= key %>">
                 <div class="clip"><%= key %></div><span class="close pull-right">&times;</span>


### PR DESCRIPTION
apparently, ActiveRecord has a bug...
foo.update_attributes(params) creates a new bar, but it fails validations so isn't saved in DB.

foo.bars will have unsaved bars, but foo.bars.includes(:baz) will discard the unsaved bars.

I :heart: Rails, don't you?
