### PR TITLE
refs #9470 - set :limit on column, fix MailNotification initializer

### DIFF
--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -25,7 +25,7 @@ class MailNotification < ActiveRecord::Base
 
   def initialize(*args)
     params = args.shift
-    params[:type] =  "PuppetError" if params[:name] == 'puppet_error_state'
+    params[:type] = "PuppetError" if params.is_a?(Hash) && params[:name] == 'puppet_error_state'
     args.unshift(params)
     super(*args)
   end

--- a/db/migrate/20151210143537_add_type_to_mail_notification.rb
+++ b/db/migrate/20151210143537_add_type_to_mail_notification.rb
@@ -1,6 +1,6 @@
 class AddTypeToMailNotification < ActiveRecord::Migration
   def change
-    add_column :mail_notifications, :type, :string
+    add_column :mail_notifications, :type, :string, :limit => 255
     MailNotification.reset_column_information
     puppet_error = MailNotification.find_by_name('puppet_error_state')
     if puppet_error.present?

--- a/test/factories/mail_notification.rb
+++ b/test/factories/mail_notification.rb
@@ -1,21 +1,18 @@
 FactoryGirl.define do
   factory :mail_notification do
-    ignore do
-      sequence(:name) {|n| "notification#{n}"}
-      default_interval "Daily"
-      mailer "HostMailer"
-      mailer_method "test_mail"
-      description "Notifies a user"
-      subscription_type "report"
-      queryable false
-    end
+    sequence(:name) {|n| "notification#{n}"}
+    default_interval "Daily"
+    mailer "HostMailer"
+    mailer_method "test_mail"
+    description "Notifies a user"
+    subscription_type "report"
+    queryable false
 
     trait :puppet_error do
       sequence(:name) {"puppet_error_state"}
       mailer "HostMailer"
       mailer_method "puppet"
+      type "PuppetError"
     end
-
-    initialize_with { MailNotification.new ({:name => name, :mailer => mailer, :mailer_method => mailer_method} )  }
   end
 end

--- a/test/unit/mail_notification_test.rb
+++ b/test/unit/mail_notification_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 class MailNotificationTest < ActiveSupport::TestCase
+  test 'can initialize with no arguments' do
+    assert MailNotification.new
+  end
+
+  test 'can initialize with a hash argument' do
+    assert MailNotification.new :name => 'test'
+  end
+
   test "can find notification as hash key" do
     mailer = FactoryGirl.create(:mail_notification)
     assert_equal MailNotification[mailer.name], mailer
@@ -26,8 +34,8 @@ class MailNotificationTest < ActiveSupport::TestCase
     mailer.deliver(:foo, :users => users)
   end
 
-  test "when a notification with 'puppet_error_state' name generated, a subclass PuppeError should created" do
-    mailer =  FactoryGirl.build(:mail_notification, :puppet_error)
-    assert mailer.type == 'PuppetError'
+  test "when name is set to 'puppet_error_state', type should be set to PuppetError" do
+    mailer = MailNotification.new(:name => 'puppet_error_state')
+    assert_equal 'PuppetError', mailer.type
   end
 end


### PR DESCRIPTION
MailNotification.new failed unless it had a Hash argument, hence the
factory had been changed from default behaviour.  It also then ignored
all attributes except a given few listed in initialize_with.
