### PR TITLE
fixes #13817 - test certificate.subject_alternative_names for presence

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -68,7 +68,7 @@ module Foreman::Controller::SmartProxyAuth
           # If the client sent certificate contains a subject or sans, use them for request_hosts, else fall back to the dn set in the request environment
           request_hosts = []
           if certificate
-            if certificate.subject_alternative_names
+            if certificate.subject_alternative_names.present?
               request_hosts += certificate.subject_alternative_names
             elsif certificate.subject
               request_hosts << certificate.subject


### PR DESCRIPTION
Otherwise certificate SAN test is always true even with no SAN. This
results in request_hosts being empty and thus ENC authentication fails.

With test by Dominic Cleal dominic@cleal.org

Updates PR #3213.
