### PR TITLE
fixes #13236 - apply power operations to several hosts at once

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -14,7 +14,8 @@ class HostsController < ApplicationController
                         submit_multiple_build multiple_disable submit_multiple_disable
                         multiple_enable submit_multiple_enable multiple_puppetrun
                         update_multiple_puppetrun multiple_disassociate update_multiple_disassociate
-                        rebuild_config submit_rebuild_config select_multiple_owner update_multiple_owner)
+                        rebuild_config submit_rebuild_config select_multiple_owner update_multiple_owner
+                        select_multiple_power_state update_multiple_power_state)
 
   add_smart_proxy_filters PUPPETMASTER_ACTIONS, :features => ['Puppet']
 
@@ -27,6 +28,7 @@ class HostsController < ApplicationController
   before_filter :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_filter :set_host_type, :only => [:update]
   before_filter :find_multiple, :only => MULTIPLE_ACTIONS
+  before_filter :validate_update_multiple_power_state, :only => :update_multiple_power_state
   helper :hosts, :reports, :interfaces
 
   def index(title = nil)
@@ -431,6 +433,31 @@ class HostsController < ApplicationController
     redirect_back_or_to hosts_path
   end
 
+  def select_multiple_power_state
+  end
+
+  def validate_update_multiple_power_state
+    if (params[:power].nil?) or (action=params[:power][:action]).nil? or !PowerManager::REAL_ACTIONS.include?(action)
+      error _('No or invalid power state selected!')
+      redirect_to(select_multiple_power_state_hosts_path) and return false
+    end
+  end
+
+  def update_multiple_power_state
+    action = params[:power][:action]
+    @hosts.each do |host|
+      begin
+        host.power.send(action.to_sym) if host.supports_power?
+      rescue => error
+        message = _('Failed to set power state for %s.') % host
+        Foreman::Logging.exception(message, error)
+      end
+    end
+
+    notice _('The power state of the selected hosts will be set to %s') % _(action)
+    redirect_back_or_to hosts_path
+  end
+
   def multiple_destroy
   end
 
@@ -653,7 +680,8 @@ class HostsController < ApplicationController
           'update_multiple_organization', 'select_multiple_organization',
           'update_multiple_location', 'select_multiple_location',
           'disassociate', 'update_multiple_disassociate', 'multiple_disassociate',
-          'select_multiple_owner', 'update_multiple_owner'
+          'select_multiple_owner', 'update_multiple_owner',
+          'select_multiple_power_state', 'update_multiple_power_state'
         :edit
       when 'multiple_destroy', 'submit_multiple_destroy'
         :destroy

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -159,7 +159,8 @@ module HostsHelper
       [_('Disable Notifications'), multiple_disable_hosts_path],
       [_('Enable Notifications'), multiple_enable_hosts_path],
       [_('Disassociate Hosts'), multiple_disassociate_hosts_path],
-      [_('Rebuild Config'), rebuild_config_hosts_path]
+      [_('Rebuild Config'), rebuild_config_hosts_path],
+      [_('Change Power State'), select_multiple_power_state_hosts_path]
     ]
     actions.insert(1, [_('Build Hosts'), multiple_build_hosts_path]) if SETTINGS[:unattended]
     actions <<  [_('Run Puppet'), multiple_puppetrun_hosts_path] if Setting[:puppetrun]
@@ -353,7 +354,7 @@ module HostsHelper
               )
             end
         ),
-        if host.compute_resource_id || host.bmc_available?
+        if host.supports_power?
           button_group(
               link_to(_("Loading power state ..."), '#', :disabled => true, :id => :loading_power_state)
           )

--- a/app/models/concerns/hostext/power_interface.rb
+++ b/app/models/concerns/hostext/power_interface.rb
@@ -1,0 +1,28 @@
+module Hostext
+  module PowerInterface
+    extend ActiveSupport::Concern
+
+    def power
+      opts = {:host => self}
+      if compute_resource_id && uuid
+        PowerManager::Virt.new(opts)
+      elsif bmc_available?
+        PowerManager::BMC.new(opts)
+      else
+        raise ::Foreman::Exception.new(N_("Unknown power management support - can't continue"))
+      end
+    end
+
+    def supports_power?
+      compute_resource_id || bmc_available?
+    end
+
+    def supports_power_and_running?
+      return false unless supports_power?
+      power.ready?
+      # return false if the proxyapi/bmc raised an error (and therefore do not know if power is supported)
+    rescue ProxyAPI::ProxyException
+      false
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,5 +1,6 @@
 class Host::Managed < Host::Base
   include Hostext::Search
+  include Hostext::PowerInterface
   include SelectiveClone
   include HostParams
   include Facets::ManagedHostExtensions
@@ -771,25 +772,6 @@ class Host::Managed < Host::Base
     ipmi = bmc_nic
     return false if ipmi.nil?
     ipmi.password.present? && ipmi.username.present? && ipmi.provider == 'IPMI'
-  end
-
-  def power
-    opts = {:host => self}
-    if compute_resource_id && uuid
-      PowerManager::Virt.new(opts)
-    elsif bmc_available?
-      PowerManager::BMC.new(opts)
-    else
-      raise ::Foreman::Exception.new(N_("Unknown power management support - can't continue"))
-    end
-  end
-
-  def supports_power_and_running?
-    return false unless compute_resource_id || bmc_available?
-    power.ready?
-    # return false if the proxyapi/bmc raised an error (and therefore do not know if power is supported)
-  rescue ProxyAPI::ProxyException
-    false
   end
 
   def ipmi_boot(booting_device)

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -358,6 +358,7 @@ Foreman::AccessControl.map do |permission_set|
                                                :select_multiple_organization, :update_multiple_organization,
                                                :disassociate, :multiple_disassociate, :update_multiple_disassociate,
                                                :select_multiple_owner, :update_multiple_owner,
+                                               :select_multiple_power_state, :update_multiple_power_state,
                                                :select_multiple_location, :update_multiple_location].push(*ajax_actions),
                                     :compute_resources => [:associate].push(cr_ajax_actions),
                                     :compute_resources_vms => [:associate],

--- a/app/services/power_manager.rb
+++ b/app/services/power_manager.rb
@@ -1,4 +1,6 @@
 module PowerManager
   SUPPORTED_ACTIONS = [N_('start'), N_('stop'), N_('poweroff'), N_('reboot'), N_('reset'), N_('state'),
                        N_('on'), N_('off'), N_('soft'), N_('cycle'), N_('status'), N_('ready?')]
+
+  REAL_ACTIONS = [N_('start'), N_('stop'), N_('poweroff'), N_('reboot'), N_('reset'), N_('soft'), N_('cycle')]
 end

--- a/app/views/hosts/select_multiple_power_state.html.erb
+++ b/app/views/hosts/select_multiple_power_state.html.erb
@@ -1,0 +1,11 @@
+<%= render 'selected_hosts', :hosts => @hosts %>
+
+<%= form_for :power, :url => update_multiple_power_state_hosts_path(:host_ids => params[:host_ids]) do |f| %>
+  <%= selectable_f f,
+    :action,
+    [[_("Select desired state"), "disabled"]] +
+    PowerManager::REAL_ACTIONS.map { |a| [_(a.to_s.capitalize), a] },
+    {},
+    { :onchange => "toggle_multiple_ok_button(this)" }
+  %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,8 @@ Foreman::Application.routes.draw do
         post 'update_multiple_environment'
         get 'select_multiple_owner'
         post 'update_multiple_owner'
+        get 'select_multiple_power_state'
+        post 'update_multiple_power_state'
         get 'multiple_puppetrun'
         post 'update_multiple_puppetrun'
         get 'multiple_destroy'

--- a/test/unit/host_power_interface_test.rb
+++ b/test/unit/host_power_interface_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class HostPowerInterfaceTest < ActiveSupport::TestCase
+  test "#supports_power? should return true with compute resource" do
+    host = FactoryGirl.build(:host, :on_compute_resource)
+    host.unstub(:queue_compute)
+    assert host.supports_power?
+  end
+
+  test "#supports_power? should return false without compute resource" do
+    host = FactoryGirl.build(:host)
+    refute host.supports_power?
+  end
+
+  test "#supports_power_and_running? should return true with compute resource and power ready" do
+    power_mock = mock('power')
+    power_mock.stubs(:ready?).returns(true)
+    host = FactoryGirl.build(:host, :on_compute_resource)
+    host.unstub(:queue_compute)
+    host.stubs(:power).returns(power_mock)
+    assert host.supports_power_and_running?
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -153,20 +153,6 @@ class HostTest < ActiveSupport::TestCase
     assert_equal host.vm_compute_attributes, :cpus => 4
   end
 
-  test "#supports_power_and_running should return true with compute resource" do
-    power_mock = mock('subnet')
-    power_mock.stubs(:ready?).returns(true)
-
-    host = FactoryGirl.build(:host, :compute_resource => compute_resources(:ec2))
-    host.stubs(:power).returns(power_mock)
-    assert host.supports_power_and_running?
-  end
-
-  test "#supports_power_and_running should return false without compute resource" do
-    host = FactoryGirl.build(:host)
-    refute host.supports_power_and_running?
-  end
-
   test "fetches nil vm compute attributes for bare metal" do
     host = FactoryGirl.create(:host)
     assert_equal host.vm_compute_attributes, nil


### PR DESCRIPTION
This commit adds the ability to select multiple hosts and apply power operations
(reboot, shutdown, boot) to them.
