### PR TITLE
refs #11833, #11791 - fix N+1 query during config status applicability check

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -360,7 +360,7 @@ class Host::Managed < Host::Base
 
   # Determine if host is setup for configuration
   def configuration?
-    !!puppet_proxy
+    puppet_proxy_id.present?
   end
 
   # the environment used by #clases nees to be self.environment and not self.parent.environment

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -270,7 +270,7 @@ class HostTest < ActiveSupport::TestCase
     host = FactoryGirl.build(:host)
     refute host.configuration?
 
-    proxy = FactoryGirl.build(:smart_proxy)
+    proxy = FactoryGirl.create(:smart_proxy)
     host.puppet_proxy = proxy
     assert host.configuration?
   end


### PR DESCRIPTION
Reapplies the fix from 7397bf1 which was lost in e543c57.

Creating the proxy in the test is required to populate the ID field.
