### PR TITLE
fixes #12082 - moving modules outside setup blocks in orchestration test

### DIFF
--- a/test/unit/orchestration_test.rb
+++ b/test/unit/orchestration_test.rb
@@ -1,6 +1,29 @@
 require 'test_helper'
 
 class OrchestrationTest < ActiveSupport::TestCase
+
+  module Orchestration::TestModule
+    extend ActiveSupport::Concern
+
+    included do
+      register_rebuild(:rebuild_test, N_('TEST'))
+    end
+
+    def rebuild_test
+    end
+  end
+
+  module Orchestration::HostTest
+    extend ActiveSupport::Concern
+
+    included do
+      register_rebuild(:rebuild_host, N_('HOST'))
+    end
+
+    def rebuild_host
+    end
+  end
+
   def test_host_should_have_queue
     h = Host.new
     assert_respond_to h, :queue
@@ -66,16 +89,6 @@ class OrchestrationTest < ActiveSupport::TestCase
 
   context "when subscribing orchestration methods to nic" do
     setup do
-      module Orchestration::TestModule
-        extend ActiveSupport::Concern
-
-        included do
-          register_rebuild(:rebuild_test, N_('TEST'))
-        end
-
-        def rebuild_test
-        end
-      end
       @nic.class.send :include, Orchestration::TestModule
     end
 
@@ -91,16 +104,6 @@ class OrchestrationTest < ActiveSupport::TestCase
 
   context "when subscribing orchestration methods to host" do
     setup do
-      module Orchestration::HostTest
-        extend ActiveSupport::Concern
-
-        included do
-          register_rebuild(:rebuild_host, N_('HOST'))
-        end
-
-        def rebuild_host
-        end
-      end
       @host.class.send :include, Orchestration::HostTest
     end
 


### PR DESCRIPTION
in rails 4, setup is called more than once for some reason. that causes issues with the "included" block being called twice. solution is simple - move modules outside so they're evaluated once.
