### PR TITLE
Fixes #11846 - Specify join_table and foreign keys for habtm associations

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -13,10 +13,10 @@ class Operatingsystem < ActiveRecord::Base
   has_many :hostgroups
   has_many :images, :dependent => :destroy
   has_and_belongs_to_many :media
-  has_and_belongs_to_many :ptables
+  has_and_belongs_to_many :ptables, :join_table => :operatingsystems_ptables, :foreign_key => :operatingsystem_id, :association_foreign_key => :ptable_id
   has_and_belongs_to_many :architectures
   has_and_belongs_to_many :puppetclasses
-  has_and_belongs_to_many :provisioning_templates
+  has_and_belongs_to_many :provisioning_templates, :join_table => :operatingsystems_provisioning_templates, :foreign_key => :operatingsystem_id, :association_foreign_key => :provisioning_template_id
   has_many :os_default_templates, :dependent => :destroy
   accepts_nested_attributes_for :os_default_templates, :allow_destroy => true,
     :reject_if => :reject_empty_provisioning_template

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -18,7 +18,7 @@ class ProvisioningTemplate < Template
   belongs_to :template_kind
   accepts_nested_attributes_for :template_combinations, :allow_destroy => true,
     :reject_if => ->(tc) { tc[:environment_id].blank? and tc[:hostgroup_id].blank? }
-  has_and_belongs_to_many :operatingsystems
+  has_and_belongs_to_many :operatingsystems, :join_table => :operatingsystems_provisioning_templates, :association_foreign_key => :operatingsystem_id, :foreign_key => :provisioning_template_id
   has_many :os_default_templates
   before_save :check_for_snippet_assoications
 

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -15,7 +15,7 @@ class Ptable < Template
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   has_many_hosts
   has_many :hostgroups
-  has_and_belongs_to_many :operatingsystems
+  has_and_belongs_to_many :operatingsystems, :join_table => :operatingsystems_ptables, :association_foreign_key => :operatingsystem_id, :foreign_key => :ptable_id
   validates :layout, :presence => true
   validates :name, :uniqueness => true
   validate_inclusion_in_families :os_family


### PR DESCRIPTION
Rails 4 does not figure out these associations automatically and it
won't find the tables. Instead, we have to specify join tables for habtm
associations. This is a Rails 3 compatible change.
