### PR TITLE
Fixes #7537 - Adds test connection button to LDAP form

### DIFF
--- a/app/assets/javascripts/auth_source_ldap.js
+++ b/app/assets/javascripts/auth_source_ldap.js
@@ -1,3 +1,25 @@
+function test_connection(item, url) {
+  $('#test_connection_indicator').show();
+  $(item).addClass("disabled");
+  var data = $("form").serialize();
+  $.ajax({
+    url: url,
+    type: 'put',
+    data: data,
+    success: function (result, textstatus, xhr) {
+      notify("<p>" + result.message + "</p>", 'success');
+    },
+    error: function (xhr) {
+      var error = $.parseJSON(xhr.responseText).message;
+      notify("<p>" + error + "</p>", 'error');
+    },
+    complete: function (result) {
+      $('#test_connection_indicator').hide();
+      $(item).removeClass("disabled");
+    }
+  })
+}
+
 function change_ldap_port(item) {
   var port = $('#auth_source_ldap_port');
   if (port.length > 0) {

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class AuthSourceLdapsController < V2::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_filter :find_resource, :only => %w{show update destroy test}
 
       api :GET, "/auth_source_ldaps/", N_("List all LDAP authentication sources")
       param_group :search_and_pagination, ::Api::V2::BaseController
@@ -54,11 +54,34 @@ module Api
         process_response @auth_source_ldap.update_attributes(params[:auth_source_ldap])
       end
 
+      api :PUT, "/auth_source_ldaps/:id/test/", N_("Test LDAP connection")
+      param :id, String, :required => true
+
+      def test
+        begin
+          test = @auth_source_ldap.test_connection
+        rescue Foreman::Exception => exception
+          render :test, :locals => {:success => false, :message => exception.message} and return
+        end
+        render :test, :locals => {:success => true, :message => test[:message]}
+      end
+
       api :DELETE, "/auth_source_ldaps/:id/", N_("Delete an LDAP authentication source")
       param :id, String, :required => true
 
       def destroy
         process_response @auth_source_ldap.destroy
+      end
+
+      private
+
+      def action_permission
+        case params[:action]
+          when 'test'
+            'edit'
+          else
+            super
+        end
       end
     end
   end

--- a/app/controllers/auth_source_ldaps_controller.rb
+++ b/app/controllers/auth_source_ldaps_controller.rb
@@ -36,4 +36,15 @@ class AuthSourceLdapsController < ApplicationController
       process_error
     end
   end
+
+  def test_connection
+    temp_auth_source_ldap = AuthSourceLdap.new(params[:auth_source_ldap])
+    begin
+      msg = temp_auth_source_ldap.test_connection
+    rescue Foreman::Exception => exception
+      Foreman::Logging.exception("Failed to connect to LDAP server", exception)
+      render :json => {:message => exception.message}, :status => :unprocessable_entity and return
+    end
+    render :json => msg, :status => :ok
+  end
 end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -28,17 +28,18 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :authentication_providers do |map|
+    ajax_actions = [:test_connection]
     map.permission :view_authenticators,    {:auth_source_ldaps => [:index, :show],
                                              :"api/v1/auth_source_ldaps" => [:index, :show],
                                              :"api/v2/auth_source_ldaps" => [:index, :show]
     }
-    map.permission :create_authenticators,  {:auth_source_ldaps => [:new, :create],
+    map.permission :create_authenticators,  {:auth_source_ldaps => [:new, :create].push(*ajax_actions),
                                              :"api/v1/auth_source_ldaps" => [:create],
                                              :"api/v2/auth_source_ldaps" => [:create]
     }
-    map.permission :edit_authenticators,    {:auth_source_ldaps => [:edit, :update],
+    map.permission :edit_authenticators,    {:auth_source_ldaps => [:edit, :update].push(*ajax_actions),
                                              :"api/v1/auth_source_ldaps" => [:update],
-                                             :"api/v2/auth_source_ldaps" => [:update]
+                                             :"api/v2/auth_source_ldaps" => [:update, :test]
     }
     map.permission :destroy_authenticators, {:auth_source_ldaps => [:destroy],
                                              :"api/v1/auth_source_ldaps" => [:destroy],

--- a/app/views/api/v2/auth_source_ldaps/test.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/test.json.rabl
@@ -1,0 +1,10 @@
+object @auth_source_ldap
+
+extends "api/v2/auth_source_ldaps/base"
+
+node :success do
+  locals[:success]
+end
+node :message do
+  locals[:message]
+end

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -11,7 +11,8 @@
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
       <%= text_f f, :name %>
-      <%= text_f f, :host %>
+      <%= text_f f, :host, :help_inline => link_to_function(_("Test Connection"), "test_connection(this, '#{url_for test_connection_auth_source_ldaps_url}')",
+                      :title => _("Test LDAP connectivity"), :id => "test_connection_button", :class =>"btn btn-success") + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe %>
       <%= checkbox_f(f, :tls, {:label => "LDAPS", :onchange => 'change_ldap_port(this)'}) %>
       <%= number_f f, :port, :min => 1, :max => 65535,
                       :data => { :default_ports => AuthSourceLdap::DEFAULT_PORTS } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,7 +248,11 @@ Foreman::Application.routes.draw do
 
     resources :permissions, :only => [:index]
 
-    resources :auth_source_ldaps, :except => [:show]
+    resources :auth_source_ldaps, :except => [:show] do
+      collection do
+        put 'test_connection'
+      end
+    end
 
     resources :external_usergroups, :except => [:index, :new, :create, :show, :edit, :update, :destroy] do
       member do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -409,6 +409,7 @@ Foreman::Application.routes.draw do
       end
       get 'orchestration/(:id)/tasks', :to => 'tasks#index'
       resources :plugins, :only => [:index]
+      put 'auth_source_ldaps/(:id)/test', :to => 'auth_source_ldaps#test'
     end
   end
 end

--- a/test/functional/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v2/auth_source_ldaps_controller_test.rb
@@ -38,4 +38,19 @@ class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test "LDAP testing success" do
+    AuthSourceLdap.any_instance.stubs(:test_connection).returns(:message => 'success')
+    put :test, { :id => auth_sources(:one).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
+  end
+
+  test "LDAP testing failed" do
+    AuthSourceLdap.any_instance.stubs(:test_connection).raises(Foreman::Exception)
+    put :test, { :id => auth_sources(:one).to_param }
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response[:success]
+  end
 end

--- a/test/functional/auth_source_ldaps_controller_test.rb
+++ b/test/functional/auth_source_ldaps_controller_test.rb
@@ -88,4 +88,16 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     auth_source_ldap = AuthSourceLdap.find(auth_source_ldap.id)
     assert_equal old_pass, auth_source_ldap.account_password
   end
+
+  test "LDAP test succeeded" do
+    AuthSourceLdap.any_instance.stubs(:test_connection).returns(:success => true)
+    put :test_connection, {:id => AuthSourceLdap.first, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
+    assert_response :success
+  end
+
+  test "LDAP test failed" do
+    AuthSourceLdap.any_instance.stubs(:test_connection).raises(Foreman::Exception, 'Exception message')
+    put :test_connection, {:id => AuthSourceLdap.first, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
+    assert_response :unprocessable_entity
+  end
 end

--- a/test/unit/auth_sources/auth_source_ldap_test.rb
+++ b/test/unit/auth_sources/auth_source_ldap_test.rb
@@ -246,6 +246,18 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     refute_equal ldap.ldap_con('user', 'pass'), ldap.ldap_con('user', 'pass')
   end
 
+  test "test connection succeed" do
+    setup_ldap_stubs
+    LdapFluff.any_instance.stubs(:test).returns(true)
+    assert_nothing_raised {@auth_source_ldap.send(:test_connection)}
+  end
+
+  test "test connection failed" do
+    setup_ldap_stubs
+    LdapFluff.any_instance.stubs(:test).raises(StandardError, 'Exception message')
+    assert_raise(Foreman::WrappedException) {@auth_source_ldap.send(:test_connection)}
+  end
+
   context 'account_password encryption' do
     setup do
       AuthSourceLdap.any_instance.expects(:encryption_key).at_least_once


### PR DESCRIPTION
Plus API support for testing LDAP connection.
screenshots:
![ldap_error](https://cloud.githubusercontent.com/assets/11807069/10072700/4d3c5830-62cc-11e5-86b3-74dffe07c57f.png)

![ldap_success](https://cloud.githubusercontent.com/assets/11807069/10072704/51c92b1c-62cc-11e5-8c62-012e294f0508.png)
