### PR TITLE
Fixes #12099 - Template locked? relying on rake makes tests fail

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -13,6 +13,7 @@ module Foreman
   end
 
   def self.in_rake?(rake_task = nil)
+    return false if Rails.env.test?
     defined?(Rake) && Rake.application.top_level_tasks.any? do |running_rake_task|
       rake_task.nil? || running_rake_task.start_with?(rake_task)
     end


### PR DESCRIPTION
app/models/template.rb has a method locked? that relies on
!Foreman.in_rake? to bypass the locked validation when running some
operations through Rake such as migrations or cloning templates. On
Rails 4 rake test is also interpreted as being 'in rake' and tests fail
when running them through rake test but not when running template tests
individually.
