### PR TITLE
fixes #13124 use patternfly icons for status

### DIFF
--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -7,11 +7,11 @@ function setItemStatus(item, response) {
   if(response.success) {
     item.attr('title', __('Active'));
     item.addClass('text-success');
-    item.html(icon_text('ok-sign', "", "glyphicon"));
+    item.html(icon_text('ok', "", "pficon"));
   } else {
     item.attr('title', response.message);
     item.addClass('text-danger');
-    item.html(icon_text('exclamation-sign', "", "glyphicon"));
+    item.html(icon_text('error-circle-o', "", "pficon"));
   }
   item.tooltip({html: true});
 }
@@ -34,7 +34,7 @@ function generateItem(item, status, text) {
   } else {
     item.attr('title', text);
     item.addClass('text-danger');
-    item.html(icon_text('exclamation-sign', "", "glyphicon"));
+    item.html(icon_text('error-circle-o', "", "pficon"));
   }
   item.tooltip({html: true});
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -438,10 +438,10 @@ module ApplicationHelper
 
   def spinner(text = '', options = {})
     if text.present?
-      "<p class='spinner-label'> #{text} </p><div id='#{options[:id]}' class='spinner spinner-sm spinner-inline #{options[:class]}'>
+      "<p class='spinner-label'> #{text} </p><div id='#{options[:id]}' class='spinner spinner-xs spinner-inline #{options[:class]}'>
       </div>".html_safe
     else
-      "<div id='#{options[:id]}' class='spinner spinner-sm #{options[:class]}'></div>".html_safe
+      "<div id='#{options[:id]}' class='spinner spinner-xs #{options[:class]}'></div>".html_safe
     end
   end
 

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -111,17 +111,17 @@ module HostsHelper
 
   def host_global_status_icon_class(status)
     icon_class = case status
-      when HostStatus::Global::OK
-        'glyphicon-ok-sign'
-      when HostStatus::Global::WARN
-        'glyphicon-info-sign'
-      when HostStatus::Global::ERROR
-        'glyphicon-exclamation-sign'
-      else
-        'glyphicon-question-sign'
-    end
+                 when HostStatus::Global::OK
+                   'pficon-ok'
+                 when HostStatus::Global::WARN
+                   'pficon-info'
+                 when HostStatus::Global::ERROR
+                   'pficon-error-circle-o'
+                 else
+                   'pficon-help'
+                 end
 
-    "host-status glyphicon #{icon_class} #{host_global_status_class(status)}"
+    "host-status #{icon_class} #{host_global_status_class(status)}"
   end
 
   def host_global_status_class(status)

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -306,7 +306,7 @@ module LayoutHelper
       when blank?
         ""
       when :indicator
-        content_tag(:span, content_tag(:div, '', :class => 'hide spinner spinner-sm'),
+        content_tag(:span, content_tag(:div, '', :class => 'hide spinner spinner-xs'),
                     :class => 'help-block').html_safe
       else
         content_tag(:span, help_inline, :class => "help-block help-inline")


### PR DESCRIPTION
this changes the following to use patternfly status icons(https://www.patternfly.org/styles/icons/)
- hosts list
- about page
- smart proxy index

Additionally, I've updated the default spinner to be xs class,
this is in order for the spinner take the same size as the status icons.
