### PR TITLE
Fixed #12119 - increased partition table limit to 20k

### DIFF
--- a/db/migrate/20151009082810_change_ptable_layout_limit.rb
+++ b/db/migrate/20151009082810_change_ptable_layout_limit.rb
@@ -1,0 +1,9 @@
+class ChangePtableLayoutLimit < ActiveRecord::Migration
+  def up
+    change_column :ptables, :layout, :string, :limit => 20000, :null => false
+  end
+
+  def down
+    change_column :ptables, :layout, :string, :limit => 4096, :null => false
+  end
+end


### PR DESCRIPTION
For some reason, we default to 4096. Or we can set to unlimited as well.
