### PR TITLE
Fixes #11816 - Remove whitelist_attributes as it's deprecated

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -144,12 +144,6 @@ module Foreman
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = false
-
     # enables in memory cache store with ttl
     #config.cache_store = TimedCachedStore.new
     config.cache_store = :file_store, Rails.root.join("tmp", "cache")


### PR DESCRIPTION
config.active_record.whitelist_attributes = false is already the default
so it's not necessary. Also Rails 4 deprecates it so we can remove it.
