### PR TITLE
Fixes #3200 - Add select boxes to settings

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,4 +1,9 @@
 module SettingsHelper
+  extend ActiveSupport::Concern
+  included do
+    alias_method_chain :value, :collection
+  end
+
   def value(setting)
     if setting.readonly?
       return readonly_field(
@@ -7,20 +12,16 @@ module SettingsHelper
     end
 
     case setting.settings_type
-    when "boolean"
-      edit_select(setting, :value, {:select_values => {:true => "true", :false => "false"}.to_json } )
-    else
-      case setting.name
-      when "default_location"
-        edit_select(setting, :value, {:select_values => Hash[Location.all.map{|loc| [loc[:title], loc[:title]]}].to_json } )
-      when "default_organization"
-        edit_select(setting, :value, {:select_values => Hash[Organization.all.map{|org| [org[:title], org[:title]]}].to_json } )
-      when "default_puppet_environment"
-        edit_select(setting, :value, {:select_values => Hash[Environment.all.map{|env| [env[:name], env[:name]]}].to_json } )
+      when "boolean"
+        edit_select(setting, :value, {:select_values => {:true => "true", :false => "false"}.to_json } )
       else
         edit_textfield(setting, :value,{:helper => :show_value})
-      end
     end
+  end
+
+  def value_with_collection(setting)
+    return value_without_collection(setting) unless self.respond_to? "#{setting.name}_collection"
+    edit_select(setting, :value, {:select_values => self.send("#{setting.name}_collection").to_json } )
   end
 
   def show_value(setting)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -272,7 +272,12 @@ class Setting < ActiveRecord::Base
     true
   end
 
-  def self.set(name, description, default, full_name = nil, value = nil)
+  def self.set(name, description, default, full_name = nil, value = nil, options = {})
+    if options.has_key? :collection
+      SettingsHelper.module_eval do
+        define_method("#{name}_collection".to_sym){ options[:collection] }
+      end
+    end
     {:name => name, :value => value, :description => description, :default => default, :full_name => full_name}
   end
 

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -7,7 +7,7 @@ class Setting::Puppet < Setting
       [
         self.set('puppet_interval', N_("Puppet interval in minutes"), 30, N_('Puppet interval')),
         self.set('outofsync_interval', N_("Duration in minutes after the Puppet interval for servers to be classed as out of sync."), 5, N_('Out of sync interval')),
-        self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment')),
+        self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Hash[Environment.all.map{|env| [env[:name], env[:name]]}] }),
         self.set('modulepath',N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
         self.set('document_root', N_("Document root where puppetdoc files should be created"), "#{Rails.root}/public/puppet/rdoc", N_('Document root')),
         self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
@@ -25,8 +25,8 @@ class Setting::Puppet < Setting
         self.set('legacy_puppet_hostname', N_("Foreman will truncate hostname to 'puppet' if it starts with puppet"), false, N_('Legacy Puppet hostname')),
         self.set('location_fact', N_("Hosts created after a puppet run will be placed in the location this fact dictates. The content of this fact should be the full label of the location."), 'foreman_location', N_('Location fact')),
         self.set('organization_fact', N_("Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."), 'foreman_organization', N_('Organization fact')),
-        self.set('default_location', N_("Hosts created after a puppet run that did not send a location fact will be placed in this location"), '', N_('Default location')),
-        self.set('default_organization', N_("Hosts created after a puppet run that did not send a organization fact will be placed in this organization"), '', N_('Default organization')),
+        self.set('default_location', N_("Hosts created after a puppet run that did not send a location fact will be placed in this location"), '', N_('Default location'), nil, { :collection => Hash[Location.all.map{|loc| [loc[:title], loc[:title]]}] }),
+        self.set('default_organization', N_("Hosts created after a puppet run that did not send a organization fact will be placed in this organization"), '', N_('Default organization'), nil, {:collection => Hash[Organization.all.map{|org| [org[:title], org[:title]]}] }),
         self.set('always_show_configuration_status', N_("All hosts will show a configuration status even when a Puppet smart proxy is not assigned"), false, N_('Always show configuration status')),
       ].compact.each { |s| self.create s.update(:category => "Setting::Puppet")}
 

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -215,6 +215,22 @@ class SettingTest < ActiveSupport::TestCase
     check_value_returns_from_cache_with :name => "test_cache", :default => true, :value => true, :description => "test foo"
   end
 
+  test "create a setting with values collection " do
+    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => {:a => "a", :b => "b"} } )
+    setting = Setting.create(options)
+    self.extend(SettingsHelper)
+    assert_equal self.send("#{setting.name}_collection"), { :a => "a", :b => "b" }
+  end
+
+  test "create a setting with a dynamic collection" do
+    dynamic_hash = {:a => "a"}
+    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => dynamic_hash } )
+    setting = Setting.create(options)
+    dynamic_hash[:b] = "b"
+    self.extend(SettingsHelper)
+    assert_equal self.send("#{setting.name}_collection"), { :a => "a", :b => "b" }
+  end
+
   # tests for default type constraints
   test "arrays cannot be empty by default" do
     check_setting_did_not_save_with :name => "foo", :value => [], :default => ["a", "b", "c"], :description => "test foo"


### PR DESCRIPTION
Instead of entering a raw value, sometimes it necessary to choose a value from a collection of values.
The collection can be constant hash or dynamic, such as hostgroup names.

How to create a setting with a dynamic collection:

``` ruby
self.set('setting_name', N_("description"), nil, N_('UI name'), nil, {:collection => Proc.new { Hash[Host.all.map{|host| [host[:id], host[:name]]}]},
```

The collection's type is hash:

``` ruby
{ :key1 => value1}
```

When the key is the setting's value, and the value is the presented  text in the select box.
