### PR TITLE
Refs #12155 - Use Proc instead of lambda on mailer for Rails 4

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 require 'uri'
 
 class ApplicationMailer < ActionMailer::Base
-  default :from => -> { Setting[:email_reply_address] || "noreply@foreman.example.org" }
+  default :from => Proc.new { Setting[:email_reply_address] || "noreply@foreman.example.org" }
 
   def mail(headers = {}, &block)
     if headers.present?


### PR DESCRIPTION
**Problem**
On Rails 3, using a lambda with no arguments works fine in an
ActionMailer default. However on Rails 4, the lambda will whine because
there is no handling of arguments and ActionMailer is trying to pass a
HostMailer.

**Solution**
Use Procs instead of lambda to allow it to work with and without arguments.

**How to reproduce the error**
Checkout https://github.com/eLobato/foreman/tree/rails4_from_scratch,
change the -> by ->(args) and put a debug breakpoint inside. Verify
ActionMailer is passed. On Rails 3 this is not the case.
