### PR TITLE
Fixes #14067 - Host#edit integration tests should not wait for tasks or show graphs

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -1,8 +1,10 @@
 require 'integration_test_helper'
 require 'integration/shared/host_finders'
+require 'integration/shared/host_orchestration_stubs'
 
 class HostJSTest < IntegrationTestWithJavascript
   include HostFinders
+  include HostOrchestrationStubs
 
   before do
     SETTINGS[:locations_enabled] = false
@@ -28,8 +30,7 @@ class HostJSTest < IntegrationTestWithJavascript
       assert class_params.find("textarea:enabled")
       class_params.find("a[data-tag='remove']").click
       assert class_params.find("textarea:disabled")
-      click_button('Submit')
-      assert page.has_link?("Edit")
+      click_on_submit
 
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
@@ -39,8 +40,7 @@ class HostJSTest < IntegrationTestWithJavascript
       class_params.find("a[data-tag='override']").click
       assert class_params.find("textarea:enabled")
       class_params.find("textarea").set("false")
-      click_button('Submit')
-      assert page.has_link?("Edit")
+      click_on_submit
 
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
@@ -85,8 +85,7 @@ class HostJSTest < IntegrationTestWithJavascript
       assert page.has_selector?('#inherited_parameters .btn[data-tag=override]')
       page.find('#inherited_parameters .btn[data-tag=override]').click
       assert page.has_no_selector?('#inherited_parameters .btn[data-tag=override]')
-      click_button('Submit')
-      assert page.has_link?("Edit")
+      click_on_submit
 
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
@@ -166,8 +165,7 @@ class HostJSTest < IntegrationTestWithJavascript
       Timeout.timeout(Capybara.default_max_wait_time) do
         loop while find(:css, '#interfaceModal', :visible => false).visible?
       end
-      click_button 'Submit' #create new host
-      wait_for_ajax
+      click_on_submit
       find('#host-show') #wait for host details page
 
       host = Host::Managed.search_for('name ~ "myhost1"').first
@@ -214,9 +212,7 @@ class HostJSTest < IntegrationTestWithJavascript
       end
 
       wait_for_ajax
-      click_button 'Submit' #create new host
-      wait_for_ajax
-      find('#host-show') #wait for host details page
+      click_on_submit
 
       host = Host::Managed.search_for('name ~ "myhost1"').first
       assert_equal env2.name, host.environment.name
@@ -248,7 +244,7 @@ class HostJSTest < IntegrationTestWithJavascript
       page.find('#environment_id').find("option[value='#{@host.environment_id}']").select_option
 
       # remove hosts cookie on submit
-      index_modal.find('.btn-primary').trigger('click')
+      index_modal.find('.btn-primary').click
       assert_empty(page.driver.cookies['_ForemanSelectedhosts'])
       assert has_selector?("div", :text => "Updated hosts: changed environment")
     end
@@ -264,9 +260,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
       select2 env1.name, :from => 'host_environment_id'
       wait_for_ajax
-
-      click_button 'Submit' #create new host
-      find_link 'YAML' #wait for host details page
+      click_on_submit
 
       host.reload
       assert_equal env1.name, host.environment.name
@@ -308,14 +302,12 @@ class HostJSTest < IntegrationTestWithJavascript
       assert class_params.has_selector?("a[data-tag='override']", :visible => :hidden)
       assert_equal find("#s2id_host_lookup_values_attributes_#{lookup_key.id}_value .select2-chosen").text, "false"
       select2 "true", :from => "host_lookup_values_attributes_#{lookup_key.id}_value"
-      click_button('Submit')
+      click_on_submit
 
-      assert page.has_link?("Edit")
       visit edit_host_path(host)
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
       assert_equal find("#s2id_host_lookup_values_attributes_#{lookup_key.id}_value .select2-chosen").text, "true"
-      click_button('Submit')
     end
   end
 

--- a/test/integration/shared/host_orchestration_stubs.rb
+++ b/test/integration/shared/host_orchestration_stubs.rb
@@ -1,0 +1,16 @@
+module HostOrchestrationStubs
+  extend ActiveSupport::Concern
+
+  def click_on_submit
+    click_button('Submit')
+    wait_for_orchestration_requests # host-progress bar should disappear
+    wait_for_ajax # wait for runtime/nics/etc.. ajax requests in Host#show
+    assert page.has_link?('Edit')
+  end
+
+  def wait_for_orchestration_requests
+    has_no_selector?("#host-progress",
+                     :visible => :all,
+                     :wait => 2 * Capybara.default_max_wait_time)
+  end
+end


### PR DESCRIPTION
When you click on Host#edit Submit button, a few orchestration tasks
will be created. After that, the show page will call (via AJAX) a few
URLS to fetch 'overview', 'resources', 'nics', etc... to fill up the
table on the left side. These are all irrelevant to tests that only
concern the form, and pose a problem.

**Problem**
The server we test on is not multithreaded, these tasks will run
sequentially. Therefore, the default Capybara waiting time, or
Capybara.default_max_time might not be enough to wait for all requests.

**Solution**
We can stub out these calls, and wait until the #host-progress div has
disappeared for POST/PATCH requests.

---

This should fix some of the spotty tests in http://projects.theforeman.org/issues/13293, specifically 'correctly override global params' - 'class parameters and overrides are displayed correctly for booleans' - some of the other methods "fixed" here also were prone to fail.

Reproduce the failures on host_integration by adding this to ApplicationController, and reducing `Capybara.default_max_wait_time` to 10.

``` ruby
  after_filter -> do
    `sleep 5`
    puts "#{request.method} #{request.url} took #{Time.now - @@req_time} to complete"
  end
  before_filter -> { @@req_time = Time.now }
```
