### PR TITLE
Fixes #10357 - Realms for organizations and locations can be retrieved through API

### DIFF
--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -42,6 +42,10 @@ child :domains do
   extends "api/v2/domains/base"
 end
 
+child :realms do
+  extends "api/v2/realms/base"
+end
+
 child :environments do
   extends "api/v2/environments/base"
 end

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -20,7 +20,8 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     assert !show_response.empty?
     #assert child nodes are included in response'
     NODES = ["users", "smart_proxies", "subnets", "compute_resources", "media", "config_templates",
-             "domains", "environments", "hostgroups", "organizations", "parameters"].sort
+             "provisioning_templates", "domains", "ptables", "realms", "environments", "hostgroups",
+             "organizations", "parameters"].sort
     NODES.each do |node|
       assert show_response.keys.include?(node), "'#{node}' child node should be in response but was not"
     end


### PR DESCRIPTION
I added the realms to the rabl view for organizations and locations. Other elements that were described as missing are already there.
