### PR TITLE
Fixes #12794 - Defined logic when properties should be sent to server

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -238,7 +238,8 @@ function hostgroup_changed(element) {
 function reset_explicit_values(element) {
   $("[name=is_overridden_btn]").each(function(i, btn) {
     var item = $(btn)
-    item.attr('data-explicit', false);
+    var formControl = item.closest('.input-group').find('.form-control');
+    formControl.attr('disabled', true);
   })
 }
 
@@ -298,17 +299,7 @@ function update_form(element, options) {
 
 //Serializes only those input elements from form that are set explicitly
 function serializeForm() {
-  return $($('form')[0].elements).filter(isExplicit).serialize()
-}
-
-//This function decides for a given input element is it set explicitly by the user.
-function isExplicit(index, element) {
-  if (element.nextSibling == undefined) return true;
-  if (element.nextSibling.children == undefined) return true;
-  if (element.nextSibling.children[0] == undefined) return true;
-  if (element.nextSibling.children[0].dataset == undefined) return true;
-  if (element.nextSibling.children[0].dataset.explicit == undefined) return true;
-  return element.nextSibling.children[0].dataset.explicit == 'true';
+  return $('form').serialize()
 }
 
 function subnet_contains(number, cidr, ip){

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -229,9 +229,17 @@ function hostgroup_changed(element) {
       reload_host_params();
     }
   } else { // a new host
+    reset_explicit_values(element);
     set_inherited_value(element);
     update_form(element);
   }
+}
+
+function reset_explicit_values(element) {
+  $("[name=is_overridden_btn]").each(function(i, btn) {
+    var item = $(btn)
+    item.attr('data-explicit', false);
+  })
 }
 
 function set_inherited_value(hostgroup_elem) {
@@ -299,6 +307,7 @@ function isExplicit(index, element) {
   if (element.nextSibling.children == undefined) return true;
   if (element.nextSibling.children[0] == undefined) return true;
   if (element.nextSibling.children[0].dataset == undefined) return true;
+  if (element.nextSibling.children[0].dataset.explicit == undefined) return true;
   return element.nextSibling.children[0].dataset.explicit == 'true';
 }
 

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -61,7 +61,7 @@ module HostsAndHostgroupsHelper
              { :include_blank => blank_or_inherit_f(f, :puppet_ca_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
                :disable_button_enabled => override && !explicit_value?(:puppet_ca_proxy_id),
-               :user_set => params[:host] && params[:host][:puppet_ca_proxy_id]
+               :user_set => user_set?(:puppet_ca_proxy_id)
              },
              { :label       => _("Puppet CA"),
                :help_inline => _("Use this puppet server as a CA server") }
@@ -76,7 +76,7 @@ module HostsAndHostgroupsHelper
              { :include_blank => blank_or_inherit_f(f, :puppet_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
                :disable_button_enabled => override && !explicit_value?(:puppet_proxy_id),
-               :user_set => params[:host] && params[:host][:puppet_proxy_id]
+               :user_set => user_set?(:puppet_proxy_id)
 
              },
              { :label       => _("Puppet Master"),
@@ -94,7 +94,7 @@ module HostsAndHostgroupsHelper
                 { :include_blank => true,
                   :disable_button => can_override ? _(INHERIT_TEXT) : nil,
                   :disable_button_enabled => override && !explicit_value?(:realm_id),
-                  :user_set => params[:host] && params[:host][:realm_id]
+                  :user_set => user_set?(:realm_id)
                 },
                 { :help_inline   => :indicator }
             ).html_safe
@@ -114,5 +114,15 @@ module HostsAndHostgroupsHelper
     return true if params[:action] == 'clone'
     return false unless params[:host]
     !!params[:host][field]
+  end
+
+  def user_set?(field)
+    # if the host has no hostgroup
+    return true unless @host && @host.hostgroup
+    # when editing a host, the values are specified explicitly
+    return true if params[:action] == 'edit'
+    return true if params[:action] == 'clone'
+    # check if the user set the field explicitly despite setting a hostgroup.
+    params[:host] && params[:host][:hostgroup_id] && params[:host][field]
   end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -62,7 +62,7 @@
             { :include_blank => true,
               :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
               :disable_button_enabled => inherited_by_default?(:compute_profile_id, @host),
-              :user_set => params[:host] && params[:host][:compute_profile_id]
+              :user_set => user_set?(:compute_profile_id)
             },
             { :label => _("Compute profile"), :'data-url' => compute_resource_selected_hosts_path,
               :onchange => 'computeResourceSelected(this);',
@@ -73,7 +73,7 @@
         <%= select_f f, :environment_id, Environment.with_taxonomy_scope_override(@location,@organization).order(:name), :id, :to_label, { :include_blank => true,
              :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
              :disable_button_enabled => inherited_by_default?(:environment_id, @host),
-             :user_set => params[:host] && params[:host][:environment_id]
+             :user_set => user_set?(:environment_id)
            },
            {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
             :'data-host-id' => @host.id, :help_inline => :indicator} %>

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -59,4 +59,40 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
     click_link 'Parameters'
     assert page.has_no_selector?('#params .has-error')
   end
+
+  describe 'JS enabled tests' do
+    setup do
+      @old_driver = Capybara.current_driver
+      Capybara.current_driver = Capybara.javascript_driver
+      login_admin
+    end
+
+    teardown do
+      Capybara.current_driver = @old_driver
+    end
+
+    test 'submit updates taxonomy' do
+      group = FactoryGirl.create(:hostgroup, :with_puppetclass)
+      new_location = FactoryGirl.create(:location)
+
+      visit edit_hostgroup_path(group)
+      page.find(:css, "a[href='#locations']").click()
+      select_from_list 'hostgroup_location_ids', new_location
+
+      click_button "Submit"
+      #wait for submit to finish
+      page.find('#search-form')
+
+      group.locations.reload
+
+      assert_not_nil group.locations.first{ |l| l.name == new_location.name }
+    end
+  end
+
+  private
+
+  def select_from_list(list_id, item)
+    span = page.all(:css, "#ms-#{list_id} .ms-selectable ul li span").first{ |i| i.text == item.name }
+    span.click
+  end
 end

--- a/test/integration/support/disable_animations.js
+++ b/test/integration/support/disable_animations.js
@@ -1,0 +1,12 @@
+var disableAnimationStyles = '-webkit-transition: none !important;' +
+                             '-moz-transition: none !important;' +
+                             '-ms-transition: none !important;' +
+                             '-o-transition: none !important;' +
+                             'transition: none !important;'
+
+window.onload = function() {
+  var animationStyles = document.createElement('style');
+  animationStyles.type = 'text/css';
+  animationStyles.innerHTML = '* {' + disableAnimationStyles + '}';
+  document.head.appendChild(animationStyles);
+};

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ Spork.prefork do
   # need to restart spork for it take effect.
 
   # Remove previous test log to speed tests up
+  # Comment out these lines to enable test logging
   test_log = File.expand_path('../../log/test.log', __FILE__)
   FileUtils.rm(test_log) if File.exist?(test_log)
 
@@ -24,7 +25,16 @@ Spork.prefork do
   require 'capybara/poltergeist'
 
   Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, {:js_errors => true, :timeout => 60})
+    opts = {
+      # To enable debugging uncomment `:inspector => true` and
+      # add `page.driver.debug` in code to open webkit inspector
+      # :inspector => true
+      :js_errors => true,
+      :timeout => 60,
+      #disable animations to speed up the tests
+      :extensions => ["#{Rails.root}/test/integration/support/disable_animations.js"],
+    }
+    Capybara::Poltergeist::Driver.new(app, opts)
   end
   Capybara.default_wait_time = 30
 
@@ -287,6 +297,20 @@ Spork.prefork do
     def fix_mismatches
       Location.all_import_missing_ids
       Organization.all_import_missing_ids
+    end
+
+    def select2(value, attrs)
+      first("#s2id_#{attrs[:from]}").click
+      find(".select2-input").set(value)
+      within ".select2-results" do
+        find("span", text: value).click
+      end
+    end
+
+    def wait_for_ajax
+      Timeout.timeout(Capybara.default_wait_time) do
+        loop until page.evaluate_script('jQuery.active').zero?
+      end
     end
   end
 


### PR DESCRIPTION
Redefined the logic when the parameters should be sent to server:
If hostgroup is not set - always send the parameters.
On hostgroup change - remove inherited parameters from the request, so the values from the hostgroup will take place.
On save - send the values according to the state of the "inherit" button.

The new tests of this PR are working if I use selenium driver, but when using poltergeist, I see that the test is filling the form, stays stuck at our progress message and never shows the `/hosts/:id` page.

It would be great if the code will be reviewed, in the meantime I will keep on working on forcing poltergeist to work. Right now my main suspect is animation, I am thinking about using code from [here](https://gist.github.com/andyjbas/9962218) as my next step.
