### PR TITLE
fixes #12873 - update Rails to 4.1.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ require File.expand_path('../lib/regexp_extensions', FOREMAN_GEMFILE)
 
 source 'https://rubygems.org'
 
-gem 'rails', '4.1.5'
+gem 'rails', '4.1.14.1'
 gem 'json', '~> 1.5'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord', '~> 4.0'

--- a/config/initializers/0_maintain_test_schema.rb
+++ b/config/initializers/0_maintain_test_schema.rb
@@ -1,1 +1,1 @@
-ActiveRecord::Migration.maintain_test_schema! if Rails.env.test?
+ActiveRecord::Migration.maintain_test_schema! if Rails.env.test? && !Foreman.in_rake?('db:test:prepare')

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -46,18 +46,24 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   describe 'pagelets on show page' do
+    setup do
+      @view_paths = SmartProxiesController.view_paths
+      SmartProxiesController.prepend_view_path File.expand_path('../../static_fixtures/views', __FILE__)
+    end
+
     def teardown
       Pagelets::Manager.clear
+      SmartProxiesController.view_paths = @view_paths
     end
 
     test 'show page passes subject into pagelets' do
       Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
                                                           :name => "VisibleTab",
-                                                          :partial => "../../test/static_fixtures/views/test",
+                                                          :partial => "/test",
                                                           :onlyif => Proc.new { |subject| subject.has_feature? "DHCP" })
       Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
                                                           :name => "HiddenTab",
-                                                          :partial => "../../test/static_fixtures/views/test",
+                                                          :partial => "/test",
                                                           :onlyif => Proc.new { |subject| subject.has_feature? "TFTP" })
       proxy = smart_proxies(:one)
       visit smart_proxy_path(proxy)

--- a/test/unit/helpers/pagelets_helper_test.rb
+++ b/test/unit/helpers/pagelets_helper_test.rb
@@ -2,6 +2,11 @@ require 'test_helper'
 
 class PageletsHelperTest < ActionView::TestCase
   include PageletsHelper
+
+  setup do
+    controller.prepend_view_path File.expand_path('../../../static_fixtures/views', __FILE__)
+  end
+
   teardown do
     Pagelets::Manager.clear
   end
@@ -13,10 +18,10 @@ class PageletsHelperTest < ActionView::TestCase
   test "should find pagelets for page and mountpoint" do
     Pagelets::Manager.add_pagelet("test/test", :main_tabs,
                                                :name => "Name",
-                                               :partial => "../../test/static_fixtures/views/test")
+                                               :partial => "test")
     Pagelets::Manager.add_pagelet("smart_proxies/show", :main_tabs,
                                                        :name => "My name",
-                                                       :partial => "../../test/static_fixtures/views/test")
+                                                       :partial => "test")
     pagelets = pagelets_for(:main_tabs)
     assert pagelets.any? { |p| p.name == "Name" }
     refute pagelets.any? { |p| p.name == "My name"}
@@ -25,11 +30,11 @@ class PageletsHelperTest < ActionView::TestCase
   test "should show appropriate tab headers" do
     Pagelets::Manager.add_pagelet("test/test", :main_tabs,
                                                :name => "Visible",
-                                               :partial => "../../test/static_fixtures/views/test",
+                                               :partial => "test",
                                                :onlyif => Proc.new { true })
     Pagelets::Manager.add_pagelet("test/test", :main_tabs,
                                                :name => "Hidden",
-                                               :partial => "../../test/static_fixtures/views/test",
+                                               :partial => "test",
                                                :onlyif => Proc.new { false })
     result = render_tab_header_for :main_tabs
     assert result.match /Visible/
@@ -39,7 +44,7 @@ class PageletsHelperTest < ActionView::TestCase
   test "show page renders basic pagelets" do
     Pagelets::Manager.add_pagelet("test/test", :main_tabs,
                                                         :name => "TestTab",
-                                                        :partial => "../../test/static_fixtures/views/test")
+                                                        :partial => "test")
     result = render_tab_content_for :main_tabs
     assert result.match /This is test partial/
   end
@@ -47,7 +52,7 @@ class PageletsHelperTest < ActionView::TestCase
   test "show page renders correct id for pagelet" do
     Pagelets::Manager.add_pagelet("test/test", :main_tabs,
                                                         :name => "TestTab",
-                                                        :partial => "../../test/static_fixtures/views/test",
+                                                        :partial => "test",
                                                         :id => "my-special-id")
     result = render_tab_content_for :main_tabs
     assert result.match /id='my-special-id'/


### PR DESCRIPTION
maintain_test_schema! changed behaviour and now launches db:test:prepare
in the background, causing the environment to be loaded again.  A check
in the initializer prevents this from happening recursively.

Ideally this call would be removed from the initializers and leave it to
rails/test_help, but requires one of three solutions:
1. validates_lengths_from_database and validate_inclusion_in_families
   must be lazier, not checking the database during class
   initialisation.  The Rails environment and even some models could be
   loaded but only start working after the DB is available, instead of
   not setting up their validators.
2. Remove all model class loading from the environment setup.  The
   apipie initializer can be made lazier, the HostObserver can be
   refactored, but many plugins still cause models to be loaded through
   to_prepare hooks.
3. Ignore the problem, always set up the test DB schema externally
   before using rake tasks, without relying on rails/test_help and
   maintain_test_schema.

Any of these would allow for the Rails environment to be loaded either
before the test DB schema is maintained without an effect on behaviour.

Test failures in the pagelets tests are fixed, which previously
referenced partials stored outside of the known view paths.  These are
blocked by Rails in the Action View CVE-2016-0752 fix, so instead the
static fixtures directory is added to the view search paths.

Opening, but should probably wait until Katello has fixed a DB migration: http://projects.theforeman.org/issues/13242
