### PR TITLE
Fixes #11863 - Rewrite except_hidden user scope for Rails 4 compatibility

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,8 +55,10 @@ class User < ActiveRecord::Base
         where(["#{self.table_name}.admin = ? OR #{Usergroup.table_name}.admin = ?", true, true])
   }
   scope :except_hidden, lambda {
-    if (hidden = AuthSourceHidden.all).present?
-      where("#{self.table_name}.auth_source_id <> ?", hidden)
+    if (hidden = AuthSourceHidden.pluck('auth_sources.id')).present?
+      where(self.arel_table[:auth_source_id].not_in(hidden))
+    else
+      where(nil)
     end
   }
   scope :visible,         -> { except_hidden }


### PR DESCRIPTION
As it is written right now it needs a `.references(:users)` at the end
in order to work. We can rewrite the query to be compatible with Rails 4
and Rails 3 at the same time.
