### PR TITLE
Fixes #13079 - Conditionally hide the pagelets

### DIFF
--- a/app/helpers/pagelets_helper.rb
+++ b/app/helpers/pagelets_helper.rb
@@ -14,6 +14,7 @@ module PageletsHelper
   def render_tab_content_for(mountpoint, opts = {})
     result = ""
     pagelets_for(mountpoint).each do |pagelet|
+      next unless pagelet.onlyif.call opts[:subject]
       result += "<div id='#{pagelet.id}' class='tab-pane'>"
       result += render_pagelet(pagelet, opts)
       result +=  "</div>"
@@ -24,12 +25,17 @@ module PageletsHelper
   def render_tab_header_for(mountpoint, opts = {})
     result = ""
     pagelets_for(mountpoint).each do |pagelet|
+      next unless pagelet.onlyif.call opts[:subject]
       result += "<li><a href='##{pagelet.id}' data-toggle='tab'>#{_(pagelet.name)}</a></li>"
     end
     result.html_safe
   end
 
-  def render_pagelet(pagelet, opts)
-    render(pagelet.partial, opts.merge!({ :pagelet => pagelet })).html_safe
+  def render_pagelet(pagelet, opts = {})
+    if pagelet.onlyif.call opts[:subject]
+      render(pagelet.partial, opts.merge!({ :pagelet => pagelet, controller_name.singularize.to_sym => opts[:subject] })).html_safe
+    else
+      "".html_safe
+    end
   end
 end

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -28,7 +28,7 @@ module SmartProxiesHelper
       actions << display_link_if_authorized(_("Import subnets"), hash_for_import_subnets_path(:smart_proxy_id => proxy))
     end
 
-    actions << render_pagelets_for(:smart_proxy_title_actions)
+    actions << render_pagelets_for(:smart_proxy_title_actions, :subject => proxy)
 
     actions
   end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -183,7 +183,8 @@ module Foreman #:nodoc:
     #                       :name => N_("Example Pagelet"),
     #                       :partial => "path/to/partial",
     #                       :priority => 10000,
-    #                       :id => 'custom-html-id'
+    #                       :id => 'custom-html-id',
+    #                       :onlyif => Proc.new { |subject| subject.should_show_pagelet? }
     # end
     def extend_page(page_name, &block)
       yield Pagelets::Manager.new(page_name) if block_given?

--- a/app/services/pagelets/manager.rb
+++ b/app/services/pagelets/manager.rb
@@ -32,6 +32,10 @@ module Pagelets
         pagelets_at(page_name, mountpoint).sort
       end
 
+      def clear
+        @pagelets.clear
+      end
+
       private
 
       def handle_empty_keys_for(page_name, mountpoint)

--- a/app/services/pagelets/pagelet.rb
+++ b/app/services/pagelets/pagelet.rb
@@ -7,6 +7,7 @@ module Pagelets
       @partial = partial
       @priority = priority
       @opts = opts
+      @opts[:onlyif] ||= Proc.new { true }
     end
 
     def <=>(other)

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -7,7 +7,7 @@
     <% if service_features.any? %>
       <li><a href="#services" data-toggle="tab"><%= _('Services') %></a></li>
     <% end %>
-    <%= render_tab_header_for(:main_tabs, :smart_proxy => @smart_proxy) %>
+    <%= render_tab_header_for(:main_tabs, :subject => @smart_proxy) %>
   </ul>
   <div id="proxy-tab-content" class="proxy-content tab-content">
     <div class="tab-pane active in" id="properties">
@@ -51,10 +51,10 @@
             <%= @smart_proxy.features.to_sentence %> <%= refresh_proxy_icon(@smart_proxy, authorizer) %>
           </div>
         </div>
-        <%= render_pagelets_for(:overview_content, :smart_proxy => @smart_proxy) %>
+        <%= render_pagelets_for(:overview_content, :subject => @smart_proxy) %>
       </div>
       <div class="col-md-6">
-        <%= render_pagelets_for(:details_content, :smart_proxy => @smart_proxy) %>
+        <%= render_pagelets_for(:details_content, :subject => @smart_proxy) %>
       </div>
     </div>
     <% if service_features.any? %>
@@ -71,6 +71,6 @@
         </div>
       </div>
     <% end %>
-    <%= render_tab_content_for(:main_tabs, :smart_proxy => @smart_proxy)%>
+    <%= render_tab_content_for(:main_tabs, :subject => @smart_proxy)%>
   </div>
 </div>

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -39,4 +39,25 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_selector?('h3', :text => "DHCP")
     assert page.has_content? "Version"
   end
+
+  describe 'pagelets on show page' do
+    def teardown
+      Pagelets::Manager.clear
+    end
+
+    test 'show page passes subject into pagelets' do
+      Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
+                                                          :name => "VisibleTab",
+                                                          :partial => "../../test/static_fixtures/views/test",
+                                                          :onlyif => Proc.new { |subject| subject.has_feature? "DHCP" })
+      Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
+                                                          :name => "HiddenTab",
+                                                          :partial => "../../test/static_fixtures/views/test",
+                                                          :onlyif => Proc.new { |subject| subject.has_feature? "TFTP" })
+      proxy = smart_proxies(:one)
+      visit smart_proxy_path(proxy)
+      assert page.has_link?("VisibleTab")
+      refute page.has_link?("HiddenTab")
+    end
+  end
 end

--- a/test/static_fixtures/views/_test.html.erb
+++ b/test/static_fixtures/views/_test.html.erb
@@ -1,0 +1,1 @@
+<div>This is test partial</div>

--- a/test/unit/helpers/pagelets_helper_test.rb
+++ b/test/unit/helpers/pagelets_helper_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class PageletsHelperTest < ActionView::TestCase
+  include PageletsHelper
+  teardown do
+    Pagelets::Manager.clear
+  end
+
+  def action_name
+    "test"
+  end
+
+  test "should find pagelets for page and mountpoint" do
+    Pagelets::Manager.add_pagelet("test/test", :main_tabs,
+                                               :name => "Name",
+                                               :partial => "../../test/static_fixtures/views/test")
+    Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
+                                                       :name => "My name",
+                                                       :partial => "../../test/static_fixtures/views/test")
+    pagelets = pagelets_for(:main_tabs)
+    assert pagelets.any? { |p| p.name == "Name" }
+    refute pagelets.any? { |p| p.name == "My name"}
+  end
+
+  test "should show appropriate tab headers" do
+    Pagelets::Manager.add_pagelet("test/test", :main_tabs,
+                                               :name => "Visible",
+                                               :partial => "../../test/static_fixtures/views/test",
+                                               :onlyif => Proc.new { true })
+    Pagelets::Manager.add_pagelet("test/test", :main_tabs,
+                                               :name => "Hidden",
+                                               :partial => "../../test/static_fixtures/views/test",
+                                               :onlyif => Proc.new { false })
+    result = render_tab_header_for :main_tabs
+    assert result.match /Visible/
+    refute result.match /Hidden/
+  end
+
+  test "show page renders basic pagelets" do
+    Pagelets::Manager.add_pagelet("test/test", :main_tabs,
+                                                        :name => "TestTab",
+                                                        :partial => "../../test/static_fixtures/views/test")
+    result = render_tab_content_for :main_tabs
+    assert result.match /This is test partial/
+  end
+
+  test "show page renders correct id for pagelet" do
+    Pagelets::Manager.add_pagelet("test/test", :main_tabs,
+                                                        :name => "TestTab",
+                                                        :partial => "../../test/static_fixtures/views/test",
+                                                        :id => "my-special-id")
+    result = render_tab_content_for :main_tabs
+    assert result.match /id='my-special-id'/
+  end
+end

--- a/test/unit/pagelet_test.rb
+++ b/test/unit/pagelet_test.rb
@@ -20,7 +20,7 @@ class PageletTest < ActiveSupport::TestCase
   end
 
   test 'should override default id' do
-    pagelet = ::Pagelets::Pagelet.new("test pagelet", "tests/show", 50, { :id => "custom-id"})
+    pagelet = ::Pagelets::Pagelet.new("test pagelet", "tests/show", 50, { :id => "custom-id" })
     assert_equal "test pagelet", pagelet.name
     assert_equal "custom-id", pagelet.id
   end


### PR DESCRIPTION
Pagelet can be conditionally hidden by supplying a proc during pagelet registration. The proc evaluates in the context of a view, see plugin.rb for example usage. This aims to take care of rendering tab headers for empty tabs. 
