### PR TITLE
fixes #13112 - add options to HostStatus#relevant? to optimise reports

### DIFF
--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -26,7 +26,7 @@ module HostStatus
       end
     end
 
-    def relevant?
+    def relevant?(options = {})
       SETTINGS[:unattended] && host.managed?
     end
 

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -77,7 +77,9 @@ module HostStatus
       end
     end
 
-    def relevant?
+    def relevant?(options = {})
+      handle_options(options)
+
       host.configuration? || last_report.present? || Setting[:always_show_configuration_status]
     end
 

--- a/app/models/host_status/global.rb
+++ b/app/models/host_status/global.rb
@@ -7,7 +7,16 @@ module HostStatus
     attr_accessor :status
 
     def self.build(statuses, options = {})
-      max_status = statuses.select { |s| s.relevant? }.map { |s| s.to_global(options) }.max
+      relevant_statuses = statuses.select do |s|
+        if s.method(:relevant?).arity.zero?
+          Foreman::Deprecation.deprecation_warning('1.13', "#{s.class.name}#relevant? should take an options argument")
+          s.relevant?
+        else
+          s.relevant?(options)
+        end
+      end
+
+      max_status = relevant_statuses.map { |s| s.to_global(options) }.max
 
       new(max_status || OK)
     end

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -50,7 +50,7 @@ module HostStatus
 
     # Whether this status should be displayed to users, it may not be relevant for certain
     # types of hosts
-    def relevant?
+    def relevant?(options = {})
       true
     end
 


### PR DESCRIPTION
To match other methods on HostStatus::Status instances, relevant? has a
new options argument which is used from the global status building to
optimise config report loading.  This prevents an N+1 query on the
hosts index page.

Previous methods defined with zero arguments are still supported with
a deprecation warning.
