### PR TITLE
Fixes #12131 - long strings in reports are hard-wrapped

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -535,3 +535,14 @@ i.glyphicon.host-status {
 span.glyphicon.host-status {
   top: 3px;
 }
+
+.break-me {
+  white-space: -moz-pre-wrap; /* Mozilla */
+  white-space: -hp-pre-wrap; /* HP printers */
+  white-space: -o-pre-wrap; /* Opera 7 */
+  white-space: -pre-wrap; /* Opera 4-6 */
+  white-space: pre-wrap; /* CSS 2.1 */
+  white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */
+  word-wrap: break-word; /* IE */
+  word-break: break-all;
+}

--- a/app/views/reports/_metrics.html.erb
+++ b/app/views/reports/_metrics.html.erb
@@ -20,7 +20,7 @@
       <tbody>
         <% metrics.sort.each do |title, value|%>
           <tr>
-            <td>
+            <td class="break-me">
               <%= title %>
             </td>
             <td>

--- a/app/views/reports/_output.html.erb
+++ b/app/views/reports/_output.html.erb
@@ -10,8 +10,8 @@
     <% logs.each do |log| %>
       <tr>
         <td><span <%= report_tag log.level %>><%= h log.level %></span></td>
-        <td><%= h log.source %></td>
-        <td><%= h log.message %></td>
+        <td class="break-me"><%= h log.source %></td>
+        <td class="break-me"><%= h log.message %></td>
       </tr>
     <% end %>
     <tr id='ntsh' <%= "style='display: none;'".html_safe if logs.size > 0%>><td colspan="3">


### PR DESCRIPTION
I reproduced this with Salt (see the ticket), but I believe Puppet is able to
break this too.
