### PR TITLE
WIP - disable gettext domain for test env

### DIFF
--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -7,6 +7,9 @@ locale_domain = 'foreman'
 Foreman::Gettext::Support.register_available_locales locale_domain, locale_dir
 Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
 
+# this prevents from reading 'en' translations in test environment
+locale_domain = 'foreman_test' if Rails.env.test?
+
 I18n.config.enforce_available_locales = false
 I18n.config.available_locales = FastGettext.default_available_locales
 


### PR DESCRIPTION
For unknown reason, integration tests fail to find some page elements which are
translated in 'en' localization (e.g. Hostgroup vs Host group). We apparently
rely on base (key) strings while it's being localized. Such a test is:

``` ruby
    test 'parameters change after parent update' do
      group = FactoryGirl.create(:hostgroup)
      group.group_parameters << GroupParameter.create(:name => "x", :value => "original")
      child = FactoryGirl.create(:hostgroup)

      visit clone_hostgroup_path(child)
      assert page.has_link?('Parameters', :href => '#params')
      click_link 'Parameters'
      assert page.has_no_selector?("#inherited_parameters #name_x")

      click_link 'Hostgroup' # HERE IT FAILS - the page contains "Host group"
      select2(group.name, :from => 'hostgroup_parent_id')
      wait_for_ajax

      click_link 'Parameters'
      assert page.has_selector?("#inherited_parameters #name_x")
    end
```

This patch is for discussion. I don't know what causes this, the admin users
should come from fixtures and it has no locale set (it's `nil` - I have tested
that). When I put breakpoints in the test, I see the current user does not have
a locale set. I can't tell what causes this translation.
