### PR TITLE
Fixes #13235 - content from application layout extracted into a partial

### DIFF
--- a/app/views/layouts/_application_content.html.erb
+++ b/app/views/layouts/_application_content.html.erb
@@ -1,0 +1,24 @@
+<div id="main">
+  <%= content_tag('div', flash[:error],   :class => 'flash hide error')   if flash[:error] %>
+  <%= content_tag('div', flash[:warning], :class => 'flash hide warning') if flash[:warning] %>
+  <%= content_tag('div', flash[:notice],  :class => 'flash hide notice')  if flash[:notice] %>
+  <div id="content" class="container">
+    <% unless @page_header.blank? %>
+      <div class="row form-group">
+        <h1 class="col-md-8"><%=h @page_header %></h1>
+      </div>
+    <% end %>
+    <div class="row">
+      <div class="title_filter <%= searchable? ? "col-md-6" : "col-md-4" %>">
+        <%= render "common/searchbar" if searchable? %>
+        <%= yield(:search_bar) %>&nbsp;
+      </div>
+      <div id="title_action" class="<%= searchable? ? "col-md-6" : "col-md-8" %>">
+        <div class="btn-toolbar pull-right"><%=h yield(:title_actions) %></div>
+      </div>
+    </div>
+
+    <%= yield %>
+  </div>
+</div>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,27 +1,5 @@
 <%= content_for(:content) do %>
-  <div id="main">
-    <%= content_tag('div', flash[:error],   :class => 'flash hide error')   if flash[:error] %>
-    <%= content_tag('div', flash[:warning], :class => 'flash hide warning') if flash[:warning] %>
-    <%= content_tag('div', flash[:notice],  :class => 'flash hide notice')  if flash[:notice] %>
-    <div id="content" class="container">
-      <% unless @page_header.blank? %>
-        <div class="row form-group">
-          <h1 class="col-md-8"><%=h @page_header %></h1>
-        </div>
-      <% end %>
-      <div class="row">
-        <div class="title_filter <%= searchable? ? "col-md-6" : "col-md-4" %>">
-          <%= render "common/searchbar" if searchable? %>
-          <%= yield(:search_bar) %>&nbsp;
-        </div>
-        <div id="title_action" class="<%= searchable? ? "col-md-6" : "col-md-8" %>">
-          <div class="btn-toolbar pull-right"><%=h yield(:title_actions) %></div>
-        </div>
-      </div>
-
-      <%= yield %>
-    </div>
-  </div>
+  <%= render :partial => 'layouts/application_content' %>
 <% end %>
 
 <%= render :template => 'layouts/base' %>


### PR DESCRIPTION
Extracting the content_for part of application layout into a separate partial will enable for using in with different parent layouts. This is key for rendering the standard foreman views with layout containing bastion_katello assets.

Intended usage:

``` ruby
# katello/layouts/foreman_with_bastion.html.erb
<%= content_for(:content) do %>
  <%= render :partial => 'layouts/application_content' %>
<% end %>

<%= render :file => 'bastion/layouts/assets' %>
```
