### PR TITLE
Fixes #13216 - Added ability to extend API by creating facet subnode

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -75,6 +75,13 @@ module Api
             param_group :interface_attributes, ::Api::V2::InterfacesController
           end
           param :compute_attributes, Hash, :desc => N_("Additional compute resource specific attributes.")
+
+          Facets.registered_facets.values.each do |facet_config|
+            next unless facet_config.api_param_group && facet_config.api_controller
+            param "#{facet_config.name}_attributes".to_sym, Hash, :desc => facet_config.api_param_group_description || (N_("Parameters for host's %s facet") % facet_config.name) do
+              param_group facet_config.api_param_group, facet_config.api_controller
+            end
+          end
         end
       end
 
@@ -333,4 +340,3 @@ Return the host's compute attributes that can be used to create a clone of this 
     end
   end
 end
-

--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -1,0 +1,76 @@
+require 'facets'
+
+module Facets
+  module ManagedHostExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      Facets::ManagedHostExtensions.refresh_facet_relations(self)
+
+      def attributes
+        hash = super
+
+        # include all facet attributes by default
+        facets_with_definitions.each do |facet, facet_definition|
+          hash["#{facet_definition.name}_attributes"] = facet.attributes.reject { |key, _| %w(created_at updated_at).include? key }
+        end
+        hash
+      end
+    end
+
+    class << self
+      def refresh_facet_relations(klass)
+        Facets.registered_facets.values.each do |facet_config|
+          self.register_facet_relation(klass, facet_config)
+        end
+      end
+
+      # This method is used to add all relation objects necessary for accessing facet from the host object.
+      # It:
+      # 1. Adds active record one to one association
+      # 2. Adds the ability to set facet's attributes via Host#attributes= method
+      # 3. Extends Host::Managed model with extension module defined by facet's configuration
+      # 4. Includes facet in host's cloning mechanism
+      # 5. Adds compatibility properties forwarders so old property calls will still work after moving them to a facet:
+      #    host.foo # => will call Host.my_facet.foo
+      def register_facet_relation(klass, facet_config)
+        klass.class_eval do
+          has_one facet_config.name, :class_name => facet_config.model.name, :foreign_key => :host_id, :inverse_of => :host
+          accepts_nested_attributes_for facet_config.name
+          alias_method "#{facet_config.name}_attributes", facet_config.name
+
+          include facet_config.extension if facet_config.extension
+
+          include_in_clone facet_config.name
+
+          facet_config.compatibility_properties.each do |prop|
+            define_method(prop) { |*args| forward_property_call(prop, args, facet_config.name) }
+          end if facet_config.compatibility_properties
+        end
+      end
+    end
+
+    def facets
+      facets_with_definitions.keys
+    end
+
+    # This method will return a hash of facets for a specific host including the coresponding definitions.
+    # The output should look like this:
+    # { host.puppet_aspect => Facets.registered_facets[:puppet_aspect] }
+    def facets_with_definitions
+      Hash[(Facets.registered_facets.values.map do |facet_config|
+        facet = send(facet_config.name)
+        [facet, facet_config] if facet
+      end).compact]
+    end
+
+    private
+
+    def forward_property_call(property, args, facet)
+      facet_instance = send(facet)
+      return nil unless facet_instance
+
+      facet_instance.send(property, *args)
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -2,6 +2,7 @@ class Host::Managed < Host::Base
   include Hostext::Search
   include SelectiveClone
   include HostParams
+  include Facets::ManagedHostExtensions
 
   has_many :host_classes, :foreign_key => :host_id
   has_many :puppetclasses, :through => :host_classes, :dependent => :destroy

--- a/app/services/facets.rb
+++ b/app/services/facets.rb
@@ -24,6 +24,8 @@ module Facets
     entry.instance_eval(&block) if block_given?
 
     configuration[entry.name] = entry
+
+    Facets::ManagedHostExtensions.register_facet_relation(Host::Managed, entry)
   end
 
   #declare private module methods.

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -24,3 +24,9 @@ attributes :configuration_status => :puppet_status
 HostStatus.status_registry.each do |status_class|
   attributes "#{status_class.humanized_name}_status", "#{status_class.humanized_name}_status_label", :if => @object.get_status(status_class).relevant?
 end
+
+@object.facets_with_definitions.each do |_facet, definition|
+  node do
+    partial(definition.api_list_view, :object => @object) if definition.api_list_view
+  end
+end

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -25,3 +25,9 @@ end
 child :config_groups do
   extends "api/v2/config_groups/main"
 end
+
+@host.facets_with_definitions.each do |_facet, definition|
+  node do
+    partial(definition.api_single_view, :object => @host) if definition.api_single_view
+  end
+end

--- a/test/unit/facet_configuration_test.rb
+++ b/test/unit/facet_configuration_test.rb
@@ -12,6 +12,13 @@ class FacetConfigurationTest < ActiveSupport::TestCase
   module TestHelper
   end
 
+  teardown do
+    Host::Managed.cloned_parameters[:include].delete(:test_model)
+    Host::Managed.cloned_parameters[:include].delete(:test_facet)
+    Host::Managed.cloned_parameters[:include].delete(:test_class)
+    Host::Managed.cloned_parameters[:include].delete(:facet_name)
+  end
+
   test 'enables block configuration' do
     config = {}
     Facets.stubs(:configuration).returns(config)

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'facet_test_helper'
+
+class TestFacet < HostFacets::Base
+end
+
+module TestModule
+  class ModuleTestFacet < HostFacets::Base
+  end
+end
+
+class FacetTest < ActiveSupport::TestCase
+  setup do
+    @config = {}
+    Facets.stubs(:configuration).returns(@config)
+  end
+
+  teardown do
+    Host::Managed.cloned_parameters[:include].delete(:test_model)
+    Host::Managed.cloned_parameters[:include].delete(:test_facet)
+    Host::Managed.cloned_parameters[:include].delete(:namespaced_facet)
+  end
+
+  context 'namespaced facets' do
+    setup do
+      Facets.register TestModule::ModuleTestFacet, :namespaced_facet
+
+      @host = Host::Managed.new
+      @facet = @host.build_namespaced_facet
+    end
+
+    test 'can create a namespaced facet' do
+      assert_equal @facet, @host.facets.first
+    end
+
+    test 'returns facets attributes' do
+      attributes = @host.attributes
+
+      assert_not_nil attributes["namespaced_facet_attributes"]
+    end
+  end
+
+  context 'managed host behavior' do
+    setup do
+      Facets.register TestFacet
+
+      @host = Host::Managed.new
+      @facet = @host.build_test_facet
+    end
+
+    test 'registered facets are subscribed properly' do
+      assert_equal @facet, @host.facets.first
+    end
+
+    test 'facets are cloned to the new host' do
+      facet_clone = @facet.dup
+      @facet.stubs(:dup).returns(facet_clone)
+
+      cloned_host = @host.clone
+
+      assert_equal facet_clone, cloned_host.test_facet
+      assert_equal facet_clone, cloned_host.facets.first
+    end
+
+    test 'facets are included in attributes' do
+      attributes = @host.attributes
+
+      assert_not_nil attributes["test_facet_attributes"]
+    end
+  end
+end


### PR DESCRIPTION
This is a second part of host facets change. It contains a code that enables access to registered facets from the host model and API (v2) extension that enables adding properties to host's JSON.

First part of the change was merged here: #2944.
More complete explanations can be found here: #2665.
