### PR TITLE
Fixes #12644, #12643 - Correctly authorize in lookup key index

### DIFF
--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -7,7 +7,7 @@ class LookupKeysController < ApplicationController
     @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])
                                 .includes(:puppetclass)
                                 .paginate(:page => params[:page])
-    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.pluck(:puppetclass_id).compact.uniq)
+    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map(&:puppetclass_id).compact.uniq)
   end
 
   def edit

--- a/app/controllers/puppetclass_lookup_keys_controller.rb
+++ b/app/controllers/puppetclass_lookup_keys_controller.rb
@@ -5,7 +5,7 @@ class PuppetclassLookupKeysController < LookupKeysController
     @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])
                                 .paginate(:page => params[:page])
                                 .includes(:param_classes)
-    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.pluck(:puppetclass_id).compact.uniq)
+    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map{|key| key.param_class.try(:id)}.compact.uniq)
   end
 
   def resource


### PR DESCRIPTION
There was a problem with the authorizer for lookup key indices that led
to problems with sorting and searching.
Because `#includes` lazy loads the included relation, and the authorizer
didn't need the relation, it didn't load the puppetclass or the
lookup_value table. However, the search_for scope added an order_by or a
where condition to @lookup_keys, which caused the authorizer collection
to create an invalid query.
