### PR TITLE
fixes #7517 - remove overridden class parameters from envs on import

### DIFF
--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -230,7 +230,7 @@ class PuppetClassImporter
       key        = db_class.class_params.find_by_key param_name
       key_in_env = EnvironmentClass.key_in_environment(env, db_class, key)
 
-      if key && key_in_env && !key.override?
+      if key && key_in_env
         #detach
         key_in_env.destroy
         # destroy if the key is not in any environment.


### PR DESCRIPTION
When a class parameter is overridden and the class import indicates it
should be removed, now delete the EnvironmentClass association.

This also changes behaviour when an overridden parameter is removed from
all environments as it and any LookupValues will now be deleted too.
Previously only non-overridden parameters would be deleted.  This
matches the behaviour of classes being removed from all environments.
