### PR TITLE
Fixes #11812 - Remove whiny nils and add eager load

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,8 +6,7 @@ Foreman::Application.configure do
   # since you don't have to restart the webserver when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
+  config.eager_load = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,8 +7,7 @@ Foreman::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
+  config.eager_load = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true


### PR DESCRIPTION
In Rails 4 eager_load is mandatory, and whiny_nils are already useless
in Foreman as we don't support 1.8.7.
