### PR TITLE
Fixes #13107 - compute attributes has indifferent access again

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -91,7 +91,7 @@ module Host
         primary_interface_attrs.each do |attr|
           values_for_primary_interface[attr] = new_attrs.delete(attr) if new_attrs.has_key?(attr)
         end
-        args.unshift(new_attrs.to_hash)
+        args.unshift(new_attrs)
       end
 
       super(*args)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -141,6 +141,12 @@ class HostTest < ActiveSupport::TestCase
       :environment => environments(:production), :disk => "empty partition"
   end
 
+  test "should save compute attributes with indifferent access" do
+    h = Host.new :name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.3", :compute_attributes => {'attr1' => 'blah'}
+    assert_equal 'blah', h.compute_attributes['attr1']
+    assert_equal 'blah', h.compute_attributes[:attr1]
+  end
+
   test "doesn't set compute attributes on update" do
     host = FactoryGirl.create(:host)
     Host.any_instance.expects(:set_compute_attributes).never


### PR DESCRIPTION
During upgrade to Rails 4.1, our host#create code no longer sends attributes
into the ActiveRecord create/new initializers with indifferent access. One
of these attributes, `compute_attributes` then does not work breaking
provisioning completely.

I suspect this commit:

https://github.com/rails/rails/commit/df24b8790f22384a068fece7042f04ffd2fcb33e

There was a bug in Rails that prevented from converting to plain hash in
some cases and this was fixed. We should perhaps do review of our codebase
of all `to_hash` methods, I expect more of them.

Reproducer - Rails 4.1:

```
{"a" => 1, "b" => [{"c" => 2}]}.with_indifferent_access.to_hash["b"][0][:c]
=> nil
```

Rails 3.x:

```
{"a" => 1, "b" => [{"c" => 2}]}.with_indifferent_access.to_hash["b"][0][:c]
=> 2
```

I can only reproduce when there is an array in the hash, apparently this bug
had to do something with mixed hashes. This one was tough.
