### PR TITLE
fixes #13113 - Add roles name in the title of the page

### DIFF
--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,5 +1,5 @@
 <% if @role
-     title _("Filters for role") + " " + @role.to_s
+     title _("Filters for role %s") % @role.to_s
    else 
      title _("Filters")
    end %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,4 +1,8 @@
-<% title _("Filters") %>
+<% if @role
+     title _("Filters for role") + " " + @role.to_s
+   else 
+     title _("Filters")
+   end %>
 
 <% title_actions link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role)),
                  documentation_button('4.1.2RolesandPermissions') %>

--- a/test/functional/filters_controller_test.rb
+++ b/test/functional/filters_controller_test.rb
@@ -37,7 +37,7 @@ class FiltersControllerTest < ActionController::TestCase
     assert_response :success
     refute_empty assigns(:filters)
     assert_equal Filter.search_for("role = #{role.name}").count, assigns(:filters).count
-    assert_match "Filter for role Manager", @response.body
+    assert_match "Filters for role Manager", @response.body
   end
 
   test "should get new" do

--- a/test/functional/filters_controller_test.rb
+++ b/test/functional/filters_controller_test.rb
@@ -37,6 +37,7 @@ class FiltersControllerTest < ActionController::TestCase
     assert_response :success
     refute_empty assigns(:filters)
     assert_equal Filter.search_for("role = #{role.name}").count, assigns(:filters).count
+    assert_match "Filter for role Manager", @response.body
   end
 
   test "should get new" do


### PR DESCRIPTION
Display the role name in title of the page in case of this is present.
If the user use the search bar for filter the role, the string filter is only use in the title (in this case, th rolesname is in the searchbar)
