### PR TITLE
Fixes #11817 - Do not allow multi-line URL validations

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -19,7 +19,7 @@ class Medium < ActiveRecord::Base
   VALID_NFS_PATH=/\A([-\w\d\.]+):(\/[\w\d\/\$\.]+)\Z/
   validates :name, :uniqueness => true, :presence => true
   validates :path, :uniqueness => true, :presence => true,
-                   :format => { :with => /^(http|https|ftp|nfs):\/\//,
+                   :format => { :with => /\A(http|https|ftp|nfs):\/\//,
                                 :message => N_("Only URLs with schema http://, https://, ftp:// or nfs:// are allowed (e.g. nfs://server/vol/dir)")
                               }
   validates :media_path, :config_path, :image_path, :allow_blank => true,

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -19,7 +19,7 @@ class SmartProxy < ActiveRecord::Base
   has_many :puppet_ca_hosts, :class_name => 'Host::Managed',  :foreign_key => 'puppet_ca_proxy_id'
   has_many :puppet_ca_hostgroups, :class_name => 'Hostgroup', :foreign_key => 'puppet_ca_proxy_id'
   has_many :realms,                                           :foreign_key => 'realm_proxy_id'
-  URL_HOSTNAME_MATCH = %r{^(?:http|https):\/\/([^:\/]+)}
+  URL_HOSTNAME_MATCH = %r{\A(?:http|https):\/\/([^:\/]+)}
   validates :name, :uniqueness => true, :presence => true
   validates :url, :presence => true, :format => { :with => URL_HOSTNAME_MATCH, :message => N_('is invalid - only  http://, https:// are allowed') },
             :uniqueness     => { :message => N_('Only one declaration of a proxy is allowed') }


### PR DESCRIPTION
medium.rb and smart_proxy.rb allow multi line URLs through its
validation. Rails 4 forces use to either allow multi-line URLs or fix
the validation, but we can do this already.
