### PR TITLE
fixes #12954 - config status is relevant if there are reports

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -34,7 +34,7 @@ module HostStatus
       elsif out_of_sync?
         # out of sync
         return HostStatus::Global::WARN
-      elsif no_reports? && host.configuration?
+      elsif no_reports? && (host.configuration? || Setting[:always_show_configuration_status])
         # no reports and configuration is set
         return HostStatus::Global::WARN
       else
@@ -78,7 +78,7 @@ module HostStatus
     end
 
     def relevant?
-      host.configuration?
+      host.configuration? || last_report.present? || Setting[:always_show_configuration_status]
     end
 
     def self.is(config_status)

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -26,7 +26,8 @@ class Setting::Puppet < Setting
         self.set('location_fact', N_("Hosts created after a puppet run will be placed in the location this fact dictates. The content of this fact should be the full label of the location."), 'foreman_location', N_('Location fact')),
         self.set('organization_fact', N_("Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."), 'foreman_organization', N_('Organization fact')),
         self.set('default_location', N_("Hosts created after a puppet run that did not send a location fact will be placed in this location"), '', N_('Default location')),
-        self.set('default_organization', N_("Hosts created after a puppet run that did not send a organization fact will be placed in this organization"), '', N_('Default organization'))
+        self.set('default_organization', N_("Hosts created after a puppet run that did not send a organization fact will be placed in this organization"), '', N_('Default organization')),
+        self.set('always_show_configuration_status', N_("All hosts will show a configuration status even when a Puppet smart proxy is not assigned"), false, N_('Always show configuration status')),
       ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
 
       true

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -281,3 +281,8 @@ attributes58:
   category: Setting::Provisioning
   default: "['lo', 'usb*', 'vnet*', 'macvtap*']"
   description: 'Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
+attributes59:
+  name: always_show_configuration_status
+  category: Setting::Puppet
+  default: "false"
+  description: 'All hosts will show a configuration status even when a Puppet smart proxy is not assigned'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,8 +62,10 @@ Spork.prefork do
     set_fixture_class :nics => Nic::BMC
 
     setup :begin_gc_deferment
+    setup :reset_setting_cache
     teardown :reconsider_gc_deferment
     teardown :clear_current_user
+    teardown :reset_setting_cache
 
     DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 1.0).to_f
 
@@ -85,6 +87,10 @@ Spork.prefork do
 
     def clear_current_user
       User.current = nil
+    end
+
+    def reset_setting_cache
+      Setting.cache.clear
     end
 
     # for backwards compatibility to between Minitest syntax
@@ -327,15 +333,10 @@ end
 Spork.each_run do
   # This code will be run each time you run your specs.
   class ActionController::TestCase
-    setup :setup_set_script_name, :set_api_user, :reset_setting_cache, :turn_of_login
-    teardown :reset_setting_cache
+    setup :setup_set_script_name, :set_api_user, :turn_of_login
 
     def turn_of_login
       SETTINGS[:require_ssl] = false
-    end
-
-    def reset_setting_cache
-      Setting.cache.clear
     end
 
     def setup_set_script_name

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -167,8 +167,17 @@ class DomainTest < ActiveSupport::TestCase
     assert Domain.first.nameservers.empty?
   end
 
-  test "should query remote nameservers" do
-    assert Domain.first.nameservers.empty?
+  test "should query remote nameservers from domain SOA" do
+    domain = FactoryGirl.build(:domain)
+
+    ns = mock
+    ns.expects(:mname).returns('10.1.1.1')
+
+    resolv = mock('Resolv::DNS')
+    resolv.expects(:getresources).with(domain.name, Resolv::DNS::Resource::IN::SOA).returns([ns])
+    Resolv::DNS.expects(:new).returns(resolv)
+
+    assert_equal ['10.1.1.1'], domain.nameservers
   end
 
   # test taxonomix methods


### PR DESCRIPTION
For a host that has config management reports, but no Puppet proxy set,
consider the config status relevant.  This will have the side effect of
considering the status still relevant even if a host has a proxy unset
and old reports, but helps in an environment with reports but no proxy.

Depending on the presence of a report in a no-proxy environment does
mean that the "no reports" status probably wouldn't ever be set, as the
status wouldn't yet be relevant.
