### PR TITLE
Fixes #9470 - Adds an option to send puppet error emails for all hosts to a user

### DIFF
--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -4,7 +4,7 @@ class MailNotification < ActiveRecord::Base
   INTERVALS = [N_("Daily"), N_("Weekly"), N_("Monthly")]
   SUBSCRIPTION_TYPES = %w(alert report)
 
-  attr_accessible :description, :mailer, :method, :name, :subscriptable, :subscription_type, :category, :queryable
+  attr_accessible :description,:mailer_method, :mailer, :name, :subscriptable, :subscription_type, :category, :queryable, :method, :type
 
   has_many :user_mail_notifications, :dependent => :destroy
   has_many :users, :through => :user_mail_notifications
@@ -23,10 +23,21 @@ class MailNotification < ActiveRecord::Base
 
   default_scope -> { order("mail_notifications.name") }
 
+  def initialize(*args)
+    params = args.shift
+    params[:type] =  "PuppetError" if params[:name] == 'puppet_error_state'
+    args.unshift(params)
+    super(*args)
+  end
+
   # Easy way to reference the notification to support something like:
   #   MailNotification[:some_error_notification].deliver(options)
   def self.[](name)
     self.find_by_name(name)
+  end
+
+  def subscription_options
+    [N_("Subscribe")]
   end
 
   def deliver(*args)

--- a/app/models/mail_notifications/puppet_error.rb
+++ b/app/models/mail_notifications/puppet_error.rb
@@ -1,0 +1,7 @@
+class PuppetError < MailNotification
+  scope :all_hosts, -> { PuppetError.includes(:user_mail_notifications).where(:user_mail_notifications => {:interval => 'Subscribe to all hosts'} ) }
+
+  def subscription_options
+    [N_("Subscribe to my hosts"), N_("Subscribe to all hosts")]
+  end
+end

--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -1,6 +1,5 @@
 <%= f.hidden_field :mail_notification_id, :value => f.object.mail_notification.id %>
-<% values = f.object.mail_notification.subscription_type == 'alert' ? [N_("Subscribe")] : MailNotification::INTERVALS %>
-
+<% values = f.object.mail_notification.subscription_type == 'alert' ? f.object.mail_notification.subscription_options : MailNotification::INTERVALS %>
 <%= select_f(f, :interval, values, :to_s, :to_translation, { :include_blank => _('No emails') }, {:label => f.object.mail_notification.name.humanize,
              :help_inline => _(f.object.mail_notification.description)}) %>
 <%= mail_notification_query_builder(f.object.mail_notification, f) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,6 +109,7 @@ module Foreman
     config.autoload_paths += %W(#{config.root}/app/models/parameters)
     config.autoload_paths += %W(#{config.root}/app/models/trends)
     config.autoload_paths += %W(#{config.root}/app/models/taxonomies)
+    config.autoload_paths += %W(#{config.root}/app/models/mail_notifications)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/db/migrate/20151210143537_add_type_to_mail_notification.rb
+++ b/db/migrate/20151210143537_add_type_to_mail_notification.rb
@@ -1,0 +1,11 @@
+class AddTypeToMailNotification < ActiveRecord::Migration
+  def change
+    add_column :mail_notifications, :type, :string
+    MailNotification.reset_column_information
+    puppet_error = MailNotification.find_by_name('puppet_error_state')
+    if puppet_error.present?
+      puppet_error.type = 'PuppetError'
+      puppet_error.save
+    end
+  end
+end

--- a/db/seeds.d/16-mail_notifications.rb
+++ b/db/seeds.d/16-mail_notifications.rb
@@ -2,7 +2,6 @@
 # and method, and need to define the corresponding ActionMailer and method.
 # For system notifications, set subscriptable to false.  For recurring reports,
 # set subscription_type to 'report', and for ad hoc mails, use 'alert'
-
 notifications = [
   {
     :name              => 'puppet_summary',
@@ -10,14 +9,6 @@ notifications = [
     :mailer            => 'HostMailer',
     :method            => 'summary',
     :subscription_type => 'report'
-  },
-
-  {
-    :name              => 'puppet_error_state',
-    :description       => N_('A notification when a host reports a puppet error'),
-    :mailer            => 'HostMailer',
-    :method            => 'error_state',
-    :subscription_type => 'alert'
   },
 
   {
@@ -52,6 +43,14 @@ notifications = [
     :method             => 'tester',
     :subscriptable      => false,
     :subscription_type  => nil
+  },
+
+  {
+    :name               => 'puppet_error_state',
+    :description        => N_('A notification when a host reports a puppet error'),
+    :mailer             => 'HostMailer',
+    :method             => 'error_state',
+    :subscription_type  => 'alert',
   }
 ]
 

--- a/test/factories/mail_notification.rb
+++ b/test/factories/mail_notification.rb
@@ -1,12 +1,21 @@
 FactoryGirl.define do
   factory :mail_notification do
-    sequence(:name) {|n| "notification#{n}"}
-    default_interval "Daily"
-    mailer "HostMailer"
-    mailer_method "test_mail"
-    description "Notifies a user"
-    subscription_type "report"
-    queryable false
+    ignore do
+      sequence(:name) {|n| "notification#{n}"}
+      default_interval "Daily"
+      mailer "HostMailer"
+      mailer_method "test_mail"
+      description "Notifies a user"
+      subscription_type "report"
+      queryable false
+    end
+
+    trait :puppet_error do
+      sequence(:name) {"puppet_error_state"}
+      mailer "HostMailer"
+      mailer_method "puppet"
+    end
+
+    initialize_with { MailNotification.new ({:name => name, :mailer => mailer, :mailer_method => mailer_method} )  }
   end
 end
-

--- a/test/fixtures/mail_notifications.yml
+++ b/test/fixtures/mail_notifications.yml
@@ -12,6 +12,7 @@ puppet_error_state:
   mailer: HostMailer
   method: error_state
   subscription_type: alert
+  type: PuppetError
 
 welcome:
   name: welcome

--- a/test/unit/mail_notification_test.rb
+++ b/test/unit/mail_notification_test.rb
@@ -25,4 +25,9 @@ class MailNotificationTest < ActiveSupport::TestCase
     HostMailer.expects(:test_mail).with(:foo, :user => users[1]).returns(mail)
     mailer.deliver(:foo, :users => users)
   end
+
+  test "when a notification with 'puppet_error_state' name generated, a subclass PuppeError should created" do
+    mailer =  FactoryGirl.build(:mail_notification, :puppet_error)
+    assert mailer.type == 'PuppetError'
+  end
 end


### PR DESCRIPTION
Adds an option to the puppet error state notification - Subscribe to all hosts, when error occurs from any host, the user will get an email
