### PR TITLE
Fixes #12015 - Pin version of fog-google - backport for foreman-1.9

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,5 +1,5 @@
 group :gce do
-  gem 'fog-google', '~> 0.0'
+  gem 'fog-google', '<= 0.1.0'
   gem 'google-api-client', '>= 0.7', '< 0.9', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
Pin version of fog-google since it no longer supports ruby 1.9

(cherry picked from commit 31752232dc7f1b55f9ea47260d26ad18f101c112)

Foreman_remote_execution is running CI against 1.9 stable: we need it to work again
