### PR TITLE
fixes #12095 - prevent escaping of lookup key default value with ERB

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -109,6 +109,7 @@ class LookupKey < ActiveRecord::Base
   end
 
   def value_before_type_cast(val)
+    return val if val.nil? || contains_erb?(val)
     case key_type.to_sym
       when :json, :array
         begin


### PR DESCRIPTION
When the current default value is retrieved from a lookup key via
default_value_before_type_cast, do not re-dump values containing ERB as
they will not have been cast already.  This prevents them being escaped
again in the Puppet class edit form, and matches LookupValue behaviour.
