### PR TITLE
fixes #12479 - Configure API revision for vSphere Compute Resource

### DIFF
--- a/app/controllers/api/v1/compute_resources_controller.rb
+++ b/app/controllers/api/v1/compute_resources_controller.rb
@@ -34,6 +34,7 @@ module Api
         param :tenant, String, :desc => "for OpenStack only"
         param :server, String, :desc => "for VMware"
         param :set_console_password, :bool, :desc => N_("for Libvirt and VMware only")
+        param :api_revision, String, :desc => "API revision, for VMware only"
       end
 
       def create
@@ -54,6 +55,7 @@ module Api
         param :region, String, :desc => "for EC2 only"
         param :tenant, String, :desc => "for OpenStack only"
         param :server, String, :desc => "for VMware"
+        param :api_revision, String, :desc => "API revision, for VMware only"
       end
 
       def update

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -7,7 +7,8 @@ module Api
                                                      'project', 'key_path', 'email', 'zone',
                                                      'display_type', 'ovirt_quota', 'public_key',
                                                      'region', 'server', 'datacenter', 'pubkey_hash',
-                                                     'nics_attributes', 'volumes_attributes', 'memory'])
+                                                     'nics_attributes', 'volumes_attributes', 'memory',
+                                                     'api_revision'])
 
       include Api::Version2
       include Api::TaxonomyScope
@@ -44,6 +45,7 @@ module Api
           param :tenant, String, :desc => N_("for OpenStack only")
           param :server, String, :desc => N_("for VMware")
           param :set_console_password, :bool, :desc => N_("for Libvirt and VMware only")
+          param :api_revision, String, :desc => N_("API revision, for VMware only")
           param_group :taxonomies, ::Api::V2::BaseController
         end
       end

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -418,6 +418,18 @@ module Foreman::Model
       attrs[:pubkey_hash] = key
     end
 
+    def api_revision
+      attrs[:api_revision] || '5.0'
+    end
+
+    def api_revision=(rev)
+      attrs[:api_revision] = rev
+    end
+
+    def api_revisions
+      ['4.0', '5.0', '5.5', '6.0']
+    end
+
     def associated_host(vm)
       associate_by("mac", vm.mac)
     end
@@ -445,7 +457,8 @@ module Foreman::Model
         :vsphere_username             => user,
         :vsphere_password             => password,
         :vsphere_server               => server,
-        :vsphere_expected_pubkey_hash => pubkey_hash
+        :vsphere_expected_pubkey_hash => pubkey_hash,
+        :vsphere_rev                  => api_revision,
       )
     rescue => e
       if e.message =~ /The remote system presented a public key with hash (\w+) but we're expecting a hash of/

--- a/app/views/api/v2/compute_resources/vmware.json.rabl
+++ b/app/views/api/v2/compute_resources/vmware.json.rabl
@@ -1,1 +1,1 @@
-attributes :user, :datacenter, :server, :set_console_password
+attributes :user, :datacenter, :server, :set_console_password, :api_revision

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -7,6 +7,7 @@
                  :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
                  :'data-url' => test_connection_compute_resources_path) + image_tag('/assets/spinner.gif', :id => 'test_connection_indicator', :class => 'hide').html_safe }) %>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
+<%= selectable_f f, :api_revision, f.object.api_revisions, { }, :label => _("API Revision"), :help_inline => _("API revision Foreman uses to connect to vSphere."), :size => "col-md-1" %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console passwords"),
                   :help_inline => _("Set a randomly generated password on the display connection") %>

--- a/app/views/compute_resources/show/_vmware.html.erb
+++ b/app/views/compute_resources/show/_vmware.html.erb
@@ -6,3 +6,7 @@
   <td><%= _("Console passwords") %></td>
   <td><%= @compute_resource.set_console_password? ? _("Enabled") : _("Disabled") %></td>
 </tr>
+<tr>
+  <td><%= _("API Revision") %></td>
+  <td><%= @compute_resource.api_revision %></td>
+</tr>


### PR DESCRIPTION
Fog defaults to using 4.0 API revision to connect to vSphere. For features like storage pools or setting the boot order one needs to use at least 5.0. As a user I should be able to configure the api revision Foreman passes to fog.

This adds two changes to the GUI:

![image](https://cloud.githubusercontent.com/assets/4107560/11161984/d4fc0b7e-8a8d-11e5-82e0-a01a8857cb43.png)

![image](https://cloud.githubusercontent.com/assets/4107560/11161973/8adf41c8-8a8d-11e5-8440-f9fe0f98e038.png)
