### PR TITLE
Fixes #11444 - Correctly count hosts in domain

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -8,7 +8,7 @@ class Domain < ActiveRecord::Base
   include StripLeadingAndTrailingDot
   include Parameterizable::ByIdName
 
-  audited :allow_mass_assignment => true, :except => [:hosts_count, :hostgroups_count]
+  audited :allow_mass_assignment => true, :except => [:total_hosts, :hostgroups_count]
 
   validates_lengths_from_database
   has_many :hostgroups
@@ -30,7 +30,7 @@ class Domain < ActiveRecord::Base
   validates :fullname, :uniqueness => true, :allow_blank => true, :allow_nil => true
 
   scoped_search :on => [:name, :fullname], :complete_value => true
-  scoped_search :on => :hosts_count
+  scoped_search :on => :total_hosts, :alias => 'hosts_count'
   scoped_search :on => :hostgroups_count
   scoped_search :in => :domain_parameters,    :on => :value, :on_key=> :name, :complete_value => true, :only_explicit => true, :rename => :params
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -50,17 +50,14 @@ module Nic
     scope :provision, -> { where(:provision => true) }
 
     belongs_to :subnet
-    belongs_to :domain, :counter_cache => 'hosts_count'
+    belongs_to :domain
 
     belongs_to_host :inverse_of => :interfaces, :class_name => "Host::Base"
-    # do counter cache only for primary interfaces
-    def belongs_to_counter_cache_after_create_for_domain
-      super if self.primary
-    end
 
-    def belongs_to_counter_cache_before_destroy_for_domain
-      super if self.primary
-    end
+    # We only want to update the counters for primary interfaces, don't use cached_counter
+    after_commit :update_domain_counters_on_create,  :on => :create
+    after_commit :update_domain_counters_on_update,  :on => :update
+    after_commit :update_domain_counters_on_destroy, :on => :destroy
 
     # keep extra attributes needed for sub classes.
     serialize :attrs, Hash
@@ -221,6 +218,35 @@ module Nic
 
     def mac_uniqueness
       interface_attribute_uniqueness(:mac, Nic::Base.physical.is_managed)
+    end
+
+    def update_domain_counters_on_create
+      return unless primary? && domain_id.present?
+      domain.increment!('total_hosts')
+    end
+
+    def update_domain_counters_on_update
+      primary_changed = previous_changes.include? 'primary'
+      domain_changed  = previous_changes.include? 'domain_id'
+      if primary_changed
+        if primary? #changed from non-primary to primary
+          domain.increment!('total_hosts') if domain_id.present?
+        else #changed from primary to non-primary
+          if domain_changed
+            Domain.unscoped.find(previous_changes['domain_id'][0]).decrement!('total_hosts') if previous_changes['domain_id'][0].present?
+          else
+            domain.decrement!('total_hosts') if domain_id.present?
+          end
+        end
+      elsif domain_changed && primary?
+        Domain.unscoped.find(previous_changes['domain_id'][0]).decrement!('total_hosts') if previous_changes['domain_id'][0].present?
+        domain.increment!('total_hosts') if domain_id.present?
+      end
+    end
+
+    def update_domain_counters_on_destroy
+      return unless primary? && domain_id.present?
+      domain.decrement!('total_hosts')
     end
 
     private

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -14,7 +14,7 @@
     <% for domain in @domains %>
     <tr>
       <td class="display-two-pane ellipsis"><%= link_to_if_authorized (domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer) %></td>
-      <td><%= link_to domain.hosts_count, hosts_path(:search => "domain = #{domain}") %>
+      <td><%= link_to domain.total_hosts, hosts_path(:search => "domain = #{domain}") %>
       <td><%= display_delete_if_authorized hash_for_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % domain.name } %></td>
       </tr>
     <% end %>

--- a/db/migrate/20151019174035_rename_domain_host_count.rb
+++ b/db/migrate/20151019174035_rename_domain_host_count.rb
@@ -1,0 +1,11 @@
+class RenameDomainHostCount < ActiveRecord::Migration
+  #prevent wierdness with rails treating hosts_count as cached counter in some cases
+  def up
+    rename_column :domains, :hosts_count, :total_hosts
+    Domain.all.each {|d| d.update_attribute('total_hosts', Nic::Base.primary.where(:domain_id => d.id).count)}
+  end
+
+  def down
+    rename_column :domains, :total_hosts, :hosts_count
+  end
+end

--- a/lib/tasks/fix_cached_counters.rake
+++ b/lib/tasks/fix_cached_counters.rake
@@ -1,10 +1,15 @@
 desc 'Fix cached counters by reseting them to the correct count, in case they got corrupted somehow'
 task :fix_cached_counters => :environment do
   puts "Correcting cached counters: (this may take a few minutes)"
-  [ Architecture, Environment, Operatingsystem, Domain, Realm].each do |cl|
+  [ Architecture, Environment, Operatingsystem, Realm].each do |cl|
     cl.unscoped.all.each{|el| cl.reset_counters(el.id, :hosts, :hostgroups)}
     puts "#{cl} corrected"
   end
+  Domain.all.each do |el|
+    Domain.reset_counters(el.id, :hostgroups)
+    el.update_attribute('total_hosts', Nic::Base.primary.where(:domain_id => el.id).count)
+  end
+  puts "Domains corrected"
   Puppetclass.all.each{|el| Puppetclass.reset_counters(el.id, :hostgroup_classes, :lookup_keys)}
   puts "Puppetclass corrected"
   Model.all.each{|el| Model.reset_counters(el.id, :hosts)}


### PR DESCRIPTION
Only hosts that have a primary nic assigned to a domain should be
counted in the domain host count. Previous implementation was flawed in
that it only updated the counter in certain occasions and not all,
leading sometimes to incorrect host counts.
I have implemented the counter updates in `after_commit` to reduce
chance of deadlocks.
