### PR TITLE
fixes #12345 - fix sparc host creation

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -98,7 +98,7 @@ module Orchestration::DHCP
     if provision?
       dhcp_attr.merge!({:filename => operatingsystem.boot_filename(self), :nextServer => boot_server})
       if jumpstart?
-        jumpstart_arguments = os.jumpstart_params self, model.vendor_class
+        jumpstart_arguments = os.jumpstart_params self.host, model.vendor_class
         dhcp_attr.merge! jumpstart_arguments unless jumpstart_arguments.empty?
       end
     end

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -57,7 +57,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     h = FactoryGirl.build(:host, :with_dhcp_orchestration,
                           :model => FactoryGirl.create(:model, :vendor_class => 'Sun-Fire-V210'))
     h.expects(:jumpstart?).at_least_once.returns(true)
-    h.os.expects(:jumpstart_params).at_least_once.with(h.provision_interface, h.model.vendor_class).returns(:vendor => '<Sun-Fire-V210>')
+    h.os.expects(:jumpstart_params).at_least_once.with(h, h.model.vendor_class).returns(:vendor => '<Sun-Fire-V210>')
     h.valid?
     d = h.provision_interface.dhcp_record
     assert_instance_of Net::DHCP::SparcRecord, d


### PR DESCRIPTION
dhcp_attrs method is wrongly giving the Nic::Managed object as the first argument to jumpstart_params() which expects a Host::Managed object. This has been fixed.

-PP
