### PR TITLE
fixes #12194 - join fact tables multiple times for each search term

### DIFF
--- a/app/models/concerns/scoped_search_extensions.rb
+++ b/app/models/concerns/scoped_search_extensions.rb
@@ -8,16 +8,16 @@ module ScopedSearchExtensions
       "%#{value}%"
     end
 
-    def cast_facts(key, operator, value)
+    def cast_facts(table, key, operator, value)
       is_int = (value =~ /\A[-+]?\d+\z/ ) || (value.is_a?(Integer))
       is_pg = ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'postgresql'
       # Once Postgresql 8 support is removed (used in CentOS 6), this could be replaced to only keep the first form (working well with PG 9)
       if (is_int && !is_pg)
-        casted = "CAST(fact_values.value AS DECIMAL) #{operator} #{value}"
+        casted = "CAST(#{table}.value AS DECIMAL) #{operator} #{value}"
       elsif (is_int && is_pg && operator !~ /LIKE/i)
-        casted = "fact_values.value ~ E'^\\\\d+$' AND CAST(fact_values.value AS DECIMAL) #{operator} #{value}"
+        casted = "#{table}.value ~ E'^\\\\d+$' AND CAST(#{table}.value AS DECIMAL) #{operator} #{value}"
       else
-        casted = sanitize_sql_for_conditions(["fact_values.value #{operator} ?", value])
+        casted = sanitize_sql_for_conditions(["#{table}.value #{operator} ?", value])
       end
       casted
     end

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -104,14 +104,14 @@ class FactValue < ActiveRecord::Base
 
   def self.search_cast_facts(key, operator, value)
     {
-      :conditions => "#{sanitize_sql_for_conditions(["fact_names.name = ?", key.split('.')[1]])} AND #{cast_facts(key,operator,value)}",
+      :conditions => "#{sanitize_sql_for_conditions(["fact_names.name = ?", key.split('.')[1]])} AND #{cast_facts('fact_values', key, operator, value)}",
       :include    => :fact_name,
     }
   end
 
   def self.search_value_cast_facts(key, operator, value)
     {
-      :conditions => cast_facts(key,operator,value)
+      :conditions => cast_facts('fact_values', key, operator, value)
     }
   end
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1504,6 +1504,10 @@ class HostTest < ActiveSupport::TestCase
       hosts = Host::Managed.search_for("facts.custom_fact = find_me")
       assert_equal hosts.count, 1
       assert_equal ["num001.example.com"], hosts.map { |h| h.name }.sort
+
+      hosts = Host::Managed.search_for("facts.memory_mb > 6544 and facts.custom_fact = find_me")
+      assert_equal hosts.count, 1
+      assert_equal ["num001.example.com"], hosts.map { |h| h.name }.sort
     end
 
     test "search by fact name is not vulnerable to SQL injection in name" do


### PR DESCRIPTION
scoped_search usually generates a new inner join for each search term
when searching through a key/value table layout to correctly search for
hosts via multiple facts.  Since the change to ext_method in 3f8e6c33, a
fixed table name was used.  This is changed to multiple joins to match
how scoped_search works with multiple search terms.
