### PR TITLE
Refs #12089 - tests for config templates controller param wrapping

### DIFF
--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -37,6 +37,20 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "should update associated operating systems with unwrapped parameters" do
+    tpl = templates(:pxekickstart)
+    os = operatingsystems(:solaris10)
+    refute tpl.operatingsystem_ids.include?(os.id), "OS can't be associated to the config template before the test"
+
+    ProvisioningTemplate.any_instance.stubs(:valid?).returns(true)
+    put :update, { :id => tpl.to_param,
+                   :operatingsystem_ids => [os.to_param] }
+    assert_response :ok
+
+    tpl.reload
+    assert tpl.operatingsystem_ids.include?(os.id), "OS was not assigned to the config template"
+  end
+
   test "should not update invalid" do
     put :update, { :id              => templates(:pxekickstart).to_param,
                    :config_template => { :name => "" } }


### PR DESCRIPTION
Issue http://projects.theforeman.org/issues/12089 is actually fixed in current develop and the patch for the issue goes to 1.9-stable branch only (in https://github.com/theforeman/foreman/pull/2851).

I'm adding only the tests as a watchdog for regressions. See discussion below the redmine issue for more details.
