### PR TITLE
fixes #14114 - pin rake to avoid rubocop/rake 11.x incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
 source 'https://rubygems.org'
 
 gem 'rails', '4.1.14.2'
+gem 'rake', '< 11'
 gem 'rest-client', '~> 1.6.0', :require => 'rest_client'
 gem 'audited-activerecord', '~> 4.0'
 gem 'will_paginate', '~> 3.0'


### PR DESCRIPTION
Once https://github.com/bbatsov/rubocop/pull/2931 is released then rubocop can be updated (which means a jump from 0.35 to 0.37 too).
