### PR TITLE
Fixes #13401 - ssh_provision: safe stderr as well

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -53,7 +53,7 @@ class Foreman::Provision::SSH
   def command
     # Use the users home to store the provision script since we can't reliably
     # tell if other locations are writeable or executable by the user.
-    "#{command_prefix} bash -c '(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script}) | tee #{remote_script}.log; exit ${PIPESTATUS[0]}'"
+    "#{command_prefix} bash -c '(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script}) 2>&1 | tee #{remote_script}.log; exit ${PIPESTATUS[0]}'"
   end
 
   def defaults


### PR DESCRIPTION
The log file currently only gets stdout which leaves only guessing when
looking for provision errors.
