### PR TITLE
fixes #12624 - add plugin interface to add provision methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -72,7 +72,7 @@ Metrics/BlockNesting:
 # Offense count: 48
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 770
+  Max: 850
 
 # Offense count: 131
 Metrics/CyclomaticComplexity:
@@ -91,7 +91,7 @@ Metrics/MethodLength:
 # Offense count: 16
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 427
+  Max: 450
 
 # Offense count: 4
 # Configuration parameters: CountKeywordArgs.

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -65,7 +65,7 @@ module Api
           param :host_parameters_attributes, Array
           param :build, :bool
           param :enabled, :bool
-          param :provision_method, String
+          param :provision_method, String, :desc => N_("The method used to provision the host. Possible provision_methods may be %{provision_methods}") # values are defined in apipie initializer
           param :managed, :bool, :desc => N_("True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not")
           param :progress_report_id, String, :desc => N_("UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks")
           param :comment, String, :desc => N_("Additional information about this host")

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -20,6 +20,20 @@ module HostsHelper
     "compute_resources_vms/form/#{compute_resource_name}/#{partial}"
   end
 
+  def provision_method_partial_exist?(provision_method, partial)
+    return false unless provision_method
+
+    ActionController::Base.view_paths.any? do |path|
+      File.exist?(File.join(path, 'hosts', 'provision_method', provision_method, "_#{partial}.html.erb"))
+    end
+  end
+
+  def provision_method_partial(provision_method, partial)
+    return nil unless provision_method
+
+    "hosts/provision_method/#{provision_method}/#{partial}"
+  end
+
   def nic_info_js(compute_resource)
     javascript_include_tag("compute_resources/#{compute_resource.provider.downcase}/nic_info.js")
   end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -92,12 +92,13 @@ module Foreman #:nodoc:
     end
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
-    attr_reader :id, :logging, :default_roles
+    attr_reader :id, :logging, :default_roles, :provision_methods
 
     def initialize(id)
       @id = id.to_sym
       @logging = Plugin::Logging.new(@id)
       @default_roles = {}
+      @provision_methods = {}
     end
 
     def after_initialize
@@ -274,6 +275,12 @@ module Foreman #:nodoc:
     # register custom host status class, it should inherit from HostStatus::Status
     def register_custom_status(klass)
       HostStatus.status_registry.add(klass)
+    end
+
+    # register a provision method
+    def provision_method(name, friendly_name)
+      return if @provision_methods.key?(name.to_s)
+      @provision_methods[name.to_s] = friendly_name
     end
   end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -134,6 +134,7 @@
 
     </div>
 
+    <%= hidden_field_tag 'bare_metal_capabilities', @host.bare_metal_capabilities %>
     <%= f.hidden_field :overwrite? %>
     <%= submit_or_cancel f, @host.overwrite?, :cancel_path => @host.new_record? || !@host.name_changed? ? @host : edit_host_path(@host.name_was) %>
   <% end %>

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -8,27 +8,19 @@
 </span>
 
 <div id='provisioning_method' <%= display? (@host.capabilities.size < 2)  %> >
-  <%= field(f, :provision_method, :label => _('Provisioning Method'), :required => true) do
-      radio_button_f(f, :provision_method, :value=>'build', :checked=> @host.pxe_build?, :text=> _("Network Based"), :disabled => !@host.new_record?)+
-      radio_button_f(f, :provision_method, :value=>'image', :checked=> @host.image_build?, :text=> _("Image Based"), :disabled => !@host.new_record?)
+  <%= field(f, :provision_method, :label => _('Provisioning Method'), :required => true, :size => 'col-md-10') do
+    Host::Managed.provision_methods.sort_by { |name, friendly_name| name }.collect do |provision_method, friendly_name|
+      radio_button_f(f, :provision_method, :value=>provision_method, :text=> _(friendly_name), :disabled => !@host.new_record?)
+    end.join(' ').html_safe
   end %>
 </div>
-<div id='network_provisioning' <%= display? !@host.pxe_build? %> >
-  <% if @host.new_record? or @host.type_changed? -%>
-      <%= checkbox_f f, :build, :checked => true, :help_inline => _("Enable this host for provisioning") %>
+
+<% Host::Managed.provision_methods.sort_by { |name, friendly_name| name }.each do |provision_method, friendly_name| %>
+  <% if provision_method_partial_exist?(provision_method, 'form') %>
+    <%= render provision_method_partial(provision_method, 'form'), :f => f, :host => @host %>
   <% end %>
-  <span id="media_select">
-    <%= render 'common/os_selection/operatingsystem', :item => @host %>
-  </span>
+<% end %>
 
-
-  <%= textarea_f f, :disk, :size => "col-md-8", :rows => "4",
-           :help_block => _("What ever text(or ERB template) you use in here, would be used as your OS disk layout options If you want to use the partition table option, delete all of the text from this field") %>
-</div>
-
-<div id='image_provisioning' <%= display? !@host.image_build? %> >
-
-</div>
 <div id='root_password'>
   <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more"), :required => true, :unset => action_name == "edit" %>
 </div>

--- a/app/views/hosts/provision_method/build/_form.html.erb
+++ b/app/views/hosts/provision_method/build/_form.html.erb
@@ -1,0 +1,12 @@
+<div id='network_provisioning' <%= display? !@host.pxe_build? %> >
+  <% if @host.new_record? or @host.type_changed? -%>
+      <%= checkbox_f f, :build, :checked => true, :help_inline => _("Enable this host for provisioning") %>
+  <% end %>
+  <span id="media_select">
+    <%= render 'common/os_selection/operatingsystem', :item => @host %>
+  </span>
+
+
+  <%= textarea_f f, :disk, :size => "col-md-8", :rows => "4",
+           :help_block => _("What ever text(or ERB template) you use in here, would be used as your OS disk layout options If you want to use the partition table option, delete all of the text from this field") %>
+</div>

--- a/app/views/hosts/provision_method/image/_form.html.erb
+++ b/app/views/hosts/provision_method/image/_form.html.erb
@@ -1,0 +1,3 @@
+<div id='image_provisioning' <%= display? !@host.image_build? %> >
+
+</div>

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -20,6 +20,7 @@ Apipie.configure do |config|
     :providers => ComputeResource.providers.join(', '),
     :default_nic_type => InterfaceTypeMapper::DEFAULT_TYPE.humanized_name.downcase,
     :template_kinds => -> { TemplateKind.scoped.map(&:name).join(", ") },
+    :provision_methods => -> { Host::Managed.provision_methods.map { |method, friendly_name| "#{method} (#{_(friendly_name)})" }.join(', ') },
   }
 
   config.translate = lambda do |str, loc|

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -260,4 +260,12 @@ class PluginTest < ActiveSupport::TestCase
     assert_include HostStatus.status_registry, status
     HostStatus.status_registry.delete status
   end
+
+  def test_add_provision_method
+    Foreman::Plugin.register :awesome_provision do
+      name 'Awesome provision'
+      provision_method 'awesome', 'Awesomeness Based'
+    end
+    assert_equal 'Awesomeness Based', Host::Managed.provision_methods['awesome']
+  end
 end


### PR DESCRIPTION
This adds the possibility to add a provision_method via foreman's plugin api and show these methods in the gui.
