### PR TITLE
fixes #13272 - use instance variable for basic_edit_test test helper

### DIFF
--- a/test/functional/architectures_controller_test.rb
+++ b/test/functional/architectures_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class ArchitecturesControllerTest < ActionController::TestCase
+  setup do
+    @model = Architecture.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(Architecture.first)
+  basic_edit_test
 
   def test_new_submit_button_id
     get :new, {}, set_session_user

--- a/test/functional/auth_source_ldaps_controller_test.rb
+++ b/test/functional/auth_source_ldaps_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class AuthSourceLdapsControllerTest < ActionController::TestCase
+  setup do
+    @model = AuthSourceLdap.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(AuthSourceLdap.first)
+  basic_edit_test
 
   def test_create_invalid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(false)

--- a/test/functional/domains_controller_test.rb
+++ b/test/functional/domains_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class DomainsControllerTest < ActionController::TestCase
+  setup do
+    @model = Domain.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(Domain.first)
+  basic_edit_test
 
   def test_create_invalid
     Domain.any_instance.stubs(:valid?).returns(false)

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class EnvironmentsControllerTest < ActionController::TestCase
+  setup do
+    @model = Environment.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(Environment.first)
+  basic_edit_test
 
   test "should create new environment" do
     assert_difference 'Environment.count' do

--- a/test/functional/filters_controller_test.rb
+++ b/test/functional/filters_controller_test.rb
@@ -1,13 +1,14 @@
 require 'test_helper'
 
 class FiltersControllerTest < ActionController::TestCase
-  basic_index_test('filters')
-  basic_new_test
-  basic_edit_test(Filter.first, 'filter')
-
   setup do
+    @model = Filter.first
     User.current = users(:admin)
   end
+
+  basic_index_test('filters')
+  basic_new_test
+  basic_edit_test('filter')
 
   test "changes should expire topbar cache" do
     user1 = FactoryGirl.create(:user, :with_mail)

--- a/test/functional/media_controller_test.rb
+++ b/test/functional/media_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class MediaControllerTest < ActionController::TestCase
+  setup do
+    @model = Medium.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(Medium.first)
+  basic_edit_test
 
   def test_create_invalid
     Medium.any_instance.stubs(:valid?).returns(false)

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -18,9 +18,13 @@
 require 'test_helper'
 
 class RolesControllerTest < ActionController::TestCase
+  setup do
+    @model = Role.first
+  end
+
   basic_index_test('roles')
   basic_new_test
-  basic_edit_test(Role.first)
+  basic_edit_test
 
   test 'creates role' do
     post :create, { :role => {:name => 'test role'}}, set_session_user

--- a/test/functional/shared/basic_rest_response_test.rb
+++ b/test/functional/shared/basic_rest_response_test.rb
@@ -22,14 +22,17 @@ module BasicRestResponseTest
       end
     end
 
-    def basic_edit_test(model, object_found = nil)
+    def basic_edit_test(object_found = nil)
       context 'GET #edit' do
-        setup { get :edit, { :id => model }, set_session_user }
+        setup do
+          get :edit, { :id => @model }, set_session_user
+        end
+
         should respond_with(:success)
         should render_template(:edit)
         test 'assigns the found object to an instance variable' do
           object_found ||= assigns[:resource_class].to_s.tableize.singularize
-          assert_equal model, assigns(:"#{object_found}")
+          assert_equal @model, assigns(:"#{object_found}")
         end
       end
     end

--- a/test/functional/subnets_controller_test.rb
+++ b/test/functional/subnets_controller_test.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
 class SubnetsControllerTest < ActionController::TestCase
+  setup do
+    @model = Subnet.first
+  end
+
   basic_index_test
   basic_new_test
-  basic_edit_test(Subnet.first)
+  basic_edit_test
 
   def test_create_invalid
     Subnet.any_instance.stubs(:valid?).returns(false)

--- a/test/functional/usergroups_controller_test.rb
+++ b/test/functional/usergroups_controller_test.rb
@@ -3,11 +3,12 @@ require 'test_helper'
 class UsergroupsControllerTest < ActionController::TestCase
   setup do
     as_admin { FactoryGirl.create(:usergroup) }
+    @model = Usergroup.first
   end
 
   basic_index_test
   basic_new_test
-  basic_edit_test(Usergroup.first || FactoryGirl.create(:usergroup))
+  basic_edit_test
 
   def test_create_invalid
     Usergroup.any_instance.stubs(:valid?).returns(false)

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -1,14 +1,15 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
-  basic_index_test('users')
-  basic_new_test
-  basic_edit_test(User.last, 'user')
-
-  def setup
+  setup do
     setup_users
+    @model = User.last
     Setting::Auth.load_defaults
   end
+
+  basic_index_test('users')
+  basic_new_test
+  basic_edit_test('user')
 
   test "#index should not show hidden users" do
     get :index, { :search => "login = #{users(:anonymous).login}" }, set_session_user


### PR DESCRIPTION
Some helper methods now exist for testing edit pages in `test/functional/shared/basic_rest_response_test.rb`

`basic_edit_test` takes a record as an argument, which for most models is passed as `ModelClass.first`, however, `.first` may not exist at class evaluation if there's no fixtures. This is the case with Usergroups.

And due to database cleaning, the object needs to be created within the context of the basic_edit_test method, so passing something like `FactoryGirl.create(...)` directly also doesn't work in some cases.

See: https://groups.google.com/forum/#!topic/foreman-dev/n1wCaH76N8Y
