### PR TITLE
Fixes #14183 - showing whitespace validation in smart variables

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -104,7 +104,10 @@ class LookupKey < ActiveRecord::Base
   end
 
   def to_param
-    Parameterizable.parameterize("#{id}-#{key}")
+    # to_param is used in views to create a link to the lookup_key.
+    # If the key has whitespace in it the link will break so this replaced the whitespace.
+    search_key = key.tr(' ','_') unless key.nil?
+    Parameterizable.parameterize("#{id}-#{search_key}")
   end
 
   def to_s

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -221,6 +221,11 @@ class LookupKeyTest < ActiveSupport::TestCase
     end
   end
 
+  test "to_param should replace whitespace with underscore" do
+    lookup_key = VariableLookupKey.new(:key => "smart variable", :path => "hostgroup", :puppetclass => Puppetclass.first, :default_value => "default")
+    assert_equal "-smart_variable", lookup_key.to_param
+  end
+
   test "when changed, an audit entry should be added" do
     env = FactoryGirl.create(:environment)
     pc = FactoryGirl.create(:puppetclass, :with_parameters, :environments => [env])


### PR DESCRIPTION
When https://github.com/theforeman/foreman/commit/54188a7c45c79df42387cba7025b2e7f9a3fbe2a was merged the was a problem with all validations in lookup_key. Now that it has been fixed the validation that whitespace isn't allowed in smart variable's key should be seen.
Since `to_param` uses the key as is with whitspace the view can get links to smart variables that contain whitespace and that won't allow to click them and see the error e.g: `href="#1450-my key"`.
