### PR TITLE
fixes #12109 -removing owner_id presence validation

### DIFF
--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -7,7 +7,7 @@ class HostClass < ActiveRecord::Base
   belongs_to_host
   belongs_to :puppetclass
 
-  validates :host_id, :presence => true
+  validates :host, :presence => true
   validates :puppetclass_id, :presence => true, :uniqueness => {:scope => :host_id}
 
   def name

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -22,8 +22,9 @@ class UserRole < ActiveRecord::Base
   has_many :cached_user_roles, :dependent => :destroy
 
   validates :role_id, :presence => true
-  validates :owner_id, :presence => true, :uniqueness => {:scope => [:role_id, :owner_type],
-                                                          :message => N_("has this role already")}
+  validates :owner_id, :uniqueness => {:scope => [:role_id, :owner_type],
+                                       :message => N_("has this role already")},
+                                       :unless => -> {owner.blank?}
 
   delegate :expire_topbar_cache, :to => :owner
 


### PR DESCRIPTION
in rails 4, owner is not populated when creating a join model
(user.roles << role created a UserRole on the background)
in rails 3, this is not a problem, in rails 4, the presence validation
fails because no owner_id exists nor does an owner exist. at that
moment, there’s no need to do the uniqueness validation, as it’s the
user’s first roles. thus, this fix.
