### PR TITLE
Fixes #13171: Prevent frozen array error when plugins have assets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -190,6 +190,14 @@ module Foreman
     config.logger = Foreman::Logging.logger('app')
     config.active_record.logger = Foreman::Logging.logger('sql')
 
+    if config.serve_static_assets
+      ::Rails::Engine.subclasses.map(&:instance).each do |engine|
+        if File.exist?("#{engine.root}/public/assets")
+          config.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
+        end
+      end
+    end
+
     config.to_prepare do
       ApplicationController.descendants.each do |child|
         # reinclude the helper module in case some plugin extended some in the to_prepare phase,

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -59,18 +59,9 @@ Foreman::Application.configure do |app|
   config.assets.precompile << /\.(?:svg|eot|woff|gif|ttf)$/
   config.assets.precompile += javascript.map { |js| js + '.js' } + stylesheets + %w(background-size.htc)
 
-  # Serve plugin static assets if the application is configured to do so
-  if config.serve_static_assets
-    ::Rails::Engine.subclasses.map(&:instance).each do |engine|
-      if File.exist?("#{engine.root}/public/assets")
-        app.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
-      end
-    end
-  end
-
   # Adds plugin assets to the application digests hash if a manifest file exists for a plugin
   config.after_initialize do
-    if (manifest_file = Dir.glob("#{Rails.root}/public/assets/manifest*.json").first)
+    if (manifest_file = Dir.glob("#{Rails.root}/public/assets/.sprockets-manifest*.json").first)
       foreman_manifest = JSON.parse(File.read(manifest_file))
 
       ::Rails::Engine.subclasses.map(&:instance).each do |engine|


### PR DESCRIPTION
When the application is configured to serve static assets, the
public/asset paths of the plugins need to be added to the middleware
stack. However, this needs to occur prior to the middleware stack
being built. This is attainable by moving it into the main application
configuration logic.

This also includes an update to the sprockets manifest name that
appears to have changed with sprockets version updates. This means
that plugin assets and their manifests were not being loaded in
production environments.
