### PR TITLE
fixes #12404 - rake console now works

### DIFF
--- a/lib/tasks/console.rake
+++ b/lib/tasks/console.rake
@@ -1,4 +1,8 @@
 task :console => :environment do
   require 'rails/commands/console'
+
+  ARGV.delete("console")
+  ARGV.delete("--trace")
+
   Rails::Console.start(Rails.application)
 end


### PR DESCRIPTION
not sure whether ruby 2.1 is at blame, but IRB's initializer tries to use the command line arguments to decide how to run the console.
problem? running `rake console (--trace)` will lead to ARGV to contain `["console"]` (and maybe --trace), which, in turn, will run the "MagicFile" method of running IRB, which, in turn, will fail because there is no file named console.

It took me hours to go deep enough the rabbit hole to understand IRB's super complex initialization process. And I ended up with this fix.

It basically does nothing in rails 3, and fixes the issue in rails 4.
