### PR TITLE
fixes #14155 - fix leaks between tests with random ordering

### DIFF
--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -4,7 +4,6 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
   def setup
     @location = taxonomies(:location1)
     @location.organization_ids = [taxonomies(:organization1).id]
-    Rabl.configuration.use_controller_name_as_json_root = false
   end
 
   test "should get index" do
@@ -110,13 +109,22 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     refute response['locations']
   end
 
-  test "root name on index is configured to be controller name" do
-    Rabl.configuration.use_controller_name_as_json_root = true
-    get :index, {}
-    response = ActiveSupport::JSON.decode(@response.body)
-    assert response.is_a?(Hash)
-    refute response['results']
-    assert response['locations'].is_a?(Array)
+  context "use_controller_name_as_json_root is enabled" do
+    setup do
+      Rabl.configuration.use_controller_name_as_json_root = true
+    end
+
+    teardown do
+      Rabl.configuration.use_controller_name_as_json_root = false
+    end
+
+    test "root name on index is configured to be controller name" do
+      get :index, {}
+      response = ActiveSupport::JSON.decode(@response.body)
+      assert response.is_a?(Hash)
+      refute response['results']
+      assert response['locations'].is_a?(Array)
+    end
   end
 
   test "root name on index can be overwritten by param root_name" do

--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -1,12 +1,6 @@
 require 'test_helper'
 
 class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
-  os = {
-    :name  => "awsome_os",
-    :major => "1",
-    :minor => "2"
-  }
-
   test "should get index" do
     get :index, { }
     assert_response :success
@@ -23,15 +17,14 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
 
   test "should create os" do
     assert_difference('Operatingsystem.count') do
-      post :create, { :operatingsystem => os }
+      post :create, { :operatingsystem => os_params }
     end
     assert_response :created
     assert_not_nil assigns(:operatingsystem)
   end
 
   test "should create os with os parameters" do
-    os_with_params = os.dup
-    os_with_params[:os_parameters_attributes] = {0=>{:name => "foo", :value => "bar"}}
+    os_with_params = os_params.merge(:os_parameters_attributes => {0=>{:name => "foo", :value => "bar"}})
     assert_difference('OsParameter.count') do
       assert_difference('Operatingsystem.count') do
         post :create, { :operatingsystem => os_with_params }
@@ -43,7 +36,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
 
   test "should not create os without version" do
     assert_difference('Operatingsystem.count', 0) do
-      post :create, { :operatingsystem => os.except(:major) }
+      post :create, { :operatingsystem => os_params.except(:major) }
     end
     assert_response :unprocessable_entity
   end
@@ -63,7 +56,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should update associated architectures by ids with UNWRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { },
+      put :update, { :id => os.to_param, :operatingsystem => { },
                      :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id } ] }
     end
     assert_response :success
@@ -72,7 +65,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should update associated architectures by name with UNWRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { },
+      put :update, { :id => os.to_param,  :operatingsystem => { },
                      :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name } ] }
     end
     assert_response :success
@@ -81,7 +74,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should add association of architectures by ids with WRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => { :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id }] } }
+      put :update, { :id => os.to_param, :operatingsystem => { :architectures => [{ :id => architectures(:x86_64).id }, { :id => architectures(:sparc).id }] } }
     end
     assert_response :success
   end
@@ -89,7 +82,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should add association of architectures by name with WRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count') do
-      put :update, { :id => operatingsystems(:redhat).to_param,  :operatingsystem => { :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name }] } }
+      put :update, { :id => os.to_param,  :operatingsystem => { :architectures => [{ :name => architectures(:x86_64).name }, { :name => architectures(:sparc).name }] } }
     end
     assert_response :success
   end
@@ -97,7 +90,7 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   test "should remove association of architectures with WRAPPED node" do
     os = operatingsystems(:redhat)
     assert_difference('os.architectures.count', -1) do
-      put :update, { :id => operatingsystems(:redhat).to_param, :operatingsystem => {:architectures => [] } }
+      put :update, { :id => os.to_param, :operatingsystem => {:architectures => [] } }
     end
     assert_response :success
   end
@@ -112,5 +105,15 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     get :show, { :id => operatingsystems(:redhat).description }
     assert_response :success
     assert_equal operatingsystems(:redhat), assigns(:operatingsystem)
+  end
+
+  private
+
+  def os_params
+    {
+      :name  => "awsome_os",
+      :major => "1",
+      :minor => "2"
+    }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -246,7 +246,7 @@ Spork.prefork do
     alias_method :assert_not_valid, :refute_valid
 
     def with_env(values = {})
-      old_values = ENV.to_hash.slice(values.keys)
+      old_values = values.inject({}) { |ov,(key,val)| ov.update(key => ENV[key]) }
       ENV.update values
       result = yield
       ENV.update old_values


### PR DESCRIPTION
- A test for the Rabl use_controller_name_as_json_root extension was
  leaking as the old value was only reset in `setup` methods. When the
  test was last in the test case, the configuration wasn't reset.
- The with_env helper failed to unset environment variables that weren't
  set before, it now stores a nil value and resets them.
- OS functional tests used a class-level `os` variable to hold default
  parameters, but was reassigned in some tests.
