### PR TITLE
fixes #12669 - making sure that code which requires a new attribute doesn't break migrations

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -219,6 +219,9 @@ module HostCommon
   protected
 
   def set_lookup_value_matcher
+    #in migrations, this method can get called before the attribute exists
+    #the #attribute_names method is cached, so it's not going to be a performance issue
+    return true unless self.class.attribute_names.include?("lookup_value_matcher")
     self.lookup_value_matcher = lookup_value_match
   end
 


### PR DESCRIPTION
the lookup_value_matcher attribute code adds a callback which expects
the attribute to exist, but when upgrading foreman, this can be a bit of
an issue, when db:migrate touches existing hosts/hostgroups, and the
attribute hasn't been added yet. Bottom line - adding a simple (cached)
check for the attribute's existence, which solves this issue.
