### PR TITLE
fixes #13804 - set enforce_available_locales in app config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -127,6 +127,9 @@ module Foreman
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Don't enforce known locales with exceptions, as fast_gettext has a fallback to default 'en'
+    config.i18n.enforce_available_locales = false
+
     # Disable fieldWithErrors divs
     config.action_view.field_error_proc = Proc.new {|html_tag, instance| "#{html_tag}".html_safe }
 

--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -8,7 +8,7 @@ Foreman::Gettext::Support.register_available_locales locale_domain, locale_dir
 Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
 
 I18n.config.enforce_available_locales = false
-I18n.config.available_locales = FastGettext.default_available_locales
+I18n.config.available_locales = FastGettext.default_available_locales.map { |loc| loc.tr('_', '-') }
 
 FastGettext.default_text_domain = locale_domain
 FastGettext.locale = "en"


### PR DESCRIPTION
Rails 4.1.9 in rails/rails@4399a23 sets I18n.enforce_available_locales
to the value in the Rails app config, which now defaults to true,
overwriting the false value set in the initialiser.  Set it in the app
config to ensure it remains off (since fast_gettext always sets the
best valid locale).

The translation of known locale names which triggers the error on en_GB
and pt_BR is also fixed, as fast_gettext uses underscores and i18n uses
hyphens.
