### PR TITLE
fixes #11883 - fix classes accessors when cloning host groups

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -146,9 +146,9 @@ module HostCommon
     cg_ids = if is_a?(Hostgroup)
                path.each.map(&:config_group_ids).flatten.uniq
              else
-               config_group_ids + (hostgroup ? hostgroup.path.each.map(&:config_group_ids).flatten.uniq : [] )
+               hostgroup ? hostgroup.path.each.map(&:config_group_ids).flatten.uniq : []
              end
-    ConfigGroupClass.where(:config_group_id => cg_ids).pluck(:puppetclass_id)
+    ConfigGroupClass.where(:config_group_id => (config_group_ids + cg_ids)).pluck(:puppetclass_id)
   end
 
   def hg_class_ids

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -195,7 +195,7 @@ class Hostgroup < ActiveRecord::Base
 
   # Clone the hostgroup
   def clone(name = "")
-    new = self.deep_clone(:include => [:config_groups, :lookup_values, :puppetclasses, :locations, :organizations, :group_parameters],
+    new = self.deep_clone(:include => [:config_groups, :lookup_values, :hostgroup_classes, :locations, :organizations, :group_parameters],
                           :except => [:name, :title])
     new.name = name
     new.title = name

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -9,7 +9,7 @@ class HostgroupClass < ActiveRecord::Base
 
   attr_accessible :hostgroup_id, :hostgroup, :puppetclass_id, :puppetclass
 
-  validates :hostgroup_id, :presence => true
+  validates :hostgroup, :presence => true
   validates :puppetclass_id, :presence => true, :uniqueness => {:scope => :hostgroup_id}
 
   def name

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -371,8 +371,7 @@ class HostgroupTest < ActiveSupport::TestCase
     test "clone should clone puppet classes" do
       group.puppetclasses << FactoryGirl.create(:puppetclass)
       cloned = group.clone("new_name")
-      assert cloned.puppetclasses.size == 1
-      assert_equal cloned.puppetclasses, group.puppetclasses
+      assert_equal group.hostgroup_classes.map(&:puppetclass_id), cloned.hostgroup_classes.map(&:puppetclass_id)
     end
 
     test "clone should clone parameters values but update ids" do
@@ -391,6 +390,17 @@ class HostgroupTest < ActiveSupport::TestCase
       cloned = group.clone("new_name")
       cloned.save
       assert_equal cloned.lookup_values.map(&:value), group.lookup_values.map(&:value)
+    end
+
+    test '#classes etc. on cloned group return the same' do
+      parent = FactoryGirl.create(:hostgroup, :with_config_group, :with_puppetclass)
+      group = FactoryGirl.create(:hostgroup, :with_config_group, :with_puppetclass, :parent => parent)
+      cloned = group.clone('cloned')
+      assert_equal group.individual_puppetclasses.map(&:id), cloned.individual_puppetclasses.map(&:id)
+      assert_equal group.classes_in_groups.map(&:id), cloned.classes_in_groups.map(&:id)
+      assert_equal group.classes.map(&:id), cloned.classes.map(&:id)
+      assert_equal group.available_puppetclasses.map(&:id), cloned.available_puppetclasses.map(&:id)
+      assert_valid cloned
     end
   end
 end


### PR DESCRIPTION
Ensures parameters from classes via config group associations show up
under the parameters tab when cloning host groups.
