### PR TITLE
Refs #6007 - fixing safe_value for lookup key

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -32,7 +32,6 @@ module HostCommon
     has_many :lookup_values, :primary_key => :lookup_value_matcher, :foreign_key => :match, :dependent => :destroy
     # See "def lookup_values_attributes=" under, for the implementation of accepts_nested_attributes_for :lookup_values
     accepts_nested_attributes_for :lookup_values
-    has_many :lookup_keys, :through => :lookup_values
 
     attr_accessible :compute_profile, :compute_profile_id, :compute_profile_name,
       :grub_pass, :image_id, :image_name, :image_file, :lookup_value_matcher,

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -20,7 +20,7 @@ class LookupKey < ActiveRecord::Base
                                 :reject_if => :reject_invalid_lookup_values,
                                 :allow_destroy => true
 
-  delegate :value, :to => :default_value
+  alias_attribute :value, :default_value
   before_validation :cast_default_value
 
   validates :key, :presence => true

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -317,6 +317,15 @@ class LookupKeyTest < ActiveSupport::TestCase
     assert_include key.errors.keys, :default_value
   end
 
+  test "safe_value can be shown for key" do
+    key = FactoryGirl.build(:puppetclass_lookup_key, :as_smart_class_param, :hidden_value => false,
+                            :override => true, :key_type => 'string',
+                            :default_value => 'aaa', :puppetclass => puppetclasses(:one))
+    assert_equal key.default_value, key.safe_value
+    key.hidden_value = true
+    assert_equal key.hidden_value, key.safe_value
+  end
+
   context "when key is a boolean and default_value is a string" do
     def setup
       @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,


### PR DESCRIPTION
I found this when trying to use `safe_value` in a different fix.
This wasn't noticeable since `safe_value` isn't used for lookup_key right now.
