### PR TITLE
Fixes #13768 - Provide a default hostname

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'rails-observers', '~> 0.1'
 gem 'protected_attributes', '~> 1.1.1'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
+gem 'haikunator', '~> 1'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -102,6 +102,7 @@ module Host
       super(*args)
 
       build_required_interfaces
+      self.name ||= Haikunator.haikunate if Setting['default_hostname']
       values_for_primary_interface.each do |name, value|
         self.send "#{name}=", value
       end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -22,7 +22,7 @@ class Setting::General < Setting
         self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), false, N_('Use Gravatar')),
         self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true, N_('DB pending migration')),
         self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true, N_('DB pending seed')),
-        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout'))
+        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout')),
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -23,6 +23,7 @@ class Setting::Provisioning < Setting
         self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),
         self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
         self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
+        self.set('default_hostname', N_("Should Foreman provide a default name for new hosts?"), true, N_('Default hostname')),
       ].each { |s| self.create! s.update(:category => "Setting::Provisioning")}
     end
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -286,3 +286,8 @@ attributes59:
   category: Setting::Puppet
   default: "false"
   description: 'All hosts will show a configuration status even when a Puppet smart proxy is not assigned'
+attributes60:
+  name: default_hostname
+  category: Setting::Provisioning
+  default: true
+  description: 'Should Foreman provide a name for new hosts?'

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -8,8 +8,19 @@ class HostTest < ActiveSupport::TestCase
     Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
   end
 
-  test "should not save without a hostname" do
+  test "should provide a default hostname" do
     host = Host.new
+    assert host.name.present?
+  end
+
+  test "should honor default_hostname setting" do
+    Setting.expects(:[]).with('default_hostname').returns(false)
+    host = Host.new
+    refute host.name.present?
+  end
+
+  test "should not save without a hostname" do
+    host = Host.new(:name => '')
     host.valid?
     assert host.errors[:name].include?("can't be blank")
   end
@@ -915,7 +926,7 @@ class HostTest < ActiveSupport::TestCase
       h  = Host.new
       h.hostgroup = hg
       h.architecture = architectures(:sparc)
-      assert !h.valid?
+      assert h.valid?
       assert_equal hg.operatingsystem, h.operatingsystem
       assert_not_equal hg.architecture, h.architecture
       assert_equal h.architecture, architectures(:sparc)
@@ -1531,7 +1542,7 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryGirl.create(:host, :hostname => 'num001.example.com')
       host.import_facts({:architecture => "x86_64", :interfaces => 'eth0', :operatingsystem => 'RedHat-test', :operatingsystemrelease => '6.2',:memory_mb => "64498",:custom_fact => "find_me"})
 
-      hosts = Host::Managed.search_for("facts.memory_mb > 112889")
+      hosts = Host::Managed.search_for("facts.memory_mb > 112890")
       assert_equal hosts.count, 0
 
       hosts = Host::Managed.search_for("facts.memory_mb > 6544")


### PR DESCRIPTION
In order to save the user from thinking about what hostname to use, we
can do like Heroku and other similar services and provide them a default
hostname.
