### PR TITLE
fixes #11980 - pin net-ssh to 2.x on Ruby 1.9.3

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,4 +1,5 @@
 group :fog do
   gem 'fog', '1.34.0', :require => false
   gem 'fog-core', '1.32.1'
+  gem 'net-ssh', '< 3' if RUBY_VERSION.start_with? '1.9.'
 end


### PR DESCRIPTION
http://ci.theforeman.org/job/test_develop_pull_request/12782/ is running.
