### PR TITLE
Fixes #11912 - Remove deprecated assert_present assert_blank

### DIFF
--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -33,9 +33,9 @@ class SeedsTest < ActiveSupport::TestCase
     end
     [User::ANONYMOUS_ADMIN, User::ANONYMOUS_API_ADMIN].each do |login|
       user = User.unscoped.find_by_login(login)
-      assert_present user, "cannot find user #{login}"
-      assert_blank user.password_hash
-      assert_blank user.password_salt
+      assert user.present?, "cannot find user #{login}"
+      assert user.password_hash.blank?
+      assert user.password_salt.blank?
       assert user.admin?
       assert user.hidden?
       assert_valid user
@@ -48,8 +48,8 @@ class SeedsTest < ActiveSupport::TestCase
         seed
       end
       user = User.find_by_login('admin')
-      assert_present user.password_hash
-      assert_present user.password_salt
+      assert user.password_hash.present?
+      assert user.password_salt.present?
       assert user.admin?
       assert_valid user
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -200,8 +200,9 @@ Spork.prefork do
     def refute_with_errors(condition, model, field = nil, match = nil)
       refute condition, "#{model.inspect} errors: #{model.errors.full_messages.join(';')}"
       if field
-        assert_blank model.errors.map { |a,m| model.errors.full_message(a, m) unless field == a }.compact
-        assert_present model.errors[field].find { |e| e.match(match) },
+        model_errors = model.errors.map { |a,m| model.errors.full_message(a, m) unless field == a }.compact
+        assert model_errors.blank?, "#{model} contains #{model_errors}, it should not contain any"
+        assert model.errors[field].find { |e| e.match(match) }.present?,
                        "#{field} error matching #{match} not found: #{model.errors[field].inspect}" if match
       end
     end

--- a/test/unit/ensure_no_cycle_test.rb
+++ b/test/unit/ensure_no_cycle_test.rb
@@ -45,7 +45,7 @@ class EnsureNoCycleTest < ActiveSupport::TestCase
     assert_raises Foreman::CyclicGraphException do
       @graph.ensure(record)
     end
-    assert_present record.errors[:base], 'cycle did not add error to record'
+    assert record.errors[:base].present?, 'cycle did not add error to record'
   end
 
   test "#ensure passes when record does not create cycle" do

--- a/test/unit/widget_test.rb
+++ b/test/unit/widget_test.rb
@@ -28,7 +28,7 @@ class WidgetTest < ActiveSupport::TestCase
     assert_equal 1, widget.col
     assert_equal 1, widget.row
     refute widget.hide
-    assert_blank widget.data
+    assert widget.data.blank?
     assert_equal widget.user_id, @user.id
   end
 


### PR DESCRIPTION
Rails 4.1 deprecates assert_present and assert_blank as per
http://guides.rubyonrails.org/4_1_release_notes.html . We don't use
these extensively, so we can afford to remove them and use the
recommended assert object.present? and assert object.blank?

Merging this won't introduce any failures on Rails 3 and it will reduce
the diff between the develop and rails 4 branches
