### PR TITLE
fixes #13168 - permit safemode templates read-only access to AR relations

### DIFF
--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -4,3 +4,9 @@ class ActiveRecord::Base
   include StripWhitespace
   include Parameterizable::ById
 end
+
+# Permit safemode template rendering to have basic read-only access over
+# model relations
+class ActiveRecord::AssociationRelation::Jail < Safemode::Jail
+  allow :[], :each, :first, :to_a
+end

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -71,5 +71,19 @@ class RendererTest < ActiveSupport::TestCase
       tmpl = unattended_render(template)
       assert_equal 'xabc', tmpl
     end
+
+    test "#{renderer_name} should render with AR relation method calls" do
+      host = FactoryGirl.create(:host)
+      send "setup_#{renderer_name}"
+      tmpl = render_safe("<% @host.managed_interfaces.each do |int| -%><%= int.to_s -%><% end -%>", [], { :host => host })
+      assert_equal host.name, tmpl
+    end
+  end
+
+  test 'ActiveRecord::AssociationRelation jail test' do
+    allowed = [:[], :each, :first, :to_a]
+    allowed.each do |m|
+      assert ActiveRecord::AssociationRelation::Jail.allowed?(m), "Method #{m} is not available in ActiveRecord::AssociationRelation::Jail while should be allowed."
+    end
   end
 end


### PR DESCRIPTION
Templates such as kickstart_networking_setup use relations of
Host::Managed to access network interfaces.  Since Rails 4, these return
relation objects rather than arrays which being core Ruby, had permitted
methods defined in safemode itself.
