### PR TITLE
Fixes #12068 - Prepend puppetclass or variable to lookup_key_id

### DIFF
--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -242,7 +242,8 @@ class PuppetClassImporter
   def add_new_parameter(env, klass, changed_params)
     changed_params["new"].map do |param_name, value|
       param = find_or_create_puppet_class_param klass, param_name, value
-      EnvironmentClass.create! :puppetclass_id => klass.id, :environment_id => env.id, :lookup_key_id => param.id
+      EnvironmentClass.create! :puppetclass_id => klass.id, :environment_id => env.id,
+        :puppetclass_lookup_key_id => param.id
     end
   end
 

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -40,7 +40,8 @@ class LookupKeyTest < ActiveSupport::TestCase
     as_admin do
       key   = PuppetclassLookupKey.create!(:key => "dns", :path => "domain\npuppetversion", :override=>true)
       value = LookupValue.create!(:value => "[1.2.3.4,2.3.4.5]", :match => "domain =  mydomain.net", :lookup_key => key)
-      EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:production), :lookup_key => key)
+      EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:production),
+                               :puppetclass_lookup_key => key)
     end
 
     key.reload
@@ -81,7 +82,8 @@ class LookupKeyTest < ActiveSupport::TestCase
       value2 = LookupValue.create!(:value => "v2", :match => "hostgroup=Unusual", :lookup_key => key)
 
       LookupValue.create!(:value => "v22", :match => "fqdn=#{@host2.fqdn}", :lookup_key => key)
-      EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:testing), :lookup_key => key)
+      EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:testing),
+                               :puppetclass_lookup_key => key)
       HostClass.create!(:host => @host1,:puppetclass=>puppetclass)
       HostClass.create!(:host => @host2,:puppetclass=>puppetclass)
       HostClass.create!(:host => @host3,:puppetclass=>puppetclass)


### PR DESCRIPTION
Parameters for some objects such as EnvironmentClass, are passed as
simply lookup_key_id. On Rails 3 parameters are not as strongly checked
and it works just fine.

On Rails 4 parameters will depend on the associations of the model.
This means we should specify what kind of lookup_key is it.
