### PR TITLE
Fixes #11924 - Substitute .scoped by .where(nil) to force return relation

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -49,7 +49,7 @@ module Api
     def parent_scope
       parent_name, scope = parent_resource_details
 
-      return resource_class.scoped unless scope
+      return resource_class.where(nil) unless scope
 
       association = resource_class.reflect_on_all_associations.find {|assoc| assoc.plural_name == parent_name.pluralize}
       resource_class.joins(association.name).merge(scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -135,7 +135,7 @@ class ApplicationController < ActionController::Base
     @resource_base ||= if model_of_controller.respond_to?(:authorized)
                          model_of_controller.authorized(current_permission)
                        else
-                         model_of_controller.scoped
+                         model_of_controller.where(nil)
                        end
   end
 

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -54,7 +54,7 @@ class FiltersController < ApplicationController
     @resource_base ||= if @role.present?
                          @role.filters.authorized(current_permission)
                        else
-                         Filter.scoped.authorized(current_permission)
+                         Filter.where(nil).authorized(current_permission)
                        end
   end
 

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -156,11 +156,11 @@ module TaxonomyHelper
       association = resource.to_s.classify.constantize
     end
     return unless User.current.allowed_to?("view_#{resource}".to_sym)
-    ids = "#{association.scoped.klass.to_s.underscore.singularize}_ids".to_sym
+    ids = "#{association.where(nil).klass.to_s.underscore.singularize}_ids".to_sym
 
     content_tag(:div, :id => resource, :class => "tab-pane") do
       all_checkbox(f, resource) +
-      multiple_selects(f, association.scoped.klass.to_s.underscore.pluralize.to_sym, association, taxonomy.selected_or_inherited_ids[ids],
+      multiple_selects(f, association.where(nil).klass.to_s.underscore.pluralize.to_sym, association, taxonomy.selected_or_inherited_ids[ids],
                            {:disabled => taxonomy.used_and_selected_or_inherited_ids[ids],
                             :label => translated_label(resource, :select)},
                            {'data-mismatches' => taxonomy.need_to_be_selected_ids[ids].to_json,

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -21,10 +21,11 @@ class Bookmark < ActiveRecord::Base
 
   scope :my_bookmarks, lambda {
     user = User.current
-    return {} unless SETTINGS[:login] and !user.nil?
-
-    user       = User.current
-    conditions = sanitize_sql_for_conditions(["((bookmarks.public = ?) OR (bookmarks.owner_id = ? AND bookmarks.owner_type = 'User'))", true, user.id])
+    if !SETTINGS[:login] || user.nil?
+      conditions = {}
+    else
+      conditions = sanitize_sql_for_conditions(["((bookmarks.public = ?) OR (bookmarks.owner_id = ? AND bookmarks.owner_type = 'User'))", true, user.id])
+    end
     where(conditions)
   }
 

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -16,7 +16,7 @@ module Authorizable
       if user.nil?
         self.where('1=0')
       elsif user.admin?
-        self.scoped
+        self.where(nil)
       else
         Authorizer.new(user).find_collection(resource || self, :permission => permission)
       end

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -200,7 +200,7 @@ module HostCommon
   end
 
   def available_puppetclasses
-    return Puppetclass.scoped if environment_id.blank?
+    return Puppetclass.where(nil) if environment_id.blank?
     environment.puppetclasses - parent_classes
   end
 

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -63,7 +63,7 @@ module Taxonomix
     # default scope is not called if we just use #scoped therefore we have to enforce quering
     # to get correct default values
     def enforce_default
-      self.scoped.limit(0).all unless which_ancestry_method.present?
+      self.where(nil).limit(0).all unless which_ancestry_method.present?
     end
 
     def taxable_ids(loc = which_location, org = which_organization, inner_method = which_ancestry_method)

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -28,7 +28,7 @@ class ConfigGroup < ActiveRecord::Base
   alias_method :individual_puppetclasses, :puppetclasses
 
   def available_puppetclasses
-    Puppetclass.scoped
+    Puppetclass.where(nil)
   end
 
   # for auditing

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -177,7 +177,7 @@ class Hostgroup < ActiveRecord::Base
   def params
     parameters = {}
     # read common parameters
-    CommonParameter.scoped.each {|p| parameters.update Hash[p.name => p.value] }
+    CommonParameter.where(nil).each {|p| parameters.update Hash[p.name => p.value] }
     # read OS parameters
     operatingsystem.os_parameters.each {|p| parameters.update Hash[p.name => p.value] } if operatingsystem
     # read group parameters only if a host belongs to a group

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -46,8 +46,8 @@ module Nic
     scope :physical, -> { where(:virtual => false) }
     scope :is_managed, -> { where(:managed => true) }
 
-    scope :primary, -> { { :conditions => { :primary => true } } }
-    scope :provision, -> { { :conditions => { :provision => true } } }
+    scope :primary, -> { where(:primary => true) }
+    scope :provision, -> { where(:provision => true) }
 
     belongs_to :subnet
     belongs_to :domain, :counter_cache => 'hosts_count'
@@ -225,7 +225,7 @@ module Nic
 
     private
 
-    def interface_attribute_uniqueness(attr, base = Nic::Base.scoped)
+    def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil))
       in_memory_candidates = self.host.present? ? self.host.interfaces.select { |i| i.persisted? && !i.marked_for_destruction? } : [self]
       db_candidates = base.where(attr => self.public_send(attr))
       db_candidates = db_candidates.select { |c| c.id != self.id && in_memory_candidates.map(&:id).include?(c.id) }

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -28,7 +28,7 @@ class Role < ActiveRecord::Base
   audited :allow_mass_assignment => true
 
   scope :givable, -> { where(:builtin => 0).order(:name) }
-  scope :for_current_user, -> { User.current.admin? ? {} : where(:id => User.current.role_ids) }
+  scope :for_current_user, -> { User.current.admin? ? where('0 != 0') : where(:id => User.current.role_ids) }
   scope :builtin, lambda { |*args|
     compare = 'not' if args.first
     where("#{compare} builtin = 0")

--- a/db/migrate/20150521121315_rename_config_template_to_provisioning_template.rb
+++ b/db/migrate/20150521121315_rename_config_template_to_provisioning_template.rb
@@ -5,15 +5,15 @@ class RenameConfigTemplateToProvisioningTemplate < ActiveRecord::Migration
     old_name = 'ConfigTemplate'
     new_name = 'ProvisioningTemplate'
 
-    Template.update_all "type = '#{new_name}'", "type = '#{old_name}'"
-    Audit.update_all "auditable_type = '#{new_name}'", "auditable_type = '#{old_name}'"
-    TaxableTaxonomy.update_all "taxable_type = '#{new_name}'", "taxable_type = '#{old_name}'"
-    Permission.update_all "resource_type = '#{new_name}'", "resource_type = '#{old_name}'"
+    Template.where(:type => old_name).update_all(:type => new_name)
+    Audit.where(:auditable_type => old_name).update_all(:auditable_type => new_name)
+    TaxableTaxonomy.where(:taxable_type => old_name).update_all(:taxable_type => new_name)
+    Permission.where(:resource_type => old_name).update_all(:resource_type => new_name)
 
     PERMISSIONS.each do |from|
       to = from.sub('templates', 'provisioning_templates')
       say "renaming permission #{from} to #{to}"
-      Permission.update_all "name = '#{to}'", "name = '#{from}'"
+      Permission.where(:name => from).update_all(:name => to)
     end
 
     if foreign_keys('os_default_templates').find { |f| f.options[:name] == 'os_default_templates_config_template_id_fk' }.present?
@@ -56,15 +56,15 @@ class RenameConfigTemplateToProvisioningTemplate < ActiveRecord::Migration
     PERMISSIONS.each do |to|
       from = to.sub('provisioning_templates', 'templates')
       say "renaming permission #{from} to #{to}"
-      Permission.update_all "name = '#{to}'", "name = '#{from}'"
+      Permission.where(:name => from).update_all(:name => to)
     end
 
     old_name = 'ConfigTemplate'
     new_name = 'ProvisioningTemplate'
 
-    Template.update_all "type = '#{old_name}'", "type = '#{new_name}'"
-    Audit.update_all "auditable_type = '#{old_name}'", "auditable_type = '#{new_name}'"
-    TaxableTaxonomy.update_all "taxable_type = '#{old_name}'", "taxable_type = '#{new_name}'"
-    Permission.update_all "resource_type = '#{old_name}'", "resource_type = '#{new_name}'"
+    Template.where(:type => new_name).update_all(:type => old_name)
+    Audit.where(:auditable_type => new_name).update_all(:auditable_type => old_name)
+    TaxableTaxonomy.where(:taxable_type => new_name).update_all(:taxable_type => old_name)
+    Permission.where(:resource_type => new_name).update_all(:resource_type => old_name)
   end
 end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -111,7 +111,7 @@ class ActiveRecord::Base
   alias_attribute :to_s, :to_label
 
   def self.unconfigured?
-    scoped.reorder('').limit(1).pluck(self.base_class.primary_key).empty?
+    where(nil).reorder('').limit(1).pluck(self.base_class.primary_key).empty?
   end
 
   def self.per_page

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1936,19 +1936,19 @@ class HostTest < ActiveSupport::TestCase
   test "available_puppetclasses should return all if no environment" do
     host = FactoryGirl.create(:host)
     host.update_attribute(:environment_id, nil)
-    assert_equal Puppetclass.scoped, host.available_puppetclasses
+    assert_equal Puppetclass.where(nil), host.available_puppetclasses
   end
 
   test "available_puppetclasses should return environment-specific classes" do
     host = FactoryGirl.create(:host, :with_environment)
-    refute_equal Puppetclass.scoped, host.available_puppetclasses
+    refute_equal Puppetclass.where(nil), host.available_puppetclasses
     assert_equal host.environment.puppetclasses.sort, host.available_puppetclasses.sort
   end
 
   test "available_puppetclasses should return environment-specific classes (and that are NOT already inherited by parent)" do
     hostgroup        = FactoryGirl.create(:hostgroup, :with_puppetclass)
     host             = FactoryGirl.create(:host, :hostgroup => hostgroup, :environment => hostgroup.environment)
-    refute_equal Puppetclass.scoped, host.available_puppetclasses
+    refute_equal Puppetclass.where(nil), host.available_puppetclasses
     refute_equal host.environment.puppetclasses.sort, host.available_puppetclasses.sort
     assert_equal (host.environment.puppetclasses - host.parent_classes).sort, host.available_puppetclasses.sort
   end

--- a/test/unit/provisioning_template_test.rb
+++ b/test/unit/provisioning_template_test.rb
@@ -128,7 +128,7 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
 
   test '#preview_host_collection obeys view_hosts permission' do
     provisioning_template = FactoryGirl.build(:provisioning_template)
-    Host.expects(:authorized).with(:view_hosts).returns(Host.scoped)
+    Host.expects(:authorized).with(:view_hosts).returns(Host.where(nil))
     provisioning_template.preview_host_collection
   end
 

--- a/test/unit/ptable_test.rb
+++ b/test/unit/ptable_test.rb
@@ -90,7 +90,7 @@ class PtableTest < ActiveSupport::TestCase
 
   test '#preview_host_collection obeys view_hosts permission' do
     ptable = FactoryGirl.build(:ptable)
-    Host.expects(:authorized).with(:view_hosts).returns(Host.scoped)
+    Host.expects(:authorized).with(:view_hosts).returns(Host.where(nil))
     ptable.preview_host_collection
   end
 end


### PR DESCRIPTION
On Rails 4 .scoped is deprecated. Calling .all on the model returns the
equivalent ActiveRecord relation object on Rails 4, but on Rails 3 it
returns an Array right away.

A proper replacement we can use is where(nil) - it's ugly but it returns
the same relation in both Rails 3 and 4. There are a couple of fixes too
on models such as bookmark.rb which return where conditions ({} and
similar) instead of a relation, which is also a deprecated behavior.

We could possibly substitute these by .all after the Rails 4 migration
if they feel too 'unidiomatic'.
