### PR TITLE
Fixes #12461 - Compute profile is properly selected.

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -2,7 +2,7 @@ $(document).on('ContentLoad', function(){onHostEditLoad()});
 $(document).on('AddedClass', function(event, link){load_puppet_class_parameters(link)});
 
 function update_nics(success_callback) {
-  var data = $('form').serialize().replace('method=put', 'method=post');
+  var data = serializeForm().replace('method=put', 'method=post');
   $('#network').html(spinner_placeholder(__('Loading interfaces information ...')));
   $('#network_tab a').removeClass('tab-error');
 
@@ -46,7 +46,7 @@ function computeResourceSelected(item){
     $("#compute_resource_tab").show();
     $("#compute_profile").show();
     $('#vm_details').empty();
-    var data = $('form').serialize().replace('method=put', 'method=post');
+    var data = serializeForm().replace('method=put', 'method=post');
     $('#compute_resource').html(spinner_placeholder(__('Loading virtual machine information ...')));
     $('#compute_resource_tab a').removeClass('tab-error');
     $(item).indicator_show();
@@ -121,7 +121,7 @@ function submit_with_all_params(){
   $.ajax({
     type:'POST',
     url: url,
-    data: $('form').serialize(),
+    data: serializeForm(),
     success: function(response){
       $('#' + resource + '-progress').hide();
       $('#content').replaceWith($("#content", response));
@@ -186,7 +186,7 @@ function load_puppet_class_parameters(item) {
   if ($('#puppetclass_' + id + '_params_loading').length > 0) return; // already loading
   if ($('[id^="#puppetclass_' + id + '_params\\["]').length > 0) return; // already loaded
   var url = $(item).attr('data-url');
-  var data = $("form").serialize().replace('method=put', 'method=post');
+  var data = serializeForm().replace('method=put', 'method=post');
   if (url.match('hostgroups')) {
     data = data + '&hostgroup_id=' + host_id
   } else {
@@ -261,7 +261,7 @@ function location_changed(element) {
 function update_form(element, options) {
   options = options || {};
   var url = $(element).data('url');
-  var data = $('form').serialize().replace('method=put', 'method=post');
+  var data = serializeForm().replace('method=put', 'method=post');
   if (options.data) data = data+options.data;
   $(element).indicator_show();
   $.ajax({
@@ -281,6 +281,20 @@ function update_form(element, options) {
       $(document.body).trigger('ContentLoad');
     }
   })
+}
+
+//Serializes only those input elements from form that are set explicitly
+function serializeForm() {
+  return $($('form')[0].elements).filter(isExplicit).serialize()
+}
+
+//This function decides for a given input element is it set explicitly by the user.
+function isExplicit(index, element) {
+  if (element.nextSibling == undefined) return true;
+  if (element.nextSibling.children == undefined) return true;
+  if (element.nextSibling.children[0] == undefined) return true;
+  if (element.nextSibling.children[0].dataset == undefined) return true;
+  return element.nextSibling.children[0].dataset.explicit == 'true';
 }
 
 function subnet_contains(number, cidr, ip){

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -59,7 +59,8 @@
          be different from the defaults, or the defaults could have changed after the vm was created. %>
         <div id="compute_profile" <%= display?(!@host.compute_resource_id) %> >
           <%= select_f f, :compute_profile_id, ComputeProfile.visibles, :id, :name,
-            { :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
+            { :include_blank => true,
+              :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
               :disable_button_enabled => inherited_by_default?(:compute_profile_id, @host),
               :user_set => params[:host] && params[:host][:compute_profile_id]
             },

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2719,6 +2719,22 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  context 'hostgroup defaults' do
+    setup do
+      @group1 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:one))
+      @group2 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:two))
+    end
+
+    test 'sets proper compute attributes on hostgroup change' do
+      host = FactoryGirl.create(:host, :managed, :compute_resource => compute_resources(:one), :hostgroup => @group1)
+      assert_not_equal 4, host.compute_attributes['cpus']
+
+      host.attributes = host.apply_inherited_attributes('hostgroup_id' => @group2.id)
+      host.set_hostgroup_defaults
+      assert_equal 4, host.compute_attributes['cpus']
+    end
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
1. Now the javascript filters out fields that are not set explicitly.
2. Change in the hostgroup automatically resets the compute profile and attributes.
3. `:include_blank` added to compute profile selector
