### PR TITLE
fixes #13941 - expect deprecation warnings in tests

### DIFF
--- a/test/functional/api/v1/config_templates_controller_test.rb
+++ b/test/functional/api/v1/config_templates_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class Api::V1::ConfigTemplatesControllerTest < ActionController::TestCase
+  setup do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Config templates were renamed to provisioning templates')
+  end
+
   test "should get index" do
     get :index
     templates = ActiveSupport::JSON.decode(@response.body)

--- a/test/functional/api/v1/hosts_controller_test.rb
+++ b/test/functional/api/v1/hosts_controller_test.rb
@@ -50,6 +50,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
 
   test "should create host with host_parameters_attributes" do
     disable_orchestration
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
     assert_difference('Host.count') do
       attrs = [{"name" => "compute_resource_id", "value" => "1", "nested" => "true"}]
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
@@ -59,6 +60,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
 
   test "should create host with host_parameters_attributes sent in a hash" do
     disable_orchestration
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
     assert_difference('Host.count') do
       attrs = {"0" => {"name" => "compute_resource_id", "value" => "1", "nested" => "true"}}
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
@@ -87,6 +89,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
   end
 
   test "should show status hosts" do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
     get :status, { :id => @host.to_param }
     assert_response :success
   end
@@ -126,6 +129,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
   test "should allow show status for restricted user who owns the hosts" do
     host = FactoryGirl.create(:host, :owner => users(:restricted))
     setup_user 'view', 'hosts', "owner_type = User and owner_id = #{users(:restricted).id}", :restricted
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
     get :status, { :id => host.to_param }
     assert_response :success
   end

--- a/test/functional/api/v1/reports_controller_test.rb
+++ b/test/functional/api/v1/reports_controller_test.rb
@@ -4,6 +4,10 @@ require 'functional/shared/report_host_permissions_test'
 class Api::V1::ReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
 
+  setup do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Reports were renamed to ConfigReports')
+  end
+
   test "should get index" do
     FactoryGirl.create(:report)
     get :index, { }

--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
+  setup do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/config_templates were moved to /provisioning_templates}))
+  end
+
   test "should get index" do
     get :index
     templates = ActiveSupport::JSON.decode(@response.body)

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -104,6 +104,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should create host with host_parameters_attributes" do
     disable_orchestration
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
     assert_difference('Host.count') do
       attrs = [{"name" => "compute_resource_id", "value" => "1", "nested" => "true"}]
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
@@ -113,6 +114,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should create host with host_parameters_attributes sent in a hash" do
     disable_orchestration
+    Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
     assert_difference('Host.count') do
       attrs = {"0" => {"name" => "compute_resource_id", "value" => "1", "nested" => "true"}}
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
@@ -224,6 +226,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test "should show status hosts" do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
     get :status, { :id => @host.to_param }
     assert_response :success
   end
@@ -266,6 +269,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test "should allow show status for restricted user who owns the hosts" do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
     host = FactoryGirl.create(:host, :owner => users(:restricted))
     setup_user 'view', 'hosts', "owner_type = User and owner_id = #{users(:restricted).id}", :restricted
     get :status, { :id => host.to_param }

--- a/test/functional/api/v2/reports_controller_test.rb
+++ b/test/functional/api/v2/reports_controller_test.rb
@@ -4,6 +4,10 @@ require 'functional/shared/report_host_permissions_test'
 class Api::V2::ReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
 
+  setup do
+    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/reports were moved to /config_reports}))
+  end
+
   describe "Non Admin User" do
     def setup
       User.current = users(:one) #use an unprivileged user, not apiadmin
@@ -29,6 +33,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       User.current=nil
       post :create, {:report => create_a_puppet_transaction_report }, set_session_user
       assert_response :success
+      Foreman::Deprecation.expects(:api_deprecation_warning)
       post :create, {:report => create_a_puppet_transaction_report }, set_session_user
       assert_response :unprocessable_entity
     end

--- a/test/functional/api/v2/template_combinations_controller_test.rb
+++ b/test/functional/api/v2/template_combinations_controller_test.rb
@@ -1,54 +1,103 @@
 require 'test_helper'
 
 class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
-  test "should get index using deprecated parameter" do
-    get :index, {:config_template_id => templates(:mystring2).id}
-    template_combinations = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 2, template_combinations['results'].size, "Should contain template_combinations in the response"
-    assert_response :success
-  end
-
-  test "should get index" do
-    get :index, {:provisioning_template_id => templates(:mystring2).id}
-    template_combinations = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 2, template_combinations['results'].size, "Should contain template_combinations in the response"
-    assert_response :success
-  end
-
-  test "should get template combination" do
-    get :show, { :config_template_id => templates(:mystring2).to_param, :id => template_combinations(:two).id }
-    assert_response :success
-    template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert !template_combination.empty?
-    assert_equal template_combination["config_template_id"], template_combinations(:two).provisioning_template_id
-  end
-
-  test "should create valid" do
-    TemplateCombination.any_instance.stubs(:valid?).returns(true)
-    as_admin do
-      post :create, { :template_combination => { :environment_id => environments(:production).id, :hostgroup_id => hostgroups(:unusual).id },
-        :config_template_id => templates(:mystring2).id }
+  context 'with provisioning_template_id' do
+    setup do
+      Foreman::Deprecation.expects(:api_deprecation_warning).never
     end
-    template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert_equal(template_combination["environment_id"], environments(:production).id)
-    assert_equal(template_combination["hostgroup_id"], hostgroups(:unusual).id)
-    assert_equal(template_combination["config_template_id"], templates(:mystring2).id)
-    assert_response :created
+
+    test "should get index" do
+      get :index, {:provisioning_template_id => templates(:mystring2).id}
+      template_combinations = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 2, template_combinations['results'].size, "Should contain template_combinations in the response"
+      assert_response :success
+    end
+
+    test "should get template combination" do
+      get :show, { :provisioning_template_id => templates(:mystring2).to_param, :id => template_combinations(:two).id }
+      assert_response :success
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert !template_combination.empty?
+      assert_equal template_combination["provisioning_template_id"], template_combinations(:two).provisioning_template_id
+    end
+
+    test "should create valid" do
+      TemplateCombination.any_instance.stubs(:valid?).returns(true)
+      as_admin do
+        post :create, { :template_combination => { :environment_id => environments(:production).id, :hostgroup_id => hostgroups(:unusual).id },
+          :provisioning_template_id => templates(:mystring2).id }
+      end
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert_equal(template_combination["environment_id"], environments(:production).id)
+      assert_equal(template_combination["hostgroup_id"], hostgroups(:unusual).id)
+      assert_equal(template_combination["provisioning_template_id"], templates(:mystring2).id)
+      assert_response :created
+    end
+
+    test "should update template combination" do
+      put :update, { :template_combination => { :environment_id => environments(:testing).id, :hostgroup_id => hostgroups(:common).id },
+                     :provisioning_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
+
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert_equal(template_combination["environment_id"], environments(:testing).id)
+      assert_equal(template_combination["hostgroup_id"], hostgroups(:common).id)
+      assert_response :success
+    end
+
+    test "should destroy" do
+      delete :destroy, { :provisioning_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
+      assert_response :ok
+      refute TemplateCombination.exists?(template_combinations(:two).id)
+    end
   end
 
-  test "should update template combination" do
-    put :update, { :template_combination => { :environment_id => environments(:testing).id, :hostgroup_id => hostgroups(:common).id },
-                   :config_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
+  context 'with deprecated config_template_id' do
+    setup do
+      Foreman::Deprecation.expects(:api_deprecation_warning).with('Config templates were renamed to provisioning templates')
+    end
 
-    template_combination = ActiveSupport::JSON.decode(@response.body)
-    assert_equal(template_combination["environment_id"], environments(:testing).id)
-    assert_equal(template_combination["hostgroup_id"], hostgroups(:common).id)
-    assert_response :success
-  end
+    test "should get index" do
+      get :index, {:config_template_id => templates(:mystring2).id}
+      template_combinations = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 2, template_combinations['results'].size, "Should contain template_combinations in the response"
+      assert_response :success
+    end
 
-  test "should destroy" do
-    delete :destroy, { :config_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
-    assert_response :ok
-    refute TemplateCombination.exists?(template_combinations(:two).id)
+    test "should get template combination" do
+      get :show, { :config_template_id => templates(:mystring2).to_param, :id => template_combinations(:two).id }
+      assert_response :success
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert !template_combination.empty?
+      assert_equal template_combination["config_template_id"], template_combinations(:two).provisioning_template_id
+    end
+
+    test "should create valid" do
+      TemplateCombination.any_instance.stubs(:valid?).returns(true)
+      as_admin do
+        post :create, { :template_combination => { :environment_id => environments(:production).id, :hostgroup_id => hostgroups(:unusual).id },
+          :config_template_id => templates(:mystring2).id }
+      end
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert_equal(template_combination["environment_id"], environments(:production).id)
+      assert_equal(template_combination["hostgroup_id"], hostgroups(:unusual).id)
+      assert_equal(template_combination["config_template_id"], templates(:mystring2).id)
+      assert_response :created
+    end
+
+    test "should update template combination" do
+      put :update, { :template_combination => { :environment_id => environments(:testing).id, :hostgroup_id => hostgroups(:common).id },
+                     :config_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
+
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert_equal(template_combination["environment_id"], environments(:testing).id)
+      assert_equal(template_combination["hostgroup_id"], hostgroups(:common).id)
+      assert_response :success
+    end
+
+    test "should destroy" do
+      delete :destroy, { :config_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
+      assert_response :ok
+      refute TemplateCombination.exists?(template_combinations(:two).id)
+    end
   end
 end

--- a/test/functional/smart_proxy_auth_test.rb
+++ b/test/functional/smart_proxy_auth_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class SmartProxyAuthApiTest < ActionController::TestCase
-  tests "api/v2/reports"
+  tests "api/v2/config_reports"
 
   def described_class
     Api::V2::ReportsController

--- a/test/unit/foreman_deprecation_test.rb
+++ b/test/unit/foreman_deprecation_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ForemanDeprecationTest < ActiveSupport::TestCase
   test "deadline version is higher than current version and version name in right format" do
+    ActiveSupport::Deprecation.expects(:warn).with("You are using a deprecated behavior, it will be removed in version 1.9, More info", instance_of(Array))
     assert_nothing_raised do
       Foreman::Deprecation.deprecation_warning("1.9", "More info")
     end
@@ -15,9 +16,9 @@ class ForemanDeprecationTest < ActiveSupport::TestCase
     end
   end
   test "calling API deprecation" do
+    ActiveSupport::Deprecation.expects(:warn).with("Your API call uses deprecated behavior, More info", instance_of(Array))
     assert_nothing_raised do
       Foreman::Deprecation.api_deprecation_warning("More info")
     end
   end
 end
-

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -10,12 +10,14 @@ class ReportImporterTest < ActiveSupport::TestCase
   end
 
   test 'it should import reports with no metrics' do
+    expect_deprecation_warning
     r = TestReportImporter.import(read_json_fixture('report-empty.json'))
     assert r
     assert_equal({}, r.metrics)
   end
 
   test 'it should import reports where logs is nil' do
+    expect_deprecation_warning
     r = Report.import read_json_fixture('report-no-logs.json')
     assert_empty r.logs
   end
@@ -37,6 +39,7 @@ class ReportImporterTest < ActiveSupport::TestCase
     end
 
     test 'when owner is not subscribed to notifications, no mail should be sent on error' do
+      expect_deprecation_warning
       @owner.mail_notifications = []
       assert_no_difference 'ActionMailer::Base.deliveries.size' do
         report = read_json_fixture('report-errors.json')
@@ -47,6 +50,7 @@ class ReportImporterTest < ActiveSupport::TestCase
   end
 
   test 'when a host has no owner, no mail should be sent on error' do
+    expect_deprecation_warning
     host = FactoryGirl.create(:host, :owner => nil)
     report = read_json_fixture('report-errors.json')
     report["host"] = host.name
@@ -67,6 +71,7 @@ class ReportImporterTest < ActiveSupport::TestCase
   end
 
   test 'if report has no error, no mail should be sent' do
+    expect_deprecation_warning
     assert_no_difference 'ActionMailer::Base.deliveries.size' do
       TestReportImporter.import read_json_fixture('report-applied.json')
     end
@@ -87,6 +92,12 @@ class ReportImporterTest < ActiveSupport::TestCase
     reporter = ReportImporter.new(report)
     host = reporter.send(:host)
     assert_equal host, db_host
+  end
+
+  private
+
+  def expect_deprecation_warning
+    Foreman::Deprecation.expects(:deprecation_warning).with('1.13', 'Report model has turned to be STI, please use child classes')
   end
 end
 


### PR DESCRIPTION
When testing deprecated routes, parameters etc, expect the deprecation
warnings to both test that it's logged and to prevent the logging from
cluttering test output.
