### PR TITLE
Fixes #12311 - Fix issue with failed initialization of rack openid middleware.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -151,6 +151,16 @@ module Foreman
     # enables JSONP support in the Rack middleware
     config.middleware.use Rack::JSONP if SETTINGS[:support_jsonp]
 
+    # Enable Rack OpenID middleware
+    begin
+      require 'rack/openid'
+      require 'openid/store/filesystem'
+      openid_store_path = Pathname.new(Rails.root).join('db').join('openid-store')
+      config.middleware.use Rack::OpenID, OpenID::Store::Filesystem.new(openid_store_path)
+    rescue LoadError
+      nil
+    end
+
     # Enable the asset pipeline
     config.assets.enabled = true
 

--- a/config/initializers/rack_openid.rb
+++ b/config/initializers/rack_openid.rb
@@ -1,8 +1,0 @@
-begin
-  require 'rack/openid'
-  require 'openid/store/filesystem'
-  openid_store_path = Pathname.new(Rails.root).join('db').join('openid-store')
-  Rails.configuration.middleware.use Rack::OpenID, OpenID::Store::Filesystem.new(openid_store_path)
-rescue LoadError
-  nil
-end


### PR DESCRIPTION
This fix is for rails4 but is backwards compatible with rails3

When placed in a rails initializer the rack middleware fails to
load, throwing a can't modify frozen array error. Moving the
initialization to the application config resolves this issue.
