### PR TITLE
Fixes #13050 - Do not pass paths with /assets to helpers

### DIFF
--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -123,9 +123,9 @@
 }
 
 .statistics-pie.small .overlay {
-  background: image-url('/assets/pie_overlay.png') no-repeat;
+  background: image-url('pie_overlay.png') no-repeat;
   background-size: cover;
-  -ms-behavior: asset-url('/assets/background-size.htc');
+  -ms-behavior: asset-url('background-size.htc');
   z-index: 1;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -337,23 +337,23 @@ module ApplicationHelper
   end
 
   def avatar_image_tag(user, html_options = {})
-    if user.avatar_hash.nil?
-      default_image = path_to_image("user.jpg")
-      if Setting["use_gravatar"]
-        image_url = gravatar_url(user.mail, default_image)
-        html_options.merge!(:onerror=>"this.src='#{default_image}'", :alt => _('Change your avatar at gravatar.com'))
-      else
-        image_url = default_image
-      end
+    if user.avatar_hash.present?
+      image_tag("avatars/#{user.avatar_hash}.jpg", html_options)
+    elsif Setting[:use_gravatar] && user.mail.present?
+      image_tag(gravatar_image(user.mail),
+                html_options.merge!(gravatar_html_options))
     else
-      image_url = path_to_image("avatars/#{user.avatar_hash}.jpg")
+      image_tag('user.jpg', html_options)
     end
-    image_tag(image_url, html_options)
   end
 
-  def gravatar_url(email, default_image)
-    return default_image if email.blank?
+  def gravatar_image(email)
     "#{request.protocol}secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=mm&s=30"
+  end
+
+  def gravatar_html_options
+    { :onerror => "this.src='#{path_to_image('user.jpg')}'",
+      :alt     => _('Change your avatar at gravatar.com') }
   end
 
   def readonly_field(object, property, options = {})

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,5 @@
 Foreman::Application.configure do |app|
   # Settings specified here will take precedence over those in config/application.rb.
-
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,105 +1,99 @@
 # Be sure to restart your server when you modify this file.
+Foreman::Application.configure do |app|
+  # Version of your assets, change this if you want to expire all your assets.
+  config.assets.version = '1.0'
 
-app    = Rails.application
-config = app.config
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # Rails.application.config.assets.precompile += %w( search.js )
 
-# Version of your assets, change this if you want to expire all your assets.
-config.assets.version = '1.0'
+  #  config.assets.precompile += %w()
+  javascript = %w(compute_resource
+                  compute_resources/libvirt/nic_info
+                  compute_resources/ovirt/nic_info
+                  compute_resources/vmware/nic_info
+                  lookup_keys
+                  editor
+                  diff
+                  host_edit
+                  host_edit_interfaces
+                  hosts
+                  jquery.cookie
+                  host_checkbox
+                  nfs_visibility
+                  noVNC/base64
+                  noVNC/des
+                  noVNC/display
+                  noVNC/input
+                  noVNC/jsunzip
+                  noVNC/logo
+                  noVNC/playback
+                  noVNC/rfb
+                  noVNC/ui
+                  noVNC/util
+                  noVNC/websock
+                  noVNC/webutil
+                  noVNC
+                  reports
+                  spice
+                  trends
+                  charts
+                  taxonomy_edit
+                  gettext/all
+                  filters
+                  users
+                  class_edit
+                  dashboard
+                  auth_source_ldap
+                  subnets
+                  hidden_values
+                  password_strength
+                  proxy_status)
 
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+  stylesheets = %w( )
 
-#  config.assets.precompile += %w()
-javascript = %w(compute_resource
-                compute_resources/libvirt/nic_info
-                compute_resources/ovirt/nic_info
-                compute_resources/vmware/nic_info
-                lookup_keys
-                editor
-                diff
-                host_edit
-                host_edit_interfaces
-                hosts
-                jquery.cookie
-                host_checkbox
-                nfs_visibility
-                noVNC/base64
-                noVNC/des
-                noVNC/display
-                noVNC/input
-                noVNC/jsunzip
-                noVNC/logo
-                noVNC/playback
-                noVNC/rfb
-                noVNC/ui
-                noVNC/util
-                noVNC/websock
-                noVNC/webutil
-                noVNC
-                reports
-                spice
-                trends
-                charts
-                taxonomy_edit
-                gettext/all
-                filters
-                users
-                class_edit
-                dashboard
-                auth_source_ldap
-                subnets
-                hidden_values
-                password_strength
-                proxy_status)
+  # Add the fonts path
+  config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')
 
-stylesheets = %w( )
+  # Precompile additional assets
+  config.assets.precompile << /\.(?:svg|eot|woff|gif|ttf)$/
+  config.assets.precompile += javascript.map { |js| js + '.js' } + stylesheets + %w(background-size.htc)
 
-# Add the fonts path
-config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')
-
-# Precompile additional assets
-config.assets.precompile << /\.(?:svg|eot|woff|ttf)$/
-
-config.assets.precompile += javascript.map { |js| js + '.js' } + stylesheets + %w(background-size.htc)
-
-# Defaults to Rails.root.join("public/assets")
-# config.assets.manifest = YOUR_PATH
-
-# Serve plugin static assets if the application is configured to do so
-if config.serve_static_assets
-  ::Rails::Engine.subclasses.map(&:instance).each do |engine|
-    if File.exist?("#{engine.root}/public/assets")
-      app.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
-    end
-  end
-end
-
-# Adds plugin assets to the application digests hash if a manifest file exists for a plugin
-config.after_initialize do
-  if (manifest_file = Dir.glob("#{Rails.root}/public/assets/manifest*.json").first)
-    foreman_manifest = JSON.parse(File.read(manifest_file))
-
+  # Serve plugin static assets if the application is configured to do so
+  if config.serve_static_assets
     ::Rails::Engine.subclasses.map(&:instance).each do |engine|
-      [engine.root, app.root].each do |root_dir|
-        manifest_path = File.join(root_dir, "public/assets/#{engine.engine_name}/#{engine.engine_name}.json")
-
-        if File.file?(manifest_path)
-          assets = JSON.parse(File.read(manifest_path))
-
-          foreman_manifest['files']  = foreman_manifest['files'].merge(assets['files'])
-          foreman_manifest['assets'] = foreman_manifest['assets'].merge(assets['assets'])
-        end
+      if File.exist?("#{engine.root}/public/assets")
+        app.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
       end
     end
+  end
 
-    manifest_filename = 'asset_manifest.json'
-    tmp_path          = "#{Rails.root}/tmp"
+  # Adds plugin assets to the application digests hash if a manifest file exists for a plugin
+  config.after_initialize do
+    if (manifest_file = Dir.glob("#{Rails.root}/public/assets/manifest*.json").first)
+      foreman_manifest = JSON.parse(File.read(manifest_file))
 
-    Tempfile.open(manifest_filename, tmp_path) do |file|
-      file.write(foreman_manifest.to_json)
-      app.assets_manifest              = Sprockets::Manifest.new(app.assets, file.path)
-      ActionView::Base.assets_manifest = app.assets_manifest
+      ::Rails::Engine.subclasses.map(&:instance).each do |engine|
+        [engine.root, app.root].each do |root_dir|
+          manifest_path = File.join(root_dir, "public/assets/#{engine.engine_name}/#{engine.engine_name}.json")
+
+          if File.file?(manifest_path)
+            assets = JSON.parse(File.read(manifest_path))
+
+            foreman_manifest['files']  = foreman_manifest['files'].merge(assets['files'])
+            foreman_manifest['assets'] = foreman_manifest['assets'].merge(assets['assets'])
+          end
+        end
+      end
+
+      manifest_filename = 'asset_manifest.json'
+      tmp_path          = "#{Rails.root}/tmp"
+
+      Tempfile.open(manifest_filename, tmp_path) do |file|
+        file.write(foreman_manifest.to_json)
+        app.assets_manifest              = Sprockets::Manifest.new(app.assets, file.path)
+        ActionView::Base.assets_manifest = app.assets_manifest
+      end
     end
   end
 end


### PR DESCRIPTION
Sprockets 3 does not recommend that, and the new option
`config.assets.raise_runtime_errors` on development.rb will raise errors
on development when doing it.

We only do it in one stylesheet and a helper, so fixing those let
foreman load without these errors.
