### PR TITLE
fixes #13978 - replace AR value_to_boolean with our caster

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -51,11 +51,11 @@ module HostCommon
         if id.present?
           lookup_value = self.lookup_values.to_a.find {|i| i.id.to_i == id.to_i }
           if lookup_value
-            mark_for_destruction = ActiveRecord::ConnectionAdapters::Column.value_to_boolean attr.delete(:_destroy)
+            mark_for_destruction = Foreman::Cast.to_bool(attr.delete(:_destroy))
             lookup_value.attributes = attr
             lookup_value.mark_for_destruction if mark_for_destruction
           end
-        elsif !ActiveRecord::ConnectionAdapters::Column.value_to_boolean attr.delete(:_destroy)
+        elsif !Foreman::Cast.to_bool(attr.delete(:_destroy))
           self.lookup_values.build(attr.merge(:match => lookup_value_match, :host_or_hostgroup => self))
         end
       end


### PR DESCRIPTION
In Rails 4.2, value_to_boolean was moved further into ActiveRecord's
column type classes.  Replace the use of this internal method with
Foreman's own well-tested caster.
