### PR TITLE
Fixes #12611 - CVE-2015-7518 prevent XSS on host edit form

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -11,7 +11,7 @@ module CommonParametersHelper
 
   def parameter_value_field(value)
     source_name = value[:source_name] ? "(#{value[:source_name]})" : nil
-    popover_tag = popover('', _("<b>Source:</b> %{type} %{name}") % { :type => _(value[:source]), :name => source_name }, :data => { :placement => 'top' })
+    popover_tag = popover('', _("<b>Source:</b> %{type} %{name}") % { :type => _(value[:source]), :name => html_escape(source_name) }, :data => { :placement => 'top' })
     content_tag(:div, parameter_value_content("value_#{value[:safe_value]}", value[:safe_value], :popover => popover_tag, :disabled => true) + fullscreen_input, :class => 'input-group')
   end
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -118,8 +118,8 @@ module LookupKeysHelper
      <b>Type:</b> %{type}<br/>
      <b>Matcher:</b> %{matcher}<br/>
      <b>Inherited value:</b> %{inherited_value}") %
-    { :desc => lookup_key.description, :type => lookup_key.key_type,
-      :matcher => matcher, :inherited_value => inherited_value }
+    { :desc => html_escape(lookup_key.description), :type => lookup_key.key_type,
+      :matcher => html_escape(matcher), :inherited_value => html_escape(inherited_value) }
   end
 
   def lookup_key_warnings(required, has_value)

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -403,6 +403,22 @@ class HostsControllerTest < ActionController::TestCase
     assert Host.find(@host1.id).host_parameters[0][:value] == "hello"
     assert Host.find(@host2.id).host_parameters[0][:value] == "hello"
   end
+
+  test "parameter details should be html escaped" do
+    hg = FactoryGirl.create(:hostgroup, :name => "<script>alert('hacked')</script>")
+    host = FactoryGirl.create(:host, :with_puppetclass, :hostgroup => hg)
+    FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
+                                :override => true, :key_type => 'string',
+                                :default_value => "<script>alert('hacked!');</script>",
+                                :description => "<script>alert('hacked!');</script>",
+                                :puppetclass => host.puppetclasses.first)
+    FactoryGirl.create(:hostgroup_parameter, :hostgroup => hg)
+    get :edit, {:id => host.name}, set_session_user
+    refute response.body.include?("<script>alert(")
+    assert response.body.include?("&lt;script&gt;alert(")
+    assert_equal 3, response.body.scan("&lt;script&gt;alert(").size
+  end
+
   test "should get errors" do
     get :errors, {}, set_session_user
     assert_response :success


### PR DESCRIPTION
The host edit forms allowed stored XSS attacks by storing html content
in smart class parameter and smart variable description or inherited
values, which is then passed unescaped to an html-allowing popover.
This patch makes sure these user-controlled strings are correctly
escaped before being inserted into the popover.
