### PR TITLE
fixes #11309 - allow bulk hosts tool to open in new page

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -135,6 +135,11 @@ function build_modal(element, url) {
 
 }
 
+function build_redirect(url) {
+  var url = url + "?" + $.param({host_ids: $.foremanSelectedHosts});
+  window.location.replace(url);
+}
+
 function update_counter() {
   var item = $("#check_all");
   if ($.foremanSelectedHosts) {

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -156,7 +156,13 @@ module HostsHelper
   def multiple_actions_select
     select_action_button( _("Select Action"), {:id => 'submit_multiple'},
       multiple_actions.map do |action|
-        link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0])
+        # If the action array has 3 entries, the third one is whether to use a modal dialog or not
+        modal = action.size == 3 ? action[3] : true
+        if modal
+          link_to_function(action[0], "build_modal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following hosts are about to be changed") % action[0])
+        else
+          link_to_function(action[0], "build_redirect('#{action[1]}')")
+        end
       end.flatten
     )
   end


### PR DESCRIPTION
Remote execution needs to open a job invocation in a new page, and it's really ugly how we do it now, by opening the modal and redirecting.

![modal](https://cloud.githubusercontent.com/assets/429763/10979309/b8607fb0-83c9-11e5-804f-76199846b93c.gif)

This PR lets bulk action tool open a new page instead of a modal window by setting an optional third array item.  So it looks like this:

![no-modal](https://cloud.githubusercontent.com/assets/429763/10979366/1a206620-83ca-11e5-896b-932a25d3eb2a.gif)
