### PR TITLE
fixes #12830 - Support rebooting hosts when setting multiple hosts to build

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -479,14 +479,6 @@ module HostsHelper
     )
   end
 
-  def supports_power_and_running(host)
-    return false unless host.compute_resource_id || host.bmc_available?
-    host.power.ready?
-  # return false if the proxyapi/bmc raised an error (and therefore do not know if power is supported)
-  rescue ProxyAPI::ProxyException
-    false
-  end
-
   def build_error_link(type, id)
     case type
       when :templates

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -786,6 +786,14 @@ class Host::Managed < Host::Base
     end
   end
 
+  def supports_power_and_running?
+    return false unless compute_resource_id || bmc_available?
+    power.ready?
+    # return false if the proxyapi/bmc raised an error (and therefore do not know if power is supported)
+  rescue ProxyAPI::ProxyException
+    false
+  end
+
   def ipmi_boot(booting_device)
     bmc_proxy.boot({:function => 'bootdevice', :device => booting_device})
   end

--- a/app/views/hosts/multiple_build.html.erb
+++ b/app/views/hosts/multiple_build.html.erb
@@ -1,6 +1,7 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_tag submit_multiple_build_hosts_path({:host_ids => params[:host_ids]}) do %>
+<%= form_for :host, :url => submit_multiple_build_hosts_path({:host_ids => params[:host_ids]}) do |f| %>
   <span class="label label-info"><%= _('Provision') %></span>
   <%= _('these hosts for a build operation on next boot') %>
+  <%= checkbox_f(f, :build, :help_text => _('Reboot now')) %>
 <% end %>

--- a/app/views/hosts/review_before_build.html.erb
+++ b/app/views/hosts/review_before_build.html.erb
@@ -26,7 +26,7 @@
              :url    => hash_for_setBuild_host_path(:id => @host).merge(:auth_object => @host, :permission => 'build_hosts'),
              :html   => { :id => 'build_form' } do |form|
 %>
-  <%= checkbox_f(form, :build, :help_text => _('Reboot now') % @host) if supports_power_and_running(@host) %>
+  <%= checkbox_f(form, :build, :help_text => _('Reboot now') % @host) if @host.supports_power_and_running? %>
   <div class="modal-footer">
     <%= modal_close %>
     <%= review_build_button(form, build_state(@build)) %>

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -153,6 +153,20 @@ class HostTest < ActiveSupport::TestCase
     assert_equal host.vm_compute_attributes, :cpus => 4
   end
 
+  test "#supports_power_and_running should return true with compute resource" do
+    power_mock = mock('subnet')
+    power_mock.stubs(:ready?).returns(true)
+
+    host = FactoryGirl.build(:host, :compute_resource => compute_resources(:ec2))
+    host.stubs(:power).returns(power_mock)
+    assert host.supports_power_and_running?
+  end
+
+  test "#supports_power_and_running should return false without compute resource" do
+    host = FactoryGirl.build(:host)
+    refute host.supports_power_and_running?
+  end
+
   test "fetches nil vm compute attributes for bare metal" do
     host = FactoryGirl.create(:host)
     assert_equal host.vm_compute_attributes, nil


### PR DESCRIPTION
When setting multiple hosts to build, this commit adds support to reboot the hosts in addition to enabling rebuild.
