### PR TITLE
Fixes #13870 - encrypts specific settings values in db

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -13,7 +13,7 @@ module AuditsHelper
       when /.*_id$/
         name.classify.gsub('Id','').constantize.find(change).to_label
       else
-        change.to_s
+        change.to_s == "[encrypted]" ? _(change.to_s) : change.to_s
     end.truncate(50)
   rescue
     _("N/A")

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -32,6 +32,7 @@ module AuditExtensions
     scoped_search :in => :search_users, :on => :login, :complete_value => true, :rename => :user, :only_explicit => true
 
     before_save :ensure_username, :ensure_auditable_and_associated_name
+    before_save :filter_encrypted, :if => Proc.new {|audit| audit.audited_changes.present?}
     after_validation :fix_auditable_type
 
     include Authorizable
@@ -42,6 +43,17 @@ module AuditExtensions
   end
 
   private
+
+  def filter_encrypted
+    self.audited_changes.each do |name,change|
+      next if change.nil? || change.to_s.empty?
+      if change.is_a? Array
+        change.map! {|c| c.to_s.start_with?(EncryptValue::ENCRYPTION_PREFIX) ? N_("[encrypted]") : c}
+      else
+        audited_changes[name] = N_("[encrypted]") if change.to_s.start_with?(EncryptValue::ENCRYPTION_PREFIX)
+      end
+    end
+  end
 
   def ensure_username
     self.user_as_model = User.current

--- a/app/models/concerns/encrypt_value.rb
+++ b/app/models/concerns/encrypt_value.rb
@@ -1,0 +1,75 @@
+module EncryptValue
+  ENCRYPTION_PREFIX = "encrypted-"
+  def matches_prefix?(str)
+    ENCRYPTION_PREFIX == str.to_s[0..(ENCRYPTION_PREFIX.length - 1)]
+  end
+
+  def encryption_key
+    return ENV['ENCRYPTION_KEY'] if ENV['ENCRYPTION_KEY'].present?
+    return EncryptionKey::ENCRYPTION_KEY if defined? EncryptionKey::ENCRYPTION_KEY
+    nil
+  end
+
+  def is_encryptable?(str)
+    if !encryption_key.present?
+      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be encrypted", Logger::WARN
+      false
+    elsif str.blank?
+      puts_and_logs "String is blank', so #{self.class.name} #{name} was not encrypted", Logger::DEBUG
+      false
+    elsif matches_prefix?(str)
+      puts_and_logs "String starts with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not encrypted again", Logger::DEBUG
+      false
+    else
+      true
+    end
+  end
+
+  def is_decryptable?(str)
+    if !matches_prefix?(str)
+      puts_and_logs "String does not start with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not decrypted", Logger::DEBUG
+      false
+    elsif !encryption_key.present?
+      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be decrypted", Logger::WARN
+      false
+    else
+      true
+    end
+  end
+
+  def encrypt_field(str)
+    return str unless is_encryptable?(str)
+    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+    begin
+      # add prefix to encrypted string
+      str_encrypted = "#{ENCRYPTION_PREFIX}#{encryptor.encrypt_and_sign(str)}"
+      puts_and_logs "Successfully encrypted field for #{self.class.name} #{name}"
+      str = str_encrypted
+    rescue
+      puts_and_logs "WARNING: Encryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
+    end
+    str
+  end
+
+  def decrypt_field(str)
+    return str unless is_decryptable?(str)
+    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+    begin
+      # remove prefix before decrypting string
+      str_no_prefix = str.gsub(/^#{ENCRYPTION_PREFIX}/, "")
+      str_decrypted = encryptor.decrypt_and_verify(str_no_prefix)
+      puts_and_logs "Successfully decrypted field for #{self.class.name} #{name}"
+      str = str_decrypted
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      puts_and_logs "WARNING: Decryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
+    end
+    str
+  end
+
+  private
+
+  def puts_and_logs(msg, level = Logger::INFO)
+    logger.add level, msg
+    puts msg if Foreman.in_rake? && !Rails.env.test? && level >= Logger::INFO
+  end
+end

--- a/app/models/concerns/encryptable.rb
+++ b/app/models/concerns/encryptable.rb
@@ -1,8 +1,6 @@
 module Encryptable
   extend ActiveSupport::Concern
-
-  ENCRYPTION_PREFIX = "encrypted-"
-
+  include EncryptValue
   included do
     before_save :encrypt_setters
   end
@@ -44,78 +42,5 @@ module Encryptable
         self.send("#{field}=", encrypt_field(read_attribute(field.to_sym)))
       end
     end
-  end
-
-  def matches_prefix?(str)
-    ENCRYPTION_PREFIX == str.to_s[0..(ENCRYPTION_PREFIX.length - 1)]
-  end
-
-  def encryption_key
-    return ENV['ENCRYPTION_KEY'] if ENV['ENCRYPTION_KEY'].present?
-    return EncryptionKey::ENCRYPTION_KEY if defined? EncryptionKey::ENCRYPTION_KEY
-    nil
-  end
-
-  def is_encryptable?(str)
-    if !encryption_key.present?
-      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be encrypted", Logger::WARN
-      false
-    elsif str.blank?
-      puts_and_logs "String is blank', so #{self.class.name} #{name} was not encrypted", Logger::DEBUG
-      false
-    elsif matches_prefix?(str)
-      puts_and_logs "String starts with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not encrypted again", Logger::DEBUG
-      false
-    else
-      true
-    end
-  end
-
-  def is_decryptable?(str)
-    if !matches_prefix?(str)
-      puts_and_logs "String does not start with the prefix '#{ENCRYPTION_PREFIX}', so #{self.class.name} #{name} was not decrypted", Logger::DEBUG
-      false
-    elsif !encryption_key.present?
-      puts_and_logs "Missing ENCRYPTION_KEY configuration, so #{self.class.name} #{name} could not be decrypted", Logger::WARN
-      false
-    else
-      true
-    end
-  end
-
-  def encrypt_field(str)
-    return str unless is_encryptable?(str)
-    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
-    begin
-      # add prefix to encrypted string
-      str_encrypted = "#{ENCRYPTION_PREFIX}#{encryptor.encrypt_and_sign(str)}"
-      puts_and_logs "Successfully encrypted field for #{self.class.name} #{name}"
-      str = str_encrypted
-    rescue
-      puts_and_logs "WARNING: Encryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
-    end
-    str
-  end
-
-  def decrypt_field(str)
-    return str unless is_decryptable?(str)
-    encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
-    begin
-      # remove prefix before decrypting string
-      str_no_prefix = str.gsub(/^#{ENCRYPTION_PREFIX}/, "")
-      str_decrypted = encryptor.decrypt_and_verify(str_no_prefix)
-      puts_and_logs "Successfully decrypted field for #{self.class.name} #{name}"
-      str = str_decrypted
-    rescue ActiveSupport::MessageVerifier::InvalidSignature
-      puts_and_logs "WARNING: Decryption failed for string. Please check that the ENCRYPTION_KEY has not changed.", Logger::WARN
-    end
-    str
-  end
-
-  private
-
-  def puts_and_logs(msg, level = Logger::INFO)
-    logger.add level, msg
-    puts msg if Foreman.in_rake? && !Rails.env.test? && level >= Logger::INFO
   end
 end

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -13,8 +13,8 @@ class Setting::Auth < Setting
     self.transaction do
       [
         self.set('oauth_active', N_("Foreman will use OAuth for API authorization"), false, N_('OAuth active')),
-        self.set('oauth_consumer_key', N_("OAuth consumer key"), '', N_('OAuth consumer key')),
-        self.set('oauth_consumer_secret', N_("OAuth consumer secret"), '', N_("OAuth consumer secret")),
+        self.set('oauth_consumer_key', N_("OAuth consumer key"), '', N_('OAuth consumer key'), nil, {:encrypted => true}),
+        self.set('oauth_consumer_secret', N_("OAuth consumer secret"), '', N_("OAuth consumer secret"), nil, {:encrypted => true}),
         self.set('oauth_map_users', N_("Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."), true, N_('OAuth map users')),
         self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
         self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
@@ -25,7 +25,7 @@ class Setting::Auth < Setting
         self.set('ssl_client_dn_env', N_('Environment variable containing the subject DN from a client SSL certificate'), 'SSL_CLIENT_S_DN', N_('SSL client DN env')),
         self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY', N_('SSL client verify env')),
         self.set('ssl_client_cert_env', N_("Environment variable containing a client's SSL certificate"), 'SSL_CLIENT_CERT', N_('SSL client cert env')),
-        self.set('websockets_ssl_key', N_("Private key that Foreman will use to encrypt websockets "), nil, N_('Websockets SSL key')),
+        self.set('websockets_ssl_key', N_("Private key file that Foreman will use to encrypt websockets "), nil, N_('Websockets SSL key')),
         self.set('websockets_ssl_cert', N_("Certificate that Foreman will use to encrypt websockets "), nil, N_('Websockets SSL certificate')),
         # websockets_encrypt depends on key/cert when true, so initialize it last
         self.set('websockets_encrypt', N_("VNC/SPICE websocket proxy console access encryption (websockets_ssl_key/cert setting required)"), !!SETTINGS[:require_ssl], N_('Websockets encryption')),

--- a/db/migrate/20160315161936_add_encrypted_to_settings.rb
+++ b/db/migrate/20160315161936_add_encrypted_to_settings.rb
@@ -1,0 +1,5 @@
+class AddEncryptedToSettings < ActiveRecord::Migration
+  def change
+    add_column :settings, :encrypted, :boolean, :null => false, :default => false
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -302,3 +302,9 @@ attributes62:
   category: Setting::Auth
   default: "true"
   description: 'Permits access to BMC interface passwords through ENC YAML output and in templates'
+attributes63:
+  name: password
+  category: Setting::Puppet
+  default: nil
+  description: 'Encrypted password'
+  encrypted: true

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -24,4 +24,15 @@ class AuditExtensionsTest < ActiveSupport::TestCase
     hosts = Audit.complete_for("host = ", {:controller => 'audits'})
     assert hosts.count > 0
   end
+
+  test "audit's change is filtered when data is encrypted" do
+    setting = settings(:attributes63)
+    setting.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+    setting.value = '654321'
+    as_admin do
+      assert setting.save
+    end
+    a = Audit.where(auditable_type: 'Setting')
+    assert_equal "[encrypted]", a.last.audited_changes["value"][1]
+  end
 end


### PR DESCRIPTION
In the following [PR](https://github.com/theforeman/foreman/pull/3030#discussion_r49939234) the use case came up.

In order to encrypt a setting value,  set its `encrypted` flag to true:

``` ruby
self.set('root_pass', N_("Default encrypted root password on provisioned hosts"), nil, N_('Root password')), nil, {:encrypted => true})
```
