### PR TITLE
fixes #9359 - display puppetca in yaml always when a puppetca is configured

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -67,7 +67,7 @@ module HostCommon
 
   def puppetca?
     return false if self.respond_to?(:managed?) and !managed?
-    !!(puppet_ca_proxy and puppet_ca_proxy.url.present?)
+    puppetca_exists?
   end
 
   def puppetca_exists?

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -73,6 +73,7 @@ module HostCommon
   def puppetca_exists?
     !!(puppet_ca_proxy and puppet_ca_proxy.url.present?)
   end
+
   # no need to store anything in the db if the entry is plain "puppet"
   # If the system is using smart proxies and the user has run the smartproxy:migrate task
   # then the puppetmaster functions handle smart proxy objects

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -70,6 +70,9 @@ module HostCommon
     !!(puppet_ca_proxy and puppet_ca_proxy.url.present?)
   end
 
+  def puppetca_exists?
+    !!(puppet_ca_proxy and puppet_ca_proxy.url.present?)
+  end
   # no need to store anything in the db if the entry is plain "puppet"
   # If the system is using smart proxies and the user has run the smartproxy:migrate task
   # then the puppetmaster functions handle smart proxy objects

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -395,7 +395,7 @@ class Host::Managed < Host::Base
     end
     if SETTINGS[:unattended]
       param["root_pw"]      = root_pass unless (!operatingsystem.nil? && operatingsystem.password_hash == 'Base64')
-      param["puppet_ca"]    = puppet_ca_server if puppetca?
+      param["puppet_ca"]    = puppet_ca_server if puppetca_exists? 
     end
     param["comment"]      = comment unless comment.blank?
     param["foreman_env"]  = environment.to_s unless environment.nil? or environment.name.nil?

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -395,7 +395,7 @@ class Host::Managed < Host::Base
     end
     if SETTINGS[:unattended]
       param["root_pw"]      = root_pass unless (!operatingsystem.nil? && operatingsystem.password_hash == 'Base64')
-      param["puppet_ca"]    = puppet_ca_server if puppetca_exists? 
+      param["puppet_ca"]    = puppet_ca_server if puppetca_exists?
     end
     param["comment"]      = comment unless comment.blank?
     param["foreman_env"]  = environment.to_s unless environment.nil? or environment.name.nil?


### PR DESCRIPTION
add a method for the check if a puppetca is define and declared in a smartproxy.

Use this method when we build the yaml of the host, don't test is the host is managed
