### PR TITLE
fixes #14179 - don't merge NIC compute attrs in ComputeProfileMerge

### DIFF
--- a/app/services/compute_attribute_merge.rb
+++ b/app/services/compute_attribute_merge.rb
@@ -4,7 +4,11 @@ class ComputeAttributeMerge
 
     host.compute_attributes ||= {}.with_indifferent_access
 
-    vm_attrs = compute_attrs.vm_attrs
+    # Exclude interfaces compute attributes from merge, use InterfaceMerge
+    # instead for more precise merging of interfaces
+    interface_attrs_key = "#{compute_attrs.compute_resource.interfaces_attrs_name}_attributes"
+    vm_attrs = compute_attrs.vm_attrs.except(interface_attrs_key)
+
     vm_attrs = vm_attrs.deep_merge(host.compute_attributes)
 
     host.compute_attributes = vm_attrs

--- a/test/unit/compute_attribute_merge_test.rb
+++ b/test/unit/compute_attribute_merge_test.rb
@@ -85,4 +85,31 @@ class ComputeAttributeMergeTest < ActiveSupport::TestCase
 
     assert_equal(expected_attrs, @host.compute_attributes)
   end
+
+  test "it does not merge interfaces / nics_attributes" do
+    @profile_attributes.compute_resource.expects(:interfaces_attrs_name).returns(:nics)
+
+    @profile_attributes.stubs(:vm_attrs).returns(
+    {
+      'cpus' => 1,
+      'memory' => 4294967296,
+      'nics_attributes' => {
+        '0' => {
+          'attr0a' => 'a',
+          'attr0b' => 'b'
+        }
+      }
+    })
+    @host.compute_attributes = {
+      'cpus' => 2,
+    }
+    expected_attrs = {
+      'cpus' => 2,
+      'memory' => 4294967296,
+    }
+
+    @merge.run(@host, @profile_attributes)
+
+    assert_equal(expected_attrs, @host.compute_attributes)
+  end
 end


### PR DESCRIPTION
When creating a host over the API and specifying interface compute
attributes, the interface attributes were overwritten from the compute
profile.  Example request:

```
{"host":{"interfaces_attributes":{"0":{"primary":"true","compute_attributes":{"model":"e1000"}}}, ...}}
```

ComputeProfileMerge stores :interfaces_attributes (name varies based on
the CR type) from the profile in host.compute_attributes, while
InterfaceMerge stores attributes in each interface.  When
Orchestration::Compute#add_interfaces_to_compute_attrs runs to merge
per-interface attributes into host.compute_attributes, the step was
skipped as host.compute_attributes[:interfaces_attributes] already
existed from ComputeProfileMerge.

This change excludes interface attributes from being merged by
ComputeProfileMerge, so InterfaceMerge is responsible for copying them
into the interface.
