### PR TITLE
Refs #11825 - use before_create for template associations

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -29,7 +29,7 @@ class Taxonomy < ActiveRecord::Base
   validates :title, :presence => true, :uniqueness => {:scope => :type}
 
   before_validation :sanitize_ignored_types
-  after_create :assign_default_templates
+  before_create :assign_default_templates
 
   scoped_search :on => :description, :complete_enabled => :false, :only_explicit => true
 
@@ -183,8 +183,8 @@ class Taxonomy < ActiveRecord::Base
            :to => :tax_host
 
   def assign_default_templates
-    Template.where(:default => true).each do |template|
-      self.send("#{template.class.to_s.underscore.pluralize}") << template
+    Template.where(:default => true).group_by { |t| t.class.to_s.underscore.pluralize }.each do |association, templates|
+      self.send("#{association}=", self.send(association) + templates)
     end
   end
 


### PR DESCRIPTION
We hit an issue in foreman_remote_execution, when trying to add has_many
association to taxonomies, after the after_create defined, due to the behavior
described in https://github.com/rails/rails/issues/12180#issuecomment-29543330
