### PR TITLE
Fixes #13725 - MAC conflicts are reported correctly

### DIFF
--- a/lib/net/dhcp/record.rb
+++ b/lib/net/dhcp/record.rb
@@ -40,7 +40,7 @@ module Net::DHCP
 
     # Returns an array of record objects which are conflicting with our own
     def conflicts
-      conflicts = [proxy.record(network, ip)].delete_if { |c| c == self }.compact
+      conflicts = [proxy.record(network, mac), proxy.record(network, ip)].delete_if { |c| c == self }.compact
       @conflicts ||= conflicts.uniq {|c| c.attrs}
     end
 

--- a/test/lib/net/dhcp_test.rb
+++ b/test/lib/net/dhcp_test.rb
@@ -92,16 +92,30 @@ class DhcpTest < ActiveSupport::TestCase
     refute record1.valid?
   end
 
-  test "dhcp record validation should fail on MAC conflict" do
+  test "dhcp record must not validate when there is IP conflict" do
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/aa:bb:cc:dd:ee:01").returns(@lease1)
     ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.1").returns(@lease1)
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/aa:bb:cc:dd:ee:02").raises(RestClient::ResourceNotFound, 'Record not found')
     record1 = Net::DHCP::Record.new(:hostname => "discovered_host1", :mac => "aa:bb:cc:dd:ee:02",
                                     :network => "127.0.0.0", :ip => "127.0.0.1",
                                     "proxy" => subnets(:one).dhcp_proxy)
     refute record1.conflicts.empty?
+    refute record1.valid?
   end
 
-  test "dhcp record validation on multiple discovered leases" do
-    lease2 = '{
+  test "dhcp record must not validate when there is MAC conflict" do
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/aa:bb:cc:dd:ee:01").returns(@lease1)
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.1").returns(@lease1)
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.2").raises(RestClient::ResourceNotFound, 'Record not found')
+    record1 = Net::DHCP::Record.new(:hostname => "discovered_host1", :mac => "aa:bb:cc:dd:ee:01",
+                                    :network => "127.0.0.0", :ip => "127.0.0.2",
+                                    "proxy" => subnets(:one).dhcp_proxy)
+    refute record1.conflicts.empty?
+    refute record1.valid?
+  end
+
+  test "dhcp record must validate with multiple leases with same MAC" do
+    @lease2 = '{
       "starts": "2014-05-09 11:55:21 UTC",
       "ends": "2214-05-09 12:05:21 UTC",
       "state": "active",
@@ -109,13 +123,15 @@ class DhcpTest < ActiveSupport::TestCase
       "subnet": "127.0.0.0/255.0.0.0",
       "ip": "127.0.0.2"
     }'
-    lease2.stubs(:code).returns(200)
-    lease2.stubs(:body).returns(lease2)
+    @lease2.stubs(:code).returns(200)
+    @lease2.stubs(:body).returns(@lease2)
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/aa:bb:cc:dd:ee:01").returns(@lease2)
     ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.1").returns(@lease1)
-    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.2").returns(lease2)
+    ProxyAPI::Resource.any_instance.stubs(:get).with("127.0.0.0/127.0.0.2").returns(@lease2)
     record1 = Net::DHCP::Record.new(:hostname => "discovered_host1", :mac => "aa:bb:cc:dd:ee:01",
                                     :network => "127.0.0.0", :ip => "127.0.0.2",
                                     "proxy" => subnets(:one).dhcp_proxy)
     assert record1.conflicts.empty?
+    assert record1.valid?
   end
 end


### PR DESCRIPTION
Discovered hosts sometimes create two leases on the same interface (MAC). This is caused by some BIOSes (e.g. DELL) which send Client-UID tag which effectively forces ISC DHCP to create two leases.

The fix provided in http://projects.theforeman.org/issues/8727 was to simply drop MAC address validation in orchestration and today it looks like this was wrong solution.

Meantime, we discovered a bug in our proxy (http://projects.theforeman.org/issues/8538) that showed multiple leases as multiple entries and exposed those via API. This was the real cause of the problem and it was fixed making the initial attempt (8727) basically useless, but we haven't noticed.

Until now, Ohad observed that if there is a MAC conflict (e.g. creating a host with existing MAC address _reservation_ - not lease this time), orchestration layer does not catch this since we are ignoring MAC conflicts at the moment.

This patch fixes this, effectively by reverting the 8727 patch. Discovered hosts with multiple leases no longer causes any conflicts because proxy DHCP loading code was changed.
