### PR TITLE
fixes #12080 - Validation of belongs_to should be for the object not its ID

### DIFF
--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -9,7 +9,7 @@ class ConfigGroupClass < ActiveRecord::Base
   belongs_to :puppetclass
   belongs_to :config_group, :counter_cache => true
 
-  validates :puppetclass_id, :presence => true
-  validates :config_group_id, :presence => true,
+  validates :puppetclass, :presence => true
+  validates :config_group, :presence => true,
                               :uniqueness => {:scope => :puppetclass_id}
 end

--- a/app/models/user_mail_notification.rb
+++ b/app/models/user_mail_notification.rb
@@ -4,7 +4,7 @@ class UserMailNotification < ActiveRecord::Base
   belongs_to :user
   belongs_to :mail_notification
 
-  validates :user_id, :presence => true
+  validates :user, :presence => true
   validates :mail_notification, :presence => true
 
   scope :daily, -> { where(:interval => 'Daily') }


### PR DESCRIPTION
in rails 4, when doing this: Foo.create(bar_attributes: whatever), and Bar has a presence validation on foo_id, that validation will fail because foo_id isn't set yet (it will be set once the Foo is created)

solution is to validate presence on foo instead of foo_id - as foo is indeed populated on the object initialisation process.
