### PR TITLE
refs #12147 - fixing dhcp test to work properly with rails 4

### DIFF
--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -159,7 +159,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
       Nic::BMC.create! :host => h, :mac => "aa:aa:aa:ab:bd:bb", :ip => h.ip.succ, :domain => h.domain,
                        :subnet => h.subnet, :name => "bmc1-#{h}", :provider => 'IPMI'
     end
-    h.reload
+    h = Host.find(h.id)
     bmc = h.interfaces.bmc.first
     bmc.mac = next_mac(bmc.mac)
     assert h.valid?
@@ -176,7 +176,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     end
     h.reload
     h.mac = next_mac(h.mac)
-    bmc = h.interfaces.bmc.first
+    bmc = h.interfaces.bmc.first.reload
     assert !bmc.new_record?
     bmc.mac = next_mac(bmc.mac)
     assert h.valid?


### PR DESCRIPTION
In rails 4, the #reload method doesn't reset instance variables on the
reloaded instance, so we fetch it again as a new item. That said, the
reload method does work correctly for associations, just to be
consistent. Updated test to work for both rails 3 and 4.
