### PR TITLE
fixes #13111 - use negated Capybara lookups to wait for JS handlers

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,7 +6,7 @@ group :test do
   gem 'minitest', '~> 5.1.0'
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
-  gem 'capybara', '~> 2.0'
+  gem 'capybara', '~> 2.5'
   gem 'database_cleaner', '~> 1.3'
   gem 'launchy', '~> 2.4'
   gem 'spork-rails', '~> 4.0.0'

--- a/test/integration/config_report_test.rb
+++ b/test/integration/config_report_test.rb
@@ -24,6 +24,6 @@ class ConfigReportIntegrationTest < ActionDispatch::IntegrationTest
   test "delete a report redirects to reports index" do
     visit config_report_path(@report)
     first(:link, "Delete").click
-    assert_equal(current_path, config_reports_path)
+    assert_current_path config_reports_path
   end
 end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -10,7 +10,7 @@ class DashboardIntegrationTest < ActionDispatch::IntegrationTest
     visit dashboard_path
     assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
     click_link(text)
-    assert_equal hosts_path, current_path, "new path #{hosts_path} was expected but it was #{current_path}"
+    assert_current_path hosts_path, :only_path => true
     assert_not_nil find_field('search').value
   end
 

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -267,7 +267,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
       click_button 'Ok' #close interfaces
       #wait for the dialog to close
-      Timeout.timeout(Capybara.default_wait_time) do
+      Timeout.timeout(Capybara.default_max_wait_time) do
         loop while find(:css, '#interfaceModal', :visible => false).visible?
       end
       click_button 'Submit' #create new host
@@ -313,7 +313,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       click_button 'Ok'
 
       #wait for the dialog to close
-      Timeout.timeout(Capybara.default_wait_time) do
+      Timeout.timeout(Capybara.default_max_wait_time) do
         loop while find(:css, '#interfaceModal', :visible => false).visible?
       end
 
@@ -333,7 +333,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     click_link @host.fqdn
     assert page.has_link?("Delete", :href => "/hosts/#{@host.fqdn}")
     first(:link, "Delete").click
-    assert_equal(current_path, hosts_path)
+    assert_current_path hosts_path
   end
 
   describe "hosts index multiple actions" do
@@ -377,8 +377,9 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
       assert_equal class_params.find("textarea").value, "false"
-      refute class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:enabled")
       class_params.find("a[data-tag='remove']").click
+      assert class_params.find("textarea:disabled")
       click_button('Submit')
       assert page.has_link?("Edit")
 
@@ -386,9 +387,9 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
       assert_equal class_params.find("textarea").value, "true"
-      assert class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:disabled")
       class_params.find("a[data-tag='override']").click
-      refute class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:enabled")
       class_params.find("textarea").set("false")
       click_button('Submit')
       assert page.has_link?("Edit")
@@ -397,7 +398,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
       assert_equal class_params.find("textarea").value, "false"
-      refute class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:enabled")
     end
 
     test 'can override puppetclass lookup values' do
@@ -412,19 +413,19 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert class_params.has_selector?("a[data-tag='remove']", :visible => :visible)
       assert class_params.has_selector?("a[data-tag='override']", :visible => :hidden)
       assert_equal class_params.find("textarea").value, "false"
-      refute class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:enabled")
 
       class_params.find("a[data-tag='remove']").click
       assert class_params.has_selector?("a[data-tag='remove']", :visible => :hidden)
       assert class_params.has_selector?("a[data-tag='override']", :visible => :visible)
       assert_equal class_params.find("textarea").value, "true"
-      assert class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:disabled")
 
       class_params.find("a[data-tag='override']").click
       assert class_params.has_selector?("a[data-tag='remove']", :visible => :visible)
       assert class_params.has_selector?("a[data-tag='override']", :visible => :hidden)
       assert_equal class_params.find("textarea").value, "true"
-      refute class_params.find("textarea")[:disabled]
+      assert class_params.find("textarea:enabled")
     end
 
     test 'correctly show hash type overrides' do
@@ -449,14 +450,14 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       click_link 'Parameters'
       assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
       page.find('#inherited_parameters .btn[data-tag=override]').click
-      refute page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      assert page.has_no_selector?('#inherited_parameters .btn[data-tag=override]')
       click_button('Submit')
       assert page.has_link?("Edit")
 
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
-      refute page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      assert page.has_no_selector?('#inherited_parameters .btn[data-tag=override]')
       page.find('#global_parameters_table a[data-original-title="Remove Parameter"]').click
       assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
     end

--- a/test/integration/location_test.rb
+++ b/test/integration/location_test.rb
@@ -38,9 +38,9 @@ class LocationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(locations_path,"New Location",new_location_path)
     fill_in "location_name", :with => "Raleigh"
     click_button "Submit"
-    assert_equal step2_location_path(Location.unscoped.order(:id).last), current_path, "redirect path #{step2_location_path(Location.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_location_path(Location.unscoped.order(:id).last)
     click_link "Assign All"
-    assert_equal locations_path, current_path, "redirect path #{locations_path} was expected but it was #{current_path}"
+    assert_current_path locations_path
     assert page.has_link? "Raleigh"
   end
 
@@ -49,9 +49,9 @@ class LocationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(locations_path,"New Location",new_location_path)
     fill_in "location_name", :with => "Raleigh"
     click_button "Submit"
-    assert_equal step2_location_path(Location.unscoped.order(:id).last), current_path, "redirect path #{step2_location_path(Location.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_location_path(Location.unscoped.order(:id).last)
     click_link "Manually Assign"
-    assert_equal assign_hosts_location_path(Location.unscoped.order(:id).last), current_path, "redirect path #{assign_hosts_location_path(Location.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path assign_hosts_location_path(Location.unscoped.order(:id).last)
     assert_submit_button(locations_path, "Assign to Location")
     assert page.has_link? "Raleigh"
   end
@@ -61,9 +61,9 @@ class LocationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(locations_path,"New Location",new_location_path)
     fill_in "location_name", :with => "Raleigh"
     click_button "Submit"
-    assert_equal step2_location_path(Location.unscoped.order(:id).last), current_path, "redirect path #{step2_location_path(Location.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_location_path(Location.unscoped.order(:id).last)
     click_link "Proceed to Edit"
-    assert_equal edit_location_path(Location.unscoped.order(:id).last), current_path, "redirect path #{edit_location_path(Location.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path edit_location_path(Location.unscoped.order(:id).last)
     assert page.has_selector?('h1', :text => "Edit"), "Edit was expected in the <h1> tag, but was not found"
   end
 

--- a/test/integration/organization_test.rb
+++ b/test/integration/organization_test.rb
@@ -38,9 +38,9 @@ class OrganizationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(organizations_path,"New Organization",new_organization_path)
     fill_in "organization_name", :with => "Finance"
     click_button "Submit"
-    assert_equal step2_organization_path(Organization.unscoped.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_organization_path(Organization.unscoped.order(:id).last)
     click_link "Assign All"
-    assert_equal organizations_path, current_path, "redirect path #{organizations_path} was expected but it was #{current_path}"
+    assert_current_path organizations_path
     assert page.has_link? "Finance"
   end
 
@@ -49,9 +49,9 @@ class OrganizationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(organizations_path,"New Organization",new_organization_path)
     fill_in "organization_name", :with => "Finance"
     click_button "Submit"
-    assert_equal step2_organization_path(Organization.unscoped.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_organization_path(Organization.unscoped.order(:id).last)
     click_link "Manually Assign"
-    assert_equal assign_hosts_organization_path(Organization.unscoped.order(:id).last), current_path, "redirect path #{assign_hosts_organization_path(Organization.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path assign_hosts_organization_path(Organization.unscoped.order(:id).last)
     assert_submit_button(organizations_path, "Assign to Organization")
     assert page.has_link? "Finance"
   end
@@ -61,9 +61,9 @@ class OrganizationIntegrationTest < ActionDispatch::IntegrationTest
     assert_new_button(organizations_path,"New Organization",new_organization_path)
     fill_in "organization_name", :with => "Finance"
     click_button "Submit"
-    assert_equal step2_organization_path(Organization.unscoped.order(:id).last), current_path, "redirect path #{step2_organization_path(Organization.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path step2_organization_path(Organization.unscoped.order(:id).last)
     click_link "Proceed to Edit"
-    assert_equal edit_organization_path(Organization.unscoped.order(:id).last), current_path, "redirect path #{edit_organization_path(Organization.unscoped.order(:id).last)} was expected but it was #{current_path}"
+    assert_current_path edit_organization_path(Organization.unscoped.order(:id).last)
     assert page.has_selector?('h1', :text => "Edit"), "Edit was expected in the <h1> tag, but was not found"
   end
 

--- a/test/integration/puppetclass_lookup_key_test.rb
+++ b/test/integration/puppetclass_lookup_key_test.rb
@@ -33,7 +33,7 @@ class PuppetclassLookupKeyIntegrationTest < ActionDispatch::IntegrationTest
         click_link "port"
       end
       page.find("#puppetclass_lookup_key_override").click
-      refute page.find("#puppetclass_lookup_key_hidden_value")[:disabled]
+      assert page.find("#puppetclass_lookup_key_hidden_value:enabled")
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ Spork.prefork do
     }
     Capybara::Poltergeist::Driver.new(app, opts)
   end
-  Capybara.default_wait_time = 30
+  Capybara.default_max_wait_time = 30
 
   Capybara.javascript_driver = :poltergeist
 
@@ -279,12 +279,12 @@ Spork.prefork do
     def assert_new_button(index_path,new_link_text,new_path)
       visit index_path
       click_link new_link_text
-      assert_equal new_path, current_path, "new path #{new_path} was expected but it was #{current_path}"
+      assert_current_path new_path
     end
 
     def assert_submit_button(redirect_path,button_text = "Submit")
       click_button button_text
-      assert_equal redirect_path, current_path, "redirect path #{redirect_path} was expected but it was #{current_path}"
+      assert_current_path redirect_path
     end
 
     def assert_delete_row(index_path, link_text, delete_text = "Delete", dropdown = false)
@@ -325,7 +325,7 @@ Spork.prefork do
     end
 
     def wait_for_ajax
-      Timeout.timeout(Capybara.default_wait_time) do
+      Timeout.timeout(Capybara.default_max_wait_time) do
         loop until page.evaluate_script('jQuery.active').zero?
       end
     end


### PR DESCRIPTION
Various integration tests failed intermittently as they didn't wait for
asynchronous JS to run when clicking buttons.  Instances of refuting
existence of an element after a click were changed to negated Capybara
lookups which wait until the element is removed, instead of failing
immediately when finding an element that hadn't yet been removed.

Assertions on the value of current_path are changed to the built-in
assertion in Capybara 2.5 which waits for redirections to occur.
