### PR TITLE
fixes #13817 - ENC smart proxy validation fails

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -68,7 +68,7 @@ module Foreman::Controller::SmartProxyAuth
           # If the client sent certificate contains a subject or sans, use them for request_hosts, else fall back to the dn set in the request environment
           request_hosts = []
           if certificate
-            if certificate.subject_alternative_names
+            if ! certificate.subject_alternative_names.empty?
               request_hosts += certificate.subject_alternative_names
             elsif certificate.subject
               request_hosts << certificate.subject


### PR DESCRIPTION
Must test certificate.subject_alternative_names for empty string, else if statement is always true even with no SAN. This results request_hosts being empty and thus ENC authentication fails.
