### PR TITLE
Fixes 13067 - Added currect padding for dropdown menus

### DIFF
--- a/app/assets/stylesheets/topbar.scss
+++ b/app/assets/stylesheets/topbar.scss
@@ -124,7 +124,7 @@
 }
 
 .nav-header {
-  padding: 3px 20px;
+  padding: 3px 10px;
   font-size: 11px;
   font-weight: bold;
   line-height: 20px;


### PR DESCRIPTION
Fixed for all dropdowns, example:
before:
![selection_006](https://cloud.githubusercontent.com/assets/11405684/12296036/cbca4480-ba0d-11e5-9252-db3251735610.png)

after fix:
![selection_005](https://cloud.githubusercontent.com/assets/11405684/12295999/7c316d90-ba0d-11e5-8878-72707ba74147.png)
