### PR TITLE
Fixes #12365 - Recognize virtual interfaces with alphanum aliases as such

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,6 +1,6 @@
 class FactParser
   delegate :logger, :to => :Rails
-  VIRTUAL = /\A([a-z0-9]+)_(\d+)\Z/
+  VIRTUAL = /\A([a-z0-9]+)_([a-z0-9]+)\Z/
   BRIDGES = /\A(vir)?br\d+(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -135,6 +135,16 @@ class FactParserTest < ActiveSupport::TestCase
     end
   end
 
+  test "#find_virtual_interface finds an interface with an alphanum alias" do
+    parser.stub(:get_interfaces, ['eth0', 'eth0_bar']) do
+      parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0_bar').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
+      result = parser.send(:find_virtual_interface, parser.interfaces)
+      assert_includes result, 'eth0_bar'
+      refute_includes result, 'eth0'
+    end
+  end
+
   test "#find_virtual_interface does not find physical interfaces" do
     parser.stub(:get_interfaces, ['eth0', 'enp0s25', 'em1', 'eno1']) do
       parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)


### PR DESCRIPTION
We have in our lab virtual interfaces with the login of the developers
(e.g eth0:roidelapluie). They are recognized as physical interface and
overwrite eth0.

Expected in the foreman:
eth0 phy
eth0_roidelapluie virt
eth0_julien virt

got:
eth0_julien phy

This commit fixes that by changing the regex that checks for virtual
interfaces.
