### PR TITLE
Fixes #9425 - Remove the Default User role

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -25,8 +25,7 @@ class RolesController < ApplicationController
   end
 
   def new
-    # Prefills the form with 'default user' role permissions
-    @role = Role.new({:permissions => Role.default_user.permissions})
+    @role = Role.new
   end
 
   def create

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -23,7 +23,6 @@ class Role < ActiveRecord::Base
   include Parameterizable::ByIdName
 
   # Built-in roles
-  BUILTIN_DEFAULT_USER  = 1
   BUILTIN_ANONYMOUS     = 2
   audited :allow_mass_assignment => true
 
@@ -100,23 +99,10 @@ class Role < ActiveRecord::Base
     all(:conditions => {:builtin => 0}, :order => 'name')
   end
 
-  # Return the builtin 'default user' role.  If the role doesn't exist,
-  # it will be created on the fly.
-  def self.default_user
-    default_user_role = where(:builtin => BUILTIN_DEFAULT_USER).first
-    if default_user_role.nil?
-      default_user_role = create!(:name => 'Default user') do |role|
-        role.builtin = BUILTIN_DEFAULT_USER
-      end
-      raise ::Foreman::Exception.new(N_('Unable to create the default user role.')) if default_user_role.new_record?
-    end
-    default_user_role
-  end
-
   # Return the builtin 'anonymous' role.  If the role doesn't exist,
   # it will be created on the fly.
   def self.anonymous
-    anonymous_role = where(:builtin => BUILTIN_ANONYMOUS).first
+    anonymous_role = find_by_builtin(BUILTIN_ANONYMOUS)
     if anonymous_role.nil?
       anonymous_role = create!(:name => 'Anonymous') do |role|
         role.builtin = BUILTIN_ANONYMOUS

--- a/db/migrate/20160225115638_remove_default_user_role.rb
+++ b/db/migrate/20160225115638_remove_default_user_role.rb
@@ -1,0 +1,8 @@
+class RemoveDefaultUserRole < ActiveRecord::Migration
+  def up
+    role = Role.where(:builtin => 1).first
+    return if role.nil?
+    role.filters.destroy_all
+    role.delete
+  end
+end

--- a/db/seeds.d/03-roles.rb
+++ b/db/seeds.d/03-roles.rb
@@ -53,18 +53,11 @@ default_permissions =
                                   :destroy_usergroups, :view_users, :edit_users, :view_realms, :view_mail_notifications],
     }
 
-default_user_permissions = [:view_hosts, :view_puppetclasses, :view_hostgroups, :view_domains,
-                            :view_operatingsystems, :view_media, :view_models, :view_environments,
-                            :view_architectures, :view_ptables, :view_globals, :view_external_variables,
-                            :view_authenticators, :access_settings, :access_dashboard,
-                            :view_config_reports, :view_subnets, :view_facts, :view_locations,
-                            :view_organizations, :view_statistics, :view_realms, :view_mail_notifications]
 anonymous_permissions    = [:view_bookmarks, :view_tasks]
 
 Role.without_auditing do
   default_permissions.each do |role_name, permission_names|
     create_role(role_name, permission_names, 0)
   end
-  create_role('Default user', default_user_permissions, Role::BUILTIN_DEFAULT_USER)
   create_role('Anonymous', anonymous_permissions, Role::BUILTIN_ANONYMOUS)
 end

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -334,63 +334,6 @@ viewer_21_0:
 viewer_22_0:
   filter: viewer_22
   permission: view_realms
-default_user_1_0:
-  filter: default_user_1
-  permission: view_hosts
-default_user_2_0:
-  filter: default_user_2
-  permission: view_puppetclasses
-default_user_3_0:
-  filter: default_user_3
-  permission: view_hostgroups
-default_user_4_0:
-  filter: default_user_4
-  permission: view_domains
-default_user_5_0:
-  filter: default_user_5
-  permission: view_operatingsystems
-default_user_6_0:
-  filter: default_user_6
-  permission: view_media
-default_user_7_0:
-  filter: default_user_7
-  permission: view_models
-default_user_8_0:
-  filter: default_user_8
-  permission: view_environments
-default_user_9_0:
-  filter: default_user_9
-  permission: view_architectures
-default_user_10_0:
-  filter: default_user_10
-  permission: view_ptables
-default_user_11_0:
-  filter: default_user_11
-  permission: view_globals
-default_user_12_0:
-  filter: default_user_12
-  permission: view_external_variables
-default_user_13_0:
-  filter: default_user_13
-  permission: view_authenticators
-default_user_14_0:
-  filter: default_user_14
-  permission: access_settings
-default_user_14_1:
-  filter: default_user_14
-  permission: access_dashboard
-default_user_14_2:
-  filter: default_user_14
-  permission: view_statistics
-default_user_15_0:
-  filter: default_user_15
-  permission: view_reports
-default_user_16_0:
-  filter: default_user_16
-  permission: view_facts
-default_user_17_0:
-  filter: default_user_17
-  permission: view_realms
 anonymous_1_0:
   filter: anonymous_1
   permission: view_tasks

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -94,40 +94,6 @@ viewer_21:
   role_id: 5
 viewer_22:
   role_id: 5
-default_user_1:
-  role_id: 6
-default_user_2:
-  role_id: 6
-default_user_3:
-  role_id: 6
-default_user_4:
-  role_id: 6
-default_user_5:
-  role_id: 6
-default_user_6:
-  role_id: 6
-default_user_7:
-  role_id: 6
-default_user_8:
-  role_id: 6
-default_user_9:
-  role_id: 6
-default_user_10:
-  role_id: 6
-default_user_11:
-  role_id: 6
-default_user_12:
-  role_id: 6
-default_user_13:
-  role_id: 6
-default_user_14:
-  role_id: 6
-default_user_15:
-  role_id: 6
-default_user_16:
-  role_id: 6
-default_user_17:
-  role_id: 6
 anonymous_1:
   role_id: 7
 destroy_hosts_1:

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -24,11 +24,6 @@ viewer:
   id: "5"
   builtin: "0"
 
-default_user:
-  name: Default user
-  id: "6"
-  builtin: "1"
-
 anonymous:
   name: Anonymous
   id: "7"

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -65,35 +65,6 @@ class RoleTest < ActiveSupport::TestCase
     end
   end
 
-  context "Default_user" do
-    should "return the default_user role" do
-      role = Role.default_user
-      assert role.builtin?
-      assert_equal Role::BUILTIN_DEFAULT_USER, role.builtin
-    end
-
-    context "with a missing default_user role" do
-      setup do
-        role_ids = Role.where("builtin = #{Role::BUILTIN_DEFAULT_USER}").pluck(:id)
-        UserRole.where(:role_id => role_ids).destroy_all
-        Filter.where(:role_id => role_ids).destroy_all
-        Role.where(:id => role_ids).delete_all
-      end
-
-      should "create a new default_user role" do
-        assert_difference('Role.count') do
-          Role.default_user
-        end
-      end
-
-      should "return the default_user role" do
-        role = Role.default_user
-        assert role.builtin?
-        assert_equal Role::BUILTIN_DEFAULT_USER, role.builtin
-      end
-    end
-  end
-
   describe ".for_current_user" do
     context "there are two roles, one of them is assigned to current user" do
       let(:first) { Role.create(:name => 'First') }


### PR DESCRIPTION
The Default User role is not actually used anywhere, and causes
confusion with the Anonymous role. Removing it.
