### PR TITLE
fixes #13355 - facet test tables get created when tests run

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,7 @@ Spork.prefork do
   require 'factory_girl_rails'
   require 'capybara/poltergeist'
   require 'functional/shared/basic_rest_response_test'
+  require 'facet_test_helper'
 
   Capybara.register_driver :poltergeist do |app|
     opts = {

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'facet_test_helper'
 
 class TestFacet < HostFacets::Base
 end


### PR DESCRIPTION
moving the require to the test helper ensures that the code gets
evaluated before Spork.prefork, thus, the tables get created.
