### PR TITLE
refs #11807 - change nested lookup_values destroy test params to match UI

### DIFF
--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2339,7 +2339,7 @@ class HostTest < ActiveSupport::TestCase
       lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :puppetclass => host.classes.first, :overrides => {"fqdn=#{host.name}" => 'old value'})
       lval = host.lookup_values.first
 
-      host.lookup_values_attributes = {'0' => {'lookup_key_id' => lkey.id.to_s, 'value' => 'new value', '_destroy' => 'false', 'id' => lval.id.to_s}}.with_indifferent_access
+      host.lookup_values_attributes = {'0' => {'lookup_key_id' => lkey.id.to_s, 'value' => 'new value', '_destroy' => '0', 'id' => lval.id.to_s}}.with_indifferent_access
       assert_equal 'old value', LookupValue.find(lval.id).value
 
       host.save!
@@ -2350,7 +2350,7 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryGirl.create(:host, :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lookup_keys(:complex).id, "value"=>"some_value", "match" => "fqdn=abc.mydomain.net"}})
       lookup_value = host.lookup_values.first
       assert_no_difference('LookupValue.count') do
-        host.lookup_values_attributes = {"lv" => {:id => lookup_value.id, :_destroy => true}}
+        host.lookup_values_attributes = {'0' => {'lookup_key_id' => lookup_keys(:complex).id.to_s, 'id' => lookup_value.id.to_s, '_destroy' => '1'}}.with_indifferent_access
       end
 
       assert_difference('LookupValue.count', -1) do


### PR DESCRIPTION
A followup to #2716 as I just realised from a duplicate ticket that the destroy action hadn't been working either for nested lookup values.  The fix for updating values already fixed it, but the existing test was buggy as it was using integers instead of strings.
