### PR TITLE
Fixes #13745 - Fix usage of primary_interface when migrating interfaces

### DIFF
--- a/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
+++ b/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
@@ -26,7 +26,7 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
       nic.subnet_id = host.attributes.with_indifferent_access[:subnet_id]
       nic.domain_id = host.attributes.with_indifferent_access[:domain_id]
       nic.virtual = false
-      nic.identifier = host.primary_interface || "eth0"
+      nic.identifier = host.attributes.with_indifferent_access[:primary_interface] || "eth0"
       nic.managed = host.attributes.with_indifferent_access[:managed]
       nic.primary = true
       nic.provision = true


### PR DESCRIPTION
Without this patch a migration from < 1.8 to >= 1.8 would set the identifier of primary interface to eth0 regardless of primary_interface value.
