### PR TITLE
Fixes #13849 - Now the facets will not require id attribute for update

### DIFF
--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -36,8 +36,9 @@ module Facets
       def register_facet_relation(klass, facet_config)
         klass.class_eval do
           has_one facet_config.name, :class_name => facet_config.model.name, :foreign_key => :host_id, :inverse_of => :host
-          accepts_nested_attributes_for facet_config.name
+          accepts_nested_attributes_for facet_config.name, :update_only => true
           alias_method "#{facet_config.name}_attributes", facet_config.name
+          attr_accessible "#{facet_config.name}_attributes"
 
           include facet_config.extension if facet_config.extension
 

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -66,5 +66,24 @@ class FacetTest < ActiveSupport::TestCase
 
       assert_not_nil attributes["test_facet_attributes"]
     end
+
+    test 'facets are updated without specifying id explicitly' do
+      saved_host = FactoryGirl.create(:host)
+      saved_host.build_test_facet
+      saved_host.save!
+      TestFacet.class_eval do
+        def my_attribute
+        end
+
+        def my_attribute=(val)
+        end
+
+        attr_accessible :my_attribute
+      end
+
+      saved_host.attributes = {'test_facet_attributes' => { 'my_attribute' => 'my_value'}}
+
+      assert_not_nil saved_host.test_facet.id
+    end
   end
 end


### PR DESCRIPTION
We don't want to specify `:id` attribute when updating a host with saved facet, but it is required by default in `accepts_nested_attributes_for`
