### PR TITLE
Fixes #8800 - Clip table cells only when needed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,7 +22,7 @@
 //= require underscore
 //= require editor
 
-$(document).on('ContentLoad', function(){onContentLoad()});
+$(document).on('ContentLoad', onContentLoad);
 Turbolinks.enableProgressBar();
 
 $(window).bind('beforeunload', function() {
@@ -79,6 +79,9 @@ function onContentLoad(){
   //set the tooltips
   $('a[rel="popover"]').popover();
   $('[rel="twipsy"]').tooltip({ container: 'body' });
+  $('.ellipsis').tooltip({ container: 'body',
+                           title: function(){return (this.scrollWidth > this.clientWidth) ? this.textContent : null;}
+                        });
   $('*[title]').not('*[rel]').tooltip();
   $('[data-table=inline]').not('.dataTable').dataTable(
       {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -259,6 +259,10 @@ table {
   }
 }
 
+.table-fixed {
+  table-layout: fixed;
+}
+
 /*table sorter bootstrap css*/
 .dataTables_length {
     label {
@@ -342,6 +346,7 @@ table {
 }
 
 .ellipsis {
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -4,7 +4,7 @@ module HostsAndHostgroupsHelper
   def model_name(host)
     name = host.try(:model)
     name = host.compute_resource.name if host.compute_resource
-    trunc_with_tooltip(name, 14)
+    name
   end
 
   def accessible_hostgroups

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -84,7 +84,7 @@ module HostsHelper
     tooltip = host.host_statuses.select(&:relevant?).sort_by(&:type).map { |status| "#{_(status.name)}: #{_(status.to_label)}" }.join(', ')
 
     content = content_tag(:span, "", {:rel => "twipsy", :class => style, :"data-original-title" => tooltip} )
-    content += link_to(trunc_with_tooltip("  #{host}"), host_path(host))
+    content += link_to("  #{host}", host_path(host))
     content
   end
 

--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -45,7 +45,7 @@ module OperatingsystemsHelper
   end
 
   def os_name(record, opts = {})
-    icon(record, opts).html_safe << trunc_with_tooltip(record.to_label)
+    icon(record, opts).html_safe << record.to_label
   end
 
   def os_habtm_family(type, obj)

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -1,23 +1,23 @@
 <% title _("Architectures") %>
 <% title_actions display_link_if_authorized(_("New Architecture"), hash_for_new_architecture_path), help_path %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Architecture|Name") %></th>
+      <th class="col-md-4"><%= sort :name, :as => s_("Architecture|Name") %></th>
       <th><%= _("Operating Systems") %></th>
-      <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
-      <th></th>
+      <th class="col-md-1"><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
   <% for architecture in @architectures %>
     <tr>
-      <td class='col-md-3 display-two-pane'><%= link_to_if_authorized(trunc_with_tooltip(architecture.name),
+      <td class='display-two-pane ellipsis'><%= link_to_if_authorized(architecture.name,
                                                      hash_for_edit_architecture_path(:id => architecture).merge(:auth_object => architecture, :authorizer => authorizer)) %></td>
-      <td><%=h architecture.operatingsystems.map(&:to_label).to_sentence %></td>
+      <td class="ellipsis"><%= architecture.operatingsystems.map(&:to_label).to_sentence %></td>
       <td><%= link_to architecture.hosts_count, hosts_path(:search => "architecture = #{architecture}") %>
-      <td align="right">
+      <td>
         <%= display_delete_if_authorized hash_for_architecture_path(:id => architecture).merge(:auth_object => architecture, :authorizer => authorizer),
           :data => { :confirm => _("Delete %s?") % architecture.name } %>
       </td>

--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -2,17 +2,17 @@
 
 <% title_actions display_link_if_authorized(_('New Compute Profile'), hash_for_new_compute_profile_path),
                  documentation_button('5.2.2UsingComputeProfiles') %>
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name %></th>
+      <th class="col-md-11"><%= sort :name %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% @compute_profiles.each do |compute_profile| %>
       <tr>
-        <td><%= link_to_if_authorized trunc_with_tooltip(compute_profile.name), hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer, :auth_action => 'edit') %></td>
+        <td class="ellipsis"><%= link_to_if_authorized compute_profile.name, hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer, :auth_action => 'edit') %></td>
         <td><%= action_buttons(
                   display_link_if_authorized(_('Edit'), hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer, :auth_action => 'edit')),
                   display_link_if_authorized(_('Rename'), hash_for_edit_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer)),

--- a/app/views/compute_resources/index.html.erb
+++ b/app/views/compute_resources/index.html.erb
@@ -2,19 +2,19 @@
 <% title_actions display_link_if_authorized(_("New Compute Resource"), hash_for_new_compute_resource_path),
                  documentation_button('5.2ComputeResources') %>
 
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("ComputeResource|Name") %></th>
-      <th><%= sort :type, :as => _("Type") %></th>
+      <th class="col-md-6"><%= sort :name, :as => s_("ComputeResource|Name") %></th>
+      <th class="col-md-5"><%= sort :type, :as => _("Type") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% @compute_resources.each do |compute| %>
       <tr>
-        <td><%= link_to compute.name, compute %></td>
-        <td><%= compute.provider_friendly_name %></td>
+        <td class="ellipsis"><%= link_to compute.name, compute %></td>
+        <td class="ellipsis"><%= compute.provider_friendly_name %></td>
         <td>
           <%= action_buttons(link_to_if_authorized(_('Edit'), hash_for_edit_compute_resource_path(compute).merge(:auth_object => compute, :authorizer => authorizer)),
                             display_delete_if_authorized(hash_for_compute_resource_path(:id => compute).merge(:auth_object => compute, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % compute.name })) %>

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -58,10 +58,10 @@
     </div>
   <% end %>
   <div id="compute_profiles" class="tab-pane">
-    <table class="table table-bordered table-striped table-two-pane">
+    <table class="table table-bordered table-striped table-two-pane table-fixed">
       <thead>
         <tr>
-          <th><%= _("Compute profile") %></th>
+          <th class="col-md-8"><%= _("Compute profile") %></th>
           <th><%= _("VM Attributes") %></th>
         </tr>
       </thead>
@@ -74,7 +74,7 @@
                             new_compute_profile_compute_resource_compute_attribute_path(compute_profile.to_param, @compute_resource.to_param)
                           end %>
           <tr>
-            <td><%= link_to(compute_profile.name, which_path, :class => compute_attribute.try(:id) ? '' : 'new_two_pane') %></td>
+            <td class="ellipsis"><%= link_to(compute_profile.name, which_path, :class => compute_attribute.try(:id) ? '' : 'new_two_pane') %></td>
             <td>
               <% set = @compute_resource.compute_attributes.where(:compute_profile_id => compute_profile.id).first %>
               <%= set ? set.name : content_tag(:span, _("unspecified"), :class => 'gray') %>

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -4,10 +4,10 @@
 
 <% title_actions display_link_if_authorized(_('New Config Group'), hash_for_new_config_group_path), help_path %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name %></th>
+      <th class="col-md-6"><%= sort :name %></th>
       <th><%= sort :config_group_classes_count, :as => _('Puppet classes'), :default => "DESC" %></th>
       <th><%= sort :hosts_count, :as => _('Hosts'), :default => "DESC" %></th>
       <th><%= sort :hostgroups_count, :as => _('Host groups'), :default => "DESC" %></th>
@@ -17,7 +17,7 @@
   <tbody>
     <% @config_groups.each do |config_group| %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(config_group.name), hash_for_edit_config_group_path(config_group).merge(:auth_object => config_group, :authorizer => authorizer) %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized config_group.name, hash_for_edit_config_group_path(config_group).merge(:auth_object => config_group, :authorizer => authorizer) %></td>
         <td><%= link_to config_group.config_group_classes_count, puppetclasses_path(:search => %Q{config_group = "#{config_group}"}) %></td>
         <td><%= link_to config_group.hosts_count, hosts_path(:search => %Q{config_group = "#{config_group}"}) %></td>
         <td><%= link_to config_group.hostgroups_count, hostgroups_path(:search => %Q{config_group = "#{config_group}"}) %></td>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -2,10 +2,10 @@
 
 <% title_actions display_link_if_authorized(_("New Domain"), hash_for_new_domain_path), help_path %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Domain|Fullname") %></th>
+      <th class="col-md-8"><%= sort :name, :as => s_("Domain|Fullname") %></th>
       <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
       <th></th>
     </tr>
@@ -13,7 +13,7 @@
   <tbody>
     <% for domain in @domains %>
     <tr>
-      <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer) %></td>
+      <td class="display-two-pane ellipsis"><%= link_to_if_authorized (domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer) %></td>
       <td><%= link_to domain.hosts_count, hosts_path(:search => "domain = #{domain}") %>
       <td><%= display_delete_if_authorized hash_for_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % domain.name } %></td>
       </tr>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -2,10 +2,10 @@
 
 <%= environments_title_actions %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_('Environment|Name') %></th>
+      <th class="col-md-8"><%= sort :name, :as => s_('Environment|Name') %></th>
       <th><%= sort :hosts_count, :as => _('Hosts'), :default => "DESC" %></th>
       <th></th>
     </tr>
@@ -13,8 +13,8 @@
   <tbody>
     <% @environments.each do |environment| %>
       <tr>
-        <td class="display-two-pane">
-          <%= link_to_if_authorized trunc_with_tooltip(environment.name), hash_for_edit_environment_path(:id => environment).merge(:auth_object => environment, :authorizer => authorizer) %>
+        <td class="display-two-pane ellipsis">
+          <%= link_to_if_authorized environment.name, hash_for_edit_environment_path(:id => environment).merge(:auth_object => environment, :authorizer => authorizer) %>
         </td>
         <td><%= link_to environment.hosts_count, hosts_path(:search => "environment = #{environment}") %></td>
         <td>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -1,15 +1,15 @@
 <%= javascript "jquery.cookie", "host_checkbox" %>
 <% title header ||= "" %>
-<table class="table table-bordered table-striped table-condensed" >
+<table class="table table-fixed table-bordered table-striped table-condensed" >
   <thead>
     <tr>
-      <th class="ca"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
-      <th class=''><%= sort :name, :as => _('Name') %></th>
-      <th class="hidden-xs"><%= sort :os, :as => _("Operating system") %></th>
-      <th class="hidden-xs"><%= sort :environment, :as => _('Environment') %></th>
-      <th class="hidden-tablet hidden-xs"><%= sort :model, :as => _('Model') %></th>
-      <th class="hidden-tablet hidden-xs"><%= sort :hostgroup, :as => _("Host group") %></th>
-      <th class="hidden-tablet hidden-xs"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
+      <th class="ca" width="40px"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
+      <th width="30%"><%= sort :name, :as => _('Name') %></th>
+      <th class="hidden-xs" width="12%"><%= sort :os, :as => _("Operating system") %></th>
+      <th class="hidden-xs" width="10%"><%= sort :environment, :as => _('Environment') %></th>
+      <th class="hidden-tablet hidden-xs" width="10%"><%= sort :model, :as => _('Model') %></th>
+      <th class="hidden-tablet hidden-xs" width="18%"><%= sort :hostgroup, :as => _("Host group") %></th>
+      <th class="hidden-tablet hidden-xs" width="10%"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
       <th></th>
     </tr>
   </thead>
@@ -19,13 +19,13 @@
         <td class="ca">
           <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' %>
         </td>
-        <td class='ellipsis'><%= name_column(host) %>
+        <td class="ellipsis"><%= name_column(host) %>
         </td>
-        <td class="hidden-xs"><%= (icon(host.operatingsystem, :size => "18x18") + trunc_with_tooltip(" #{host.operatingsystem.to_label}",14)).html_safe if host.operatingsystem %></td>
-        <td class="hidden-xs"><%= trunc_with_tooltip(host.try(:environment), 14) %></td>
+        <td class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "18x18") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
+        <td class="hidden-xs ellipsis"><%= host.environment %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= model_name host %></td>
-        <td class="hidden-tablet hidden-xs ellipsis"><%= label_with_link host.hostgroup, 26, @hostgroup_authorizer %></td>
-        <td class="hidden-tablet hidden-xs"><%= last_report_column(host) %></td>
+        <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 26, @hostgroup_authorizer %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
         <td>
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -4,23 +4,23 @@
                  documentation_button('4.4.2InstallationMedia'),
                  help_path %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Medium|Name") %></th>
-      <th><%= sort :path, :as => s_("Medium|Path") %></th>
-      <th><%= sort :family, :as => s_("Medium|Os family") %></th>
-      <th><%= _("Operating Systems") %></th>
+      <th class="col-md-2"><%= sort :name, :as => s_("Medium|Name") %></th>
+      <th class="col-md-6"><%= sort :path, :as => s_("Medium|Path") %></th>
+      <th class="col-md-1"><%= sort :family, :as => s_("Medium|Os family") %></th>
+      <th class="col-md-2"><%= _("Operating Systems") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for medium in @media %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(medium), hash_for_edit_medium_path(:id => medium).merge(:auth_object => medium, :authorizer => authorizer) %></td>
-        <td><%= medium.path %></td>
-        <td><%= lookup_family(medium.os_family) %></td>
-        <td><%= medium.operatingsystems.map(&:to_label).to_sentence %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized medium, hash_for_edit_medium_path(:id => medium).merge(:auth_object => medium, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= medium.path %></td>
+        <td class="ellipsis"><%= lookup_family(medium.os_family) %></td>
+        <td class="ellipsis"><%= medium.operatingsystems.map(&:to_label).to_sentence %></td>
         <td>
           <%= display_delete_if_authorized hash_for_medium_path(:id => medium).
             merge(:auth_object => medium, :authorizer => authorizer),

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -2,24 +2,24 @@
 
 <% title_actions display_link_if_authorized(_("New Model"), hash_for_new_model_path) %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Model|Name") %></th>
-      <th><%= sort :vendor_class, :as => _("Vendor class") %></th>
-      <th><%= sort :hardware_model, :as => s_("Model|Hardware model") %></th>
-      <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
+      <th class="col-md-4"><%= sort :name, :as => s_("Model|Name") %></th>
+      <th class="col-md-3"><%= sort :vendor_class, :as => _("Vendor class") %></th>
+      <th class="col-md-3"><%= sort :hardware_model, :as => s_("Model|Hardware model") %></th>
+      <th class="col-md-1"><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for model in @models %>
       <tr>
-        <td class="display-two-pane"><%=link_to_if_authorized trunc_with_tooltip(model.name), hash_for_edit_model_path(:id => model).merge(:auth_object => model, :authorizer => authorizer) %></td>
-        <td><%=h(model.vendor_class)%></td>
-        <td><%=h(model.hardware_model)%></td>
-        <td class="ra"><%= link_to model.hosts_count, hosts_path(:search => "model = \"#{model}\"") %></td>
-        <td class="ra">
+        <td class="display-two-pane ellipsis"><%=link_to_if_authorized model.name, hash_for_edit_model_path(:id => model).merge(:auth_object => model, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= model.vendor_class %></td>
+        <td class="ellipsis"><%= model.hardware_model %></td>
+        <td><%= link_to model.hosts_count, hosts_path(:search => "model = \"#{model}\"") %></td>
+        <td>
           <%= display_delete_if_authorized hash_for_model_path(:id => model).merge(:auth_object => model, :authorizer => authorizer),
                                            :confirm => _("Delete %s?") % model.name %>
         </td>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -2,10 +2,10 @@
 <% title_actions display_link_if_authorized(_("New Operating system"), hash_for_new_operatingsystem_path),
                  documentation_button('4.4.1OperatingSystems') %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :title, :as => s_("Operatingsystem|Name") %></th>
+      <th class="col-md-8"><%= sort :title, :as => s_("Operatingsystem|Name") %></th>
       <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
       <th></th>
     </tr>
@@ -13,9 +13,9 @@
   <tbody>
     <% for operatingsystem in @operatingsystems %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
-        <td class="ra"><%= link_to operatingsystem.hosts_count, hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
-        <td class="ra">
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
+        <td><%= link_to operatingsystem.hosts_count, hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
+        <td>
           <%= display_delete_if_authorized hash_for_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer),
             :data => { :confirm => _("Delete %s?") % operatingsystem.fullname } %>
         </td>

--- a/app/views/provisioning_templates/index.html.erb
+++ b/app/views/provisioning_templates/index.html.erb
@@ -7,26 +7,26 @@
                 documentation_button('4.4.3ProvisioningTemplates')
 %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("ProvisioningTemplate|Name") %></th>
-      <th><%= _("Host group / Environment") %></th>
-      <th><%= sort :kind, :as => _("Kind") %></th>
-      <th><%= sort :snippet, :as => s_("ProvisioningTemplate|Snippet") %></th>
-      <th><%= sort :locked, :as => s_("ProvisioningTemplate|Locked"), :default => "DESC" %></th>
-      <th></th>
+      <th class="col-md-3"><%= sort :name, :as => s_("ProvisioningTemplate|Name") %></th>
+      <th class="col-md-4"><%= _("Host group / Environment") %></th>
+      <th class="col-md-2"><%= sort :kind, :as => _("Kind") %></th>
+      <th class="col-md-1"><%= sort :snippet, :as => s_("ProvisioningTemplate|Snippet") %></th>
+      <th class="col-md-1"><%= sort :locked, :as => s_("ProvisioningTemplate|Locked"), :default => "DESC" %></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
     <% for provisioning_template in @templates %>
     <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(provisioning_template),
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized provisioning_template,
                                          hash_for_edit_provisioning_template_path(:id => provisioning_template.to_param).
                                          merge(:auth_object => provisioning_template, :authorizer => authorizer,
                                          :permission => 'edit_provisioning_templates') %>
         </td>
-        <td><%= combination provisioning_template %></td>
+        <td class="ellipsis"><%= combination provisioning_template %></td>
         <td><%= provisioning_template.try(:template_kind) %></td>
         <td align='center'><%= checked_icon provisioning_template.snippet %></td>
         <td align='center'><%= locked_icon provisioning_template.locked?, _("This template is locked for editing.") %>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -3,23 +3,23 @@
                  documentation_button('4.4.4PartitionTables'),
                  help_path %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Ptable|Name") %></th>
-      <th><%= sort :family, :as => s_("Ptable|Os family") %></th>
-      <th><%= _("Operating systems") %></th>
-      <th><%= sort :snippet, :as => s_("Ptable|Snippet") %></th>
-      <th><%= sort :locked, :as => s_("Ptable|Locked"), :default => "DESC" %></th>
-      <th></th>
+      <th class="col-md-4"><%= sort :name, :as => s_("Ptable|Name") %></th>
+      <th class="col-md-1"><%= sort :family, :as => s_("Ptable|Os family") %></th>
+      <th class="col-md-4"><%= _("Operating systems") %></th>
+      <th class="col-md-1"><%= sort :snippet, :as => s_("Ptable|Snippet") %></th>
+      <th class="col-md-1"><%= sort :locked, :as => s_("Ptable|Locked"), :default => "DESC" %></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
     <% for ptable in @templates %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(ptable), hash_for_edit_ptable_path(:id => ptable).merge(:auth_object => ptable, :authorizer => authorizer) %></td>
-        <td><%= lookup_family(ptable.os_family) %></td>
-        <td><%= ptable.operatingsystems.map(&:to_label).to_sentence %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized ptable, hash_for_edit_ptable_path(:id => ptable).merge(:auth_object => ptable, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= lookup_family(ptable.os_family) %></td>
+        <td class="ellipsis"><%= ptable.operatingsystems.map(&:to_label).to_sentence %></td>
         <td align='center'><%= checked_icon ptable.snippet %></td>
         <td align='center'>
           <%= locked_icon ptable.locked?, _("This template is locked for editing.") %>

--- a/app/views/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/puppetclass_lookup_keys/index.html.erb
@@ -1,20 +1,20 @@
 <%= javascript "lookup_keys" %>
 <% title _("Smart class parameters") %>
 <% title_actions documentation_button('4.2.5ParameterizedClasses') %>
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :key, :as => _("Parameter") %></th>
-      <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
+      <th class="col-md-5"><%= sort :key, :as => _("Parameter") %></th>
+      <th class="col-md-5"><%= sort :puppetclass, :as => _("Puppetclass") %></th>
       <th><%= sort :values_count, :as => _('Number of values'), :default => "DESC" %></th>
     </tr>
   </thead>
   <tbody>
     <% @lookup_keys.each do |lookup_key| %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(lookup_key.key), hash_for_edit_puppetclass_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'edit_external_variables', :authorizer => authorizer) %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized lookup_key.key, hash_for_edit_puppetclass_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'edit_external_variables', :authorizer => authorizer) %></td>
         <% puppet_class = lookup_key.param_class %>
-        <td><%= link_to_if_authorized trunc_with_tooltip(puppet_class), hash_for_edit_puppetclass_path(:id => puppet_class).merge(:auth_object => puppet_class, :authorizer => @puppetclass_authorizer) if puppet_class %></td>
+        <td class="ellipsis"><%= link_to_if_authorized puppet_class, hash_for_edit_puppetclass_path(:id => puppet_class).merge(:auth_object => puppet_class, :authorizer => @puppetclass_authorizer) if puppet_class %></td>
         <td><%=h lookup_key.lookup_values_count %></td>
       </tr>
     <% end %>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -3,28 +3,28 @@
 <% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path),
                  documentation_button('4.2.2Classes') %>
 
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Puppetclass|Name") %></th>
-      <th><%= sort :environment, :as => _("Environments and documentation") %></th>
-      <th><%= _('Host groups') %></th>
+      <th class="col-md-3"><%= sort :name, :as => s_("Puppetclass|Name") %></th>
+      <th class="col-md-3"><%= sort :environment, :as => _("Environments and documentation") %></th>
+      <th class="col-md-2"><%= _('Host groups') %></th>
       <th><%= sort :total_hosts, :as => _('Hosts'), :default => "DESC" %></th>
-      <th><%= sort :params_count, :as => _('Parameters'), :default => "DESC" %></th>
-      <th><%= sort :variables_count, :as => _('Variables'), :default => "DESC" %></th>
-      <th></th>
+      <th class="col-md-1"><%= sort :params_count, :as => _('Parameters'), :default => "DESC" %></th>
+      <th class="col-md-1"><%= sort :variables_count, :as => _('Variables'), :default => "DESC" %></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
     <% for puppetclass in @puppetclasses %>
       <tr>
-        <td><%=link_to_if_authorized trunc_with_tooltip(puppetclass.name), hash_for_edit_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer) %></td>
-        <td>
+        <td class="ellipsis"><%=link_to_if_authorized puppetclass.name, hash_for_edit_puppetclass_path(:id => puppetclass).merge(:auth_object => puppetclass, :authorizer => authorizer) %></td>
+        <td class="">
           <% puppetclass.environments.uniq.each do |environment| %>
             <%= link_to_function environment, 'show_rdoc(this)', :'data-url' => rdoc_classes_path(environment, puppetclass.name) %>
           <% end %>
         </td>
-        <td><%= puppetclass.all_hostgroups(false).map {|hg| link_to_if_authorized trunc_with_tooltip(hg), hash_for_edit_hostgroup_path(:id=>hg).merge(:auth_object => hg, :authorizer => @hostgroups_authorizer)}.to_sentence.html_safe %></td>
+        <td class=""><%= puppetclass.all_hostgroups(false).map {|hg| link_to_if_authorized trunc_with_tooltip(hg, 24), hash_for_edit_hostgroup_path(:id=>hg).merge(:auth_object => hg, :authorizer => @hostgroups_authorizer)}.to_sentence.html_safe %></td>
         <td> <%= link_to puppetclass.total_hosts, hosts_path(:search => "class = #{puppetclass.name}")%></td>
         <td><%= puppetclass.global_class_params_count %> </td>
         <td><%= puppetclass.variable_lookup_keys_count %> </td>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -2,10 +2,10 @@
 <% title_actions(display_link_if_authorized(_("New Realm"), hash_for_new_realm_path),
                  documentation_button('4.3.8Realm')) %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Realm|Name") %></th>
+      <th class="col-md-8"><%= sort :name, :as => s_("Realm|Name") %></th>
       <th><%= sort :hosts_count, :as => _("Hosts"), :default => 'DESC' %></th>
       <th></th>
     </tr>
@@ -13,7 +13,7 @@
   <tbody>
     <% for realm in @realms %>
     <tr>
-      <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(realm.name), hash_for_edit_realm_path(:id => realm)%></td>
+      <td class="display-two-pane ellipsis"><%= link_to_if_authorized realm.name, hash_for_edit_realm_path(:id => realm)%></td>
       <td><%= link_to realm.hosts_count, hosts_path(:search => "realm = #{realm}") %>
       <td><%= display_delete_if_authorized hash_for_realm_path(:id => realm), :data => { :confirm => _("Delete %s?") % realm.name } %></td>
       </tr>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -2,18 +2,18 @@
 <% title_actions link_to_if_authorized(_("New role"), hash_for_new_role_path),
                  documentation_button('4.1.2RolesandPermissions') %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Role|Name") %></th>
+      <th class="col-md-8"><%= sort :name, :as => s_("Role|Name") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for role in @roles %>
       <tr>
-        <td class="display-two-pane">
-          <%= content_tag(role.builtin? ? 'em' : 'span', role.builtin? ? role.name : link_to_if_authorized(trunc_with_tooltip(role.name), hash_for_edit_role_path(:id => role))) %>
+        <td class="display-two-pane ellipsis">
+          <%= content_tag(role.builtin? ? 'em' : 'span', role.builtin? ? role.name : link_to_if_authorized(role.name, hash_for_edit_role_path(:id => role))) %>
         </td>
         <td>
           <% links = [display_link_if_authorized(_('Filters'),    hash_for_filters_path(:role_id => role)),

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -3,21 +3,21 @@
 <% title_actions display_link_if_authorized(_("New Smart Proxy"), hash_for_new_smart_proxy_path),
                  documentation_button('4.3SmartProxies') %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= s_("SmartProxy|Name") %></th>
-      <th><%= s_("SmartProxy|Url") %></th>
-      <th><%= _("Features") %></th>
+      <th class="col-md-2"><%= s_("SmartProxy|Name") %></th>
+      <th class="col-md-5"><%= s_("SmartProxy|Url") %></th>
+      <th class="col-md-3"><%= _("Features") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for proxy in @smart_proxies %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(proxy.name), hash_for_edit_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer) %></td>
-        <td><%=h proxy.url %></td>
-        <td><%=h proxy.features.to_sentence %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized proxy.name, hash_for_edit_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= proxy.url %></td>
+        <td class="ellipsis"><%= proxy.features.to_sentence %></td>
         <td><%= action_buttons(*proxy_actions(proxy, authorizer)) %></td>
       </tr>
     <% end %>

--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -3,26 +3,26 @@
 <%= javascript 'subnets' %>
 <% title_actions display_link_if_authorized(_("New Subnet"), hash_for_new_subnet_path) %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :name, :as => s_("Subnet|Name") %></th>
-      <th><%= sort :network, :as => s_("Subnet|Network") %></th>
-      <th><%= _("Domains") %></th>
-      <th><%= sort :vlanid, :as => s_('Subnet|Vlanid') %></th>
-      <th><%= _("DHCP Proxy") %></th>
+      <th class="col-md-3"><%= sort :name, :as => s_("Subnet|Name") %></th>
+      <th class="col-md-2"><%= sort :network, :as => s_("Subnet|Network") %></th>
+      <th class="col-md-3"><%= _("Domains") %></th>
+      <th class="col-md-1"><%= sort :vlanid, :as => s_('Subnet|Vlanid') %></th>
+      <th class="col-md-2"><%= _("DHCP Proxy") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for subnet in @subnets %>
       <tr>
-        <td class="display-two-pane"><%=link_to_if_authorized trunc_with_tooltip(subnet.name), hash_for_edit_subnet_path(:id => subnet).merge(:auth_object => subnet, :authorizer => authorizer) %></td>
+        <td class="display-two-pane ellipsis"><%=link_to_if_authorized subnet.name, hash_for_edit_subnet_path(:id => subnet).merge(:auth_object => subnet, :authorizer => authorizer) %></td>
         <td><%=subnet.network_address %></td>
-        <td><%=subnet.domains.to_sentence %></td>
+        <td class="ellipsis"><%=subnet.domains.to_sentence %></td>
         <td><%=subnet.vlanid %></td>
-        <td><%=subnet.dhcp %></td>
-        <td align="right">
+        <td class="ellipsis"><%=subnet.dhcp %></td>
+        <td>
           <%= display_delete_if_authorized hash_for_subnet_path(:id => subnet).merge(:auth_object => subnet, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % subnet.name } %>
         </td>
       </tr>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -20,7 +20,7 @@
   </div>
 <% end %>
 
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped table-fixed">
   <thead>
     <tr>
       <th class='col-md-10'><%= _("Name") %></th>
@@ -30,7 +30,7 @@
   <tbody>
     <% @trends.each do |trend| %>
       <tr>
-        <td><%= link_to trend.to_label, trend_path(:id => trend), :title => _("Show Trends") %></td>
+        <td class="ellipsis"><%= link_to trend.to_label, trend_path(:id => trend), :title => _("Show Trends") %></td>
         <td>
           <%= action_buttons(
                   display_link_if_authorized(_("Edit"), hash_for_edit_trend_path(:id => trend)),

--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -3,21 +3,21 @@
 
 <% title_actions display_link_if_authorized(_("New User group"), hash_for_new_usergroup_path) %>
 
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= s_("Usergroup|Name") %></th>
-      <th><%= _("Users") %></th>
-      <th><%= _("User Groups") %></th>
+      <th class="col-md-4"><%= s_("Usergroup|Name") %></th>
+      <th class="col-md-4"><%= _("Users") %></th>
+      <th class="col-md-3"><%= _("User Groups") %></th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     <% for usergroup in @usergroups %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(usergroup.name), hash_for_edit_usergroup_path(:id => usergroup.id).merge(:auth_object => usergroup, :authorizer => authorizer) %></td>
-        <td><%= h usergroup.users.except_hidden.map(&:login).to_sentence %></td>
-        <td><%= h usergroup.usergroups.map(&:name).to_sentence %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized trunc_with_tooltip(usergroup.name), hash_for_edit_usergroup_path(:id => usergroup.id).merge(:auth_object => usergroup, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= usergroup.users.except_hidden.map(&:login).to_sentence %></td>
+        <td class="ellipsis"><%= usergroup.usergroups.map(&:name).to_sentence %></td>
         <td>
           <%= display_delete_if_authorized hash_for_usergroup_path(:id => usergroup).merge(:auth_object => usergroup, :authorizer => authorizer),
             :data => { :confirm => (_("Delete %s?") % usergroup.name) } %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <% title_actions  display_link_if_authorized(_("New User"), hash_for_new_user_path) %>
 
-<table class="table table-bordered table-striped table-condensed table-two-pane">
+<table class="table table-bordered table-striped table-condensed table-two-pane table-fixed">
   <thead>
     <tr>
       <th><%= sort :login, :as => s_("User|Login") %></th>
@@ -13,19 +13,19 @@
       <th><%= sort :admin, :as => s_("User|Admin") %></th>
       <th><%= sort :last_login_on, :as => s_("User|Last login on"), :default => 'DESC' %></th>
       <th><%= _("Authorized by") %></th>
-      <th></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
     <% for user in @users %>
       <tr>
-        <td class="display-two-pane"><%= avatar_image_tag user, :class => "avatar" %> <%=link_to_if_authorized trunc_with_tooltip(user.login), hash_for_edit_user_path(:id => user).merge(:auth_object => user, :authorizer => authorizer) %></td>
-        <td><%=h user.firstname %></td>
-        <td><%=h user.lastname %></td>
-        <td><%=h user.mail %></td>
-        <td><%=checked_icon user.admin? %></td>
-        <td><%=h last_login_on_column(user)%></td>
-        <td><%=h auth_source_column(user)%></td>
+        <td class="display-two-pane ellipsis"><%= avatar_image_tag user, :class => "avatar" %> <%=link_to_if_authorized user.login, hash_for_edit_user_path(:id => user).merge(:auth_object => user, :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= user.firstname %></td>
+        <td class="ellipsis"><%= user.lastname %></td>
+        <td class="ellipsis"><%= user.mail %></td>
+        <td><%= checked_icon user.admin? %></td>
+        <td class="ellipsis"><%= last_login_on_column(user)%></td>
+        <td class="ellipsis"><%= auth_source_column(user)%></td>
         <td><%= display_delete_if_authorized hash_for_user_path(:id => user).merge(:auth_object => user, :authorizer => authorizer),
           :data => { :confirm => _("Delete %s?") % user.name } %></td>
       </tr>

--- a/app/views/variable_lookup_keys/index.html.erb
+++ b/app/views/variable_lookup_keys/index.html.erb
@@ -1,20 +1,20 @@
 <%= javascript "lookup_keys" %>
 <% title _("Smart variables") %>
 <% title_actions documentation_button('4.2.4SmartVariables') %>
-<table class="table table-bordered table-striped table-two-pane">
+<table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th><%= sort :key, :as => _("Variable") %></th>
-      <th><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-      <th><%= sort :values_count, :as => _('Number of values'), :default => "DESC" %></th>
-      <th></th>
+      <th class="col-md-5"><%= sort :key, :as => _("Variable") %></th>
+      <th class="col-md-4"><%= sort :puppetclass, :as => _("Puppetclass") %></th>
+      <th class="col-md-2"><%= sort :values_count, :as => _('Number of values'), :default => "DESC" %></th>
+      <th class="col-md-1"></th>
     </tr>
   </thead>
   <tbody>
     <% @lookup_keys.each do |lookup_key| %>
       <tr>
-        <td class="display-two-pane"><%= link_to_if_authorized trunc_with_tooltip(lookup_key.key), hash_for_edit_variable_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'edit_external_variables', :authorizer => authorizer) %></td>
-        <td><%= link_to_if_authorized trunc_with_tooltip(lookup_key.puppetclass), hash_for_edit_puppetclass_path(:id => lookup_key.puppetclass).merge(:auth_object => lookup_key.puppetclass, :authorizer => @puppetclass_authorizer) %></td>
+        <td class="display-two-pane ellipsis"><%= link_to_if_authorized lookup_key.key, hash_for_edit_variable_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'edit_external_variables', :authorizer => authorizer) %></td>
+        <td class="ellipsis"><%= link_to_if_authorized lookup_key.puppetclass, hash_for_edit_puppetclass_path(:id => lookup_key.puppetclass).merge(:auth_object => lookup_key.puppetclass, :authorizer => @puppetclass_authorizer) %></td>
         <td><%=h lookup_key.lookup_values_count %></td>
         <td><%= display_delete_if_authorized hash_for_variable_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'destroy_external_variables', :authorizer => authorizer),
           :data => { :confirm => _("Delete %s?") % lookup_key.key } %></td>


### PR DESCRIPTION
For clipping to work, table must have class `table-fixed` and the cell have class `ellipsis`. Also column widths should be set in table head.
Clipping will occur automagically with tooltip.
