### PR TITLE
Fixes #12938 - Prevent password autofill for hidden lookup keys

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -60,9 +60,13 @@ module LayoutHelper
     end
   end
 
+  def fakepassword
+    password_field_tag(:fakepassword, nil, :style => 'display: none')
+  end
+
   def password_f(f, attr, options = {})
     unset_button = options.delete(:unset)
-    password_field_tag(:fakepassword, nil, :style => 'display: none') +
+    fakepassword +
     field(f, attr, options) do
       options[:autocomplete]   ||= 'off'
       options[:placeholder]    ||= password_placeholder(f.object, attr)

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -21,6 +21,7 @@
         <%= password_f f, :default_value, :size => "col-md-8", :no_label => false, :value => f.object.default_value_before_type_cast,
                        :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)), :fullscreen => true %>
     <% else %>
+        <%= fakepassword %>
         <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
                        :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)),
                        :fullscreen => :true,


### PR DESCRIPTION
Lookupkeys autofilled the value field with the saved password if
no other hidden field already exited on the form since the fake
password placeholder was not added to the form.
