### PR TITLE
Fixes #11898 - Information about releases available on 'About' page

### DIFF
--- a/app/assets/javascripts/about.js
+++ b/app/assets/javascripts/about.js
@@ -1,5 +1,6 @@
 $(function() {
   "use strict";
+
   $(".compute-status").each(function(index, item) {
     var item = $(item);
     var url = item.data('url');
@@ -18,4 +19,52 @@ $(function() {
       }
     });
   });
+
+  $(document).ready(loadUpdates);
+
+  function loadUpdates() {
+    if ($('#plugins-table').length > 0) {
+      $.ajax({
+        type: 'get',
+        url: $('#plugins-table').data('url'),
+        success: listVersions
+      });
+    }
+
+    if ($('#latest-updates').length > 0) {
+      $.ajax({
+        type: 'get',
+        url: $('#latest-updates').data('url'),
+        success: showLatest,
+      });
+    }
+  }
+
+  function showLatest(response) {
+    $('#latest-updates').next().remove();
+    response.current_latest = response.current_latest || "N/A"
+    response.lastest = response.latest || "N/A"
+    var versions = response.current_latest + ", " + response.latest
+    $('#latest-updates').append("<span>" + versions + "</span>")
+  }
+
+  function listVersions(response) {
+    var rows = $('#plugins-table > tbody > tr')
+    response.forEach(function (item) {
+      var row = null,
+          name = Object.keys(item).pop();
+      row = $(rows).filter(function (index, ele) {
+        if($(ele).children().first().text() === name) {
+          return ele;
+        }
+      });
+      showPluginUpdate(row, item[name]);
+    });
+  }
+
+  function showPluginUpdate(row, version) {
+    $(row).children().last().find("div").remove();
+    version = version || "N/A";
+    $(row).children().last().append("<div>" + version + "</div>");
+  }
 });

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -15,4 +15,21 @@ class AboutController < ApplicationController
       }
     end
   end
+
+  def plugin_updates
+    render :json => Updates.find("updates/wiki").fetch_plugin_updates.to_json
+  end
+
+  def core_updates
+    render :json => Updates.find("updates/wiki").fetch_core_updates.to_json
+  end
+
+  def action_permission
+    case params[:action]
+    when 'plugin_updates', 'core_updates'
+      :view
+    else
+      super
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -401,7 +401,7 @@ module ApplicationHelper
   def documentation_url(section = "", options = {})
     root_url = options[:root_url] || "http://www.theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#"
     if section.empty?
-      "http://www.theforeman.org/documentation.html##{SETTINGS[:version].short}"
+      "http://theforeman.org/documentation.html##{SETTINGS[:version].short}"
     else
       root_url + section
     end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -22,7 +22,9 @@ class Setting::General < Setting
         self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), false, N_('Use Gravatar')),
         self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true, N_('DB pending migration')),
         self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true, N_('DB pending seed')),
-        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout'))
+        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout')),
+        self.set('foreman_updates', N_("Connect to Foreman website for latest information on updates"), false, N_('Find Foreman updates')),
+        self.set('foreman_updates_override', N_("Location of files with information on updates. Takes precedence over connecting to Foreman website. Disabled if empty."), "/etc/foreman/updates", N_('Override for Foreman updates'))
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -6,6 +6,7 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :user_logout, { :users => [:logout] }, :public => true
     map.permission :my_account, { :users => [:edit] }, :public => true
     map.permission :api_status, { :"api/v1/home" => [:status], :"api/v2/home" => [:status]}, :public => true
+    map.permission :updates, { :about => [:core_updates, :plugin_updates] }, :public => true
   end
 
   permission_set.security_block :architectures do |map|

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -93,6 +93,7 @@ module Foreman #:nodoc:
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
     attr_reader :id, :logging, :default_roles, :provision_methods, :compute_resources, :to_prepare_callbacks
+    attr_accessor :foreman_req
 
     def initialize(id)
       @id = id.to_sym
@@ -127,6 +128,7 @@ module Foreman #:nodoc:
     # Raises a PluginRequirementError exception if the requirement is not met
     # matcher format is gem dependency format
     def requires_foreman(matcher)
+      @foreman_req = matcher
       current = SETTINGS[:version].notag
       unless Gem::Dependency.new('', matcher).match?('', current)
         raise PluginRequirementError.new(N_("%{id} plugin requires Foreman %{matcher} but current is %{current}" % {:id=>id, :matcher => matcher, :current=>current}))
@@ -323,6 +325,10 @@ module Foreman #:nodoc:
 
     def register_facet(klass, name, &block)
       Facets.register(klass, name, &block)
+    end
+
+    def register_update_source(klass, opts = {})
+      Updates.register_source(klass, opts)
     end
 
     def in_to_prepare(&block)

--- a/app/services/updates.rb
+++ b/app/services/updates.rb
@@ -1,0 +1,16 @@
+module Updates
+  def self.register_source(class_name, opts = {})
+    registry.add(class_name.new opts)
+  end
+
+  def self.registry
+    @registry ||= Set.new
+  end
+
+  def self.find(name)
+    registry.find { |update| update.humanized_name == name}
+  end
+end
+
+require_dependency 'updates/base'
+require_dependency 'updates/wiki'

--- a/app/services/updates/base.rb
+++ b/app/services/updates/base.rb
@@ -1,0 +1,67 @@
+require 'uri'
+require 'net/http'
+require 'json'
+
+module Updates
+  class Base
+    attr_reader :cache_duration
+
+    def initialize(opts = {})
+      @cache_duration = opts[:cache_duration] || 2.hours
+    end
+
+    def url
+      raise NotImplementedError, "Method 'url' needs to be implemented"
+    end
+
+    def file_name
+      raise NotImplementedError, "Method 'file_name' needs to be implemented"
+    end
+
+    def humanized_name
+      self.class.name.underscore
+    end
+
+    def fetch_from_file
+      if Setting[:foreman_updates_override].present?
+        begin
+          file_path = File.join(Setting[:foreman_updates_override], file_name)
+          File.open(file_path, "r") do |file|
+            JSON.parse(file.read)
+          end
+        rescue => e
+          Rails.logger.warn "Failed to read from #{file_path}: #{e.message}"
+          {}
+        end
+      else
+        {}
+      end
+    end
+
+    def fetch_from_web
+      if Setting[:foreman_updates]
+        Rails.cache.fetch(humanized_name, :expires_in => cache_duration) do
+          uri = URI.parse url
+          request = Net::HTTP::Get.new(uri.request_uri)
+          request['Content-Type'] = 'application/json'
+          begin
+            result = Net::Http.start(uri.host, uri.port, :read_timeout => 1000) { |http| http.request(request) }
+            result.value
+          rescue => e
+            Rails.logger.warn "Could not retrieve latest releases from #{url}. Cause: #{e.message}"
+            return {}
+          end
+          JSON.parse(result.body)
+        end
+      else
+        {}
+      end
+    end
+
+    def fetch
+      from_file = fetch_from_file
+      return from_file unless from_file.empty?
+      fetch_from_web
+    end
+  end
+end

--- a/app/services/updates/wiki.rb
+++ b/app/services/updates/wiki.rb
@@ -1,0 +1,49 @@
+module Updates
+  class Wiki < Base
+    def url
+      "http://projects.theforeman.org/releases.json"
+    end
+
+    def file_name
+      "updates.json"
+    end
+
+    def fetch_plugin_updates
+      latest_plugin_version_for_current_foreman fetch
+    end
+
+    def fetch_core_updates
+      latest_core_version_for_current_foreman fetch
+    end
+
+    def latest_core_version_for_current_foreman(data)
+      res = { :latest => "", :current_latest => "" }
+      return res if data.empty?
+      major = data['core'].keys.first
+      minor = data['core'][major].keys.first
+      res[:latest] = data['core'][major][minor].first
+      res[:current_latest] = data['core'][SETTINGS[:version].major][SETTINGS[:version].minor].first rescue SETTINGS[:version].to_s
+      res
+    end
+
+    def latest_plugin_version_for_current_foreman(data)
+      Foreman::Plugin.all.map do |plugin|
+        next { plugin.id.to_s => "" } if data.empty?
+        if data['plugins'][plugin.id.to_s]
+          latest = data["plugins"][plugin.id.to_s].select do |item, value|
+            value['requires_foreman'] == plugin_short_req(plugin.foreman_req)
+          end
+          { plugin.id.to_s => latest.empty? ? "" : latest.first.first }
+        else
+          { plugin.id.to_s => "" }
+        end
+      end
+    end
+
+    def plugin_short_req(matcher)
+      matcher.match(/ (\d+\.\d+)/)[1]
+    end
+  end
+end
+
+Updates.register_source(Updates::Wiki)

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -93,13 +93,16 @@
           <% if @plugins.empty? %>
             <p class="ca"><%= _("No plugins found") %></p>
           <% else %>
-            <table class="table table-striped table-fixed">
+            <table class="table table-striped table-fixed"
+                   id="plugins-table"
+                   data-url="<%= plugin_updates_about_index_path %>">
               <thead>
                 <tr>
                   <th class="col-md-4"><%= _("Name") %></th>
                   <th class="col-md-6"><%= _("Description") %></th>
                   <th class="col-md-2"><%= _("Author") %></th>
-                  <th class="col-md-2"><%= _("Version") %></th>
+                  <th class="col-md-3"><%= _("Version") %></th>
+                  <th class="col-md-2"><%= _("Latest Known Version")%></th>
                 </tr>
               </thead>
               <tbody>
@@ -109,6 +112,7 @@
                   <td class="ellipsis"><%= _(plugin.description) %></td>
                   <td class="ellipsis"><%= plugin.author_url.blank? ? plugin.author : link_to(plugin.author, plugin.author_url)%></td>
                   <td><%= plugin.version %></td>
+                  <td><%= spinner %></td>
                 </tr>
               <% end %>
               </tbody>
@@ -140,6 +144,10 @@
     <div class="stats-well" id="copyright-div">
       <h4><%= _("System Information") %> </h4>
       <p id="copyright-p"><%= (_("Version %{version}  © 2009-%{year} Paul Kelly and %{author}") % {:version => SETTINGS[:version], :year=>DateTime.now.year, :author=>mail_to("ohadlevy@gmail.com", "Ohad Levy" )}).html_safe %></p>
+      <p id="latest-updates" data-url="<%= core_updates_about_index_path %>">
+        <%= _("Latest releases: ") %>
+      </p>
+      <%= spinner %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -475,6 +475,10 @@ Foreman::Application.routes.draw do
   end
 
   resources :about, :only => :index do
+    collection do
+      get 'plugin_updates'
+      get 'core_updates'
+    end
   end
 
   resources :interfaces, :only => :new

--- a/test/unit/updates/wiki_test.rb
+++ b/test/unit/updates/wiki_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class WikiTest < ActiveSupport::TestCase
+  setup do
+    @data = {
+      "core" => {
+        "1" => {
+          "10" => ["1.10.2", "1.10.1"],
+          "9"  => ["1.9.3", "1.9.0-RC1"]
+        },
+        "0" => {
+          "0" => ["0.0.1"]
+        }
+      },
+      "plugins" => {
+        "foreman-tasks" => {
+          "0.7.15" => {
+            "requires_foreman" => "1.9"
+          },
+          "0.7.1" => {
+            "requires_foreman" => "1.6"
+          }
+        },
+        "foreman_docker" => {
+          "2.0.1" => {
+            "requires_foreman" => "1.11"
+          },
+          "1.8.6" => {
+            "requires_foreman" => "1.9"
+          }
+        }
+      }
+    }
+    @wiki = Updates::Wiki.new
+  end
+
+  test 'should get latest plugin versions' do
+    Foreman::Plugin.stubs(:all).returns(setup_plugins)
+    SETTINGS[:version] = Foreman::Version.new "1.9.3"
+    assert_equal [{"foreman-tasks" => "0.7.15"}, {"foreman_docker" => "1.8.6"}], @wiki.latest_plugin_version_for_current_foreman(@data)
+  end
+
+  test 'should get latest core version' do
+    SETTINGS[:version] = Foreman::Version.new "1.9.1"
+    assert_equal({ :latest => "1.10.2", :current_latest => "1.9.3" }, @wiki.latest_core_version_for_current_foreman(@data))
+  end
+
+  private
+
+  def setup_plugins
+    ["foreman-tasks", "foreman_docker"].map do |item|
+      p = Foreman::Plugin.send :new, item
+      p.foreman_req = ">= 1.9"
+      p
+    end
+  end
+end


### PR DESCRIPTION
Needs [changes](https://github.com/theforeman/theforeman.org/pull/550) on our Wiki to work. The main idea is that we load json data provided by wiki, sift through it and display what we want. I added latest released versions of core and latest version of plugins if available.
