### PR TITLE
Fixes #12059 - AuthSourceLdap allow_nil should be removed

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -27,7 +27,7 @@ class AuthSourceLdap < AuthSource
   include Encryptable
   encrypts :account_password
 
-  validates :host, :presence => true, :length => {:maximum => 60}, :allow_nil => true
+  validates :host, :presence => true, :length => {:maximum => 60}
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :presence => true, :if => Proc.new { |auth| auth.onthefly_register? }
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :length => {:maximum => 30}, :allow_nil => true
   validates :account_password, :length => {:maximum => 60}, :allow_nil => true


### PR DESCRIPTION
When we migrated to the new migration syntax, the clause
`validate_length_of :host` was wrongly translated. It contains a clause
`allow_nil` that allows it to be nil, but in Rails 3 the `:presence =>
true` clause takes precedence.

If you try to run `AuthSourceLdap.new(:host => nil)` it will fail as it
needs a host (correctly). This clause has to be removed so that Rails
4 doesn't allow to create `AuthSourceLdap` without a host, as
`:allow_nil` takes precedence in Rails 4.

This behavior is already tested in auth_source_ldap_test.rb line 18.
