### PR TITLE
Fixes #14106 - Compress 15-30% (on avg) controller responses with Rack::Deflater

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,5 +4,6 @@ require ::File.expand_path('../config/environment',  __FILE__)
 # apply a prefix to the application, if one is defined
 # e.g. http://some.server.com/prefix where '/prefix' is defined by env variable
 map ENV['RAILS_RELATIVE_URL_ROOT'] || '/'  do
+  use Rack::Deflater
   run Foreman::Application
 end


### PR DESCRIPTION
Using Rack::Deflater we can compress our responses for HTML and assets
using gzip automatically. This allows us to serve considerably smaller
(in kb) pages, which should go over the wire faster as well.

Trying out /login, /hosts, and /dashboard, processing times were similar
with and without this, but the page size was reduced up to 80% in some
cases.

See the following gist with benchmarks using siege:
https://gist.github.com/dLobatog/600f151fd0676345c95a - notice some
pages like /login are reduced a whooping 75% in size.
