### PR TITLE
Fixes #12279 - add default order to roles

### DIFF
--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -9,6 +9,7 @@ module Api
       param :per_page, String, :desc => "number of entries per request"
 
       def index
+        params[:order] ||= 'name'
         @roles = Role.search_for(*search_options).paginate(paginate_options)
       end
 

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -8,6 +8,7 @@ module Api
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
+        params[:order] ||= 'name'
         @roles = resource_scope_for_index
       end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -20,6 +20,7 @@ class RolesController < ApplicationController
   before_filter :find_resource, :only => [:clone, :edit, :update, :destroy]
 
   def index
+    params[:order] ||= 'name'
     @roles = Role.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -35,6 +35,7 @@ class Role < ActiveRecord::Base
   }
 
   validates_lengths_from_database
+
   before_destroy :check_deletable
 
   has_many :user_roles, :dependent => :destroy

--- a/test/functional/api/v1/roles_controller_test.rb
+++ b/test/functional/api/v1/roles_controller_test.rb
@@ -9,6 +9,7 @@ class Api::V1::RolesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:roles)
     roles = ActiveSupport::JSON.decode(@response.body)
     assert !roles.empty?
+    assert_equal Role.order(:name).pluck(:name), roles.map { |r| r['role']['name'] }
   end
 
   test "should show individual record" do

--- a/test/functional/api/v2/roles_controller_test.rb
+++ b/test/functional/api/v2/roles_controller_test.rb
@@ -9,6 +9,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:roles)
     roles = ActiveSupport::JSON.decode(@response.body)
     assert !roles.empty?
+    assert_equal Role.order(:name).pluck(:name), roles['results'].map { |r| r['name'] }
   end
 
   test "should show individual record" do

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -24,7 +24,7 @@ class RolesControllerTest < ActionController::TestCase
     assert_template 'index'
 
     assert_not_nil assigns(:roles)
-    assert_equal Role.all.sort, [assigns(:roles)].flatten.sort
+    assert_equal Role.order(:name).all, assigns(:roles)
 
     assert_tag :tag => 'a', :attributes => { :href => '/roles/1-Manager/edit' },
       :content => 'Manager'


### PR DESCRIPTION
Sorry for another default scope, the reason is that I wanted to keep it consistent with other models rather then adding `params[:order] ||= 'name'` in UI and API controllers.
