### PR TITLE
Fixes #12618 - Now calls for compute attributes are explicit.

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -560,6 +560,7 @@ class HostsController < ApplicationController
               Host.new(params[:host])
             end
     @host.set_hostgroup_defaults
+    @host.set_compute_attributes unless params[:host][:compute_profile_id]
     render :partial => "form"
   end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -604,9 +604,7 @@ class Host::Managed < Host::Base
 
   def set_hostgroup_defaults
     return unless hostgroup
-    assign_hostgroup_attributes(%w{domain_id compute_profile_id})
-
-    set_compute_attributes if compute_profile_id_changed?
+    assign_hostgroup_attributes(%w{domain_id})
 
     if SETTINGS[:unattended] and (new_record? or managed?)
       assign_hostgroup_attributes(%w{operatingsystem_id architecture_id})

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -963,6 +963,64 @@ class HostsControllerTest < ActionController::TestCase
     assert_not_nil flash[:error]
   end
 
+  test '#process_hostgroup changes compute attributes' do
+    Fog.mock!
+    group1 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:one))
+    host = FactoryGirl.build(:host, :managed, :on_compute_resource)
+    #remove unneeded expectation to :queue_compute
+    host.unstub(:queue_compute)
+    host.hostgroup = group1
+    host.compute_resource = compute_resources(:one)
+    host.compute_profile = compute_profiles(:one)
+    host.set_compute_attributes
+
+    group2 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:two))
+
+    attrs = host.attributes.except('id', 'created_at', 'updated_at')
+    attrs['hostgroup_id'] = group2.id
+    attrs.delete 'compute_profile_id'
+
+    host.compute_resource.class.any_instance.expects(:max_cpu_count).returns(10)
+    host.compute_resource.class.any_instance.expects(:max_memory).returns(10000000000)
+
+    xhr :put, :process_hostgroup, { :host => attrs }, set_session_user
+
+    assert_response :success
+    assert_template :partial => '_form'
+    assert_select '#host_compute_attributes_cpus option[selected]', "5"
+    Fog.unmock!
+  end
+
+  test '#process_hostgroup does not change compute attributes if compute profile selected manually' do
+    Fog.mock!
+    group1 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:one))
+    host = FactoryGirl.build(:host, :managed, :on_compute_resource)
+    #remove unneeded expectation to :queue_compute
+    host.unstub(:queue_compute)
+    host.hostgroup = group1
+    host.compute_resource = compute_resources(:one)
+    host.compute_profile = compute_profiles(:one)
+    host.set_compute_attributes
+    Foreman::Model::Libvirt.any_instance.stubs(:hypervisor).returns(stub(:hypervisor))
+
+    group2 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:two))
+
+    attrs = host.attributes.except('id', 'created_at', 'updated_at')
+    attrs['hostgroup_id'] = group2.id
+    attrs['compute_attributes'] = { 'cpus' => 3 }
+    attrs.delete 'uuid'
+
+    host.compute_resource.class.any_instance.expects(:max_cpu_count).returns(10)
+    host.compute_resource.class.any_instance.expects(:max_memory).returns(10000000000)
+
+    xhr :put, :process_hostgroup, { :host => attrs }, set_session_user
+
+    assert_response :success
+    assert_template :partial => '_form'
+    assert_select '#host_compute_attributes_cpus option[selected]', "3"
+    Fog.unmock!
+  end
+
   private
 
   def initialize_host

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2762,18 +2762,27 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
-  context 'hostgroup defaults' do
+  context 'compute resources' do
     setup do
       @group1 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:one))
       @group2 = FactoryGirl.create(:hostgroup, :compute_profile => compute_profiles(:two))
     end
 
-    test 'sets proper compute attributes on hostgroup change' do
+    test 'set_hostgroup_defaults doesnt touch compute attributes' do
       host = FactoryGirl.create(:host, :managed, :compute_resource => compute_resources(:one), :hostgroup => @group1)
       assert_not_equal 4, host.compute_attributes['cpus']
 
       host.attributes = host.apply_inherited_attributes('hostgroup_id' => @group2.id)
       host.set_hostgroup_defaults
+      assert_not_equal 4, host.compute_attributes['cpus']
+    end
+
+    test 'set_compute_attributes changes the compute attributes' do
+      host = FactoryGirl.create(:host, :managed, :compute_resource => compute_resources(:one), :hostgroup => @group1)
+      assert_not_equal 4, host.compute_attributes['cpus']
+
+      host.attributes = host.apply_inherited_attributes('hostgroup_id' => @group2.id)
+      host.set_compute_attributes
       assert_equal 4, host.compute_attributes['cpus']
     end
   end


### PR DESCRIPTION
Replaces https://github.com/theforeman/foreman/pull/2937.
