### PR TITLE
Fixes #12457 - Use .exists? to check subnet exists on Rails 4

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -188,7 +188,7 @@ class Subnet < ActiveRecord::Base
       # do not import existing networks.
       attrs = { :network => s["network"], :mask => s["netmask"] }
 
-      next if first(:conditions => attrs)
+      next if exists?(attrs)
       attrs.merge!(parse_dhcp_options(s['options'])) if s['options'].present?
       new(attrs.update(:dhcp => proxy))
     end.compact


### PR DESCRIPTION
On app/models/subnet.rb, the method `self.import` uses `if
first(:conditions => attrs)`. It no longer is an alias for
`find(:first, *args)` but now it just fetches the first X
records (`first(X)`). `.exists?` is a suitable equivalent
