### PR TITLE
Fixes #13340 - Seed Fedora Atomic installation media

### DIFF
--- a/db/seeds.d/10-installation_media.rb
+++ b/db/seeds.d/10-installation_media.rb
@@ -6,6 +6,7 @@ Medium.without_auditing do
     { :name => "CentOS mirror", :os_family => "Redhat", :path => "http://mirror.centos.org/centos/$version/os/$arch" },
     { :name => "Debian mirror", :os_family => "Debian", :path => "http://ftp.debian.org/debian" },
     { :name => "Fedora mirror", :os_family => "Redhat", :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/" },
+    { :name => "Fedora Atomic mirror", :os_family => "Redhat", :path => "http://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/$arch/os/" },
     { :name => "FreeBSD mirror", :os_family => "Freebsd", :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$version-RELEASE/" },
     { :name => "OpenSUSE mirror", :os_family => "Suse", :path => "http://download.opensuse.org/distribution/$version/repo/oss", :operatingsystems => os_suse },
     { :name => "Ubuntu mirror", :os_family => "Debian", :path => "http://archive.ubuntu.com/ubuntu" },


### PR DESCRIPTION
Fedora Atomic now has a repository where you can get the isolinux stuff
from -https://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/x86_64/os/

This allows us to perform fully unattended installations through
foreman. Before, you would have to download the image and prepare your
own local installation media to PXE boot it
(http://blog.daniellobato.me/unattended-deployments-of-fedora-and-rhel-atomic-with-foreman/).

We still have a problem. The URL used for isolinux is completely
different from the URL `ostreesetup` in the Kickstart needs to pull the
ostree. That URL looks like this:
https://dl.fedoraproject.org/pub/fedora/linux/atomic/22/ , so using
`host.operatingsystem.medium_uri` in the Kickstart is out of question
(right?)

The problem is circumvented on the Kickstart [1] the best way I could
given the prior circumstances, we pass a parameter 'atomic-upstream' to
any hosts that you want to provision with upstream Atomic, but the
isolinux stuff had to be downloaded from the local installation media.
Should I change the kickstart to disregard that parameter and always use
the upstream URL now that we can? It'd mean people who want a local
installation media would have to change the Kickstart to take that into
account.

[1] -
https://github.com/theforeman/community-templates/blob/develop/kickstart/provision_atomic.erb#L21
