### PR TITLE
fixes #13866 - pin jwt for Ruby 1.9.3 compatibility (fix test_develop)

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -2,4 +2,5 @@ group :gce do
   gem 'fog-google', '<= 0.1.0'
   gem 'google-api-client', '>= 0.7', '< 0.9', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
+  gem 'jwt', '< 1.5.3'
 end


### PR DESCRIPTION
Testing manually via http://ci.theforeman.org/job/test_develop_pull_request/14542/
