### PR TITLE
fixes #13352 - order dashboard widgets by ID for consistency

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -10,7 +10,7 @@
   <% else %>
     <div id='dashboard' class="dashboard gridster col-md-12">
       <ul>
-        <% User.current.widgets.each do |widget| %>
+        <% User.current.widgets.order(:id).each do |widget| %>
           <%= content_tag(:li, widget_data(widget)) do %>
             <div class='widget_control'>
               <a class='remove' data-url='<%= widget_path(widget) %>'>&times;</a>


### PR DESCRIPTION
When a user's dashboard widgets are seeded, they receive default row and
column positions of 1, so gridster organises the widgets in the order
they are defined in the view - which before this change, is up to the
database and can vary in order.

Ordering widgets by ID ensures the widgets will start in the order they
were added to the database in (which in turn is from the widget
registration order). If a user saves the dashboard, the saved row/col
values take precedence.
