### PR TITLE
fixes #14253 - add attr_accessible to Widget

### DIFF
--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -6,6 +6,8 @@ class Widget < ActiveRecord::Base
 
   serialize :data
 
+  attr_accessible :col, :hide, :row, :sizex, :sizey
+
   before_validation :default_values
 
   def default_values

--- a/app/services/dashboard/manager.rb
+++ b/app/services/dashboard/manager.rb
@@ -16,9 +16,14 @@ module Dashboard
       @allowed_templates.merge(templates)
     end
 
-    def self.add_widget_to_user(user, widget)
-      raise ::Foreman::Exception.new(N_("Unallowed template for dashboard widget: %s"), widget[:template]) unless @allowed_templates.include?(widget[:template])
-      user.widgets.create!(widget)
+    def self.add_widget_to_user(user, widget_params)
+      raise ::Foreman::Exception.new(N_("Unallowed template for dashboard widget: %s"), widget_params[:template]) unless @allowed_templates.include?(widget_params[:template])
+
+      widget = user.widgets.build(widget_params.except(:name, :template))
+      widget.name = widget_params[:name]
+      widget.template = widget_params[:template]
+      widget.save!
+      widget
     end
 
     def self.reset_user_to_default(user)

--- a/test/factories/user_related.rb
+++ b/test/factories/user_related.rb
@@ -26,6 +26,10 @@ FactoryGirl.define do
       sequence(:mail) {|n| "email#{n}@example.com" }
       mail_notifications { [FactoryGirl.create(:mail_notification)] }
     end
+
+    trait :with_widget do
+      after(:create) { |user,evaluator| FactoryGirl.create(:widget, :user => user) }
+    end
   end
 
   factory :permission do
@@ -94,5 +98,10 @@ FactoryGirl.define do
     trait :on_name_starting_with_b do
       search 'name ~ b*'
     end
+  end
+
+  factory :widget do
+    sequence(:name) {|n| "Status Table #{n}" }
+    template 'status_widget'
   end
 end

--- a/test/functional/dashboard_controller_test.rb
+++ b/test/functional/dashboard_controller_test.rb
@@ -17,4 +17,40 @@ class DashboardControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test '#destroy removes a widget from the user' do
+    widget = FactoryGirl.create(:widget, :user => users(:admin))
+    delete :destroy, { :id => widget.id, :format => 'json' }, set_session_user
+    assert_response :success
+    assert_equal widget.id.to_s, @response.body
+    assert_empty users(:admin).widgets.reload
+  end
+
+  test "#destroy returns forbidden for other user's widget" do
+    other_user = FactoryGirl.create(:user, :with_widget)
+    widget = other_user.widgets.first
+    delete :destroy, { :id => widget.id, :format => 'json' }, set_session_user
+    assert_response :forbidden
+    assert_equal widget.id.to_s, @response.body
+    assert_includes other_user.widgets.reload, widget
+  end
+
+  test "#reset_to_default resets user's widgets" do
+    Dashboard::Manager.expects(:reset_user_to_default).with(users(:admin))
+    put :reset_default, {}, set_session_user
+    assert_redirected_to root_path
+  end
+
+  test "#save_positions updates each widget" do
+    widget = FactoryGirl.create(:widget, :user => users(:admin))
+    params = {
+      widget.id.to_s => {:hide => 'false', :col => '4', :row => '3', :sizex => '8', :sizey => '1'},
+    }
+    post :save_positions, {:widgets => params, :format => 'json'}, set_session_user
+    assert_response :success
+    widget.reload
+    assert_equal false, widget.hide
+    assert_equal 4, widget.col
+    assert_equal 3, widget.row
+  end
 end


### PR DESCRIPTION
Add position/view related attributes to widget as accessible attributes
and protect data such as template and name. Under Rail 4.2, saving the
dashboard was failing due to attribute protection, so new functional
tests cover the whole controller.
