### PR TITLE
fixes #13255 - delay initalization of api class.

### DIFF
--- a/app/services/proxy_status.rb
+++ b/app/services/proxy_status.rb
@@ -5,7 +5,6 @@ class ProxyStatus
   def initialize(proxy, opts = {})
     @proxy = proxy
     @cache_duration = opts[:cache_duration] || 3.minutes
-    @api ||= ProxyAPI::Version.new(:url => proxy.url)
   end
 
   def api_versions
@@ -38,8 +37,12 @@ class ProxyStatus
 
   private
 
-  attr_reader :proxy, :cache_duration, :api
+  attr_reader :proxy, :cache_duration
   alias_method :version, :api_versions
+
+  def api
+    @api ||= ProxyAPI::Version.new(:url => proxy.url)
+  end
 
   def fetch_proxy_data
     begin

--- a/test/unit/proxy_status_test.rb
+++ b/test/unit/proxy_status_test.rb
@@ -54,5 +54,12 @@ class ProxyStatusTest < ActiveSupport::TestCase
         ProxyStatus.new(@proxy).api_versions
       end
     end
+
+    test 'it should catch connection setup exceptions' do
+      ProxyAPI::Version.any_instance.stubs(:proxy_versions).raises(Errno::ENOENT)
+      assert_raise(Foreman::WrappedException, "Unable to connect to smart proxy") do
+        ProxyStatus.new(@proxy).api_versions
+      end
+    end
   end
 end


### PR DESCRIPTION
this ensures that exception are raized when using the class.
before this patch, connection related exceptions where being ignored
(for example Errno::ENOENT when cert files are not found/permissions denied)

/cc @shlomizadok
