### PR TITLE
Fixes #12451 - Turns 'Load Datacenter' button as a button-group in vmware form

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -32,6 +32,7 @@ function providerSelected(item)
 }
 
 function testConnection(item) {
+  $(item).addClass("disabled");
   var cr_id = $("form").data('id');
   var password = $("input#compute_resource_password").val();
   $('.tab-error').removeClass('tab-error');
@@ -48,13 +49,14 @@ function testConnection(item) {
         $("#compute_resource_password").prop('disabled', false);
       }
       if (!/alert-danger/i.test(result)) {
-        notify("<p>" + __("Test connection was successful") + "</p>", 'success')
+        notify("<p>" + __("Test connection was successful") + "</p>", 'success');
       }
     },
     complete:function (result) {
       //we need to restore the password field as it is not sent back from the server.
       $("input#compute_resource_password").val(password);
       reloadOnAjaxComplete('#test_connection_indicator');
+      $(item).removeClass("disabled");
     }
   });
 }
@@ -139,7 +141,7 @@ function ovirt_clusterSelected(item){
 }
 
 function ovirt_datacenterSelected(item){
-  testConnection($('#test_connection_button'));
+  testConnection($('#btn_datacenter'));
 }
 
 function libvirt_network_selected(item){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -570,3 +570,7 @@ table {
 .masked-input {
   font-family: 'AllBullets';
 }
+
+.select-margin {
+  margin-left: -40px !important;
+}

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,9 +1,33 @@
 module FormHelper
-  def text_f(f, attr, options = {})
+  def text_f(f, attr, options = {}, btn_options = {})
+    btn_group = btn_options.delete(:button_group)
+    btn_class = btn_options.delete(:class) || 'col-md-4 select-margin'
+    label = btn_options.delete(:label)
+    documentation = btn_options.delete(:documentation)
     field(f, attr, options) do
       addClass options, "form-control"
       options[:focus_on_load] ||= attr.to_s == 'name'
-      f.text_field attr, options
+      text_field =
+        content_tag :div, :class => btn_group ? "col-md-8" : "" do
+          f.text_field attr, options
+        end
+      if btn_group
+        button =
+          if documentation
+            content_tag :div, :class => btn_class do
+              content_tag :span, class: 'input-group-btn' do
+                documentation_button(label)
+              end
+            end
+          else
+            button_input_group label, btn_options
+          end
+        content_tag :div, :class => "row" do
+          input_group text_field, button
+        end
+      else
+        text_field
+      end
     end
   end
 
@@ -175,11 +199,27 @@ module FormHelper
     end
   end
 
-  def selectable_f(f, attr, array, select_options = {}, html_options = {})
+  def selectable_f(f, attr, array, select_options = {}, html_options = {}, btn_options = {})
+    btn_group = btn_options.delete(:button_group)
+    label = btn_options.delete(:label)
     html_options.merge!(:size => 'col-md-10') if html_options[:multiple]
     field(f, attr, html_options) do
       addClass html_options, "form-control"
-      f.select attr, array, select_options, html_options
+      select_field =
+          content_tag :div, :class => btn_group ? "col-md-8" : "" do
+            f.select attr, array, select_options, html_options
+          end
+      if btn_group
+        button =
+            content_tag :div, :class => "col-md-4 select-margin" do
+              button_input_group label, btn_options
+            end
+        content_tag :div, :class => "row" do
+          input_group select_field, button
+        end
+      else
+        select_field
+      end
     end
   end
 

--- a/app/views/compute_resources/form/_ec2.html.erb
+++ b/app/views/compute_resources/form/_ec2.html.erb
@@ -1,8 +1,9 @@
-<%= text_f f, :user, :label => _("Access Key"), :help_inline => documentation_button('5.2.3EC2Notes') %>
+<%= text_f f, :user, {:label => _("Access Key"), :size => "col-md-6"}, {:button_group => true, :label => '5.2.3EC2Notes', :documentation => true} %>
 <%= password_f f, :password, :label => _("Secret Key"), :unset => unset_password? %>
 
 <% regions = f.object.regions rescue [] %>
-<%= selectable_f(f, :region, regions, {}, {:label => _('Region'), :disabled => regions.empty?,
-                 :help_inline => link_to_function(regions.empty? ? _("Load Regions") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{regions.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<%= selectable_f(f, :region, regions, {}, {:label => _('Region'), :disabled => regions.empty?, :size => "col-md-6",
+                 :help_inline => hidden_spinner('', :id => 'test_connection_indicator').html_safe},
+                 {:button_group => true, :label =>regions.empty? ? _("Load Regions") : _("Test Connection"),
+                  :class =>"btn + #{regions.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter', :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>
+

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -1,9 +1,9 @@
-<%= text_f f, :project, :label => _("Google Project ID"), :help_inline => documentation_button('5.2.4GoogleComputeEngineNotes') %>
+<%= text_f f, :project, {:label => _("Google Project ID"), :size => "col-md-6"}, {:button_group => true, :label => '5.2.4GoogleComputeEngineNotes', :documentation => true} %>
 <%= text_f f, :email, :label => _("Client Email"), :class => 'col-md-8' %>
-<%= text_f f, :key_path, :label => _("Certificate path"), :help_inline => _('The file path where your p12 file is located'), :class => 'col-md-8' %>
+<%= text_f f, :key_path, :label => _("Certificate path"), :help_inline => _('The file path where your p12 file is located') %>
 
 <% zones = f.object.zones rescue [] %>
-<%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?,
-                 :help_inline => link_to_function(zones.empty? ? _("Load zones") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{zones.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?, :size => "col-md-6",
+                 :help_inline => hidden_spinner('', :id => 'test_connection_indicator').html_safe},
+                 {:button_group => true, :label => zones.empty? ? _("Load zones") : _("Test Connection"),
+                  :class =>"btn + #{zones.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter', :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
+<%= text_f f, :url, {:size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system")}, {:button_group => true, :label => '5.2.5LibvirtNotes', :documentation => true} %>
 
 <%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display type") %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -1,10 +1,10 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens"), :help_inline => documentation_button('5.2.6OpenStackNotes') %>
+<%= text_f f, :url, {:size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens")}, {:button_group => true, :label => '5.2.6OpenStackNotes', :documentation => true} %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
 
 <% tenants = f.object.tenants rescue [] %>
-<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty?,
-                 :help_inline => link_to_function(tenants.empty? ? _("Load Tenants") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{tenants.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty?, :size => "col-md-6",
+                 :help_inline => hidden_spinner('', :id => 'test_connection_indicator').html_safe},
+                 {:button_group => true, :label => tenants.empty? ? _("Load Tenants") : _("Test Connection"),
+                  :class =>"btn + #{tenants.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter', :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>
 <%= checkbox_f f, :allow_external_network, {:checked => f.object.allow_external_network, :label => _("Allow external network as main network")} %>

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -1,13 +1,12 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://ovirt.example.com/api"), :help_inline => documentation_button('5.2.7oVirt/RHEVNotes') %>
+<%= text_f f, :url, {:size => "col-md-8", :help_block => _("e.g. https://ovirt.example.com/api")}, {:button_group => true, :label => '5.2.7oVirt/RHEVNotes', :documentation => true}%>
 <%= text_f f, :user, :help_block => _("e.g. admin@internal") %>
 <%= password_f f, :password, :unset => unset_password? %>
-<% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
-<%= selectable_f(f, :uuid, datacenters, {}, {:label => _('Datacenter'),
+<% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue [] %>
+<%= selectable_f(f, :uuid, datacenters, {}, {:label => _('Datacenter'), :size => "col-md-6",
                  :onchange => 'ovirt_datacenterSelected();',
-                 :help_inline => link_to_function(datacenters.empty? ? _("Load Datacenters") : _("Test Connection"), "testConnection(this)",
-                 :id => 'test_connection_button',
-                 :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline => hidden_spinner('', :id => 'test_connection_indicator').html_safe },
+                 {:button_group => true, :label => datacenters.empty? ? _("Load Datacenters") : _("Test Connection"),
+                  :class => "btn #{datacenters.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter', :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>
 <% quotas = (f.object.uuid.nil? && controller.action_name != 'test_connection') ? [] : f.object.quotas.all rescue []%>
 <%= select_f f, :ovirt_quota, quotas, :id, :name, {}, :label => _("Quota ID") %>
 <%= textarea_f f, :public_key, :label => _("X509 Certification Authorities"), :size => "col-md-8",

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -1,8 +1,7 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0"), :help_inline => documentation_button('5.2.8RackspaceNotes') %>
+<%= text_f f, :url, {:size => "col-md-8", :help_block => _("e.g. https://identity.api.rackspacecloud.com/v2.0")}, {:button_group => true, :label => '5.2.8RackspaceNotes', :documentation => true} %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :label => _("API Key"), :unset => unset_password? %>
 <% flavors = f.object.flavors rescue [] %>
-<%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region'),
-                 :help_inline => link_to_function(_("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{flavors.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region'), :size => "col-md-6", :help_inline => hidden_spinner('', :id => 'test_connection_indicator').html_safe },
+                 {:button_group => true, :label => _("Test Connection"), :class => "btn #{flavors.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter',
+                  :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -1,11 +1,11 @@
-<%= text_f f, :server, :label => _("VCenter/Server"), :size => "col-md-8", :help_inline => documentation_button('5.2.9VMwareNotes') %>
+<%= text_f f, :server, {:label => _("VCenter/Server"), :size => "col-md-8"}, {:button_group => true, :label => '5.2.9VMwareNotes', :documentation => true} %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
-<% datacenters = list_datacenters f.object%>
-<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'),
-                 :help_inline => link_to_function(datacenters.empty? ? _("Load Datacenters") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<% datacenters = list_datacenters f.object %>
+<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'),:size => "col-md-6",
+                 :help_inline =>  hidden_spinner('', :id => 'test_connection_indicator').html_safe},
+                 {:button_group => true, :label => datacenters.empty? ? _("Load Datacenters") : _("Test Connection"),
+                  :class => "btn #{datacenters.empty? ? "btn-default" : "btn-success"}", :id => 'btn_datacenter', :onclick => "testConnection(this)", :'data-url' => test_connection_compute_resources_path }) %>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console passwords"),

--- a/test/integration/compute_resource_test.rb
+++ b/test/integration/compute_resource_test.rb
@@ -19,7 +19,7 @@ class ComputeResourceIntegrationTest < ActionDispatch::IntegrationTest
     click_link "Vmware"
     click_link "Edit"
     fill_in "compute_resource_password", :disabled => true, :with => "123456"
-    click_link "Load Datacenters"
+    click_button "Load Datacenters"
     assert_equal "123456", find_field("compute_resource_password",:disabled => true).value
   end
 end


### PR DESCRIPTION
This validation causes the 'Load Datacenter' button to disappear, because it generates inline text and it overrides the button. 

Before: 
![error_old](https://cloud.githubusercontent.com/assets/11807069/11425345/f62e3bae-945c-11e5-9a29-7f7b81d1c566.png)

Suggestion:

![no_error](https://cloud.githubusercontent.com/assets/11807069/11423102/3581dfda-944a-11e5-9f7d-4322255d3c2e.png)
![error](https://cloud.githubusercontent.com/assets/11807069/11423101/3581d4a4-944a-11e5-89ce-e99f460976f7.png)
