### PR TITLE
refs #12147 - task#as_json should return hash

### DIFF
--- a/app/services/orchestration/task.rb
+++ b/app/services/orchestration/task.rb
@@ -24,7 +24,7 @@ module Orchestration
     end
 
     def as_json(options = {})
-      super :only => [:name, :timestamp, :status]
+      { :name => name, :timestamp => timestamp, :status => status, :priority => priority }
     end
 
     private


### PR DESCRIPTION
ActiveSupport 4 does not add the as_json method on all objects, thus,
this doesn't work on rails 4, for compatibility we use same syntax in
rails 3.
