### PR TITLE
Fixes #8799 - Show override button when removing overriden global param

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -166,14 +166,11 @@ function remove_fields(link) {
 
 function mark_params_override(){
   $('#inherited_parameters .override-param').removeClass('override-param');
-  $('#inherited_parameters [data-tag=override]').show();
   $('#parameters').find('[id$=_name]:visible').each(function(){
     var param_name = $(this);
     $('#inherited_parameters').find('[id^=name_]').each(function(){
       if (param_name.val() == $(this).text()){
-        $(this).addClass('override-param');
-        $(this).closest('tr').find('textarea').addClass('override-param');
-        $(this).closest('tr').find('[data-tag=override]').hide();
+        $(this).closest('tr').addClass('override-param');
       }
     });
   });

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -422,7 +422,7 @@ function use_image_selected(element){
 }
 
 function override_param(item){
-  var param = $(item).closest('tr');
+  var param = $(item).closest('tr').addClass('override-param');
   var n = param.find('[id^=name_]').text();
   var param_value = param.find('[id^=value_]');
   var v = param_value.val();
@@ -431,7 +431,6 @@ function override_param(item){
   var new_param = $('#parameters').find('.fields').last();
   new_param.find('[id$=_name]').val(n);
   new_param.find('[id$=_value]').val(v == param_value.data('hidden-value') ? '' : v);
-  mark_params_override();
 }
 
 function override_class_param(item){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -193,20 +193,6 @@ select {
   margin-top: 9px;
 }
 
-.override-param {
-  text-decoration: line-through;
-}
-
-tr.override-param{
-  text-decoration: none;
-  span.col-md-2, textarea {
-    text-decoration: line-through;
-  }
-  a, i {
-    text-decoration: none;
-  }
-}
-
 #title_action{
   padding-bottom: 12px;
 }

--- a/app/assets/stylesheets/hosts.scss
+++ b/app/assets/stylesheets/hosts.scss
@@ -51,6 +51,17 @@
       border-bottom-right-radius: 4px;
     }
   }
+
+  .override-param {
+    text-decoration: line-through;
+    a, i {
+      text-decoration: none;
+    }
+    .btn[data-tag]{
+      display: none;
+    }
+  }
+
 }
 
 #interfaceModal .modal-dialog{

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -17,7 +17,7 @@
           <td><%= parameter_value_field inherited_parameters[name] %></td>
           <td>
             <%= link_to_function(_("override"), "override_param(this)", :title => _("Override this value"),
-                                 :'data-tag' => 'override', :class => "btn btn-default") if authorized_via_my_scope("host_editing", "create_params") && !overriden %>
+                                 :'data-tag' => 'override', :class => "btn btn-default") if authorized_via_my_scope("host_editing", "create_params") %>
           </td>
         </tr>
       <% end %>

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -298,6 +298,26 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   describe 'edit page' do
+    test 'correctly override global params' do
+      host = FactoryGirl.create(:host)
+
+      visit edit_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      page.find('#inherited_parameters .btn[data-tag=override]').click
+      refute page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      click_button('Submit')
+      assert page.has_link?("Edit")
+
+      visit edit_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      refute page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      page.find('#global_parameters_table a').click
+      assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+    end
+
     test 'shows errors on invalid lookup values' do
       host = FactoryGirl.create(:host, :with_puppetclass)
       lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,


### PR DESCRIPTION
Previously, when removing an override for an existing parameter the
override button was not displayed again until the page was reloaded.
Also saved call to `mark_params_override()` when overriding a single
parameter since we already know which row needs to be marked as
overriden, and used some css to simplify `mark_params_override()`.

Note this code will be rendered useless once global parameters are
turned into lookup keys as they will use the same inline-editing
available for lookup keys, however until that change is made this will
improve usability of global parmeter overrides.
