### PR TITLE
fixes #11836 - depuppetize settings

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -70,10 +70,10 @@ module Foreman::Controller::SmartProxyAuth
     return false unless request_hosts
 
     hosts = Hash[proxies.map { |p| [URI.parse(p.url).host, p] }]
-    allowed_hosts = hosts.keys.push(*Setting[:trusted_puppetmaster_hosts])
+    allowed_hosts = hosts.keys.push(*Setting[:trusted_hosts])
     logger.debug { ("Verifying request from #{request_hosts} against #{allowed_hosts.inspect}") }
     unless host = allowed_hosts.detect { |p| request_hosts.include? p }
-      logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_puppetmaster_hosts"
+      logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_hosts"
       return false
     end
     @detected_proxy = hosts[host] if host

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -516,23 +516,23 @@ class HostsController < ApplicationController
   end
 
   def errors
-    merge_search_filter("last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0)")
+    merge_search_filter("last_report > \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0)")
     index _("Hosts with errors")
   end
 
   def active
-    merge_search_filter("last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.applied > 0 or status.restarted > 0)")
+    merge_search_filter("last_report > \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.applied > 0 or status.restarted > 0)")
     index _("Active Hosts")
   end
 
   def pending
-    merge_search_filter("last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.pending > 0)")
+    merge_search_filter("last_report > \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.pending > 0)")
     index _("Pending Hosts")
   end
 
   def out_of_sync
-    merge_search_filter("last_report < \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and status.enabled = true")
-    index _("Hosts which didn't run puppet in the last %s") % (view_context.time_ago_in_words((Setting[:puppet_interval]+Setting[:outofsync_interval]).minutes.ago))
+    merge_search_filter("last_report < \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and status.enabled = true")
+    index _("Hosts which didn't run puppet in the last %s") % (view_context.time_ago_in_words((Setting[:configuration_interval]+Setting[:outofsync_interval]).minutes.ago))
   end
 
   def disabled

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -48,11 +48,11 @@ module DashboardHelper
 
   def count_reports(hosts)
     data = []
-    interval = Setting[:puppet_interval] / 10
-    start = Time.zone.now - Setting[:puppet_interval].minutes
+    interval = Setting[:configuration_interval] / 10
+    start = Time.zone.now - Setting[:configuration_interval].minutes
     (0..9).each do |i|
       t = start + (interval.minutes * i)
-      data << [Setting[:puppet_interval] - i*interval, hosts.run_distribution(t, t + interval.minutes).count]
+      data << [Setting[:configuration_interval] - i*interval, hosts.run_distribution(t, t + interval.minutes).count]
     end
     data
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -76,8 +76,8 @@ class Host::Managed < Host::Base
 
   attr_reader :cached_host_params
 
-  scope :recent,      ->(*args) { {:conditions => ["last_report > ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago)]} }
-  scope :out_of_sync, ->(*args) { {:conditions => ["last_report < ? and enabled != ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago), false]} }
+  scope :recent,      ->(*args) { {:conditions => ["last_report > ?", (args.first || (Setting[:configuration_interval] + Setting[:outofsync_interval]).minutes.ago)]} }
+  scope :out_of_sync, ->(*args) { {:conditions => ["last_report < ? and enabled != ?", (args.first || (Setting[:configuration_interval] + Setting[:outofsync_interval]).minutes.ago), false]} }
 
   scope :with_os, -> { where('hosts.operatingsystem_id IS NOT NULL') }
 
@@ -351,7 +351,7 @@ class Host::Managed < Host::Base
   end
 
   def no_report
-    last_report.nil? or last_report < Time.now - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes and enabled?
+    last_report.nil? or last_report < Time.now - (Setting[:configuration_interval] + Setting[:outofsync_interval]).minutes and enabled?
   end
 
   def disabled?
@@ -403,7 +403,7 @@ class Host::Managed < Host::Base
       param["owner_email"] = owner.is_a?(User) ? owner.mail : owner.users.map(&:mail)
     end
 
-    if Setting[:ignore_puppet_facts_for_provisioning]
+    if Setting[:ignore_facts_for_provisioning]
       param["ip"]  = ip
       param["mac"] = mac
     end

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -17,7 +17,7 @@ module HostStatus
       if (host && !host.enabled?) || no_reports?
         false
       else
-        !reported_at.nil? && reported_at < (Time.now - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes)
+        !reported_at.nil? && reported_at < (Time.now - (Setting[:configuration_interval] + Setting[:outofsync_interval]).minutes)
       end
     end
 

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -18,7 +18,7 @@ class Setting::Auth < Setting
         self.set('oauth_map_users', N_("Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."), true, N_('OAuth map users')),
         self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
         self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
-        self.set('trusted_puppetmaster_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted puppetmaster hosts')),
+        self.set('trusted_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted hosts')),
         self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert, N_('SSL certificate')),
         self.set('ssl_ca_file', N_( "SSL CA file that Foreman will use to communicate with its proxies"), ssl_ca_file, N_('SSL CA file')),
         self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ssl_priv_key, N_('SSL private key')),

--- a/app/models/setting/configuration.rb
+++ b/app/models/setting/configuration.rb
@@ -1,0 +1,35 @@
+class Setting::Configuration < Setting
+  def self.load_defaults
+    # Check the table exists
+    return unless super
+
+    self.transaction do
+      [
+        self.set('configuration_interval', N_("How often your configuration management runs"), 30, N_('Configuration interval')),
+        self.set('outofsync_interval', N_("Duration in minutes after the configuration interval for servers to be classed as out of sync."), 5, N_('Out of sync interval')),
+        self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment')),
+        self.set('modulepath',N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
+        self.set('document_root', N_("Document root where puppetdoc files should be created"), "#{Rails.root}/public/puppet/rdoc", N_('Document root')),
+        self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
+        self.set('puppet_server', N_("Default Puppet server hostname"), "puppet", N_('Puppet server')),
+        self.set('Default_variables_Lookup_Path', N_("Foreman will evaluate host smart variables in this order by default"), ["fqdn", "hostgroup", "os", "domain"], N_('Default variables lookup path')),
+        self.set('Enable_Smart_Variables_in_ENC', N_("Foreman smart variables will be exposed via the ENC yaml output"), true, N_('Enable smart variables in ENC')),
+        self.set('Parametrized_Classes_in_ENC', N_("Foreman will use the new (2.6.5+) format for classes in the ENC yaml output"), true, N_('Parameterized classes in ENC')),
+        self.set('interpolate_erb_in_parameters', N_("Foreman will parse ERB in parameters value in the ENC output"), true, N_('Interpolate ERB in parameters')),
+        self.set('enc_environment', N_("Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"), true, N_('ENC environment')),
+        self.set('use_uuid_for_certificates', N_("Foreman will use random UUIDs for certificate signing instead of hostnames"), false, N_('Use UUID for certificates')),
+        self.set('update_environment_from_facts', N_("Foreman will update a host's environment from its facts"), false, N_('Update environment from facts')),
+        self.set('host_group_matchers_inheritance', N_("Foreman host group matchers will be inherited by children when evaluating smart class parameters"), true, N_('Host group matchers inheritance')),
+        self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true, N_('Create new host when facts are uploaded')),
+        self.set('create_new_host_when_report_is_uploaded', N_("Foreman will create the host when a report is received"), true, N_('Create new host when report is uploaded')),
+        self.set('legacy_puppet_hostname', N_("Foreman will truncate hostname to 'puppet' if it starts with puppet"), false, N_('Legacy Puppet hostname')),
+        self.set('location_fact', N_("Hosts created by facts or a report will be placed in this location. The content of this fact should be the full label of the location."), 'foreman_location', N_('Location fact')),
+        self.set('organization_fact', N_("Hosts created by facts or a report will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."), 'foreman_organization', N_('Organization fact')),
+        self.set('default_location', N_("Hosts created by facts or a report that did not send a location fact will be placed in this location"), '', N_('Default location')),
+        self.set('default_organization', N_("Hosts created by facts or a report that did not send a organization fact will be placed in this organization"), '', N_('Default organization'))
+      ].compact.each { |s| self.create s.update(:category => "Setting::Configuration")}
+
+      true
+    end
+  end
+end

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -13,7 +13,7 @@ class Setting::Provisioning < Setting
         self.set('unattended_url', N_("URL hosts will retrieve templates from during build (normally http as many installers don't support https)"), unattended_url, N_('Unattended URL')),
         self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true, N_('Safemode rendering')),
         self.set('manage_puppetca', N_("Foreman will automate certificate signing upon provision of new host"), true, N_('Manage PuppetCA')),
-        self.set('ignore_puppet_facts_for_provisioning', N_("Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"), false, N_('Ignore Puppet facts for provisioning')),
+        self.set('ignore_facts_for_provisioning', N_("Stop updating IP address and MAC values from facts (affects all interfaces)"), false, N_('Ignore facts for provisioning')),
         self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1", N_('Remote address')),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6, N_('Token duration')),

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -1,35 +1,7 @@
+# Do not use - these settings are now in Setting::Configuration, but this model
+# has to stay in order to be able to migrate them
 class Setting::Puppet < Setting
   def self.load_defaults
-    # Check the table exists
-    return unless super
-
-    self.transaction do
-      [
-        self.set('puppet_interval', N_("Puppet interval in minutes"), 30, N_('Puppet interval')),
-        self.set('outofsync_interval', N_("Duration in minutes after the Puppet interval for servers to be classed as out of sync."), 5, N_('Out of sync interval')),
-        self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment')),
-        self.set('modulepath',N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
-        self.set('document_root', N_("Document root where puppetdoc files should be created"), "#{Rails.root}/public/puppet/rdoc", N_('Document root')),
-        self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
-        self.set('puppet_server', N_("Default Puppet server hostname"), "puppet", N_('Puppet server')),
-        self.set('Default_variables_Lookup_Path', N_("Foreman will evaluate host smart variables in this order by default"), ["fqdn", "hostgroup", "os", "domain"], N_('Default variables lookup path')),
-        self.set('Enable_Smart_Variables_in_ENC', N_("Foreman smart variables will be exposed via the ENC yaml output"), true, N_('Enable smart variables in ENC')),
-        self.set('Parametrized_Classes_in_ENC', N_("Foreman will use the new (2.6.5+) format for classes in the ENC yaml output"), true, N_('Parameterized classes in ENC')),
-        self.set('interpolate_erb_in_parameters', N_("Foreman will parse ERB in parameters value in the ENC output"), true, N_('Interpolate ERB in parameters')),
-        self.set('enc_environment', N_("Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"), true, N_('ENC environment')),
-        self.set('use_uuid_for_certificates', N_("Foreman will use random UUIDs for certificate signing instead of hostnames"), false, N_('Use UUID for certificates')),
-        self.set('update_environment_from_facts', N_("Foreman will update a host's environment from its facts"), false, N_('Update environment from facts')),
-        self.set('host_group_matchers_inheritance', N_("Foreman host group matchers will be inherited by children when evaluating smart class parameters"), true, N_('Host group matchers inheritance')),
-        self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true, N_('Create new host when facts are uploaded')),
-        self.set('create_new_host_when_report_is_uploaded', N_("Foreman will create the host when a report is received"), true, N_('Create new host when report is uploaded')),
-        self.set('legacy_puppet_hostname', N_("Foreman will truncate hostname to 'puppet' if it starts with puppet"), false, N_('Legacy Puppet hostname')),
-        self.set('location_fact', N_("Hosts created after a puppet run will be placed in the location this fact dictates. The content of this fact should be the full label of the location."), 'foreman_location', N_('Location fact')),
-        self.set('organization_fact', N_("Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."), 'foreman_organization', N_('Organization fact')),
-        self.set('default_location', N_("Hosts created after a puppet run that did not send a location fact will be placed in this location"), '', N_('Default location')),
-        self.set('default_organization', N_("Hosts created after a puppet run that did not send a organization fact will be placed in this organization"), '', N_('Default organization'))
-      ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
-
-      true
-    end
+    true
   end
 end

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -92,7 +92,7 @@ class FactParser
   end
 
   def parse_interfaces?
-    support_interfaces_parsing? && !Setting['ignore_puppet_facts_for_provisioning']
+    support_interfaces_parsing? && !Setting['ignore_facts_for_provisioning']
   end
 
   private

--- a/app/views/dashboard/_distribution_widget.html.erb
+++ b/app/views/dashboard/_distribution_widget.html.erb
@@ -1,4 +1,4 @@
 <h4 class="header">
-  <%= n_("Run distribution in the last %s minute", "Run distribution in the last %s minutes", Setting[:puppet_interval]) % Setting[:puppet_interval] %>
+  <%= n_("Run distribution in the last %s minute", "Run distribution in the last %s minutes", Setting[:configuration_interval]) % Setting[:configuration_interval] %>
 </h4>
 <%= render_run_distribution(@hosts, :class => 'statistics-bar') %>

--- a/app/views/dashboard/_status_widget.html.erb
+++ b/app/views/dashboard/_status_widget.html.erb
@@ -3,17 +3,17 @@
 </h4>
 <ul>
   <%= searchable_links _('Hosts that had performed modifications without error'),
-                       "last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
+                       "last_report > \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
                        :active_hosts_ok_enabled
   %>
 
   <%= searchable_links _('Hosts in error state'),
-                       "last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
+                       "last_report > \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
                        :bad_hosts_enabled
   %>
 
-  <%=searchable_links _("Good host reports in the last %s") % time_ago_in_words((Setting[:puppet_interval]+Setting[:outofsync_interval]).minutes.ago),
-                      "last_report > \"#{Setting[:puppet_interval]+Setting[:outofsync_interval]} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
+  <%=searchable_links _("Good host reports in the last %s") % time_ago_in_words((Setting[:configuration_interval]+Setting[:outofsync_interval]).minutes.ago),
+                      "last_report > \"#{Setting[:configuration_interval]+Setting[:outofsync_interval]} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
                       :ok_hosts_enabled
   %>
 
@@ -23,7 +23,7 @@
   %>
 
   <%= searchable_links _('Out of sync hosts'),
-                       "last_report < \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and status.enabled = true",
+                       "last_report < \"#{Setting[:configuration_interval] + Setting[:outofsync_interval]} minutes ago\" and status.enabled = true",
                        :out_of_sync_hosts_enabled
   %>
 

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,7 +1,8 @@
 <% title _("Settings") %>
 <% title_actions documentation_button('3.5.2ConfigurationOptions') %>
 <ul class="nav nav-tabs" data-tabs="tabs">
-  <% @settings.group_by(&:category).each do |category, setting| %>
+    <% @settings.group_by(&:category).each do |category, setting| %>
+    <% next if setting.blank? %>
     <li class='<%= category == @settings.first.category ? "active" : ""%>'>
       <a href='<%= "##{short_cat(category)}" %>' data-toggle="tab"><%= _(short_cat(category)) %></a>
     </li>
@@ -9,6 +10,7 @@
 </ul>
 <div class="tab-content">
   <% @settings.group_by(&:category).each do |category, setting| %>
+    <% next if setting.blank? %>
     <div class="tab-pane <%= "active" if category == @settings.first.category %>" id='<%= short_cat(category) %>' >
       <table class="table table-bordered table-striped">
         <thead>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -7,7 +7,7 @@
     <%= alert_close %>
     <p><strong><%= _("No trend counter defined.") %></strong></p>
     <p><%= _("To define trend counters, use the Add Trend Counter button.") %><br/>
-      <%= (_("To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting.puppet_interval).html_safe %></p>
+      <%= (_("To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting[:configuration_interval]).html_safe %></p>
   </div>
 <% end %>
 
@@ -15,7 +15,7 @@
   <div class="alert alert-info alert-dismissable">
     <%= alert_close %>
     <p><strong><%= _("No trend counter found.") %></strong></p>
-    <p><%= ( _("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting.puppet_interval).html_safe %>
+    <p><%= ( _("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting[:configuration_interval]).html_safe %>
     </p>
   </div>
 <% end %>

--- a/db/migrate/20150915193833_make_puppet_settings_generic.rb
+++ b/db/migrate/20150915193833_make_puppet_settings_generic.rb
@@ -1,0 +1,28 @@
+class MakePuppetSettingsGeneric < ActiveRecord::Migration
+  def up
+    Setting::Puppet.all.each do |setting|
+      setting.update_column(:category, 'Setting::Configuration')
+    end
+
+    rename_setting('puppet_interval', 'configuration_interval')
+    rename_setting('trusted_puppetmaster_hosts', 'trusted_hosts')
+  end
+
+  def down
+    execute "UPDATE settings SET name='puppet_interval' WHERE name='configuration_interval'"
+    execute "UPDATE settings SET name='trusted_puppetmaster_hosts' WHERE name='trusted_hosts'"
+
+    Setting::Configuration.all.each do |setting|
+      setting.update_column(:category, 'Setting::Puppet')
+    end
+  end
+
+  private
+
+  def rename_setting(source, destination)
+    if (old = Setting.find_by_name(source))
+      Setting[destination] = old.value
+      old.delete
+    end
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -35,39 +35,39 @@ attributes7:
   default: /var/lib/puppet/ssl/private_keys/super.some.host.fqdn.pem
   description: SSL Private Key file that foreman would use to communicate with its proxies
 attributes8:
-  name: puppet_interval
+  name: configuration_interval
   settings_type: integer
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 30
-  description: Setting::Puppet interval in minutes
+  description: Setting::Configuration interval in minutes
 attributes9:
   name: default_puppet_environment
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: production
-  description: "The Setting::Puppet environment foreman would default to in case it can't auto detect it"
+  description: "The Setting::Configuration environment foreman would default to in case it can't auto detect it"
 attributes10:
   name: modulepath
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: /etc/puppet/modules
-  description: "The Setting::Puppet default module path in case that Foreman can't auto detect it"
+  description: "The Setting::Configuration default module path in case that Foreman can't auto detect it"
 attributes11:
   name: document_root
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: /home/olevy/git/foreman/public/puppet/rdoc
   description: Document root where puppetdoc files should be created
 attributes12:
   name: puppet_server
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: puppet
-  description: Default Setting::Puppet Server hostname
+  description: Default Setting::Configuration Server hostname
 attributes13:
   name: failed_report_email_notification
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "false"
   description: Enable Email Alerts per each failed puppet report
 attributes14:
   name: Default_variables_Lookup_Path
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: ["fqdn", "hostgroup", "os", "domain"]
   description: The Default path in which foreman resolves host specific variables
 attributes15:
@@ -82,7 +82,7 @@ attributes16:
   description: The amount of records shown per page in foreman
 attributes17:
   name: update_environment_from_facts
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "false"
   description: Foreman will update a hosts environment from its facts
 attributes18:
@@ -92,12 +92,12 @@ attributes18:
   description: idle timeout
 attributes19:
   name: enc_environment
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: Should Foreman provide puppet environment in ENC yaml output? (this avoids the mismatch error between puppet.conf and ENC environment)
 attributes20:
   name: use_uuid_for_certificates
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "false"
   description: "Should Foreman use random UUID's for certificate signing instead of hostnames"
 attributes21:
@@ -122,9 +122,9 @@ attributes24:
   description: "Setting::Authorize login delegation with REMOTE_USER environment variable for API calls"
 attributes25:
   name: Parametrized_Classes_in_ENC
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "false"
-  description: "Should Foreman use the new format (2.6.5+) to answer Setting::Puppet in its ENC yaml output?"
+  description: "Should Foreman use the new format (2.6.5+) to answer Setting::Configuration in its ENC yaml output?"
 attribute26:
   name: token_duration
   category: Setting::Provisioning
@@ -151,7 +151,7 @@ attribute30:
   default: "SSL_CLIENT_VERIFY"
   description: "Environment variable containing the verification status of a client SSL certificate"
 attribute32:
-  name: trusted_puppetmaster_hosts
+  name: trusted_hosts
   category: Setting::Auth
   default: []
   description: "Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
@@ -162,12 +162,12 @@ attribute33:
   description: "Should Foreman use gravatar to display user icons"
 attribute36:
   name: puppetrun
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: "Enables Puppetrun Support"
 attribute37:
   name: create_new_host_when_facts_are_uploaded
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: "Foreman will create the host when new facts are received"
 attribute38:
@@ -177,12 +177,12 @@ attribute38:
   description: "Should we use the originating IP of the built request to update the Host's IP?"
 attribute39:
   name: legacy_puppet_hostname
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "false"
   description: "Foreman will truncate hostname to 'puppet' if it starts with puppet"
 attribute40:
   name: interpolate_erb_in_parameters
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: "Should Foreman parse ERB to return dynamic parameters?"
 attribute41:
@@ -192,7 +192,7 @@ attribute41:
   description: "Should Foreman use the short hostname instead of the FQDN for creating new virtual machines"
 attribute42:
   name: create_new_host_when_report_is_uploaded
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: "Foreman will create the host when a report is received"
 attributes43:
@@ -202,27 +202,27 @@ attributes43:
   description: The URL Foreman should point to in templates etc
 attributes44:
   name: default_organization
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 'Organization 1'
   description: 'Default organization when importing hosts'
 attributes45:
   name: default_location
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 'Location 1'
   description: 'Default location when importing hosts'
 attributes46:
   name: location_fact
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 'foreman_location'
   description: 'Fact to set location from when importing hosts'
 attributes47:
   name: organization_fact
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 'foreman_organization'
   description: 'Fact to set organization from when importing hosts'
 attributes48:
   name: Enable_Smart_Variables_in_ENC
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: "true"
   description: "Foreman smart variables will be exposed via the ENC yaml output"
 attributes49:
@@ -258,7 +258,7 @@ attributes54:
 attributes55:
   name: outofsync_interval
   settings_type: integer
-  category: Setting::Puppet
+  category: Setting::Configuration
   default: 5
   description: "Duration in minutes after the Puppet interval for servers to be classed as out of sync."
 attributes56:

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -549,7 +549,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['else.where']
+    Setting[:trusted_hosts] = ['else.where']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
@@ -563,7 +563,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['foreman.example']
+    Setting[:trusted_hosts] = ['foreman.example']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = 'CN=foreman.example,OU=PUPPET,O=FOREMAN,ST=North Carolina,C=US'
@@ -577,7 +577,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['foreman.linux.lab.local']
+    Setting[:trusted_hosts] = ['foreman.linux.lab.local']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = '/C=US/ST=NC/L=City/O=Example/OU=IT/CN=foreman.linux.lab.local/emailAddress=user@example.com'

--- a/test/integration/setting_test.rb
+++ b/test/integration/setting_test.rb
@@ -4,7 +4,7 @@ class SettingIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
     assert_index_page(settings_path,"Settings",false,true,false)
     assert page.has_link?("General", :href => "#General")
-    assert page.has_link?("Puppet", :href => "#Puppet")
+    assert page.has_link?("Configuration", :href => "#Configuration")
     assert page.has_link?("Provisioning", :href => "#Provisioning")
     assert page.has_link?("Auth", :href => "#Auth")
   end

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -31,10 +31,10 @@ class FactParserTest < ActiveSupport::TestCase
 
   test "#parse_interfaces? should answer based on current setttings" do
     parser.stub(:support_interfaces_parsing?, true) do
-      Setting.expects(:[]).with('ignore_puppet_facts_for_provisioning').returns(false)
+      Setting.expects(:[]).with('ignore_facts_for_provisioning').returns(false)
       assert parser.parse_interfaces?
 
-      Setting.expects(:[]).with('ignore_puppet_facts_for_provisioning').returns(true)
+      Setting.expects(:[]).with('ignore_facts_for_provisioning').returns(true)
       refute parser.parse_interfaces?
     end
   end

--- a/test/unit/host_status/configuration_status_test.rb
+++ b/test/unit/host_status/configuration_status_test.rb
@@ -44,7 +44,7 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
 
   test '#out_of_sync? is true if reported_at is set and is too long ago' do
     assert @status.reported_at.present?
-    window = (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes
+    window = (Setting[:configuration_interval] + Setting[:outofsync_interval]).minutes
     assert @status.reported_at < Time.now - window
 
     assert @status.out_of_sync?

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -226,12 +226,27 @@ class SettingTest < ActiveSupport::TestCase
     check_zero_value_not_allowed_for 'entries_per_page'
   end
 
-  test "puppet_interval should not be zero" do
-    check_zero_value_not_allowed_for 'puppet_interval'
+  test "puppet_interval is deprecated" do
+    Foreman::Deprecation.expects(:deprecation_warning).with('1.12', 'Use Setting[:configuration_interval] instead')
+    assert_equal Setting[:puppet_interval], Setting[:configuration_interval]
   end
 
-  test "trusted_puppetmaster_hosts can be empty array" do
-    check_empty_array_allowed_for "trusted_puppetmaster_hosts"
+  test "configuration_interval should not be zero" do
+    check_zero_value_not_allowed_for 'configuration_interval'
+  end
+
+  test "trusted_puppetmaster_hosts is deprecated" do
+    Foreman::Deprecation.expects(:deprecation_warning).with('1.12', 'Use Setting[:trusted_hosts] instead')
+    assert_equal Setting[:trusted_puppetmaster_hosts], Setting[:trusted_hosts]
+  end
+
+  test "trusted_hosts can be empty array" do
+    check_empty_array_allowed_for "trusted_hosts"
+  end
+
+  test "ignore_puppet_facts_for_provisioning is deprecated" do
+    Foreman::Deprecation.expects(:deprecation_warning).with('1.12', 'Use Setting[:ignore_facts_for_provisioning] instead')
+    assert_equal Setting[:ignore_puppet_facts_for_provisioning], Setting[:ignore_facts_for_provisioning]
   end
 
   test "foreman_url must be a URI" do


### PR DESCRIPTION
- `puppet_interval` :arrow_right: `configuration_interval`
- `trusted_puppetmaster_hosts` :arrow_right: `trusted_hosts`
- `ignore_puppet_facts_for_provisioning` :arrow_right: `ignore_facts_for_provisioning`
- Adds ability to deprecate settings
- Renames Setting::Puppet to Setting:Configuration
