### PR TITLE
fixes #13515 - fix issue where expecting scope but receiving array

### DIFF
--- a/app/services/association_authorizer.rb
+++ b/app/services/association_authorizer.rb
@@ -14,6 +14,7 @@ class AssociationAuthorizer
   end
 
   def self.permission_name(klass, permission, should_raise_exception)
+    klass = klass.first if klass.is_a?(Array)
     suffix = klass.respond_to?(:permission_name) ? klass.permission_name : klass.to_s.underscore.pluralize
     permission = "#{permission}_#{suffix}"
     if Permission.where(:name => permission).present?


### PR DESCRIPTION
the permission name method expects a scope, but sometimes received an
array instead, in that case, the correct way to bypass the issue is to
use the class of the first item in the array.

the issue does't exist in develop.
