### PR TITLE
Fixes #11767 - avoid cleaning of interface attributes

### DIFF
--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -36,7 +36,7 @@
 <div class="form-group">
   <label class="col-xs-2 control-label"><%= _('Provisioning templates') %></label>
   <div class="col-xs-10">
-    <%= link_to_function icon_text("refresh", _("Resolve")), "template_info('#templates_info','#{template_used_hosts_url}')", :class => "btn btn-default" %>
+    <%= link_to_function icon_text("refresh", _("Resolve")), "template_info('#templates_info','#{template_used_hosts_url(:id => @host.id)}')", :class => "btn btn-default" %>
     <div class="help-block">
       <%= _("Display the templates that will be used to provision this host") %>
     </div>

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -881,8 +881,10 @@ class HostsControllerTest < ActionController::TestCase
     @host.setBuild
     nic=FactoryGirl.create(:nic_managed, :host => @host)
     attrs = @host.attributes
-    attrs[:interfaces_attributes] = nic.attributes
-    xhr :put, :template_used, {:provisioning => 'build', :host => attrs }, set_session_user
+    attrs[:interfaces_attributes] = nic.attributes.except 'updated_at', 'created_at', 'attrs'
+    ActiveRecord::Base.any_instance.expects(:destroy).never
+    ActiveRecord::Base.any_instance.expects(:save).never
+    xhr :put, :template_used, {:provisioning => 'build', :host => attrs, :id => @host.id }, set_session_user
     assert_response :success
     assert_template :partial => '_provisioning'
   end
@@ -891,15 +893,19 @@ class HostsControllerTest < ActionController::TestCase
     @host.setBuild
     attrs = @host.attributes
     attrs[:host_parameters_attributes] = {'0' => {:name => 'foo', :value => 'bar', :id => '34'}}
+    ActiveRecord::Base.any_instance.expects(:destroy).never
+    ActiveRecord::Base.any_instance.expects(:save).never
     xhr :put, :template_used, {:provisioning => 'build', :host => attrs }, set_session_user
     assert_response :success
     assert_template :partial => '_provisioning'
   end
 
   test 'process_taxonomy renders a host from the params correctly' do
-    nic=FactoryGirl.create(:nic_managed, :host => @host)
+    nic = FactoryGirl.build(:nic_managed, :host => @host)
     attrs = @host.attributes
-    attrs[:interfaces_attributes] = nic.attributes
+    attrs[:interfaces_attributes] = nic.attributes.except 'updated_at', 'created_at', 'attrs'
+    ActiveRecord::Base.any_instance.expects(:destroy).never
+    ActiveRecord::Base.any_instance.expects(:save).never
     xhr :put, :process_taxonomy, { :host => attrs }, set_session_user
     assert_response :success
     assert response.body.include?(nic.attributes["mac"])


### PR DESCRIPTION
This is alternative approach to fix #11767 which avoids removing params. It's covered by tests which I had to fix, they sent attributes that do not come from form. Also it's needed to use existing host during editing so NICs sent as nested attributes are correctly matched.

Before testing, please read [8405](http://projects.theforeman.org/issues/8405) and [9058](http://projects.theforeman.org/issues/9058) as well as [11767](http://projects.theforeman.org/issues/11767) and [11768](http://projects.theforeman.org/issues/11768) since they are all related and should be fixed by this patch.
