### PR TITLE
refs #13348 - use proxies with expected features for search tests (fixes test_develop)

### DIFF
--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -22,6 +22,10 @@ FactoryGirl.define do
       features { |sp| [sp.association(:feature, :puppetca)] }
     end
 
+    factory :puppet_and_ca_smart_proxy do
+      features { |sp| [sp.association(:feature, :puppet), sp.association(:feature, :puppetca) ] }
+    end
+
     factory :realm_smart_proxy do
       features { |sp| [sp.association(:feature, :realm)] }
     end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1718,7 +1718,7 @@ class HostTest < ActiveSupport::TestCase
 
     test "can search hosts by smart proxy" do
       host = FactoryGirl.create(:host)
-      proxy = FactoryGirl.create(:smart_proxy)
+      proxy = FactoryGirl.create(:puppet_and_ca_smart_proxy)
       results = Host.search_for("smart_proxy = #{proxy.name}")
       assert_equal 0, results.count
       host.update_attribute(:puppet_proxy_id, proxy.id)

--- a/test/unit/smart_proxy_test.rb
+++ b/test/unit/smart_proxy_test.rb
@@ -67,7 +67,7 @@ class SmartProxyTest < ActiveSupport::TestCase
   end
 
   test "can count connected hosts" do
-    proxy = FactoryGirl.create(:smart_proxy)
+    proxy = FactoryGirl.create(:puppet_smart_proxy)
     FactoryGirl.create(:host, :with_environment, :puppet_proxy => proxy)
     as_admin do
       assert_equal 1, proxy.hosts_count


### PR DESCRIPTION
Running tests manually at http://ci.theforeman.org/job/test_develop_pull_request/14485/ as test_develop is red.
