### PR TITLE
Fixes #13097 - Vertically center select2 option text

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -464,7 +464,7 @@ table {
 
 .select2-container .select2-choices .select2-search-field input, .select2-container .select2-choice, .select2-container .select2-choices .select2-chosen{
   font-family: 'Open Sans', Helvetica, Arial, sans-serif;
-  line-height: 2.2;
+  line-height: 2.0;
 }
 
 .navbar-editor > span > .select2-container .select2-choices .select2-search-field input, .select2-container .select2-choice, .select2-container .select2-choices .select2-chosen {


### PR DESCRIPTION
Notice how after the update to patternfly, the text in a select2 option
is now not vertically centered, but a bit below the center.

Problem: http://i.imgur.com/JC2jfQ1.png
Fix: http://i.imgur.com/R6WjaMh.png
