### PR TITLE
fixes #13004 - inherit compute profile from parent host groups

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -123,7 +123,7 @@ class HostsController < ApplicationController
   def compute_resource_selected
     return not_found unless (params[:host] && (id=params[:host][:compute_resource_id]))
     Taxonomy.as_taxonomy @organization, @location do
-      compute_profile_id = params[:host][:compute_profile_id] || Hostgroup.find_by_id(params[:host][:hostgroup_id]).try(:compute_profile_id)
+      compute_profile_id = params[:host][:compute_profile_id] || Hostgroup.find_by_id(params[:host][:hostgroup_id]).try(:inherited_compute_profile_id)
       compute_resource = ComputeResource.authorized(:view_compute_resources).find_by_id(id)
       render :partial => "compute", :locals => { :compute_resource => compute_resource,
                                                  :vm_attrs         => compute_resource.compute_profile_attributes_for(compute_profile_id) }


### PR DESCRIPTION
When selecting a compute resource on the New Host form and the VM
attributes tab is refreshed using an inherited compute profile, the
profile was taken from the host group only if explicitly set on it.  The
compute profile is now inherited from the host group parent if set.

Best reviewed with `?w=1`.
