### PR TITLE
refs #11029 - improve string for i18n, fix non-host case

### DIFF
--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -1,4 +1,10 @@
-<% title(_("Fact Values") + " | #{params[:host_id]}")%>
+<%
+if params[:host_id].present?
+  title(_("Fact Values | %{host_name}") % {:host_name => params[:host_id]})
+else
+  title(_("Fact Values"))
+end
+%>
 <% title_actions documentation_button('3.5.5FactsandtheENC') %>
 
 <table class="<%= table_css_classes('ellipsis')%>">


### PR DESCRIPTION
The full title string has been extracted for better localisation,
instead of appending hardcoded strings.  The title when viewing all
facts without a host is restored to the previous string.
