### PR TITLE
fixes #14064 - disable auditing of Puppetclass#hostgroups_count

### DIFF
--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -24,7 +24,7 @@ class Puppetclass < ActiveRecord::Base
   accepts_nested_attributes_for :class_params, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
 
   validates :name, :uniqueness => true, :presence => true, :no_whitespace => true
-  audited :allow_mass_assignment => true, :except => [:total_hosts, :variable_lookup_keys_count, :global_class_params_count]
+  audited :allow_mass_assignment => true, :except => [:total_hosts, :hostgroups_count, :variable_lookup_keys_count, :global_class_params_count]
 
   alias_attribute :smart_variables, :lookup_keys
   alias_attribute :smart_variable_ids, :lookup_key_ids


### PR DESCRIPTION
Under Rails 4.2, the hostgroups_count counter on Puppetclass now detects
HostgroupClass record creations, causing an extra audit entry to be
created when incrementing hostgroups_count and a test to fail:

```
  1) Failure:
HostgroupClassTest#test_0001_when creating a new hostgroup class object, an audit entry needs to be added [test/unit/hostgroup_class_test.rb:13]:
"Audit.count" didn't change by 1.
Expected: 2
  Actual: 3
```

The regular audit entry is being created, but the counter should always
have been excluded from auditing.
