### PR TITLE
fixes #14094 - replace foreign_keys calls with foreign_key_exists?

### DIFF
--- a/db/migrate/20131114084718_extend_user_role.rb
+++ b/db/migrate/20131114084718_extend_user_role.rb
@@ -1,6 +1,6 @@
 class ExtendUserRole < ActiveRecord::Migration
   def up
-    if foreign_keys('user_roles').find { |f| f.options[:name] == 'user_roles_user_id_fk' }.present?
+    if foreign_key_exists?('user_roles', :name => 'user_roles_user_id_fk')
       remove_foreign_key 'user_roles', :name => 'user_roles_user_id_fk'
     end
     add_column :user_roles, :owner_type, :string, :default => 'User', :null => false, :limit => 255

--- a/db/migrate/20150514114044_migrate_ptables_to_templates.rb
+++ b/db/migrate/20150514114044_migrate_ptables_to_templates.rb
@@ -16,13 +16,13 @@ class MigratePtablesToTemplates < ActiveRecord::Migration
   end
 
   def up
-    if foreign_keys('operatingsystems_ptables').find { |f| f.options[:name] == 'operatingsystems_ptables_ptable_id_fk' }.present?
+    if foreign_key_exists?('operatingsystems_ptables', :name => 'operatingsystems_ptables_ptable_id_fk')
       remove_foreign_key "operatingsystems_ptables", :name => "operatingsystems_ptables_ptable_id_fk"
     end
-    if foreign_keys('hostgroups').find { |f| f.options[:name] == 'hostgroups_ptable_id_fk' }.present?
+    if foreign_key_exists?('hostgroups', :name => 'hostgroups_ptable_id_fk')
       remove_foreign_key "hostgroups", :name => "hostgroups_ptable_id_fk"
     end
-    if foreign_keys('hosts').find { |f| f.options[:name] == 'hosts_ptable_id_fk' }.present?
+    if foreign_key_exists?('hosts', :name => 'hosts_ptable_id_fk')
       remove_foreign_key "hosts",  :name => "hosts_ptable_id_fk"
     end
     add_column :templates, :os_family, :string, :limit => 255

--- a/db/migrate/20150521121315_rename_config_template_to_provisioning_template.rb
+++ b/db/migrate/20150521121315_rename_config_template_to_provisioning_template.rb
@@ -16,13 +16,13 @@ class RenameConfigTemplateToProvisioningTemplate < ActiveRecord::Migration
       Permission.where(:name => from).update_all(:name => to)
     end
 
-    if foreign_keys('os_default_templates').find { |f| f.options[:name] == 'os_default_templates_config_template_id_fk' }.present?
+    if foreign_key_exists?('os_default_templates', :name => 'os_default_templates_config_template_id_fk')
       remove_foreign_key "os_default_templates", :name => "os_default_templates_config_template_id_fk"
     end
-    if foreign_keys('template_combinations').find { |f| f.options[:name] == 'template_combinations_config_template_id_fk' }.present?
+    if foreign_key_exists?('template_combinations', :name => 'template_combinations_config_template_id_fk')
       remove_foreign_key "template_combinations", :name => "template_combinations_config_template_id_fk"
     end
-    if foreign_keys('config_templates_operatingsystems').find { |f| f.options[:name] == 'config_templates_operatingsystems_config_template_id_fk' }.present?
+    if foreign_key_exists?('config_templates_operatingsystems', :name => 'config_templates_operatingsystems_config_template_id_fk')
       remove_foreign_key "config_templates_operatingsystems", :name => "config_templates_operatingsystems_config_template_id_fk"
     end
 


### PR DESCRIPTION
foreign_keys throws an exception under SQLite in Rails 4.2, so prefer
the _exists? call to check for presence of a key as it returns false on
DBs without FK support.
