### PR TITLE
fixes #11766, refs #11506 - differentiate between puppet facts and those from plugins

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -49,7 +49,7 @@ class FactImporter
   attr_reader :host, :facts
 
   def delete_removed_facts
-    to_delete = host.fact_values.joins(:fact_name).where('fact_names.name NOT IN (?)', facts.keys)
+    to_delete = host.fact_values.joins(:fact_name).where("fact_names.type = '#{fact_name_class}' AND fact_names.name NOT IN (?)", facts.keys)
     # N+1 DELETE SQL, but this would allow us to use callbacks (e.g. auditing) when deleting.
     deleted = to_delete.destroy_all
     @counters[:deleted] = deleted.size
@@ -96,6 +96,6 @@ class FactImporter
   end
 
   def db_facts
-    @db_facts ||= host.fact_values.includes(:fact_name).index_by(&:name)
+    @db_facts ||= host.fact_values.includes(:fact_name).where("fact_names.type = '#{fact_name_class}'").index_by(&:name)
   end
 end

--- a/test/factories/facts_related.rb
+++ b/test/factories/facts_related.rb
@@ -8,4 +8,9 @@ FactoryGirl.define do
     sequence(:value) {|n| "value#{n}" }
     host
   end
+
+  factory :fact_name_other, :class => FactName do
+    type 'FactNameOther'
+    sequence(:name) {|n| "fact#{n}" }
+  end
 end

--- a/test/unit/puppet_fact_importer_test.rb
+++ b/test/unit/puppet_fact_importer_test.rb
@@ -74,6 +74,20 @@ class PuppetFactImporterTest < ActiveSupport::TestCase
     assert_equal 1, importer.counters[:added]
   end
 
+  test "importer retains 'other' facts" do
+    assert_equal '2.6.9', value('kernelversion')
+    FactoryGirl.create(:fact_value, :value => 'othervalue',:host => @host,
+                       :fact_name => FactoryGirl.create(:fact_name_other, :name => 'otherfact'))
+    import('ipaddress' => '10.0.19.5', 'uptime' => '1 picosecond')
+    assert_equal 'othervalue', value('otherfact')
+    assert_nil value('kernelversion')
+    assert_equal '10.0.19.5', value('ipaddress')
+    assert_equal '1 picosecond', value('uptime')
+    assert_equal 1, importer.counters[:deleted]
+    assert_equal 1, importer.counters[:updated]
+    assert_equal 1, importer.counters[:added]
+  end
+
   def import(facts)
     @importer = PuppetFactImporter.new(@host, facts)
     importer.import!


### PR DESCRIPTION
Katello will be including subscription-manager facts as part of the host / content-host unification. This PR prevents an update to puppet facts from also removing rhsm facts.
