### PR TITLE
fixes #12623 - convert VM IDs to strings for DB lookup

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -148,7 +148,7 @@ class Host::Managed < Host::Base
 
   scope :for_token, ->(token) { joins(:token).where(:tokens => { :value => token }).where("expires >= ?", Time.now.utc.to_s(:db)).select('hosts.*') }
 
-  scope :for_vm, ->(cr,vm) { where(:compute_resource_id => cr.id, :uuid => Array.wrap(vm).compact.map(&:identity)) }
+  scope :for_vm, ->(cr,vm) { where(:compute_resource_id => cr.id, :uuid => Array.wrap(vm).compact.map(&:identity).map(&:to_s)) }
 
   # audit the changes to this model
   audited :except => [:last_report, :puppet_status, :last_compile, :lookup_value_matcher], :allow_mass_assignment => true

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -165,7 +165,7 @@ FactoryGirl.define do
     trait :on_compute_resource do
       uuid Foreman.uuid
       association :compute_resource, :factory => :ec2_cr
-      after(:build) { |host| host.class.skip_callback(:validation, :after, :queue_compute) }
+      after(:build) { |host| host.expects(:queue_compute) }
     end
 
     trait :with_subnet do

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2761,6 +2761,21 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '.for_vm' do
+    test 'returns hosts with matching CR and identity' do
+      uuid = Foreman.uuid
+      vm = mock('vm', :identity => uuid)
+      host = FactoryGirl.create(:host, :on_compute_resource, :uuid => uuid)
+      assert_equal [host], Host::Managed.for_vm(host.compute_resource, vm).to_a
+    end
+
+    test 'returns hosts with matching an integer identity' do
+      vm = mock('vm', :identity => 42)
+      host = FactoryGirl.create(:host, :on_compute_resource, :uuid => '42')
+      assert_equal [host], Host::Managed.for_vm(host.compute_resource, vm).to_a
+    end
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
Some CR types return the VM identities as integers, but the `uuid`
column is a string type.  Convert all VM IDs to strings before
comparing to prevent SQL errors on PostgreSQL.

Replaced skip_callback in test factories to prevent it leaking into
other tests and permanently skipping the callback.
