### PR TITLE
[WIP] Implement autocomplete UI component in AngularJS

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+    "json": "bower.json",
+    "directory": ".tmp/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ _build
 zeus.json
 custom_plan.rb
 pkg/
+.tmp
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,24 @@
+var requireDir = require('require-dir'),
+    path = require('path');
+
+module.exports = function (grunt) {
+    var configs = requireDir('./grunt');
+
+    grunt.loadTasks(path.join(__dirname, '/node_modules/grunt-eslint/tasks'));
+    grunt.loadTasks(path.join(__dirname, '/node_modules/grunt-karma/tasks'));
+
+    grunt.initConfig(configs);
+
+    grunt.registerTask('ci', [
+        'eslint',
+        'karma:ci'
+    ]);
+
+    grunt.registerTask('test', [
+        'karma:unit'
+    ]);
+
+    grunt.registerTask('default', [
+        'ci'
+    ]);
+};

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,12 @@
 //= require underscore
 //= require editor
 
+//= require angular
+//= require angular-ui-bootstrap
+//= require angular-ui-bootstrap-tpls
+//= require components/foreman.module
+//= require_tree ./components
+
 $(document).on('ContentLoad', onContentLoad);
 Turbolinks.enableProgressBar();
 

--- a/app/assets/javascripts/components/autocomplete-controller.controller.js
+++ b/app/assets/javascripts/components/autocomplete-controller.controller.js
@@ -1,0 +1,52 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc controller
+     * @name  Foreman.controller:AutocompleteController
+     *
+     * @description
+     *   Handles retrieving autocomplete data.
+     */
+    function AutocompleteController($http) {
+        var self = this;
+
+        self.formatResults = function(results) {
+            var rows = [],
+                categoriesFound = [];
+
+            angular.forEach(results, function (row) {
+                if (row.category && row.category.length > 0) {
+                    if (categoriesFound.indexOf(row.category) === -1) {
+                        categoriesFound.push(row.category);
+                        rows.push({category: row.category, isCategory: true});
+                    }
+                }
+                rows.push(row);
+            });
+
+            return rows;
+        };
+
+        self.autocomplete = function (term) {
+            var promise;
+
+            promise = $http.get(
+                self.url + '/auto_complete_search',
+                {params: {search: term}}
+            ).then(function (response) {
+                return self.formatResults(response.data);
+            });
+
+            return promise;
+        };
+    }
+
+
+    angular
+        .module('Foreman')
+        .controller('AutocompleteController', AutocompleteController);
+
+    AutocompleteController.$inject = ['$http'];
+
+})();

--- a/app/assets/javascripts/components/foreman-bootstrap.js
+++ b/app/assets/javascripts/components/foreman-bootstrap.js
@@ -1,0 +1,3 @@
+angular.element(document).ready(function () {
+    angular.bootstrap(document, ['Foreman']);
+});

--- a/app/assets/javascripts/components/foreman.module.js
+++ b/app/assets/javascripts/components/foreman.module.js
@@ -1,0 +1,7 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('Foreman', ['ui.bootstrap']);
+
+})();

--- a/app/assets/javascripts/components/tfm-autocomplete.directive.js
+++ b/app/assets/javascripts/components/tfm-autocomplete.directive.js
@@ -1,0 +1,59 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc directive
+     * @name  Foreman.directive:tfmAutocomplete
+     *
+     * @description
+     *   Configures typahead directive based on autcomplete result format.
+     *
+     * @example
+     *   <input tfm-autocomplete="/hosts" search="fakeSearch"/>
+     */
+    function tfmAutocomplete() {
+        var template = [
+            '<span>',
+                '<script type="text/ng-template" id="autocomplete-scoped-search.html">',
+                    '<i class="ui-autocomplete-category" ng-show="match.model.isCategory">',
+                        '{{ match.model.category }}',
+                    '</i>',
+
+                    '<a ng-hide="match.model.isCategory">',
+                        '<i class="ui-autocomplete-completed">',
+                            '{{ match.model.completed }}',
+                        '</i>',
+                        '{{ match.model.part }}',
+                    '</a>',
+                '</script>',
+                '<input class="form-control"',
+                        'type="text"',
+                        'name="search"',
+                        'placeholder="Search..."',
+                        'ng-model="autocomplete.selected"',
+                        'ng-trim="false"',
+                        'uib-typeahead="item.label for item in autocomplete.autocomplete($viewValue)"',
+                        'tfm-typeahead-empty=""',
+                        'typeahead-template-url="autocomplete-scoped-search.html"/>',
+                '<span>'
+            ];
+
+        return {
+            scope: {
+                url: '@tfmAutocomplete',
+                selected: '@search'
+            },
+            restrict: 'EA',
+            replace: true,
+            controllerAs: 'autocomplete',
+            bindToController: true,
+            controller: 'AutocompleteController',
+            template: template.join('')
+        };
+    }
+
+    angular
+        .module('Foreman')
+        .directive('tfmAutocomplete', tfmAutocomplete);
+
+})();

--- a/app/assets/javascripts/components/tfm-typeahead-empty.directive.js
+++ b/app/assets/javascripts/components/tfm-typeahead-empty.directive.js
@@ -1,0 +1,34 @@
+(function () {
+
+    /**
+     * @ngdoc directive
+     * @name Foreman.directive:tfmTypeaheadEmpty
+     *
+     *
+     * @description
+     *  Used to support autocompletion on focus, not just after the user types a single character
+     *
+     * @example
+        <input typeahead="item as item.label for item in table.autocomplete($viewValue)"
+               tfm-typeahead-empty />
+     */
+    function tfmTypeaheadEmpty() {
+        return {
+            require: 'ngModel',
+            link: function (scope, element, attrs, modelCtrl) {
+                element.bind('focus', function () {
+                    if (angular.isUndefined(modelCtrl.$viewValue) || modelCtrl.$viewValue === '') {
+                        modelCtrl.$setViewValue(' ');
+                    } else {
+                        modelCtrl.$setViewValue(modelCtrl.$viewValue);
+                    }
+                });
+            }
+        };
+    }
+
+    angular
+        .module('Foreman')
+        .directive('tfmTypeaheadEmpty', tfmTypeaheadEmpty);
+
+})();

--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag send("#{auto_complete_controller_name}_path"), :method => "get",:id =>"search-form" do %>
   <div class="input-group">
-    <%= auto_complete_search(:search, params[:search].try(:squeeze," "), :placeholder => _("Filter") + ' ...').html_safe %>
+    <input tfm-autocomplete="<%= send("#{auto_complete_controller_name}_path") %>" search="<%= params[:search] %>"/>
     <span class="input-group-btn">
       <button class="btn btn-default" type="submit">
         <%= icon_text("search", content_tag(:span,_("Search"), :class=>"hidden-xs")) %>

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,102 @@
+{
+  "name": "bastion",
+  "version": "0.0.1",
+  "main": [],
+  "dependencies": {
+    "json3": "~3.2.4",
+    "es5-shim": "~2.0.8",
+    "angular": "=1.2.9",
+    "angular-bootstrap": "0.10.0",
+    "angular": "=1.2.9",
+    "angular-sanitize": "=1.2.9",
+    "angular-resource": "=1.2.9",
+    "angular-route": "=1.2.9",
+    "angular-gettext": "=1.0.0",
+    "angular-ui-router": "=0.2.10",
+    "angular-blocks": "~>0.1.8",
+    "angular-i18n": "1.3.13",
+    "underscore": "=1.5.2",
+    "ngInfiniteScroll": "1.2.1",
+    "ngUpload": "~0.5.5",
+    "bootstrap": "~3.1.1",
+    "font-awesome": "4.2.0",
+    "angular-animate": "=1.2.0",
+    "angular-uuid4": "0.1.0",
+    "patternfly": "1.1.3"
+  },
+  "devDependencies": {
+    "jquery": "=1.9.1",
+    "angular-mocks": "=1.2.9",
+    "angular-scenario": "=1.2.9"
+  },
+  "resolutions": {
+    "angular": "1.2.9",
+    "jquery": "=1.9.1"
+  },
+  "exportsOverride": {
+    "json3": {
+      "javascripts/bastion/json3": "lib/json3.js"
+    },
+    "es5-shim": {
+      "javascripts/bastion/es5-shim": "es5-shim.js"
+    },
+    "angular": {
+      "javascripts/bastion/angular": "angular.js"
+    },
+    "angular-sanitize": {
+      "javascripts/bastion/angular-sanitize": "angular-sanitize.js"
+    },
+    "angular-resource": {
+      "javascripts/bastion/angular-resource": "angular-resource.js"
+    },
+    "angular-route": {
+      "javascripts/bastion/angular-route": "angular-route.js"
+    },
+    "angular-gettext": {
+      "javascripts/bastion/angular-gettext": "dist/angular-gettext.js"
+    },
+    "angular-blocks": {
+      "javascripts/bastion/angular-blocks": "src/angular-blocks.js"
+    },
+    "angular-bootstrap": {
+      "javascripts/bastion/angular-bootstrap": [
+        "ui-bootstrap.js",
+        "ui-bootstrap-tpls.js"
+      ]
+    },
+    "angular-animate": {
+      "javascripts/bastion/angular-animate": "angular-animate.js"
+    },
+    "angular-i18n": {
+      "javascripts/bastion/angular-i18n": "*.js"
+    },
+    "angular-ui-router": {
+      "javascripts/bastion/angular-ui-router": "release/angular-ui-router.js"
+    },
+    "angular-uuid4": {
+      "javascripts/bastion/angular-uuid4": "angular-uuid4.js"
+    },
+    "underscore": {
+      "javascripts/bastion/underscore": "underscore.js"
+    },
+    "ngUpload": {
+      "javascripts/bastion/ngUpload": "ng-upload.js"
+    },
+    "ngInfiniteScroll": {
+      "javascripts/bastion/ngInfiniteScroll": "build/ng-infinite-scroll.js"
+    },
+    "bootstrap": {
+      "stylesheets/bastion/bootstrap/less": "less/*.less",
+      "fonts/bastion/bootstrap": "dist/fonts/*"
+    },
+    "font-awesome": {
+      "stylesheets/bastion/font-awesome/less": "less/*.less",
+      "stylesheets/bastion/font-awesome/scss": "scss/*.scss",
+      "fonts/bastion/font-awesome/": "font/*"
+    },
+    "patternfly": {
+      "fonts/bastion/patternfly/": "dist/fonts",
+      "stylesheets/bastion/patternfly": "less/*.less"
+    }
+  }
+}

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -19,4 +19,6 @@ group :assets do
   gem 'jquery-turbolinks', '~> 2.1'
   gem 'select2-rails', '~> 3.5'
   gem 'underscore-rails', '~> 1.8'
+  gem 'angularjs-rails', '~> 1.4.0'
+  gem 'angular-ui-bootstrap-rails', '~> 0.14.3'
 end

--- a/eslint.yaml
+++ b/eslint.yaml
@@ -1,0 +1,58 @@
+---
+plugins:
+  - angular
+
+env:
+  browser: true
+  node: true
+
+globals:
+  angular: true
+  _: true
+  $: true
+
+rules:
+  strict: 0
+  quotes: 0
+  camelcase: 2
+  indent: 2
+  new-cap:
+    - 2
+    - {"newIsCap": true, "capIsNew": false}
+  no-mixed-spaces-and-tabs: 2
+  no-multiple-empty-lines: 2
+  no-trailing-spaces: 2
+  space-after-function-name: 2
+  space-after-keywords: 2
+  space-before-blocks: 2
+  space-infix-ops: 2
+  brace-style: 2
+  semi: 2
+  block-scoped-var: 2
+  consistent-return: 2
+  curly: 2
+  eqeqeq: 2
+  guard-for-in: 2
+  no-else-return: 2
+  no-loop-func: 2
+  vars-on-top: 2
+  no-debugger: 2
+  no-cond-assign: 2
+  no-console: 2
+  no-extra-semi: 2
+  no-irregular-whitespace: 2
+  dot-notation:
+    - 2
+    - {"allowPattern": "^[a-z]+(_[a-z]+)+$"}
+
+  # Angular Plugin Rules
+  angular:
+    ng_angularelement: 2
+    ng_directive_name:
+      - 2
+      - bst
+    ng_empty_controller: 2
+    ng_module_name:
+      - 2
+      - Bastion
+

--- a/grunt/eslint.js
+++ b/grunt/eslint.js
@@ -1,0 +1,10 @@
+module.exports = {
+    options: {
+        configFile: __dirname + '/../eslint.yaml',
+        quiet: true
+    },
+    target: [
+        'Gruntfile.js',
+        'app/assets/javascripts/components/**/*.js',
+    ]
+};

--- a/grunt/karma.js
+++ b/grunt/karma.js
@@ -1,0 +1,51 @@
+var basePath = __dirname + '/../',
+    pluginName = process.cwd().split('/').pop();
+
+
+module.exports = {
+    options: {
+        frameworks: ['jasmine'],
+        runnerPort: 9100,
+        colors: true,
+        browsers: ['PhantomJS'],
+        reporters: ['progress'],
+        singleRun: true,
+        preprocessors: {
+            'app/assets/javascripts/**/*.html': ['ng-html2js']
+        },
+        files: [
+            basePath + '.tmp/bower_components/jquery/jquery.js',
+            basePath + '.tmp/bower_components/underscore/underscore.js',
+            basePath + '.tmp/bower_components/angular/angular.js',
+            basePath + '.tmp/bower_components/angular-bootstrap/ui-bootstrap.js',
+            basePath + '.tmp/bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
+            basePath + '.tmp/bower_components/angular-mocks/angular-mocks.js',
+
+            basePath + 'app/assets/javascripts/components/foreman.module.js',
+            basePath + 'app/assets/javascripts/components/**/*.js',
+            'test/js/**/*.js'
+        ],
+        ngHtml2JsPreprocessor: {
+            cacheIdFromPath: function (filepath) {
+                return filepath.replace(/app\/assets\/javascripts\/bastion\w*\//, '');
+            }
+        }
+    },
+    server: {
+        autoWatch: true
+    },
+    unit: {
+        singleRun: true
+    },
+    ci: {
+        reporters: ['progress', 'coverage'],
+        preprocessors: {
+            'app/assets/javascripts/**/*.js': ['coverage']
+        },
+        coverageReporter: {
+            type: 'cobertura',
+            dir: 'coverage/'
+        }
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "foreman",
+  "version": "0.0.1",
+  "dependencies": {
+    "grunt": "~0.4.5",
+    "grunt-bower-task": "~0.3.4",
+    "require-dir": "~0.1.0",
+    "karma": "~0.12.23",
+    "grunt-karma": "~0.9.0",
+    "karma-jasmine": "~0.1.5",
+    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-ng-html2js-preprocessor": "~0.1.0",
+    "karma-coverage": "~0.2.6",
+    "grunt-htmlhint": "~0.4.1",
+    "grunt-concurrent": "~1.0.0",
+    "grunt-angular-gettext": "~0.2.15",
+    "grunt-eslint": "~6.0.0",
+    "eslint": "~0.14.1",
+    "eslint-plugin-angular": "0.0.3"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "scripts": {
+    "postinstall": "bower install"
+  }
+}

--- a/test/js/components/autocomplete-controller.controller.test.js
+++ b/test/js/components/autocomplete-controller.controller.test.js
@@ -1,0 +1,47 @@
+describe('Controller: AutocompleteController', function() {
+    var controller,
+        $httpBackend,
+        $rootScope;
+
+    beforeEach(module('Foreman'));
+
+    beforeEach(inject(function($injector) {
+        var $controller = $injector.get('$controller');
+
+        $httpBackend = $injector.get('$httpBackend');
+        $rootScope = $injector.get('$rootScope');
+
+        controller = $controller('AutocompleteController');
+        controller.url = '/hosts';
+    }));
+
+    describe('that expects API calls', function () {
+
+        afterEach(function() {
+            $httpBackend.flush();
+            $httpBackend.verifyNoOutstandingExpectation();
+            $httpBackend.verifyNoOutstandingRequest();
+        });
+
+        it("calls the auto complete search API", function() {
+            $httpBackend.expectGET('/hosts/auto_complete_search?search=')
+                    .respond([]);
+
+            controller.autocomplete('');
+        });
+
+        it("calls the auto complete search API", function() {
+            $httpBackend.expectGET('/hosts/auto_complete_search?search=name+%3D+testhost')
+                    .respond([]);
+
+            controller.autocomplete('name = testhost');
+        });
+    });
+
+    it("formatResults should return data formatted properly", function() {
+        var data = [];
+
+        expect(controller.formatResults(data)).toBeDefined();
+    });
+
+});

--- a/test/js/components/tfm-autocomplete.directive.test.js
+++ b/test/js/components/tfm-autocomplete.directive.test.js
@@ -1,0 +1,40 @@
+describe('Directive: tfmAutocomplete', function() {
+    var scope,
+        compile,
+        element,
+        elementScope;
+
+    beforeEach(module(
+        'Foreman'
+    ));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_) {
+        compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    beforeEach(function() {
+        element = angular.element('<input tfm-autocomplete="/hosts"/>');
+
+        compile(element)(scope);
+        scope.$digest();
+
+        elementScope = element.isolateScope();
+    });
+
+    it("should be an input", function() {
+        expect(element.find('input').length).toBe(1);
+    });
+
+    it("should contain directive uib-typeahead", function() {
+        expect(element.find('[uib-typeahead]').length).toBe(1);
+    });
+
+    it("should have an input with name search", function() {
+        expect(element.find('[name="search"]').length).toBe(1);
+    });
+
+    it("should use typeahead-empty for handling initially empty input", function() {
+        expect(element.find('[tfm-typeahead-empty=""]').length).toBe(1);
+    });
+});

--- a/test/js/components/tfm-typeahead-empty.directive.test.js
+++ b/test/js/components/tfm-typeahead-empty.directive.test.js
@@ -1,0 +1,48 @@
+describe('Directive: tfmTypeaheadEmpty', function() {
+    var scope,
+        compile,
+        element,
+        elementScope;
+
+    beforeEach(module(
+        'Foreman'
+    ));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_) {
+        compile = _$compile_;
+        scope = _$rootScope_;
+    }));
+
+    beforeEach(function() {
+        element = angular.element('<input ng-model="myInput" type="text" tfm-typeahead-empty/>');
+
+        compile(element)(scope);
+        scope.$digest();
+
+        elementScope = element.isolateScope();
+    });
+
+    it("should adjust empty string", function() {
+        scope.myInput = '';
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe(' ');
+    });
+
+    it("should adjust undefined", function() {
+        scope.myInput = undefined;
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe(' ');
+    });
+
+    it("should not adjust otherss", function() {
+        scope.myInput = 'foo';
+        scope.$digest();
+        element.triggerHandler('focus');
+
+        expect(scope.myInput).toBe('foo');
+    });
+});


### PR DESCRIPTION
@ohadlevy You once asked what it would look like to use the autocomplete component we had implemented in Bastion for use on Katello's angularJS based pages and here it is. This does not make use of Bastion directly as I assumed you wanted to see it stand-alone. This does copy a number of items from Bastion such as a small component we had to write so that when a user focused the input and the input is empty it would populate the autocomplete list. This makes use of the existing angularjs and angularjs ui bootstrap [1] for Rails gems. Further, this includes testing and linting (using karma and eslint) along with all the files and configuration that are necessary drawn from our experience (and code) building Bastion [1].

To run the tests (as taken from [3]):

```
sudo yum install nodejs npm
sudo npm install -g grunt-cli phantomjs bower
cd foreman/
npm install
grunt ci
```

The files are named following a convention we employed previously, and every component is broken into it's own file with it's own dedicated test file. I have isolated all of these components under a single directory 

[1] https://angular-ui.github.io/bootstrap/#/typeahead
[2] https://github.com/katello/bastion
[3] https://github.com/Katello/bastion/blob/master/Rakefile#L49
