### PR TITLE
fixes #12342 - unsaved (new or cloned) hostgrops should keep their puppetclasses

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -96,7 +96,9 @@ class HostgroupsController < ApplicationController
 
     @hostgroup ||= Hostgroup.new
     @hostgroup.environment = @environment if @environment
+
     @hostgroup.puppetclasses = Puppetclass.where(:id => params[:hostgroup][:puppetclass_ids])
+    @hostgroup.config_groups = ConfigGroup.where(:id => params[:hostgroup][:config_group_ids])
     render :partial => 'puppetclasses/class_selection', :locals => {:obj => (@hostgroup), :type => 'hostgroup'}
   end
 

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -191,7 +191,10 @@ module HostCommon
   end
 
   def individual_puppetclasses
-    conditions = {:id => host_class_ids - cg_class_ids}
+    ids = host_class_ids - cg_class_ids
+    return puppetclasses if ids.blank? && new_record?
+
+    conditions = {:id => ids}
     if environment
       environment.puppetclasses.where(conditions)
     else

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -447,6 +447,13 @@ class HostgroupTest < ActiveSupport::TestCase
       refute cloned.valid?
       assert_equal 1, cloned.errors[:name].size
     end
+
+    test "when updating environment for a new (or cloned) hostgroup, the individual_puppetclasses method should return correctly" do
+      group = FactoryGirl.create(:hostgroup, :with_config_group, :with_puppetclass)
+      cloned = Hostgroup.new
+      cloned.puppetclasses = group.puppetclasses
+      assert_equal cloned.individual_puppetclasses, group.individual_puppetclasses
+    end
   end
 
   describe '#param_true?' do


### PR DESCRIPTION
Unsaved hostgroups didn't respond correctly to individual_puppetclasses
because that method expects some objects to be saved in the DB. In case
of selecting a new environment, that lead to puppetclasses disappearing.
Solution is - when the object is not saved yet, fallback on the
puppetclasses method.
