### PR TITLE
fixes #13897 - explicitly set limit on string columns

### DIFF
--- a/db/migrate/20090714132448_create_hosts.rb
+++ b/db/migrate/20090714132448_create_hosts.rb
@@ -2,8 +2,8 @@ class CreateHosts < ActiveRecord::Migration
   def up
     # Copied from the Puppet schema to replace loading their schema directly
     create_table :hosts do |t|
-      t.column :name, :string, :null => false
-      t.column :ip, :string
+      t.column :name, :string, :null => false, :limit => 255
+      t.column :ip, :string, :limit => 255
       t.column :environment, :text
       t.column :last_compile, :datetime
       t.column :last_freshcheck, :datetime
@@ -17,7 +17,7 @@ class CreateHosts < ActiveRecord::Migration
     add_index :hosts, :name
 
     create_table :fact_names do |t|
-      t.column :name, :string, :null => false
+      t.column :name, :string, :null => false, :limit => 255
       t.column :updated_at, :datetime
       t.column :created_at, :datetime
     end
@@ -36,10 +36,10 @@ class CreateHosts < ActiveRecord::Migration
     add_column :hosts, :mac, :string, :limit => 17, :default => ""
     add_column :hosts, :sp_mac, :string, :limit => 17, :default => ""
     add_column :hosts, :sp_ip, :string, :limit => 15, :default => ""
-    add_column :hosts, :sp_name, :string, :default => ""
+    add_column :hosts, :sp_name, :string, :limit => 255, :default => ""
     add_column :hosts, :root_pass, :string, :limit => 64
     add_column :hosts, :serial, :string, :limit => 12
-    add_column :hosts, :puppetmaster, :string
+    add_column :hosts, :puppetmaster, :string, :limit => 255
     add_column :hosts, :puppet_status, :integer,  :null => false, :default => 0
 
     add_column :hosts, :domain_id, :integer

--- a/db/migrate/20090714132449_add_audits_table.rb
+++ b/db/migrate/20090714132449_add_audits_table.rb
@@ -2,17 +2,17 @@ class AddAuditsTable < ActiveRecord::Migration
   def up
     create_table :audits, :force => true do |t|
       t.column :auditable_id, :integer
-      t.column :auditable_type, :string
+      t.column :auditable_type, :string, :limit => 255
       t.column :user_id, :integer
-      t.column :user_type, :string
-      t.column :username, :string
-      t.column :action, :string
+      t.column :user_type, :string, :limit => 255
+      t.column :username, :string, :limit => 255
+      t.column :action, :string, :limit => 255
       t.column :changes, :text
       t.column :version, :integer, :default => 0
-      t.column :comment, :string
+      t.column :comment, :string, :limit => 255
       t.column :auditable_parent_id, :integer
-      t.column :auditable_parent_type, :string
-      t.column :request_uuid, :string
+      t.column :auditable_parent_type, :string, :limit => 255
+      t.column :request_uuid, :string, :limit => 255
       t.column :created_at, :datetime
     end
 

--- a/db/migrate/20090718060746_create_domains.rb
+++ b/db/migrate/20090718060746_create_domains.rb
@@ -1,8 +1,8 @@
 class CreateDomains < ActiveRecord::Migration
   def up
     create_table :domains do |t|
-      t.string :name, :default => "", :null => false
-      t.string  :dnsserver
+      t.string :name, :default => "", :null => false, :limit => 255
+      t.string  :dnsserver,  :limit => 255
       t.string  :gateway,    :limit => 40
       t.string  :fullname,   :limit => 32
       t.timestamps

--- a/db/migrate/20090722141107_create_environments.rb
+++ b/db/migrate/20090722141107_create_environments.rb
@@ -1,7 +1,7 @@
 class CreateEnvironments < ActiveRecord::Migration
   def up
     create_table :environments do |t|
-      t.string :name, :null => false
+      t.string :name, :null => false, :limit => 255
       t.timestamps
     end
     create_table :environments_puppetclasses, :id => false do |t|

--- a/db/migrate/20090802062223_create_puppetclasses.rb
+++ b/db/migrate/20090802062223_create_puppetclasses.rb
@@ -1,8 +1,8 @@
 class CreatePuppetclasses < ActiveRecord::Migration
   def up
     create_table :puppetclasses do |t|
-      t.string :name
-      t.string :nameindicator
+      t.string :name, :limit => 255
+      t.string :nameindicator, :limit => 255
       t.integer :operatingsystem_id
 
       t.timestamps

--- a/db/migrate/20090804130144_create_parameters.rb
+++ b/db/migrate/20090804130144_create_parameters.rb
@@ -1,7 +1,7 @@
 class CreateParameters < ActiveRecord::Migration
   def up
     create_table :parameters do |t|
-      t.string :name, :value
+      t.string :name, :value, :limit => 255
       t.references :host
       t.timestamps
     end

--- a/db/migrate/20090820130541_create_auth_sources.rb
+++ b/db/migrate/20090820130541_create_auth_sources.rb
@@ -5,9 +5,9 @@ class CreateAuthSources < ActiveRecord::Migration
       t.string  "name",              :limit => 60, :default => "",    :null => false
       t.string  "host",              :limit => 60
       t.integer "port"
-      t.string  "account"
+      t.string  "account",           :limit => 255
       t.string  "account_password",  :limit => 60
-      t.string  "base_dn"
+      t.string  "base_dn",           :limit => 255
       t.string  "attr_login",        :limit => 30
       t.string  "attr_firstname",    :limit => 30
       t.string  "attr_lastname",     :limit => 30

--- a/db/migrate/20090905150131_create_hostgroups.rb
+++ b/db/migrate/20090905150131_create_hostgroups.rb
@@ -1,7 +1,7 @@
 class CreateHostgroups < ActiveRecord::Migration
   def up
     create_table :hostgroups do |t|
-      t.string :name
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20090905155444_add_type_to_parameter.rb
+++ b/db/migrate/20090905155444_add_type_to_parameter.rb
@@ -1,6 +1,6 @@
 class AddTypeToParameter < ActiveRecord::Migration
   def up
-    add_column :parameters, :type, :string
+    add_column :parameters, :type, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20091012135004_create_users.rb
+++ b/db/migrate/20091012135004_create_users.rb
@@ -1,10 +1,10 @@
 class CreateUsers < ActiveRecord::Migration
   def up
     create_table :users do |t|
-      t.string :login
-      t.string :firstname
-      t.string :lastname
-      t.string :mail
+      t.string :login, :limit => 255
+      t.string :firstname, :limit => 255
+      t.string :lastname, :limit => 255
+      t.string :mail, :limit => 255
       t.boolean :admin
       t.datetime :last_login_on
       t.integer :auth_source_id

--- a/db/migrate/20091016031017_create_sessions.rb
+++ b/db/migrate/20091016031017_create_sessions.rb
@@ -1,7 +1,7 @@
 class CreateSessions < ActiveRecord::Migration
   def up
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, :null => false, :limit => 255
       t.text :data
       t.timestamps
     end

--- a/db/migrate/20091219132338_create_lookup_keys.rb
+++ b/db/migrate/20091219132338_create_lookup_keys.rb
@@ -1,7 +1,7 @@
 class CreateLookupKeys < ActiveRecord::Migration
   def up
     create_table :lookup_keys do |t|
-      t.string :key
+      t.string :key, :limit => 255
       t.timestamps
     end
     add_index :lookup_keys, :key

--- a/db/migrate/20091219132839_create_lookup_values.rb
+++ b/db/migrate/20091219132839_create_lookup_values.rb
@@ -1,8 +1,8 @@
 class CreateLookupValues < ActiveRecord::Migration
   def up
     create_table :lookup_values do |t|
-      t.string :priority
-      t.string :value
+      t.string :priority, :limit => 255
+      t.string :value, :limit => 255
       t.references :lookup_key
 
       t.timestamps

--- a/db/migrate/20100416124600_create_usergroups.rb
+++ b/db/migrate/20100416124600_create_usergroups.rb
@@ -1,7 +1,7 @@
 class CreateUsergroups < ActiveRecord::Migration
   def up
     create_table :usergroups do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.timestamps
     end
     create_table :usergroup_members do |t|

--- a/db/migrate/20100419151910_add_owner_to_hosts.rb
+++ b/db/migrate/20100419151910_add_owner_to_hosts.rb
@@ -5,7 +5,7 @@ class AddOwnerToHosts < ActiveRecord::Migration
 
   def up
     add_column :hosts, :owner_id,   :integer
-    add_column :hosts, :owner_type, :string
+    add_column :hosts, :owner_type, :string, :limit => 255
 
     Host.reset_column_information
 

--- a/db/migrate/20100625155400_create_notices.rb
+++ b/db/migrate/20100625155400_create_notices.rb
@@ -4,7 +4,7 @@ class CreateNotices < ActiveRecord::Migration
     create_table :notices do |t|
       t.string  :content, :null => false, :limit => 1024
       t.boolean :global,  :null => false, :default => true
-      t.string  :level,   :null => false
+      t.string  :level,   :null => false, :limit => 255
       t.timestamps
     end
     # Global messages have to be acknowledged by every user individually

--- a/db/migrate/20101121080425_create_config_templates.rb
+++ b/db/migrate/20101121080425_create_config_templates.rb
@@ -1,7 +1,7 @@
 class CreateConfigTemplates < ActiveRecord::Migration
   def up
     create_table :config_templates do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.text :template
       t.boolean :snippet
       t.references :template_kind

--- a/db/migrate/20101123152150_create_template_kinds.rb
+++ b/db/migrate/20101123152150_create_template_kinds.rb
@@ -1,7 +1,7 @@
 class CreateTemplateKinds < ActiveRecord::Migration
   def up
     create_table :template_kinds do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.timestamps
     end
   end

--- a/db/migrate/20101130100315_create_proxies.rb
+++ b/db/migrate/20101130100315_create_proxies.rb
@@ -1,8 +1,8 @@
 class CreateProxies < ActiveRecord::Migration
   def up
     create_table :smart_proxies do |t|
-      t.string :name
-      t.string :url
+      t.string :name, :limit => 255
+      t.string :url, :limit => 255
       t.timestamps
     end
   end

--- a/db/migrate/20110117162722_add_host_group_defaults.rb
+++ b/db/migrate/20110117162722_add_host_group_defaults.rb
@@ -5,8 +5,8 @@ class AddHostGroupDefaults < ActiveRecord::Migration
     add_column :hostgroups, :architecture_id, :integer
     add_column :hostgroups, :medium_id, :integer
     add_column :hostgroups, :ptable_id, :integer
-    add_column :hostgroups, :root_pass, :string
-    add_column :hostgroups, :puppetmaster, :string
+    add_column :hostgroups, :root_pass, :string, :limit => 255
+    add_column :hostgroups, :puppetmaster, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20110417102947_add_table_bookmarks.rb
+++ b/db/migrate/20110417102947_add_table_bookmarks.rb
@@ -1,12 +1,12 @@
 class AddTableBookmarks < ActiveRecord::Migration
   def up
     create_table :bookmarks, :force => true do |t|
-      t.column :name, :string
-      t.column :query, :string
-      t.column :controller, :string
+      t.column :name, :string, :limit => 255
+      t.column :query, :string, :limit => 255
+      t.column :controller, :string, :limit => 255
       t.column :public, :boolean
       t.column :owner_id, :integer
-      t.column :owner_type, :string
+      t.column :owner_type, :string, :limit => 255
     end
 
     add_index :bookmarks, :name

--- a/db/migrate/20110616080444_add_look_up_key_id_to_puppet_class.rb
+++ b/db/migrate/20110616080444_add_look_up_key_id_to_puppet_class.rb
@@ -3,13 +3,13 @@ class AddLookUpKeyIdToPuppetClass < ActiveRecord::Migration
     add_column :lookup_keys, :puppetclass_id, :integer
     add_index :lookup_keys, :puppetclass_id
 
-    add_column :lookup_keys, :default_value, :string
-    add_column :lookup_keys, :path, :string
+    add_column :lookup_keys, :default_value, :string, :limit => 255
+    add_column :lookup_keys, :path, :string, :limit => 255
     add_index :lookup_keys, :path
 
-    add_column :lookup_keys, :description, :string
-    add_column :lookup_keys, :validator_type, :string
-    add_column :lookup_keys, :validator_rule, :string
+    add_column :lookup_keys, :description, :string, :limit => 255
+    add_column :lookup_keys, :validator_type, :string, :limit => 255
+    add_column :lookup_keys, :validator_rule, :string, :limit => 255
     rename_column :lookup_values, :priority, :match
   end
 

--- a/db/migrate/20110619130336_add_ancestry_to_hostgroup.rb
+++ b/db/migrate/20110619130336_add_ancestry_to_hostgroup.rb
@@ -1,6 +1,6 @@
 class AddAncestryToHostgroup < ActiveRecord::Migration
   def up
-    add_column :hostgroups, :ancestry, :string
+    add_column :hostgroups, :ancestry, :string, :limit => 255
     add_index :hostgroups, :ancestry
   end
 

--- a/db/migrate/20110628115422_create_settings.rb
+++ b/db/migrate/20110628115422_create_settings.rb
@@ -1,11 +1,11 @@
 class CreateSettings < ActiveRecord::Migration
   def up
     create_table :settings do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.text :value
       t.text :description
-      t.string :category
-      t.string :settings_type
+      t.string :category, :limit => 255
+      t.string :settings_type, :limit => 255
       t.text :default, :null => false
       t.timestamps
     end

--- a/db/migrate/20110712064120_update_audits_table.rb
+++ b/db/migrate/20110712064120_update_audits_table.rb
@@ -1,9 +1,9 @@
 class UpdateAuditsTable < ActiveRecord::Migration
   def up
     unless Audit.column_names.include?("comment")
-      add_column :audits, :comment, :string
+      add_column :audits, :comment, :string, :limit => 255
       add_column :audits, :auditable_parent_id, :integer
-      add_column :audits, :auditable_parent_type, :string
+      add_column :audits, :auditable_parent_type, :string, :limit => 255
       add_index :audits, [:auditable_parent_id, :auditable_parent_type], :name => 'auditable_parent_index'
     end
   end

--- a/db/migrate/20111124095054_add_remote_address_to_audits.rb
+++ b/db/migrate/20111124095054_add_remote_address_to_audits.rb
@@ -1,6 +1,6 @@
 class AddRemoteAddressToAudits < ActiveRecord::Migration
   def up
-    add_column :audits, :remote_address, :string
+    add_column :audits, :remote_address, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20111205231500_add_gateway_and_dns_to_subnets.rb
+++ b/db/migrate/20111205231500_add_gateway_and_dns_to_subnets.rb
@@ -1,8 +1,8 @@
 class AddGatewayAndDnsToSubnets < ActiveRecord::Migration
   def up
-    add_column :subnets, :gateway, :string
-    add_column :subnets, :dns_primary, :string
-    add_column :subnets, :dns_secondary, :string
+    add_column :subnets, :gateway, :string, :limit => 255
+    add_column :subnets, :dns_primary, :string, :limit => 255
+    add_column :subnets, :dns_secondary, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20120102071633_add_from_and_to_ranges_to_subnets.rb
+++ b/db/migrate/20120102071633_add_from_and_to_ranges_to_subnets.rb
@@ -1,12 +1,12 @@
 class AddFromAndToRangesToSubnets < ActiveRecord::Migration
   def up
-    add_column :subnets, :from, :string
-    add_column :subnets, :to, :string
+    add_column :subnets, :from, :string, :limit => 255
+    add_column :subnets, :to, :string, :limit => 255
     remove_column :subnets, :ranges
   end
 
   def down
-    add_column :subnets, :ranges, :string
+    add_column :subnets, :ranges, :string, :limit => 255
     remove_column :subnets, :to
     remove_column :subnets, :from
   end

--- a/db/migrate/20120122131037_create_compute_resources.rb
+++ b/db/migrate/20120122131037_create_compute_resources.rb
@@ -1,13 +1,13 @@
 class CreateComputeResources < ActiveRecord::Migration
   def up
     create_table :compute_resources do |t|
-      t.string :name
-      t.string :description
-      t.string :url
-      t.string :user
-      t.string :password
-      t.string :uuid
-      t.string :type
+      t.string :name, :limit => 255
+      t.string :description, :limit => 255
+      t.string :url, :limit => 255
+      t.string :user, :limit => 255
+      t.string :password, :limit => 255
+      t.string :uuid, :limit => 255
+      t.string :type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20120126113850_add_uuid_and_compute_id_to_host.rb
+++ b/db/migrate/20120126113850_add_uuid_and_compute_id_to_host.rb
@@ -1,6 +1,6 @@
 class AddUuidAndComputeIdToHost < ActiveRecord::Migration
   def up
-    add_column :hosts, :uuid, :string
+    add_column :hosts, :uuid, :string, :limit => 255
     add_column :hosts, :compute_resource_id, :integer
   end
 

--- a/db/migrate/20120311081257_create_nics.rb
+++ b/db/migrate/20120311081257_create_nics.rb
@@ -1,10 +1,10 @@
 class CreateNics < ActiveRecord::Migration
   def up
     create_table :nics do |t|
-      t.string :mac
-      t.string :ip
-      t.string :type
-      t.string :name
+      t.string :mac, :limit => 255
+      t.string :ip, :limit => 255
+      t.string :type, :limit => 255
+      t.string :name, :limit => 255
       t.references :host
       t.references :subnet
       t.references :domain
@@ -39,7 +39,7 @@ class CreateNics < ActiveRecord::Migration
   def down
     add_column :hosts, :sp_mac, :string, :limit => 17, :default => ""
     add_column :hosts, :sp_ip, :string, :limit => 15, :default => ""
-    add_column :hosts, :sp_name, :string, :default => ""
+    add_column :hosts, :sp_name, :string, :limit => 255, :default => ""
     add_column :hosts, :sp_subnet_id, :integer
 
     Nic::BMC.all.each do |bmc|

--- a/db/migrate/20120313081913_add_puppet_master_proxy_to_host_and_host_group.rb
+++ b/db/migrate/20120313081913_add_puppet_master_proxy_to_host_and_host_group.rb
@@ -34,7 +34,7 @@ class AddPuppetMasterProxyToHostAndHostGroup < ActiveRecord::Migration
     rename_column :hosts, :puppet_ca_proxy_id, :puppetproxy_id
     remove_column :hostgroups, :puppet_proxy_id
     rename_column :hostgroups, :puppet_ca_proxy_id, :puppetproxy_id
-    add_column :hosts, :puppetmaster_name, :string
-    add_column :hostgroups, :puppetmaster_name, :string
+    add_column :hosts, :puppetmaster_name, :string, :limit => 255
+    add_column :hostgroups, :puppetmaster_name, :string, :limit => 255
   end
 end

--- a/db/migrate/20120506143325_create_images.rb
+++ b/db/migrate/20120506143325_create_images.rb
@@ -4,9 +4,9 @@ class CreateImages < ActiveRecord::Migration
       t.integer :operatingsystem_id
       t.integer :compute_resource_id
       t.integer :architecture_id
-      t.string :uuid
-      t.string :username
-      t.string :name
+      t.string :uuid, :limit => 255
+      t.string :username, :limit => 255
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20120509131302_add_cert_name_to_host.rb
+++ b/db/migrate/20120509131302_add_cert_name_to_host.rb
@@ -1,6 +1,6 @@
 class AddCertNameToHost < ActiveRecord::Migration
   def up
-    add_column :hosts, :certname, :string
+    add_column :hosts, :certname, :string, :limit => 255
     add_index "hosts", :certname
   end
 

--- a/db/migrate/20120510113417_create_key_pairs.rb
+++ b/db/migrate/20120510113417_create_key_pairs.rb
@@ -3,7 +3,7 @@ class CreateKeyPairs < ActiveRecord::Migration
     create_table :key_pairs do |t|
       t.text :secret
       t.integer :compute_resource_id
-      t.string :name
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20120621135042_create_taxonomies.rb
+++ b/db/migrate/20120621135042_create_taxonomies.rb
@@ -1,8 +1,8 @@
 class CreateTaxonomies < ActiveRecord::Migration
   def up
     create_table :taxonomies do |t|
-      t.string :name
-      t.string :type
+      t.string :name, :limit => 255
+      t.string :type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
+++ b/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
@@ -1,8 +1,8 @@
 class AddAuditableNameAndAssociatedNameToAudit < ActiveRecord::Migration
   def up
-    add_column :audits, :auditable_name, :string  unless column_exists? :audits, :auditable_name
-    add_column :audits, :associated_name, :string unless column_exists? :audits, :associated_name
-    add_index :audits, :id                        unless index_exists?  :audits, :id
+    add_column :audits, :auditable_name, :string, :limit => 255 unless column_exists? :audits, :auditable_name
+    add_column :audits, :associated_name, :string, :limit => 255 unless column_exists? :audits, :associated_name
+    add_index :audits, :id unless index_exists?  :audits, :id
     Audit.reset_column_information
     say "About to review all audits, this may take a while..."
     Audit.includes(:user, :auditable, :associated).find_in_batches do |audits|

--- a/db/migrate/20120624093958_add_os_family_to_media.rb
+++ b/db/migrate/20120624093958_add_os_family_to_media.rb
@@ -1,6 +1,6 @@
 class AddOsFamilyToMedia < ActiveRecord::Migration
   def up
-    add_column :media, :os_family, :string
+    add_column :media, :os_family, :string, :limit => 255
     Medium.reset_column_information
     Medium.unscoped.all.each do |m|
       family = m.operatingsystems.map(&:family).uniq.first rescue nil

--- a/db/migrate/20120624094034_add_os_family_to_ptable.rb
+++ b/db/migrate/20120624094034_add_os_family_to_ptable.rb
@@ -6,8 +6,8 @@ class AddOsFamilyToPtable < ActiveRecord::Migration
   end
 
   def up
-    add_column :ptables, :os_family, :string    unless column_exists? :ptables, :os_family
-    remove_column :ptables, :operatingsystem_id if     column_exists? :ptables, :operatingsystem_id
+    add_column :ptables, :os_family, :string, :limit => 255 unless column_exists? :ptables, :os_family
+    remove_column :ptables, :operatingsystem_id if column_exists? :ptables, :operatingsystem_id
     FakePtableWithoutFamily.reset_column_information
     FakePtableWithoutFamily.all.each do |p|
       family = p.operatingsystems.map(&:family).uniq.first rescue nil

--- a/db/migrate/20120905131841_add_lookup_keys_override_and_required.rb
+++ b/db/migrate/20120905131841_add_lookup_keys_override_and_required.rb
@@ -1,7 +1,7 @@
 class AddLookupKeysOverrideAndRequired < ActiveRecord::Migration
   def up
     add_column :lookup_keys, :is_param, :boolean, :default => false
-    add_column :lookup_keys, :key_type, :string,  :default => nil
+    add_column :lookup_keys, :key_type, :string,  :default => nil, :limit => 255
     add_column :lookup_keys, :override, :boolean, :default => false
     add_column :lookup_keys, :required, :boolean, :default => false
   end

--- a/db/migrate/20120921000313_add_iam_role_to_images.rb
+++ b/db/migrate/20120921000313_add_iam_role_to_images.rb
@@ -1,6 +1,6 @@
 class AddIamRoleToImages < ActiveRecord::Migration
   def up
-    add_column :images, :iam_role, :string
+    add_column :images, :iam_role, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20120921105349_create_tokens.rb
+++ b/db/migrate/20120921105349_create_tokens.rb
@@ -1,7 +1,7 @@
 class CreateTokens < ActiveRecord::Migration
   def up
     create_table :tokens do |t|
-      t.string :value
+      t.string :value, :limit => 255
       t.datetime :expires
       t.integer :host_id
     end

--- a/db/migrate/20121012170851_create_trends.rb
+++ b/db/migrate/20121012170851_create_trends.rb
@@ -1,12 +1,12 @@
 class CreateTrends < ActiveRecord::Migration
   def up
     create_table :trends do |t|
-      t.string :trendable_type
+      t.string :trendable_type, :limit => 255
       t.integer :trendable_id
-      t.string :name
-      t.string :type
-      t.string :fact_value
-      t.string :fact_name
+      t.string :name, :limit => 255
+      t.string :type, :limit => 255
+      t.string :fact_value, :limit => 255
+      t.string :fact_name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20121118125341_create_taxable_taxonomies.rb
+++ b/db/migrate/20121118125341_create_taxable_taxonomies.rb
@@ -3,7 +3,7 @@ class CreateTaxableTaxonomies < ActiveRecord::Migration
     create_table :taxable_taxonomies do |t|
       t.integer :taxonomy_id
       t.integer :taxable_id
-      t.string :taxable_type
+      t.string :taxable_type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20130121130826_add_digest_to_messages.rb
+++ b/db/migrate/20130121130826_add_digest_to_messages.rb
@@ -5,7 +5,7 @@ class AddDigestToMessages < ActiveRecord::Migration
     else
       remove_index(:messages, :value) if index_exists?(:messages, :value)
     end
-    add_column :messages, :digest, :string
+    add_column :messages, :digest, :string, :limit => 255
     Message.find_each {|m| m.update_attribute(:digest, Digest::SHA1.hexdigest(m.value)) }
     add_index :messages, :digest
   end

--- a/db/migrate/20130211160200_add_sti_to_hosts.rb
+++ b/db/migrate/20130211160200_add_sti_to_hosts.rb
@@ -1,6 +1,6 @@
 class AddStiToHosts < ActiveRecord::Migration
   def up
-    add_column :hosts, :type, :string
+    add_column :hosts, :type, :string, :limit => 255
     execute "UPDATE hosts set type='Host::Managed'"
     add_index :hosts, :type
   end

--- a/db/migrate/20130228145456_add_digest_to_sources.rb
+++ b/db/migrate/20130228145456_add_digest_to_sources.rb
@@ -5,7 +5,7 @@ class AddDigestToSources < ActiveRecord::Migration
     else
       remove_index(:sources, :value) if index_exists?(:sources, :value)
     end
-    add_column :sources, :digest, :string
+    add_column :sources, :digest, :string, :limit => 255
     Source.find_each {|m| m.update_attribute(:digest, Digest::SHA1.hexdigest(m.value)) }
     add_index :sources, :digest
   end

--- a/db/migrate/20130409081924_add_label_to_host_group.rb
+++ b/db/migrate/20130409081924_add_label_to_host_group.rb
@@ -1,6 +1,6 @@
 class AddLabelToHostGroup < ActiveRecord::Migration
   def up
-    add_column :hostgroups, :label, :string
+    add_column :hostgroups, :label, :string, :limit => 255
 
     Hostgroup.reset_column_information
     execute "UPDATE hostgroups set label = name WHERE ancestry IS NULL"

--- a/db/migrate/20131014133347_add_compose_flag_and_short_name_to_fact_name.rb
+++ b/db/migrate/20131014133347_add_compose_flag_and_short_name_to_fact_name.rb
@@ -1,6 +1,6 @@
 class AddComposeFlagAndShortNameToFactName < ActiveRecord::Migration
   def change
     add_column :fact_names, :compose, :boolean, :default => false, :null => false
-    add_column :fact_names, :short_name, :string
+    add_column :fact_names, :short_name, :string, :limit => 255
   end
 end

--- a/db/migrate/20131021125612_add_type_to_fact_name.rb
+++ b/db/migrate/20131021125612_add_type_to_fact_name.rb
@@ -1,5 +1,5 @@
 class AddTypeToFactName < ActiveRecord::Migration
   def change
-    add_column :fact_names, :type, :string, :default => 'FactName'
+    add_column :fact_names, :type, :string, :default => 'FactName', :limit => 255
   end
 end

--- a/db/migrate/20131107094849_add_ancestry_to_fact_names.rb
+++ b/db/migrate/20131107094849_add_ancestry_to_fact_names.rb
@@ -1,6 +1,6 @@
 class AddAncestryToFactNames < ActiveRecord::Migration
   def up
-    add_column :fact_names, :ancestry, :string
+    add_column :fact_names, :ancestry, :string, :limit => 255
     add_index :fact_names, :ancestry
   end
 

--- a/db/migrate/20131114084718_extend_user_role.rb
+++ b/db/migrate/20131114084718_extend_user_role.rb
@@ -3,7 +3,7 @@ class ExtendUserRole < ActiveRecord::Migration
     if foreign_keys('user_roles').find { |f| f.options[:name] == 'user_roles_user_id_fk' }.present?
       remove_foreign_key 'user_roles', :name => 'user_roles_user_id_fk'
     end
-    add_column :user_roles, :owner_type, :string, :default => 'User', :null => false
+    add_column :user_roles, :owner_type, :string, :default => 'User', :null => false, :limit => 255
     rename_column :user_roles, :user_id, :owner_id
 
     add_index :user_roles, :owner_type

--- a/db/migrate/20131125230654_create_realms.rb
+++ b/db/migrate/20131125230654_create_realms.rb
@@ -1,8 +1,8 @@
 class CreateRealms < ActiveRecord::Migration
   def up
     create_table :realms do |t|
-      t.string      :name, :default => "", :null => false
-      t.string      :realm_type
+      t.string      :name, :default => "", :null => false, :limit => 255
+      t.string      :realm_type, :limit => 255
       t.integer     :realm_proxy_id
       t.integer     :hosts_count, :default => 0
       t.integer     :hostgroups_count, :default => 0
@@ -11,7 +11,7 @@ class CreateRealms < ActiveRecord::Migration
 
     add_index :realms, :name, :unique => true
 
-    add_column :hosts, :otp, :string unless column_exists? :hosts, :otp
+    add_column :hosts, :otp, :string, :limit => 255 unless column_exists? :hosts, :otp
     add_column :hosts, :realm_id, :integer unless column_exists? :hosts, :realm_id
     add_column :hostgroups, :realm_id, :integer unless column_exists? :hostgroups, :realm_id
 

--- a/db/migrate/20131202120621_create_permissions.rb
+++ b/db/migrate/20131202120621_create_permissions.rb
@@ -1,8 +1,8 @@
 class CreatePermissions < ActiveRecord::Migration
   def change
     create_table :permissions do |t|
-      t.string :name, :null => false
-      t.string :resource_type
+      t.string :name, :null => false, :limit => 255
+      t.string :resource_type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20131204174455_add_description_to_operatingsystem.rb
+++ b/db/migrate/20131204174455_add_description_to_operatingsystem.rb
@@ -1,5 +1,5 @@
 class AddDescriptionToOperatingsystem < ActiveRecord::Migration
   def change
-    add_column :operatingsystems, :description, :string
+    add_column :operatingsystems, :description, :string, :limit => 255
   end
 end

--- a/db/migrate/20131212125626_add_ldap_avatar_support.rb
+++ b/db/migrate/20131212125626_add_ldap_avatar_support.rb
@@ -1,6 +1,6 @@
 class AddLdapAvatarSupport < ActiveRecord::Migration
   def change
-    add_column :auth_sources, :attr_photo, :string
+    add_column :auth_sources, :attr_photo, :string, :limit => 255
     add_column :users, :avatar_hash, :string, :limit => 128
   end
 

--- a/db/migrate/20131224153518_create_compute_profiles.rb
+++ b/db/migrate/20131224153518_create_compute_profiles.rb
@@ -1,7 +1,7 @@
 class CreateComputeProfiles < ActiveRecord::Migration
   def change
     create_table :compute_profiles do |t|
-      t.string :name
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20131224153743_create_compute_attributes.rb
+++ b/db/migrate/20131224153743_create_compute_attributes.rb
@@ -3,7 +3,7 @@ class CreateComputeAttributes < ActiveRecord::Migration
     create_table :compute_attributes do |t|
       t.integer :compute_profile_id
       t.integer :compute_resource_id
-      t.string :name
+      t.string :name, :limit => 255
       t.text :vm_attrs
 
       t.timestamps

--- a/db/migrate/20140115130443_add_password_to_images.rb
+++ b/db/migrate/20140115130443_add_password_to_images.rb
@@ -1,5 +1,5 @@
 class AddPasswordToImages < ActiveRecord::Migration
   def change
-    add_column :images, :password, :string
+    add_column :images, :password, :string, :limit => 255
   end
 end

--- a/db/migrate/20140128123153_add_ancestry_to_taxonomies.rb
+++ b/db/migrate/20140128123153_add_ancestry_to_taxonomies.rb
@@ -1,9 +1,9 @@
 class AddAncestryToTaxonomies < ActiveRecord::Migration
   def up
-    add_column :taxonomies, :ancestry, :string
+    add_column :taxonomies, :ancestry, :string, :limit => 255
     add_index :taxonomies, :ancestry
     # migration 20131120225132 is run by the katello plugin that adds 'label' to taxonomies
-    add_column(:taxonomies, :label, :string) unless ActiveRecord::Migrator.get_all_versions.include?(20131120225132)
+    add_column(:taxonomies, :label, :string, :limit => 255) unless ActiveRecord::Migrator.get_all_versions.include?(20131120225132)
   end
 
   def down

--- a/db/migrate/20140219183342_change_label_to_title.rb
+++ b/db/migrate/20140219183342_change_label_to_title.rb
@@ -4,7 +4,7 @@ class ChangeLabelToTitle < ActiveRecord::Migration
 
     # migration 20131120225132 is run by the katello plugin that adds 'label' to taxonomies
     if ActiveRecord::Migrator.get_all_versions.include?(20131120225132)
-      add_column :taxonomies, :title, :string
+      add_column :taxonomies, :title, :string, :limit => 255
     else
       rename_column :taxonomies, :label, :title
     end

--- a/db/migrate/20140304184854_add_provision_method_to_hosts.rb
+++ b/db/migrate/20140304184854_add_provision_method_to_hosts.rb
@@ -1,6 +1,6 @@
 class AddProvisionMethodToHosts < ActiveRecord::Migration
   def up
-    add_column :hosts, :provision_method, :string
+    add_column :hosts, :provision_method, :string, :limit => 255
     Host::Managed.unscoped.each do |h|
       h.update_attribute(:provision_method, h.capabilities.first)
     end

--- a/db/migrate/20140320000449_add_server_type_to_auth_source.rb
+++ b/db/migrate/20140320000449_add_server_type_to_auth_source.rb
@@ -1,5 +1,5 @@
 class AddServerTypeToAuthSource < ActiveRecord::Migration
   def change
-    add_column :auth_sources, :server_type, :string, :default => 'posix'
+    add_column :auth_sources, :server_type, :string, :default => 'posix', :limit => 255
   end
 end

--- a/db/migrate/20140320004050_add_groups_base_to_auth_source.rb
+++ b/db/migrate/20140320004050_add_groups_base_to_auth_source.rb
@@ -1,5 +1,5 @@
 class AddGroupsBaseToAuthSource < ActiveRecord::Migration
   def change
-    add_column :auth_sources, :groups_base, :string
+    add_column :auth_sources, :groups_base, :string, :limit => 255
   end
 end

--- a/db/migrate/20140325093623_add_lowerlogin_to_users.rb
+++ b/db/migrate/20140325093623_add_lowerlogin_to_users.rb
@@ -1,6 +1,6 @@
 class AddLowerloginToUsers < ActiveRecord::Migration
   def up
-    add_column :users, :lower_login, :string
+    add_column :users, :lower_login, :string, :limit => 255
     add_index  :users, :lower_login, :unique => true
 
     User.reset_column_information

--- a/db/migrate/20140407161817_create_config_groups.rb
+++ b/db/migrate/20140407161817_create_config_groups.rb
@@ -1,7 +1,7 @@
 class CreateConfigGroups < ActiveRecord::Migration
   def change
     create_table :config_groups do |t|
-      t.string :name
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140407162059_create_host_config_groups.rb
+++ b/db/migrate/20140407162059_create_host_config_groups.rb
@@ -3,7 +3,7 @@ class CreateHostConfigGroups < ActiveRecord::Migration
     create_table :host_config_groups do |t|
       t.integer :config_group_id
       t.integer :host_id
-      t.string  :host_type
+      t.string  :host_type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140409031625_create_external_usergroups.rb
+++ b/db/migrate/20140409031625_create_external_usergroups.rb
@@ -1,7 +1,7 @@
 class CreateExternalUsergroups < ActiveRecord::Migration
   def change
     create_table :external_usergroups do |t|
-      t.string  :name,           :null => false
+      t.string  :name,           :null => false, :limit => 255
       t.integer :auth_source_id, :null => false
       t.integer :usergroup_id,   :null => false
     end

--- a/db/migrate/20140630114339_add_boot_mode_to_subnet.rb
+++ b/db/migrate/20140630114339_add_boot_mode_to_subnet.rb
@@ -4,7 +4,7 @@ class AddBootModeToSubnet < ActiveRecord::Migration
   end
 
   def up
-    add_column :subnets, :boot_mode, :string, :default => Subnet::BOOT_MODES[:static], :null => false
+    add_column :subnets, :boot_mode, :string, :default => Subnet::BOOT_MODES[:static], :null => false, :limit => 255
 
     FakeSubnet.reset_column_information
     FakeSubnet.all.each do |subnet|

--- a/db/migrate/20140705173549_add_locked_and_default_and_vendor_to_config_template.rb
+++ b/db/migrate/20140705173549_add_locked_and_default_and_vendor_to_config_template.rb
@@ -3,6 +3,6 @@ class AddLockedAndDefaultAndVendorToConfigTemplate < ActiveRecord::Migration
     add_column :config_templates, :locked, :boolean, :default => false
     # Default indicates templates the come from the provider, e.g. Foreman or Katello
     add_column :config_templates, :default, :boolean, :default => false
-    add_column :config_templates, :vendor, :string
+    add_column :config_templates, :vendor, :string, :limit => 255
   end
 end

--- a/db/migrate/20140710132249_extract_nic_attributes.rb
+++ b/db/migrate/20140710132249_extract_nic_attributes.rb
@@ -29,9 +29,9 @@ end
 
 class ExtractNicAttributes < ActiveRecord::Migration
   def up
-    add_column :nics, :provider, :string
-    add_column :nics, :username, :string
-    add_column :nics, :password, :string
+    add_column :nics, :provider, :string, :limit => 255
+    add_column :nics, :username, :string, :limit => 255
+    add_column :nics, :password, :string, :limit => 255
 
     say "Extracting serialized attributes"
     FakeBMCNic.all.each do |nic|

--- a/db/migrate/20140711142510_add_attributes_to_nic_base.rb
+++ b/db/migrate/20140711142510_add_attributes_to_nic_base.rb
@@ -2,8 +2,8 @@ class AddAttributesToNicBase < ActiveRecord::Migration
   def change
     add_column :nics, :virtual, :boolean, :default => false, :null => false
     add_column :nics, :link, :boolean, :default => true, :null => false
-    add_column :nics, :identifier, :string
-    add_column :nics, :tag, :string, :default => '', :null => false
-    add_column :nics, :physical_device, :string, :default => '', :null => false
+    add_column :nics, :identifier, :string, :limit => 255
+    add_column :nics, :tag, :string, :default => '', :null => false, :limit => 255
+    add_column :nics, :physical_device, :string, :default => '', :null => false, :limit => 255
   end
 end

--- a/db/migrate/20140725101621_add_primary_interface_to_hosts.rb
+++ b/db/migrate/20140725101621_add_primary_interface_to_hosts.rb
@@ -1,5 +1,5 @@
 class AddPrimaryInterfaceToHosts < ActiveRecord::Migration
   def change
-    add_column :hosts, :primary_interface, :string
+    add_column :hosts, :primary_interface, :string, :limit => 255
   end
 end

--- a/db/migrate/20140901115249_add_request_uuid_to_audits.rb
+++ b/db/migrate/20140901115249_add_request_uuid_to_audits.rb
@@ -1,7 +1,7 @@
 class AddRequestUuidToAudits < ActiveRecord::Migration
   def up
-    add_column :audits, :request_uuid, :string unless column_exists? :audits, :request_uuid
-    add_index  :audits, :request_uuid          unless index_exists?  :audits, :request_uuid
+    add_column :audits, :request_uuid, :string, :limit => 255 unless column_exists? :audits, :request_uuid
+    add_index  :audits, :request_uuid unless index_exists?  :audits, :request_uuid
   end
 
   def down

--- a/db/migrate/20140902102858_convert_ipam_to_string.rb
+++ b/db/migrate/20140902102858_convert_ipam_to_string.rb
@@ -4,7 +4,7 @@ class ConvertIpamToString < ActiveRecord::Migration
   end
 
   def up
-    add_column :subnets, :ipam_tmp, :string, :default => Subnet::IPAM_MODES[:dhcp], :null => false
+    add_column :subnets, :ipam_tmp, :string, :default => Subnet::IPAM_MODES[:dhcp], :null => false, :limit => 255
     FakeSubnet.reset_column_information
     FakeSubnet.all.each do |subnet|
       if subnet.ipam

--- a/db/migrate/20140910111148_add_bond_attributes_to_nic_base.rb
+++ b/db/migrate/20140910111148_add_bond_attributes_to_nic_base.rb
@@ -2,9 +2,9 @@ require_dependency 'nic/base'
 
 class AddBondAttributesToNicBase < ActiveRecord::Migration
   def up
-    add_column :nics, :mode, :string, :null => false, :default => Nic::Bond::MODES.first
-    add_column :nics, :attached_devices, :string, :default => '', :null => false
-    add_column :nics, :bond_options, :string, :default => '', :null => false
+    add_column :nics, :mode, :string, :null => false, :default => Nic::Bond::MODES.first, :limit => 255
+    add_column :nics, :attached_devices, :string, :default => '', :null => false, :limit => 255
+    add_column :nics, :bond_options, :string, :default => '', :null => false, :limit => 255
     rename_column :nics, :physical_device, :attached_to
   end
 

--- a/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
+++ b/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
@@ -46,9 +46,9 @@ class MoveHostNicsToInterfaces < ActiveRecord::Migration
   end
 
   def down
-    add_column :hosts, :ip, :string
-    add_column :hosts, :mac, :string, :default => ''
-    add_column :hosts, :primary_interface, :string
+    add_column :hosts, :ip, :string, :limit => 255
+    add_column :hosts, :mac, :string, :default => '', :limit => 255
+    add_column :hosts, :primary_interface, :string, :limit => 255
     add_column :hosts, :subnet_id, :integer
     add_foreign_key "hosts", "subnets", :name => "hosts_subnet_id_fk"
     add_column :hosts, :domain_id, :integer

--- a/db/migrate/20140912113254_add_password_hash_to_operatingsystem.rb
+++ b/db/migrate/20140912113254_add_password_hash_to_operatingsystem.rb
@@ -1,5 +1,5 @@
 class AddPasswordHashToOperatingsystem < ActiveRecord::Migration
   def change
-    add_column :operatingsystems, :password_hash, :string, :default => 'MD5'
+    add_column :operatingsystems, :password_hash, :string, :default => 'MD5', :limit => 255
   end
 end

--- a/db/migrate/20140912114124_add_grub_password_to_hosts.rb
+++ b/db/migrate/20140912114124_add_grub_password_to_hosts.rb
@@ -1,5 +1,5 @@
 class AddGrubPasswordToHosts < ActiveRecord::Migration
   def change
-    add_column :hosts, :grub_pass, :string, :default => ""
+    add_column :hosts, :grub_pass, :string, :default => "", :limit => 255
   end
 end

--- a/db/migrate/20140912145052_add_grub_password_to_hostgroup.rb
+++ b/db/migrate/20140912145052_add_grub_password_to_hostgroup.rb
@@ -1,5 +1,5 @@
 class AddGrubPasswordToHostgroup < ActiveRecord::Migration
   def change
-    add_column :hostgroups, :grub_pass, :string, :default => ""
+    add_column :hostgroups, :grub_pass, :string, :default => "", :limit => 255
   end
 end

--- a/db/migrate/20140928131124_add_title_to_os.rb
+++ b/db/migrate/20140928131124_add_title_to_os.rb
@@ -1,6 +1,6 @@
 class AddTitleToOs < ActiveRecord::Migration
   def up
-    add_column :operatingsystems, :title, :string
+    add_column :operatingsystems, :title, :string, :limit => 255
 
     Operatingsystem.reset_column_information
     Operatingsystem.unscoped.each do |os|

--- a/db/migrate/20140928140206_create_widgets.rb
+++ b/db/migrate/20140928140206_create_widgets.rb
@@ -3,8 +3,8 @@ class CreateWidgets < ActiveRecord::Migration
     create_table :widgets do |t|
       t.references :user, :index => true
 
-      t.string  :template, :null => false
-      t.string  :name,     :null => false
+      t.string  :template, :null => false, :limit => 255
+      t.string  :name,     :null => false, :limit => 255
       t.text    :data
       t.integer :sizex, :default => 4
       t.integer :sizey, :default => 1

--- a/db/migrate/20140929073150_create_mail_notifications.rb
+++ b/db/migrate/20140929073150_create_mail_notifications.rb
@@ -1,12 +1,12 @@
 class CreateMailNotifications < ActiveRecord::Migration
   def change
     create_table :mail_notifications do |t|
-      t.string :name
-      t.string :description
-      t.string :mailer
-      t.string :method
+      t.string :name, :limit => 255
+      t.string :description, :limit => 255
+      t.string :mailer, :limit => 255
+      t.string :method, :limit => 255
       t.boolean :subscriptable, :default => true
-      t.string :default_interval
+      t.string :default_interval, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140929073343_create_user_mail_notifications.rb
+++ b/db/migrate/20140929073343_create_user_mail_notifications.rb
@@ -4,7 +4,7 @@ class CreateUserMailNotifications < ActiveRecord::Migration
       t.integer :user_id
       t.integer :mail_notification_id
       t.datetime :last_sent
-      t.string :interval
+      t.string :interval, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20141014131912_add_subscription_type_to_mail_notifications.rb
+++ b/db/migrate/20141014131912_add_subscription_type_to_mail_notifications.rb
@@ -1,5 +1,5 @@
 class AddSubscriptionTypeToMailNotifications < ActiveRecord::Migration
   def change
-    add_column :mail_notifications, :subscription_type, :string
+    add_column :mail_notifications, :subscription_type, :string, :limit => 255
   end
 end

--- a/db/migrate/20141023114229_add_timezone_to_user.rb
+++ b/db/migrate/20141023114229_add_timezone_to_user.rb
@@ -1,5 +1,5 @@
 class AddTimezoneToUser < ActiveRecord::Migration
   def change
-    add_column :users, :timezone, :string
+    add_column :users, :timezone, :string, :limit => 255
   end
 end

--- a/db/migrate/20141116131324_add_mail_query_to_user_mail_notification.rb
+++ b/db/migrate/20141116131324_add_mail_query_to_user_mail_notification.rb
@@ -1,5 +1,5 @@
 class AddMailQueryToUserMailNotification < ActiveRecord::Migration
   def change
-    add_column :user_mail_notifications, :mail_query, :string
+    add_column :user_mail_notifications, :mail_query, :string, :limit => 255
   end
 end

--- a/db/migrate/20150514072626_add_type_to_config_template.rb
+++ b/db/migrate/20150514072626_add_type_to_config_template.rb
@@ -1,6 +1,6 @@
 class AddTypeToConfigTemplate < ActiveRecord::Migration
   def change
-    add_column :config_templates, :type, :string, :default => 'ConfigTemplate'
+    add_column :config_templates, :type, :string, :default => 'ConfigTemplate', :limit => 255
     rename_table :config_templates, :templates
   end
 end

--- a/db/migrate/20150514114044_migrate_ptables_to_templates.rb
+++ b/db/migrate/20150514114044_migrate_ptables_to_templates.rb
@@ -25,7 +25,7 @@ class MigratePtablesToTemplates < ActiveRecord::Migration
     if foreign_keys('hosts').find { |f| f.options[:name] == 'hosts_ptable_id_fk' }.present?
       remove_foreign_key "hosts",  :name => "hosts_ptable_id_fk"
     end
-    add_column :templates, :os_family, :string
+    add_column :templates, :os_family, :string, :limit => 255
 
     FakeOldPtable.all.each do |old_ptable|
       say "migrating partition table #{old_ptable.name}"

--- a/db/migrate/20150606065713_add_sti_to_lookup_keys.rb
+++ b/db/migrate/20150606065713_add_sti_to_lookup_keys.rb
@@ -1,6 +1,6 @@
 class AddStiToLookupKeys < ActiveRecord::Migration
   def up
-    add_column :lookup_keys, :type, :string
+    add_column :lookup_keys, :type, :string, :limit => 255
     LookupKey.where(:is_param => true).update_all(:type => 'PuppetclassLookupKey')
     LookupKey.where(:is_param => false).update_all(:type => 'VariableLookupKey')
     add_index :lookup_keys, :type

--- a/db/migrate/20150612135546_create_host_status.rb
+++ b/db/migrate/20150612135546_create_host_status.rb
@@ -1,7 +1,7 @@
 class CreateHostStatus < ActiveRecord::Migration
   def up
     create_table :host_status do |t|
-      t.string :type
+      t.string :type, :limit => 255
       t.integer :status, :default => 0, :null => false, :limit => 5
       t.references :host, :null => false
       t.datetime :reported_at, :null => false

--- a/db/migrate/20150705131449_add_type_to_reports.rb
+++ b/db/migrate/20150705131449_add_type_to_reports.rb
@@ -1,5 +1,5 @@
 class AddTypeToReports < ActiveRecord::Migration
   def change
-    add_column :reports, :type, :string, :null => false, :default => 'ConfigReport'
+    add_column :reports, :type, :string, :null => false, :default => 'ConfigReport', :limit => 255
   end
 end

--- a/db/migrate/20150708070742_add_full_name_to_setting.rb
+++ b/db/migrate/20150708070742_add_full_name_to_setting.rb
@@ -1,6 +1,6 @@
 class AddFullNameToSetting < ActiveRecord::Migration
   def up
-    add_column :settings, :full_name, :string
+    add_column :settings, :full_name, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20150819105725_add_lookup_value_match_to_host_and_hostgroup.rb
+++ b/db/migrate/20150819105725_add_lookup_value_match_to_host_and_hostgroup.rb
@@ -1,7 +1,7 @@
 class AddLookupValueMatchToHostAndHostgroup < ActiveRecord::Migration
   def up
-    add_column :hosts, :lookup_value_matcher, :string
-    add_column :hostgroups, :lookup_value_matcher, :string
+    add_column :hosts, :lookup_value_matcher, :string, :limit => 255
+    add_column :hostgroups, :lookup_value_matcher, :string, :limit => 255
     Host::Managed.reset_column_information
     Hostgroup.reset_column_information
 

--- a/db/migrate/20151009084350_drop_ptables.rb
+++ b/db/migrate/20151009084350_drop_ptables.rb
@@ -7,7 +7,7 @@ class DropPtables < ActiveRecord::Migration
     create_table :ptables do |t|
       t.string :name, :limit => 64, :null => false
       t.text :layout, :null => false
-      t.string :os_family
+      t.string :os_family, :limit => 255
       t.timestamps
     end
   end

--- a/db/migrate/20160201131211_add_expired_logs_to_smart_proxy.rb
+++ b/db/migrate/20160201131211_add_expired_logs_to_smart_proxy.rb
@@ -1,5 +1,5 @@
 class AddExpiredLogsToSmartProxy < ActiveRecord::Migration
   def change
-    add_column :smart_proxies, :expired_logs, :string, :default => '0'
+    add_column :smart_proxies, :expired_logs, :string, :default => '0', :limit => 255
   end
 end


### PR DESCRIPTION
Rails 4.2 removes the default limit of 255 characters on PostgreSQL and
SQLite DB adapters, causing migrations on empty DBs to create columns
with no limit.  The MySQL adapter does not do this, as VARCHAR is
limited to 255 characters.

To keep the database schema identical no matter which version or adapter
is in use, specify the existing column limits explicitly on all
add_column calls.  This doesn't intend to resize any columns, which
should be done with additional DB migrations.
