### PR TITLE
Refs #12067 - Delegated method to_ip_address should be public

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -955,6 +955,22 @@ class Host::Managed < Host::Base
     result
   end
 
+  # converts a name into ip address using DNS.
+  # if we are managing DNS, we can query the correct DNS server
+  # otherwise, use normal systems dns settings to resolv
+  def to_ip_address(name_or_ip)
+    return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
+    if dns_ptr_record
+      lookup = dns_ptr_record.dns_lookup(name_or_ip)
+      return lookup.ip unless lookup.nil?
+    end
+    # fall back to normal dns resolution
+    domain.resolver.getaddress(name_or_ip).to_s
+  rescue => e
+    logger.warn "Unable to find IP address for '#{name_or_ip}': #{e}"
+    raise ::Foreman::WrappedException.new(e, N_("Unable to find IP address for '%s'"), name_or_ip)
+  end
+
   private
 
   # validate uniqueness can't prevent saving two interfaces that has same DNS name
@@ -1009,22 +1025,6 @@ class Host::Managed < Host::Base
       end
     end if environment
     status
-  end
-
-  # converts a name into ip address using DNS.
-  # if we are managing DNS, we can query the correct DNS server
-  # otherwise, use normal systems dns settings to resolv
-  def to_ip_address(name_or_ip)
-    return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
-    if dns_ptr_record
-      lookup = dns_ptr_record.dns_lookup(name_or_ip)
-      return lookup.ip unless lookup.nil?
-    end
-    # fall back to normal dns resolution
-    domain.resolver.getaddress(name_or_ip).to_s
-  rescue => e
-    logger.warn "Unable to find IP address for '#{name_or_ip}': #{e}"
-    raise ::Foreman::WrappedException.new(e, N_("Unable to find IP address for '%s'"), name_or_ip)
   end
 
   def set_default_user


### PR DESCRIPTION
Missed this one in 3b75c0a74e4e46d53d2203d05a0fffac386ded1f . It fails
on Rails 4 when called from Nic::Managed as it's delegated but not public.
