### PR TITLE
Fixes #11403 - allowed helpers/vars are not constants anymore

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -7,7 +7,7 @@ class Setting < ActiveRecord::Base
   TYPES= %w{ integer boolean hash array string }
   FROZEN_ATTRS = %w{ name category full_name }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend outofsync_interval }
-  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret }
+  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret safemode_extra_variables safemode_extra_helpers}
   URI_ATTRS = %w{ foreman_url unattended_url }
 
   class UriValidator < ActiveModel::EachValidator

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -21,6 +21,8 @@ class Setting::Provisioning < Setting
         self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false, N_('Update IP from built request')),
         self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),
         self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
+        self.set('safemode_extra_variables', N_("Extra variables allowed in safe mode"), '', N_('Safemode extra variables')),
+        self.set('safemode_extra_helpers', N_("Extra helpers allowed in safe mode"), '', N_('Safemode extra helpers')),
       ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
     end
 

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -224,12 +224,12 @@ module Foreman #:nodoc:
 
     # List of helper methods allowed for templates in safe mode
     def allowed_template_helpers(*helpers)
-      Foreman::Renderer::ALLOWED_HELPERS.concat(helpers)
+      Foreman::Renderer.add_allowed_helpers(*helpers)
     end
 
     # List of variables allowed for templates in safe mode
     def allowed_template_variables(*variables)
-      Foreman::Renderer::ALLOWED_VARIABLES.concat(variables)
+      Foreman::Renderer.add_allowed_variables(*variables)
     end
 
     # Add Compute resource

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -192,19 +192,19 @@ class PluginTest < ActiveSupport::TestCase
   end
 
   def test_register_allowed_template_helpers_and_variables
-    refute_includes Foreman::Renderer::ALLOWED_HELPERS, :my_helper
-    refute_includes Foreman::Renderer::ALLOWED_VARIABLES, :my_variable
+    refute_includes Foreman::Renderer.allowed_helpers, :my_helper
+    refute_includes Foreman::Renderer.allowed_variables, :my_variable
 
     @klass.register :foo do
       allowed_template_helpers :my_helper
       allowed_template_variables :my_variable
     end
 
-    assert_includes Foreman::Renderer::ALLOWED_HELPERS, :my_helper
-    assert_includes Foreman::Renderer::ALLOWED_VARIABLES, :my_variable
+    assert_includes Foreman::Renderer.allowed_helpers, :my_helper
+    assert_includes Foreman::Renderer.allowed_variables, :my_variable
   ensure
-    Foreman::Renderer::ALLOWED_HELPERS.delete(:my_helper)
-    Foreman::Renderer::ALLOWED_HELPERS.delete(:my_variable)
+    Foreman::Renderer.allowed_helpers.delete(:my_helper)
+    Foreman::Renderer.allowed_variables.delete(:my_variable)
   end
 
   def test_add_compute_resource


### PR DESCRIPTION
Also added safemode_extra_\* settings for user-defined overrides. Assuming
permissions are correct, this should be safe.

FYI the main problem with constant was development environment. Every single
reload of `renderer.rb` class thrown away all elements added by our plugin API.
