### PR TITLE
Fixes #13369 - Override correct long name parameter

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -179,9 +179,12 @@ function mark_params_override(){
   $('#puppetclasses_parameters').find('[data-property=class]:visible').each(function(){
     var klass = $(this).text();
     var name = $(this).closest('tr').find('[data-property=name]').text();
+    var title = $(this).closest('tr').find('[data-property=name]').attr('title');
     $('#inherited_puppetclasses_parameters [id^="puppetclass_"][id*="_params\\["][id$="\\]"]').each(function(){
       var param = $(this);
-      if (param.find('[data-property=class]').text() == klass && param.find('[data-property=name]').text() == name) {
+      if (param.find('[data-property=class]').text() == klass &&
+         ((param.find('[data-property=name]').text() == name && title == undefined) ||
+         (param.find('[data-property=name]').children('span').attr('data-original-title') == title && title != undefined))) {
         param.find('.error').removeClass('error');
         param.find('.warning').removeClass('warning');
         param.closest('tr').find('[data-property=name]').addClass('override-param');


### PR DESCRIPTION
This is against 1.10 since the js changed in 1.11 and this bug doesn't appear in develop anymore.
The override button in 1.10 adds the override to a new table and then marks the original parameter as overridden. Since this is done by name and the name to display is truncated, all parameters with the same 20 characters in their name would get marked as overridden.
There might be a nicer fix (changing `host_edit.js` and the view to be closer to global parameters that don't have the bug) but since this code has changed so much between 1.10 and 1.11 I didn't want to make a huge change.

Options from here:
1) Do a cleaner, bigger change that applies to 1.10 only
2) Use this change
3) Close this with the explanation that the bug will be fixed in 1.11
