### PR TITLE
Fixes #11822 - interface import code keeps errors

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -172,6 +172,11 @@ module Host
         iface = get_interface_scope(name, attributes).first || interface_class(name).new(:managed => false)
         # create or update existing interface
         set_interface(attributes, name, iface)
+        if iface.primary?
+          self.interfaces[0] = iface
+        else
+          self.interfaces << iface
+        end
       end
 
       ipmi = parser.ipmi_interface
@@ -180,9 +185,8 @@ module Host
         iface = existing || Nic::BMC.new(:managed => false)
         iface.provider ||= 'IPMI'
         set_interface(ipmi, 'ipmi', iface)
+        self.interfaces << iface
       end
-
-      self.interfaces.reload
     end
 
     def facts_hash

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1313,6 +1313,7 @@ class HostTest < ActiveSupport::TestCase
       parser = stub(:interfaces => hash, :ipmi_interface => {}, :suggested_primary_interface => hash.to_a.first)
 
       host.set_interfaces(parser)
+      assert_equal "Ip has already been taken", host.interfaces.collect(&:errors).collect(&:full_messages).flatten.first
       host.reload
       assert_includes host.interfaces.map(&:identifier), 'eth2'
       assert_includes host.interfaces, host.primary_interface


### PR DESCRIPTION
Until now, ActiveRecord `errors` were thrown away with `reload`. This removes
this practice which enables error reporting in discovery.
