### PR TITLE
Fixes #13545 - STI permission checking always using base class

### DIFF
--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -474,6 +474,11 @@
     resource_type: Report
     created_at: "2013-12-04 08:41:06.107515"
     updated_at: "2013-12-04 08:41:06.107515"
+  view_config_reports:
+    name: view_config_reports
+    resource_type: ConfigReport
+    created_at: "2013-12-04 08:41:06.107515"
+    updated_at: "2013-12-04 08:41:06.107515"
   destroy_reports:
     name: destroy_reports
     resource_type: Report

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -181,7 +181,7 @@ Spork.prefork do
         role.save!
         filter.role = role
         filter.save!
-        @one.roles = [ role ]
+        @one.roles << role
         yield(@one) if block_given?
         @one.save!
       end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -164,6 +164,13 @@ class HostTest < ActiveSupport::TestCase
     assert_equal host.vm_compute_attributes, nil
   end
 
+  test "can authorize Host::Managed as non-admin user" do
+    h = FactoryGirl.create(:host, :managed)
+    setup_user('view', 'hosts', 'name ~ *')
+
+    assert_includes Host.authorized('view_hosts'), h
+  end
+
   context "when unattended is false" do
     def setup
       SETTINGS[:unattended] = false

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -113,6 +113,14 @@ class ReportTest < ActiveSupport::TestCase
       report = TestReport.new
       assert_equal({}, report.metrics)
     end
+
+    test 'can view host reports as non-admin user' do
+      report = FactoryGirl.create(:config_report)
+      setup_user('view', 'hosts', "name = #{report.host.name}")
+      setup_user('view',  'config_reports')
+
+      assert_includes ConfigReport.authorized('view_config_reports').my_reports, report
+    end
   end
 end
 


### PR DESCRIPTION
This fixes permission checks on STI objects.  Due to these methods existing
in Procs and being included in the base class at run time, resource_class was
returning the base class.  I can only presume this is related to a ruby or rails 4
upgrade
