### PR TITLE
Fixes #13160 - pagelet names gets translated

### DIFF
--- a/app/helpers/pagelets_helper.rb
+++ b/app/helpers/pagelets_helper.rb
@@ -24,7 +24,7 @@ module PageletsHelper
   def render_tab_header_for(mountpoint, opts = {})
     result = ""
     pagelets_for(mountpoint).each do |pagelet|
-      result += "<li><a href='##{pagelet.id}' data-toggle='tab'>#{pagelet.name}</a></li>"
+      result += "<li><a href='##{pagelet.id}' data-toggle='tab'>#{_(pagelet.name)}</a></li>"
     end
     result.html_safe
   end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -175,11 +175,15 @@ module Foreman #:nodoc:
       Menu::Manager.map(menu).delete(item)
     end
 
-    # Extends an already registered extensible page.
+    # Extends page by adding custom pagelet to a mountpoint.
     # Usage:
     #
     # extend_page("smart_proxies/show") do |context|
-    #   context.add_pagelet :mountpoint, :name => "Example Pagelet", :partial => "path/to/partial", :priority => 10000, :id => 'custom-html-id'
+    #   context.add_pagelet :mountpoint,
+    #                       :name => N_("Example Pagelet"),
+    #                       :partial => "path/to/partial",
+    #                       :priority => 10000,
+    #                       :id => 'custom-html-id'
     # end
     def extend_page(page_name, &block)
       yield Pagelets::Manager.new(page_name) if block_given?


### PR DESCRIPTION
Pagelet name in tab header is now marked for translation, I also updated example usage.
