### PR TITLE
fixes #12118 - query model for alternative permission names

### DIFF
--- a/app/services/association_authorizer.rb
+++ b/app/services/association_authorizer.rb
@@ -1,20 +1,21 @@
 class AssociationAuthorizer
-  def self.authorized_associations(associations,  klass_name = nil, should_raise_exception = true)
+  def self.authorized_associations(associations,  klass_name = nil, should_raise_exception = true, action = 'view')
     if associations.included_modules.include?(Authorizable)
       associations_klass = associations
       if associations.respond_to?(:klass)
         associations_klass = associations.klass
       end
       klass_name ||= associations_klass
-      permission = view_permission_name(klass_name, should_raise_exception)
+      permission = permission_name(klass_name, action, should_raise_exception)
       associations.authorized(permission, associations_klass) if permission
     else
       associations
     end
   end
 
-  def self.view_permission_name(klass, should_raise_exception)
-    permission = "view_#{klass.to_s.underscore.pluralize}"
+  def self.permission_name(klass, permission, should_raise_exception)
+    suffix = klass.respond_to?(:permission_name) ? klass.permission_name : klass.to_s.underscore.pluralize
+    permission = "#{permission}_#{suffix}"
     if Permission.where(:name => permission).present?
       permission
     elsif should_raise_exception

--- a/test/unit/association_authorizer_test.rb
+++ b/test/unit/association_authorizer_test.rb
@@ -27,17 +27,30 @@ class AssociationAuthorizerTest < ActiveSupport::TestCase
 
   test "authorized_associations should raise unknown permission exception when should_raise_exception is true" do
     assert_raise(Foreman::Exception) do
-      AssociationAuthorizer.view_permission_name('non_existing_permission', true)
+      AssociationAuthorizer.permission_name('non_existing_permission', 'view', true)
     end
   end
 
   test "authorized_associations should return false for unknown permission when should_raise_exception is false" do
-    permission = AssociationAuthorizer.view_permission_name('non_existing_permission', false)
+    permission = AssociationAuthorizer.permission_name('non_existing_permission', 'view', false)
     assert_equal false, permission
   end
 
   test "authorized_associations should return permission if it exists" do
-    permission = AssociationAuthorizer.view_permission_name(:host, false)
+    permission = AssociationAuthorizer.permission_name(:host, 'view', false)
     assert_equal "view_hosts", permission
+  end
+
+  test "authorized_associations should use overridden permission name if class has one" do
+    FactoryGirl.create(:permission, :name => 'view_buildings')
+
+    class House
+      def self.permission_name
+        'buildings'
+      end
+    end
+
+    permission = AssociationAuthorizer.permission_name(House, 'view', false)
+    assert_equal 'view_buildings', permission
   end
 end


### PR DESCRIPTION
Any chance this could make 1.10? foreman_salt is currently broken.

The first solution was extensible by foreman_salt, but then removed in  08d4fc31447487181f59e7be54121fc681f3a5b4 and replaced with the service.  The service is certainly nicer, but not so easy to extend cleanly without something like this.
