### PR TITLE
fixes #11346 - on new host, nic shouldn't try to call matcher

### DIFF
--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -86,6 +86,7 @@ module Nic
     def update_lookup_value_fqdn_matchers
       return unless primary?
       return unless fqdn_changed?
+      return unless host.present?
       LookupValue.where(:match => "fqdn=#{fqdn_was}").update_all(:match => host.send(:lookup_value_match))
     end
 


### PR DESCRIPTION
there's no point in doing the call anyway (can, theoretically, use the
fqdn field instead of asking the host) because there shouldn't be any
lookup keys with that host's fqdn, as it's a new host.
also, fqdn_was is an empty string in that case
