### PR TITLE
fixes #13039 - remove TemplateKind DB calls from UnattendedCtlr

### DIFF
--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -18,7 +18,7 @@ module Foreman::Controller::ProvisioningTemplates
     port     = uri.port
     protocol = uri.scheme
 
-    url_for(:only_path => false, :action => :template, :controller => '/unattended',
+    url_for(:only_path => false, :action => :hostgroup_template, :controller => '/unattended',
             :id => template.name, :hostgroup => hostgroup.name, :protocol => protocol,
             :host => host, :port => port)
   end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -328,7 +328,7 @@ class HostsController < ApplicationController
   end
 
   def pxe_config
-    redirect_to(:controller => "unattended", :action => "pxe_#{@host.operatingsystem.pxe_type}_config", :host_id => @host) if @host
+    redirect_to(:controller => "unattended", :action => 'host_template', :kind => "pxe_#{@host.operatingsystem.pxe_type}_config", :host_id => @host) if @host
   end
 
   def storeconfig_klasses

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -270,7 +270,8 @@ module HostsHelper
             content_tag(:td,
                         action_buttons(
                           display_link_if_authorized(_("Edit"), hash_for_edit_provisioning_template_path(:id => tmplt.to_param), :rel => "external"),
-                          link_to(_("Review"), url_for(:controller => '/unattended', :action => kind, :hostname => @host.name),
+                          link_to(_("Review"), url_for(:controller => '/unattended', :action => 'host_template',
+                                                       :kind => kind, :hostname => @host.name),
                                   :rel => 'external', :"data-provisioning-template" => true))
             )
         end

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -58,9 +58,9 @@ module HostTemplateHelpers
       path     = config.path
     end
 
-    url_for :only_path => false, :controller => "/unattended", :action => action,
+    url_for :only_path => false, :controller => "/unattended", :action => 'host_template',
       :protocol  => protocol, :host => host, :port => port, :script_name => path,
-      :token     => (@host.token.value unless @host.token.nil?)
+      :token     => (@host.token.value unless @host.token.nil?), :kind => action
   end
 
   attr_writer(:url_options)

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -334,7 +334,7 @@ Foreman::AccessControl.map do |permission_set|
                                                :externalNodes, :pxe_config, :storeconfig_klasses, :auto_complete_search, :bmc,
                                                :runtime, :resources, :templates, :overview, :nics],
                                     :dashboard => [:OutOfSync, :errors, :active],
-                                    :unattended => [:template, :provision],
+                                    :unattended => [:host_template, :hostgroup_template],
                                      :"api/v1/hosts" => [:index, :show, :status],
                                      :"api/v2/hosts" => [:index, :show, :status, :get_status, :vm_compute_attributes, :template],
                                      :"api/v2/interfaces" => [:index, :show],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Foreman::Application.routes.draw do
     end
 
     constraints(:hostgroup => /[^\/]+/) do
-      get 'unattended/template/:id/:hostgroup', :to => "unattended#template"
+      get 'unattended/template/:id/:hostgroup', :to => "unattended#hostgroup_template"
     end
   end
 
@@ -398,10 +398,12 @@ Foreman::Application.routes.draw do
   get 'status', :to => 'home#status', :as => "status"
 
   # get only for alterator unattended scripts
-  get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'provision', :format => 'html',
+  get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'host_template', :format => 'html',
     :constraints => { :metadata => /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
+  # get for end of build action
+  get 'unattended/built/(:id(:format))', :controller => 'unattended', :action => 'built'
   # get for all unattended scripts
-  get 'unattended/(:action/(:id(:format)))', :controller => 'unattended'
+  get 'unattended/(:kind/(:id(:format)))', :controller => 'unattended', :action => 'host_template'
 
   resources :tasks, :only => [:show]
 

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -52,9 +52,9 @@ module Foreman
         path     = config.path
       end
 
-      url_for :only_path => false, :controller => "/unattended", :action => action,
+      url_for :only_path => false, :controller => "/unattended", :action => 'host_template',
               :protocol  => protocol, :host => host, :port => port, :script_name => path,
-              :token     => (@host.token.value unless @host.try(:token).nil?)
+              :token     => (@host.token.value unless @host.try(:token).nil?), :kind => action
     end
 
     # provide embedded snippets support as simple erb templates

--- a/test/lib/foreman/access_permissions_test.rb
+++ b/test/lib/foreman/access_permissions_test.rb
@@ -12,7 +12,10 @@ require 'foreman/access_permissions'
 # an appropriate permission so views using those requests function.
 class AccessPermissionsTest < ActiveSupport::TestCase
   MAY_SKIP_REQUIRE_LOGIN = [
-    "users/login", "users/logout", "users/extlogin", "users/extlogout", "home/status", "notices/destroy", "unattended/",
+    "users/login", "users/logout", "users/extlogin", "users/extlogout", "home/status", "notices/destroy",
+
+    # unattended built action is not for interactive use
+    "unattended/built",
 
     # puppetmaster interfaces
     "fact_values/create", "reports/create",


### PR DESCRIPTION
UnattendedController created actions/methods during initialisation per
known TemplateKind, relying on the DB being populated.  This caused
ordering issues when a plugin loaded the controller in a test
environment as the kinds weren't yet in the DB.  The actions then were
not created.

The per-TemplateKind actions have been simplified to one fixed action
which is routed in the same way.
