### PR TITLE
Fixes #12380 - Added the ability to select where pagination mechanism

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -5,7 +5,8 @@ class FiltersController < ApplicationController
   before_filter :setup_search_options, :only => :index
 
   def index
-    @filters = resource_base.includes(:role, :permissions).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+    @filters = resource_base.includes(:role, :permissions).search_for(params[:search], :order => params[:order])
+    @filters = @filters.paginate(:page => params[:page]) unless params[:paginate] == 'client'
     @roles_authorizer = Authorizer.new(User.current, :collection => @filters.map(&:role_id))
   end
 

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -1,13 +1,13 @@
 <% if @role
      title _("Filters for role %s") % @role.to_s
-   else 
+   else
      title _("Filters")
    end %>
 
 <% title_actions link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role)),
                  documentation_button('4.1.2RolesandPermissions') %>
 
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped" <%= "data-table='inline'".html_safe if params[:paginate] == 'client' %> >
   <thead>
     <tr>
       <% unless params[:role_id] %>
@@ -51,4 +51,4 @@
     <% end %>
   </tbody>
 </table>
-<%= will_paginate_with_info @filters %>
+<%= will_paginate_with_info(@filters) unless params[:paginate] == 'client' %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -18,7 +18,7 @@
         <%= alert :header => '', :class => 'alert-warning',
                   :text => _("Please save the role first. You can edit it later to add filters") %>
       <% else %>
-        <div data-ajax-url="<%= filters_path(:role_id => @role) %> table">
+        <div data-ajax-url="<%= filters_path(:role_id => @role, :paginate => 'client') %> table" data-on-complete="activateDatatables">
           <%= spinner(_('Loading filters ...')) %>
         </div>
         <hr>

--- a/test/functional/filters_controller_test.rb
+++ b/test/functional/filters_controller_test.rb
@@ -49,4 +49,23 @@ class FiltersControllerTest < ActionController::TestCase
     end
     assert_redirected_to filters_path
   end
+
+  test 'should return server pagination controls by default' do
+    role = roles(:manager)
+    get :index, {:role_id => role.id}, set_session_user
+    assert_response :success
+    refute_empty assigns(:filters)
+
+    pagination_line = css_select('div.pagination').first
+    assert_match "Displaying", pagination_line.children.first.content
+  end
+
+  test 'should return data-tables pagination when asked for it' do
+    role = roles(:manager)
+    get :index, {:role_id => role.id, :paginate => 'client'}, set_session_user
+    assert_response :success
+    refute_empty assigns(:filters)
+
+    assert_select "table[data-table='inline']"
+  end
 end


### PR DESCRIPTION
In filters you can now add paginate=client if you want the server to generate client side pagination. If the option is omitted the regular server side pagination (based on `will_paginate`) mechanism will be used. 
Now role's two-pane will call the client paginated version of the page, so it will be displayed and paginated properly.
