### PR TITLE
fixes #12512 - always install fog-core/net-* dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,13 @@ gem 'i18n', '~> 0.6.4'
 gem 'rails-i18n', '~> 3.0.0'
 gem 'turbolinks', '~> 2.5'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
+gem 'fog-core', '1.34.0'
+gem 'net-scp'
+if RUBY_VERSION.start_with? '1.9.'
+  gem 'net-ssh', '< 3'
+else
+  gem 'net-ssh'
+end
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,10 +1,3 @@
 group :fog do
   gem 'fog', '1.36.0', :require => false
-  gem 'fog-core', '1.34.0'
-  if RUBY_VERSION.start_with? '1.9.'
-    gem 'net-ssh', '< 3'
-  else
-    gem 'net-ssh'
-  end
-  gem 'net-scp'
 end


### PR DESCRIPTION
fog-core 1.33 made net-\* deps optional, but Foreman relies on them for
image provisioning on many CR types.  Since the 'fog' Bundler group is
optional (e.g. the 'ec2' group can be used standalone as fog-aws depends
on fog-core), these deps have been moved into the main Gemfile so they
are always available for any CR when the 'fog' group isn't installed.
fog-core was also moved to ensure it's always pinned appropriately.

Although the gems aren't always required, this will make using the CR
Bundler groups less complex than adding another group specifically for
fog-core and net-*, for Bundler users, in packages and in plugins.
