### PR TITLE
fixes #12215 - "`ruby_22` is not a valid platform"

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -13,5 +13,5 @@ group :test do
   gem 'factory_girl_rails', '~> 4.5', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.1'
   gem "poltergeist"
-  gem 'test-unit', :platforms => :ruby_22
+  gem 'test-unit' if RUBY_VERSION >= '2.2'
 end


### PR DESCRIPTION
Jenkins output:

```
17:38:21 /usr/bin/bundle package
17:38:21 `ruby_22` is not a valid platform. The available options are: [:ruby, :ruby_18,
17:38:21 :ruby_19, :ruby_20, :ruby_21, :mri, :mri_18, :mri_19, :mri_20, :mri_21, :rbx,
17:38:21 :jruby, :jruby_18, :jruby_19, :mswin, :mingw, :mingw_18, :mingw_19, :mingw_20,
17:38:21 :mingw_21, :x64_mingw, :x64_mingw_20, :x64_mingw_21]
17:38:21 debian/rules:11: recipe for target 'build/foreman' failed
```
