### PR TITLE
Fixes #12343 - Fixing parameters caster for boolean values

### DIFF
--- a/app/services/foreman/parameters/caster.rb
+++ b/app/services/foreman/parameters/caster.rb
@@ -10,7 +10,7 @@ module Foreman
         }
         options.reverse_merge!(defaults)
         @item, @options = item, options
-        @value = @options[:value] || @item.send(@options[:attribute_name])
+        @value = @options[:value].nil? ? @item.send(@options[:attribute_name]) : @options[:value]
       end
 
       def cast!

--- a/test/lib/parameters/caster_test.rb
+++ b/test/lib/parameters/caster_test.rb
@@ -39,6 +39,12 @@ class CasterTest < ActiveSupport::TestCase
       assert_equal item.foo, false
     end
 
+    test "boolean is casted correctly when changing value from true to false" do
+      item = OpenStruct.new(:foo => "true")
+      Foreman::Parameters::Caster.new(item, :attribute_name => :foo, :to => :boolean, :value => false).cast!
+      assert_equal false, item.foo
+    end
+
     test "array (json)" do
       item = OpenStruct.new(:foo => [1,2,3].to_json)
       Foreman::Parameters::Caster.new(item, :attribute_name => :foo, :to => :array).cast!


### PR DESCRIPTION
This happened when there was a boolean smart class parameter with a default value true and you tried to override it with the value false.
The classification returns the correct value but when that value is casted `@options[:value]` is false so you get the previous value for that key (true).
