### PR TITLE
fixes #13567 - fixing locale:pack

### DIFF
--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -12,7 +12,7 @@ module Facets
 
         # include all facet attributes by default
         facets_with_definitions.each do |facet, facet_definition|
-          hash["#{facet_definition.name}_attributes"] = facet.attributes.reject { |key, _| %w(created_at updated_at).include? key }
+          hash["#{facet_definition.name}_attributes"] = facet.attributes.reject { |key| %w(created_at updated_at).include? key }
         end
         hash
       end


### PR DESCRIPTION
apparently, the PO generator treats underscore as something important,
it assumes it's the GetText underscore method, thus, breaking
things in a spactacular way.
removing it solves it.
