### PR TITLE
Fixes #11844 - Remove duplicate scope in FactValue

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -28,7 +28,6 @@ class FactValue < ActiveRecord::Base
     end
   }
 
-  scope :distinct, -> { select('DISTINCT fact_values.value') }
   scope :required_fields, -> { includes(:host, :fact_name) }
   scope :facts_counter, ->(value, name_id) { where(:value => value, :fact_name_id => name_id) }
   scope :with_fact_parent_id, ->(find_ids) { joins(:fact_name).merge FactName.with_parent_id(find_ids) }


### PR DESCRIPTION
ActiveRecord 4.1.5 includes a class method distinct and we have to
either rename or delete the distinct scope in FactValue on Rails 4.
Since I didn't find any instance of it, I think we can just remove it.
