### PR TITLE
fixes #12615 - remove unused term-ansicolor dependency

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -9,8 +9,6 @@ group :development do
   gem 'immigrant', '~> 0.1'
 
   gem 'pry'
-  gem 'term-ansicolor'
-  gem 'tins', '< 1.7.0', :require => false if RUBY_VERSION.start_with? '1.9.'
 
   gem 'bullet'
   gem "parallel_tests"


### PR DESCRIPTION
Under Ruby 1.9.3, `bundle pack` is usually failing to resolve the tins
dependency between rubocop and term-ansicolor.

Remove the term-ansicolor dependency, which appears to be a development-
only dep of pry's coderay dep.  coderay's syntax colour support works
fine without it at runtime.
