### PR TITLE
fixes #13054 - make proxy action buttons consistent

### DIFF
--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -2,35 +2,41 @@ module SmartProxiesHelper
   TABBED_FEATURES = ["Puppet","Puppet CA"]
 
   def proxy_actions(proxy, authorizer)
-    [ display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy), :class => 'edit_two_pane') ] +
-    [if proxy.has_feature?('Puppet CA')
-       [display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
-                                                      merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer)),
-        display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
-                                                  merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))]
-     end] +
-    [ display_delete_if_authorized(hash_for_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer),
-                                   :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'delete') ]
+    actions = []
+    actions << display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy))
+    actions << display_delete_if_authorized(hash_for_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer),
+                                            :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'delete')
+    actions << feature_actions(proxy, authorizer)
+    actions
   end
 
-  def smart_proxy_title_actions(proxy, authorizer)
-    actions = [display_link_if_authorized(_("Refresh features"), hash_for_refresh_smart_proxy_path(:id => proxy).
-                                                                 merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)]
+  def feature_actions(proxy, authorizer)
+    actions = []
+
+    actions << display_link_if_authorized(_("Refresh features"), hash_for_refresh_smart_proxy_path(:id => proxy).
+                                                                 merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)
+
     if proxy.has_feature?('Puppet CA')
-      actions << [display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
-                                                                merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer))]
-      actions << [display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
-                                                            merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))]
+      actions << display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_puppetca_index_path(:smart_proxy_id => proxy).
+                                                               merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer))
+
+      actions << display_link_if_authorized(_("Autosign"), hash_for_smart_proxy_autosign_index_path(:smart_proxy_id => proxy).
+                                                           merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer))
     end
+
     if SETTINGS[:unattended] and proxy.has_feature?('DHCP')
       actions << display_link_if_authorized(_("Import subnets"), hash_for_import_subnets_path(:smart_proxy_id => proxy))
     end
 
+    actions
+  end
+
+  def smart_proxy_title_actions(proxy, authorizer)
     title_actions(
       button_group(
         link_to(_("Back"), smart_proxies_path)
       ),
-      select_action_button(_("Select Action"), {}, actions),
+      select_action_button(_("Select Action"), {}, feature_actions(proxy, authorizer)),
       button_group(
         display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy))
       ),


### PR DESCRIPTION
Small refactor.

The action button helper methods are never pretty, this tries to clean it up a little and make it DRY'er.  It's so the feature-related actions (Autosign, etc) show up on the Smart Proxy row and on the edit page's `Select Actions` drop down.
