### PR TITLE
Refs #12720 - Allow puppet CA cache to work for https proxies

### DIFF
--- a/app/services/proxy_status/base.rb
+++ b/app/services/proxy_status/base.rb
@@ -18,6 +18,15 @@ module ProxyStatus
       'Base'
     end
 
+    # Avoid marshalling @api as it may cause problems when caching https proxies.
+    def marshal_dump
+      [@proxy, @cache_duration, @cache]
+    end
+
+    def marshal_load(array)
+      @proxy, @cache_duration, @cache = array
+    end
+
     protected
 
     def api_class


### PR DESCRIPTION
When dumping CA certificates to cache, the status object is also dumped.
Since the status object points to the API resource, Marshal will try
dumping the API resource as well. This will fail for https proxies as
the SSL certificates cannot be dumped. This prevents the dumping of the
api link which will be recreated once the object is loaded back from
cache.
