### PR TITLE
Fixes #12441 validate uniqueness for nic identifier and host

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -164,7 +164,7 @@ module Host
       if !self.managed? && self.primary_interface.mac.blank? && self.primary_interface.identifier.blank?
         identifier, values = parser.suggested_primary_interface(self)
         self.primary_interface.mac = Net::Validations.normalize_mac(values[:macaddress]) if values.present?
-        self.primary_interface.identifier = identifier
+        self.primary_interface.update_attribute(:identifier, identifier)
         self.primary_interface.save!
       end
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -27,6 +27,10 @@ module Nic
 
     validates :host, :presence => true, :if => Proc.new { |nic| nic.require_host? }
 
+    validates :identifier, :uniqueness => { :scope => :host_id },
+              :if => Proc.new { |nic| nic.identifier && nic.host },
+              :unless => Proc.new { |nic| nic.identifier_was.present? }
+
     validate :exclusive_primary_interface
     validate :exclusive_provision_interface
     validates :domain, :presence => true, :if => Proc.new { |nic| nic.host_managed? && nic.primary? }

--- a/test/unit/nics/base_test.rb
+++ b/test/unit/nics/base_test.rb
@@ -98,5 +98,18 @@ class NicBaseTest < ActiveSupport::TestCase
         end
       end
     end
+
+    describe 'creation of another nic with already used identifier' do
+      let(:nic) do
+        nic = host.interfaces.build(:managed => true, :type => 'Nic::Managed')
+        nic.identifier = host.primary_interface.identifier
+        nic
+      end
+
+      test 'it is invalid because of conflicting identifier' do
+        refute nic.valid?
+        assert nic.errors.has_key?(:identifier)
+      end
+    end
   end
 end


### PR DESCRIPTION
Taking a stab at fixing #12441. This helps prevent an issue where a when the mac address of a nic changes a duplicate row is inserted with the same identifier, which causes validation problems in the web interface and doesn't make a terrible amount of sense.
