### PR TITLE
Fixes #12478 - don't update :attached_to if parsed :attached_to is nil

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -334,7 +334,7 @@ module Host
       iface.ip = attributes.delete(:ipaddress)
       iface.virtual = attributes.delete(:virtual) || false
       iface.tag = attributes.delete(:tag) || ''
-      iface.attached_to = attributes.delete(:attached_to) || ''
+      iface.attached_to = attributes.delete(:attached_to) if attributes[:attached_to].present?
       iface.link = attributes.delete(:link) if attributes.has_key?(:link)
       iface.identifier = name
       iface.host = self


### PR DESCRIPTION
Facter doesn't return data to populate :attached_to, this PR maintains the existing data when updating the interface.
