### PR TITLE
refs #12147 - correcting route for unattended controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,7 +387,7 @@ Foreman::Application.routes.draw do
   get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'provision', :format => 'html',
     :constraints => { :metadata => /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
   # get for all unattended scripts
-  get 'unattended/(:action/(:id(.format)))', :controller => 'unattended'
+  get 'unattended/(:action/(:id(:format)))', :controller => 'unattended'
 
   resources :tasks, :only => [:show]
 


### PR DESCRIPTION
this is actually a bug in 3 as well, as format is never sent this way, but the routes ignore the .format, and in 4 they add it and don't treat it as a parameter.
