### PR TITLE
Fixes #12691 - Small Rails 4 backwards compatible changes

### DIFF
--- a/app/controllers/api/v2/smart_variables_controller.rb
+++ b/app/controllers/api/v2/smart_variables_controller.rb
@@ -43,7 +43,7 @@ module Api
       param_group :smart_variable, :as => :create
 
       def create
-        @smart_variable   = LookupKey.new(params[:smart_variable]) unless @puppetclass
+        @smart_variable   = VariableLookupKey.new(params[:smart_variable]) unless @puppetclass
         @smart_variable ||= @puppetclass.lookup_keys.build(params[:smart_variable])
         process_response @smart_variable.save
       end

--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -51,7 +51,7 @@ class UsergroupsController < ApplicationController
 
   def get_external_usergroups_to_refresh
     # we need to load current status, so we call all explicitly
-    @external_usergroups = @usergroup.external_usergroups.all
+    @external_usergroups = @usergroup.external_usergroups.to_a
   end
 
   def external_usergroups

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -19,7 +19,7 @@ Apipie.configure do |config|
     :operatingsystem_families => Operatingsystem.families.join(", "),
     :providers => ComputeResource.providers.join(', '),
     :default_nic_type => InterfaceTypeMapper::DEFAULT_TYPE.humanized_name.downcase,
-    :template_kinds => -> { TemplateKind.scoped.map(&:name).join(", ") },
+    :template_kinds => -> { TemplateKind.pluck(:name).join(", ") },
     :provision_methods => -> { Host::Managed.provision_methods.map { |method, friendly_name| "#{method} (#{_(friendly_name)})" }.join(', ') },
   }
 

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -24,7 +24,7 @@ class RolesControllerTest < ActionController::TestCase
     assert_template 'index'
 
     assert_not_nil assigns(:roles)
-    assert_equal Role.order(:name).all, assigns(:roles)
+    assert_equal Role.order(:name).to_a, assigns(:roles)
 
     assert_tag :tag => 'a', :attributes => { :href => '/roles/1-Manager/edit' },
       :content => 'Manager'


### PR DESCRIPTION
Following on 10409, rebasing the Rails 4 PR with develop has needed some
changes that can be backported to develop now.
