### PR TITLE
Fixes #12957 - removing current_parameters from hostgroup

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -456,13 +456,10 @@ function reload_host_params(){
   var host_id = $("form").data('id');
   var url = $('#params-tab').data('url');
   var data = $("[data-submit='progress_bar']").serialize().replace('method=patch', 'method=post');
-  if (url.match('hostgroups')) {
-    var parent_id = $('#hostgroup_parent_id').val()
-    data = data + '&hostgroup_id=' + host_id + '&hostgroup_parent_id=' + parent_id
-  } else {
-    data = data + '&host_id=' + host_id
+  if (url.length > 0) {
+    data = data + '&host_id=' + host_id;
+    load_with_placeholder('inherited_parameters', url, data);
   }
-  load_with_placeholder('inherited_parameters', url, data)
 }
 
 function reload_puppetclass_params(){

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -3,8 +3,8 @@ class HostgroupsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
   before_filter :find_resource,  :only => [:nest, :clone, :edit, :update, :destroy]
-  before_filter :ajax_request,   :only => [:process_hostgroup, :current_parameters, :puppetclass_parameters]
-  before_filter :taxonomy_scope, :only => [:new, :edit, :process_hostgroup, :current_parameters]
+  before_filter :ajax_request,   :only => [:process_hostgroup, :puppetclass_parameters]
+  before_filter :taxonomy_scope, :only => [:new, :edit, :process_hostgroup]
 
   def index
     @hostgroups = resource_base.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
@@ -71,15 +71,6 @@ class HostgroupsController < ApplicationController
       end
     rescue Ancestry::AncestryException
       process_error(:error_msg => _("Cannot delete group %{current} because it has nested groups.") % { :current => @hostgroup.title } )
-    end
-  end
-
-  def current_parameters
-    Taxonomy.as_taxonomy @organization, @location do
-      hostgroup_parent_parameters = Hostgroup.authorized(:view_hostgroups).find(params['hostgroup_parent_id']).parameters(true) if params['hostgroup_parent_id'].present?
-      hostgroup_parameters = params['hostgroup_id'] != "null" ? Hostgroup.authorized(:view_hostgroups).find(params['hostgroup_id']).group_parameters : []
-      render :partial => "common_parameters/inherited_parameters",
-             :locals  => { :inherited_parameters => hostgroup_parent_parameters, :parameters => hostgroup_parameters }
     end
   end
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -278,7 +278,7 @@ Foreman::AccessControl.map do |permission_set|
 
   permission_set.security_block :hostgroups do |map|
     ajax_actions = [:architecture_selected, :domain_selected, :environment_selected, :medium_selected, :os_selected,
-                    :use_image_selected, :process_hostgroup, :current_parameters, :puppetclass_parameters]
+                    :use_image_selected, :process_hostgroup, :puppetclass_parameters]
     host_ajax_actions = [:process_hostgroup]
     pc_ajax_actions = [:parameters]
 

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -9,7 +9,7 @@
       <li><a href="#network" data-toggle="tab"><%= _('Network') %></a></li>
       <li><a href="#os" data-toggle="tab"><%= _('Operating System') %></a></li>
     <% end %>
-    <li><a href="#params" id='params-tab' data-url='<%= current_parameters_hostgroups_path %>' data-url2='<%= puppetclass_parameters_hostgroups_path %>' data-toggle="tab"><%= _('Parameters') %></a></li>
+    <li><a href="#params" id='params-tab' data-url='' data-url2='<%= puppetclass_parameters_hostgroups_path %>' data-toggle="tab"><%= _('Parameters') %></a></li>
     <% if show_location_tab? %>
       <li><a href="#locations" data-toggle="tab"><%= _('Locations') %></a></li>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,6 @@ Foreman::Application.routes.draw do
       post 'use_image_selected'
       post 'medium_selected'
       post 'process_hostgroup'
-      post 'current_parameters'
       post 'puppetclass_parameters'
     end
   end

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -87,6 +87,24 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
 
       assert_not_nil group.locations.first{ |l| l.name == new_location.name }
     end
+
+    test 'parameters change after parent update' do
+      group = FactoryGirl.create(:hostgroup)
+      group.group_parameters << GroupParameter.create(:name => "x", :value => "original")
+      child = FactoryGirl.create(:hostgroup)
+
+      visit clone_hostgroup_path(child)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert page.has_no_selector?("#inherited_parameters #name_x")
+
+      click_link 'Hostgroup'
+      select2(group.name, :from => 'hostgroup_parent_id')
+      wait_for_ajax
+
+      click_link 'Parameters'
+      assert page.has_selector?("#inherited_parameters #name_x")
+    end
   end
 
   private


### PR DESCRIPTION
`current_parameters` in host refreshes all host parameters including those that are inherited from hg, os, etc.
In hostgroup the only parameters present are the hostgroup's and it's ancestor's group parameters.
When the parent changes the parameters are already refreshed through process_hostgroup.
current_parameters is invoked in other cases (like changing an os) that are relavant for host but not for hostgroup as they have no affect on hostgroup's parameters tab. ([copied from redmine](http://projects.theforeman.org/issues/12957))
