### PR TITLE
Fixes #12637 - improved discovered lease test

### DIFF
--- a/test/lib/net/dhcp_test.rb
+++ b/test/lib/net/dhcp_test.rb
@@ -105,7 +105,7 @@ class DhcpTest < ActiveSupport::TestCase
       "starts": "2014-05-09 11:55:21 UTC",
       "ends": "2214-05-09 12:05:21 UTC",
       "state": "active",
-      "mac": "aa:bb:cc:dd:ee:ff",
+      "mac": "aa:bb:cc:dd:ee:01",
       "subnet": "127.0.0.0/255.0.0.0",
       "ip": "127.0.0.2"
     }'
@@ -113,7 +113,7 @@ class DhcpTest < ActiveSupport::TestCase
     lease2.stubs(:body).returns(lease2)
     ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.1").returns(@lease1)
     ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.2").returns(lease2)
-    record1 = Net::DHCP::Record.new(:hostname => "discovered_host1", :mac => "aa:bb:cc:dd:ee:ff",
+    record1 = Net::DHCP::Record.new(:hostname => "discovered_host1", :mac => "aa:bb:cc:dd:ee:01",
                                     :network => "127.0.0.0", :ip => "127.0.0.2",
                                     "proxy" => subnets(:one).dhcp_proxy)
     assert record1.conflicts.empty?


### PR DESCRIPTION
I know referencing released and old issues is not good, but this just improves
unit test. It was green, it is green. It was just not testing correctly.

The issue is that the patch from referenced issue allowed multiple leases on
same MAC address. This is what happens when initramdisk intializes network,
acquires one IP, then booted linux acquires another one (on the same
interface). We were testing two different MAC addresses, which is indeed green
too.
