### PR TITLE
fixes #13574 - remove DB access from Setting class scope

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -28,7 +28,7 @@ class Setting < ActiveRecord::Base
 
   validates_lengths_from_database
   # audit the changes to this model
-  audited :only => [:value], :on => [:update], :allow_mass_assignment => true
+  audited :except => [:name, :description, :category, :settings_type, :full_name], :on => [:update], :allow_mass_assignment => true
 
   validates :name, :presence => true, :uniqueness => true
   validates :description, :presence => true


### PR DESCRIPTION
Plugins tend to register an initialiser before config/initializers/ to
require their own Setting subclasses.  This loads them before
config/initializers/foreman.rb, which calls load_defaults on each known
Setting class.  When loading Setting in a test environment or without a
database yet, the class was getting partially loaded once due to a DB
call in validates_lengths_from_database 0.4.0 and also in the audited
:only call.

When partially loaded, the Setting.load_defaults method wasn't defined,
so calling `super` from a subclass failed:

```
NoMethodError: super: no superclass method `load_defaults' for #<Class:0x00000002d13e48>
gems/activerecord-4.1.5/lib/active_record/dynamic_matchers.rb:26:in `method_missing'
app/models/setting/general.rb:5:in `load_defaults'
```

In vlfd 0.5.0, the DB call was removed and it failed on audited instead.
Changing the audited options prevents that DB call and so the class now
loads just once on both 0.4.0 and 0.5.0.  This also removes the need
for the hack in plugin initialisers to check if Setting.table_exists?
before loading their subclass as class loading is reliable.

---

Successful plugin tests: http://ci.theforeman.org/job/test_plugin_matrix/1036/, http://ci.theforeman.org/job/test_plugin_matrix/1037/

~~I'm planning on sending a PR to the audited gem to remove the needless DB lookup.~~  Correction: https://github.com/collectiveidea/audited/pull/236 and https://github.com/collectiveidea/audited/pull/240 do this already, but have not yet been merged.
