### PR TITLE
fixes #13055, #13054 - clean up and make proxy actions extensible

### DIFF
--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -2,35 +2,48 @@ module SmartProxiesHelper
   TABBED_FEATURES = ["Puppet","Puppet CA"]
 
   def proxy_actions(proxy, authorizer)
-    [ display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy), :class => 'edit_two_pane') ] +
-    [if proxy.has_feature?('Puppet CA')
-       [display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
-                                                      merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer)),
-        display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
-                                                  merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))]
-     end] +
-    [ display_delete_if_authorized(hash_for_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer),
-                                   :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'delete') ]
+    actions = []
+    actions << display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy))
+    actions << display_delete_if_authorized(hash_for_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer),
+                                            :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'delete')
+    actions << feature_actions(proxy, authorizer)
+    actions
   end
 
-  def smart_proxy_title_actions(proxy, authorizer)
-    actions = [display_link_if_authorized(_("Refresh features"), hash_for_refresh_smart_proxy_path(:id => proxy).
-                                                                 merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)]
+  def feature_actions(proxy, authorizer)
+    actions = []
+
+    actions << display_link_if_authorized(_("Refresh features"), hash_for_refresh_smart_proxy_path(:id => proxy).
+                                                                 merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)
+
     if proxy.has_feature?('Puppet CA')
-      actions << [display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
-                                                                merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer))]
-      actions << [display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
-                                                            merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))]
+      actions << display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
+                                                               merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer))
+
+      actions << display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
+                                                           merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))
     end
+
     if SETTINGS[:unattended] and proxy.has_feature?('DHCP')
       actions << display_link_if_authorized(_("Import subnets"), hash_for_import_subnets_path(:smart_proxy_id => proxy))
     end
 
+    Foreman::Plugin.proxy_actions.each do |link_text, options|
+      if proxy.has_feature?(options[:feature]) || options[:feature].blank?
+        actions << display_link_if_authorized(_(link_text), options.merge(:auth_object => proxy, :authorizer => authorizer, :smart_proxy_id => proxy))
+      end
+    end
+
+    actions
+  end
+
+
+  def smart_proxy_title_actions(proxy, authorizer)
     title_actions(
       button_group(
         link_to(_("Back"), smart_proxies_path)
       ),
-      select_action_button(_("Select Action"), {}, actions),
+      select_action_button(_("Select Action"), {}, feature_actions(proxy, authorizer)),
       button_group(
         display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy))
       ),

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -34,9 +34,12 @@ module Foreman #:nodoc:
   class Plugin
     @registered_plugins = {}
     @tests_to_skip = {}
+    @proxy_actions = {}
+
     class << self
       attr_reader   :registered_plugins
-      attr_accessor :tests_to_skip
+      attr_accessor :tests_to_skip, :proxy_actions
+
       private :new
 
       def def_field(*names)
@@ -193,6 +196,10 @@ feature"
       @security_block = name
       self.instance_eval(&block)
       @security_block = nil
+    end
+
+    def proxy_action(link_text, options)
+      self.class.proxy_actions[link_text] = options
     end
 
     # Defines a permission called name for the given controller=>actions

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -268,4 +268,13 @@ class PluginTest < ActiveSupport::TestCase
     end
     assert_equal 'Awesomeness Based', Host::Managed.provision_methods['awesome']
   end
+
+  def test_proxy_actions
+    Foreman::Plugin.register :foo_plugin do
+      name 'Foo plugin'
+      proxy_action N_('Foo'), {:controller => 'foo', :action => :index, :permission => 'view_smart_proxy_foos'}
+    end
+
+    assert_equal Foreman::Plugin.proxy_actions['Foo'], {:controller => 'foo', :action => :index, :permission => 'view_smart_proxy_foos'}
+  end
 end


### PR DESCRIPTION
Smart proxy button extensions are broken in foreman_salt, so I figured I'd try to see if you'll accept a plugin extension point for this, as @domcleal has recommended this over my love of `alias_method_chain`.

It also makes the helper DRY'er by keeping both sets of action buttons (on the row, and the smart proxy page) in one method.
