### PR TITLE
fixes #11375, #11782 - validate a host's lookup_values

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -30,7 +30,7 @@ module HostCommon
 
     alias_method :all_puppetclasses, :classes
 
-    has_many :lookup_values, :primary_key => :lookup_value_matcher, :foreign_key => :match, :validate => false, :dependent => :destroy
+    has_many :lookup_values, :primary_key => :lookup_value_matcher, :foreign_key => :match, :dependent => :destroy
     # See "def lookup_values_attributes=" under, for the implementation of accepts_nested_attributes_for :lookup_values
     accepts_nested_attributes_for :lookup_values
 

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -199,6 +199,10 @@ class Hostgroup < ActiveRecord::Base
                           :except => [:name, :title, :lookup_value_matcher])
     new.name = name
     new.title = name
+    new.lookup_values.each do |lv|
+      lv.match = new.lookup_value_match
+      lv.host_or_hostgroup = new
+    end
     new
   end
 
@@ -207,11 +211,13 @@ class Hostgroup < ActiveRecord::Base
     unscoped_find(ancestry.to_s.split('/').last.to_i).update_puppetclasses_total_hosts if ancestry.present?
   end
 
-  private
+  protected
 
   def lookup_value_match
     "hostgroup=#{to_label}"
   end
+
+  private
 
   def nested_root_pw
     Hostgroup.sort_by_ancestry(ancestors).reverse.each do |a|

--- a/app/views/common_parameters/_puppetclass_parameter.html.erb
+++ b/app/views/common_parameters/_puppetclass_parameter.html.erb
@@ -1,7 +1,16 @@
+<%
+# LookupValue#match is generated automatically by Host#lookup_values_attributes=
+# from the name, so don't present errors directly to the user.  Any validation
+# errors should also be visible against the Host#name field.
+if f.object.errors[:match].any?
+  logger.debug("Ignoring #{f.object.inspect} match errors: #{f.object.errors[:match]}")
+  f.object.errors.delete(:match)
+end
+%>
 <div class="fields">
   <table>
     <tbody>
-      <tr class="<%= 'error' if f.object.errors.any? %>">
+      <tr class="<%= 'has-error' if f.object.errors.any? %>">
         <td class="col-md-3">
           <%= f.hidden_field :lookup_key_id, :'data-property' => 'lookup_key_id' %>
           <% puppetclass = f.object.lookup_key ? f.object.lookup_key.param_class : nil %>

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -34,7 +34,7 @@ FactoryGirl.define do
         end
         after(:create) do |lkey, evaluator|
           evaluator.puppetclass.environments.each do |env|
-            FactoryGirl.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :lookup_key_id => lkey.id
+            FactoryGirl.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
           end
         end
       end

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -296,4 +296,35 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert has_selector?("div", :text => "Updated hosts: changed environment")
     end
   end
+
+  describe 'edit page' do
+    test 'shows errors on invalid lookup values' do
+      host = FactoryGirl.create(:host, :with_puppetclass)
+      FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
+                         :key_type => 'boolean', :default_value => true,
+                         :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => false})
+
+      visit edit_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert page.has_no_selector?('#params tr.has-error')
+
+      fill_in 'host_lookup_values_attributes_0_value', :with => 'invalid'
+      click_button('Submit')
+      assert page.has_selector?('#params tr.has-error')
+    end
+  end
+
+  describe 'clone page' do
+    test 'shows no errors on lookup values' do
+      host = FactoryGirl.create(:host, :with_puppetclass)
+      FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
+                         :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => 'test'})
+
+      visit clone_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert page.has_no_selector?('#params tr.has-error')
+    end
+  end
 end

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -20,4 +20,31 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
     assert_submit_button(hostgroups_path)
     assert page.has_link? 'db Old'
   end
+
+  test 'edit shows errors on invalid lookup values' do
+    group = FactoryGirl.create(:hostgroup, :with_puppetclass)
+    FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
+                       :key_type => 'boolean', :default_value => true,
+                       :puppetclass => group.puppetclasses.first, :overrides => {group.lookup_value_matcher => false})
+
+    visit edit_hostgroup_path(group)
+    assert page.has_link?('Parameters', :href => '#params')
+    click_link 'Parameters'
+    assert page.has_no_selector?('#params tr.has-error')
+
+    fill_in 'hostgroup_lookup_values_attributes_0_value', :with => 'invalid'
+    click_button('Submit')
+    assert page.has_selector?('#params tr.has-error')
+  end
+
+  test 'clone shows no errors on lookup values' do
+    group = FactoryGirl.create(:hostgroup, :with_puppetclass)
+    FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
+                       :puppetclass => group.puppetclasses.first, :overrides => {group.lookup_value_matcher => 'test'})
+
+    visit clone_hostgroup_path(group)
+    assert page.has_link?('Parameters', :href => '#params')
+    click_link 'Parameters'
+    assert page.has_no_selector?('#params tr.has-error')
+  end
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -247,6 +247,33 @@ class HostTest < ActiveSupport::TestCase
     assert_equal '80', lookup_value.value
   end
 
+  test "should be able to update complex YAML lookup value" do
+    host = FactoryGirl.create(:host)
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :key_type => 'yaml')
+    lookup_value = FactoryGirl.create(:lookup_value, :lookup_key_id => lookup_key.id,
+                                      :match => host.lookup_value_matcher, :value => YAML.dump(:foo => :bar))
+    host.reload
+    assert_difference('LookupValue.count', 0) do
+      assert host.update_attributes!(:lookup_values_attributes => {'0' =>
+                                                                   {:lookup_key_id => lookup_key.id.to_s, :value => YAML.dump(:updated => :value),
+                                                                    :match => host.lookup_value_matcher,
+                                                                    :id => lookup_value.id.to_s, :_destroy => 'false'}})
+    end
+    lookup_value.reload
+    assert_equal({:updated => :value}, lookup_value.value)
+  end
+
+  test "should raise nested lookup value validation errors" do
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :key_type => 'hash')
+    host = FactoryGirl.build(:host)
+    host.attributes = {:lookup_values_attributes => {'0' =>
+                                                     {:lookup_key_id => lookup_key.id.to_s, :value => '{"a":',
+                                                      :match => host.lookup_value_matcher,
+                                                      :_destroy => 'false'}}}
+    assert host.lookup_values.first.present?
+    refute_valid host, :'lookup_values.value', /invalid hash/
+  end
+
   test "should import facts from json stream" do
     h=Host.new(:name => "sinn1636.lan")
     h.disk = "!" # workaround for now

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -388,7 +388,7 @@ class HostgroupTest < ActiveSupport::TestCase
       lv.match = group.send(:lookup_value_match)
       lv.save!
       cloned = group.clone("new_name")
-      cloned.save
+      cloned.save!
       assert_equal 1, group.lookup_values.reload.count
       assert_equal 1, cloned.lookup_values.count
       assert_equal group.lookup_values.map(&:value), cloned.lookup_values.map(&:value)


### PR DESCRIPTION
Enabling validation ensures the casting and validation within
LookupValue runs during host/hostgroup save.  Tweaks to hostgroup
cloning ensure that the newly cloned hostgroup now passes validation
when it has associated lookup values.

Don't show any LookupValue#match errors in the host/hostgroup forms
as the value is autogenerated by the nested attribute setter.
