### PR TITLE
Refs #13279 - checked_icon should use fa-check not png

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,7 +189,7 @@ module ApplicationHelper
   end
 
   def checked_icon(condition)
-    image_tag("toggle_check.png") if condition
+    icon_text('check', '', :kind => 'fa') if condition
   end
 
   def locked_icon(condition, hovertext)


### PR DESCRIPTION
toggle_check.png does not exist anymore and we can rely on the
font-awesome fa-check icon to display the check. Visit
provisioning_templates and see the Snippet column to see the icon.
