### PR TITLE
Fixes #13426 - Change status colors to adapt to Patternfly palette

### DIFF
--- a/app/assets/stylesheets/status-colors.scss
+++ b/app/assets/stylesheets/status-colors.scss
@@ -1,11 +1,11 @@
 .status-ok {
-  color: #5CB85C;
+  color: $brand-success;
 }
 
 .status-error {
-  color: #D9534F
+  color: $brand-danger;
 }
 
 .status-warn, .status-question {
-  color: #DB843D;
+  color: $brand-warning;
 }


### PR DESCRIPTION
The status colors are a bit off from the colors suggested in the palette.
https://www.patternfly.org/styles/color-palette/
