### PR TITLE
Fixes #12523 - Openstack does not work with Fog 1.36

### DIFF
--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -44,9 +44,10 @@ end
 
 if SETTINGS[:openstack]
   require 'fog/openstack'
+  require 'fog/openstack/compute'
+  Fog::Compute::OpenStack::Real.send(:include, FogExtensions::Openstack::Core)
   require 'fog/openstack/models/compute/server'
   Fog::Compute::OpenStack::Server.send(:include, FogExtensions::Openstack::Server)
-
   require 'fog/openstack/models/compute/flavor'
   Fog::Compute::OpenStack::Flavor.send(:include, FogExtensions::Openstack::Flavor)
 end

--- a/app/models/concerns/fog_extensions/openstack/core.rb
+++ b/app/models/concerns/fog_extensions/openstack/core.rb
@@ -1,0 +1,18 @@
+module FogExtensions
+  module Openstack
+    module Core
+      extend ActiveSupport::Concern
+
+      private
+
+      def authenticate
+        super
+        if @openstack_identity_public_endpoint || @openstack_management_url
+          @identity_connection = Fog::Core::Connection.new(
+            @openstack_identity_public_endpoint || @openstack_management_url,
+            false, @connection_options)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem:
In a recent refactor of Openstack in Fog, defining @identity_connection
was moved to a class method. This causes it to be unavailable in
instances of Fog::Compute::Openstack::Real which we use to retrieve
servers and so forth. More info on:
https://github.com/fog/fog/commit/4d5287020d961e794ac279c640c69a66238c33f7#commitcomment-14475988

Solution:
Monkeypatch until a new version of Fog is released. This patch just
modifies the authenticate method slightly so that the
@identity_connection variable is set up at the end of it.
