### PR TITLE
fixes #12207 - objects with ancestors should not call ancestors if cached

### DIFF
--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -34,7 +34,7 @@ module NestedAncestryCommon
   alias_method :get_label, :get_title
 
   def to_param
-    Parameterizable.parameterize("#{id}-#{get_title}")
+    Parameterizable.parameterize("#{id}-#{title}")
   end
 
   module ClassMethods

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -357,6 +357,20 @@ class HostgroupTest < ActiveSupport::TestCase
     assert_equal "#{hostgroup.id}-a-b",  hostgroup.to_param
   end
 
+  test "to_param calls ancestry when title is not yet saved" do
+    parent = FactoryGirl.create(:hostgroup, :name => 'a')
+    hostgroup = Hostgroup.new(:parent => parent, :name => 'b')
+    hostgroup.expects(:ancestry).once
+    hostgroup.to_param
+  end
+
+  test "to_param doesn't call ancestry when title is saved" do
+    parent = FactoryGirl.create(:hostgroup, :name => 'a')
+    hostgroup = Hostgroup.create(:parent => parent, :name => 'b')
+    hostgroup.expects(:ancestry).never
+    hostgroup.to_param
+  end
+
   context "#clone" do
     let(:group) {FactoryGirl.create(:hostgroup, :name => 'a')}
 


### PR DESCRIPTION
up until now, ancestry objects always called their ancestors when linking to the object because to_param called get_title instead of title (which can be cached)
this caused a LOT of pointless queries, slowed down Hosts#index alot.
