### PR TITLE
Fixes #13442 - foreman-debug exits with 0 on success

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -196,6 +196,9 @@ done
 
 [ $UPLOAD -eq 1 -a $NOTAR -eq 1 ] && error "Options -u and -a cannot be used together" && exit 2
 
+# some tasks take long time, print a banner (unless quiet mode was selected)
+qprintf "Processing... (takes a while)"
+
 # determine distribution family
 if [ -f /etc/debian_version ]; then
     OS=debian
@@ -340,3 +343,5 @@ if [ $UPLOAD_DISABLED -eq 0 -a $UPLOAD -eq 1 ]; then
 else
   [[ $UPLOAD_DISABLED -eq 0 ]] && qprintf "To upload a tarball to our secure site, please use the -u option.\n"
 fi
+
+exit 0


### PR DESCRIPTION
Small fix - when `UPLOAD_DISABLED` is set it returned 1.
