### PR TITLE
Fixes #12083 - Set domain to the most specific existing subdomain

### DIFF
--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -91,9 +91,9 @@ module Nic
       # no hostname was given or a domain was selected, since this is before validation we need to ignore
       # it and let the validations to produce an error
       return if name.empty?
-      if domain.nil? && name.match(/\./) && !changed_attributes['domain_id'].present?
+      if domain.nil? && name.include?('.') && !changed_attributes['domain_id'].present?
         # try to assign the domain automatically based on our existing domains from the host FQDN
-        self.domain = Domain.all.select{|d| name.match(/#{d.name}\Z/)}.first rescue nil
+        self.domain = Domain.find_by(:name => name.partition('.')[2])
       elsif persisted? && changed_attributes['domain_id'].present?
         # if we've just updated the domain name, strip off the old one
         old_domain = Domain.find(changed_attributes["domain_id"])


### PR DESCRIPTION
If there are domains that have subdomains, setting a host name that
contains the domain name will sometimes choose the wrong domain for
the host. This patch makes the host pick the most specific existing
domain automatically.
