### PR TITLE
refs #12147 - adding safety guards to method_missing on compute attributes

### DIFF
--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -12,6 +12,8 @@ class ComputeAttribute < ActiveRecord::Base
   before_save :update_name
 
   def method_missing(method, *args, &block)
+    return super if method.to_s[-1]=="="
+    return super unless respond_to?(:vm_attrs)
     return vm_attrs["#{method}"] if vm_attrs.keys.include?(method.to_s)
     raise Foreman::Exception.new(N_('%s is an unknown attribute'), method)
   end


### PR DESCRIPTION
There's no need to pass to vm_atts when the method is a setter, also,
there's no need to pass if vm_attrs is blank. Those safety guards are
required in rails4, and compatible with 3.
