### PR TITLE
fixes #13144 - enable missing precompiled asset errors in test env

### DIFF
--- a/app/views/config_reports/show.html.erb
+++ b/app/views/config_reports/show.html.erb
@@ -1,4 +1,4 @@
-<%= javascript 'reports', 'ace/ace' %>
+<%= javascript 'reports' %>
 <% title "#{@config_report.host}"%>
 
 <p class='ra'> <%= _("Reported at %s ") % @config_report.reported_at %> </p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,6 +16,11 @@ Foreman::Application.configure do
   config.serve_static_assets  = true
   config.static_cache_control = 'public, max-age=3600'
 
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
Remove extraneous ace/ace JS, which is included through vendor.
