### PR TITLE
Fixes #12098 - Dangling Fog.mock makes compute_resource_vms test fail

### DIFF
--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -20,6 +20,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
 
   test "password is saved encrypted when created" do
     Fog.mock!
+    teardown { Fog.unmock! }
     ComputeResource.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
     compute_resource = ComputeResource.new_provider(:name => "new12345", :provider => "EC2", :url => "eu-west-1",
                                                     :user => "username", :password => "abcdef")


### PR DESCRIPTION
test/unit/compute_resource_test.rb contains a Fog.mock! without a
Fog.unmock!. This causes
test/functional/compute_resource_vms_controller_test.rb to fail only
when ran through rake test on Rails 4. Fix is as simple as adding the
missing unmock!.
