### PR TITLE
Fixes #12566 - host_parameters_attributes accepts nested flag

### DIFF
--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -1,6 +1,9 @@
 module Api
   module V1
     class HostsController < V1::BaseController
+      include Api::CompatibilityChecker
+      before_filter :check_create_host_nested, :only => [:create, :update]
+
       before_filter :find_resource, :only => %w{show update destroy status}
 
       api :GET, "/hosts/", "List all hosts."
@@ -45,7 +48,10 @@ module Api
         param :owner_id, :number
         param :puppet_ca_proxy_id, :number
         param :image_id, :number
-        param :host_parameters_attributes, Array
+          param :host_parameters_attributes, Array, :desc => N_("Host's parameters (array or indexed hash)") do
+            param :name, String, :desc => N_("Name of the parameter"), :required => true
+            param :value, String, :desc => N_("Parameter value"), :required => true
+          end
         param :build, :bool
         param :enabled, :bool
         param :provision_method, String

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -7,6 +7,9 @@ module Api
       include Api::TaxonomyScope
       include Foreman::Controller::SmartProxyAuth
 
+      include Api::CompatibilityChecker
+      before_filter :check_create_host_nested, :only => [:create, :update]
+
       before_filter :find_optional_nested_object, :except => [:facts]
       before_filter :find_resource, :except => [:index, :create, :facts]
       before_filter :permissions_check, :only => %w{power boot puppetrun}
@@ -62,7 +65,10 @@ module Api
           param :owner_type, Host::Base::OWNER_TYPES, :desc => N_("Host's owner type")
           param :puppet_ca_proxy_id, :number
           param :image_id, :number
-          param :host_parameters_attributes, Array
+          param :host_parameters_attributes, Array, :desc => N_("Host's parameters (array or indexed hash)") do
+            param :name, String, :desc => N_("Name of the parameter"), :required => true
+            param :value, String, :desc => N_("Parameter value"), :required => true
+          end
           param :build, :bool
           param :enabled, :bool
           param :provision_method, String

--- a/app/controllers/concerns/api/compatibility_checker.rb
+++ b/app/controllers/concerns/api/compatibility_checker.rb
@@ -1,0 +1,13 @@
+module Api
+  module CompatibilityChecker
+    extend ActiveSupport::Concern
+
+    # removes unsupported "nested" flag from "host_parameters_attributes" (both Array and Hash formats supported)
+    def check_create_host_nested
+      params[:host] && params[:host][:host_parameters_attributes] && params[:host][:host_parameters_attributes].each do |attribute|
+        attribute = attribute[1] if attribute.is_a? Array
+        Foreman::Deprecation.api_deprecation_warning("Field host_parameters_attributes.nested ignored") unless attribute.delete(:nested).nil?
+      end
+    end
+  end
+end

--- a/test/functional/api/v1/hosts_controller_test.rb
+++ b/test/functional/api/v1/hosts_controller_test.rb
@@ -48,6 +48,24 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should create host with host_parameters_attributes" do
+    disable_orchestration
+    assert_difference('Host.count') do
+      attrs = [{"name" => "compute_resource_id", "value" => "1", "nested" => "true"}]
+      post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
+    end
+    assert_response :created
+  end
+
+  test "should create host with host_parameters_attributes sent in a hash" do
+    disable_orchestration
+    assert_difference('Host.count') do
+      attrs = {"0" => {"name" => "compute_resource_id", "value" => "1", "nested" => "true"}}
+      post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
+    end
+    assert_response :created
+  end
+
   test "should create host with managed is false if parameter is passed" do
     disable_orchestration
     post :create, { :host => valid_attrs.merge!(:managed => false) }

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -84,6 +84,24 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :created
   end
 
+  test "should create host with host_parameters_attributes" do
+    disable_orchestration
+    assert_difference('Host.count') do
+      attrs = [{"name" => "compute_resource_id", "value" => "1", "nested" => "true"}]
+      post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
+    end
+    assert_response :created
+  end
+
+  test "should create host with host_parameters_attributes sent in a hash" do
+    disable_orchestration
+    assert_difference('Host.count') do
+      attrs = {"0" => {"name" => "compute_resource_id", "value" => "1", "nested" => "true"}}
+      post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
+    end
+    assert_response :created
+  end
+
   test "should create interfaces" do
     disable_orchestration
 


### PR DESCRIPTION
This is for compatibility reasons. I wish we had an expectation for deprecation
warnings, so we can actually silence them and also test them! Should not be too
difficult to do I guess, ideas?
