### PR TITLE
Fixes #12728 - Add attr_accessible to Report

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,6 +5,8 @@ class Report < ActiveRecord::Base
   include Authorizable
   include ConfigurationStatusScopedSearch
 
+  attr_accessible :host, :reported_at, :status, :metrics
+
   validates_lengths_from_database
   belongs_to_host
   has_many :messages, :through => :logs

--- a/test/unit/host_status/global_test.rb
+++ b/test/unit/host_status/global_test.rb
@@ -22,7 +22,7 @@ class GlobalTest < ActiveSupport::TestCase
 
   test '.build(statuses, :last_reports => [reports]) uses reports cache for configuration statuses' do
     status = HostStatus::ConfigurationStatus.new
-    report = Report.new(:host_id => 1)
+    report = Report.new(:host => Host.last)
     status.expects(:relevant?).returns(true)
     status.expects(:to_global).returns(:result)
     global = HostStatus::Global.build([ status ], :last_reports => [ report ])


### PR DESCRIPTION
While testing openscap arf reports, we encountered issues with saving the reports as those attributes where not accessible. Not sure how lack of those attrs plays nicely with ConfigReport
