### PR TITLE
Fixes #13040 - oVirt now autoloads SSL certificate

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -255,7 +255,7 @@ module Foreman::Model
       client.datacenters
       @client = client
     rescue => e
-      if e.message =~ /SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed/
+      if e.message =~ /SSL_connect.*certificate verify failed/
         raise Foreman::FingerprintException.new(
                   N_("The remote system presented a public key signed by an unidentified certificate authority. If you are sure the remote system is authentic, go to the compute resource edit page, press the 'Test Connection' or 'Load Datacenters' button and submit"),
                   ca_cert)


### PR DESCRIPTION
This is because the exception is not in different format due to OpenSSL library
change (?):

```
SSL_connect returned=1 errno=0 state=error: certificate verify failed
```

We are expecting only

```
SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B:
```

certificate verify failed
