### PR TITLE
Refs #13076 - correct spacing under tabs

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -113,9 +113,12 @@ a {
   margin-right: 18px;
 }
 
-div#host-show .nav.nav-tabs{
-  margin-bottom: 10px;
-  font-size: 12px;
+.nav.nav-tabs{
+  margin-bottom: 20px;
+  #host-show &{
+    margin-bottom: 10px;
+    font-size: 12px;
+  }
 }
 
 .tab-content{


### PR DESCRIPTION
Previous commit removed all spacing beneath nav tabs, this comit reverts
that and only reduces the spacing for the host show tabs.
