### PR TITLE
Fixes #14045 - change inherit button height to match select2

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -17,6 +17,6 @@ group :assets do
   gem 'gridster-rails', '~> 0.5'
   gem 'jquery_pwstrength_bootstrap', '~> 1.2'
   gem 'jquery-turbolinks', '~> 2.1'
-  gem 'select2-rails', '~> 3.5'
+  gem 'select2-rails', '< 3.5.10'
   gem 'underscore-rails', '~> 1.8'
 end


### PR DESCRIPTION
This is only for 1.10 - the height of select2 was 26px and the inherit button was still 32px.
