### PR TITLE
Fixes #13964 - include installer scenarios in foreman-debug

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -102,11 +102,15 @@ add_files() {
         application/x-xz)
           xzcat "$FILE" | $TAIL_OR_CAT | sed -r "$FILTER" > "$DIR$FILE.txt"
           ;;
-        text/plain)
+        text/plain | application/xml)
           $TAIL_OR_CAT "$FILE" | sed -r "$FILTER" > "$DIR$FILE"
           [ $PRINTPASS -eq 1 ] && grep -H "\*\*\*\*\*" "$DIR$FILE"
           ;;
-        ?)
+        inode/symlink)
+          cp -a "$FILE" "$DIR$FILE"
+          add_files $(readlink -f $FILE)
+          ;;
+        *)
           echo "Skipping file $FILE: unknown MIME type $MIME" >> "$DIR/skipped_files"
           ;;
       esac
@@ -283,6 +287,7 @@ add_cmd "scl enable $SCLNAME 'gem list'" "gem_list_scl"
 add_cmd "bundle --local --gemfile=/usr/share/foreman/Gemfile" "bundle_list"
 add_cmd "facter" "facts"
 add_files /etc/foreman/* /var/log/foreman/*.log*
+add_files /etc/foreman-installer/scenarios.d/{*,*/*,*/.*} /var/log/foreman-installer/*.log*
 add_files /usr/share/foreman/Gemfile*
 add_cmd "virsh list" "virsh_list"
 add_files /etc/libvirt/* /etc/libvirt/storage/* /etc/libvirt/qemu/* /etc/libvirt/qemu/networks


### PR DESCRIPTION
- added paths to the installer configs and logs including migrations
- fixed the add_files to really accept symlinks. The file filter let them in but they were refused by mime-type filter
- fixed case's "else" to log skipped files
- during debugging I found out that XML files were silently skipped so I've added a fix as well, can be removed from this PR as it is not related to the issue (let me know if it is the case) 
