### PR TITLE
Fixes #13341 - Seeded Fedora installation media URL is wrong

### DIFF
--- a/db/seeds.d/10-installation_media.rb
+++ b/db/seeds.d/10-installation_media.rb
@@ -5,7 +5,7 @@ Medium.without_auditing do
   [
     { :name => "CentOS mirror", :os_family => "Redhat", :path => "http://mirror.centos.org/centos/$version/os/$arch" },
     { :name => "Debian mirror", :os_family => "Debian", :path => "http://ftp.debian.org/debian" },
-    { :name => "Fedora mirror", :os_family => "Redhat", :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Fedora/$arch/os/" },
+    { :name => "Fedora mirror", :os_family => "Redhat", :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/" },
     { :name => "FreeBSD mirror", :os_family => "Freebsd", :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$version-RELEASE/" },
     { :name => "OpenSUSE mirror", :os_family => "Suse", :path => "http://download.opensuse.org/distribution/$version/repo/oss", :operatingsystems => os_suse },
     { :name => "Ubuntu mirror", :os_family => "Debian", :path => "http://archive.ubuntu.com/ubuntu" },


### PR DESCRIPTION
Since Fedora 22, Fedora offers several flavors of its distribution. See
them at http://dl.fedoraproject.org/pub/fedora/linux/releases/22/

The old installation media URL that we seed doesn't cover this and 404s.
I chose to substitute it by Server.

Maybe we should have 'Fedora pets' (Server) and 'Fedora cattle' (Cloud)
:)
