### PR TITLE
fixes #12151- Should return empty hash incase of missing environment

### DIFF
--- a/lib/proxy_api/puppet.rb
+++ b/lib/proxy_api/puppet.rb
@@ -22,7 +22,7 @@ module ProxyAPI
       pcs = parse(get "environments/#{env}/classes")
       Hash[pcs.map { |k| [k.keys.first, Foreman::ImporterPuppetclass.new(k.values.first)] }]
     rescue RestClient::ResourceNotFound
-      []
+      {}
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to get classes from Puppet for %s"), env)
     end

--- a/test/lib/proxy_api/puppet_test.rb
+++ b/test/lib/proxy_api/puppet_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ProxyApiPuppetTest < ActiveSupport::TestCase
+  def setup
+    @url = "http://localhost:8443"
+    @puppet = ProxyAPI::Puppet.new({:url => @url})
+  end
+
+  test "constructor should complete" do
+    @puppet.stubs(:get).raises(RestClient::ResourceNotFound, 'Resource Not Found')
+    response = @puppet.classes('production')
+    empty_hash = Hash.new
+    assert_equal(response, empty_hash)
+  end
+end

--- a/test/lib/proxy_api/puppet_test.rb
+++ b/test/lib/proxy_api/puppet_test.rb
@@ -9,7 +9,8 @@ class ProxyApiPuppetTest < ActiveSupport::TestCase
   test "should return empty hash incase of empty classes" do
     @puppet.stubs(:get).raises(RestClient::ResourceNotFound, 'Resource Not Found')
     response = @puppet.classes('production')
-    empty_hash = Hash.new
+    empty_hash = {}
     assert_equal(response, empty_hash)
   end
 end
+

--- a/test/lib/proxy_api/puppet_test.rb
+++ b/test/lib/proxy_api/puppet_test.rb
@@ -6,7 +6,7 @@ class ProxyApiPuppetTest < ActiveSupport::TestCase
     @puppet = ProxyAPI::Puppet.new({:url => @url})
   end
 
-  test "constructor should complete" do
+  test "should return empty hash incase of empty classes" do
     @puppet.stubs(:get).raises(RestClient::ResourceNotFound, 'Resource Not Found')
     response = @puppet.classes('production')
     empty_hash = Hash.new


### PR DESCRIPTION
When a puppet environment having no puppet class inside it and then try to  import from another environment. it throws below error 

undefined method `values' for []:Array
foreman/app/services/puppet_class_importer.rb:82

Crashing Url: https://foreman-server/environments/import_environments?env=production&proxy=some-proxy
