### PR TITLE
fixes #11996 - use preload to avoid multiple fact/host table joins

### DIFF
--- a/app/controllers/api/v1/fact_values_controller.rb
+++ b/app/controllers/api/v1/fact_values_controller.rb
@@ -16,7 +16,7 @@ module Api
           my_facts.
           no_timestamp_facts.
           search_for(*search_options).paginate(paginate_options).
-          includes(:fact_name, :host)
+          preload(:fact_name, :host)
         render :json => FactValue.build_facts_hash(values.all)
       end
     end

--- a/app/controllers/api/v2/fact_values_controller.rb
+++ b/app/controllers/api/v2/fact_values_controller.rb
@@ -13,7 +13,7 @@ module Api
           my_facts.
           no_timestamp_facts.
           search_for(*search_options).paginate(paginate_options).
-          includes(:fact_name, :host)
+          preload(:fact_name, :host)
         @fact_values = FactValue.build_facts_hash(values.all)
       end
     end

--- a/test/functional/api/v1/fact_values_controller_test.rb
+++ b/test/functional/api/v1/fact_values_controller_test.rb
@@ -29,4 +29,16 @@ class Api::V1::FactValuesControllerTest < ActionController::TestCase
     expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
     assert_equal expected_hash, fact_values
   end
+
+  test "should get facts as non-admin user with joined search" do
+    user = as_admin { FactoryGirl.create(:user, :roles => [roles(:viewer)]) }
+    @host.update_attribute(:hostgroup, FactoryGirl.create(:hostgroup))
+    as_user(user) do
+      get :index, {:search => "host.hostgroup = #{@host.hostgroup.name}"}
+    end
+    assert_response :success
+    fact_values   = ActiveSupport::JSON.decode(@response.body)
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
+    assert_equal expected_hash, fact_values
+  end
 end

--- a/test/functional/api/v2/fact_values_controller_test.rb
+++ b/test/functional/api/v2/fact_values_controller_test.rb
@@ -29,4 +29,16 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
     expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
     assert_equal expected_hash, fact_values
   end
+
+  test "should get facts as non-admin user with joined search" do
+    user = as_admin { FactoryGirl.create(:user, :roles => [roles(:viewer)]) }
+    @host.update_attribute(:hostgroup, FactoryGirl.create(:hostgroup))
+    as_user(user) do
+      get :index, {:search => "host.hostgroup = #{@host.hostgroup.name}"}
+    end
+    assert_response :success
+    fact_values   = ActiveSupport::JSON.decode(@response.body)['results']
+    expected_hash = FactValue.build_facts_hash(FactValue.where(:host_id => @host.id))
+    assert_equal expected_hash, fact_values
+  end
 end


### PR DESCRIPTION
When retrieving fact_values as a non-admin user, the my_facts scope
performs a join to the hosts table.  The .includes(:host) also performs
a join via eager loading, and when both are combined with a scoped
search on host.hostgroup (joined via hosts to hostgroups), the three
joins with table renaming cause errors.
