### PR TITLE
fixes #13437 Bookmarks public attribute set to required

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -13,6 +13,7 @@ class Bookmark < ActiveRecord::Base
   validates :name, :uniqueness => {:scope => :controller}, :unless => Proc.new{|b| Bookmark.my_bookmarks.where(:name => b.name).empty?}
   validates :name, :query, :presence => true
   validates :controller, :presence => true, :no_whitespace => true, :bookmark_controller => true
+  validates :public, inclusion: { in: [true, false] }
   default_scope -> { order(:name) }
   before_validation :set_default_user
 

--- a/db/migrate/20160203110216_add_default_value_for_bookmark_public_field.rb
+++ b/db/migrate/20160203110216_add_default_value_for_bookmark_public_field.rb
@@ -1,0 +1,10 @@
+class AddDefaultValueForBookmarkPublicField < ActiveRecord::Migration
+  def up
+    Bookmark.where(:public => nil).update_all(:public => false)
+    change_column :bookmarks, :public, :boolean, :default => false, :null => false
+  end
+
+  def down
+    change_column :bookmarks, :public, :boolean, :default => true
+  end
+end

--- a/test/unit/bookmark_test.rb
+++ b/test/unit/bookmark_test.rb
@@ -42,4 +42,12 @@ class BookmarkTest < ActiveSupport::TestCase
     b = FactoryGirl.build(:bookmark, :name => 'My plugin controller', :controller => 'my_plugins', :query => 'foo=bar', :public => true)
     assert(b.valid?, 'plugin controller bookmark should be valid')
   end
+
+  test "public should default to false" do
+    bookmark = Bookmark.new({:name => "private", :query => "bar", :controller => "hosts"})
+    assert_equal(false, bookmark.public)
+    assert bookmark.valid?
+    bookmark.public = nil
+    refute bookmark.valid?
+  end
 end


### PR DESCRIPTION
Fixes a bug where `public` attribute was not required during a creation of a new bookmark, resulting in saving the AR with `public: null`.
The patch makes the `public` attribute mandatory in the POST request
