### PR TITLE
fixes #5510 - Set network as first boot device for VMs in VMware comp…

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -481,7 +481,8 @@ module Foreman::Model
         :interfaces => [new_interface],
         :volumes    => [new_volume],
         :scsi_controller => { :type => scsi_controller_default_type },
-        :datacenter => datacenter
+        :datacenter => datacenter,
+        :boot_order => ['network', 'disk'],
       )
     end
   end


### PR DESCRIPTION
…ute resources

This only works if connecting to via vsphere api version > 5.0. Fog defaults to 4.0, so I added a setting for this.

What do you think?
