### PR TITLE
Fixes #13230 - Oauth headers change in rails 4

### DIFF
--- a/app/services/sso/oauth.rb
+++ b/app/services/sso/oauth.rb
@@ -19,7 +19,7 @@ module SSO
 
       if OAuth::Signature.verify(request, :consumer_secret => Setting['oauth_consumer_secret'])
         if Setting['oauth_map_users']
-          user_name = request.headers['foreman_user']
+          user_name = request.headers['HTTP_FOREMAN_USER']
           User.find_by_login(user_name).tap do |obj|
             Rails.logger.warn "Oauth: mapping to user '#{user_name}' failed" if obj.nil?
           end.try(:login)

--- a/test/unit/sso/oauth_test.rb
+++ b/test/unit/sso/oauth_test.rb
@@ -35,7 +35,7 @@ class OauthTest < ActiveSupport::TestCase
     end
 
     test 'authenticates normal user' do
-      controller = get_controller(true, {'foreman_user' => users(:one).login})
+      controller = get_controller(true, {'HTTP_FOREMAN_USER' => users(:one).login})
       oauth = SSO::Oauth.new(controller)
       expect_oauth
       assert_equal users(:one).login, oauth.authenticated?


### PR DESCRIPTION
This was a change made in rails 4. HTTP_ is prefixed to headers. 

See [rails code](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/headers.rb#L109-L110) and [relevant stack overflow article](http://stackoverflow.com/questions/19972313/accessing-custom-header-variables-in-ruby-on-rails)
