### PR TITLE
Refs #11846 - Specify join_tables for taxonomies

### DIFF
--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -4,7 +4,7 @@ class Location < Taxonomy
   include Foreman::ThreadSession::LocationModel
   include Parameterizable::ByIdName
 
-  has_and_belongs_to_many :organizations
+  has_and_belongs_to_many :organizations, :join_table => 'locations_organizations'
   has_many_hosts :dependent => :nullify
 
   has_many :location_parameters, :class_name => 'LocationParameter', :foreign_key => :reference_id, :dependent => :destroy, :inverse_of => :location

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -4,7 +4,7 @@ class Organization < Taxonomy
   include Foreman::ThreadSession::OrganizationModel
   include Parameterizable::ByIdName
 
-  has_and_belongs_to_many :locations
+  has_and_belongs_to_many :locations, :join_table => 'locations_organizations'
   has_many_hosts :dependent => :nullify
 
   has_many :organization_parameters, :class_name => 'OrganizationParameter', :foreign_key => :reference_id,            :dependent => :destroy, :inverse_of => :organization


### PR DESCRIPTION
Missed this as part of the previous fix for 11846. As a brief reminder,
it's necessary to specify the join table for habtm associations on Rails
4, and it doesn't hurt on Rails 3, so we should do it before the upgrade.
