### PR TITLE
Fixes #5859 - don't rely on a mac address being present when overriding the conflicts

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -152,10 +152,11 @@ module Orchestration::DHCP
   end
 
   def queue_remove_dhcp_conflicts
-    return unless (dhcp? and overwrite?)
+    return if !dhcp? || !overwrite?
+
     logger.debug "Scheduling DHCP conflicts removal"
     queue.create(:name   => _("DHCP conflicts removal for %s") % self, :priority => 5,
-                 :action => [self, :del_dhcp_conflicts]) if dhcp_record and dhcp_record.conflicting?
+                 :action => [self, :del_dhcp_conflicts])
   end
 
   def ip_belongs_to_subnet?

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -92,6 +92,17 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     assert h.queue.items.select {|x| x.action.last == :del_dhcp }.empty?
   end
 
+  test "the queue_dhcp doen's fail when mac address is blank but provided by compute resource" do
+    cr = FactoryGirl.build(:libvirt_cr)
+    cr.stubs(:provided_attributes).returns({:mac => :mac})
+    host = FactoryGirl.build(:host, :with_dhcp_orchestration, :compute_resource => cr)
+    interface = host.interfaces.first
+    interface.mac = nil
+    interface.stubs(:dhcp? => true, :overwrite? => true)
+
+    assert interface.send(:queue_dhcp)
+  end
+
   test "new host should create a BMC dhcp reservation" do
     h = FactoryGirl.build(:host, :with_dhcp_orchestration, :name => 'dummy-123')
     assert h.new_record?


### PR DESCRIPTION
We tried to initiate the `dhcp_record` for checking if conflicts were
there. The problem was the mac address was not available at that stage
when using the compute resources. It also turns out there is no need
to initiate the dhcp_record at this stage, as we do that again while
actually removing the conflicts (and if no conflicts are there,
nothing happens anyway).
