### PR TITLE
fixes #12632 - remove hardcoded SSH compression algorithm

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -59,7 +59,7 @@ class Foreman::Provision::SSH
       :keys_only    => true,
       :config       => false,
       :auth_methods => %w( publickey ),
-      :compression  => "zlib",
+      :compression  => true,
       :logger       => logger,
     }
   end


### PR DESCRIPTION
net-ssh behaviour changed in 2.10 from treating a specified algorithm
as a preference (and falling back to one it knew) to treating it as a
whitelist of algorithms.  OpenSSH servers need the algorithm
`zlib@openssh.com` rather than plain `zlib`, so negotiation failed.
Instead, specify `true` to use net-ssh's list of supported compression
algorithms.

https://github.com/net-ssh/net-ssh/blob/v3.0.1/lib/net/ssh/transport/algorithms.rb#L211
