### PR TITLE
Fixes #11972 - ignore specific interfaces via settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -175,6 +175,14 @@ class Setting < ActiveRecord::Base
     end
   end
 
+  def self.regexp_expand_wildcard_string(string)
+    "\\A#{Regexp.escape(string).gsub('\*', '.*')}\\Z"
+  end
+
+  def self.convert_array_to_regexp(array)
+    Regexp.new(array.map {|string| regexp_expand_wildcard_string(string) }.join('|'))
+  end
+
   private
 
   def self.create_existing(s, opts)

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -14,6 +14,7 @@ class Setting::Provisioning < Setting
         self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true, N_('Safemode rendering')),
         self.set('manage_puppetca', N_("Foreman will automate certificate signing upon provision of new host"), true, N_('Manage PuppetCA')),
         self.set('ignore_puppet_facts_for_provisioning', N_("Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"), false, N_('Ignore Puppet facts for provisioning')),
+        self.set('ignored_interface_identifiers', N_("Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*"), ['lo', 'usb*', 'vnet*', 'macvtap*'], N_('Ignore interfaces with matching identifier')),
         self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1", N_('Remote address')),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6, N_('Token duration')),

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -158,11 +158,16 @@ class FactParser
 
   # these interfaces are ignored when parsing interface facts
   def ignored_interfaces
-    /\A(lo(?!cal_area_connection)|usb|vnet|macvtap)/
+    @ignored_interfaces ||= Setting.convert_array_to_regexp(Setting[:ignored_interface_identifiers])
   end
 
   def remove_ignored(interfaces)
-    interfaces.clone.delete_if { |i| i.match(ignored_interfaces) }
+    interfaces.clone.delete_if do |identifier|
+      if (remove = identifier.match(ignored_interfaces))
+        logger.debug "skipping interface with identifier '#{identifier}' since it was matched by 'ignored_interface_identifiers' setting "
+      end
+      remove
+    end
   end
 
   def normalize_interfaces(interfaces)

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -271,3 +271,8 @@ attributes57:
   category: Setting::Provisioning
   default: "true"
   description: "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
+attributes58:
+  name: ignored_interface_identifiers
+  category: Setting::Provisioning
+  default: "['lo', 'usb*', 'vnet*', 'macvtap*']"
+  description: 'Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -54,7 +54,7 @@ class FactParserTest < ActiveSupport::TestCase
   end
 
   test "#interfaces gets facts hash for desired interfaces, keeping same values it gets from parser" do
-    parser.stub(:get_interfaces, ['eth1', 'lo', 'eth0', 'eth0.0', 'local', 'usb0', 'vnet0', 'br0', 'virbr0', 'Local_Area_Connection_2', 'macvtap0']) do
+    parser.stub(:get_interfaces, ['eth1', 'lo', 'eth0', 'eth0.0', 'usb0', 'vnet0', 'br0', 'virbr0', 'Local_Area_Connection_2', 'macvtap0']) do
       parser.expects(:get_facts_for_interface).with('eth1').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'custom' => 'value'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0.0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
@@ -63,7 +63,6 @@ class FactParserTest < ActiveSupport::TestCase
       parser.expects(:get_facts_for_interface).with('local_area_connection_2').returns({'link' => 'true', 'macaddress' => '00:00:00:00:de:ef'}.with_indifferent_access)
       result = parser.interfaces
       refute_includes result.keys, 'lo'
-      refute_includes result.keys, 'local'
       refute_includes result.keys, 'usb0'
       refute_includes result.keys, 'vnet0'
       refute_includes result.keys, 'macvtap0'

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -351,6 +351,23 @@ class SettingTest < ActiveSupport::TestCase
     assert_valid Setting.create!(:name => 'test_broken_cache', :description => 'foo', :default => 'default')
   end
 
+  test '.expand_wildcard_string wraps the regexp with \A and \Z' do
+    assert Setting.regexp_expand_wildcard_string('a').start_with? '\A'
+    assert Setting.regexp_expand_wildcard_string('a').end_with? '\Z'
+  end
+
+  test '.regexp_expand_wildcard_string converts all * to .*' do
+    assert_equal '\A.*a.*\Z', Setting.regexp_expand_wildcard_string('*a*')
+  end
+
+  test '.regexp_expand_wildcard_string escape other regexp characters, e.g. dot' do
+    assert_equal '\A.*\..*\Z', Setting.regexp_expand_wildcard_string('*.*')
+  end
+
+  test '.convert_array_to_regexp joins all strings with pipe and makes it regexp' do
+    assert_equal /\Aa.*\Z|\Ab.*\Z/, Setting.convert_array_to_regexp(['a*', 'b*'])
+  end
+
   private
 
   def check_parsed_value(settings_type, expected_value, string_value)


### PR DESCRIPTION
for reviewer - the `local` interface was just to test that we ignore all `\Alo.*` except local_area_network which does not make sense, if you e.g. name your bond to be `local_gateway`
