### PR TITLE
Fixes #13726 - rename delete button on pending certs

### DIFF
--- a/app/views/puppetca/_list.html.erb
+++ b/app/views/puppetca/_list.html.erb
@@ -26,7 +26,9 @@
                       display_link_if_authorized(_("Sign"), hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param, :id => cert), :method => :put)
                     end,
                     if cert.state != "revoked"
-                      display_delete_if_authorized(hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param, :id => cert, :text => _("Revoke")))
+                      display_delete_if_authorized(hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param,
+                                                                                      :id => cert,
+                                                                                      :text =>  cert.state == "pending" ? _("Delete") : _("Revoke")))
                     end)
             %>
         </td>


### PR DESCRIPTION
A small text change if the cert is pending:
![image](https://cloud.githubusercontent.com/assets/433583/13108479/de832842-d57b-11e5-8744-bf64a50a282b.png)
Clicking adds the usual alert:
![image](https://cloud.githubusercontent.com/assets/433583/13108492/fa688246-d57b-11e5-8fef-5ee3de12c185.png)
And upon completion the certificate is deleted (@ohadlevy, it seems to work for me with latest nightly proxy):
![image](https://cloud.githubusercontent.com/assets/433583/13108551/79cb9988-d57c-11e5-91e9-3e0b4f8b16c0.png)
