### PR TITLE
fixes #14006 - use URL helpers in mailers

### DIFF
--- a/app/views/audit_mailer/summary.html.erb
+++ b/app/views/audit_mailer/summary.html.erb
@@ -11,10 +11,10 @@
            user_search_param = login ? "user = #{login}" : %Q{username = "#{audit.username}"}
         %>
         <b>
-          <%= link_to(audit.username, audits_path(:host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme, :search => user_search_param)) %>
+          <%= link_to(audit.username, audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => user_search_param)) %>
           <span style="color: #cccccc"><%= audit_remote_address audit %></span>
           <%= audit_action_name audit%> <%= audited_type audit %>:
-          <%=link_to(audit_title(audit), audit_path(:id => audit, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme), {:style => 'color: #2a6496'}) %>
+          <%=link_to(audit_title(audit), audit_url(:id => audit, :host => @url.host, :port => @url.port, :protocol => @url.scheme), {:style => 'color: #2a6496'}) %>
         </b>
 
       </li>
@@ -26,6 +26,6 @@
   <% end %>
 </ul>
 <p>
-  <%= link_to(_('Full audits list'), audits_path(:host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme, :search => @query)) %>
+  <%= link_to(_('Full audits list'), audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => @query)) %>
 </p>
 </body>

--- a/app/views/audit_mailer/summary.text.erb
+++ b/app/views/audit_mailer/summary.text.erb
@@ -6,11 +6,11 @@
 
 <% @audits.each do |audit| %>
 <%= audit.username %> (<%= audit.remote_address %>) <%= audit_action_name audit%> <%= audited_type audit %>: <%= audit_title(audit) %>
-(<%= audit_path(:id => audit, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>)
+(<%= audit_url(:id => audit, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>)
 -
 <% end %>
 <% else %>
 <%= _('No audit changes for this period') %>
 <% end %>
 
-<%= audits_path(:host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme, :search => @query) %>
+<%= audits_url(:host => @url.host, :port => @url.port, :protocol => @url.scheme, :search => @query) %>

--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -33,7 +33,7 @@
         <td style="<%= td_style %>">
       <% end %>
       <% if v > 0 %>
-        <%= link_to v, config_reports_path(:search=>"host = #{host} and #{m} > 0", :host => @url.host, :port => @url.port, :protocol => @url.scheme, :only_path => false) %>
+        <%= link_to v, config_reports_url(:search=>"host = #{host} and #{m} > 0", :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>
       <% else %>
         <%= v %>
       <% end %>

--- a/app/views/host_mailer/_link_to_host.html.erb
+++ b/app/views/host_mailer/_link_to_host.html.erb
@@ -1,4 +1,4 @@
 <% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
 <td style="<%= td_style %>">
-  <%= link_to host, host_path(:id => host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>
+  <%= link_to host, host_url(:id => host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>
 </td>

--- a/app/views/host_mailer/error_state.html.erb
+++ b/app/views/host_mailer/error_state.html.erb
@@ -8,7 +8,7 @@
     <div style="background: #e1e2e3; padding: 20px 40px; margin: 5px 0px 10px;">
       <%= render :partial => 'error_states', :locals => {:logs => @report.logs } %>
       <br>
-      <%= link_to _("For more information"), config_report_path(@report, :host => @url.host, :port => @url.port, :protocol => @url.scheme, :only_path => false)  %>
+      <%= link_to _("For more information"), config_report_url(@report, :host => @url.host, :port => @url.port, :protocol => @url.scheme)  %>
     </div>
   </body>
 </html>

--- a/app/views/host_mailer/host_built.html.erb
+++ b/app/views/host_mailer/host_built.html.erb
@@ -9,7 +9,7 @@
       <table class="hostInfo" style="min-width: 400px; border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: justify; width: 100%;" bgcolor="#ffffff">
         <tr>
           <td width="18%" style="text-align: left; border-collapse: collapse; background-image: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" align="left"><b><%= _("Hostname") %></b></td>
-          <td width="82%" style="border-collapse: collapse; text-align: left; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" align="center" bgcolor="#FFFFFF"><%= link_to @host, host_path(:id => @host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %></td>
+          <td width="82%" style="border-collapse: collapse; text-align: left; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" align="center" bgcolor="#FFFFFF"><%= link_to @host, host_url(:id => @host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %></td>
         </tr>
         <tr>
           <td width="18%" style="text-align: left; border-collapse: collapse; background-image: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" align="left"><b><%= _("IP") %></b></td>

--- a/app/views/host_mailer/host_built.text.erb
+++ b/app/views/host_mailer/host_built.text.erb
@@ -5,4 +5,4 @@
   <%= _("IP:") %>       <%= @host.ip %>
 
 <%= _("View in Foreman:") %>
-  <%= host_path(:id => @host, :host => @url.host, :port => @url.port, :only_path => false, :protocol => @url.scheme) %>
+  <%= host_url(:id => @host, :host => @url.host, :port => @url.port, :protocol => @url.scheme) %>


### PR DESCRIPTION
Rails 4.2 deprecates mailers from using _path helpers and from path
helpers being called with only_path => false.  They should all be
changed to use _url helpers.
