### PR TITLE
Fixes #12074: Pin rack-cache to less than 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.21'
+gem 'rack-cache', '< 1.3.0'
 gem 'json', '~> 1.5'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord', '3.0.0'


### PR DESCRIPTION
The 1.3.0 version of rack-cache requires Ruby 2.0 or greater.
