### PR TITLE
Fixes #12698 - Insufficient URL validation for Smart Proxy and Medium

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -22,9 +22,7 @@ class Medium < ActiveRecord::Base
   VALID_NFS_PATH=/\A([-\w\d\.]+):(\/[\w\d\/\$\.]+)\Z/
   validates :name, :uniqueness => true, :presence => true
   validates :path, :uniqueness => true, :presence => true,
-                   :format => { :with => /\A(http|https|ftp|nfs):\/\//,
-                                :message => N_("Only URLs with schema http://, https://, ftp:// or nfs:// are allowed (e.g. nfs://server/vol/dir)")
-                              }
+    :url_schema => ['http', 'https', 'ftp', 'nfs']
   validates :media_path, :config_path, :image_path, :allow_blank => true,
                 :format => { :with => VALID_NFS_PATH, :message => N_("does not appear to be a valid nfs mount path")},
                 :if => Proc.new { |m| m.respond_to? :media_path }

--- a/app/validators/url_schema_validator.rb
+++ b/app/validators/url_schema_validator.rb
@@ -1,0 +1,14 @@
+class UrlSchemaValidator < ActiveModel::EachValidator
+  def initialize(args)
+    @schemas = args[:in]
+    super
+  end
+
+  def validate_each(record, attribute, value)
+    unless value =~ /\A#{URI.regexp(@schemas)}\z/
+      error_message = _('URL must be valid and schema must be one of %s') %
+        @schemas.to_sentence
+      record.errors.add(attribute, error_message)
+    end
+  end
+end

--- a/test/unit/medium_test.rb
+++ b/test/unit/medium_test.rb
@@ -27,18 +27,24 @@ class MediumTest < ActiveSupport::TestCase
     assert !other_medium.save
   end
 
-  test "path can't be blank" do
-    medium = Medium.new :name => "Archlinux mirror", :path => "  "
-    assert medium.path.strip.empty?
-    assert !medium.save
-  end
+  context 'path validations' do
+    setup do
+      @medium = FactoryGirl.build(:medium)
+    end
 
-  test "path must be unique" do
-    medium = Medium.new :name => "Archlinux mirror", :path => "http://www.google.com"
-    assert medium.save!
+    test "can't be blank" do
+      @medium.path = '  '
+      assert @medium.path.strip.empty?
+      refute_valid @medium
+    end
 
-    other_medium = Medium.new :name => "Ubuntu mirror", :path => "http://www.google.com"
-    assert !other_medium.save
+    test 'must be unique' do
+      @medium.path = 'http://www.google.com'
+      assert @medium.save!
+
+      other_medium = FactoryGirl.build(:medium, :path => @medium.path)
+      refute_valid other_medium
+    end
   end
 
   test "should destroy and nullify host.medium_id if medium is in use but host.build? is false" do

--- a/test/unit/validators/url_schema_validator_test.rb
+++ b/test/unit/validators/url_schema_validator_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class UrlSchemaValidatorTest < ActiveSupport::TestCase
+  class Validatable
+    include ActiveModel::Validations
+    validates :url, :url_schema => ['http', 'https', 'nfs', 'ftp']
+    attr_accessor :url
+  end
+
+  setup do
+    @validatable = Validatable.new
+  end
+
+  test 'url regexp does not match new lines' do
+    @validatable.url = "http://puppet.example.com:4568\njavascript('alert')"
+    refute_valid @validatable
+  end
+
+  test 'passes if url uses one of the specified schemas' do
+    @validatable.url = 'ftp://puppet.example.com:4568'
+    assert_valid @validatable
+  end
+
+  test 'fails if url contains the wrong schema' do
+    @validatable.url = 'unix://puppet.example.com:4568'
+    refute_valid @validatable
+    assert_match /URL must be valid/, @validatable.errors.messages.to_s
+  end
+end


### PR DESCRIPTION
Problem: The regex that validates smart proxies URLs only matches
'beginning of text'. This allows us to add just \n after a valid URL and
put anything after it. For instance, javascript:alert('hacked'). I
haven't found any link to the Foreman proxy URL so the script would not
trigger, but if we were to put link_to @smart_proxy.url somewhere (or a
    plugin did this) it would be unsafe.

Solution: Make the regex match the end of the URL with \Z. I substituted
the regex by an standard one, URI.regexp so we don't have to maintain it
anymore.

Extra: I added one test for this, but other tests have been rearranged
to use stubs rather than building actual SmartProxy objects &
associations.
