### PR TITLE
Fixes #13165 - select2 fields border radius should be square

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -267,7 +267,7 @@ div.form-group .glyphicon-info-sign{
 .select2-dropdown-open.select2-drop-above [class^="select2-choice"],
 .select2-drop,
 .select2-container .select2-choices {
-  border-radius: 0px;
+  border-radius: 0px !important;
 }
 
 .btn-group > .btn + .dropdown-toggle {


### PR DESCRIPTION
With patternfly border-radius are supposed to be 0px. However some of
them are not, even if we override it, because the select2 stylesheet
coming from the gem has set '!important' to some CSS rules.

Before: ![](http://i.imgur.com/YSVys3l.png)
How it should look: ![](http://i.imgur.com/Kd6FM64.png)
