### PR TITLE
fixes #11124 - Interface compute attributes not merged from API request over compute profile

### DIFF
--- a/app/services/interface_merge.rb
+++ b/app/services/interface_merge.rb
@@ -20,7 +20,7 @@ class InterfaceMerge
   private
 
   def merge(nic, vm_nic, compute_attrs)
-    nic.compute_attributes = vm_nic
+    nic.compute_attributes = vm_nic.merge(nic.compute_attributes)
     nic.compute_attributes['from_profile'] = compute_attrs.compute_profile.name
     nic
   end

--- a/test/unit/interface_merge_test.rb
+++ b/test/unit/interface_merge_test.rb
@@ -46,6 +46,16 @@ class InterfaceMergeTest < ActiveSupport::TestCase
     assert_equal 'eth2', interfaces[2].identifier
   end
 
+  test "it does not overwrite compute attributes already set" do
+    interfaces = [
+      FactoryGirl.build(:nic_managed, :identifier => 'eth0', :compute_attributes => {'attr' => 9}),
+    ]
+    @merge.run(interfaces, @attributes)
+
+    assert_equal expected_attrs(9), interfaces[0].compute_attributes
+    assert_equal 'eth0', interfaces[0].identifier
+  end
+
   test "it creates NICs when there aren't any" do
     interfaces = []
     @merge.run(interfaces, @attributes)


### PR DESCRIPTION
Nic's compute_attributes are always overwritten by the ones coming from the compute profile.

Before the change (with some logger.debug):

```
2015-10-20 10:14:43 [app] [D] Before api merge_interfaces: [#<Nic::Managed id: nil, mac: nil, ip: nil, type: "Nic::Managed", name: "tst-tiproe-01", host_id: nil, subnet_id: 51, domain_id: 10, attrs: {}, created_at: nil, updated_at: nil, provider: nil, username: nil, password: nil, virtual: false, link: true, identifier: nil, tag: "", attached_to: "", managed: true, mode: "balance-rr", attached_devices: "", bond_options: "", primary: true, provision: true, compute_attributes: {"network"=>"dvportgroup-565867", "type"=>"VirtualVmxnet3", "_destroy"=>"0"}>]
2015-10-20 10:14:43 [app] [D] After api merge_interfaces: [#<Nic::Managed id: nil, mac: nil, ip: nil, type: "Nic::Managed", name: "tst-tiproe-01", host_id: nil, subnet_id: 51, domain_id: 10, attrs: {}, created_at: nil, updated_at: nil, provider: nil, username: nil, password: nil, virtual: false, link: true, identifier: nil, tag: "", attached_to: "", managed: true, mode: "balance-rr", attached_devices: "", bond_options: "", primary: true, provision: true, compute_attributes: {"type"=>"VirtualE1000", "network"=>"LX-LAN-VLAN-709", "from_profile"=>"1CPU-1GB-50GB"}>]
```

Not the compute_attributes getting overridden here.

After the change (expected behaviour):

```
2015-10-20 10:32:07 [app] [D] Before api merge_interfaces: [#<Nic::Managed id: nil, mac: nil, ip: nil, type: "Nic::Managed", name: "tst-tiproe-01", host_id: nil, subnet_id: 51, domain_id: 10, attrs: {}, created_at: nil, updated_at: nil, provider: nil, username: nil, password: nil, virtual: false, link: true, identifier: nil, tag: "", attached_to: "", managed: true, mode: "balance-rr", attached_devices: "", bond_options: "", primary: true, provision: true, compute_attributes: {"network"=>"dvportgroup-565867", "type"=>"VirtualVmxnet3", "_destroy"=>"0"}>]
2015-10-20 10:32:07 [app] [D] After api merge_interfaces: [#<Nic::Managed id: nil, mac: nil, ip: nil, type: "Nic::Managed", name: "tst-tiproe-01", host_id: nil, subnet_id: 51, domain_id: 10, attrs: {}, created_at: nil, updated_at: nil, provider: nil, username: nil, password: nil, virtual: false, link: true, identifier: nil, tag: "", attached_to: "", managed: true, mode: "balance-rr", attached_devices: "", bond_options: "", primary: true, provision: true, compute_attributes: {"type"=>"VirtualVmxnet3", "network"=>"dvportgroup-565867", "_destroy"=>"0", "from_profile"=>"1CPU-1GB-50GB"}>]
```
