### PR TITLE
Fixes #11767 - set interface[:id] to nil only if it exists

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -729,7 +729,7 @@ class HostsController < ApplicationController
     attributes = params[:host].dup
     if params[:host][:interfaces_attributes]
       attributes[:interfaces_attributes] = params[:host][:interfaces_attributes].dup.except(:created_at, :updated_at, :attrs)
-      attributes[:interfaces_attributes][:id] = nil
+      attributes[:interfaces_attributes][:id] = nil if attributes[:interfaces_attributes][:id]
     end
     attributes
   end


### PR DESCRIPTION
Not sure why `attributes[:interfaces_attributes][:id] = nil` is needed in the first place though
