### PR TITLE
Fixes #7567 - Substitute find_or_create_by by first_or_create

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -70,7 +70,7 @@ class Setting < ActiveRecord::Base
 
   def self.[]=(name, value)
     name   = name.to_s
-    record = find_or_create_by_name name
+    record = where(:name => name).first_or_create
     record.value = value
     record.save!
   end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -199,7 +199,7 @@ module Foreman #:nodoc:
       return false if pending_migrations
 
       options[:engine] ||= self.id.to_s
-      Permission.find_or_create_by_name_and_resource_type(name, options[:resource_type])
+      Permission.where(:name => name).first_or_create(:resource_type => options[:resource_type])
       options.merge!(:security_block => @security_block)
       Foreman::AccessControl.map do |map|
         map.permission name, hash, options
@@ -212,7 +212,7 @@ module Foreman #:nodoc:
       return false if pending_migrations || Rails.env.test?
 
       Role.transaction do
-        role = Role.find_or_create_by_name(name)
+        role = Role.where(:name => name).first_or_create
         role.add_permissions!(permissions) if role.permissions.empty?
       end
     end

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -190,7 +190,7 @@ class PuppetClassImporter
 
   def add_classes_to_foreman(env_name, klasses)
     env         = find_or_create_env env_name
-    new_classes = klasses.map { |k| Puppetclass.find_or_create_by_name(k[0]) }
+    new_classes = klasses.map { |k| Puppetclass.where(:name => k[0]).first_or_create }
 
     new_classes.each do |new_class|
       EnvironmentClass.create! :puppetclass_id => new_class.id, :environment_id => env.id

--- a/config/initializers/fix_cache.rb
+++ b/config/initializers/fix_cache.rb
@@ -2,9 +2,10 @@
 # recreate cache
 
 if (Setting.table_exists? rescue(false))
-  fix_db_cache = Setting::General.find_or_initialize_by_name('fix_db_cache',
-                                                     :description   => 'Fix DB cache on next Foreman restart',
-                                                     :settings_type => 'boolean', :default => false)
+  fix_db_cache = Setting::General.where(:name => 'fix_db_cache').
+    first_or_initialize(:description => 'Fix DB cache on next Foreman restart',
+                        :settings_type => 'boolean',
+                        :default => false)
 
   CacheManager.recache! if !Foreman.in_rake? && fix_db_cache.value
 end

--- a/db/migrate/20140219183343_migrate_permissions.rb
+++ b/db/migrate/20140219183343_migrate_permissions.rb
@@ -82,7 +82,7 @@ class MigratePermissions < ActiveRecord::Migration
   def make_sure_all_permissions_are_present
     engine_permissions = Foreman::AccessControl.permissions.select { |p| p.engine.present? }
     engine_permissions.each do |permission|
-      FakePermission.find_or_create_by_name_and_resource_type(permission.name, permission.resource_type)
+      FakePermission.where(:name => permission.name, :resource_type => permission.resource_type).first_or_create
     end
   end
 

--- a/db/seeds.d/03-permissions.rb
+++ b/db/seeds.d/03-permissions.rb
@@ -163,6 +163,6 @@ permissions = [
   ['User', 'destroy_users'],
 ]
 permissions.each do |resource, permission|
-  Permission.find_or_create_by_resource_type_and_name resource, permission
+  Permission.where(:name => permission, :resource_type => resource).first_or_create
 end
 

--- a/db/seeds.d/05-taxonomies.rb
+++ b/db/seeds.d/05-taxonomies.rb
@@ -2,7 +2,7 @@
 if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION'] && !Organization.any?
   Organization.without_auditing do
     User.current = User.anonymous_admin
-    Organization.find_or_create_by_name!(:name => ENV['SEED_ORGANIZATION'])
+    Organization.where(:name => ENV['SEED_ORGANIZATION']).first_or_create
     User.current = nil
   end
 end
@@ -11,7 +11,7 @@ end
 if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION'] && !Location.any?
   Location.without_auditing do
     User.current = User.anonymous_admin
-    Location.find_or_create_by_name!(:name => ENV['SEED_LOCATION'])
+    Location.where(:name => ENV['SEED_LOCATION']).first_or_create!
     User.current = nil
   end
 end

--- a/db/seeds.d/06-architectures.rb
+++ b/db/seeds.d/06-architectures.rb
@@ -1,5 +1,5 @@
 # Architectures
 Architecture.without_auditing do
-  Architecture.find_or_create_by_name "x86_64"
-  Architecture.find_or_create_by_name "i386"
+  Architecture.where(:name => "x86_64").first_or_create
+  Architecture.where(:name => "i386").first_or_create
 end

--- a/db/seeds.d/11-smart_proxy_features.rb
+++ b/db/seeds.d/11-smart_proxy_features.rb
@@ -1,5 +1,5 @@
 # Proxy features
 [ "TFTP", "DNS", "DHCP", "Puppet", "Puppet CA", "BMC", "Chef Proxy", "Realm", "Facts" ].each do |input|
-  f = Feature.find_or_create_by_name(input)
+  f = Feature.where(:name => input).first_or_create
   raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
 end

--- a/lib/tasks/reset_permissions.rake
+++ b/lib/tasks/reset_permissions.rake
@@ -14,8 +14,8 @@ END_DESC
 
   task :reset => :environment do
     User.as_anonymous_admin do
-      user = User.find_or_create_by_login(:login => ENV["username"] || 'admin', :firstname => 'Admin', :lastname => 'User', :mail => Setting[:administrator])
-      src  = AuthSourceInternal.find_or_create_by_type "AuthSourceInternal"
+      user = User.where(:login => ENV["username"] || 'admin').first_or_create(:firstname => 'Admin', :lastname => 'User', :mail => Setting[:administrator])
+      src  = AuthSourceInternal.where(:type => "AuthSourceInternal").first_or_create
       src.update_attribute :name, "Internal"
       user.admin = true
       user.auth_source = src

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -284,7 +284,7 @@ class HostsControllerTest < ActionController::TestCase
   test 'user with edit host rights and facts are set should succeed in viewing host1 but fail for host2' do
     setup_user_and_host "view", "facts.architecture = \"x86_64\""
     as_admin do
-      fn_id = FactName.find_or_create_by_name("architecture").id
+      fn_id = FactName.where(:name => "architecture").first_or_create.id
       FactValue.create! :host => @host1, :fact_name_id => fn_id, :value    => "x86_64"
       FactValue.create! :host => @host2, :fact_name_id => fn_id, :value    => "i386"
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,7 +147,7 @@ Spork.prefork do
         permission = Permission.find_by_name("#{operation}_#{type}") || FactoryGirl.create(:permission, :name => "#{operation}_#{type}")
         filter = FactoryGirl.build(:filter, :search => search)
         filter.permissions = [ permission ]
-        role = Role.find_or_create_by_name :name => "#{operation}_#{type}"
+        role = Role.where(:name => "#{operation}_#{type}").first_or_create
         role.filters = [ filter ]
         role.save!
         filter.role = role

--- a/test/unit/domain_parameter_test.rb
+++ b/test/unit/domain_parameter_test.rb
@@ -6,7 +6,7 @@ class DomainParameterTest < ActiveSupport::TestCase
     assert !parameter.save
 
     setup_user "create"
-    domain = Domain.find_or_create_by_name("domain")
+    domain = Domain.where(:name => "domain").first_or_create
     parameter.reference_id = domain.id
     assert parameter.save
   end

--- a/test/unit/group_parameter_test.rb
+++ b/test/unit/group_parameter_test.rb
@@ -10,7 +10,7 @@ class GroupParameterTest < ActiveSupport::TestCase
 
     group_parameter.name = "valid"
     group_parameter.value = "valid"
-    hostgroup = Hostgroup.find_or_create_by_name("valid")
+    hostgroup = Hostgroup.where(:name => "valid").first_or_create
     group_parameter.reference_id = hostgroup.id
     assert group_parameter.save
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -21,7 +21,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "should not save hostname with periods in shortname" do
-    host = Host.new :name => "my.host", :domain => Domain.find_or_create_by_name("mydomain.net"), :managed => true
+    host = Host.new :name => "my.host", :domain => Domain.where(:name => "mydomain.net").first_or_create, :managed => true
     host.valid?
     assert_equal "must not include periods", host.errors[:name].first
   end
@@ -103,25 +103,25 @@ class HostTest < ActiveSupport::TestCase
 
   test "should add domain name to hostname" do
     host = Host.create :name => "myhost", :mac => "aabbccddeeff", :ip => "123.01.02.03",
-      :domain => Domain.find_or_create_by_name("company.com")
+      :domain => Domain.where(:name => "company.com").first_or_create
     assert_equal "myhost.company.com", host.name
   end
 
   test "should not add domain name to hostname if it already include it" do
     host = Host.create :name => "myhost.company.com", :mac => "aabbccddeeff", :ip => "123.1.2.3",
-      :domain => Domain.find_or_create_by_name("company.com")
+      :domain => Domain.where(:name => "company.com").first_or_create
     assert_equal "myhost.company.com", host.name
   end
 
   test "should add hostname if it contains domain name" do
     host = Host.create :name => "myhost.company.com", :mac => "aabbccddeeff", :ip => "123.01.02.03",
-      :domain => Domain.find_or_create_by_name("company.com")
+      :domain => Domain.where(:name => "company.com").first_or_create
     assert_equal "myhost.company.com", host.name
   end
 
   test "should not append domainname to fqdn for unmanaged host" do
     host = Host.create :name => "myhost.sub.comp.net", :mac => "aabbccddeeff", :ip => "123.01.02.03",
-      :domain => Domain.find_or_create_by_name("company.com"),
+      :domain => Domain.where(:name => "company.com").first_or_create,
       :certname => "myhost.sub.comp.net",
       :managed => false
     assert_equal "myhost.sub.comp.net", host.name
@@ -129,7 +129,7 @@ class HostTest < ActiveSupport::TestCase
 
   test "should save hosts with full stop in their name" do
     host = Host.create :name => "my.host.company.com", :mac => "aabbccddeeff", :ip => "123.01.02.03",
-      :domain => Domain.find_or_create_by_name("company.com")
+      :domain => Domain.where(:name => "company.com").first_or_create
     assert_equal "my.host.company.com", host.name
   end
 
@@ -1469,7 +1469,7 @@ class HostTest < ActiveSupport::TestCase
         filter = FactoryGirl.build(:filter)
         filter.permissions = [ Permission.find_by_name('edit_hosts') ]
         filter.save!
-        role = Role.find_or_create_by_name :name => "testing_role"
+        role = Role.where(:name => "testing_role").first_or_create
         role.filters = [ filter ]
         role.save!
         @one.roles = [ role ]

--- a/test/unit/puppetclass_test.rb
+++ b/test/unit/puppetclass_test.rb
@@ -37,7 +37,7 @@ class PuppetclassTest < ActiveSupport::TestCase
       filter1.permissions = Permission.where(:name => ['create_external_variables'])
       filter2 = FactoryGirl.build(:filter)
       filter2.permissions = Permission.where(:name => ['edit_puppetclasses'])
-      role = Role.find_or_create_by_name :name => "testing_role"
+      role = Role.where(:name => "testing_role").first_or_create
       role.filters = [ filter1, filter2 ]
       role.save!
       filter1.role = role

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -235,7 +235,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test "foreman_url must be a URI" do
-    assert Setting.find_or_create_by_name(:name => "foreman_url", :default => "http://foo.com")
+    attrs = { :name => "foreman_url", :default => "http://foo.com" }
+    assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting = Setting.find_by_name("foreman_url")
     setting.value="##"
     assert !setting.save
@@ -243,7 +244,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test "foreman_url must have proper URI format" do
-    assert Setting.find_or_create_by_name(:name => "foreman_url", :default => "http://foo.com")
+    attrs = { :name => "foreman_url", :default => "http://foo.com" }
+    assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting = Setting.find_by_name("foreman_url")
     setting.value = "random_string"
     assert !setting.save
@@ -251,14 +253,16 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test "foreman_url cannot be blank" do
-    setting = Setting.find_or_create_by_name(:name => "foreman_url", :default => "http://foo.com")
+    attrs = { :name => "foreman_url", :default => "http://foo.com" }
+    setting = Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting.value = ""
     assert !setting.save
     assert_equal "must be a valid URI", setting.errors[:value].first
   end
 
   test "unattended_url must be a URI" do
-    assert Setting.find_or_create_by_name(:name => "unattended_url", :default => "http://foo.com")
+    attrs = { :name => "unattended_url", :default => "http://foo.com" }
+    assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting = Setting.find_by_name("unattended_url")
     setting.value="##"
     assert !setting.save
@@ -266,7 +270,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test "unattended_url must have proper URI format" do
-    assert Setting.find_or_create_by_name(:name => "foreman_url", :default => "http://foo.com")
+    attrs = { :name => "foreman_url", :default => "http://foo.com" }
+    assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting = Setting.find_by_name("foreman_url")
     setting.value = "random_string"
     assert !setting.save
@@ -364,7 +369,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def check_frozen_change(attr_name, value)
-    assert Setting.find_or_create_by_name(:name => "foo", :default => 5, :description => "test foo")
+    attrs = { :name => "foo", :default => 5, :description => "test foo" }
+    assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting = Setting.find_by_name("foo")
 
     setting.send("#{attr_name}=", value)
@@ -373,7 +379,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def check_zero_value_not_allowed_for(setting_name)
-    setting = Setting.find_or_create_by_name(setting_name, :value => 0, :default => 30)
+    attrs = { :name => setting_name, :value => 0, :default => 30 }
+    setting = Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting.value = 0
 
     refute_valid setting, :value, "must be greater than 0"
@@ -383,7 +390,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def check_length_must_be_under_8(setting_name)
-    setting = Setting.find_or_create_by_name(setting_name, :default => 30)
+    attrs = { :name => setting_name, :default => 30 }
+    setting = Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting.value = 123456789
 
     refute_valid setting, :value, /is too long \(maximum is 8 characters\)/
@@ -393,7 +401,8 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def check_empty_array_allowed_for(setting_name)
-    setting = Setting.find_or_create_by_name(setting_name, :value => [], :default => [])
+    attrs = { :name => setting_name, :value => [], :default => [] }
+    setting = Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting.value = []
     assert_valid setting
 
@@ -407,7 +416,7 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def check_properties_saved_and_loaded_ok(options = {})
-    assert Setting.find_or_create_by_name(options)
+    assert Setting.where(:name => options[:name]).first || Setting.create(options)
     s = Setting.find_by_name options[:name]
     assert_equal options[:value], s.value
     assert_equal options[:default], s.default

--- a/test/unit/subnet_test.rb
+++ b/test/unit/subnet_test.rb
@@ -85,7 +85,7 @@ class SubnetTest < ActiveSupport::TestCase
   end
 
   def create_a_domain_with_the_subnet
-    @domain = Domain.find_or_create_by_name("domain")
+    @domain = Domain.where(:name => "domain").first_or_create
     @subnet = Subnet.new(:network => "123.123.123.1",:mask => "255.255.255.0",:name => "valid")
     assert @subnet.save
     assert @subnet.domain_ids = [domains(:mydomain).id]

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -218,7 +218,7 @@ class UserTest < ActiveSupport::TestCase
   test "non-admin user can't assign roles he does not have himself" do
     setup_user "create"
     create_role          = Role.find_by_name 'create_users'
-    extra_role           = Role.find_or_create_by_name :name => "foobar"
+    extra_role           = Role.where(:name => "foobar").first_or_create
     record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id,
                                     :role_ids => [extra_role.id, create_role.id].map(&:to_s)
     record.password_hash = "asd"
@@ -241,7 +241,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "admin can set admin flag and set any role" do
     as_admin do
-      extra_role           = Role.find_or_create_by_name :name => "foobar"
+      extra_role           = Role.where(:name => "foobar").first_or_create
       record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id,
                                       :role_ids => [extra_role.id].map(&:to_s)
       record.password_hash = "asd"
@@ -254,7 +254,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "user cannot assign role he has not assigned himself" do
     setup_user "edit"
-    extra_role      = Role.find_or_create_by_name :name => "foobar"
+    extra_role      = Role.where(:name => "foobar").first_or_create
     record          = users(:one)
     record.role_ids = [extra_role.id]
     assert_not record.save
@@ -273,7 +273,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "user cannot escalate his own roles" do
     setup_user "edit"
-    extra_role      = Role.find_or_create_by_name :name => "foobar"
+    extra_role      = Role.where(:name => "foobar").first_or_create
     record = User.current
     record.role_ids = record.role_ids + [extra_role.id]
     refute record.save
@@ -282,7 +282,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "admin can add any role" do
     as_admin do
-      extra_role      = Role.find_or_create_by_name :name => "foobar"
+      extra_role      = Role.where(:name => "foobar").first_or_create
       record          = users(:one)
       record.role_ids = [extra_role.id]
       assert record.valid?
@@ -385,7 +385,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "use that can change admin flag #can_assign? any role" do
     user       = users(:one)
-    extra_role = Role.find_or_create_by_name :name => "foobar"
+    extra_role = Role.where(:name => "foobar").first_or_create
     user.stub :can_change_admin_flag?, true do
       assert user.can_assign?([extra_role.id])
     end
@@ -399,8 +399,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "non admin user #can_assign? only his assigned roles" do
     user   = users(:one)
-    foobar = Role.find_or_create_by_name :name => "foobar"
-    barfoo = Role.find_or_create_by_name :name => "barfoo"
+    foobar = Role.where(:name => "foobar").first_or_create
+    barfoo = Role.where(:name => "barfoo").first_or_create
     user.roles<< foobar
 
     assert user.can_assign?([foobar.id])
@@ -411,8 +411,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "role_ids change detection" do
     user   = users(:one)
-    foobar = Role.find_or_create_by_name :name => "foobar"
-    barfoo = Role.find_or_create_by_name :name => "barfoo"
+    foobar = Role.where(:name => "foobar").first_or_create
+    barfoo = Role.where(:name => "barfoo").first_or_create
     user.roles<< foobar
 
     user.role_ids = [foobar.id]
@@ -432,8 +432,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "role_ids can be empty array which removes all roles" do
     user   = users(:one)
-    foobar = Role.find_or_create_by_name :name => "foobar"
-    Role.find_or_create_by_name :name => "barfoo"
+    foobar = Role.where(:name => "foobar").first_or_create
+    Role.where(:name => "barfoo").first_or_create
     user.roles<< foobar
 
     user.role_ids = []
@@ -442,8 +442,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "role_ids can be nil resulting in no role" do
     user   = users(:one)
-    foobar = Role.find_or_create_by_name :name => "foobar"
-    Role.find_or_create_by_name :name => "barfoo"
+    foobar = Role.where(:name => "foobar").first_or_create
+    Role.where(:name => "barfoo").first_or_create
     user.roles<< foobar
 
     user.role_ids = nil
@@ -566,7 +566,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "existing AuthSource" do
       setup do
-        @apache_source = AuthSourceExternal.find_or_create_by_name('apache_module')
+        @apache_source = AuthSourceExternal.where(:name => 'apache_module').first_or_create
       end
 
       test "not existing" do
@@ -824,7 +824,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'can search users by role id' do
     # Setup role and assign to user
-    role = Role.find_or_create_by_name(:name => "foobar")
+    role = Role.where(:name => "foobar").first_or_create
     user = users(:one)
     user.role_ids = [role.id]
 

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -29,19 +29,11 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   def populate_usergroups
-    @u1 = User.find_or_create_by_login :login => "u1", :mail => "u1@someware.com", :firstname => "u1", :auth_source => auth_sources(:one)
-    @u2 = User.find_or_create_by_login :login => "u2", :mail => "u2@someware.com", :firstname => "u2", :auth_source => auth_sources(:one)
-    @u3 = User.find_or_create_by_login :login => "u3", :mail => "u3@someware.com", :firstname => "u3", :auth_source => auth_sources(:one)
-    @u4 = User.find_or_create_by_login :login => "u4", :mail => "u4@someware.com", :firstname => "u4", :auth_source => auth_sources(:one)
-    @u5 = User.find_or_create_by_login :login => "u5", :mail => "u5@someware.com", :firstname => "u5", :auth_source => auth_sources(:one)
-    @u6 = User.find_or_create_by_login :login => "u6", :mail => "u6@someware.com", :firstname => "u6", :auth_source => auth_sources(:one)
-
-    @ug1 = Usergroup.find_or_create_by_name :name => "ug1"
-    @ug2 = Usergroup.find_or_create_by_name :name => "ug2"
-    @ug3 = Usergroup.find_or_create_by_name :name => "ug3"
-    @ug4 = Usergroup.find_or_create_by_name :name => "ug4"
-    @ug5 = Usergroup.find_or_create_by_name :name => "ug5"
-    @ug6 = Usergroup.find_or_create_by_name :name => "ug6"
+    (1..6).each do |number|
+      instance_variable_set("@ug#{number}", FactoryGirl.create(:usergroup, :name=> "ug#{number}"))
+      instance_variable_set("@u#{number}", FactoryGirl.create(:user, :mail => "u#{number}@someware.com",
+                                                              :login => "u#{number}"))
+    end
 
     @ug1.users      = [@u1, @u2]
     @ug2.users      = [@u2, @u3]
@@ -83,7 +75,7 @@ class UsergroupTest < ActiveSupport::TestCase
 
   test "cannot be destroyed when in use by a host" do
     disable_orchestration
-    @ug1 = Usergroup.find_or_create_by_name :name => "ug1"
+    @ug1 = Usergroup.where(:name => "ug1").first_or_create
     @h1  = FactoryGirl.create(:host)
     @h1.update_attributes :owner => @ug1
     @ug1.destroy
@@ -91,8 +83,8 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   test "can be destroyed when in use by another usergroup, it removes association automatically" do
-    @ug1 = Usergroup.find_or_create_by_name :name => "ug1"
-    @ug2 = Usergroup.find_or_create_by_name :name => "ug2"
+    @ug1 = Usergroup.where(:name => "ug1").first_or_create
+    @ug2 = Usergroup.where(:name => "ug2").first_or_create
     @ug1.usergroups = [@ug2]
     assert @ug1.destroy
     assert @ug2.reload
@@ -100,8 +92,8 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   test "removes user join model records" do
-    ug1 = Usergroup.find_or_create_by_name :name => "ug1"
-    u1  = User.find_or_create_by_login :login => "u1", :mail => "u1@someware.com", :auth_source => auth_sources(:one)
+    ug1 = Usergroup.where(:name => "ug1").first_or_create
+    u1  = FactoryGirl.build(:user)
     ug1.users = [u1]
     assert_difference('UsergroupMember.count', -1) do
       ug1.destroy


### PR DESCRIPTION
Rails 3 and 4 both support the syntax 'where(args).first_or_create'.
find_or_create_by is no longer valid on Rails 4 so we should remove it
here already
