### PR TITLE
Fixes #13174 - title_actions extension point

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -5,7 +5,10 @@ module LayoutHelper
   end
 
   def title_actions(*elements)
-    content_for(:title_actions) { elements.join(" ").html_safe }
+    content_for(:title_actions) do
+      pagelets = Pagelets::Manager.sorted_pagelets_at(params, :title_action_buttons).collect { |pt| render(pt.partial.chomp).chomp }
+      (pagelets + elements).join(" ").html_safe
+    end
   end
 
   def button_group(*elements)

--- a/app/services/pagelets/manager.rb
+++ b/app/services/pagelets/manager.rb
@@ -10,6 +10,7 @@ module Pagelets
 
     class << self
       def add_pagelet(page_name, mountpoint, opts)
+        page_name = from_params(page_name)
         handle_empty_keys_for page_name, mountpoint
         raise ::Foreman::Exception.new(N_("Cannot add pagelet to page %s without partial"), page_name) unless opts[:partial]
         raise ::Foreman::Exception.new(N_("Cannot add pagelet to page %s without mountpoint"), page_name) if mountpoint.nil?
@@ -20,16 +21,17 @@ module Pagelets
 
       def default_pagelet_priority(page_name, mountpoint)
         # We need a default priority value for the first pagelet if it is not specified
-        @pagelets[page_name][mountpoint].map(&:priority).push(0).max + 100
+        @pagelets[from_params(page_name)][mountpoint].map(&:priority).push(0).max + 100
       end
 
       def pagelets_at(page_name, mountpoint)
+        page_name = from_params(page_name)
         handle_empty_keys_for page_name, mountpoint
         @pagelets[page_name][mountpoint]
       end
 
       def sorted_pagelets_at(page_name, mountpoint)
-        pagelets_at(page_name, mountpoint).sort
+        pagelets_at(from_params(page_name), mountpoint).sort
       end
 
       def clear
@@ -42,6 +44,10 @@ module Pagelets
         @pagelets ||= {}.with_indifferent_access
         @pagelets[page_name] ||= {}
         @pagelets[page_name][mountpoint] ||= []
+      end
+
+      def from_params(name_or_hash)
+        name_or_hash.is_a?(Hash) ? "#{name_or_hash['controller']}/#{name_or_hash['action']}" : name_or_hash
       end
     end
   end

--- a/test/unit/pagelet_manager_test.rb
+++ b/test/unit/pagelet_manager_test.rb
@@ -34,4 +34,14 @@ class PageletManagerTest < ActiveSupport::TestCase
       Pagelets::Manager.add_pagelet('test', nil, {:partial => 'test'})
     end
   end
+
+  test 'should accept hash as page name' do
+    hash = {
+      'controller' => "c",
+      'action' => "a"
+    }
+    ::Pagelets::Manager.add_pagelet(hash, :point, :name => "test", :partial => "tests")
+
+    assert_equal "test", ::Pagelets::Manager.sorted_pagelets_at("c/a", :point).first.name
+  end
 end


### PR DESCRIPTION
This allows plugins to add buttons to the top-right corner. This mount point is
available in most "index" and some "show" contexts.

Example for bootdisk (adding a bootdisk button which will open up modal dialog
with subnet selection and instructions):

``` ruby
extend_page "subnets/index" do |cx|
  cx.add_pagelet :title_action_buttons, :name => "Bootdisk", :partial => "subnets/index/bootdisk_button"
end
```

And the partial:

```
<a data-id="id_xyz" href="#">Bootdisk</a>
```
