### PR TITLE
fixes #12977 - set minimum sprockets-rails to 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 gem 'activerecord-session_store', '~> 0.1.1'
 gem 'rails-observers', '~> 0.1'
 gem 'protected_attributes', '~> 1.1.1'
+gem 'sprockets-rails', '>= 2.2.2'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))


### PR DESCRIPTION
fb9f45e uses the app.assets_manifest setting in the production
environment to reconfigure asset manifests on the fly, but this was
introduced only in 2.2.2 and not ~> 2.0 which Rails 4.1.x depends on.
