### PR TITLE
Fixes #12554 - Use proper Operating System name representation

### DIFF
--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -17,7 +17,7 @@
       <%= text_f f, :name, :help_inline => _("OS name from facter; e.g. RedHat") %>
       <%= text_f f, :major, :help_inline => _("OS major version from facter; e.g. 6"), :class => "col-md-2" %>
       <%= text_f f, :minor, :help_inline => _("OS minor version from facter; e.g. 5"), :class => "col-md-2" %>
-      <%= text_f f, :description, :help_inline => _("e.g. RHEL 6.5") %>
+      <%= text_f f, :description, :help_inline => _("OS friendly name; e.g. RHEL 6.5") %>
       <%= select_f f, :family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family") }, { :label => _("Family"), :onchange => 'show_release(this);' } %>
       <div id="release_name" <%= display?(!@operatingsystem.use_release_name?) %>>
         <%= text_f f, :release_name, :help_inline => _("e.g. karmic, lucid, hw0910 etc") %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -5,7 +5,7 @@
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
     <tr>
-      <th class="col-md-8"><%= sort :title, :as => s_("Operatingsystem|Name") %></th>
+      <th class="col-md-8"><%= sort :title, :as => s_("Operatingsystem|Title") %></th>
       <th><%= sort :hosts_count, :as => _("Hosts"), :default => "DESC" %></th>
       <th></th>
     </tr>


### PR DESCRIPTION
We should always have entity name to be used for column 'Name', not the description (even if it exists). Seems more logical to fix in that helper method rather than in '..index' page.
