### PR TITLE
Fixes #13873 - Add UI extension point to show facets.

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -808,3 +808,39 @@ function pxeLoaderCompatibilityCheck() {
 }
 
 $(document).on('change', '#host_pxe_loader', pxeLoaderCompatibilityCheck);
+
+function disableFacet(name) {
+  var fieldset_name = 'fieldset.' + name;
+  var title_name = 'li>a.' + name;
+  $(fieldset_name).prop('disabled', true);
+  $(title_name).parent().addClass('disabled');
+
+  //disable select2 fields explicitly
+  $(fieldset_name + ' select').each(function(i, select) {
+    var item = $(select)
+    item.prop('oldDisabledState', item.prop('disabled'));
+    item.prop('disabled', true);
+  })
+}
+
+function enableFacet(name) {
+  var fieldset_name = 'fieldset.' + name;
+  var title_name = 'li>a.' + name;
+  $(fieldset_name).prop('disabled', false);
+  $(title_name).parent().removeClass('disabled');
+
+  //revert select2 fields state
+  $(fieldset_name + ' select').each(function(i, select) {
+    var item = $(select)
+    item.prop('disabled', item.prop('oldDisabledState'));
+  })
+}
+
+function triggerFacet(name) {
+  var fieldset_name = 'fieldset.' + name;
+  if ($(fieldset_name).prop('disabled')) {
+    enableFacet(name);
+  } else {
+    disableFacet(name);
+  }
+}

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -1,0 +1,32 @@
+module FacetsHelper
+  # override host's tabs to add all facets as tabs
+  def facet_tabs(host)
+    base_tabs = {}
+
+    host.facets_with_definitions.each do |facet, facet_definition|
+      facet_tabs = {}
+      facet_tabs[facet_definition.name] = facet if lookup_context.find_all(facet.to_partial_path, [], true).any?
+
+      facet_tabs.merge!(helper_tabs(host, facet_definition))
+
+      base_tabs[facet_definition.name] = facet_tabs
+    end
+
+    base_tabs
+  end
+
+  private
+
+  def helper_tabs(host, facet_definition)
+    tab_definitions = {}
+    return tab_definitions unless facet_definition.tabs
+
+    if facet_definition.tabs.is_a? Hash
+      tab_definitions.merge!(facet_definition.tabs)
+    else
+      method_result = send(facet_definition.tabs, host)
+      tab_definitions.merge!(method_result)
+    end
+    tab_definitions
+  end
+end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -4,6 +4,7 @@ module HostsHelper
   include ComputeResourcesVmsHelper
   include HostsNicHelper
   include BmcHelper
+  include FacetsHelper
 
   def provider_partial_exist?(compute_resource, partial)
     return false unless compute_resource
@@ -487,5 +488,24 @@ module HostsHelper
 
   def power_status_visible?
     SETTINGS[:unattended] && Setting[:host_power_status]
+  end
+
+  def load_tabs(host)
+    @tabs = facet_tabs(host)
+  end
+
+  def host_tab(group, id, val, host_form)
+    content_tag(:div, :id => id, :class => "tab-pane") do
+      disable_tab(group) +
+      content_tag(:fieldset, :class => group) do
+        render(val, :f => host_form)
+      end
+    end
+  end
+
+  def disable_tab(group)
+    button_tag :type => 'button', :class => 'btn btn-primary active', :data => { :toggle => 'button' }, :onclick => "triggerFacet('#{group}')" do
+      "Manage"
+    end
   end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -7,6 +7,7 @@
 
   <%= form_for @host, :url => (@host.new_record? ? hosts_path : host_path(:id => @host.id)), :html => {:data => {:id => @host.try(:id), :type_changed => !!@host.type_changed?, :submit => 'progress_bar'}} do |f| %>
     <%= base_errors_for @host %>
+    <% load_tabs @host %>
 
     <ul class="nav nav-tabs" data-tabs="tabs">
       <li class="active"><a href="#primary" data-toggle="tab"><%= _('Host') %></a></li>
@@ -25,6 +26,15 @@
       <li><a href="#params" id='params-tab' data-url='<%= current_parameters_hosts_path %>' data-url2='<%= puppetclass_parameters_hosts_path %>' data-toggle="tab"><%= _('Parameters') %></a></li>
 
       <li><a href="#info" data-toggle="tab"><%= _('Additional Information') %></a></li>
+
+      <% @tabs.each do |facet_name, tabs| %>
+        <% tabs.keys.each do |tab| %>
+          <li>
+            <a href="#<%= tab %>" data-toggle="tab" class="<%=facet_name%>"><%= _(tab) %>
+            </a>
+          </li>
+        <% end %>
+      <% end %>
     </ul>
 
     <div class="tab-content">
@@ -133,6 +143,11 @@
         <%= textarea_f f, :comment, :help_block => _("Additional information about this host"), :size => "col-md-8", :rows => "3", :class => "no-stretch" %>
       </div>
 
+      <% @tabs.each do |group, tabs| %>
+        <% tabs.each do |id, tab| %>
+          <%= host_tab group, id, tab, f %>
+        <% end %>
+      <% end %>
     </div>
 
     <%= hidden_field_tag 'bare_metal_capabilities', @host.bare_metal_capabilities %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -8,6 +8,11 @@
         <th class="ca" width="5%"><%= _('Power') %></th>
       <% end %>
       <th width="25%"><%= sort :name, :as => _('Name') %></th>
+
+      <% Facets.registered_facets.values.each do |config| %>
+      <%= render "#{config.name.to_s.pluralize}/host/list_headers" if lookup_context.find_all("list_headers", "#{config.name.to_s.pluralize}/host/", true).any? %>
+      <% end %>
+
       <th class="hidden-xs" width="17%"><%= sort :os_title, :as => _("Operating system") %></th>
       <th class="hidden-xs" width="10%"><%= sort :environment, :as => _('Environment') %></th>
       <th class="hidden-tablet hidden-xs" width="10%"><%= sort :model, :as => _('Model') %></th>
@@ -31,6 +36,11 @@
         <% end %>
         <td class="ellipsis"><%= name_column(host) %>
         </td>
+
+        <% Facets.registered_facets.values.each do |config| %>
+        <%= render("#{config.name.to_s.pluralize}/host/list", { :host => host }) if lookup_context.find_all("list", "#{config.name.to_s.pluralize}/host/", true).any? %>
+        <% end %>
+
         <td class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
         <td class="hidden-xs ellipsis"><%= host.environment %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= host.compute_resource_or_model %></td>

--- a/test/unit/helpers/facets_helper_test.rb
+++ b/test/unit/helpers/facets_helper_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'facet_test_helper'
+
+class FacetsHelperTest < ActionView::TestCase
+  class TestFacet < HostFacets::Base
+  end
+
+  include FacetsHelper
+
+  context 'facets related' do
+    setup do
+      @facet_model = TestFacet.new
+      @host = mock('host')
+      @facet_config = Facets::Entry.new(FacetsHelperTest::TestFacet, :test_facet)
+      @host.stubs(:facets_with_definitions).returns({ @facet_model => @facet_config })
+    end
+
+    teardown do
+      Host::Managed.cloned_parameters[:include].delete(:test_facet)
+    end
+
+    test '#load_tabs returns hash of facets' do
+      expects(:lookup_context).returns(stub(:find_all => ['/some/path/to/template']))
+      tabs = facet_tabs(@host)
+
+      assert_equal @facet_model, tabs[:test_facet][:test_facet]
+    end
+
+    test '#load_tabs skips facet definition if no template exists' do
+      expects(:lookup_context).returns(stub(:find_all => []))
+      tabs = facet_tabs(@host)
+
+      assert_nil tabs[:test_facet][:test_facet]
+    end
+
+    test '#helper_tabs returns hash if hash specified' do
+      @facet_config.add_tabs(:my_new_tab => 'my/tab/template.html.erb')
+      tabs = facet_tabs(@host)
+
+      assert_equal 'my/tab/template.html.erb', tabs[:test_facet][:my_new_tab]
+    end
+
+    test '#helper_tabs returns hash if method specified' do
+      expects(:my_tabs_method).returns({:my_new_tab => 'my/tab/template.html.erb'})
+      @facet_config.add_tabs(:my_tabs_method)
+      tabs = facet_tabs(@host)
+
+      assert_equal 'my/tab/template.html.erb', tabs[:test_facet][:my_new_tab]
+    end
+  end
+end


### PR DESCRIPTION
This commit adds following extension points to the UI:
**in `hosts/_form.html.erb`**: For each facet that is connected to a host, it will create a tab for it. The framework will try to render facet object itself, so it expects the proper partial template to exist. For example in puppet_facet, it will try to find `app/views/puppet_facets/_puppet_facet.html.erb`. Additionally it will show any tab that was specified during facet's registration by invoking the `tabs` method.

**in `hosts/_list.html.erb`**: There are two extension points there, one to add additional column headers, and one to add additional column data. In both cases the framework looks for a specific paths: `<plural_facet_name>/host/_list_headers.html.erb` for the headers and `<plural_facet_name>/host/_list.html.erb` for the values.
