### PR TITLE
fixes #10662 - set default_locale to 'en'

### DIFF
--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -11,6 +11,7 @@ I18n.config.enforce_available_locales = false
 I18n.config.available_locales = FastGettext.default_available_locales
 
 FastGettext.default_text_domain = locale_domain
+FastGettext.default_locale = "en"
 FastGettext.locale = "en"
 
 Foreman::Gettext::Support.register_human_localenames


### PR DESCRIPTION
When a default locale isn't set and FastGettext.set_locale() is called
with an unknown locale, it picks the first available.  This depends on
the readdir order of locale/, which depends on filesystem behaviour.

Now when generating the default language API docs, they are always in
English and when accessing the web UI with an unknown language
preference, the 'en' locale is provided.

Can be tested by changing the order of FastGettext.available_locales early in the initialiser and then running the apipie:cache rake task.  My installation happens to order it with en_GB first, so the API v2 docs have references to "organisations" rather than "organizations".
