### PR TITLE
fixes #14200 - exclude form templates from select2 initialisation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -142,7 +142,7 @@ function onContentLoad(){
   $.cookie('timezone', tz.name(), { path: '/', secure: location.protocol === 'https:' });
 
   $('.full-value').SelectOnClick();
-  $('select:not(.without_select2)').select2({ allowClear: true });
+  $('select:not(.without_select2)').not('.form_template select').select2({ allowClear: true });
 
   $('input.remove_form_templates').closest('form').submit(function(event) {
     $(this).find('.form_template').remove()


### PR DESCRIPTION
Form templates shouldn't be initialised with select2, as the elements
are copied through add_child_node, e.g. when adding a new external user
group inside the user group form.  add_child_node calls select2 after
copying the form instead.
