### PR TITLE
fixes #12431 - pin tins for Ruby 1.9.3 compatibility

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,6 +1,5 @@
 group :development do
   gem 'maruku', '~> 0.7'
-  gem 'term-ansicolor'
   gem 'rubocop', '0.28.0'
 
   # for generating i18n files
@@ -10,6 +9,9 @@ group :development do
   gem 'immigrant', '~> 0.1'
 
   gem 'pry'
+  gem 'term-ansicolor'
+  gem 'tins', '< 1.7.0', :require => false if RUBY_VERSION.start_with? '1.9.'
+
   gem 'bullet'
   gem "parallel_tests"
 end


### PR DESCRIPTION
Note that this doesn't affect tests on Jenkins as we usually exclude the development bundler group.
