### PR TITLE
Fixes #12822 - Separates LookupValue into two classes

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -43,6 +43,7 @@ module Api
       param_group :override_value, :as => :create
 
       def create
+        params[:override_value].merge!(type: "PuppetLookupValue") if @smart.puppet?
         @override_value = @smart.lookup_values.create!(params[:override_value])
         @smart.update_attribute(:override, true)
         process_response @override_value

--- a/app/controllers/lookup_values_controller.rb
+++ b/app/controllers/lookup_values_controller.rb
@@ -15,7 +15,9 @@ class LookupValuesController < ApplicationController
   end
 
   def create
+    lookup_key = LookupKey.find params[:lookup_key_id]
     @lookup_value = LookupValue.new(params[:lookup_value])
+    @lookup_value.type = lookup_key.present? and lookup_key.puppet? ? "PuppetLookupValue" : "LookupValue"
     if @lookup_value.save
       process_success({:success_redirect => lookup_key_lookup_values_url(params[:lookup_key_id])})
     else

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -82,6 +82,15 @@ class LookupKey < ActiveRecord::Base
     nil
   end
 
+  def lookup_values_attributes=(attributes)
+    attributes.each  do |key,val|
+      unless val.has_key? 'id'
+        val.merge! :type => puppet? ? "PuppetLookupValue" : "LookupValue"
+      end
+    end
+    super
+  end
+
   def reject_invalid_lookup_values(attributes)
     attributes[:match].empty?
   end

--- a/app/models/lookup_value/lookup_value.rb
+++ b/app/models/lookup_value/lookup_value.rb
@@ -2,7 +2,7 @@ class LookupValue < ActiveRecord::Base
   include Authorizable
   include CounterCacheFix
 
-  attr_accessible :match, :value, :lookup_key_id, :id, :_destroy, :host_or_hostgroup, :use_puppet_default, :lookup_key, :hidden_value
+  attr_accessible :match, :value, :lookup_key_id, :id, :_destroy, :host_or_hostgroup, :use_puppet_default, :lookup_key, :hidden_value, :type
 
   validates_lengths_from_database
   audited :associated_with => :lookup_key, :allow_mass_assignment => true
@@ -10,7 +10,6 @@ class LookupValue < ActiveRecord::Base
 
   belongs_to :lookup_key, :counter_cache => true
   validates :match, :presence => true, :uniqueness => {:scope => :lookup_key_id}, :format => LookupKey::VALUE_REGEX
-  validate :value_present?
   delegate :key, :to => :lookup_key
   before_validation :sanitize_match
 
@@ -27,10 +26,6 @@ class LookupValue < ActiveRecord::Base
   scoped_search :on => :value, :complete_value => true, :default_order => true
   scoped_search :on => :match, :complete_value => true
   scoped_search :in => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
-
-  def value_present?
-    self.errors.add(:value, :blank) if value.to_s.empty? && !use_puppet_default && lookup_key.puppet?
-  end
 
   def value=(val)
     if val.is_a?(HashWithIndifferentAccess)

--- a/app/models/lookup_value/puppet_lookup_value.rb
+++ b/app/models/lookup_value/puppet_lookup_value.rb
@@ -1,0 +1,15 @@
+class PuppetLookupValue < LookupValue
+  attr_accessible :use_puppet_default
+  validate :puppet_lookup_key?
+  validate :value_present?
+
+  private
+
+  def puppet_lookup_key?
+    lookup_key.puppet?
+  end
+
+  def value_present?
+    errors.add(:value, :blank) if value.to_s.empty? and !use_puppet_default
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,6 +109,7 @@ module Foreman
     config.autoload_paths += %W(#{config.root}/app/models/parameters)
     config.autoload_paths += %W(#{config.root}/app/models/trends)
     config.autoload_paths += %W(#{config.root}/app/models/taxonomies)
+    config.autoload_paths += %W(#{config.root}/app/models/lookup_value)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/db/migrate/20160112133345_add_type_to_lookup_value.rb
+++ b/db/migrate/20160112133345_add_type_to_lookup_value.rb
@@ -1,0 +1,11 @@
+class AddTypeToLookupValue < ActiveRecord::Migration
+  def change
+    add_column :lookup_values, :type, :string
+    LookupValue.reset_column_information
+    LookupValue.all.each do |lookup_value|
+      subclass = lookup_value.lookup_key.puppet? ?  'PuppetLookupValue' : 'LookupValue'
+      lookup_value.type = subclass
+      lookup_value.save
+    end
+  end
+end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -71,6 +71,14 @@ FactoryGirl.define do
     end
   end
 
+  factory :puppet_lookup_value do
+    sequence(:value) {|n| "value#{n}" }
+
+    trait :with_use_puppet_default do
+      use_puppet_default true
+    end
+  end
+
   factory :puppetclass do
     sequence(:name) {|n| "class#{n}" }
 

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -163,7 +163,7 @@ class LookupValueTest < ActiveSupport::TestCase
   test "boolean lookup value should not allow for nil value" do
     #boolean key
     key = lookup_keys(:three)
-    value = LookupValue.new(:value => nil, :match => "hostgroup=Common", :lookup_key_id => key.id)
+    value = PuppetLookupValue.new(:value => nil, :match => "hostgroup=Common", :lookup_key_id => key.id)
     refute value.valid?
   end
 
@@ -188,7 +188,7 @@ class LookupValueTest < ActiveSupport::TestCase
 
   test "lookup value should not allow for nil key" do
     key = lookup_keys(:three)
-    value = LookupValue.new(:value => true, :match => "", :lookup_key_id => key.id)
+    value = PuppetLookupValue.new(:value => true, :match => "", :lookup_key_id => key.id)
     refute_valid value
   end
 
@@ -230,7 +230,7 @@ class LookupValueTest < ActiveSupport::TestCase
                                 :with_override, :with_use_puppet_default,
                                 :key_type => 'string',
                                 :puppetclass => puppetclasses(:one))
-      @value = FactoryGirl.build_stubbed(:lookup_value, :value => "",
+      @value = FactoryGirl.build_stubbed(:puppet_lookup_value, :value => "",
                                          :match => "hostgroup=Common",
                                          :lookup_key_id => @key.id,
                                          :use_puppet_default => true)


### PR DESCRIPTION
LookupKey has been separated into two classes and LookupValue still has specific logic for each one. LookupValue has separated into two class as well, per LookupKey type
