### PR TITLE
Refs #12716 - Extensible show page for smart proxy - rejected version

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -220,6 +220,11 @@ class ApplicationController < ActionController::Base
     render_403
   end
 
+  def find_page
+    @page = ::Pages::Manager.find_page(controller_name, action_name)
+    raise Foreman::Exception.new(N_("Page %s has no view assigned", @page.name)) unless @page || @page.view
+  end
+
   def process_success(hash = {})
     hash[:object]                 ||= instance_variable_get("@#{controller_name.singularize}")
     hash[:object_name]            ||= hash[:object].to_s

--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -2,6 +2,7 @@ class SmartProxiesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
   before_filter :find_resource, :only => [:show, :edit, :update, :refresh, :ping, :tftp_server, :destroy]
+  before_filter :find_page, :only => [:show]
 
   def index
     @smart_proxies = resource_base.includes(:features).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -175,6 +175,32 @@ module Foreman #:nodoc:
       Menu::Manager.map(menu).delete(item)
     end
 
+    # Extends an already registered extensible page. Usage:
+    #
+    # extend_page({ :controller => :controller_name, :action => :action_name }) do |page|
+    #   Add a widget
+    #   page.add_widget :name => "My widg", :partial => "path/to/partial"
+    #
+    #   Add a tab with 2 columns, widget in right column.
+    #   Ordering of the tabs is given by the descending priority.
+    #   If no priority for a new tab is given, it is added as the last tab.
+    #   page.add_tab(:name => "My tab", :columns_count => 2, :layout => "path/to/partial", :priority => 5) do |tab|
+    #     tab.add_widget :name => "Widget name", :partial => 'path/to/partial', :column => 1
+    #   end
+    # end
+    def extend_page(url_hash, &block)
+      Pages::Manager.extend_page(url_hash, &block)
+    end
+
+    # Extends already registered tab on extensible page. Usage:
+    #
+    # extend_tab({ :controller => :controller_name, :action => :action_name }, tab_name) do |tab|
+    #  tab.add_widget(...)
+    # end
+    def extend_tab(url_hash, tab_name, &block)
+      Pages::Manager.extend_tab(url_hash, tab_name, &block)
+    end
+
     def tests_to_skip(hash)
       Rails.logger.warn "Minitest 5 deprecated the runner API and plugin tests \
 can't be skipped right now. Future versions of Foreman might bring back this \

--- a/app/services/pages/column.rb
+++ b/app/services/pages/column.rb
@@ -1,0 +1,17 @@
+module Pages
+  class Column
+    attr_reader :widgets
+
+    def initialize
+      @widgets = []
+    end
+
+    def find_widget(widget_name)
+      @widgets.find { |w| w.name == widget_name.to_sym }
+    end
+
+    def <<(widget)
+      @widgets << widget
+    end
+  end
+end

--- a/app/services/pages/loader.rb
+++ b/app/services/pages/loader.rb
@@ -1,0 +1,12 @@
+module Pages
+  class Loader
+    def self.load
+      Pages::Manager.add_page({ :controller => :smart_proxies, :action => :show }, "smart_proxies/show") do |page|
+        page.add_tab(:name => :overview, :columns_count =>  2, :layout => "smart_proxies/tabs/overview") do |tab|
+          tab.add_widget :name => :details, :partial => 'smart_proxies/widgets/details', :column => 0
+        end
+        page.add_tab(:name => :services, :columns_count => 2, :layout => "smart_proxies/tabs/services")
+      end
+    end
+  end
+end

--- a/app/services/pages/manager.rb
+++ b/app/services/pages/manager.rb
@@ -1,0 +1,49 @@
+module Pages
+  class Manager
+    class << self
+      def add_page(url_hash, view, columns_count = 1)
+        @pages ||= {}.with_indifferent_access
+        page = Pages::Page.new(url_hash, view, columns_count)
+        raise ArgumentError, "You are either trying to find non-existing view item or add a page with already existing name" if @pages[page.name]
+        yield page if block_given?
+        @pages[page.name] = page
+      end
+
+      def extend_page(url_hash)
+        page = find_page(url_hash[:controller], url_hash[:action])
+        yield page if block_given?
+      end
+
+      def extend_tab(url_hash, tab_name)
+        page = find_page(url_hash[:controller], url_hash[:action])
+        tab = page.find_tab tab_name
+        if tab
+          yield tab if block_given?
+        else
+          raise ::Foreman::Eception.new("No tab with name #{tab_name} on page #{page.name} was found")
+        end
+      end
+
+      def load_pages
+        Pages::Loader.load
+      end
+
+      def find_page(controller, action)
+        find_page_by_name("#{controller}/#{action}".to_sym)
+      end
+
+      private
+
+      def find_page_by_name(page_name)
+        if @pages.nil? || @pages[page_name].nil?
+          begin
+            load_pages
+          rescue ArgumentError => e
+            raise ::ForemanException.new(e.message)
+          end
+        end
+        @pages[page_name]
+      end
+    end
+  end
+end

--- a/app/services/pages/page.rb
+++ b/app/services/pages/page.rb
@@ -1,0 +1,15 @@
+module Pages
+  class Page < ViewItem
+    attr_reader :url_hash, :view
+
+    def initialize(url_hash, view, columns_count)
+      @url_hash = url_hash
+      @view = view
+      super columns_count
+    end
+
+    def name
+      "#{@url_hash[:controller]}/#{url_hash[:action]}".to_sym
+    end
+  end
+end

--- a/app/services/pages/tab.rb
+++ b/app/services/pages/tab.rb
@@ -1,0 +1,16 @@
+module Pages
+  class Tab < ViewItem
+    attr_reader :name, :priority, :layout
+
+    def initialize(name, priority, columns_count, layout = nil)
+      @name = name
+      @priority = priority
+      @layout = layout
+      super columns_count
+    end
+
+    def snake_name
+      @name.to_s.gsub(/\s/, "_").underscore
+    end
+  end
+end

--- a/app/services/pages/view_item.rb
+++ b/app/services/pages/view_item.rb
@@ -1,0 +1,49 @@
+module Pages
+  class ViewItem
+    attr_reader :tabs, :columns
+
+    def initialize(column_count = 1)
+      @columns = (0...column_count).map { Column.new }
+      @tabs = {}.with_indifferent_access
+    end
+
+    def find_tab(tab_name)
+      if @tabs[tab_name]
+        @tabs[tab_name]
+      elsif @tabs.values.empty?
+        nil
+      else
+        @tabs.values.map { |item| item.find_tab tab_name }.compact.first
+      end
+    end
+
+    def add_tab(opts)
+      raise ::Foreman::Exception.new("Cannot add tab with no name") unless opts[:name]
+      raise ::Foreman::Exception.new("Tab name #{opts[:name]} already exists") if find_tab(opts[:name])
+      raise ::Foreman::Exception.new("This view item already has columns, no tabs can be added") if @columns.count > 1
+      columns_count = opts[:columns_count] || 1
+      priority = opts[:priority] || last_tab_priority - 1
+      tab = Pages::Tab.new(opts[:name], priority, columns_count, opts[:layout])
+      yield tab if block_given?
+      @tabs[opts[:name]] = tab
+    end
+
+    def add_widget(opts)
+      @columns[opts[:column] ? opts[:column] : 0] << Pages::Widget.new(opts)
+    end
+
+    def sorted_tabs
+      @tabs.sort_by { |k,v| v.priority }.reverse.inject({}) do |result, ary|
+        result[ary.first] = ary.last
+        result
+      end
+    end
+
+    private
+
+    def last_tab_priority
+      # We need a default priority value for the first tab if it is not specified
+      @tabs.values.map(&:priority).min || 20
+    end
+  end
+end

--- a/app/services/pages/widget.rb
+++ b/app/services/pages/widget.rb
@@ -1,0 +1,10 @@
+module Pages
+  class Widget
+    attr_reader :name, :partial
+
+    def initialize(opts)
+      opts[:name] ? @name = opts[:name] : fail("Widget should have a name")
+      opts[:partial] ? @partial = opts[:partial] : fail("Widget should have a partial")
+    end
+  end
+end

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -1,73 +1,25 @@
 <% title(_('Smart Proxy: %s') % @smart_proxy.to_label) %>
 <%= smart_proxy_title_actions(@smart_proxy, authorizer) %>
 <% service_features = services_tab_features(@smart_proxy) %>
+
 <div class="row proxy-show" data-url="<%= ping_smart_proxy_path(@smart_proxy) %>">
+
   <ul id="proxy-tab" class="nav nav-tabs">
-    <li class="active"><a href="#properties" data-toggle="tab"><%= _('Overview') %></a></li>
-    <% if service_features.any? %>
-      <li><a href="#services" data-toggle="tab"><%= _('Services') %></a></li>
+    <% @page.sorted_tabs.each_with_index do |(name, tab), index| %>
+      <% next if name == "services" && service_features.none? %>
+      <li class="<%= 'active' if index == 0 %>">
+        <a href="#<%= tab.snake_name %>" data-toggle="tab"><%= _(name.capitalize) %></a>
+      </li>
     <% end %>
   </ul>
+
   <div id="proxy-tab-content" class="proxy-content tab-content">
-    <div class="tab-pane active in" id="properties">
-      <div class="col-md-6">
-        <div class="row">
-          <h3><%= _('Details') %></h3>
-        </div>
-        <div class="row">
-          <div class="col-md-4">
-            <%= _('Communication status') %>
-          </div>
-          <div class="col-md-8">
-            <span class="proxy-show-status">
-              <%= spinner %>
-            </span>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-4">
-            <%= _('URL') %>
-          </div>
-          <div class="col-md-8">
-            <%= @smart_proxy.url %>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-4">
-            <%= _('Version') %>
-          </div>
-          <div class="col-md-8">
-            <span class="proxy-version" data-url="<%= ping_smart_proxy_path(@smart_proxy) %>">
-              <%= spinner %>
-            </span>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-4">
-            <%= _('Features') %>
-          </div>
-          <div class="col-md-8">
-            <%= @smart_proxy.features.to_sentence %> <%= refresh_proxy_icon(@smart_proxy, authorizer) %>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-6">
-        <!--place holder for Capsule sync-->
-      </div>
-    </div>
-    <% if service_features.any? %>
-      <div class="tab-pane" id="services">
-        <div class="col-md-6">
-          <% service_features.each do |feature| %>
-            <% feature_erb = "smart_proxies/plugins/#{feature}" %>
-            <% if lookup_context.template_exists?(feature_erb, [], true) %>
-              <%= render :partial => feature_erb, :locals => {:feature => feature} %>
-            <% else %>
-              <%= render :partial => "smart_proxies/plugins/no_template", :locals => {:feature => feature} %>
-            <% end %>
-          <% end %>
-        </div>
+    <% @page.sorted_tabs.each_with_index do |(name, tab), index| %>
+      <% next if name == 'services' && service_features.none? %>
+      <div class="tab-pane <%= 'active' if index == 0 %>" id="<%= tab.snake_name %>">
+        <%= render tab.layout, { :tab => tab, :smart_proxy => @smart_proxy, :service_features => service_features } %>
       </div>
     <% end %>
   </div>
+
 </div>

--- a/app/views/smart_proxies/tabs/_overview.html.erb
+++ b/app/views/smart_proxies/tabs/_overview.html.erb
@@ -1,0 +1,7 @@
+<% tab.columns.each do |column| %>
+  <div class="col-md-<%= 12 / tab.columns.count %>">
+    <% column.widgets.each do |widget| %>
+      <%= render widget.partial, { :smart_proxy => smart_proxy, :widget => widget } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/smart_proxies/tabs/_services.html.erb
+++ b/app/views/smart_proxies/tabs/_services.html.erb
@@ -1,0 +1,16 @@
+<div class="col-md-6">
+  <% widgets_column = tab.columns.first %>
+
+  <% service_features.sort.each do |feature| %>
+    <% if(widget = widgets_column.find_widget(feature)) %>
+      <%= render :partial => widget.partial, :locals => { :widget => widget } %>
+    <% else %>
+      <% feature_erb = "smart_proxies/plugins/#{feature}" %>
+      <% if lookup_context.template_exists?(feature_erb, [], true) %>
+        <%= render :partial => feature_erb, :locals => { :feature => feature } %>
+      <% else %>
+        <%= render :partial => "smart_proxies/plugins/no_template", :locals => { :feature => feature } %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/smart_proxies/widgets/_details.html.erb
+++ b/app/views/smart_proxies/widgets/_details.html.erb
@@ -1,0 +1,39 @@
+<div class="row">
+  <h3><%= _('Details') %></h3>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <%= _('Communication status') %>
+  </div>
+  <div class="col-md-8">
+    <span class="proxy-show-status">
+      <%= spinner %>
+    </span>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <%= _('URL') %>
+  </div>
+  <div class="col-md-8">
+    <%= smart_proxy.url %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <%= _('Version') %>
+  </div>
+  <div class="col-md-8">
+    <span class="proxy-version" data-url="<%= ping_smart_proxy_path(smart_proxy) %>">
+      <%= spinner %>
+    </span>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-4">
+    <%= _('Features') %>
+  </div>
+  <div class="col-md-8">
+    <%= smart_proxy.features.to_sentence %> <%= refresh_proxy_icon(smart_proxy, authorizer) %>
+  </div>
+</div>

--- a/test/unit/page_manager_test.rb
+++ b/test/unit/page_manager_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class PageManagerTest < ActiveSupport::TestCase
+  test 'should find page' do
+    Pages::Manager.add_page({ :controller => :tests, :action => :show }, "tests/show")
+    assert Pages::Manager.find_page(:tests, :show)
+  end
+
+  test 'should yield page for extension' do
+    Pages::Manager.add_page({ :controller => :tests, :action => :show_1 }, "tests/show")
+    Pages::Manager.extend_page({ :controller => :tests, :action => :show_1 }) do |page|
+      assert_kind_of  Pages::Page, page
+    end
+  end
+
+  test 'should yield tab for extension' do
+    Pages::Manager.add_page({ :controller => :tests, :action => :show_2 }, "tests/show")
+    Pages::Manager.extend_page({ :controller => :tests, :action => :show_2 }) do |page|
+      page.add_tab(:name => :test_tab) do |tab|
+        assert_kind_of  Pages::Tab, tab
+      end
+    end
+  end
+end

--- a/test/unit/view_item_test.rb
+++ b/test/unit/view_item_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class ViewItemTest < ActiveSupport::TestCase
+  setup do
+    @page = Pages::Page.new({:controller => :tests, :action => :test_action}, "fakes/show", 1)
+  end
+
+  test 'should create page with default values' do
+    assert_equal 1, @page.columns.count
+    assert_equal "tests/test_action".to_sym, @page.name
+  end
+
+  test 'shows snake cased name for tab' do
+    tab = Pages::Tab.new(:"test tab", 25, 1)
+    assert_equal "test_tab", tab.snake_name
+  end
+
+  test 'should add tab to view item' do
+    @page.add_tab :name => :test_tab
+    assert_equal 1, @page.tabs.count
+    assert_equal 1, @page.tabs.values.first.columns.count
+    assert_equal 19, @page.tabs.values.first.priority
+  end
+
+  test 'should not add tab with the same name' do
+    @page.add_tab :name => :test_tab
+    assert_raises RuntimeError do
+      @page.add_tab :name => :test_tab
+    end
+  end
+
+  test 'should not add tab without name' do
+    @page.add_tab :name => :test_tab
+    assert_raises RuntimeError do
+      @page.add_tab({})
+    end
+  end
+
+  test 'should not add tabs where there are already columns on page' do
+    page = Pages::Page.new({:controller => :tests, :action => :another_test_action}, "fakes/show", 2)
+    assert_raises RuntimeError do
+      page.add_tab :name => :test_tab
+    end
+  end
+
+  test 'should add widget to the default column' do
+    @page.add_widget :name => :cool_widget, :partial => "widgets/cool_widget"
+    assert_equal 1, @page.columns.first.widgets.count
+  end
+
+  test 'should add widget to specified column' do
+    page = Pages::Page.new({:controller => :tests, :action => :another_test_action}, "fakes/show", 4)
+    page.add_widget :name => :cool_widget, :partial => "widgets/cool_widget", :column => 2
+    page.columns.each_with_index do |col, index|
+      index == 2 ? assert_equal(1, col.widgets.count) : assert_equal(0, col.widgets.count)
+    end
+  end
+
+  test 'should sort tabs by priority' do
+    @page.add_tab :name => :top, :priority => 20
+    @page.add_tab :name => :low, :priority => 10
+    @page.add_tab :name => :medium, :priority => 15
+    assert_equal :top, @page.sorted_tabs.values.first.name
+    assert_equal :low, @page.sorted_tabs.values.last.name
+  end
+
+  test 'should find tab by name' do
+    @page.add_tab :name => :test_tab
+    assert @page.find_tab :test_tab
+  end
+
+  test 'should find nested tab by name' do
+    @page.add_tab :name => :test_tab do |tab|
+      tab.add_tab :name => :nested_tab
+    end
+    assert @page.find_tab :nested_tab
+  end
+end


### PR DESCRIPTION
This allows us to create extensible pages. Let me know if this is a step in the right direction.

We can register new extensible page with `add_page`. We can extend an already registered page (add more content to it) with `extend_page`. We can also extend the existing tabs with `extend_tab`. 
Several columns for page/tab can be specified and their content arranged on a page accordingly. Plugins can easily extend registered pages from within their `Engine`, there are usage examples in  services/foreman/plugin.rb 
