### PR TITLE
Fixes #13968 - Show errors when all features in proxy are not recognized

### DIFF
--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -3,30 +3,39 @@ FactoryGirl.define do
     sequence(:name) {|n| "proxy#{n}" }
     sequence(:url) {|n| "https://somewhere#{n}.net:8443" }
     factory :template_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['templates',
+                                                                'tftp'])
       features { |sp| [sp.association(:template_feature), sp.association(:tftp_feature) ] }
     end
 
     factory :dhcp_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['dhcp'])
       features { |sp| [sp.association(:feature, :dhcp)] }
     end
 
     factory :dns_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['dns'])
       features { |sp| [sp.association(:feature, :dns)] }
     end
 
     factory :puppet_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet'])
       features { |sp| [sp.association(:feature, :puppet)] }
     end
 
     factory :puppet_ca_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['puppetca'])
       features { |sp| [sp.association(:feature, :puppetca)] }
     end
 
     factory :puppet_and_ca_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet',
+                                                                'puppetca'])
       features { |sp| [sp.association(:feature, :puppet), sp.association(:feature, :puppetca) ] }
     end
 
     factory :realm_smart_proxy do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['realm'])
       features { |sp| [sp.association(:feature, :realm)] }
     end
   end

--- a/test/functional/api/v1/smart_proxies_controller_test.rb
+++ b/test/functional/api/v1/smart_proxies_controller_test.rb
@@ -40,6 +40,7 @@ class Api::V1::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should create smart_proxy" do
+    ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet'])
     assert_difference('SmartProxy.count') do
       post :create, { :smart_proxy => valid_attrs }
     end
@@ -47,6 +48,7 @@ class Api::V1::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should update smart_proxy" do
+    ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet'])
     put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => valid_attrs }
     assert_response :success
   end

--- a/test/functional/api/v2/smart_proxies_controller_test.rb
+++ b/test/functional/api/v2/smart_proxies_controller_test.rb
@@ -43,6 +43,7 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should create smart_proxy" do
+    ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet'])
     assert_difference('SmartProxy.count') do
       post :create, { :smart_proxy => valid_attrs }
     end
@@ -50,6 +51,7 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   end
 
   test "should update smart_proxy" do
+    ProxyAPI::Features.any_instance.stubs(:features).returns(['puppet'])
     put :update, { :id => smart_proxies(:one).to_param, :smart_proxy => valid_attrs }
     assert_response :success
   end

--- a/test/unit/host_build_status_test.rb
+++ b/test/unit/host_build_status_test.rb
@@ -6,7 +6,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
   setup do
     User.current = users(:admin)
     @host = Host.new(:name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03", :ptable => FactoryGirl.create(:ptable), :medium => media(:one),
-                    :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
+                     :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => FactoryGirl.create(:puppet_smart_proxy),
                     :architecture => architectures(:x86_64), :environment => environments(:production), :managed => true,
                     :owner_type => "User", :root_pass => "xybxa6JUkz63w")
     @build = @host.build_status_checker
@@ -27,6 +27,9 @@ class HostBuildStatusTest < ActiveSupport::TestCase
   end
 
   test "should be able to refresh a smart proxy" do
+    SmartProxy.any_instance.expects(:refresh).
+      returns(OpenStruct.new(:messages => [])).at_least_once
+    build = @host.build_status_checker
     assert_empty build.errors[:proxies]
   end
 end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -303,7 +303,7 @@ class HostTest < ActiveSupport::TestCase
     host = FactoryGirl.build(:host)
     refute host.configuration?
 
-    proxy = FactoryGirl.create(:smart_proxy)
+    proxy = FactoryGirl.create(:puppet_smart_proxy)
     host.puppet_proxy = proxy
     assert host.configuration?
   end


### PR DESCRIPTION
When using an old version of Foreman, say '1.10' against a newer version
of the proxy, say one that contains the 'logs' feature, the /features
call will return an array ['logs'].
If you try to add a smart-proxy that only has this feature, the check we
make `reply.is_a?(Array) and reply.any?` is not enough. We should verify
we have the features in the db.

The problem is:
- Try to add new smart-proxy with features ['logs'] to old foreman (1.10)
  without this feature.
- Submit, it won't save. But it won't throw any error either.

We should display an error and say 'the features in this proxy are not
recognized by foreman'.
