### PR TITLE
fixes #13440 - rename Host#model_name to #hardware_model_name

### DIFF
--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -78,15 +78,16 @@ module HasManyCommon
 
     def belongs_to_name_for(association, options)
       assoc = association.to_s.tableize.singularize
+      assoc_name = options.delete(:name_accessor) || "#{assoc}_name"
 
       # SETTER _name= method
-      define_method "#{assoc}_name=" do |name_value|
+      define_method "#{assoc_name}=" do |name_value|
         assoc_id = assoc_klass(association).send("find_by_#{assoc_klass(association).attribute_name}", name_value).id
         self.send("#{assoc}_id=", assoc_id)
       end
 
       # GETTER _name method
-      define_method "#{assoc}_name" do
+      define_method assoc_name do
         assoc_id = self.send("#{assoc}_id")
         assoc_klass(association).find_by_id(assoc_id).try(:name_method)
       end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -10,7 +10,7 @@ extends "api/v2/hosts/base"
 attributes :ip, :environment_id, :environment_name, :last_report, :mac, :realm_id, :realm_name,
            :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
            :subnet_id, :subnet_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
-           :comment, :disk, :installed_at, :model_id, :model_name, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
+           :comment, :disk, :installed_at, :model_id, :hostgroup_id, :hostgroup_name, :owner_id, :owner_type,
            :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
            :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
@@ -20,6 +20,9 @@ attributes :location_id, :location_name         if SETTINGS[:locations_enabled]
 
 # to avoid deprecation warning on puppet_status method
 attributes :configuration_status => :puppet_status
+
+# to avoid renaming model_name to match accessors
+attributes :hardware_model_name => :model_name
 
 HostStatus.status_registry.each do |status_class|
   attributes "#{status_class.humanized_name}_status", "#{status_class.humanized_name}_status_label", :if => @object.get_status(status_class).relevant?

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -76,6 +76,16 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert !show_response.empty?
   end
 
+  test 'should show host with model name' do
+    model = FactoryGirl.create(:model)
+    @host.update_attribute(:model_id, model.id)
+    get :show, { :id => @host.to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal model.id, show_response['model_id']
+    assert_equal model.name, show_response['model_name']
+  end
+
   test "should create host" do
     disable_orchestration
     assert_difference('Host.count') do

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2866,6 +2866,42 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test 'model_name calls hardware_model_name with deprecation' do
+    host = FactoryGirl.build(:host)
+    Foreman::Deprecation.expects(:deprecation_warning).with(anything, regexp_matches(/model_name/))
+    host.expects(:hardware_model_name).returns('foo')
+    assert_equal 'foo', host.model_name
+  end
+
+  test 'model_name= calls hardware_model_name= with deprecation' do
+    host = FactoryGirl.build(:host)
+    Foreman::Deprecation.expects(:deprecation_warning).with(anything, regexp_matches(/model_name=/))
+    host.expects(:hardware_model_name=).with('foo')
+    host.model_name = 'foo'
+  end
+
+  test 'hardware_model_name= sets model_id by name' do
+    model = FactoryGirl.create(:model)
+    host = FactoryGirl.build(:host)
+    Foreman::Deprecation.expects(:deprecation_warning).never
+    host.hardware_model_name = model.name
+    assert_equal model.id, host.model_id
+  end
+
+  test '.new handles model_name without deprecation warning' do
+    model = FactoryGirl.create(:model)
+    Foreman::Deprecation.expects(:deprecation_warning).never
+    assert_equal model.id, Host::Managed.new(:model_name => model.name).model_id
+  end
+
+  test 'hardware_model_id= is aliased to model_id' do
+    host = FactoryGirl.build(:host)
+    Foreman::Deprecation.expects(:deprecation_warning).never
+    host.hardware_model_id = 42
+    assert_equal 42, host.model_id
+    assert_equal 42, host.hardware_model_id
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
Rails 4.2 defines a model_name instance method which is used in routing
and called from link_to.  Rename our model_name methods to
hardware_model_name to prevent this overlapping and causing link_to
failures.

Host#hardware_model_name is provided as an equivalent getter to replace
it, and the #model_name= getter/setters are provided but are deprecated.
The deprecation period has been brought forward one release from the
usual, so as not to block an upgrade to Rails 4.2.
