### PR TITLE
fixes #13494 - change puppet proxy for several hosts at once

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -167,6 +167,7 @@ module HostsHelper
     actions <<  [_('Assign Organization'), select_multiple_organization_hosts_path] if SETTINGS[:organizations_enabled]
     actions <<  [_('Assign Location'), select_multiple_location_hosts_path] if SETTINGS[:locations_enabled]
     actions <<  [_('Change Owner'), select_multiple_owner_hosts_path] if SETTINGS[:login]
+    actions <<  [_('Change Puppet Master'), select_multiple_puppet_proxy_hosts_path] if SmartProxy.unscoped.with_features("Puppet").count > 0
     actions
   end
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -359,6 +359,7 @@ Foreman::AccessControl.map do |permission_set|
                                                :disassociate, :multiple_disassociate, :update_multiple_disassociate,
                                                :select_multiple_owner, :update_multiple_owner,
                                                :select_multiple_power_state, :update_multiple_power_state,
+                                               :select_multiple_puppet_proxy, :update_multiple_puppet_proxy,
                                                :select_multiple_location, :update_multiple_location].push(*ajax_actions),
                                     :compute_resources => [:associate].push(cr_ajax_actions),
                                     :compute_resources_vms => [:associate],

--- a/app/views/hosts/select_multiple_puppet_proxy.html.erb
+++ b/app/views/hosts/select_multiple_puppet_proxy.html.erb
@@ -1,0 +1,12 @@
+<%= render 'selected_hosts', :hosts => @hosts %>
+
+<%= form_for :puppet, :url => update_multiple_puppet_proxy_hosts_path(:host_ids => params[:host_ids]) do |f| %>
+  <%= selectable_f f,
+    :puppet_proxy_id,
+    [[_("Select desired puppet master"), "disabled"]] +
+    [[_("*Clear puppetmaster*"), "" ]] +
+    SmartProxy.with_features("Puppet").map {|p| [p.name, p.id]},
+    {},
+    { :onchange => "toggle_multiple_ok_button(this)" }
+  %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Foreman::Application.routes.draw do
         post 'update_multiple_owner'
         get 'select_multiple_power_state'
         post 'update_multiple_power_state'
+        get 'select_multiple_puppet_proxy'
+        post 'update_multiple_puppet_proxy'
         get 'multiple_puppetrun'
         post 'update_multiple_puppetrun'
         get 'multiple_destroy'


### PR DESCRIPTION
This commit adds the possibility to select multiple
hosts and change the puppet proxy for them.
