### PR TITLE
fixes #12494 - update fog to 1.36.0

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,5 +1,10 @@
 group :fog do
-  gem 'fog', '1.34.0', :require => false
-  gem 'fog-core', '1.32.1'
-  gem 'net-ssh', '< 3' if RUBY_VERSION.start_with? '1.9.'
+  gem 'fog', '1.36.0', :require => false
+  gem 'fog-core', '1.34.0'
+  if RUBY_VERSION.start_with? '1.9.'
+    gem 'net-ssh', '< 3'
+  else
+    gem 'net-ssh'
+  end
+  gem 'net-scp'
 end


### PR DESCRIPTION
fog-core has dropped direct net-ssh/scp dependencies, so require them
here for SSH provisioning to function at runtime.
