### PR TITLE
fixes #12431 - using term-ansicolor in ruby 2.0 and higher

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,6 +1,6 @@
 group :development do
   gem 'maruku', '~> 0.7'
-  gem 'term-ansicolor'
+  gem 'term-ansicolor' if RUBY_VERSION.to_f > 1.9
   gem 'rubocop', '0.28.0'
 
   # for generating i18n files


### PR DESCRIPTION
term-ansicolor has a dependency on the tins gem which only supports ruby
2.0 and up, which breaks 1.9.3 support, adding conditional which removes
it from our gemfile for 1.9.3
