### PR TITLE
refs #12977 - set max version of sprockets-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 gem 'activerecord-session_store', '~> 0.1.1'
 gem 'rails-observers', '~> 0.1'
 gem 'protected_attributes', '~> 1.1.1'
-gem 'sprockets-rails', '>= 2.2.2'
+gem 'sprockets-rails', '>= 2.2.2', '< 3'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))


### PR DESCRIPTION
Older versions of Bundler (e.g. 1.3.5) attempt to install a 3.x version
and then fail to resolve dependencies.

```
$ bundle _1.3.5_ install
Bundler could not find compatible versions for gem "sprockets-rails":
  In Gemfile:
    rails (= 4.1.5) ruby depends on
      sprockets-rails (~> 2.0) ruby

    sprockets-rails (3.0.0)
```
