### PR TITLE
fixes #11885 - exclude lookup_value_matcher on clone

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -733,7 +733,7 @@ class Host::Managed < Host::Base
   def clone
     # do not copy system specific attributes
     host = self.deep_clone(:include => [:config_groups, :host_config_groups, :host_classes, :host_parameters, :lookup_values],
-                           :except  => [:name, :mac, :ip, :uuid, :certname, :last_report])
+                           :except  => [:name, :mac, :ip, :uuid, :certname, :last_report, :lookup_value_matcher])
     self.interfaces.each do |nic|
       host.interfaces << nic.clone
     end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -196,7 +196,7 @@ class Hostgroup < ActiveRecord::Base
   # Clone the hostgroup
   def clone(name = "")
     new = self.deep_clone(:include => [:config_groups, :lookup_values, :hostgroup_classes, :locations, :organizations, :group_parameters],
-                          :except => [:name, :title])
+                          :except => [:name, :title, :lookup_value_matcher])
     new.name = name
     new.title = name
     new

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2001,6 +2001,7 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryGirl.create(:host, :with_puppetclass)
       FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => 'test'})
       copy = host.clone
+      assert_equal 1, host.lookup_values.reload.size
       assert_equal 1, copy.lookup_values.size
       assert_equal host.lookup_values.map(&:value), copy.lookup_values.map(&:value)
     end
@@ -2026,6 +2027,14 @@ class HostTest < ActiveSupport::TestCase
       assert interface.name.blank?
       assert interface.mac.blank?
       assert interface.ip.blank?
+    end
+
+    test 'without save makes no changes' do
+      host = FactoryGirl.create(:host, :with_config_group, :with_puppetclass, :with_parameter)
+      FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => 'test'})
+      ActiveRecord::Base.any_instance.expects(:destroy).never
+      ActiveRecord::Base.any_instance.expects(:save).never
+      host.clone
     end
   end
 


### PR DESCRIPTION
Keeping lookup_value_matcher populated during a host or
hostgroup#clone caused Rails to believe the cloned object was still
associated to the existing LookupValue associated to the original
object, and it would destroy it during clone.

Interesting stack trace if it helps: https://gist.github.com/domcleal/f927c41721114fbc775b
