### PR TITLE
fixes #13244 - update Rails to 4.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
 
 source 'https://rubygems.org'
 
-gem 'rails', '4.1.14.2'
+gem 'rails', '4.2.6'
 gem 'rake', '< 11'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord', '~> 4.0'
@@ -15,7 +15,6 @@ gem 'apipie-rails', '~> 0.3.4'
 gem 'rabl', '~> 0.11'
 gem 'oauth', '~> 0.4'
 gem 'deep_cloneable', '~> 2.0'
-gem 'foreigner', '~> 1.4'
 gem 'validates_lengths_from_database', '~> 0.5'
 gem 'friendly_id', '~> 5.0'
 gem 'secure_headers', '~> 1.3'
@@ -39,6 +38,7 @@ gem 'rails-observers', '~> 0.1'
 gem 'protected_attributes', '~> 1.1.1'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
+gem 'responders', '~> 2.0'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/controllers/api/api_responder.rb
+++ b/app/controllers/api/api_responder.rb
@@ -1,8 +1,8 @@
 module Api
   class ApiResponder < ActionController::Responder
     # overview api_behavior
-    def api_behavior(error)
-      raise error unless resourceful?
+    def api_behavior
+      raise MissingRenderer.new(format) unless has_renderer?
 
       if !get? && !post?
         #return resource instead of default "head :no_content" for PUT, PATCH, and DELETE

--- a/app/models/mail_notification.rb
+++ b/app/models/mail_notification.rb
@@ -35,10 +35,10 @@ class MailNotification < ActiveRecord::Base
     if args.last.is_a?(Hash) && args.last.has_key?(:users)
       options = args.pop
       options.delete(:users).each do |user|
-        mailer.constantize.send(method, *args, options.merge(:user => user)).deliver
+        mailer.constantize.send(method, *args, options.merge(:user => user)).deliver_now
       end
     else
-      mailer.constantize.send(method, *args).deliver
+      mailer.constantize.send(method, *args).deliver_now
     end
   end
 end

--- a/bundler.d/mysql2.rb
+++ b/bundler.d/mysql2.rb
@@ -1,3 +1,3 @@
 group :mysql2 do
-  gem 'mysql2', '~> 0.3.10'
+  gem 'mysql2', '>= 0.3.13', '< 0.5'
 end

--- a/bundler.d/sqlite.rb
+++ b/bundler.d/sqlite.rb
@@ -1,3 +1,3 @@
 group :sqlite do
-  gem 'sqlite3', '~> 1.3.5'
+  gem 'sqlite3', '~> 1.3.6'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -164,6 +164,9 @@ module Foreman
       nil
     end
 
+    # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
+
     # Enable the asset pipeline
     config.assets.enabled = true
 
@@ -193,7 +196,7 @@ module Foreman
     config.logger = Foreman::Logging.logger('app')
     config.active_record.logger = Foreman::Logging.logger('sql')
 
-    if config.serve_static_assets
+    if config.serve_static_files
       ::Rails::Engine.subclasses.map(&:instance).each do |engine|
         if File.exist?("#{engine.root}/public/assets")
           config.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Foreman::Application.configure do |app|
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Foreman::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Adds additional error checking when serving assets at runtime.
@@ -57,4 +57,7 @@ Foreman::Application.configure do
 
   # Enable automatic creation/migration of the test DB when running tests
   config.active_record.maintain_test_schema = true
+
+  # Maintain standard order of running tests in case of leaking changes
+  config.active_support.test_order = :sorted
 end

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -14,3 +14,33 @@ end
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail
   allow :[], :each, :first, :to_a
 end
+
+# Provide FK helper present in Foreigner (used on Rails 4.1 and older) and
+# in the future in Rails 5, but that are missing in 4.2.
+#
+# From https://github.com/rails/rails/commit/6298ac70
+class ActiveRecord::Migration
+  def foreign_key_exists?(from_table, options_or_to_table = {})
+    return unless supports_foreign_keys?
+
+    if options_or_to_table.is_a?(Hash)
+      options = options_or_to_table
+    else
+      options = { column: foreign_key_column_for(options_or_to_table) }
+    end
+
+    foreign_keys(from_table).any? {|fk| options.keys.all? {|key| fk.options[key].to_s == options[key].to_s } }
+  end
+end
+
+# Migrations calling foreign_keys directly to check for presence will
+# fail with exceptions on SQLite3 on 4.2, while Foreigner returned [].
+module ActiveRecord::ConnectionAdapters
+  class SQLite3Adapter < AbstractAdapter
+    def foreign_keys(*args)
+      Foreman::Deprecation.deprecation_warning('1.14', 'foreign_keys calls should be replaced by foreign_key_exists?')
+      return [] unless supports_foreign_keys?
+      super
+    end
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -15,7 +15,3 @@ namespace :test do
     t.verbose = true
   end
 end
-
-Rake::Task[:test].enhance do
-  Rake::Task['test:lib'].invoke
-end

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -162,8 +162,9 @@ class Api::TestableControllerTest < ActionController::TestCase
     end
 
     it "works with a CSRF token when there is a session user" do
-      request.headers['X-CSRF-Token'] = 'TEST_TOKEN'
-      post :index, {:authenticity_token => 'TEST_TOKEN'}, set_session_user.merge(:_csrf_token => 'TEST_TOKEN')
+      token = @controller.send(:form_authenticity_token)
+      request.headers['X-CSRF-Token'] = token
+      post :index, {:authenticity_token => token}, set_session_user
       assert_response :success
     end
   end

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -12,7 +12,7 @@ class TopBarIntegrationTest < ActionDispatch::IntegrationTest
       assert page.has_link?("Foreman", :href => "/")
     end
     within("div.navbar-inner") do
-      assert page.has_link?("Dashboard", :href => "/dashboard")
+      assert page.has_link?("Dashboard", :href => "/")
       assert page.has_link?("All hosts", :href => "/hosts")
       assert page.has_link?("Config management", :href => "/config_reports?search=eventful+%3D+true")
       assert page.has_link?("Facts", :href => "/fact_values")

--- a/test/unit/application_mailer_test.rb
+++ b/test/unit/application_mailer_test.rb
@@ -12,7 +12,7 @@ class ApplicationMailerTest < ActiveSupport::TestCase
   end
 
   def mail
-    TestMailer.test.deliver
+    TestMailer.test.deliver_now
     ActionMailer::Base.deliveries.last
   end
 

--- a/test/unit/audit_mailer_test.rb
+++ b/test/unit/audit_mailer_test.rb
@@ -16,34 +16,34 @@ class AuditMailerTest <ActionMailer::TestCase
   end
 
   test 'Audit mail subject should be Audit summary' do
-    assert_not_nil(AuditMailer.summary(@options).deliver.subject)
-    assert_includes(AuditMailer.summary(@options).deliver.subject, _("Audit summary"))
+    assert_not_nil(AuditMailer.summary(@options).deliver_now.subject)
+    assert_includes(AuditMailer.summary(@options).deliver_now.subject, _("Audit summary"))
   end
 
   test 'Audit mail should support two mime-types' do
     # text is first, html second
-    assert_equal(AuditMailer.summary(@options).deliver.body.parts.length, 2)
-    assert_equal(AuditMailer.summary(@options).deliver.body.parts.first.content_type, "text/plain; charset=UTF-8")
-    assert_equal(AuditMailer.summary(@options).deliver.body.parts.last.content_type, "text/html; charset=UTF-8")
-    assert_includes(AuditMailer.summary(@options).deliver.body.parts.last.body, "<body")
+    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.length, 2)
+    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.first.content_type, "text/plain; charset=UTF-8")
+    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.last.content_type, "text/html; charset=UTF-8")
+    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, "<body")
   end
 
   test 'Audit mail should display query results' do
     @options[:query] = "action != #{@audit.action}"
-    refute_includes(AuditMailer.summary(@options).deliver.body.parts.first.body, "#{@audit.action}d")
+    refute_includes(AuditMailer.summary(@options).deliver_now.body.parts.first.body, "#{@audit.action}d")
   end
 
   test 'Audit mail should display total count of audits' do
     @options[:time] = '1973-01-13 00:12'
     count = Audit.all.count
     number_of = Setting[:entries_per_page] > count ? count : Setting[:entries_per_page]
-    assert_includes(AuditMailer.summary(@options).deliver.body.parts.first.body, "Displaying #{number_of} of #{count} audits")
+    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.first.body, "Displaying #{number_of} of #{count} audits")
   end
 
   test 'Audit html mail should include link to query' do
     @options[:time] = '1970-01-01'
     @options[:query] = 'action = create'
     query_should_be = CGI.escape(%(#{@options[:query]} and time >= "#{@options[:time]}"))
-    assert_includes(AuditMailer.summary(@options).deliver.body.parts.last.body, query_should_be)
+    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, query_should_be)
   end
 end

--- a/test/unit/host_mailer_test.rb
+++ b/test/unit/host_mailer_test.rb
@@ -30,31 +30,31 @@ class HostMailerTest < ActionMailer::TestCase
   end
 
   test "mail should have the specified recipient" do
-    assert HostMailer.summary(@options).deliver.to.include?("admin@someware.com")
+    assert HostMailer.summary(@options).deliver_now.to.include?("admin@someware.com")
   end
 
   test "mail should have a subject" do
-    assert !HostMailer.summary(@options).deliver.subject.empty?
+    assert !HostMailer.summary(@options).deliver_now.subject.empty?
   end
 
   test "mail should have a body" do
-    assert !HostMailer.summary(@options).deliver.body.empty?
+    assert !HostMailer.summary(@options).deliver_now.body.empty?
   end
 
   test "mail should report at least one host" do
-    assert HostMailer.summary(@options).deliver.body.include?(@host.name)
+    assert HostMailer.summary(@options).deliver_now.body.include?(@host.name)
   end
 
   test "mail should report disabled hosts" do
     @host.enabled = false
     @host.save
-    assert HostMailer.summary(@options).deliver.body.include?(@host.name)
+    assert HostMailer.summary(@options).deliver_now.body.include?(@host.name)
   end
 
   test 'error_state sends mail with correct headers' do
     report = FactoryGirl.create(:report)
     user = FactoryGirl.create(:user, :with_mail)
-    mail = HostMailer.error_state(report, :user => user).deliver
+    mail = HostMailer.error_state(report, :user => user).deliver_now
     assert_includes mail.from, Setting["email_reply_address"]
     assert_includes mail.to, user.mail
     assert_includes mail.subject, report.host.name

--- a/test/unit/mail_notification_test.rb
+++ b/test/unit/mail_notification_test.rb
@@ -20,7 +20,7 @@ class MailNotificationTest < ActiveSupport::TestCase
     users = FactoryGirl.create_pair(:user, :with_mail)
     mailer = FactoryGirl.create(:mail_notification)
     mail = mock('mail')
-    mail.expects(:deliver).twice
+    mail.expects(:deliver_now).twice
     HostMailer.expects(:test_mail).with(:foo, :user => users[0]).returns(mail)
     HostMailer.expects(:test_mail).with(:foo, :user => users[1]).returns(mail)
     mailer.deliver(:foo, :users => users)


### PR DESCRIPTION
- Add responders gem to support class-level respond_to usage
  - http://edgeguides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to
- Replace foreigner with native Rails 4.2 FK support
  - uses a patch from Rails 5 to support Foreigner's
    `foreign_key_exists?` helper for full compatibility
  - `foreign_keys` should be avoided in favour of the higher level
    methods as it throws a NotImplementedError on sqlite3
- Update DB adapter versions to match ActiveRecord
- Enable exceptions from after_commit handlers to detect more errors
- Change deprecated application config settings
- Remove test:lib chaining on rake test task
  - 4.2 runs lib tasks automatically now, as test:run is redefined
    to all _test files within test/ rather than units+functionals.
    The task is still needed for the jenkins:\* tasks.
- Fix deprecation of mailer #deliver method, change to #deliver_now
- Change CSRF test to use generated, not static tokens
  - 4.2 changes CSRF tokens to be different on every request and
    validated against the session, so use its generator to test the
    controller behaviour instead of hardcoding tokens.

---

Please note this is against the rails42 branch, not develop, per https://groups.google.com/forum/#!topic/foreman-dev/6ANhWVGDzNA.  Katello tests will fail, you'll need to ignore them on this branch until it's fixed.
