### PR TITLE
Fixes #11986 - Specify PUT method on form_for tags

### DIFF
--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -1,6 +1,6 @@
 <%= javascript "jquery.cookie", "host_checkbox" %>
 <% assign_selected_hosts_taxonomy_path = (@taxonomy_type == "Location") ? assign_selected_hosts_location_path : assign_selected_hosts_organization_path %>
-<%= form_for taxonomy, :url => assign_selected_hosts_taxonomy_path do |f| %>
+<%= form_for taxonomy, :url => assign_selected_hosts_taxonomy_path, :method => 'PUT' do |f| %>
   <%= base_errors_for taxonomy %>
   <%= wizard_header 3, _("Create %s") % taxonomy.class.name, _("Select Hosts"), _("Assign Selected Hosts") %>
   <div class="row">


### PR DESCRIPTION
Rails 4 will default to PATCH which we have not implemented in our
routes. This will cause at least one failure on taxonomies integration
tests. It's the only one our test suite catches, however I'd expect
other forms to fail on this when tested manually. We can keep this
issue number as a reference and add commits with integration tests
& fixes where needed.
