### PR TITLE
Refs #11813 - Use new engines listing syntax in Apipie initializer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,7 +125,7 @@ Foreman::Application.configure do |app|
 
   # Adds plugin assets to the application digests hash if a manifest file exists for a plugin
   config.after_initialize do
-    app.railties.engines.each do |engine|
+    ::Rails::Engine.subclasses.map(&:instance).each do |engine|
       [engine.root, app.root].each do |root_dir|
         manifest_path = File.join(root_dir, "public/assets/#{engine.engine_name}/manifest.yml")
 
@@ -142,7 +142,7 @@ Foreman::Application.configure do |app|
 
   # Serve plugin static assets if the application is configured to do so
   if config.serve_static_assets
-    app.railties.engines.each do |engine|
+    ::Rails::Engine.subclasses.map(&:instance).each do |engine|
       if File.exist?("#{engine.root}/public/assets")
         app.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
       end

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -45,7 +45,7 @@ if Apipie.configuration.use_cache
   cache_name = File.join(Apipie.configuration.cache_dir, Apipie.configuration.doc_base_url + '.json')
   if File.exist? cache_name
     target = max = File.mtime(cache_name)
-    roots = Rails.application.railties.engines.collect{ |e| e.root }
+    roots = ::Rails::Engine.subclasses.map(&:instance).collect{ |e| e.root }
     roots << Rails.root
     roots.each do |root|
       path = "#{root}/app/controllers/api"


### PR DESCRIPTION
I forgot to include this one in
https://github.com/theforeman/foreman/pull/2719 , luckily it will only
fail on Rails 4 if the apipie cache is loaded.
