### PR TITLE
Fixes #12201 - Parent resource finder should consider non-default names.

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -52,6 +52,8 @@ module Api
       return resource_class.where(nil) unless scope
 
       association = resource_class.reflect_on_all_associations.find {|assoc| assoc.plural_name == parent_name.pluralize}
+      #if couldn's find an association by name, try to find one by class
+      association ||= resource_class.reflect_on_all_associations.find {|assoc| assoc.class_name == parent_name.camelize}
       resource_class.joins(association.name).merge(scope)
     end
 

--- a/app/controllers/api/v2/audits_controller.rb
+++ b/app/controllers/api/v2/audits_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V2
     class AuditsController < V2::BaseController
       before_filter :find_resource, :only => %w{show}
-      before_filter :setup_search_options, :only => :index
 
       api :GET, "/audits/", N_("List all audits")
       api :GET, "/hosts/:host_id/audits/", N_("List all audits for a given host")

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -5,7 +5,7 @@ module AuditExtensions
   included do
     belongs_to :user, :class_name => 'User'
     belongs_to :search_users, :class_name => 'User', :foreign_key => :user_id
-    belongs_to :search_hosts, :class_name => 'Host', :foreign_key => :auditable_id
+    belongs_to :search_hosts, :class_name => 'Host', :foreign_key => :auditable_id, :conditions => { :audits => { :auditable_type => 'Host' } }
     belongs_to :search_hostgroups, :class_name => 'Hostgroup', :foreign_key => :auditable_id
     belongs_to :search_parameters, :class_name => 'Parameter', :foreign_key => :auditable_id
     belongs_to :search_templates, :class_name => 'ProvisioningTemplate', :foreign_key => :auditable_id

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -153,6 +153,8 @@ class Host::Managed < Host::Base
   # audit the changes to this model
   audited :except => [:last_report, :puppet_status, :last_compile, :lookup_value_matcher], :allow_mass_assignment => true
   has_associated_audits
+  #redefine audits relation because of the type change (by default the relation will look for auditable_type = 'Host::Managed')
+  has_many :audits, :foreign_key => :auditable_id, :class_name => Audited.audit_class.name, :conditions => { :auditable_type => 'Host' }
 
   # some shortcuts
   alias_attribute :os, :operatingsystem

--- a/test/functional/api/v2/audits_controller_test.rb
+++ b/test/functional/api/v2/audits_controller_test.rb
@@ -15,4 +15,23 @@ class Api::V2::AuditsControllerTest < ActionController::TestCase
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
   end
+
+  test 'should show audit for parent resource only' do
+    host = FactoryGirl.create(:host, :managed)
+
+    host.reload
+    host.model = Model.first
+    host.save!
+    host.reload
+
+    expected_audits = host.audits
+
+    get :index, { :host_id => host.id }
+
+    assert_response :success
+
+    audits = ActiveSupport::JSON.decode(@response.body)
+
+    assert_equal expected_audits.count, audits['results'].count
+  end
 end


### PR DESCRIPTION
Now the parent resource finder is less dependent on association name. If it cannot find an association by name, it will try to find it by associated object type.
