### PR TITLE
Fixes #11778 - RAILS_ENVs not defined in logger.yaml take defaults

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -76,7 +76,13 @@ module Foreman
       fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?('config/logging.yaml')
       overrides ||= {}
       @config = YAML.load_file('config/logging.yaml')
-      @config = @config[:default].deep_merge(@config[environment.to_sym]).deep_merge(overrides)
+      if @config.keys.include? environment.to_sym
+        @config = @config[:default].deep_merge(@config[environment.to_sym]).
+          deep_merge(overrides)
+      else
+        @config = @config[:default].deep_merge(overrides)
+        @config[:filename] = "#{environment}.log"
+      end
     end
 
     def ensure_log_directory(log_directory)

--- a/test/lib/foreman/logging_test.rb
+++ b/test/lib/foreman/logging_test.rb
@@ -7,6 +7,23 @@ class ForemanLoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_environment_not_found_yields_defaults
+    assert_nothing_raised do
+      Foreman::Logging.instance_variable_set("@configured", false)
+      # Stub the log file creation (foo.log)
+      Foreman::Logging.stubs(:build_file_appender).
+        with('foreman', { :environment => 'foo'} ).returns(nil).once
+      quietly { Foreman::Logging.configure(:environment => 'foo') }
+    end
+    log_filename = Foreman::Logging.instance_variable_get("@config")[:filename]
+    assert_equal 'foo.log', log_filename
+  ensure
+    # Return the foreman logger to the original one for the current environment
+    Foreman::Logging.unstub(:build_file_appender)
+    Foreman::Logging.instance_variable_set("@configured", false)
+    Foreman::Logging.configure(:environment => Rails.env)
+  end
+
   def test_default_loggers_exist
     assert Foreman::Logging.logger('app')
     assert Foreman::Logging.logger('sql')


### PR DESCRIPTION
Before this patch, Rails would fail to load entirely because
logging.rb will try to load the config for RAILS_ENV. With this
patch, it just takes the default config if not setup.
