### PR TITLE
fixes #11987 - fix checking exit code of deployment scripts

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -82,7 +82,11 @@ module Orchestration::SSHProvision
       Host.find(id).built
       respond_to?(:initialize_puppetca,true) && initialize_puppetca && delAutosign if puppetca?
     else
-      raise ::Foreman::Exception.new(N_("Provision script had a non zero exit, removing instance"))
+      if Setting[:clean_up_failed_deployment]
+        logger.info "Deleting host #{name} because of non zero exit code of deployment script."
+        Host.find(id).destroy
+      end
+      raise ::Foreman::Exception.new(N_("Provision script had a non zero exit"))
     end
 
   rescue => e

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -21,6 +21,7 @@ class Setting::Provisioning < Setting
         self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false, N_('Update IP from built request')),
         self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),
         self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
+        self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
       ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
     end
 

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -51,7 +51,7 @@ class Foreman::Provision::SSH
   end
 
   def command
-    "#{command_prefix} bash -c 'chmod 0701 #{remote_script} && #{command_prefix} #{remote_script}' | tee #{remote_script}.log"
+    "#{command_prefix} bash -c '(chmod 0701 #{remote_script} && #{command_prefix} #{remote_script}) | tee #{remote_script}.log; exit ${PIPESTATUS[0]}'"
   end
 
   def defaults

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -266,3 +266,8 @@ attributes56:
   category: Setting::General
   default: "Foreman-noreply@#{SETTINGS[:domain]}"
   description: 'Email reply address for emails that Foreman is sending'
+attributes57:
+  name: clean_up_failed_deployment
+  category: Setting::Provisioning
+  default: false
+  description: "Foreman will delete virtual machine if provisioning script ends with non zero exit code"

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -269,5 +269,5 @@ attributes56:
 attributes57:
   name: clean_up_failed_deployment
   category: Setting::Provisioning
-  default: false
+  default: "true"
   description: "Foreman will delete virtual machine if provisioning script ends with non zero exit code"

--- a/test/unit/orchestration/ssh_test.rb
+++ b/test/unit/orchestration/ssh_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class SshOrchestrationTest < ActiveSupport::TestCase
+  setup :disable_orchestration
+
+  test 'failed SSH deployment deletes host if enabled' do
+    Setting[:clean_up_failed_deployment] = true
+    ssh = mock('ssh client')
+    ssh.expects(:deploy!).returns(false)
+    host = FactoryGirl.create(:host, :managed)
+    host.expects(:client).returns(ssh)
+    host.send(:setSSHProvision)
+    refute Host::Managed.find_by_id(host.id)
+  end
+
+  test 'failed SSH deployment retains host if disabled' do
+    Setting[:clean_up_failed_deployment] = false
+    ssh = mock('ssh client')
+    ssh.expects(:deploy!).returns(false)
+    host = FactoryGirl.create(:host, :managed)
+    host.expects(:client).returns(ssh)
+    host.send(:setSSHProvision)
+    assert Host::Managed.find_by_id(host.id)
+  end
+end


### PR DESCRIPTION
This commit fixes checking exit codes returned from provisioning templates, which were ignored
because of sending results through pipe to command tee. Also adds deleting hosts which deployment
fails because of non zero exit code.
