### PR TITLE
Fixes #13091 - Paginate VMs for supporting compute resources

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -156,6 +156,19 @@ function activateDatatables() {
         "sPaginationType": "bootstrap"
       }
   );
+  $('[data-table=server]').not('.dataTable').each(function () {
+    var url = $(this).data('source');
+    $(this).dataTable(
+      {
+        "bProcessing": true,
+        "bServerSide": true,
+        "bSort": false,
+        "sAjaxSource": url,
+        "sDom": "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'><'col-md-6'p>>",
+        "sPaginationType": "bootstrap"
+      }
+    );
+  });
 }
 
 function preserve_selected_options(elem) {

--- a/app/assets/javascripts/compute_resource.js
+++ b/app/assets/javascripts/compute_resource.js
@@ -6,8 +6,9 @@ $(function() {
       if (status == "error") {
         $(this).closest(".tab-content").find("#spinner").html(Jed.sprintf(__("There was an error listing VMs: %(status)s %(statusText)s"), {status: xhr.status, statusText: xhr.statusText}));
       }
-      $('.dropdown-toggle').dropdown();
-      $(document.body).trigger('ContentLoad');
+      else {
+        activateDatatables();
+      }
     });
   });
 });

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -136,6 +136,10 @@ class ComputeResource < ActiveRecord::Base
     client.servers
   end
 
+  def supports_vms_pagination?
+    false
+  end
+
   def find_vm_by_uuid(uuid)
     client.servers.get(uuid) || raise(ActiveRecord::RecordNotFound)
   end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -187,6 +187,20 @@ module Foreman::Model
       true
     end
 
+    def supports_vms_pagination?
+      true
+    end
+
+    def parse_vms_list_params(params)
+      max = (params['iDisplayLength'] || 10).to_i
+      {
+        :search => params['sSearch'] || '',
+        :max => max,
+        :page => (params['iDisplayStart'].to_i / max)+1,
+        :without_details => true
+      }
+    end
+
     def console(uuid)
       vm = find_vm_by_uuid(uuid)
       raise "VM is not running!" if vm.status == "down"

--- a/app/views/compute_resources_vms/index.html.erb
+++ b/app/views/compute_resources_vms/index.html.erb
@@ -1,4 +1,4 @@
 <% title(_("Virtual Machines on %s") % @compute_resource) %>
-<table class='<%= table_css_classes %>' data-table="inline">
+<%= vms_table do %>
   <%= render "compute_resources_vms/index/#{@compute_resource.provider.downcase}" %>
-</table>
+<% end %>

--- a/app/views/compute_resources_vms/index/_ovirt.html.erb
+++ b/app/views/compute_resources_vms/index/_ovirt.html.erb
@@ -8,21 +8,5 @@
   </tr>
 </thead>
 <tbody>
-  <% @vms.each do |vm| %>
-    <tr>
-      <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :auth_action => 'view', :authorizer => authorizer) %></td>
-      <td><%= vm.cores %></td>
-      <td>
-        <%= number_to_human_size vm.memory %>
-      </td>
-      <td>
-        <span <%= vm_power_class(vm.ready?) %>>
-          <%= vm_state(vm) %></span>
-      </td>
-      <td>
-        <%= action_buttons(vm_power_action(vm, authorizer),
-                           display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.id).merge(:auth_object => @compute_resource, :authorizer => authorizer))) %>
-      </td>
-    </tr>
-  <% end %>
+
 </tbody>

--- a/app/views/compute_resources_vms/index/_ovirt.json.erb
+++ b/app/views/compute_resources_vms/index/_ovirt.json.erb
@@ -1,0 +1,5 @@
+{
+  "sEcho": <%= params['sEcho'] || '' %>,
+  "iTotalDisplayRecords": <%= ovirt_fake_vms_count %>,
+  "aaData": <%= ovirt_vms_data %>
+}

--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem 'rbovirt', '~> 0.0.32'
+  gem 'rbovirt', '~> 0.0.36'
 end


### PR DESCRIPTION
Loading all VMs for the compute resource view can be a very heavy task,
which leads to timeouts when attempting to load all VMs for a compute
resource that has many hundreds or thousands of VMs. This patch allows
us to take advantage of datatable's ability to dynamically load data
from the server so we only load 10 VMs at a time. Currently this is only
supported for oVirt (dependant on https://github.com/abenari/rbovirt/pull/102
being merged into rbovirt) but can easily be extended for other
providers as well.
