### PR TITLE
refs #12147 - factory updates for medium - rails4 compatibility

### DIFF
--- a/test/factories/medium.rb
+++ b/test/factories/medium.rb
@@ -4,22 +4,22 @@ FactoryGirl.define do
     sequence(:path) {|n| "http://www.example.com/path#{n}" }
 
     trait :coreos do
-      sequence(:name) {'CoreOS Mirror'}
+      sequence(:name) { |n| "CoreOS Mirror #{n}"}
       sequence(:path) {'http://$release.release.core-os.net'}
     end
 
     trait :ubuntu do
-      sequence(:name) {'Ubuntu Mirror'}
+      sequence(:name) { |n| "Ubuntu Mirror #{n}"}
       sequence(:path) {'http://archive.ubuntu.com/ubuntu'}
     end
 
     trait :debian do
-      sequence(:name) {'Debian Mirror'}
+      sequence(:name) { |n| "Debian Mirror #{n}"}
       sequence(:path) {'http://ftp.debian.org/debian'}
     end
 
     trait :suse do
-      sequence(:name) {'OpenSuse Mirror'}
+      sequence(:name) { |n| "OpenSuse Mirror #{n}"}
       sequence(:path) {'http://mirror.isoc.org.il/pub/opensuse/distribution/$major.$minor/repo/oss'}
     end
   end


### PR DESCRIPTION
in rails 4 the transactional fixtures don't play well with integration tests, thus, we want to make sure that no media steps over no other media's name.
