### PR TITLE
Fixes #10649 - Adds Test email button to user's mail preferences

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -29,3 +29,26 @@ function get_select_values(select) {
 
   return result;
 }
+
+function test_mail(item, id, url) {
+  $(item).addClass("disabled");
+  $('#test_indicator').show();
+  var email = $("#user_mail").val();
+  var param = {user_email: email};
+  $.ajax({
+    url: url,
+    type: 'put',
+    data: param,
+    success: function(result, textstatus, xhr) {
+      notify("<p>" + result.message + "</p>", 'success');
+    },
+    error: function (xhr) {
+      var error = $.parseJSON(xhr.responseText).message;
+      notify("<p>" + error + "</p>", 'error');
+    },
+    complete: function (result) {
+      $('#test_indicator').hide();
+      $(item).removeClass("disabled");
+    }
+  })
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -113,6 +113,18 @@ class UsersController < ApplicationController
     render :extlogout, :layout => 'login'
   end
 
+  def test_mail
+    begin
+      render :json => {:message => _("Email address was not found")}, :status => :unprocessable_entity and return if params[:user_email].blank?
+      user = find_resource(:edit_users)
+      MailNotification[:tester].deliver(:user => user, :email => params[:user_email])
+    rescue => e
+      Foreman::Logging.exception("Unable to send email", e)
+      render :json => {:message => _("Unable to send email, check server logs for more information")}, :status => :unprocessable_entity and return
+    end
+    render :json => {:message => _("Email was sent successfully")}, :status => :ok
+  end
+
   private
 
   def find_resource(permission = :view_users)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,4 +9,12 @@ class UserMailer < ApplicationMailer
       mail(:to => user.mail, :subject => _("Welcome to Foreman"))
     end
   end
+
+  def tester(options = {})
+    user = options[:user]
+
+    set_locale_for(user) do
+      mail(:to => options[:email], :subject => _("Foreman test email"))
+    end
+  end
 end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -682,7 +682,7 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :users do |map|
-    ajax_actions = [:auth_source_selected]
+    ajax_actions = [:auth_source_selected, :test_mail]
 
     map.permission :view_users,
                    :users => [:index, :show, :auto_complete_search],

--- a/app/views/user_mailer/tester.html.erb
+++ b/app/views/user_mailer/tester.html.erb
@@ -1,0 +1,4 @@
+<body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
+<h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> test email").html_safe %></h2>
+<h4><%= _("This is a test message to confirm that Foreman's email configuration is working.") %></h4>
+</body>

--- a/app/views/user_mailer/tester.text.erb
+++ b/app/views/user_mailer/tester.text.erb
@@ -1,0 +1,3 @@
+<%= _("Foreman test email") %>
+=================================
+<%= _("This is a test message to confirm that Foreman's email configuration is working.") %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -48,7 +48,12 @@
       </br>
       <%= field_set_tag _("General") do %>
         <%= checkbox_f f, :mail_enabled %>
+        <div class='col-md-4'>
+            <%= link_to_function(_("Test email"), "test_mail(this, '#{f.object.id}', '#{test_mail_user_url(f.object)}')",
+                                                :title => _("Send a test message to the user's email address to confirm the configuration is working."), :id => "test_mail_button", :class =>"btn btn-success") + image_tag('/assets/spinner.gif', :id => 'test_indicator', :class => 'hide').html_safe if action_name == "edit" %>
+        </div>
       <% end %>
+      </br>
       <% if @user.new_record? %>
         <div class="alert alert-block alert-warning">
           <p><strong><%= _("Notice") %></strong> <%= _("Please save the user first before assigning email notifications.") %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,6 +254,8 @@ Foreman::Application.routes.draw do
       end
     end
 
+    put 'users/(:id)/test_mail', :to => 'users#test_mail', :as => 'test_mail_user'
+
     resources :external_usergroups, :except => [:index, :new, :create, :show, :edit, :update, :destroy] do
       member do
         put 'refresh'

--- a/db/seeds.d/16-mail_notifications.rb
+++ b/db/seeds.d/16-mail_notifications.rb
@@ -42,6 +42,14 @@ notifications = [
    :mailer             => 'HostMailer',
    :method             => 'host_built',
    :subscription_type  => 'alert'
+  },
+
+  {
+    :name               => :tester,
+    :description        => N_('A test message to check the email configuration is working'),
+    :mailer             => 'UserMailer',
+    :method             => 'tester',
+    :subscription_type  => false
   }
 ]
 

--- a/test/fixtures/mail_notifications.yml
+++ b/test/fixtures/mail_notifications.yml
@@ -26,3 +26,10 @@ host_built:
   mailer: HostMailer
   method: host_built
   subscription_type: alert
+
+tester:
+    name: tester
+    description: Test email configurations
+    mailer: UserMailer
+    method: tester
+    subscriptable: false


### PR DESCRIPTION
When clicked, a test mail deliverd to the user's email, and if it failed, an error details will pop
![test_mail](https://cloud.githubusercontent.com/assets/11807069/10635062/a8a9cd28-77fe-11e5-9bf6-5543849d1e00.png)
