### PR TITLE
Fixes #13557 - Rubocop enforce specifying a timezone

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,11 +143,6 @@ Rails/PluralizationGrammar:
 Rails/ReadWriteAttribute:
   Enabled: false
 
-# Offense count: 48
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Rails/TimeZone:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,14 +21,14 @@ class HomeController < ApplicationController
 
   # check for exception - set the result code and duration time
   def exception_watch(&block)
-    start = Time.now
+    start = Time.now.utc
     result = {}
     begin
       yield
       result[:result] = 'ok'
       result[:status] = :ok
       result[:version] = SETTINGS[:version].full
-      result[:db_duration_ms] = ((Time.now - start) * 1000).round.to_s
+      result[:db_duration_ms] = ((Time.now.utc - start) * 1000).round.to_s
     rescue => e
       result[:result] = 'fail'
       result[:status] = :internal_server_error

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -27,7 +27,7 @@ module TrendsHelper
     end
   end
 
-  def chart_data(trend, from = Setting.max_trend, to = Time.zone.now)
+  def chart_data(trend, from = Setting.max_trend, to = Time.now.utc)
     chart_colors = ['#4572A7','#AA4643','#89A54E','#80699B','#3D96AE','#DB843D','#92A8CD','#A47D7C','#B5CA92']
     values = trend.values
     labels = {}
@@ -39,7 +39,7 @@ module TrendsHelper
       value.trend_counters.each do |counter|
         #cut the left side of the graph
         interval_start = (counter.interval_start || from) > from ? counter.interval_start : from
-        next_timestamp = counter.try(:interval_end) || Time.now
+        next_timestamp = counter.try(:interval_end) || Time.now.utc
         #transform the timestamp values to flot format - from seconds in Ruby to milliseconds in flot
         data << [interval_start.to_i*1000, counter.count]
         data << [next_timestamp.to_i*1000 - 1, counter.count]

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -39,7 +39,7 @@ module FogExtensions
       end
 
       def created_at
-        Time.parse attributes['created']
+        Time.parse(attributes['created']).utc
       end
 
       # the original method requires a server ID, however we want to be able to call this method on new instances too

--- a/app/models/concerns/user_time.rb
+++ b/app/models/concerns/user_time.rb
@@ -1,0 +1,12 @@
+module UserTime
+  extend ActiveSupport::Concern
+
+  included do
+    validate :validate_timezone
+    attr_accessible :timezone
+
+    def validate_timezone
+      errors.add(:timezone, _("is not valid")) unless timezone.blank? || Time.find_zone(timezone)
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -350,7 +350,7 @@ class Host::Managed < Host::Base
   end
 
   def no_report
-    last_report.nil? or last_report < Time.now - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes and enabled?
+    last_report.nil? || last_report < Time.now.utc - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes && enabled?
   end
 
   def disabled?

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -17,7 +17,7 @@ module HostStatus
       if (host && !host.enabled?) || no_reports?
         false
       else
-        !reported_at.nil? && reported_at < (Time.now - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes)
+        !reported_at.nil? && reported_at < (Time.now.utc - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes)
       end
     end
 
@@ -105,7 +105,7 @@ module HostStatus
     end
 
     def update_timestamp
-      self.reported_at = last_report.try(:reported_at) || Time.now
+      self.reported_at = last_report.try(:reported_at) || Time.now.utc
     end
 
     def calculator

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -57,7 +57,7 @@ module HostStatus
     private
 
     def update_timestamp
-      self.reported_at = Time.now
+      self.reported_at = Time.now.utc
     end
 
     def update_status

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -78,7 +78,7 @@ class Report < ActiveRecord::Base
     Message.where("id not IN (#{Log.unscoped.select('DISTINCT message_id').to_sql})").delete_all
     Source.where("id not IN (#{Log.unscoped.select('DISTINCT source_id').to_sql})").delete_all
     count = where(cond).delete_all
-    logger.info Time.now.to_s + ": Expired #{count} #{to_s.underscore.humanize.pluralize}"
+    logger.info Time.now.utc.to_s + ": Expired #{count} #{to_s.underscore.humanize.pluralize}"
     count
   end
 

--- a/app/services/orchestration/task.rb
+++ b/app/services/orchestration/task.rb
@@ -30,7 +30,7 @@ module Orchestration
     private
 
     def update_ts
-      @timestamp = Time.now
+      @timestamp = Time.now.utc
     end
 
     # sort based on priority

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -34,12 +34,12 @@ class ReportImporter
   end
 
   def import
-    start_time = Time.now
+    start_time = Time.now.utc
     logger.info "processing report for #{name}"
     logger.debug { "Report: #{raw.inspect}" }
     create_report_and_logs
     if report.persisted?
-      logger.info("Imported report for #{name} in #{(Time.now - start_time).round(2)} seconds")
+      logger.info("Imported report for #{name} in #{(Time.now.utc - start_time).round(2)} seconds")
       host.refresh_statuses
     end
   end

--- a/app/services/smart_proxies/puppet_ca_certificate.rb
+++ b/app/services/smart_proxies/puppet_ca_certificate.rb
@@ -5,8 +5,8 @@ class SmartProxies::PuppetCACertificate
 
   def initialize(opts)
     @name, @state, @fingerprint, @valid_from, @expires_at, @status_object = opts.flatten
-    @valid_from = Time.parse(@valid_from) unless @valid_from.blank?
-    @expires_at = Time.parse(@expires_at) unless @expires_at.blank?
+    @valid_from = Time.parse(@valid_from).utc unless @valid_from.blank?
+    @expires_at = Time.parse(@expires_at).utc unless @expires_at.blank?
   end
 
   def sign

--- a/app/services/trend_importer.rb
+++ b/app/services/trend_importer.rb
@@ -21,7 +21,7 @@ class TrendImporter
   end
 
   def update_trend_counters
-    timestamp = Time.now
+    timestamp = Time.now.utc
     counter_hash = {}
     Trend.types.each do |trend|
       if trend.is_a? FactTrend

--- a/db/migrate/20150622090115_change_reported_at.rb
+++ b/db/migrate/20150622090115_change_reported_at.rb
@@ -1,6 +1,6 @@
 class ChangeReportedAt < ActiveRecord::Migration
   def up
-    Report.where(:reported_at => nil).update_all(:reported_at => Time.at(0))
+    Report.where(:reported_at => nil).update_all(:reported_at => Time.at(0).utc)
     change_column :reports, :reported_at, :datetime, :null => false
   end
 

--- a/lib/timed_cached_store.rb
+++ b/lib/timed_cached_store.rb
@@ -16,7 +16,7 @@ class TimedCachedStore < ActiveSupport::Cache::MemoryStore
 
   def write(name, value, options = nil)
     if options and options[:expires_in]
-      time                  = Time.now
+      time                  = Time.now.utc
       ttl                   = time + options[:expires_in].to_i
       @data[ts_field(name)] = { :created_at => time, :expires_at => ttl }
     end
@@ -42,7 +42,7 @@ class TimedCachedStore < ActiveSupport::Cache::MemoryStore
 
   def expired?(name)
     ts = @data[ts_field(name)]
-    ts and (Time.now >= ts[:expires_at])
+    ts and (Time.now.utc >= ts[:expires_at])
   rescue
     false
   end

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -39,7 +39,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
 
   test "should clone hostgroup" do
     assert_difference('Hostgroup.count') do
-      post :clone, { :id => hostgroups(:common).to_param, :name => Time.now.to_s }
+      post :clone, { :id => hostgroups(:common).to_param, :name => Time.now.utc.to_s }
     end
     assert_response :success
   end

--- a/test/functional/api/v2/tasks_controller_test.rb
+++ b/test/functional/api/v2/tasks_controller_test.rb
@@ -27,6 +27,6 @@ class Api::V2::TasksControllerTest < ActionController::TestCase
     assert_equal 'create something', task['name']
     assert_equal 'pending', task['status']
     assert_equal 10, task['priority']
-    assert Time.now - Time.parse(task['timestamp']) < 5.seconds
+    assert Time.now.utc - Time.parse(task['timestamp']).utc < 5.seconds
   end
 end

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -245,7 +245,7 @@ class UnattendedControllerTest < ActionController::TestCase
     Setting[:token_duration] = 30
     Setting[:unattended_url]    = "https://test.host"
     @request.env["REMOTE_ADDR"] = @ub_host.ip
-    @ub_host.create_token(:value => token, :expires => Time.now + 5.minutes)
+    @ub_host.create_token(:value => token, :expires => Time.now.utc + 5.minutes)
     get :host_template, {:kind => 'provision', 'token' => @ub_host.token.value }
     assert @response.body.include?("#{Setting[:unattended_url]}/unattended/finish?token=#{token}")
   end
@@ -253,7 +253,7 @@ class UnattendedControllerTest < ActionController::TestCase
   test "hosts with unknown ip and valid token should render a template" do
     Setting[:token_duration] = 30
     @request.env["REMOTE_ADDR"] = '127.0.0.1'
-    @ub_host.create_token(:value => "aaaaaa", :expires => Time.now + 5.minutes)
+    @ub_host.create_token(:value => "aaaaaa", :expires => Time.now.utc + 5.minutes)
     get :host_template, {:kind => 'provision', 'token' => @ub_host.token.value }
     assert_response :success
   end
@@ -275,7 +275,7 @@ class UnattendedControllerTest < ActionController::TestCase
       Setting[:update_ip_from_built_request] = false
       @request.env["REMOTE_ADDR"] = '127.0.0.1'
       h=@ub_host
-      h.create_token(:value => "aaaaaa", :expires => Time.now + 5.minutes)
+      h.create_token(:value => "aaaaaa", :expires => Time.now.utc + 5.minutes)
       get :built, {'token' => h.token.value }
       h_new=Host.find_by_name(h.name)
 
@@ -291,7 +291,7 @@ class UnattendedControllerTest < ActionController::TestCase
       new_ip = h.subnet.network.gsub(/\.0$/,'.100') # Must be in the subnet, which isn't fixed
       @request.env["REMOTE_ADDR"] = new_ip
       refute_equal new_ip, h.ip
-      h.create_token(:value => "aaaaab", :expires => Time.now + 5.minutes)
+      h.create_token(:value => "aaaaab", :expires => Time.now.utc + 5.minutes)
       get :built, {'token' => h.token.value }
       h_new=Host.find_by_name(h.reload.name)
       assert_response :success
@@ -304,7 +304,7 @@ class UnattendedControllerTest < ActionController::TestCase
       Setting[:update_ip_from_built_request] = true
       @request.env["REMOTE_ADDR"] = @rh_host.ip
       h=@ub_host
-      h.create_token(:value => "aaaaac", :expires => Time.now + 5.minutes)
+      h.create_token(:value => "aaaaac", :expires => Time.now.utc + 5.minutes)
       get :built, {'token' => h.token.value }
       assert_response :success
       h_new=Host.find_by_name(h.reload.name)
@@ -316,7 +316,7 @@ class UnattendedControllerTest < ActionController::TestCase
       Setting[:token_duration]    = 30
       Setting[:unattended_url]    = "http://test.host"
       @request.env["REMOTE_ADDR"] = @ub_host.ip
-      @ub_host.create_token(:value => "aaaaaa", :expires => Time.now + 5.minutes)
+      @ub_host.create_token(:value => "aaaaaa", :expires => Time.now.utc + 5.minutes)
       get :host_template, {:kind => 'provision'}
       assert @response.body.include?("http://test.host/unattended/finish?token=aaaaaa")
     end
@@ -326,7 +326,7 @@ class UnattendedControllerTest < ActionController::TestCase
     template_server_from_proxy = 'https://someproxy:8443'
     ProxyAPI::Template.any_instance.stubs(:template_url).returns(template_server_from_proxy)
     @request.env["REMOTE_ADDR"] = '127.0.0.1'
-    @host_with_template_subnet.create_token(:value => "aaaaad", :expires => Time.now + 5.minutes)
+    @host_with_template_subnet.create_token(:value => "aaaaad", :expires => Time.now.utc + 5.minutes)
     get :host_template, {:kind => 'provision', 'token' => @host_with_template_subnet.token.value }
     assert @response.body.include?("#{template_server_from_proxy}/unattended/finish?token=aaaaad")
   end
@@ -335,7 +335,7 @@ class UnattendedControllerTest < ActionController::TestCase
     Setting[:token_duration] = 30
     Setting[:unattended_url]    = "http://test.host"
     @request.env["REMOTE_ADDR"] = '127.0.0.1'
-    @host_with_template_subnet.create_token(:value => "aaaaae", :expires => Time.now + 5.minutes)
+    @host_with_template_subnet.create_token(:value => "aaaaae", :expires => Time.now.utc + 5.minutes)
     get :host_template, {:kind => 'provision', 'token' => @host_with_template_subnet.token.value }
     assert @response.body.include?("#{@host_with_template_subnet.subnet.tftp.url}/unattended/finish?token=aaaaae")
   end

--- a/test/lib/tasks/trends_test.rb
+++ b/test/lib/tasks/trends_test.rb
@@ -180,7 +180,7 @@ class TrendsTest < ActiveSupport::TestCase
 
   def create_trend_line(trend, values_line)
     point_dates = []
-    point_date = Time.now.beginning_of_day
+    point_date = Time.now.utc.beginning_of_day
     values_line.each do |value|
       point_dates << point_date
       FactoryGirl.create(:trend_counter, :trend => trend, :created_at => point_date, :updated_at => point_date, :count => value)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,19 +73,19 @@ Spork.prefork do
 
     DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 1.0).to_f
 
-    @@last_gc_run = Time.now
+    @@last_gc_run = Time.now.getlocal
 
     def begin_gc_deferment
       GC.disable if DEFERRED_GC_THRESHOLD > 0
     end
 
     def reconsider_gc_deferment
-      if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+      if DEFERRED_GC_THRESHOLD > 0 && Time.now.getlocal - @@last_gc_run >= DEFERRED_GC_THRESHOLD
         GC.enable
         GC.start
         GC.disable
 
-        @@last_gc_run = Time.now
+        @@last_gc_run = Time.now.getlocal
       end
     end
 

--- a/test/unit/host_mailer_test.rb
+++ b/test/unit/host_mailer_test.rb
@@ -6,7 +6,7 @@ class HostMailerTest < ActionMailer::TestCase
     @env = environments(:production)
     @host = FactoryGirl.create(:host, :environment => @env)
     as_admin do
-      @host.last_report = Time.at(0)
+      @host.last_report = Time.at(0).utc
       @host.save(:validate => false)
       @env.hosts << @host
       @env.save

--- a/test/unit/host_status/configuration_status_test.rb
+++ b/test/unit/host_status/configuration_status_test.rb
@@ -54,7 +54,7 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
     @status.refresh!
     assert @status.reported_at.present?
     window = (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes
-    assert @status.reported_at < Time.now - window
+    assert @status.reported_at < Time.now.utc - window
 
     assert @status.out_of_sync?
   end
@@ -65,7 +65,7 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
   end
 
   test '#out_of_sync? is false when window is big enough' do
-    original, Setting[:outofsync_interval] = Setting[:outofsync_interval], (Time.now - @report.reported_at).to_i / 60 + 1
+    original, Setting[:outofsync_interval] = Setting[:outofsync_interval], (Time.now.utc - @report.reported_at).to_i / 60 + 1
     refute @status.out_of_sync?
     Setting[:outofsync_interval] = original
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1450,7 +1450,7 @@ class HostTest < ActiveSupport::TestCase
     test "built should clean tokens" do
       Setting[:token_duration] = 30
       h = FactoryGirl.create(:host, :managed)
-      h.create_token(:value => "aaaaaa", :expires => Time.now)
+      h.create_token(:value => "aaaaaa", :expires => Time.now.utc)
       assert_equal Token.all.size, 1
       h.expire_token
       assert_equal Token.all.size, 0
@@ -1459,7 +1459,7 @@ class HostTest < ActiveSupport::TestCase
     test "built should clean tokens even when tokens are disabled" do
       Setting[:token_duration] = 0
       h = FactoryGirl.create(:host, :managed)
-      h.create_token(:value => "aaaaaa", :expires => Time.now)
+      h.create_token(:value => "aaaaaa", :expires => Time.now.utc)
       assert_equal Token.all.size, 1
       h.expire_token
       assert_equal Token.all.size, 0
@@ -1482,7 +1482,7 @@ class HostTest < ActiveSupport::TestCase
 
     test "a token can be matched to a host" do
       h = FactoryGirl.create(:host, :managed)
-      h.create_token(:value => "aaaaaa", :expires => Time.now + 1.minutes)
+      h.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minutes)
       assert_equal h, Host.for_token("aaaaaa").first
     end
 

--- a/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
@@ -28,14 +28,14 @@ class ProxyStatusPuppetcaTest < ActiveSupport::TestCase
       assert_equal(cert.name, @proxy.hostname)
       assert_equal(cert.state, "valid")
       assert_equal(cert.fingerprint, "SHA256")
-      assert_equal(cert.valid_from, Time.parse("2015-12-12T14:33:10UTC"))
-      assert_equal(cert.expires_at, Time.parse("2020-12-11T14:33:10UTC"))
+      assert_equal(cert.valid_from, Time.parse("2015-12-12T14:33:10UTC").utc)
+      assert_equal(cert.expires_at, Time.parse("2020-12-11T14:33:10UTC").utc)
       assert_equal(cert.status_object, @proxy_status)
     end
 
     test 'it returns expiry for CA certificate' do
       #the CA certificate should be the oldest valid certificate, as it signs all others
-      assert_equal(Time.parse("2020-12-11T14:33:10UTC"), @proxy_status.expiry)
+      assert_equal(Time.parse("2020-12-11T14:33:10UTC").utc, @proxy_status.expiry)
     end
   end
 

--- a/test/unit/token_test.rb
+++ b/test/unit/token_test.rb
@@ -6,21 +6,21 @@ class TokenTest < ActiveSupport::TestCase
   should validate_presence_of(:host_id)
 
   test "a token expires when set to expire" do
-    expiry = Time.now
+    expiry = Time.now.utc
     t      = Token.new :value => "aaaaaa", :expires => expiry
     assert_equal t.expires, expiry
   end
 
   test "a host can create a token" do
     h = FactoryGirl.create(:host)
-    h.create_token(:value => "aaaaaa", :expires => Time.now)
+    h.create_token(:value => "aaaaaa", :expires => Time.now.utc)
     assert_equal Token.first.value, "aaaaaa"
     assert_equal Token.first.host_id, h.id
   end
 
   test "a host can delete its token" do
     h = FactoryGirl.create(:host)
-    h.create_token(:value => "aaaaaa", :expires => Time.now + 1.minutes)
+    h.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minutes)
     assert_instance_of Token, h.token
     h.token=nil
     assert Token.where(:value => "aaaaaa", :host_id => h.id).empty?
@@ -29,8 +29,8 @@ class TokenTest < ActiveSupport::TestCase
   test "a host cannot delete tokens for other hosts" do
     h1 = FactoryGirl.create(:host)
     h2 = FactoryGirl.create(:host)
-    h1.create_token(:value => "aaaaaa", :expires => Time.now + 1.minutes)
-    h2.create_token(:value => "bbbbbb", :expires => Time.now + 1.minutes)
+    h1.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minutes)
+    h2.create_token(:value => "bbbbbb", :expires => Time.now.utc + 1.minutes)
     assert_equal Token.all.size, 2
     h1.token=nil
     assert_equal Token.all.size, 1
@@ -39,8 +39,8 @@ class TokenTest < ActiveSupport::TestCase
   test "not all expired tokens should be removed" do
     h1 = FactoryGirl.create(:host)
     h2 = FactoryGirl.create(:host)
-    h1.create_token(:value => "aaaaaa", :expires => Time.now + 1.minutes)
-    h2.create_token(:value => "bbbbbb", :expires => Time.now - 1.minutes)
+    h1.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minutes)
+    h2.create_token(:value => "bbbbbb", :expires => Time.now.utc - 1.minutes)
     assert_equal 2, Token.count
     h1.expire_token
     assert_equal 1, Token.count


### PR DESCRIPTION
Rubocop can enforce what timezone to store in the database ,
so we can ensure everything is stored using UTC and we don't
miss these things in code reviews. When objects are displayed,
they must use the time provided by set_timezone in the
controller.

This is particularly relevant for Trends, Puppet graphs, etc... to
ensure they are stored always properly

https://github.com/theforeman/theforeman.org/pull/535
