### PR TITLE
Fixes #12344 - Use Rails 4 update_all syntax in migrations

### DIFF
--- a/db/migrate/20150728122736_change_report_permissions.rb
+++ b/db/migrate/20150728122736_change_report_permissions.rb
@@ -3,22 +3,22 @@ class ChangeReportPermissions < ActiveRecord::Migration
   def up
     old_name = 'Report'
     new_name = 'ConfigReport'
-    Permission.update_all("resource_type = '#{new_name}'", "resource_type = '#{old_name}'")
+    Permission.where(:resource_type => new_name).update_all(:resource_type => old_name)
     PERMISSIONS.each do |from|
       to = from.sub('reports', 'config_reports')
       say "renaming permission #{from} to #{to}"
-      Permission.update_all("name = '#{to}'", "name = '#{from}'")
+      Permission.where(:name => to).update_all(:name => from)
     end
   end
 
   def down
     old_name = 'ConfigReport'
     new_name = 'Report'
-    Permission.update_all("resource_type = '#{new_name}'", "resource_type = '#{old_name}'")
+    Permission.where(:resource_type => new_name).update_all(:resource_type => old_name)
     PERMISSIONS.each do |from|
       to = from.sub('config_reports', 'reports')
       say "renaming permission #{from} to #{to}"
-      Permission.update_all("name = '#{to}'", "name = '#{from}'")
+      Permission.where(:name => to).update_all(:name => from)
     end
   end
 end


### PR DESCRIPTION
**Problem**
Rails 3 syntax allows `update_all(old,new)`, however on Rails 4 the only
way to accomplish that is `where(old).update_all(new)`. Reports STI
contains a migration with this.

**Solution**
Change the migration to use the `where(old).update_all(new)` syntax
