### PR TITLE
Fixes #8797 - Separate style from the HTML in emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'protected_attributes', '~> 1.1.1'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
 gem 'responders', '~> 2.0'
+gem 'roadie-rails', '~> 1.1'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,7 @@
 @import "patternfly-sprockets";
 @import "patternfly";
 @import "mixin";
-@import "/**/*";
+@import "/*";
 
 html {
   height: 100%;

--- a/app/assets/stylesheets/unimported/email.css
+++ b/app/assets/stylesheets/unimported/email.css
@@ -1,0 +1,97 @@
+body {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: #3f3f3f;
+  background-color: #f1f1f1;
+  padding: 10px 24px;
+}
+
+table {
+  min-width: 400px;
+  border: 1px solid #cccccc;
+  padding: 5px;
+  background-color: #ffffff;
+  border-collapse: collapse;
+  text-align: justify;
+  width: 100%;
+}
+
+table.center {
+  text-align: center;
+}
+
+th {
+  text-align: left;
+  border-collapse: collapse;
+  background: #f5f5f5;
+  background-image: linear-gradient(#f5f5f5, #e8e8e8);
+  padding: 4px;
+  border: 1px solid #cccccc;
+}
+
+td.hosts-rows {
+  text-align: left;
+  border-collapse: collapse;
+  background-color: #FFFFFF;
+  padding: 4px;
+  border: 1px solid #cccccc;
+}
+
+td.dashboard {
+  font-size: 125%;
+  width: 33%;
+  padding: 5px;
+  border: 1px solid #ccc;
+}
+
+div.dashboard {
+  background: #e1e2e3;
+  padding: 20px 40px;
+  margin: 5px 0px 10px;
+}
+
+td.dashboard  p{
+  font-weight: bold;
+  margin: 5px;
+  padding: 0px;
+}
+
+.hosts {
+  background: #fff;
+  padding: 10px 20px;
+  border: 1px solid #e1e2e3;
+}
+
+.host-list {
+    background: #fff;
+    margin: 5px 0px;
+    padding: 5px 20px;
+}
+
+.total {
+  background-color: #e1e2e3;
+  margin: 5px 0px;
+  padding: 0px;
+  line-height: 24px;
+}
+
+h2.headline {
+  font-weight: normal;
+  text-transform: uppercase;
+  font-size: 120%;
+}
+
+.red-mark {
+  color: red;
+}
+
+ul.none {
+  list-style-type: none;
+}
+
+li.item {
+  margin: 5px 15px;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 10px;
+  width: 70%;
+  font-size: 120%;
+}

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,7 @@
 require 'uri'
 
 class ApplicationMailer < ActionMailer::Base
+  include Roadie::Rails::Automatic
   default :from => Proc.new { Setting[:email_reply_address] || "noreply@foreman.example.org" }
 
   def mail(headers = {}, &block)
@@ -9,6 +10,13 @@ class ApplicationMailer < ActionMailer::Base
       headers['X-Foreman-Server'] = URI.parse(Setting[:foreman_url]).host unless Setting[:foreman_url].blank?
     end
     super
+  end
+
+  protected
+
+  def roadie_options
+    url = URI.parse(Setting[:foreman_url])
+    super.merge(url_options: {:host => url.host, :port => url.port, :protocol => url.scheme})
   end
 
   private

--- a/app/mailers/audit_mailer.rb
+++ b/app/mailers/audit_mailer.rb
@@ -4,14 +4,16 @@ class AuditMailer < ApplicationMailer
   def summary(options = {})
     raise ::Foreman::Exception.new(N_("Must specify a user with email enabled")) unless (user=User.find(options[:user])) && user.mail_enabled?
     time = options[:time] ? %(time >= "#{options[:time]}") : 'time > yesterday'
-    set_url
     @query   = options[:query].present? ? "#{options[:query]} and #{time}" : time.to_s
     @count   = Audit.authorized_as(user, :view_audit_logs, Audit).search_for(@query).count
     @limit   = Setting[:entries_per_page] > @count ? @count : Setting[:entries_per_page]
     @audits  = Audit.authorized_as(user, :view_audit_logs, Audit).search_for(@query).limit(@limit)
 
     set_locale_for(user) do
-      mail(:to => user.mail, :subject => _("Audit summary"))
+      mail(:to => user.mail, :subject => _("Audit summary")) do |format|
+        format.html { render :layout => 'application_mailer' }
+        format.text
+      end
     end
   end
 end

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -30,7 +30,9 @@ class HostMailer < ApplicationMailer
         :total => total
       }
 
-      mail(:to => user.mail, :subject => subject)
+      mail(:to => user.mail, :subject => subject) do |format|
+        format.html { render :layout => 'application_mailer' }
+      end
     end
   end
 
@@ -39,16 +41,20 @@ class HostMailer < ApplicationMailer
     @host = @report.host
     set_url
     set_locale_for(options[:user]) do
-      mail(:to => options[:user].mail, :subject => (_("Puppet error on %s") % @host))
+      mail(:to => options[:user].mail, :subject => (_("Puppet error on %s") % @host)) do |format|
+        format.html { render :layout => 'application_mailer' }
+      end
     end
   end
 
   def host_built(host, options = {})
     @host = host
-    set_url
 
     set_locale_for(options[:user]) do
-      mail(:to => options[:user].mail, :subject => (_("Host %s is built") % @host))
+      mail(:to => options[:user].mail, :subject => (_("Host %s is built") % @host)) do |format|
+        format.html { render :layout => 'application_mailer' }
+        format.text
+      end
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,7 +14,10 @@ class UserMailer < ApplicationMailer
     user = options[:user]
 
     set_locale_for(user) do
-      mail(:to => options[:email], :subject => _("Foreman test email"))
+      mail(:to => options[:email], :subject => _("Foreman test email")) do |format|
+        format.html { render :layout => 'application_mailer' }
+        format.text
+      end
     end
   end
 end

--- a/app/views/audit_mailer/summary.html.erb
+++ b/app/views/audit_mailer/summary.html.erb
@@ -1,20 +1,17 @@
-<body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
-<h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> audit summary").html_safe %></h2>
-<ul style="list-style-type: none;">
+<h2 class="headline"><%= _("<b>Foreman</b> audit summary").html_safe %></h2>
+<ul class="none">
   <% if @audits.size > 0 %>
     <%= n_('Displaying %{num_audits} of %{total_audits} audit',
            'Displaying %{num_audits} of %{total_audits} audits', @count) % {:num_audits => @limit, :total_audits => @count} %>
     <% @audits.each do |audit| %>
-      <li style="margin: 5px 15px; border-bottom: 1px solid #ccc; padding-bottom: 10px; width: 70%; font-size: 120%;">
-        <%
-           login = audit.user.login rescue nil
-           user_search_param = login ? "user = #{login}" : %Q{username = "#{audit.username}"}
-        %>
+      <li class="item">
+        <% login = audit.user.login rescue nil
+           user_search_param = login ? "user = #{login}" : %Q{username = "#{audit.username}"} %>
         <b>
-          <%= link_to(audit.username, audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => user_search_param)) %>
+          <%= link_to(audit.username, audits_path(:search => user_search_param)) %>
           <span style="color: #cccccc"><%= audit_remote_address audit %></span>
           <%= audit_action_name audit%> <%= audited_type audit %>:
-          <%=link_to(audit_title(audit), audit_url(:id => audit, :host => @url.host, :port => @url.port, :protocol => @url.scheme), {:style => 'color: #2a6496'}) %>
+          <%= link_to(audit_title(audit), audit_path(:id => audit), {:style => 'color: #2a6496'}) %>
         </b>
         <ul style="list-style-type: none;">
           <% details(audit).each do |detail| -%>
@@ -32,6 +29,5 @@
   <% end %>
 </ul>
 <p>
-  <%= link_to(_('Full audits list'), audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => @query)) %>
+  <%= link_to(_('Full audits list'), audits_path(:search => @query)) %>
 </p>
-</body>

--- a/app/views/audit_mailer/summary.text.erb
+++ b/app/views/audit_mailer/summary.text.erb
@@ -1,16 +1,14 @@
 <%= _("Foreman audit summary") %>
 =================================
 <% if @audits.size > 0 %>
-<%= n_('Displaying %{num_audits} of %{total_audits} audit',
-       'Displaying %{num_audits} of %{total_audits} audits', @count) % {:num_audits => @limit, :total_audits => @count} %>
-
-<% @audits.each do |audit| %>
-<%= audit.username %> (<%= audit.remote_address %>) <%= audit_action_name audit%> <%= audited_type audit %>: <%= audit_title(audit) %>
-(<%= audit_url(:id => audit, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>)
--
-<% end %>
+  <%= n_('Displaying %{num_audits} of %{total_audits} audit',
+         'Displaying %{num_audits} of %{total_audits} audits', @count) % {:num_audits => @limit, :total_audits => @count} %>
+  <% @audits.each do |audit| %>
+    <%= audit.username %> (<%= audit.remote_address %>) <%= audit_action_name audit%> <%= audited_type audit %>: <%= audit_title(audit) %>
+    (<%= audit_path(:id => audit) %>)
+  <% end %>
 <% else %>
-<%= _('No audit changes for this period') %>
+  <%= _('No audit changes for this period') %>
 <% end %>
 
-<%= audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => @query) %>
+<%= audits_path(:search => @query) %>

--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -1,17 +1,15 @@
-<% th_style = "text-align: left; border-collapse: collapse;  background: #f5f5f5; background: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" %>
-<% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
 <tr>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Hostname') %>
   </th>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Host group') %>
   </th>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Environment') %>
   </th>
   <% list.first.last[:metrics].keys.each do |header| %>
-    <th style="<%= th_style %>">
+    <th>
       <%= header %>
     </th>
   <% end %>
@@ -20,20 +18,20 @@
   <tr>
     <% host_object = Host.find_by_name(host) %>
     <%= render 'link_to_host', :host => host %>
-    <td style="<%= td_style %>">
+    <td class="hosts-rows">
       <%= host_object.hostgroup %>
     </td>
-    <td style="<%= td_style %>">
+    <td class="hosts-rows">
       <%= host_object.environment %>
     </td>
     <% params[:metrics].each do |m,v| %>
       <% if m =~ /failed|failed_restart/ and v > 0 %>
-        <td style="<%= td_style %>; color: red;">
+        <td class="hosts-rows red-mark">
       <% else %>
-        <td style="<%= td_style %>">
+        <td class="hosts-rows">
       <% end %>
       <% if v > 0 %>
-        <%= link_to v, config_reports_url(:search=>"host = #{host} and #{m} > 0", :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>
+        <%= link_to v, config_reports_path(:search=>"host = #{host} and #{m} > 0") %>
       <% else %>
         <%= v %>
       <% end %>

--- a/app/views/host_mailer/_dashboard.html.erb
+++ b/app/views/host_mailer/_dashboard.html.erb
@@ -1,23 +1,23 @@
-<table style="border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: center; width: 100%;">
+<table class="center" >
   <tbody>
     <tr>
-      <td style="font-size: 125%; width: 33%; padding: 5px; border: 1px solid #ccc;">
+      <td class="dashboard">
         <%= (n_('<b style="color: #6bb5df;">%{hosts_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Changed</p>',
+               <p>Changed</p>',
               '<b style="color: #6bb5df;">%{hosts_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Changed</p>', hosts_sum) % { :hosts_sum => hosts_sum }).html_safe %>
+               <p>Changed</p>', hosts_sum) % { :hosts_sum => hosts_sum }).html_safe %>
       </td>
-      <td style="font-size: 125%; width: 33%; padding: 5px; border: 1px solid #ccc;">
+      <td class="dashboard">
         <%= (n_('<b style="color: #6bb5df;">%{out_of_sync_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Out of sync</p>',
+               <p>Out of sync</p>',
               '<b style="color: #6bb5df;">%{out_of_sync_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Out of sync</p>', out_of_sync_sum) % { :out_of_sync_sum => out_of_sync_sum }).html_safe %>
+               <p>Out of sync</p>', out_of_sync_sum) % { :out_of_sync_sum => out_of_sync_sum }).html_safe %>
       </td>
-      <td style="font-size: 125%; width: 33%; padding: 5px; border: 1px solid #ccc;">
+      <td class="dashboard">
         <%= (n_('<b style="color: #6bb5df;">%{disabled_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Disabled</p>',
+               <p>Disabled</p>',
               '<b style="color: #6bb5df;">%{disabled_sum}</b>
-               <p style="font-weight: bold; margin: 5px; padding: 0px;">Disabled</p>', disabled_sum) % { :disabled_sum => disabled_sum }).html_safe %>
+               <p>Disabled</p>', disabled_sum) % { :disabled_sum => disabled_sum }).html_safe %>
       </td>
     </tr>
   </tbody>

--- a/app/views/host_mailer/_error_states.html.erb
+++ b/app/views/host_mailer/_error_states.html.erb
@@ -1,24 +1,22 @@
-<% th_style = "text-align: left; border-collapse: collapse;  background: #f5f5f5; background: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" %>
-<% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
 <% if logs.size > 0 %>
-  <table style="border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: justify; width: 100%;" bgcolor="#ffffff">
+  <table>
     <thead>
       <tr>
-        <th style="<%= th_style %>"><%= _("Level") %></th>
-        <th style="<%= th_style %>"><%= _("Resource") %></th>
-        <th style="<%= th_style %>"><%= _("message") %></th>
+        <th><%= _("Level") %></th>
+        <th><%= _("Resource") %></th>
+        <th><%= _("message") %></th>
       </tr>
     </thead>
     <tbody>
       <% logs.each do |log| %>
         <tr>
-          <td style="<%= td_style %>">
+          <td class="hosts-rows">
             <span <%= report_tag log.level %>><%= h log.level %></span>
           </td>
-          <td style="<%= td_style %>">
+          <td class="hosts-rows">
             <%= h log.source %>
           </td>
-          <td style="<%= td_style %>">
+          <td class="hosts-rows">
             <%= h log.message %>
           </td>
         </tr>

--- a/app/views/host_mailer/_link_to_host.html.erb
+++ b/app/views/host_mailer/_link_to_host.html.erb
@@ -1,4 +1,3 @@
-<% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
-<td style="<%= td_style %>">
-  <%= link_to host, host_url(:id => host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>
+<td class="hosts-rows">
+  <%= link_to host, host_path(:id => host) %>
 </td>

--- a/app/views/host_mailer/_list.html.erb
+++ b/app/views/host_mailer/_list.html.erb
@@ -1,12 +1,12 @@
-<div style="background: #ffffff; margin: 5px 0px; padding: 5px 20px;">
+<div class="host-list">
   <h2><%= title %></h2>
   <% if list.size > 0 %>
-    <table style="border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: justify; width: 100%;" bgcolor="#ffffff">
+    <table>
       <tbody>
         <%= render :partial => "#{state}_hosts", :locals => {:list => list } %>
       </tbody>
     </table>
-    <p style="background-color: #e1e2e3; margin: 5px 0px; padding: 0px; line-height: 24px;"><%= n_('Total of one host', 'Total of %{hosts} hosts', list.size) % {:hosts => list.size} %></p>
+    <p class="total"><%= n_('Total of one host', 'Total of %{hosts} hosts', list.size) % {:hosts => list.size} %></p>
   <% else %>
     <b><%= _('None!') %></b>
   <% end %>

--- a/app/views/host_mailer/_nonactive_hosts.html.erb
+++ b/app/views/host_mailer/_nonactive_hosts.html.erb
@@ -1,34 +1,32 @@
-<% th_style = "text-align: left; border-collapse: collapse;  background: #f5f5f5; background: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" %>
-<% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
 <tr>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Hostname') %>
   </th>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Host group') %>
   </th>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Environment') %>
   </th>
-  <th style="<%= th_style %>">
+  <th>
     <%= _('Last Report') %>
   </th>
 </tr>
 <% list.each do |host| %>
   <tr>
     <%= render 'link_to_host', :host => host %>
-    <td style="<%= td_style %>">
+    <td class="hosts-rows">
       <%= host.hostgroup %>
     </td>
-    <td style="<%= td_style %>">
+    <td class="hosts-rows">
       <%= host.environment %>
     </td>
     <% if host.last_report %>
-      <td style="<%= td_style %>">
+      <td class="hosts-rows">
         <%= time_ago_in_words(host.last_report) %>
       </td>
     <% else %>
-      <td style="<%= td_style %>">
+      <td class="hosts-rows">
         <%= _('Unknown') %>
       </td>
     <% end %>

--- a/app/views/host_mailer/error_state.html.erb
+++ b/app/views/host_mailer/error_state.html.erb
@@ -1,14 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
-  <head>
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-  </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
-    <h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> Puppet error report").html_safe %></h2>
-    <div style="background: #e1e2e3; padding: 20px 40px; margin: 5px 0px 10px;">
-      <%= render :partial => 'error_states', :locals => {:logs => @report.logs } %>
-      <br>
-      <%= link_to _("For more information"), config_report_url(@report, :host => @url.host, :port => @url.port, :protocol => @url.scheme)  %>
-    </div>
-  </body>
-</html>
+<h2 class="headline"><%= _("<b>Foreman</b> Puppet error report").html_safe %></h2>
+<div class="dashboard">
+  <%= render :partial => 'error_states', :locals => {:logs => @report.logs} %>
+  <br>
+  <%= link_to _("For more information"), config_report_path(@report) %>
+</div>

--- a/app/views/host_mailer/host_built.html.erb
+++ b/app/views/host_mailer/host_built.html.erb
@@ -1,21 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
-  <head>
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-  </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
-    <h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> Build Complete").html_safe %></h2>
-    <div style="background: #e1e2e3; padding: 20px 40px; margin: 5px 0px 10px;">
-      <table class="hostInfo" style="min-width: 400px; border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: justify; width: 100%;" bgcolor="#ffffff">
-        <tr>
-          <td width="18%" style="text-align: left; border-collapse: collapse; background-image: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" align="left"><b><%= _("Hostname") %></b></td>
-          <td width="82%" style="border-collapse: collapse; text-align: left; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" align="center" bgcolor="#FFFFFF"><%= link_to @host, host_url(:id => @host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %></td>
-        </tr>
-        <tr>
-          <td width="18%" style="text-align: left; border-collapse: collapse; background-image: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" align="left"><b><%= _("IP") %></b></td>
-          <td style="border-collapse: collapse; text-align: left; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" align="center" bgcolor="#FFFFFF"><%= @host.ip %></td>
-        </tr>
-        </table>
-    </div>
-  </body>
-</html>
+<h2 class="headline"><%= _("<b>Foreman</b> Build Complete").html_safe %></h2>
+<div class="dashboard">
+  <table>
+    <tr>
+      <td width="18%" class="hosts-rows"><b><%= _("Hostname") %></b></td>
+      <td width="82%" class="hosts-rows"><%= link_to @host, host_path(:id => @host) %></td>
+    </tr>
+    <tr>
+      <td width="18%" class="hosts-rows"><b><%= _("IP") %></b></td>
+      <td width="82%" class="hosts-rows"><%= @host.ip %></td>
+    </tr>
+  </table>
+</div>

--- a/app/views/host_mailer/host_built.text.erb
+++ b/app/views/host_mailer/host_built.text.erb
@@ -5,4 +5,4 @@
   <%= _("IP:") %>       <%= @host.ip %>
 
 <%= _("View in Foreman:") %>
-  <%= host_url(:id => @host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>
+  <%= host_path(:id => @host) %>

--- a/app/views/host_mailer/summary.html.erb
+++ b/app/views/host_mailer/summary.html.erb
@@ -1,21 +1,11 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<%# this view contains style as some email clients ignore css files %>
-<html>
-  <head>
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-    <title> Summary report for Puppet activity from Foreman </title>
-  </head>
-  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
-    <h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> Puppet summary").html_safe %></h2>
-    <h2 style="margin: 5px 0px;"><%= _("Summary from %{time} ago to now") % {:time => distance_of_time_in_words(Time.now - @timerange)} %></h2>
-    <h3 style="margin: 0px;"><%= _("Summary report from Foreman server at %{foreman_url}") % {:foreman_url => Setting[:foreman_url]} %></h3>
-    <div style="background: #e1e2e3; padding: 20px 40px; margin: 5px 0px 10px;">
-      <%= render :partial => 'dashboard', :locals => {:hosts_sum => @hosts.size, :out_of_sync_sum => @out_of_sync.size, :disabled_sum => @disabled.size } %>
-    </div>
-    <div style="background: #fff; padding: 10px 20px; border: 1px solid #e1e2e3">
-      <%= render :partial => 'list', :locals => {:state => 'active', :title => _("Hosts with interesting values (changed, failures etc)"), :list => @hosts} %>
-      <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which are currently not running Puppet"), :list => @out_of_sync } %>
-      <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which Foreman reporting is disabled"), :list => @disabled } %>
-    </div>
-  </body>
-</html>
+<h2 class="headline"><%= _("<b>Foreman</b> Puppet summary").html_safe %></h2>
+<h2 style="margin: 5px 0px;"><%= _("Summary from %{time} ago to now") % {:time => distance_of_time_in_words(Time.now - @timerange)} %></h2>
+<h3><%= _("Summary report from Foreman server at %{foreman_url}") % {:foreman_url => Setting[:foreman_url]} %></h3>
+<div class="dashboard">
+  <%= render :partial => 'dashboard', :locals => {:hosts_sum => @hosts.size, :out_of_sync_sum => @out_of_sync.size, :disabled_sum => @disabled.size} %>
+</div>
+<div class="hosts">
+  <%= render :partial => 'list', :locals => {:state => 'active', :title => _("Hosts with interesting values (changed, failures etc)"), :list => @hosts} %>
+  <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which are currently not running Puppet"), :list => @out_of_sync} %>
+  <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which Foreman reporting is disabled"), :list => @disabled} %>
+</div>

--- a/app/views/layouts/application_mailer.html.erb
+++ b/app/views/layouts/application_mailer.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <%= stylesheet_link_tag "unimported/email" %>
+    <%= yield :head %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/user_mailer/tester.html.erb
+++ b/app/views/user_mailer/tester.html.erb
@@ -1,4 +1,3 @@
-<body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
-<h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> test email").html_safe %></h2>
+<h2 class="headline"><%= _("<b>Foreman</b> test email").html_safe %></h2>
 <h4><%= _("This is a test message to confirm that Foreman's email configuration is working.") %></h4>
-</body>
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -53,7 +53,7 @@ Foreman::Application.configure do |app|
 
   javascript += FastGettext.default_available_locales.map { |loc| "locale/#{loc}/app" }
 
-  stylesheets = %w( )
+  stylesheets = %w( unimported/email.css )
 
   # Add the fonts path
   config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')

--- a/test/unit/application_mailer_test.rb
+++ b/test/unit/application_mailer_test.rb
@@ -6,8 +6,20 @@ class ApplicationMailerTest < ActiveSupport::TestCase
   class TestMailer < ::ApplicationMailer
     def test
       mail(:to => 'nobody@example.com', :subject => 'Danger, Will Robinson!') do |format|
-        format.text { render :plain => "This is a test mail." }
+        format.html { render :text =>  html_mail }
       end
+    end
+
+    def html_mail
+      %|<html>
+          <head>
+            <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+            <link href="/assets/unimported/email.css" media="screen" rel="stylesheet" />
+          </head>
+          <body>
+            <h2 class="headline"><b>Foreman</b> test email</h2>
+          </body>
+        </html>|.html_safe
     end
   end
 
@@ -18,6 +30,10 @@ class ApplicationMailerTest < ActiveSupport::TestCase
 
   test 'foreman server header is set' do
     assert_equal mail.header['X-Foreman-Server'].to_s, 'foreman.some.host.fqdn'
+  end
+
+  test 'application mailer can use external css' do
+    assert mail.body.include? 'style='
   end
 
   test 'foreman subject prefix is attached' do


### PR DESCRIPTION
By using `roadie-rails` gem  style can be separated from email html foramt. email style was separated to 'email.css' file.
