### PR TITLE
Fixes #12909 - Keep 'reset zoom' button on the left

### DIFF
--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -146,8 +146,9 @@
 }
 
 .reset-zoom{
-  float: right;
+  position: absolute;
 }
+
 #legendContainer table{
   width:  100%;
 }


### PR DESCRIPTION
Move the button to the left, where it is less "crowded"
![image](https://cloud.githubusercontent.com/assets/433583/12871778/51b08c56-cd93-11e5-9e6e-e9e5753172a6.png)

@tbrisker - thoughts?
