### PR TITLE
fixes #11345 - API GET request available_clusters sends empty hash

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -82,7 +82,7 @@ module Foreman::Model
     end
 
     def available_clusters
-      clusters
+      name_sort(dc.clusters)
     end
 
     def available_folders

--- a/app/views/api/v2/compute_resources/available_clusters.rabl
+++ b/app/views/api/v2/compute_resources/available_clusters.rabl
@@ -1,3 +1,3 @@
 collection @available_clusters
 
-attribute :name, :id
+attribute :name, :id, :full_path


### PR DESCRIPTION
This bug causes the api request "available_clusters" to return an array of strings instead of an array of hashes. This cannot be parsed by the rabl template causing the api to be broken.

Before:

```
"results": [{ }]
```

After:

```
  "results": [{"name":"TestCluster","id":"domain-c110903","full_path":"TestCluster"}]
```
