### PR TITLE
fixes #12097 - compatible updates in user_test

### DIFF
--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -231,10 +231,11 @@ class UserTest < ActiveSupport::TestCase
   test "non-admin user can delegate roles he has assigned already" do
     setup_user "create"
     create_role          = Role.find_by_name 'create_users'
-    record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id,
-                                    :role_ids => [create_role.id.to_s]
+    record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id
     record.password_hash = "asd"
     assert record.valid?
+    assert record.save
+    record.role_ids = [create_role.id.to_s]
     assert record.save
     assert_not record.new_record?
   end
@@ -242,12 +243,13 @@ class UserTest < ActiveSupport::TestCase
   test "admin can set admin flag and set any role" do
     as_admin do
       extra_role           = Role.where(:name => "foobar").first_or_create
-      record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id,
-                                      :role_ids => [extra_role.id].map(&:to_s)
+      record               = User.new :login    => "dummy", :mail => "j@j.com", :auth_source_id => AuthSourceInternal.first.id
       record.password_hash = "asd"
       record.admin         = true
       assert record.save
       assert record.valid?
+      record.role_ids = [extra_role.id].map(&:to_s)
+      assert record.save
       assert_not record.new_record?
     end
   end


### PR DESCRIPTION
user_test - in real life we don't assign roles without a user existing, thus, in test we can assign after user created as well. UserRole presence validation on owner doesn't work in creation, as apparently polymorphic associations aren't populated on create, just after they're actually saved.
