### PR TITLE
Fixes #10183 - Added a default results transformation for status action

### DIFF
--- a/app/services/power_manager/base.rb
+++ b/app/services/power_manager/base.rb
@@ -9,16 +9,53 @@ module PowerManager
       raise ::Foreman::Exception.new(N_("Invalid power state request: %{action}, supported actions are %{supported}"), { :action => action, :supported => SUPPORTED_ACTIONS })
     end
 
-    def state
-      N_("Unknown")
+    SUPPORTED_ACTIONS.each do |method|
+      define_method method do # def start
+        action_entry = find_action_entry(method)
+        method_to_call = action_entry[:action]
+        if method_to_call
+          result = send(method_to_call)
+        else
+          result = default_action(method.to_sym)
+        end
+        result = send(action_entry[:output], result) if action_entry[:output]
+        result
+      end # end
     end
 
     def logger
       Rails.logger
     end
 
+    protected
+
+    def default_action(action)
+      raise NotImplementedError.new
+    end
+
+    def action_map
+      {
+        :status => { :output => :translate_status }
+      }
+    end
+
+    def translate_status(result)
+      result = result.to_s
+      return N_("Unknown") if result.empty?
+      return 'on' if result.match(/on/i)
+      return 'off' if result.match(/off/i)
+      result
+    end
+
     private
 
     attr_reader :host
+
+    def find_action_entry(method)
+      action_entry = action_map[method.to_sym] || {} # create a valid entry
+      # if action_map is in simple format (:key => 'method'), transform it to entry
+      action_entry = {:action => action_entry.to_sym} unless action_entry.is_a?(Hash)
+      action_entry
+    end
   end
 end

--- a/app/services/power_manager/bmc.rb
+++ b/app/services/power_manager/bmc.rb
@@ -5,12 +5,6 @@ module PowerManager
       @proxy = host.bmc_proxy
     end
 
-    SUPPORTED_ACTIONS.each do |method|
-      define_method method do # def start
-        proxy.power(:action => action_map[method.to_sym]) #   proxy.power(:action => 'on')
-      end # end
-    end
-
     def ready?
       status == 'on'
     end
@@ -21,19 +15,19 @@ module PowerManager
 
     #TODO: consider moving this to the proxy code, so we can just delegate like as with Virt.
     def action_map
-      {
-        :start    => 'on',
-        :stop     => 'off',
-        :poweroff => 'off',
-        :reboot   => 'soft',
-        :reset    => 'cycle',
-        :state    => 'status',
-        :on       => 'on',
-        :off      => 'off',
-        :soft     => 'soft',
-        :cycle    => 'cycle',
-        :status   => 'status'
-      }
+      super.deep_merge({
+                         :start    => 'on',
+                         :stop     => 'off',
+                         :poweroff => 'off',
+                         :reboot   => 'soft',
+                         :reset    => 'cycle',
+                         :state    => 'status',
+                         :ready?   => 'ready?'
+                       })
+    end
+
+    def default_action(action)
+      proxy.power(:action => action.to_s) #   proxy.power(:action => 'on')
     end
   end
 end

--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -14,37 +14,36 @@ module PowerManager
       end
     end
 
-    def state
+    def virt_state
       # make sure we fetch latest vm status
       vm.reload
       vm.state
     end
 
-    (SUPPORTED_ACTIONS - ['state']).each do |method|
-      define_method method do
-        vm.send(action_map[method.to_sym])
-      end
+    def state_output(result)
+      result = result.to_s
+      return 'on' if result.match(/started/i)
+      return 'off' if result.match(/paused/i)
+      translate_status(result) # unknown output
+    end
+
+    def default_action(action)
+      vm.send(action)
+    end
+
+    def action_map
+      super.deep_merge({
+                         :on       => 'start',
+                         :off      => 'stop',
+                         :soft     => 'reboot',
+                         :cycle    => 'reset',
+                         :status   => {:action => :virt_state, :output => :state_output},
+                         :state    => {:action => :virt_state, :output => :state_output}
+                       })
     end
 
     private
 
     attr_reader :vm
-
-    def action_map
-      {
-        :on       => 'start',
-        :off      => 'stop',
-        :soft     => 'reboot',
-        :reboot   => 'reboot',
-        :cycle    => 'reset',
-        :status   => 'state',
-        :start    => 'start',
-        :stop     => 'stop',
-        :poweroff => 'poweroff',
-        :reset    => 'reset',
-        :state    => 'state',
-        :ready?   => 'ready?'
-      }
-    end
   end
 end

--- a/test/unit/power_manager_test.rb
+++ b/test/unit/power_manager_test.rb
@@ -11,9 +11,10 @@ class PowerManagerTest < ActiveSupport::TestCase
     host.unstub(:queue_compute)
     host.stubs(:compute_resource).returns(compute_resource_mock)
 
-    host.power.send(:action_map).values.uniq.each do |action|
+    (actions_list(host) - ['virt_state']).each do |action|
       vm_mock.expects(action.to_sym).at_least_once.returns(true)
     end
+    vm_mock.expects('state').at_least_once.returns('On')
     vm_mock.stubs(:reload).returns(true)
 
     PowerManager::SUPPORTED_ACTIONS.each do |action|
@@ -27,7 +28,7 @@ class PowerManagerTest < ActiveSupport::TestCase
     host.stubs(:bmc_proxy).returns(bmc_proxy_mock)
     host.stubs(:bmc_available?).returns(true)
 
-    (host.power.send(:action_map).values.uniq - ['status']).each do |action|
+    (actions_list(host) - ['status', 'ready?']).each do |action|
       bmc_proxy_mock.expects(:power).with(:action => action).at_least_once.returns(true)
     end
     bmc_proxy_mock.expects(:power).with(:action => 'status').at_least_once.returns('on')
@@ -41,5 +42,48 @@ class PowerManagerTest < ActiveSupport::TestCase
     PowerManager::REAL_ACTIONS.each do |action|
       assert_includes PowerManager::SUPPORTED_ACTIONS, action
     end
+  end
+
+  context '#status' do
+    setup do
+      @vm_mock = mock('vm')
+
+      compute_resource_mock = mock('compute_resource')
+      compute_resource_mock.stubs(:find_vm_by_uuid).returns(@vm_mock)
+
+      @host = FactoryGirl.build(:host, :on_compute_resource)
+      @host.unstub(:queue_compute)
+      @host.stubs(:compute_resource).returns(compute_resource_mock)
+      @vm_mock.stubs(:reload).returns(true)
+    end
+
+    test "should respond correctly to status when compute resource is started" do
+      @vm_mock.expects(:state).at_least_once.returns('Started')
+
+      result = @host.power.status
+
+      assert_equal 'on', result
+    end
+
+    test "should respond correctly to status when compute resource is paused" do
+      @vm_mock.expects(:state).at_least_once.returns('Paused')
+
+      result = @host.power.state
+
+      assert_equal 'off', result
+    end
+  end
+
+  def actions_list(host)
+    action_map = host.power.send(:action_map)
+    actions = PowerManager::SUPPORTED_ACTIONS - action_map.keys.map { |k| k.to_s }
+    action_map.each do |key, value|
+      action_entry = value
+      action_entry = {:action => value.to_sym} unless value.is_a?(Hash)
+      action = action_entry[:action]
+
+      actions << action.to_s if action
+    end
+    actions.uniq
   end
 end


### PR DESCRIPTION
Refactored the relationship between `PowerManager::Bmc`, `PowerManager::Virt` and the base class they both inherit. Now the base class is responsible to decide which method is run, and how its results are transformed.
