### PR TITLE
Fixes #12870 - FactName compose should be an attr_accessible

### DIFF
--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -6,7 +6,7 @@ class FactName < ActiveRecord::Base
   validates_lengths_from_database
   has_many :fact_values, :dependent => :destroy
   has_many_hosts :through => :fact_values
-  attr_accessible :parent, :name
+  attr_accessible :parent, :parent_id, :name, :compose
 
   scope :no_timestamp_fact, -> { where("fact_names.name <> ?",:_timestamp) }
   scope :timestamp_facts, -> { where(:name => :_timestamp) }


### PR DESCRIPTION
Plugins like foreman_ansible/chef/salt use `compose` to save nested
facts. However in develop this is not possible because :compose is not
in the attr_accessible list of FactName.
