### PR TITLE
Fixes #13343 - Compute resource network modal is misaligned

### DIFF
--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -7,24 +7,33 @@
                    :disabled => !new_host,
                    :onchange => 'libvirt_network_selected(this)',
                    :class => 'libvirt_network without_select2',
-                   :label_size => "col-md-2"
+                   :label_size => "col-md-3"
                  } %>
 
 <div id='nat' class='<%= 'hide' if f.object.type != 'network' %>'>
   <%= selectable_f f, :network, nat.map(&:name),
                    { :include_blank => nat.any? ? false : _("No networks") },
-                   { :class => "libvirt_nat without_select2", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_host), :label_size => "col-md-2" } %>
+                   { :class => "libvirt_nat without_select2", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_host), :label_size => "col-md-3" } %>
 </div>
 
 <div id='bridge' class='<%= 'hide' if f.object.type && (f.object.type != 'bridge') %>'>
   <% if bridge.any? %>
     <%= selectable_f f, :bridge, bridge.map(&:name),
                      { :include_blank => bridge.any? ? false : _("No bridges") },
-                     { :class => "libvirt_bridge without_select2", :label => _("Network"), :disabled => ((f.object.type && (f.object.type != 'bridge')) || !new_host), :label_size => "col-md-2" } %>
+                     { :class => "libvirt_bridge without_select2", :label => _("Network"), :disabled => ((f.object.type && (f.object.type != 'bridge')) || !new_host), :label_size => "col-md-3" } %>
   <% else %>
-    <%= text_f f, :bridge, :class => "libvirt_bridge", :label => _("Network"), :help_block => _("your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)"), :disabled => !new_host, :label_size => "col-md-2" %>
+    <%= text_f f, :bridge,
+      :class => "libvirt_bridge",
+      :label => _("Network"),
+      :help_inline => popover(
+        '',
+        _("Your libvirt host does not support interface listing, please enter here the bridge name (e.g. br0)"),
+        :rel => 'popover-modal'
+      ),
+      :disabled => !new_host,
+      :label_size => "col-md-3" %>
   <% end %>
 </div>
 
 <%= selectable_f f, :model, %w(virtio rtl8139 ne2k_pci pcnet e1000), {},
-                 { :label => _('NIC type'), :class => 'without_select2', :disabled => !new_host, :label_size => "col-md-2" } %>
+                 { :label => _('NIC type'), :class => 'without_select2', :disabled => !new_host, :label_size => "col-md-3" } %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -1,5 +1,5 @@
-<%= text_f f, :name, :disabled => !new_host, :class => "ovirt_name", :label => _('Name'), :label_size => "col-md-2" %>
+<%= text_f f, :name, :disabled => !new_host, :class => "ovirt_name", :label => _('Name'), :label_size => "col-md-3" %>
 <% selected_cluster ||= compute_resource.clusters.first.id %>
 <%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
              { }, :disabled => !new_host, :class => "ovirt_network without_select2",
-             :label         => _('Network'), :label_size => "col-md-2" %>
+             :label         => _('Network'), :label_size => "col-md-3" %>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,9 +1,9 @@
 <% networks = compute_resource.networks %>
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
-                 :class => "col-md-2 vmware_type without_select2",
-                 :label => _('NIC type'), :label_size => "col-md-2"
+                 :class => "col-md-3 vmware_type without_select2",
+                 :label => _('NIC type'), :label_size => "col-md-3"
 %>
 <%= select_f f, :network, networks, :name, :name, { },
-                 :class => "col-md-2 vmware_network without_select2",
-                 :label => _('Network'), :label_size => "col-md-2"
+                 :class => "col-md-3 vmware_network without_select2",
+                 :label => _('Network'), :label_size => "col-md-3"
 %>

--- a/app/views/nic/_provider_specific_form.html.erb
+++ b/app/views/nic/_provider_specific_form.html.erb
@@ -1,12 +1,12 @@
 <% if provider_partial_exist?(@host.compute_resource, 'network') %>
   <% hidden = f.object.virtual? ? "hidden" : "" %>
   <fieldset class="compute_attributes <%= hidden %>">
-    <h2>
+    <h3 class="col-md-offset-1">
       <%= @host.compute_resource.provider_friendly_name %>
       <% if f.object.compute_attributes["from_profile"] %>
         <span class="profile">( <%= _("from profile %s") % f.object.compute_attributes["from_profile"] %> )</span>
       <% end %>
-    </h2>
+    </h3>
     <%= f.fields_for 'compute_attributes', OpenStruct.new(f.object.compute_attributes) do |f| %>
       <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_host?(@host) %>
     <% end %>


### PR DESCRIPTION
Notice I also changed the help inline to be a popover, as per
Patternfly's recommendation -
https://www.patternfly.org/patterns/field-level-help/

Before: ![](http://i.imgur.com/tVokboI.png)
After fixing: ![](http://i.imgur.com/AJusnmF.png)
