### PR TITLE
fixes #11965 - hostgroup with config group - clone should not run validations more than once

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -16,7 +16,6 @@ class Hostgroup < ActiveRecord::Base
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many :hostgroup_classes
   has_many :puppetclasses, :through => :hostgroup_classes, :dependent => :destroy
-  validates :name, :presence => true
   validates :root_pass, :allow_blank => true, :length => {:minimum => 8, :message => _('should be 8 characters or more')}
   has_many :group_parameters, :dependent => :destroy, :foreign_key => :reference_id, :inverse_of => :hostgroup
   accepts_nested_attributes_for :group_parameters, :allow_destroy => true
@@ -195,7 +194,7 @@ class Hostgroup < ActiveRecord::Base
 
   # Clone the hostgroup
   def clone(name = "")
-    new = self.deep_clone(:include => [:config_groups, :lookup_values, :hostgroup_classes, :locations, :organizations, :group_parameters],
+    new = self.deep_clone(:include => [:lookup_values, :hostgroup_classes, :locations, :organizations, :group_parameters],
                           :except => [:name, :title, :lookup_value_matcher])
     new.name = name
     new.title = name
@@ -203,6 +202,8 @@ class Hostgroup < ActiveRecord::Base
       lv.match = new.lookup_value_match
       lv.host_or_hostgroup = new
     end
+
+    new.config_groups = self.config_groups
     new
   end
 

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -426,6 +426,13 @@ class HostgroupTest < ActiveSupport::TestCase
       ActiveRecord::Base.any_instance.expects(:save).never
       group.clone
     end
+
+    test "clone with config group should run validations once" do
+      group = FactoryGirl.create(:hostgroup, :with_config_group)
+      cloned = group.clone
+      refute cloned.valid?
+      assert_equal 1, cloned.errors[:name].size
+    end
   end
 
   describe '#param_true?' do


### PR DESCRIPTION
oddly enough the config_group.hosts had the hostgroup inside it (which is rather funky), this caused a circular validation run. simplest solution is to remove it from the deep_clone method which is kind of like black magic IMHO, and do it manually.
