### PR TITLE
Fixes #12486 - custom uniqueness validations for interface attributes

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -812,7 +812,7 @@ class Host::Managed < Host::Base
   # because the validation happens before transaction is committed, so data are not in DB
   # yet, this is the reason why we "reimplement" uniqueness validation
   def validate_dns_name_uniqueness
-    dups = self.interfaces.group_by { |i| [ i.name, i.domain_id ] }.detect { |dns, nics| dns.first.present? && nics.count > 1 }
+    dups = self.interfaces.select { |i| !i.marked_for_destruction? }.group_by { |i| [ i.name, i.domain_id ] }.detect { |dns, nics| dns.first.present? && nics.count > 1 }
     if dups.present?
       dups.last.first.errors.add(:name, :taken)
       self.errors.add :interfaces, _('Some interfaces are invalid')

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -2,9 +2,11 @@ module Nic
   class Interface < Base
     attr_accessible :ip
 
-    validates :ip, :uniqueness => true, :format => {:with => Net::Validations::IP_REGEXP}, :allow_blank => true
+    validates :ip, :format => {:with => Net::Validations::IP_REGEXP}, :allow_blank => true
 
     validate :normalize_ip
+
+    validate :ip_uniqueness, :if => Proc.new { |i| i.ip.present? }
 
     validates :attached_to, :presence => true, :if => Proc.new { |o| o.virtual && o.instance_of?(Nic::Managed) && !o.bridge? }
 
@@ -14,10 +16,9 @@ module Nic
     before_validation :copy_hostname_from_host, :if => Proc.new { |nic| nic.primary? && nic.hostname.blank? }
     before_validation :normalize_name
 
-    validates :name,  :uniqueness => {:scope => :domain_id},
-              :allow_nil => true,
-              :allow_blank => true,
-              :format => {:with => Net::Validations::HOST_REGEXP}
+    validates :name, :allow_nil => true, :allow_blank => true, :format => {:with => Net::Validations::HOST_REGEXP}
+
+    validate :name_uniqueness, :if => Proc.new { |i| i.name.present? }
 
     # aliases and vlans require identifiers so we can differentiate and properly configure them
     validates :identifier, :presence => true, :if => Proc.new { |o| o.virtual? && o.managed? && o.instance_of?(Nic::Managed) }
@@ -54,6 +55,14 @@ module Nic
     end
 
     protected
+
+    def ip_uniqueness
+      interface_attribute_uniqueness(:ip)
+    end
+
+    def name_uniqueness
+      interface_attribute_uniqueness(:name, Nic::Base.where(:domain_id => self.domain_id))
+    end
 
     # we don't allow changes to identifier which would change the interface type e.g. eth0 -> eth0,1 would make
     # a vlan virtual interface from physical one

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1163,7 +1163,8 @@ class HostTest < ActiveSupport::TestCase
 
     test "#set_interfaces creates new interface even if another virtual interface has same MAC but another identifier" do
       host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:11:22:33', :virtual => true, :ipaddress => '10.10.0.2', :identifier => 'eth0_1', :attached_to => 'eth0'})
-      FactoryGirl.create(:nic_managed, :host => host, :mac => '00:00:00:11:22:33', :ip => '10.10.0.1', :virtual => true, :identifier => 'eth0_0', :attached_to => 'eth0')
+      host.update_attribute :mac, '00:00:00:11:22:44'
+      FactoryGirl.create(:nic_managed, :host => host, :mac => '00:00:00:11:22:33', :ip => '10.10.0.1', :virtual => true, :identifier => 'eth0_0', :attached_to => 'eth0', :name => 'second')
 
       assert_difference 'host.interfaces(true).count' do
         host.set_interfaces(parser)

--- a/test/unit/nic_test.rb
+++ b/test/unit/nic_test.rb
@@ -124,6 +124,7 @@ class NicTest < ActiveSupport::TestCase
   test "Mac address uniqueness validation is skipped for virtual NICs and unmanaged hosts" do
     host = FactoryGirl.create(:host, :managed)
     Nic::Base.create! :mac => "cabbccddeeff", :host => host # physical
+    host.reload
     virtual = Nic::Base.new :mac => "cabbccddeeff", :host => host, :virtual => true
     assert virtual.valid?
     assert virtual.save
@@ -206,7 +207,7 @@ class NicTest < ActiveSupport::TestCase
   context 'BMC' do
     setup do
       disable_orchestration
-      @subnet    = FactoryGirl.create(:subnet, :dhcp)
+      @subnet    = FactoryGirl.create(:subnet, :dhcp, :ipam => Subnet::IPAM_MODES[:db])
       @domain    = FactoryGirl.create(:domain)
       @interface = FactoryGirl.create(:nic_bmc, :ip => @subnet.unused_ip,
                                       :host => FactoryGirl.create(:host),

--- a/test/unit/nics/base_test.rb
+++ b/test/unit/nics/base_test.rb
@@ -35,4 +35,56 @@ class NicBaseTest < ActiveSupport::TestCase
     assert nic.host_managed?
     SETTINGS[:unattended] = original
   end
+
+  context 'there is already an interface with a MAC and IP' do
+    let(:host) { FactoryGirl.create(:host, :managed) }
+
+    describe 'creation of another nic with already used MAC and IP' do
+      let(:nic) do
+        nic = host.interfaces.build(:mac => host.mac, :managed => true, :type => 'Nic::Managed')
+        nic.ip = host.ip
+        nic
+      end
+
+      test 'it is invalid because of conflicting mac' do
+        refute nic.valid?
+        assert nic.errors.has_key?(:mac)
+        assert nic.errors.has_key?(:ip)
+      end
+
+      test 'it is valid if conflicting interface is on same host and is marked for destruction' do
+        host.primary_interface.mark_for_destruction
+        assert nic.valid?
+      end
+    end
+
+    describe 'creation of another nic with the same name' do
+      let(:nic) { host.interfaces.build(:mac => next_mac(host.mac), :managed => true, :type => 'Nic::Managed') }
+
+      context 'the domain is different' do
+        test 'it is valid' do
+          nic.name = host.shortname
+          assert_nil nic.domain
+          assert nic.valid?
+        end
+      end
+
+      context 'the domain is the same' do
+        before do
+          nic.name = host.name
+          nic.domain = host.domain
+        end
+
+        test 'it is invalid because of the name attribute' do
+          refute nic.valid?
+          assert nic.errors.has_key?(:name)
+        end
+
+        test 'it is valid if conflicting interface is on same host and is marked for destruction' do
+          host.primary_interface.mark_for_destruction
+          assert nic.valid?
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a backport of the validation fix in develop.
Commit message edited to reflect the right redmine ticket.
