### PR TITLE
Fixes #13293 - Make tests use a shared AR db connection

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,13 +1,13 @@
 group :test do
   gem 'mocha', '~> 1.1', :require => false
   gem 'simplecov', '~> 0.9'
+  gem 'connection_pool', '~> 2.2'
   gem 'spork-minitest', '0.0.3'
   gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1.0'
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 2.5'
-  gem 'database_cleaner', '~> 1.3'
   gem 'launchy', '~> 2.4'
   gem 'spork-rails', '~> 4.0.0'
   gem 'factory_girl_rails', '~> 4.5', :require => false

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -9,15 +9,12 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
   before do
     SETTINGS[:locations_enabled] = false
     SETTINGS[:organizations_enabled] = false
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.start
     as_admin { @host = FactoryGirl.create(:host, :with_puppet, :managed) }
   end
 
   after do
     SETTINGS[:locations_enabled] = true
     SETTINGS[:organizations_enabled] = true
-    DatabaseCleaner.clean
   end
 
   def class_params
@@ -448,18 +445,18 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
-      assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      assert_selector('#inherited_parameters .btn[data-tag=override]')
       page.find('#inherited_parameters .btn[data-tag=override]').click
-      assert page.has_no_selector?('#inherited_parameters .btn[data-tag=override]')
+      refute_selector('#inherited_parameters .btn[data-tag=override]')
       click_button('Submit')
       assert page.has_link?("Edit")
 
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
-      assert page.has_no_selector?('#inherited_parameters .btn[data-tag=override]')
+      refute_selector('#inherited_parameters .btn[data-tag=override]')
       page.find('#global_parameters_table a[data-original-title="Remove Parameter"]').click
-      assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
+      assert_selector('#inherited_parameters .btn[data-tag=override]')
     end
 
     test 'shows errors on invalid lookup values' do

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -20,14 +20,15 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "edit page" do
-    visit smart_proxies_path
-    click_link "DHCP Proxy"
-    click_link "Edit"
-    fill_in "smart_proxy_name", :with => "DHCP Secure"
-    fill_in "smart_proxy_url", :with => "https://secure.net:8443"
-    assert_submit_button(smart_proxy_path(smart_proxies(:one)))
-    assert page.has_title? 'DHCP Secure'
-    assert page.has_content? "https://secure.net:8443"
+    disable_taxonomies do
+      visit edit_smart_proxy_path(smart_proxies(:one))
+      fill_in "smart_proxy_name", :with => "DHCP Secure"
+      fill_in "smart_proxy_url", :with => "https://secure.net:8443"
+      assert_submit_button(smart_proxies_path)
+      click_link "DHCP Secure"
+      assert_title(/DHCP Secure/)
+      assert page.has_content? "https://secure.net:8443"
+    end
   end
 
   test "show page" do

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -6,7 +6,6 @@ class SeedsTest < ActiveSupport::TestCase
   self.use_transactional_fixtures = false
 
   setup do
-    DatabaseCleaner.clean_with :truncation
     Setting.stubs(:[]).with(:administrator).returns("root@localhost")
     Setting.stubs(:[]).with(:send_welcome_email).returns(false)
     Foreman.stubs(:in_rake?).returns(true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -257,17 +257,11 @@ Spork.prefork do
     end
   end
 
-  # Transactional fixtures do not work with Selenium tests, because Capybara
-  # uses a separate server thread, which the transactions would be hidden
-  # from. We hence use DatabaseCleaner to truncate our test database.
-  DatabaseCleaner.strategy = :truncation
-
   class ActionDispatch::IntegrationTest
     # Make the Capybara DSL available in all integration tests
     include Capybara::DSL
 
-    # Stop ActiveRecord from wrapping tests in transactions
-    self.use_transactional_fixtures = false
+    self.use_transactional_fixtures = true
 
     def assert_index_page(index_path,title_text,new_link_text = nil,has_search = true,has_pagination = true)
       visit index_path
@@ -373,7 +367,7 @@ Spork.each_run do
     setup :login_admin
 
     teardown do
-      DatabaseCleaner.clean       # Truncate the database
+      wait_for_ajax if Capybara.current_driver == Capybara.javascript_driver
       Capybara.reset_sessions!    # Forget the (simulated) browser state
       Capybara.use_default_driver # Revert Capybara.current_driver to Capybara.default_driver
     end
@@ -387,4 +381,14 @@ Spork.each_run do
       click_button "Login"
     end
   end
+
+  class ActiveRecord::Base
+    mattr_accessor :shared_connection
+    @@shared_connection = nil
+
+    def self.connection
+      @@shared_connection || ConnectionPool::Wrapper.new(:size => 1) { retrieve_connection }
+    end
+  end
+  ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
 end


### PR DESCRIPTION
Initially this PR contained capybara-screenshot so I could investigate a bit more what was the cause for our spotty integration tests. I found it easier to get rid of truncating the db using DatabaseCleaner and using transactional fixtures again. Integration tests run much faster, but more importantly they're easier to debug. Concurrency problems are more unlikely than before because all threads are sharing the same connection to the database.
