### PR TITLE
Refs #12147 - Remove trends output from tests

### DIFF
--- a/lib/tasks/trends.rake
+++ b/lib/tasks/trends.rake
@@ -32,6 +32,6 @@ namespace :trends do
 
     TrendCounter.unscoped.where(interval_start: nil).delete_all
 
-    puts "It took #{Time.now - start} seconds to complete"
+    puts "It took #{Time.now - start} seconds to complete" unless Rails.env.test?
   end
 end


### PR DESCRIPTION
Removes the rest of trends output from tests, since ad4db10 only removes
the first part.
