### PR TITLE
Fixes #13098: Set assets environment the same as core assets

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -55,9 +55,20 @@ task 'plugin:assets:precompile', [:engine] do |t, args|
 
       def environment
         env = Rails.application.assets
+        config = Rails.application.config
+
         Rails.application.config.assets.paths.each do |path|
           env.append_path path
         end
+
+        env.version = [
+          'production',
+          config.assets.version,
+          config.action_controller.relative_url_root,
+          (config.action_controller.asset_host unless config.action_controller.asset_host.respond_to?(:call)),
+          Sprockets::Rails::VERSION
+        ].compact.join('-')
+
         env
       end
 


### PR DESCRIPTION
The introduction of Sprockets 3+ led to the environment-version
being set to ActiveSupport::StringInquirer object instead of a
String. The Sprockets digest method does not support digesting
classes of type ActiveSupport::StringInquirer.

This change explicitly sets the assets environment version to be
calculated the same as core assets when precompiling. When core
assets are precompiled using the normal Rails assets:precompile rake
task the environment string is generated in such a way as to create
a unique string and thus unique digest. The plugin:asset:precompile
task will now do the same and explicitly ensure it is set to
production given the task does not require a true Rails environment
to be declared.
