### PR TITLE
Fixes #13424 - Add Patternfly donut chart as a React component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,9 @@
 //= require jquery
 //= require jquery.turbolinks
 //= require turbolinks
+//= require react
+//= require react_ujs
+//= require components
 //= require i18n
 //= require jquery_ujs
 //= require jquery.ui.autocomplete
@@ -25,6 +28,9 @@
 //= require underscore
 //= require editor
 //= require lookup_keys
+//= require d3
+//= require c3
+//= require patternfly
 
 window.foreman = window.foreman || {};
 foreman.tools = foreman.tools || {};

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,0 +1,1 @@
+//= require_tree ./components

--- a/app/assets/javascripts/components/donut_chart.js.jsx
+++ b/app/assets/javascripts/components/donut_chart.js.jsx
@@ -1,0 +1,87 @@
+var DonutChart = React.createClass({
+  displayName: 'DonutChart',
+  /*
+     Creates a donut chart using c3 -
+     see https://www.patternfly.org/patterns/donut-chart/
+
+     [+id+] - ID for the element where the chart is rendered
+     [+className] - CSS class(es) to be applied to the div where the chart is rendered
+     [+columns+] - Array of tuples containing label, value. Values must sum 100%
+     e.g. ['success', 40], ['failed', 60]
+     [+groups+] - Set groups for the data for stacking.
+     e.g. [['dataa', 'datab'],['datac']]
+     [+colors+] - Array of HEX color codes for each group.
+     Defaults to Patternfly palette.
+  */
+
+  propTypes: {
+    className: React.PropTypes.string,
+    colors: React.PropTypes.arrayOf(React.PropTypes.string),
+    columns: React.PropTypes.arrayOf(React.PropTypes.array).isRequired,
+    groups: React.PropTypes.arrayOf(React.PropTypes.array),
+    id: React.PropTypes.string.isRequired
+  },
+
+  getDefaultProps: function() {
+    return {
+      className: 'col-md-3',
+      colors: ['#3F9C35', '#C00', '#D1D1D1', '#EC7A08']
+    };
+  },
+
+  componentDidMount: function() {
+    this.generateDonutChart();
+  },
+
+  maxPercentage: function(columns) {
+    var values = columns.map(function(subarray) { return subarray[1] });
+    var max = Math.max.apply(Math, values);
+    var sum = values.reduce(function(prev, curr) { return prev + curr });
+    return Math.round(100 * max / sum);
+  },
+
+  maxLabel: function(columns) {
+    var original = 0;
+    var values = columns.map(function(subarray) { return subarray[1] });
+    var max = Math.max.apply(Math, values);
+    return columns[values.indexOf(max)][0].toLowerCase();
+  },
+
+  generateDonutChart: function() {
+    var donutChartConfig = jQuery().c3ChartDefaults().getDefaultDonutConfig();
+    donutChartConfig.bindto = '#' + this.chart_target.id;
+    donutChartConfig.data = {
+      type: "donut",
+      columns: this.props.columns,
+      groups: this.props.groups,
+      order: null
+    };
+    donutChartConfig.color = this.props.colors;
+    donutChartConfig.tooltip = {
+      contents: function (d) {
+        return '<span class="donut-tooltip-pf" style="white-space: nowrap;">' +
+          Math.round(d[0].ratio * 100) + '% ' + d[0].name +
+            '</span>';
+      }
+    };
+    c3.generate(donutChartConfig);
+
+    var donutChartTitle = d3.select(this.chart_target).select('text.c3-chart-arcs-title');
+    donutChartTitle.text("");
+    donutChartTitle.insert('tspan').text(this.maxPercentage(this.props.columns) + '%')
+    .classed('donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
+    donutChartTitle.insert('tspan').text(this.maxLabel(this.props.columns))
+    .classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+  },
+
+  render: function() {
+    return (
+        <div>
+            <div className={this.props.className}
+                 id={this.props.id}
+                 ref={c => this.chart_target = c}
+            />
+        </div>
+    );
+  },
+});

--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -1,4 +1,5 @@
 @import "mixin";
+@import "c3";
 
 .stats-well {
  border: 1px solid #d7d7d7;

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -1,15 +1,38 @@
 module StatisticsHelper
   def charts
-    options = {:class => "statistics-pie small", :expandable => true, :'border' => 0, :show_title => true}
-    [
-      flot_pie_chart("os_dist",_("OS Distribution"), @os_count, options.merge(:search => "os_title=~VAL~")),
-      flot_pie_chart("arch_dist",_("Architecture Distribution"), @arch_count, options.merge( :search => "facts.architecture=~VAL~")),
-      flot_pie_chart("env_dist",_("Environments Distribution"), @env_count, options.merge( :search => "environment=~VAL~" )),
-      flot_pie_chart("cpu_num",_("Number of CPUs"), @cpu_count,options.merge( :search => "facts.processorcount=~VAL1~")),
-      flot_pie_chart("hardware",_("Hardware"), @model_count, options.merge( :search => "facts.manufacturer~~VAL~")),
-      flot_pie_chart("class_dist",_("Class Distribution"), @klass_count, options.merge( :search => "class=~VAL~")),
-      flot_pie_chart("mem_usage",_("Average memory usage"), [{:label=>_("free memory"), :data=>@mem_free},{:label=>_("used memory"),:data=>@mem_size-@mem_free}], options),
-      flot_pie_chart("swap_usage",_("Average swap usage"), [{:label=>_("free swap"), :data=>@swap_free},{:label=>_("used swap"), :data=>@swap_size-@swap_free}], options)
-    ]
+    { :os => @os_count, :arch => @arch_count, :env => @env_count,
+      :cpu => @cpu_count, :hardware => @model_count,
+      :class_dist => @klass_count,
+      :mem_usage => [ { :label => _("free memory"), :data => @mem_free },
+                      { :label => _("used memory"), :data => used_memory } ],
+      :swap_usage => [ { :label => _("free swap"), :data => @swap_free },
+                       { :label => _("used swap"), :data => used_swap } ]
+    }
+  end
+
+  def chart_names(chart)
+    extract_label = ->(c) { c[:label] }
+    chart.map(&extract_label)
+  end
+
+  def chart_name_data(chart)
+    chart.map(&:values)
+  end
+
+  def render_charts
+    charts.map do |selector, chart|
+      react_component('DonutChart',
+                      :columns => chart_name_data(chart),
+                      :groups => [chart_names(chart)],
+                      :id => selector.to_s)
+    end.join("\n").html_safe
+  end
+
+  def used_memory
+    @mem_size - @mem_free
+  end
+
+  def used_swap
+    @swap_size - @swap_free
   end
 end

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,6 +1,4 @@
 <% title _("Statistics"), _('Statistics') %>
 <div id="statistics">
-<% charts.each do |ch| %>
-  <%= content_tag(:div, ch, :class=>"stats-well") %>
-<% end %>
+  <%= render_charts %>
 </div>

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -15,4 +15,8 @@ gem 'uglifier', '>= 1.0.3'
 gem 'sass-rails', '~> 5.0'
 gem 'spice-html5-rails', '~> 0.1.5'
 gem 'quiet_assets', '~> 1.0'
+# Pinned until https://github.com/reactjs/react-rails/issues/431 is resolved
+gem 'react-rails', '1.4.1'
+gem 'c3-rails', '~> 0.4'
+gem 'd3-rails', '~> 3.5'
 gem 'jquery_pwstrength_bootstrap_4', :require => 'jquery_pwstrength_bootstrap'

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -12,4 +12,5 @@ group :development do
 
   gem 'bullet'
   gem "parallel_tests"
+  gem 'jasmine-rails'
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -18,4 +18,5 @@ group :test do
   gem 'test_after_commit', '~> 0.4'
   gem 'shoulda-matchers', '2.8.0'
   gem 'shoulda-context', '~> 1.2'
+  gem 'jasmine-rails'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -220,3 +220,9 @@ module Foreman
     puts "For some operations a user must be set, try User.current = User.first"
   end
 end
+
+module ReactTesting
+  class Application < Rails::Application
+    config.react.addons = true
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,5 +48,7 @@ Foreman::Application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end if defined?(Bullet)
+
+  config.react.variant = :development
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,6 @@ Foreman::Application.configure do |app|
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.react.variant = :production
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,8 @@ Foreman::Application.configure do |app|
   # Rails.application.config.assets.precompile += %w( search.js )
 
   #  config.assets.precompile += %w()
-  javascript = %w(compute_resource
+  javascript = %w(components/*
+                  compute_resource
                   compute_resources/libvirt/nic_info
                   compute_resources/ovirt/nic_info
                   compute_resources/vmware/nic_info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 require 'api_constraints'
 
 Foreman::Application.routes.draw do
+  mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   resources :mail_notifications, :only => [] do
     collection do
       get 'auto_complete_search'

--- a/spec/javascripts/components/donut_chart_spec.js.jsx
+++ b/spec/javascripts/components/donut_chart_spec.js.jsx
@@ -1,0 +1,23 @@
+describe('DonutChart', function () {
+  beforeEach(function() {
+    mockColumns = [['a', 35], ['b', 15]]
+  });
+
+  it('renders a div with the passed id', function() {
+    const donut_element = React.createElement(
+      DonutChart,
+      {columns: mockColumns, id: 'test_chart'}
+    );
+    shallowRenderer.render(donut_element);
+    const component = shallowRenderer.getRenderOutput();
+    expect(component.props.children.props.id).toEqual('test_chart')
+  });
+
+  it('computes the maximum percentage from the column variables', function() {
+    expect(DonutChart.prototype.maxPercentage(mockColumns)).toEqual(70);
+  });
+
+  it('computes the label for the maximum percentage', function() {
+    expect(DonutChart.prototype.maxLabel(mockColumns)).toEqual('a');
+  });
+});

--- a/spec/javascripts/helpers/react_helper.js
+++ b/spec/javascripts/helpers/react_helper.js
@@ -1,0 +1,2 @@
+const TestUtils = React.addons.TestUtils
+const shallowRenderer = TestUtils.createRenderer();

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,50 @@
+# path to parent directory of src_files
+# relative path from Rails.root
+# defaults to app/assets/javascripts
+src_dir: "app/assets/javascripts"
+
+# path to additional directory of source file that are not part of assets pipeline and need to be included
+# relative path from Rails.root
+# defaults to []
+# include_dir:
+#   - ../mobile_app/public/js
+
+# path to parent directory of css_files
+# relative path from Rails.root
+# defaults to app/assets/stylesheets
+css_dir: "app/assets/stylesheets"
+
+# list of file expressions to include as source files
+# relative path from src_dir
+src_files:
+  - "application.{js,js.jsx}"
+
+# list of file expressions to include as css files
+# relative path from css_dir
+css_files:
+
+# path to parent directory of spec_files
+# relative path from Rails.root
+#
+# Alternatively accept an array of directory to include external spec files
+# spec_dir:
+#   - spec/javascripts
+#   - ../engine/spec/javascripts
+#
+# defaults to spec/javascripts
+spec_dir: spec/javascripts
+
+# list of file expressions to include as helpers into spec runner
+# relative path from spec_dir
+helpers:
+  - "helpers/**/*.{js.coffee,js,coffee}"
+
+# list of file expressions to include as specs into spec runner
+# relative path from spec_dir
+spec_files:
+  - "**/*[Ss]pec.{js.jsx,js,jsx}"
+
+# path to directory of temporary files
+# (spec runner and asset cache)
+# defaults to tmp/jasmine
+tmp_dir: "tmp/jasmine"


### PR DESCRIPTION
Our donut charts do not look like they should in Patternfly.
https://www.patternfly.org/patterns/donut-chart/ uses c3, so we can do
that too.

![screenshot from 2016-01-28 08-57-38](https://cloud.githubusercontent.com/assets/598891/12638605/debc6888-c59e-11e5-9ebb-f742da1fa7bc.png)

Eventually I want to remove flot_pies too, but I have to yet figure out
how to auto refresh donut charts.
Adding this library also will allow us to change our charts in Host#show
to the newer style. https://www.patternfly.org/widgets/#basic-charts

My idea is (if this gets merged) to:

1) Enforce new javascript functionality to be written as reusable React components _with tests_
2) Ask @patternfly to create a react-patternfly repository where we store components for Patternfly. That way we can both help them popularize the project within the React community and we might get contributors, help, etc..  We would use a `react-patternfly-rails` gem that puts the components in the Rails assets pipeline, and only the Foreman specific JS would live in our repo.
3) Ensure Jenkins tests Javascript in Foreman and runs ESLint (think rubocop for js) on it.

Test this by calling `rake spec:javascript`or by going to localhost:3000/specs
