### PR TITLE
fixes #12416 - Add support for esxi 6 hw 11 profile

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -262,6 +262,7 @@ module Foreman::Model
     def vm_hw_versions
       {
         'Default' => _("Default"),
+        'vmx-11' => '11 (ESXi 6.0)',
         'vmx-10' => '10 (ESXi 5.5)',
         'vmx-09' => '9 (ESXi 5.1)',
         'vmx-08' => '8 (ESXi 5.0)',


### PR DESCRIPTION
Hi,

Added support for VMWare VM hardware version 11 for ESXi 6.0 http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746. We have tested this on a VMWare Vsphere 6 cluster provisioning with Foreman 1.9.2. 

Now that ESXi 6.0 has been out for a while now and this patch is needed to take advantage of the benefits of the new hardware profile.  

https://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.vsphere.vm_admin.doc%2FGUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html
