### PR TITLE
fixes #13980 - don't merge NIC compute attrs on New Host form

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -267,7 +267,7 @@ Return the host's compute attributes that can be used to create a clone of this 
       private
 
       def apply_compute_profile(host)
-        host.apply_compute_profile(InterfaceMerge.new)
+        host.apply_compute_profile(InterfaceMerge.new(:merge_compute_attributes => true))
         host.apply_compute_profile(ComputeAttributeMerge.new)
       end
 

--- a/app/services/interface_merge.rb
+++ b/app/services/interface_merge.rb
@@ -1,4 +1,10 @@
 class InterfaceMerge
+  attr_reader :merge_compute_attributes
+
+  def initialize(opts = {})
+    @merge_compute_attributes = !!opts[:merge_compute_attributes]
+  end
+
   def run(host, compute_attrs)
     return if compute_attrs.nil?
 
@@ -20,7 +26,12 @@ class InterfaceMerge
   private
 
   def merge(nic, vm_nic, compute_attrs)
-    nic.compute_attributes = vm_nic.merge(nic.compute_attributes)
+    nic.compute_attributes = if merge_compute_attributes
+                               vm_nic.merge(nic.compute_attributes)
+                             else
+                               vm_nic
+                             end
+
     nic.compute_attributes['from_profile'] = compute_attrs.compute_profile.name
     nic
   end

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -61,12 +61,10 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     Host.order('id asc').last
   end
 
-  def expect_attribute_modifiers(*modifier_classes)
-    modifier_classes.each do |modifier_class|
-      Host.any_instance.expects(:apply_compute_profile).once.with do |modifier|
-        modifier.is_a? modifier_class
-      end
-    end
+  def expect_attribute_modifier(modifier_class, args)
+    modifier = mock(modifier_class.name)
+    modifier_class.expects(:new).with(*args).returns(modifier)
+    Host.any_instance.expects(:apply_compute_profile).with(modifier)
   end
 
   test "should get index" do
@@ -181,13 +179,15 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "create applies attribute modifiers on the new host" do
     disable_orchestration
-    expect_attribute_modifiers(ComputeAttributeMerge, InterfaceMerge)
+    expect_attribute_modifier(ComputeAttributeMerge, [])
+    expect_attribute_modifier(InterfaceMerge, [{:merge_compute_attributes => true}])
     post :create, { :host => valid_attrs }
   end
 
   test "update applies attribute modifiers on the host" do
     disable_orchestration
-    expect_attribute_modifiers(ComputeAttributeMerge, InterfaceMerge)
+    expect_attribute_modifier(ComputeAttributeMerge, [])
+    expect_attribute_modifier(InterfaceMerge, [{:merge_compute_attributes => true}])
     put :update, { :id => @host.to_param, :host => valid_attrs }
   end
 

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -1236,6 +1236,15 @@ class HostsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test '#interfaces applies compute profile and returns interfaces partial' do
+    modifier = mock('InterfaceMerge')
+    InterfaceMerge.expects(:new).with().returns(modifier)
+    Host::Managed.any_instance.expects(:apply_compute_profile).with(modifier)
+    xhr :get, :interfaces, { :host => {:compute_resource_id => compute_resources(:one).id, :compute_profile_id => compute_profiles(:one).id}}, set_session_user
+    assert_response :success
+    assert_template :partial => '_interfaces'
+  end
+
   private
 
   def initialize_host

--- a/test/unit/interface_merge_test.rb
+++ b/test/unit/interface_merge_test.rb
@@ -46,7 +46,18 @@ class InterfaceMergeTest < ActiveSupport::TestCase
     assert_equal 'eth2', interfaces[2].identifier
   end
 
-  test "it does not overwrite compute attributes already set" do
+  test "it overwrites NIC compute attributes from the profile by default" do
+    interfaces = [
+      FactoryGirl.build(:nic_managed, :identifier => 'eth0', :compute_attributes => {'attr' => 9}),
+    ]
+    @merge.run(stub(:interfaces => interfaces), @attributes)
+
+    assert_equal expected_attrs(1), interfaces[0].compute_attributes
+    assert_equal 'eth0', interfaces[0].identifier
+  end
+
+  test "it does not overwrite NIC compute attributes already set with :merge_compute_attributes" do
+    @merge = InterfaceMerge.new(:merge_compute_attributes => true)
     interfaces = [
       FactoryGirl.build(:nic_managed, :identifier => 'eth0', :compute_attributes => {'attr' => 9}),
     ]


### PR DESCRIPTION
Removes merging of NIC's compute attributes when refreshing interfaces
on compute profile or resource selections on the New Host form. Instead,
overwrite NIC attributes from the profile (as it did before 85e82d0) as
the UI needs refreshing completely on compute profile selection.

Merging of NIC compute attributes with the compute profile is retained
on the host API where it's still valuable for supplying a partial set
of compute attributes.

---

Note that there's a regression with merging of NIC compute attrs on develop via the API controller (http://projects.theforeman.org/issues/14179) so if testing that aspect you'll need to pry to see that InterfaceMerge is doing its job.  The bug is further on in the process, during compute orchestration.
