### PR TITLE
fixes #6792 - filtering template

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -137,7 +137,7 @@ module Foreman
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password, :account_password, :facts, :root_pass, :value, :report, :password_confirmation, :secret]
+    config.filter_parameters += [:password, :account_password, :facts, :root_pass, :value, :report, :password_confirmation, :secret, :template]
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true


### PR DESCRIPTION
while this fixes the issue, because the parameter is named "template", the entire "provisioning_template" parameter is filtered. I did not find any way to bypass this.
