### PR TITLE
fixes #13265 - Any Context menu permissions

### DIFF
--- a/app/views/home/_location_dropdown.html.erb
+++ b/app/views/home/_location_dropdown.html.erb
@@ -3,15 +3,13 @@
   <% location_count = Location.my_locations.count %>
   <%= location_dropdown location_count %>
   <ul class="dropdown-menu loc-submenu">
-    <% if User.current.admin? %>
-      <li><%= link_to(_('Any Location'), main_app.clear_locations_path) %></li>
-      <%= content_tag(:li, "", :class=>"divider") %>
-    <% end %>
+    <li><%= link_to(_('Any Location'), main_app.clear_locations_path) %></li>
+    <%= content_tag(:li, "", :class=>"divider") %>
     <% Location.my_locations.each do |location| %>
       <li><%= link_to(trunc_with_tooltip(location.title), main_app.select_location_path(location)) %></li>
     <% end %>
   </ul>
 </li>
-<% if User.current.allowed_to?(:create_locations) %>
+<% if User.current.allowed_to?(:view_locations) %>
   <li><%= link_to _("Manage Locations"), main_app.locations_path, :class=> "manage-menu" %></li>
 <% end %>

--- a/app/views/home/_organization_dropdown.html.erb
+++ b/app/views/home/_organization_dropdown.html.erb
@@ -3,15 +3,13 @@
   <% orgs_count = Organization.my_organizations.count %>
   <%= organization_dropdown orgs_count %>
   <ul class="dropdown-menu org-submenu">
-    <% if User.current.admin? %>
-      <li><%= link_to(_('Any Organization'), main_app.clear_organizations_path) %></li>
-      <%= content_tag(:li, "", :class => "divider") %>
-    <% end %>
+    <li><%= link_to(_('Any Organization'), main_app.clear_organizations_path) %></li>
+    <%= content_tag(:li, "", :class => "divider") %>
     <% Organization.my_organizations.each do |organization| %>
       <li><%= link_to(trunc_with_tooltip(organization.title), main_app.select_organization_path(organization)) %></li>
     <% end %>
   </ul>
 </li>
-<% if User.current.allowed_to?(:create_organizations) %>
+<% if User.current.allowed_to?(:view_organizations) %>
   <li><%= link_to _("Manage Organizations"), main_app.organizations_path, :class => "manage-menu" %></li>
 <% end %>


### PR DESCRIPTION
modify the Any Context drop down menu for location / organization to:
- allow non admin users to be able to clear their location / organization
- allow the 'manage locations' / 'manage organizations' links on the menu to be granted for the view_locations / view_organizations permissions as this link ultimately links to the index page (currently this link is visible to users with create_\* permissions only).
