### PR TITLE
Refs #12089 - Revert fix using unwrapped parameters in config templates API controller

### DIFF
--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V2
     class ConfigTemplatesController < V2::BaseController
-      wrap_parameters :config_template
-
       include Api::Version2
       include Api::TaxonomyScope
       include Foreman::Renderer


### PR DESCRIPTION
This is already fixed in develop, and wrap_params is not needed. It
won't harm but it's basically dead code. The original commit was merged
by mistake into develop, it was supposed to be merged to 1.9-stable
only.

This reverts commit 7a3a1052eeddd984988f288b1b67a7a8adb7359e.
