### PR TITLE
Fixes #13778 - Libvirt cloud-init provisioning fails

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -124,6 +124,7 @@ module Foreman::Model
     def create_vm(args = { })
       vm = new_vm(args)
       create_volumes :prefix => vm.name, :volumes => vm.volumes, :backing_id => args[:image_id]
+      vm.iso_dir = vm.volumes.first.path.split('/')[0..-2].join('/')
       vm.save
     rescue Fog::Errors::Error => e
       Foreman::Logging.exception("Unhandled Libvirt error", e)


### PR DESCRIPTION
When you try to boot a VM with libvirt and cloud-init provisioning,
libvirt will make a initial .iso file to be provided during the VM
booting process.
This .iso file is created wherever the main volume for the VM is
created (storage-pool-path/cloud-init-data.iso).

Fog-libvirt sets iso_dir for all VMs to '/var/lib/libvirt/images'
as the default location to fetch the cloud-init .iso.
Foreman will try to use this directory when creating the VM as the
location for cloud-init.
However, that may not be right if the storage-pool is not the
default one. In my case, I run my libvirt VMs from an external
hard-drive, so Foreman needs to understand the iso_dir will be the
external hard-drive storage pool, not the default
/var/lib/libvirt/images.

Fix is simple, just set iso_dir during the VM creation process.
