### PR TITLE
fixes #12517 - VMWare VM should be created network based only if it i…

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -320,7 +320,7 @@ module Foreman::Model
 
       args = parse_networks(args)
       args = args.with_indifferent_access
-      if args[:image_id].present?
+      if args[:provision_method] == 'image'
         clone_vm(args)
       else
         vm = new_vm(args)

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -73,7 +73,7 @@ module Orchestration::Compute
   def setCompute
     logger.info "Adding Compute instance for #{name}"
     add_interfaces_to_compute_attrs
-    self.vm = compute_resource.create_vm compute_attributes.merge(:name => vm_name)
+    self.vm = compute_resource.create_vm compute_attributes.merge(:name => vm_name, :provision_method => provision_method)
   rescue => e
     failure _("Failed to create a compute %{compute_resource} instance %{name}: %{message}\n ") % { :compute_resource => compute_resource, :name => name, :message => e.message }, e
   end

--- a/test/unit/compute_resources/vmware_test.rb
+++ b/test/unit/compute_resources/vmware_test.rb
@@ -50,25 +50,57 @@ class VmwareTest < ActiveSupport::TestCase
       @cr = FactoryGirl.build(:vmware_cr)
       @cr.stubs(:test_connection)
     end
-    test "calls clone_vm when image provisioning with symbol key" do
-      args = {:image_id =>"2" }
+    test "calls clone_vm when image provisioning with symbol key and provision_method image" do
+      args = {:image_id =>"2", "provision_method" => "image" }
       @cr.stubs(:parse_networks).returns(args)
       @cr.expects(:clone_vm)
       @cr.expects(:new_vm).times(0)
       @cr.create_vm(args)
     end
-    test "calls clone_vm when image provisioning with string key" do
-      args = {"image_id" =>"2" }
+    test "calls clone_vm when image provisioning with string key and provision_method image" do
+      args = {"image_id" =>"2", "provision_method" => "image" }
       @cr.stubs(:parse_networks).returns(args)
       @cr.expects(:clone_vm)
       @cr.expects(:new_vm).times(0)
+      @cr.create_vm(args)
+    end
+    test "does not call clone_vm when image provisioning with string key and provision_method build" do
+      args = {"image_id" =>"2", "provision_method" => "build" }
+      mock_vm = mock('vm')
+      mock_vm.expects(:save).returns(mock_vm)
+      @cr.stubs(:parse_networks).returns(args)
+      @cr.expects(:clone_vm).times(0)
+      @cr.expects(:new_vm).returns(mock_vm)
       @cr.create_vm(args)
     end
   end
 
   test "#create_vm calls clone_vm when image provisioning" do
     attrs_in = HashWithIndifferentAccess.new("image_id"=>"2","cpus"=>"1", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
-    attrs_parsed = HashWithIndifferentAccess.new("image_id"=>"2","cpus"=>"1", "interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"Test network", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"Test network", "_delete"=>""}}, "volumes_attributes"=>{"new_volumes"=>{"size_gb"=>"10", "_delete"=>""}, "0"=>{"size_gb"=>"1", "_delete"=>""}})
+    attrs_parsed = HashWithIndifferentAccess.new(
+      "image_id" => "2",
+      "cpus" => "1",
+      "interfaces_attributes" => {
+        "new_interfaces" => {
+          "type" => "VirtualE1000",
+          "network" => "Test network",
+          "_delete" => "",
+        },
+        "0"=>{
+          "type" => "VirtualVmxnet3",
+          "network" => "Test network",
+          "_delete" => "",
+        }
+      },
+      "volumes_attributes"=>{
+        "new_volumes"=>{
+          "size_gb" => "10",
+          "_delete" => "",
+        },
+        "0" => {"size_gb"=>"1", "_delete"=>""}
+      },
+      "provision_method" => "image",
+    )
 
     mock_vm = mock('vm')
     cr = FactoryGirl.build(:vmware_cr)


### PR DESCRIPTION
…s selected in the gui

When creating a host network based foreman creates the host image based because the image_id is always set in the gui and only hidden.
