### PR TITLE
fixes #7548 - cannot use UTF8 characters from ldap auth source

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -65,6 +65,8 @@ class AuthSourceLdap < AuthSource
       return
     end
 
+    attrs.each { |k, v| attrs[k] = v.force_encoding('UTF-8') }
+
     logger.debug "Retrieved LDAP Attributes for #{login}: #{attrs}"
 
     attrs


### PR DESCRIPTION
net-ldap force encodes all attributes in ASCII-8BIT, see [code](https://github.com/ruby-ldap/ruby-net-ldap/blob/master/lib/net/ber/core_ext/string.rb#L32). However, this should be UTF-8. This PR fixes this by force encoding all attributes back to UTF-8 and adds tests for this.
