### PR TITLE
fixes #12959 - escape % in fact search values, auto-add wildcards

### DIFF
--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1547,6 +1547,14 @@ class HostTest < ActiveSupport::TestCase
       hosts = Host::Managed.search_for("facts.memory_mb > 6544 and facts.custom_fact = find_me")
       assert_equal hosts.count, 1
       assert_equal ["num001.example.com"], hosts.map { |h| h.name }.sort
+
+      hosts = Host::Managed.search_for("facts.custom_fact ~ %nd_me")
+      assert_equal hosts.count, 1
+      assert_equal ["num001.example.com"], hosts.map { |h| h.name }.sort
+
+      hosts = Host::Managed.search_for("facts.custom_fact ~ nd_m")
+      assert_equal hosts.count, 1
+      assert_equal ["num001.example.com"], hosts.map { |h| h.name }.sort
     end
 
     test "search by fact name is not vulnerable to SQL injection in name" do


### PR DESCRIPTION
When constructing fact search SQL queries with values containing
percent symbols (for LIKE queries), the symbols must be escaped as the
SQL conditions are later sanitised by Rails, which passes them through
the string formatter with any placeholder values from scoped_search.

Secondly, when using a LIKE search query without any wildcards,
previously a wildcard at the start and end would be added to match the
value anywhere.  This behaviour has been restored.
