### PR TITLE
Fixes #12015 - Pin version of fog-google

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,5 +1,5 @@
 group :gce do
-  gem 'fog-google', '~> 0.0'
+  gem 'fog-google', '<= 0.1.0'
   gem 'google-api-client', '>= 0.7', '< 0.9', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
Pin version of fog-google since it no longer supports Ruby 1.9. as of 0.1.1.

https://github.com/fog/fog-google/pull/73

Waiting for discussion at https://github.com/fog/fog-google/pull/68 to see if they rollback the 2.0 requirement.
