### PR TITLE
fixes #13971 - pass IDs to model.find and .exists?

### DIFF
--- a/test/functional/api/v1/reports_controller_test.rb
+++ b/test/functional/api/v1/reports_controller_test.rb
@@ -80,7 +80,7 @@ class Api::V1::ReportsControllerTest < ActionController::TestCase
   test 'cannot view the last report without hosts view permission' do
     setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
-    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current)
+    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end
 end

--- a/test/functional/api/v1/users_controller_test.rb
+++ b/test/functional/api/v1/users_controller_test.rb
@@ -100,7 +100,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
       response = ActiveSupport::JSON.decode(@response.body)
       assert response['details'] == "You are trying to delete your own account"
       assert response['message'] == "Access denied"
-      assert User.exists?(user)
+      assert User.exists?(user.id)
     end
   end
 

--- a/test/functional/api/v2/config_reports_controller_test.rb
+++ b/test/functional/api/v2/config_reports_controller_test.rb
@@ -195,7 +195,7 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
   test 'cannot view the last report without hosts view permission' do
     setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
-    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current)
+    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end
 end

--- a/test/functional/api/v2/reports_controller_test.rb
+++ b/test/functional/api/v2/reports_controller_test.rb
@@ -195,7 +195,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
   test 'cannot view the last report without hosts view permission' do
     setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
-    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current)
+    get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end
 end

--- a/test/functional/api/v2/users_controller_test.rb
+++ b/test/functional/api/v2/users_controller_test.rb
@@ -113,7 +113,7 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
       response = ActiveSupport::JSON.decode(@response.body)
       assert_equal "You are trying to delete your own account", response['error']['details']
       assert_equal "Access denied", response['error']['message']
-      assert User.exists?(user)
+      assert User.exists?(user.id)
     end
   end
 

--- a/test/functional/config_reports_controller_test.rb
+++ b/test/functional/config_reports_controller_test.rb
@@ -77,7 +77,7 @@ class ConfigReportsControllerTest < ActionController::TestCase
   test 'cannot view the last report without hosts view permission' do
     setup_user('view', 'config_reports')
     report = FactoryGirl.create(:config_report)
-    get :show, { :id => 'last', :host_id => report.host.id }, set_session_user.merge(:user => User.current)
+    get :show, { :id => 'last', :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end
 

--- a/test/functional/environments_controller_test.rb
+++ b/test/functional/environments_controller_test.rb
@@ -22,7 +22,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
     assert environment.save!
 
     put :update, { :commit => "Update", :id => environment.name, :environment => {:name => "other_environment"} }, set_session_user
-    env = Environment.find(environment)
+    env = Environment.find(environment.id)
     assert env.name == "other_environment"
 
     assert_redirected_to environments_path

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -103,7 +103,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test "should update host" do
     put :update, { :commit => "Update", :id => @host.name, :host => {:disk => "ntfs"} }, set_session_user
-    @host = Host.find(@host)
+    @host = Host.find(@host.id)
     assert_equal @host.disk, "ntfs"
   end
 
@@ -623,8 +623,8 @@ class HostsControllerTest < ActionController::TestCase
       multiple_hosts_submit_request('build', [@host1.id, @host2.id],
                                     'The selected hosts will execute a build operation on next reboot',
                                     {:host => { :build => 0 }})
-      assert Host.find(@host1).build
-      assert Host.find(@host2).build
+      assert Host.find(@host1.id).build
+      assert Host.find(@host2.id).build
     end
 
     test 'build with reboot' do
@@ -638,8 +638,8 @@ class HostsControllerTest < ActionController::TestCase
       multiple_hosts_submit_request('build', [@host1.id, @host2.id],
                                     'The selected hosts were enabled for reboot and rebuild',
                                     {:host => { :build => 1 }})
-      assert Host.find(@host1).build
-      assert Host.find(@host2).build
+      assert Host.find(@host1.id).build
+      assert Host.find(@host2.id).build
     end
 
     test 'destroy' do
@@ -649,14 +649,14 @@ class HostsControllerTest < ActionController::TestCase
 
     test 'disable notifications' do
       multiple_hosts_submit_request('disable', [@host1.id, @host2.id], 'Disabled selected hosts')
-      refute Host.find(@host1).enabled
-      refute Host.find(@host2).enabled
+      refute Host.find(@host1.id).enabled
+      refute Host.find(@host2.id).enabled
     end
 
     test 'enable notifications' do
       multiple_hosts_submit_request('enable', [@host1.id, @host2.id], 'Enabled selected hosts')
-      assert Host.find(@host1).enabled
-      assert Host.find(@host2).enabled
+      assert Host.find(@host1.id).enabled
+      assert Host.find(@host2.id).enabled
     end
 
     private

--- a/test/functional/shared/report_host_permissions_test.rb
+++ b/test/functional/shared/report_host_permissions_test.rb
@@ -6,14 +6,14 @@ module ReportHostPermissionsTest
 
       test 'cannot view any reports' do
         report = FactoryGirl.create(:config_report)
-        get :show, { :id => report.id }, set_session_user.merge(:user => User.current)
+        get :show, { :id => report.id }, set_session_user.merge(:user => User.current.id)
         assert_response :not_found
       end
 
       test 'cannot delete host reports' do
         setup_user 'destroy', 'config_reports'
         report = FactoryGirl.create(:config_report)
-        delete :destroy, { :id => report.id }, set_session_user.merge(:user => User.current)
+        delete :destroy, { :id => report.id }, set_session_user.merge(:user => User.current.id)
         assert_response :not_found
       end
     end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -137,7 +137,7 @@ class UsersControllerTest < ActionController::TestCase
 
   test "should delete different user" do
     user = users(:one)
-    delete :destroy, {:id => user}, set_session_user.merge(:user => users(:admin))
+    delete :destroy, {:id => user}, set_session_user.merge(:user => users(:admin).id)
     assert_redirected_to users_url
     assert !User.exists?(user.id)
   end
@@ -161,7 +161,7 @@ class UsersControllerTest < ActionController::TestCase
     user.update_attribute :admin, true
     delete :destroy, {:id => user.id}, set_session_user.merge(:user => user.id)
     assert_redirected_to users_url
-    assert User.exists?(user)
+    assert User.exists?(user.id)
     assert @request.flash[:notice] == "You cannot delete this user while logged in as this user."
   end
 

--- a/test/unit/host_mailer_test.rb
+++ b/test/unit/host_mailer_test.rb
@@ -23,7 +23,7 @@ class HostMailerTest < ActionMailer::TestCase
     # HostMailer relies on .size, and Rails looks to the counter_caches
     # if they exist.  Since fixtures don't populate the counter_caches,
     # we do it here:
-    Environment.reset_counters(@env, :hosts)
+    Environment.reset_counters(@env.id, :hosts)
     @env.reload
 
     ActionMailer::Base.deliveries = []

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1703,7 +1703,7 @@ class HostTest < ActiveSupport::TestCase
       parameter = hg.group_parameters.first
       results = Host.search_for(%{params.#{parameter.name} = "#{parameter.value}"})
       assert results.include?(host)
-      assert_equal parameter.value, results.find(host).params[parameter.name]
+      assert_equal parameter.value, results.find(host.id).params[parameter.name]
     end
 
     test "can search hosts by inherited params from a parent hostgroup" do
@@ -1713,7 +1713,7 @@ class HostTest < ActiveSupport::TestCase
       parameter = parent_hg.group_parameters.first
       results = Host.search_for(%{params.#{parameter.name} = "#{parameter.value}"})
       assert results.include?(host)
-      assert_equal parameter.value, results.find(host).params[parameter.name]
+      assert_equal parameter.value, results.find(host.id).params[parameter.name]
     end
 
     test "can search hosts by smart proxy" do

--- a/test/unit/taxonomix_test.rb
+++ b/test/unit/taxonomix_test.rb
@@ -67,8 +67,8 @@ class TaxonomixTest < ActiveSupport::TestCase
 
   test ".used_location_ids can work with array of locations" do
     loc1 = FactoryGirl.create(:location)
-    loc2 = FactoryGirl.create(:location, :parent_id => loc1)
-    loc3 = FactoryGirl.create(:location, :parent_id => loc2)
+    loc2 = FactoryGirl.create(:location, :parent_id => loc1.id)
+    loc3 = FactoryGirl.create(:location, :parent_id => loc2.id)
     loc4 = FactoryGirl.create(:location)
     dummy_class = @dummy.class
     dummy_class.which_ancestry_method = :subtree_ids
@@ -94,8 +94,8 @@ class TaxonomixTest < ActiveSupport::TestCase
 
   test ".used_organization_ids can work with array of organizations" do
     org1 = FactoryGirl.create(:organization)
-    org2 = FactoryGirl.create(:organization, :parent_id => org1)
-    org3 = FactoryGirl.create(:organization, :parent_id => org2)
+    org2 = FactoryGirl.create(:organization, :parent_id => org1.id)
+    org3 = FactoryGirl.create(:organization, :parent_id => org2.id)
     org4 = FactoryGirl.create(:organization)
     dummy_class = @dummy.class
     dummy_class.which_ancestry_method = :subtree_ids
@@ -126,8 +126,8 @@ class TaxonomixTest < ActiveSupport::TestCase
 
   test ".taxable_ids (and .inner_select) can work with array of taxonomies" do
     loc1 = FactoryGirl.create(:location)
-    loc2 = FactoryGirl.create(:location, :parent_id => loc1)
-    loc3 = FactoryGirl.create(:location, :parent_id => loc2)
+    loc2 = FactoryGirl.create(:location, :parent_id => loc1.id)
+    loc3 = FactoryGirl.create(:location, :parent_id => loc2.id)
     loc4 = FactoryGirl.create(:location)
     org = FactoryGirl.create(:organization)
     env1 = FactoryGirl.create(:environment, :organizations => [org], :locations => [loc2])


### PR DESCRIPTION
AR objects should not be passed to .exists? or .find, the ID should be
given instead.  Passing AR objects is deprecated in Rails 4.2.
