### PR TITLE
fixes #13974 - remove nested arrays passed to AR finders

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -30,7 +30,7 @@ module Foreman::Controller::SmartProxyAuth
   # Permits registered Smart Proxies or a user with permission
   def require_smart_proxy_or_login(features = nil)
     features = features.call if features.respond_to?(:call)
-    allowed_smart_proxies = features.blank? ? SmartProxy.all : SmartProxy.with_features(features)
+    allowed_smart_proxies = features.blank? ? SmartProxy.all : SmartProxy.with_features(*features)
 
     if !Setting[:restrict_registered_smart_proxies] or auth_smart_proxy(allowed_smart_proxies, Setting[:require_ssl_smart_proxies])
       set_admin_user

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -90,7 +90,7 @@ module Taxonomix
       inner_ids ||= inner_ids_loc if inner_ids_loc
       inner_ids ||= inner_ids_org if inner_ids_org
       # In the case of users we want the taxonomy scope to get both the users of the taxonomy and admins.
-      inner_ids << admin_ids if inner_ids && self == User
+      inner_ids.concat(admin_ids) if inner_ids && self == User
       inner_ids
     end
 


### PR DESCRIPTION
Passing a nested array to Active Record finder methods is deprecated in
Rails 4.2 and will be removed, they must be flattened first.
