### PR TITLE
Update gem file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # foreman plugins import this file therefore __FILE__ cannot be used
+require 'yaml'
 FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
-require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
+require File.expand_path('..', FOREMAN_GEMFILE)
 
 source 'https://rubygems.org'
 


### PR DESCRIPTION
# redmine_number #11059

Delete lib/regexp_extensions.rb is obsolete, it was put in for ruby_parser 2.x, but for some time now we've been on ruby_parser 3.x. It can be deleted and not loaded from Gemfile. So I removed them from gemfile
