### PR TITLE
fixes #11771 - ensure created HostStatuses are saved correctly

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -902,7 +902,7 @@ class Host::Managed < Host::Base
   end
 
   def get_status(type)
-    status = self.new_record? ? host_statuses.detect { |s| s.type == type.to_s } : host_statuses.find_by_type(type.to_s)
+    status = host_statuses.detect { |s| s.type == type.to_s }
     if status.nil?
       host_statuses.new(:host => self, :type => type.to_s)
     else

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -77,6 +77,10 @@ module HostStatus
       end
     end
 
+    def relevant?
+      host.configuration?
+    end
+
     def self.is(config_status)
       "((host_status.status >> #{bit_mask(config_status)}) != 0)"
     end

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -6,6 +6,12 @@ module HostStatus
 
     belongs_to_host :inverse_of => :host_statuses
 
+    validates :host, :presence => true
+    validates :host_id, :uniqueness => {:scope => :type}
+    validates :reported_at, :presence => true
+
+    before_validation :update_timestamp, :if => ->(status) { status.reported_at.blank? }
+
     attr_accessible :host, :type
 
     def to_global(options = {})
@@ -42,6 +48,8 @@ module HostStatus
       update_status
     end
 
+    # Whether this status should be displayed to users, it may not be relevant for certain
+    # types of hosts
     def relevant?
       true
     end

--- a/db/migrate/20151109152507_add_host_status_host_id_index.rb
+++ b/db/migrate/20151109152507_add_host_status_host_id_index.rb
@@ -1,0 +1,15 @@
+class AddHostStatusHostIdIndex < ActiveRecord::Migration
+  def up
+    # Remove all but the first status per host/type combination
+    duplicate_statuses = HostStatus::Status.having('count(*) > 1').group(:host_id, :type).select(['host_id', 'type'])
+    duplicate_statuses.each do |row|
+      HostStatus::Status.where(:type => row[:type], :host_id => row[:host_id]).offset(1).destroy_all
+    end
+
+    add_index :host_status, [:type, :host_id], :unique => true
+  end
+
+  def down
+    remove_index :host_status, [:type, :host_id]
+  end
+end

--- a/test/unit/host_status/build_status_test.rb
+++ b/test/unit/host_status/build_status_test.rb
@@ -7,6 +7,10 @@ class BuildStatusTest < ActiveSupport::TestCase
     @status.host = @host
   end
 
+  test 'is valid' do
+    assert_valid @status
+  end
+
   test '#to_label changes based on waiting_for_build?' do
     @status.stub(:waiting_for_build?, true) do
       assert_equal 'Pending installation', @status.to_label

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -459,8 +459,17 @@ class HostTest < ActiveSupport::TestCase
     assert_equal status, new_status
   end
 
-  test 'host #refresh_statuses saves all relevant statuses and refreshes global status' do
+  test 'host #get_status(type) only builds a new status once' do
     host = FactoryGirl.build(:host)
+    status1 = host.get_status(HostStatus::BuildStatus)
+    assert status1.new_record?
+    status2 = host.get_status(HostStatus::BuildStatus)
+    assert_equal status1.object_id, status2.object_id
+  end
+
+  test 'host #refresh_statuses saves all relevant statuses and refreshes global status' do
+    host = FactoryGirl.create(:host, :with_puppet, :with_reports)
+    host.reload
     host.global_status = 1
 
     host.refresh_statuses


### PR DESCRIPTION
The HostStatus reported_at timestamp is now validated to match the DB
schema and populated if it's missing.  HostStatus subclasses should
validate correctly without needing to call #refresh.

Since creation of a ConfigurationStatus etc. can be triggered by an API
render (e.g. through foreman_hooks), the #relevant? method has been
implemented to ensure it remains hidden when not actually in use.

Host::Managed#get_status will now only create a new status object if it
doesn't already exist.  It would only check those already in the DB for
an existing host, so multiple #get_status calls would create a new
status object each time, causing duplicates.  Extra validation and an
index have been added to ensure uniqueness.
