### PR TITLE
Fixes #13821 - Show different types of input depending on the param type

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -443,9 +443,10 @@ function override_param(item){
 function override_class_param(item){
   var remove = $(item).data('tag') == 'remove';
   var row = $(item).closest('tr').toggleClass('overridden');
-  var value = row.find('textarea');
+  var value = row.find('textarea') || row.find('select');
   row.find('[type=checkbox]').prop('checked', false).toggle();
   row.find('input, textarea').prop('disabled', remove);
+  row.find('input, select').prop('disabled', remove);
   row.find('.send_to_remove').prop('disabled', false);
   row.find('.destroy').val(remove);
   value.val(value.data('inherited-value'));

--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -16,23 +16,7 @@ module CommonParametersHelper
   end
 
   def parameter_value_content(id, value, options)
-    lookup_key = options[:lookup_key]
-
-    option_hash = { :rows => 1,
-                    :class => 'form-control no-stretch',
-                    :'data-property' => 'value',
-                    :'data-hidden-value' => LookupKey.hidden_value,
-                    :'data-inherited-value' => options[:inherited_value],
-                    :name => options[:name].to_s,
-                    :disabled => options[:disabled] }
-
-    if lookup_key.present? && lookup_key.hidden_value?
-      field = password_field_tag(id, value, option_hash)
-    else
-      field = text_area_tag(id, value, option_hash)
-    end
-
-    content_tag(:span, options[:popover], :class => "input-group-addon") + field
+    content_tag(:span, options[:popover], :class => "input-group-addon") + lookup_key_field(id, value, options)
   end
 
   def use_puppet_default_help link_title = nil, title = _("Use Puppet default")
@@ -50,5 +34,30 @@ module CommonParametersHelper
                                                :placeholder => _("Value")))
     end
     input_group(input, input_group_btn(hidden_toggle(f.object.hidden_value?), fullscreen_button("$(this).closest('.input-group').find('input,textarea')")))
+  end
+
+  def lookup_key_field(id, value, options)
+    lookup_key = options[:lookup_key]
+
+    option_hash = { :rows => 1,
+                    :class => 'form-control no-stretch',
+                    :'data-property' => 'value',
+                    :'data-hidden-value' => LookupKey.hidden_value,
+                    :'data-inherited-value' => options[:inherited_value],
+                    :name => options[:name].to_s,
+                    :disabled => options[:disabled] }
+
+    if lookup_key.present? && options[:lookup_key_hidden_value?]
+      password_field_tag(id, value, option_hash)
+    else
+      case options[:lookup_key_type]
+      when "boolean"
+        select_tag(id, options_for_select(['true', 'false'], value), option_hash)
+      when "integer", "real"
+        number_field_tag(id, value, option_hash)
+      else
+        text_area_tag(id, value, option_hash)
+      end
+    end
   end
 end

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -75,7 +75,9 @@ module LookupKeysHelper
       :name => "#{lookup_value_name_prefix(lookup_key.id)}[value]",
       :disabled => !lookup_key.overridden?(obj) || lookup_value.use_puppet_default,
       :inherited_value => inherited_value,
-      :lookup_key => lookup_key)
+      :lookup_key => lookup_key,
+      :lookup_key_hidden_value? => lookup_key.hidden_value?,
+      :lookup_key_type => lookup_key.key_type)
   end
 
   def value_matcher(obj, lookup_key)

--- a/app/views/puppetclasses/_class_parameters.html.erb
+++ b/app/views/puppetclasses/_class_parameters.html.erb
@@ -23,8 +23,8 @@
       <div class="input-group">
         <%= lookup_key_with_diagnostic(obj, lookup_key, lookup_value) %>
         <span class="input-group-btn">
-          <%= hidden_toggle(lookup_key.hidden_value?, 'font', 'font', true) %>
-          <%= fullscreen_button("$(this).parent().prev()") %>
+          <%= hidden_toggle(lookup_key.hidden_value?, 'font', 'font', true) if lookup_key.hidden_value? %>
+          <%= fullscreen_button("$(this).parent().prev()") unless lookup_key.key_type == "boolean" %>
           <%= override_toggle(overridden) %>
         </span>
       </div>

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -368,10 +368,10 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   describe 'edit page' do
-    test 'class parameters and overrides are displayed correctly for booleans' do
+    test 'class parameters and overrides are displayed correctly for strings' do
       host = FactoryGirl.create(:host, :with_puppetclass)
       FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
-                                      :key_type => 'boolean', :default_value => true,
+                                      :key_type => 'string', :default_value => true,
                                       :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => false})
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
@@ -404,7 +404,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     test 'can override puppetclass lookup values' do
       host = FactoryGirl.create(:host, :with_puppetclass)
       FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
-                                      :key_type => 'boolean', :default_value => "true",
+                                      :key_type => 'string', :default_value => "true",
                                       :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => "false"})
 
       visit edit_host_path(host)
@@ -465,7 +465,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     test 'shows errors on invalid lookup values' do
       host = FactoryGirl.create(:host, :with_puppetclass)
       lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
-                                      :key_type => 'boolean', :default_value => true,
+                                      :key_type => 'real', :default_value => true,
                                       :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => false})
 
       visit edit_host_path(host)
@@ -517,6 +517,28 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
 
       environment = find("#s2id_host_environment_id .select2-chosen").text
       assert_equal original_hostgroup.environment.name, environment
+    end
+
+    test 'class parameters and overrides are displayed correctly for booleans' do
+      host = FactoryGirl.create(:host, :with_puppetclass)
+      lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
+                                      :key_type => 'boolean', :default_value => 'false',
+                                      :puppetclass => host.puppetclasses.first, :overrides => {host.lookup_value_matcher => 'false'})
+      visit edit_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert class_params.has_selector?("a[data-tag='remove']", :visible => :visible)
+      assert class_params.has_selector?("a[data-tag='override']", :visible => :hidden)
+      assert_equal find("#s2id_host_lookup_values_attributes_#{lookup_key.id}_value .select2-chosen").text, "false"
+      select2 "true", :from => "host_lookup_values_attributes_#{lookup_key.id}_value"
+      click_button('Submit')
+
+      assert page.has_link?("Edit")
+      visit edit_host_path(host)
+      assert page.has_link?('Parameters', :href => '#params')
+      click_link 'Parameters'
+      assert_equal find("#s2id_host_lookup_values_attributes_#{lookup_key.id}_value .select2-chosen").text, "true"
+      click_button('Submit')
     end
   end
 

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -24,7 +24,7 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
   test 'edit shows errors on invalid lookup values' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override,
-                                    :key_type => 'boolean', :default_value => true,
+                                    :key_type => 'integer', :default_value => true,
                                     :puppetclass => group.puppetclasses.first, :overrides => {group.lookup_value_matcher => false})
 
     visit edit_hostgroup_path(group)


### PR DESCRIPTION
One problem with this is when the select box is disabled it's a slightly different grey :( Any pointers where this is defined would be useful if you don't mind? I haven't had any luck finding it.

![screenshot from 2016-02-20 13-33-53](https://cloud.githubusercontent.com/assets/13135483/13196969/fd9b4784-d7d6-11e5-9f45-71a248e25212.png)
