### PR TITLE
fixes #6535 EC2 Security Groups - empty box

### DIFF
--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -193,7 +193,7 @@ function libvirt_image_selected(item){
 }
 
 function ec2_vpcSelected(form){
-  sg_select = $('.security_group_ids')
+  sg_select = $('select.security_group_ids')
   sg_select.empty();
   security_groups = jQuery.parseJSON( sg_select.attr('data-security-groups') );
   subnets = jQuery.parseJSON( sg_select.attr('data-subnets') );


### PR DESCRIPTION
The JQuery selector returns 2 elements.
The following functions don't take that into account and thus the security_groups and subnets variables are never populated.
