### PR TITLE
fixes #14041 - don't call select2 on CR form templates

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -142,7 +142,7 @@ function onContentLoad(){
   $.cookie('timezone', tz.name(), { path: '/', secure: location.protocol === 'https:' });
 
   $('.full-value').SelectOnClick();
-  $('select:not(.without_select2)').not('.form_template select').select2({ allowClear: true });
+  activate_select2(':root');
 
   $('input.remove_form_templates').closest('form').submit(function(event) {
     $(this).find('.form_template').remove()
@@ -266,7 +266,7 @@ function template_info(div, url) {
     data: form,
     success: function(response, status, xhr) {
       $(div).html(response);
-      $('select').select2({ allowClear: true });
+      activate_select2(div);
     },
     error: function(jqXHR, textStatus, errorThrown) {
       $(div).html('<div class="alert alert-warning alert-dismissable">' +
@@ -498,7 +498,7 @@ function toggle_input_group(item) {
 function reloadOnAjaxComplete(element) {
   foreman.tools.hideSpinner()
   $('[rel="twipsy"]').tooltip();
-  $('select:not(.without_select2)').select2({ allowClear: true });
+  activate_select2(':root');
 }
 
 function set_fullscreen(element){
@@ -610,4 +610,12 @@ function icon_text(name, inner_text, icon_class) {
   var icon = '<span class="' + icon_class + " " + icon_class + "-" + name + '"/>'
   icon += typeof inner_text === "" ? "" : "<strong>" + inner_text + "</strong>";
   return icon
+}
+
+function activate_select2(container, allowClear) {
+  allowClear = typeof allowClear !== 'undefined' ? allowClear : true;
+  $(container).find('select:not(.without_select2)').
+    not('.form_template select').
+    not('#interfaceForms select').
+    select2({ 'allowClear': allowClear });
 }

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -68,7 +68,8 @@ function computeResourceSelected(item){
         $('#compute_resource_tab a').addClass('tab-error');
       },
       success: function(result){
-        $('#compute_resource').html(result).find('select:not(without_select2)').select2();
+        $('#compute_resource').html(result);
+        activate_select2('#compute_resource');
         if ($('#compute_resource').find('.alert-danger').length > 0) $('#compute_resource_tab a').addClass('tab-error');
         update_capabilities($('#capabilities').val());
       }
@@ -585,7 +586,7 @@ function interface_domain_selected(element) {
         subnet_options.attr('disabled', true);
       }
       reloadOnAjaxComplete(element);
-      subnet_options.filter('select').select2({allowClear: true})
+      activate_select2(subnet_options);
     }
   });
 }
@@ -670,7 +671,7 @@ function interface_type_selected(element) {
   request.done(function() {
     password_caps_lock_hint();
     $("#interfaceModal").find('a[rel="popover-modal"]').popover();
-    $('select:not(.without_select2)').select2({ allowClear: true });
+    activate_select2('#interfaceModal');
   });
 }
 

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -28,7 +28,7 @@ function show_interface_modal(modal_content) {
   modal_window.modal({'show': true});
 
   modal_window.find('a[rel="popover-modal"]').popover();
-  modal_window.find('select:not(.without_select2)').select2({ allowClear: true });
+  activate_select2(modal_window);
 }
 
 function save_interface_modal() {

--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -84,7 +84,7 @@ function add_child_node(item) {
     $(item).closest("form").trigger({type: 'nested:fieldAdded', field: field});
     $('a[rel="popover"]').popover();
     $('a[rel="twipsy"]').tooltip();
-    $(field).find('select:not(.matcher_key)').select2();
+    activate_select2($(field).not('.matcher_key'));
     return new_id;
 }
 

--- a/app/assets/javascripts/proxy_status/logs.js
+++ b/app/assets/javascripts/proxy_status/logs.js
@@ -41,7 +41,7 @@ function activateLogsDataTable() {
       "aTargets": [1]
     }]});
   var filter = $('#logs-filter');
-  filter.select2();
+  activate_select2(filter);
   filter.on('change', function() { filterLogsByLevel(filter.val()) });
 
   $('#logEntryModal').on('show.bs.modal', function (event) {

--- a/app/assets/javascripts/proxy_status/puppet.js
+++ b/app/assets/javascripts/proxy_status/puppet.js
@@ -5,7 +5,7 @@ function filterCerts(state) {
 function certTable() {
   activateDatatables();
   var filter = $('#puppetca-filter');
-  filter.select2();
+  activate_select2(filter);
   filter.on('change', function() {filterCerts(filter.val())});
   filterCerts(__('valid')+'|'+__('pending'));
 }

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -1,5 +1,5 @@
 
-<%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :class => "without_select2", :label => _("Storage pool"), :label_size => "col-md-2" %>
+<%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :label => _("Storage pool"), :label_size => "col-md-2" %>
 <%= text_f f, :capacity, :label => _("Size (GB)"), :onchange => 'capacity_edit(this)', :label_size => "col-md-2" %>
 <%= allocation_text_f f %>
-<%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :class => "without_select2", :label => _("Type"), :label_size => "col-md-2" %>
+<%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :label => _("Type"), :label_size => "col-md-2" %>

--- a/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
@@ -2,7 +2,7 @@
 <%= text_f f,:size_gb, :label => _('Size (GB)'), :label_size => "col-md-2", :disabled => !new_host, :class => "col-md-2" %>
 <%= f.hidden_field :size_gb if !new_host %>
 <%= select_f f, :storage_domain, compute_resource.storage_domains, :id, :name,
-             { }, :label => _('Storage domain'), :label_size => "col-md-2", :disabled => !new_host, :class => "col-md-2 without_select2" %>
+             { }, :label => _('Storage domain'), :label_size => "col-md-2", :disabled => !new_host, :class => "col-md-2" %>
 <%= f.hidden_field :storage_domain if !new_host %>
 <%= f.hidden_field :id %>
 

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -2,11 +2,11 @@
   :storage_pod,
   vsphere_storage_pods(compute_resource),
   { :include_blank => _('Deploy VM on selected datastore') },
-  :class => "span5 without_select2",
+  :class => "span5",
   :label => _("Datastore Cluster"),
   :label_size => "col-md-2",
   :onchange => 'vsphereStoragePodSelected(this)' if new_host and vsphere_storage_pods(compute_resource).any? %>
-<%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5 without_select2", :label => _("Data store"), :label_size => "col-md-2" %>
+<%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
 <%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2" %>
 <%= text_f f, :size_gb,
            :class       => "col-md-2",

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -32,7 +32,7 @@
                { :include_blank => accessible_subnets.any? ? true : _("No subnets")},
                { :disabled => accessible_subnets.empty? ? true : false,
                  :help_inline => :indicator,
-                 :class => 'interface_subnet without_select2', :'data-url' => freeip_subnets_path,
+                 :class => 'interface_subnet', :'data-url' => freeip_subnets_path,
                  :size => "col-md-8", :label_size => "col-md-3" } %>
 <% end %>
 <%= text_f f, :ip,

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -412,7 +412,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
         subnet_id = modal.find('#host_interfaces_attributes_0_subnet_id',
                    :visible => false).value
-        subnet_label = modal.find('span#select2-chosen-40').text
+        subnet_label = modal.find('#s2id_host_interfaces_attributes_0_subnet_id span.select2-chosen').text
 
         assert_equal domain.subnets.first.id.to_s, subnet_id
         assert_equal domain.subnets.first.to_label, subnet_label


### PR DESCRIPTION
select2 must be called only when the select becomes visible, not for
hidden template elements. add_child_node() already does when adding a
new set of fields from the template.  without_select2 is removed from
all CR volume fields and a typo from ce59b508 fixed to ensure the first,
default volume initialises select2 when a CR is selected.

The interface_type_selected function is fixed to only call select2 on
its elements instead of the entire page, which also broke the volume
form templates if a NIC type was changed.
