### PR TITLE
fixes #12436 - as a user I want to deploy vSphere vms on a storage pod

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -259,3 +259,39 @@ function vsphereGetResourcePools(item) {
     }
   })
 }
+
+function vsphereStoragePodSelected(item) {
+  selected = $(item).val();
+  datastore = $('select[id*=datastore]')
+  if(!selected || 0 === selected.length) {
+    enable_vsphere_dropdown(datastore);
+  } else {
+    disable_vsphere_dropdown(datastore);
+  }
+  return false;
+}
+
+function vsphereStoragePodLoad() {
+  items = $('select[id*=storage_pod]');
+  if(items.length < 1) {
+    return false;
+  }
+  items.each(function() {
+    selected = $(this).val();
+    if(selected || ! (0 === selected.length)) {
+      datastore = $('select[id*=datastore]');
+      disable_vsphere_dropdown(datastore);
+    }
+  });
+  return false;
+}
+
+$(document).on('ContentLoad', function(){vsphereStoragePodLoad()});
+
+function disable_vsphere_dropdown(item){
+  item.attr("disabled", true);
+}
+
+function enable_vsphere_dropdown(item){
+  item.attr("disabled", false);
+}

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -15,7 +15,7 @@ module Api
       before_filter :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,
                                               :available_clusters, :available_flavors, :available_folders,
                                               :available_networks, :available_resource_pools, :available_security_groups, :available_storage_domains,
-                                              :available_zones]
+                                              :available_zones, :available_storage_pods]
 
       api :GET, "/compute_resources/", N_("List all compute resources")
       param_group :taxonomy_scope, ::Api::V2::BaseController
@@ -132,6 +132,15 @@ module Api
         render :available_storage_domains, :layout => 'api/v2/layouts/index_layout'
       end
 
+      api :GET, "/compute_resources/:id/available_storage_pods", N_("List storage pods for a compute resource")
+      api :GET, "/compute_resources/:id/available_storage_pods/:storage_pod", N_("List attributes for a given storage pod")
+      param :id, :identifier, :required => true
+      param :storage_pod, String
+      def available_storage_pods
+        @available_storage_pods = @compute_resource.available_storage_pods(params[:storage_pod])
+        render :available_storage_pods, :layout => 'api/v2/layouts/index_layout'
+      end
+
       api :GET, "/compute_resources/:id/available_security_groups", N_("List available security groups for a compute resource")
       param :id, :identifier, :required => true
       def available_security_groups
@@ -161,7 +170,7 @@ module Api
 
       def action_permission
         case params[:action]
-          when 'available_images', 'available_clusters', 'available_flavors', 'available_folders', 'available_networks', 'available_resource_pools', 'available_security_groups', 'available_storage_domains', 'available_zones', 'associate'
+          when 'available_images', 'available_clusters', 'available_flavors', 'available_folders', 'available_networks', 'available_resource_pools', 'available_security_groups', 'available_storage_domains', 'available_zones', 'associate', 'available_storage_pods'
             :view
           else
             super

--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -84,6 +84,14 @@ module ComputeResourcesVmsHelper
     "#{datastore.name} (#{_('free')}: #{number_to_human_size(datastore.freespace)}, #{_('prov')}: #{number_to_human_size(datastore.capacity + (datastore.uncommitted || 0) - datastore.freespace)}, #{_('total')}: #{number_to_human_size(datastore.capacity)})"
   end
 
+  def vsphere_storage_pods(compute)
+    compute.storage_pods.map { |pod| [storage_pod_stats(pod), pod.name] }
+  end
+
+  def storage_pod_stats(pod)
+    "#{pod.name} (#{_('free')}: #{number_to_human_size(pod.freespace)}, #{_('prov')}: #{number_to_human_size(pod.capacity - pod.freespace)}, #{_('total')}: #{number_to_human_size(pod.capacity)})"
+  end
+
   def available_actions(vm, authorizer = nil)
     case vm
     when Fog::Compute::OpenStack::Server

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -238,6 +238,10 @@ class ComputeResource < ActiveRecord::Base
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end
 
+  def available_storage_pods(storage_pod = nil)
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
   # this method is overwritten for Libvirt
   def editable_network_interfaces?
     networks.any?

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -69,6 +69,26 @@ module Foreman::Model
       end
     end
 
+    def storage_pods(opts = {})
+      if opts[:storage_pod]
+        begin
+          dc.storage_pods.get(opts[:storage_pod])
+        rescue RbVmomi::VIM::InvalidArgument
+          {} # Return an empty storage pod hash if vsphere does not support the feature
+        end
+      else
+        begin
+          name_sort(dc.storage_pods.all())
+        rescue RbVmomi::VIM::InvalidArgument
+          [] # Return an empty set of storage pods if vsphere does not support the feature
+        end
+      end
+    end
+
+    def available_storage_pods(storage_pod = nil)
+      storage_pods({:storage_pod => storage_pod})
+    end
+
     def folders
       dc.vm_folders.sort_by{|f| [f.path, f.name]}
     end
@@ -376,6 +396,7 @@ module Foreman::Model
         "numCPUs" => args[:cpus],
         "memoryMB" => args[:memory_mb],
         "datastore" => args[:volumes].first[:datastore],
+        "storage_pod" => args[:volumes].first[:storage_pod],
         "resource_pool" => [args[:cluster], args[:resource_pool]],
       }
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -83,7 +83,8 @@ Foreman::AccessControl.map do |permission_set|
                                                 :"api/v1/compute_resources" => [:index, :show],
                                                 :"api/v2/compute_resources" => [:index, :show, :available_images, :available_clusters, :available_folders,
                                                                                 :available_flavors, :available_networks, :available_resource_pools,
-                                                                                :available_security_groups, :available_storage_domains, :available_zones]
+                                                                                :available_security_groups, :available_storage_domains, :available_zones,
+                                                                                :available_storage_pods]
     }
     map.permission :create_compute_resources,  {:compute_resources => [:new, :create].push(*ajax_actions),
                                                 :"api/v1/compute_resources" => [:create],

--- a/app/views/api/v2/compute_resources/available_storage_pods.rabl
+++ b/app/views/api/v2/compute_resources/available_storage_pods.rabl
@@ -1,0 +1,3 @@
+collection @available_storage_pods
+
+attribute :name, :id, :capacity, :freespace

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -1,3 +1,11 @@
+<%= selectable_f f,
+  :storage_pod,
+  vsphere_storage_pods(compute_resource),
+  { :include_blank => _('Deploy VM on selected datastore') },
+  :class => "span5 without_select2",
+  :label => _("Datastore Cluster"),
+  :label_size => "col-md-2",
+  :onchange => 'vsphereStoragePodSelected(this)' if new_host and vsphere_storage_pods(compute_resource).any? %>
 <%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5 without_select2", :label => _("Data store"), :label_size => "col-md-2" %>
 <%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2" %>
 <%= text_f f, :size_gb,

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 0.4.0'
+  gem 'fog-vsphere', '>= 0.5.0'
 end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -252,6 +252,8 @@ Foreman::Application.routes.draw do
           get :available_security_groups, :on => :member
           get :available_storage_domains, :on => :member
           get 'available_storage_domains/(:storage_domain)', :to => 'compute_resources#available_storage_domains', :on => :member
+          get :available_storage_pods, :on => :member
+          get 'available_storage_pods/(:storage_pod)', :to => 'compute_resources#available_storage_pods', :on => :member
           get 'available_clusters/(:cluster_id)/available_networks', :to => 'compute_resources#available_networks', :on => :member
           get 'available_clusters/(:cluster_id)/available_resource_pools', :to => 'compute_resources#available_resource_pools', :on => :member
           get :available_zones, :on => :member

--- a/test/functional/api/v2/compute_resources_controller_test.rb
+++ b/test/functional/api/v2/compute_resources_controller_test.rb
@@ -206,6 +206,11 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
       get :available_storage_domains, { :id => compute_resources(:vmware).to_param }
     end
 
+    test "should get available vmware storage pods" do
+      Foreman::Model::Vmware.any_instance.stubs(:available_storage_pods).returns([@vmware_object])
+      get :available_storage_pods, { :id => compute_resources(:vmware).to_param }
+    end
+
     test "should get available vmware resource pools" do
       Foreman::Model::Vmware.any_instance.stubs(:available_resource_pools).returns([@vmware_object])
       get :available_resource_pools, { :id => compute_resources(:vmware).to_param, :cluster_id => '123-456-789' }
@@ -228,6 +233,19 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     assert_response :success
     available_storage_domains = ActiveSupport::JSON.decode(@response.body)
     assert_equal storage_domain.id, available_storage_domains['results'].first.try(:[], 'id')
+  end
+
+  test "should get specific vmware storage pod" do
+    storage_pod = Object.new
+    storage_pod.stubs(:name).returns('test_vmware_pod')
+    storage_pod.stubs(:id).returns('group-p123456')
+
+    Foreman::Model::Vmware.any_instance.expects(:available_storage_pods).with('test_vmware_pod').returns([storage_pod])
+
+    get :available_storage_pods, { :id => compute_resources(:vmware).to_param, :storage_pod => 'test_vmware_pod' }
+    assert_response :success
+    available_storage_pods = ActiveSupport::JSON.decode(@response.body)
+    assert_equal storage_pod.id, available_storage_pods['results'].first.try(:[], 'id')
   end
 
   test "should associate hosts that match" do


### PR DESCRIPTION
This PR implements creating and cloning a vm on a datastore cluster instead of a datastore and adds datastore clusters to the api.

Creating on a datastore:
![image](https://cloud.githubusercontent.com/assets/4107560/11186272/34a4d660-8c81-11e5-88ba-7ec4b2396146.png)

Creating on a datastore cluster:
![image](https://cloud.githubusercontent.com/assets/4107560/11186298/482c7288-8c81-11e5-80db-ef7d42630f1f.png)

@brandonweeks: Mind to take a look? What do you think?
