### PR TITLE
fixes #12892 - moves rails binaries to Rails.root/bin

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run

--- a/script/rails
+++ b/script/rails
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
-
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
-require 'rails/commands'


### PR DESCRIPTION
this is simply the output of `rake rails:update:bin`
and deletion of old script/rails.
