### PR TITLE
 Fixes #12180 - lookup_value  presence validation moved from lookup_key

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -76,6 +76,10 @@ class LookupKey < ActiveRecord::Base
     nil
   end
 
+  def reject_invalid_lookup_values(attributes)
+    attributes[:match].empty?
+  end
+
   def audit_class
     self
   end
@@ -109,12 +113,6 @@ class LookupKey < ActiveRecord::Base
     return unless v
     using_default = v.tr("\r","") == array2path(Setting["Default_variables_Lookup_Path"])
     write_attribute(:path, using_default ? nil : v)
-  end
-
-  def reject_invalid_lookup_values(attributes)
-    attributes[:match].empty? ||
-        (attributes[:value].blank? &&
-            (attributes[:use_puppet_default].nil? || attributes[:use_puppet_default] == "0"))
   end
 
   def default_value_before_type_cast

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -28,7 +28,7 @@ class LookupValue < ActiveRecord::Base
   scoped_search :in => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
 
   def value_present?
-    self.errors.add(:value, :blank) if value.nil? && !use_puppet_default
+    self.errors.add(:value, :blank) if value.to_s.empty? && !use_puppet_default && lookup_key.puppet?
   end
 
   def value=(val)

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -217,4 +217,26 @@ class LookupValueTest < ActiveSupport::TestCase
       refute_valid @value
     end
   end
+
+  context "when key type is puppetclass lookup and value is empty" do
+    def setup
+      @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
+                                :with_override, :with_use_puppet_default,
+                                :key_type => 'string',
+                                :puppetclass => puppetclasses(:one))
+      @value = FactoryGirl.build_stubbed(:lookup_value, :value => "",
+                                         :match => "hostgroup=Common",
+                                         :lookup_key_id => @key.id,
+                                         :use_puppet_default => true)
+    end
+
+    test "value is validated if use_puppet_default is true" do
+      assert_valid @value
+    end
+
+    test "value is not validated if use_puppet_default is false" do
+      @value.use_puppet_default = false
+      refute_valid @value
+    end
+  end
 end


### PR DESCRIPTION
Global parameters can have empty values so smart variables that are also global should be allowed to accept empty values too.
The validation on lookup_value to make sure it isn't empty is in the LookupKey class therefore affecting both VariableLookupKey and PuppetClassLookupKey.
This validation should affect on the child class - PuppetClassLookupKey.
