### PR TITLE
Fixes #13095 - Center Patternfly alerts icon

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -236,13 +236,6 @@ div.form-group .glyphicon-info-sign{
 }
 
 .alert {
-  & > .pficon,
-  & > .pficon-layered {
-    font-size: 21px;
-    position: absolute;
-    left: 6px;
-    top: 6px;
-  }
   h4 {
     margin-top: 4px;
   }


### PR DESCRIPTION
Notice how the custom CSS in foreman misaligns the icon in Patternfly.

Before: ![](http://i.imgur.com/qLENdIX.png)

After: ![](http://i.imgur.com/ByG4Pm3.png)
