### PR TITLE
Fixes #13136 - align children fields from right

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -23,6 +23,7 @@ fieldset > div.col-md-1 {
 
 .children_fields{
   padding-left: 20px;
+  padding-right: 20px;
 }
 
 .form-control{


### PR DESCRIPTION
![nested_fields](https://cloud.githubusercontent.com/assets/109773/12268096/945d1184-b94b-11e5-80db-8f445321c496.png)
