### PR TITLE
fixes #13297 - ssh_provision: try keyboard-interactive as well

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -46,9 +46,9 @@ module Orchestration::SSHProvision
     if compute_resource.respond_to?(:key_pair) and compute_resource.key_pair.try(:secret)
       credentials = { :key_data => [compute_resource.key_pair.secret] }
     elsif vm.respond_to?(:password) and vm.password.present?
-      credentials = { :password => vm.password, :auth_methods => ["password"] }
+      credentials = { :password => vm.password, :auth_methods => ["password", "keyboard-interactive"] }
     elsif image.respond_to?(:password) and image.password.present?
-      credentials = { :password => image.password, :auth_methods => ["password"] }
+      credentials = { :password => image.password, :auth_methods => ["password", "keyboard-interactive"] }
     else
       raise ::Foreman::Exception.new(N_('Unable to find proper authentication method'))
     end


### PR DESCRIPTION
With password auth try keyboard-interactive as well since (non PAM
based) password authentication might be disabled in sshd_config (as e.g.
on SLES12).
