### PR TITLE
fixes #13879 - load mocha/minitest integration explicitly

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,5 +1,5 @@
 group :test do
-  gem 'mocha', '~> 1.1', :require => false
+  gem 'mocha', '~> 1.1'
   gem 'simplecov', '~> 0.9'
   gem 'spork-minitest', '0.0.3'
   gem 'single_test', '~> 0.6'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,7 @@ Spork.prefork do
   require File.expand_path('../../config/environment', __FILE__)
   require 'rails/test_help'
   require "minitest/autorun"
+  require 'mocha/mini_test'
   require 'capybara/rails'
   require 'factory_girl_rails'
   require 'capybara/poltergeist'


### PR DESCRIPTION
rails/rails@fd6aaaa removed automatic loading of mocha in Rails 4.2
from rails/test_help.
