### PR TITLE
Fixes #5883 - Reflect token expiry in build status

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -262,6 +262,11 @@ class Host::Managed < Host::Base
                      :expires => Time.now.utc + Setting[:token_duration].minutes)
   end
 
+  def token_expired?
+    return false unless Setting[:token_duration] != 0 and self.token.present?
+    self.token.expires < Time.now.utc
+  end
+
   def expire_token
     self.token.delete if self.token.present?
   end

--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -1,6 +1,7 @@
 module HostStatus
   class BuildStatus < Status
     PENDING = 1
+    TOKEN_EXPIRED = 2
     BUILT = 0
 
     def self.status_name
@@ -11,6 +12,8 @@ module HostStatus
       case to_status
         when PENDING
           N_("Pending installation")
+        when TOKEN_EXPIRED
+          N_("Token expired")
         when BUILT
           N_("Installed")
         else
@@ -18,9 +21,22 @@ module HostStatus
       end
     end
 
+    def to_global(options = {})
+      case to_status
+        when TOKEN_EXPIRED
+          HostStatus::Global::ERROR
+        else
+          HostStatus::Global::OK
+      end
+    end
+
     def to_status(options = {})
       if waiting_for_build?
-        PENDING
+        if token_expired?
+          TOKEN_EXPIRED
+        else
+          PENDING
+        end
       else
         BUILT
       end
@@ -32,6 +48,10 @@ module HostStatus
 
     def waiting_for_build?
       host && host.build
+    end
+
+    def token_expired?
+      host && host.token_expired?
     end
   end
 end


### PR DESCRIPTION
The Global Status introduced in recent Foreman releases makes it easy to
mark the build status as erroneous if the token has expired. This drags
attention to the fact that the host will not be able to mark itself as
built anymore.
