### PR TITLE
fixes #14000 - respect custom controller permissions

### DIFF
--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -24,7 +24,7 @@ module Api
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
-        @config_templates = resource_scope_for_index(:permission => :view_provisioning_templates).includes(:template_kind)
+        @config_templates = resource_scope_for_index.includes(:template_kind)
       end
 
       api :GET, "/config_templates/:id", N_("Show provisioning template details")

--- a/app/controllers/concerns/find_common.rb
+++ b/app/controllers/concerns/find_common.rb
@@ -15,6 +15,10 @@ module FindCommon
     result || scope.find(id)
   end
 
+  def controller_permission
+    controller_name
+  end
+
   def resource_name(resource = controller_name)
     resource.singularize
   end
@@ -30,7 +34,7 @@ module FindCommon
   end
 
   def scope_for(resource, options = {})
-    controller = options.delete(:controller){ controller_name }
+    controller = options.delete(:controller){ controller_permission }
     # don't call the #action_permission method here, we are not sure if the resource is authorized at this point
     # calling #action_permission here can cause an exception, in order to avoid this, ensure :authorized beforehand
     permission = options.delete(:permission)

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -278,4 +278,32 @@ class Api::TestableControllerTest < ActionController::TestCase
       assert_equal(@response.body, cookies[:timezone])
     end
   end
+
+  describe '#resource_scope' do
+    it 'uses controller name for permission name suffix by default' do
+      @controller.expects(:action_permission).returns('view')
+      Testable.expects(:authorized).with('view_testable', Testable).returns(Testable)
+      @controller.resource_scope
+    end
+
+    it 'uses controller_permission for permission name suffix' do
+      @controller.expects(:controller_permission).returns('example')
+      @controller.expects(:action_permission).returns('view')
+      Testable.expects(:authorized).with('view_example', Testable).returns(Testable)
+      @controller.resource_scope
+    end
+
+    it 'uses :controller option for permission name suffix if set' do
+      @controller.expects(:controller_permission).never
+      @controller.expects(:action_permission).returns('view')
+      Testable.expects(:authorized).with('view_example', Testable).returns(Testable)
+      @controller.resource_scope(:controller => 'example')
+    end
+
+    it 'uses :permission option for permission name if set' do
+      @controller.expects(:action_permission).never
+      Testable.expects(:authorized).with('overridden', Testable).returns(Testable)
+      @controller.resource_scope(:permission => 'overridden')
+    end
+  end
 end

--- a/test/functional/api/v2/config_templates_controller_test.rb
+++ b/test/functional/api/v2/config_templates_controller_test.rb
@@ -111,4 +111,18 @@ class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
     get :index, { :operatingsystem_id => operatingsystems(:centos5_3).fullname }
     assert_response :success
   end
+
+  test "should list templates with non-admin user" do
+    setup_user('view', 'provisioning_templates')
+    get :index, {}, set_session_user.merge(:user => User.current.id)
+    assert_response :success
+    templates = ActiveSupport::JSON.decode(@response.body)
+    assert !templates.empty?, "Should respond with templates"
+  end
+
+  test "should show template with non-admin user" do
+    setup_user('view', 'provisioning_templates')
+    get :show, { :id => templates(:pxekickstart).to_param }, set_session_user.merge(:user => User.current.id)
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Allows controller_permission method to override the permission suffix
used in resource_scope, originally from a63aa7c and removed in bb39df2.
