### PR TITLE
Fixes #12219: Pin pg to less 0.16.0

### DIFF
--- a/bundler.d/postgresql.rb
+++ b/bundler.d/postgresql.rb
@@ -1,3 +1,3 @@
 group :postgresql do
-  gem 'pg', '~> 0.11'
+  gem 'pg', '~> 0.15.0'
 end


### PR DESCRIPTION
The pg gem from 0.16.0 to 0.18.4 breaks the ability to run database
rake commands due to an improper linking when ruby-devel is installed
and trying to use Ruby greater than or 2.2.2.
