### PR TITLE
Fixes #12979 - Create helper for "new" button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -73,13 +73,6 @@ function onContentLoad(){
      notify(item, 'success');
    });
 
-  // adds buttons classes to all links
-  $("#title_action a").addClass('btn').not('.btn-info, .btn-danger').addClass("btn-default");
-
-  $("#title_action li a").removeClass("btn btn-default").addClass("la");
-  $("#title_action span").removeClass("btn btn-default").addClass("btn-group");
-  $("#title_action a[href*='new']").removeClass('btn-default').addClass("btn-primary");
-
   if ($("input[focus_on_load=true]").length > 0) {
     $("input[focus_on_load]").first().focus();
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,7 +151,7 @@ select {
 
 .delete {
   color: #b94a48 !important;
-  cursor: auto;
+  cursor: pointer;
 }
 
 .inherited {

--- a/app/helpers/bmc_helper.rb
+++ b/app/helpers/bmc_helper.rb
@@ -11,7 +11,7 @@ module BmcHelper
   end
 
   def power_actions
-    toolbar_action_buttons(
+    action_buttons(
       (PowerManager::SUPPORTED_ACTIONS - ['state']).map do |action|
         display_link_if_authorized(_(action.to_s.capitalize),
                                    { :action => "power", :id => @host, :power_action => action, :auth_object => @host },

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -134,6 +134,6 @@ module DashboardHelper
     end
     link_to(icon_text("refresh"),
             {:auto_refresh => (on == "on" ? "0" : "1")},
-            { :'data-original-title' => tooltip, :rel => 'twipsy', :class => "#{on} auto-refresh btn btn-group"})
+            { :'data-original-title' => tooltip, :rel => 'twipsy', :class => "#{on} auto-refresh btn btn-group btn-default"})
   end
 end

--- a/app/helpers/environments_helper.rb
+++ b/app/helpers/environments_helper.rb
@@ -3,6 +3,7 @@ module EnvironmentsHelper
 
   def environments_title_actions
     title_actions import_proxy_select(hash_for_import_environments_environments_path),
-                  button_group(display_link_if_authorized(_('New Puppet Environment'), hash_for_new_environment_path))
+                  button_group(new_link(_('New Puppet Environment'))),
+                  button_group(help_path)
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -314,7 +314,8 @@ module FormHelper
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
       render((partial.nil? ? association.to_s.singularize + "_fields" : partial), :f => builder)
     end
-    link_to_function(name, ("add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}')").html_safe, add_html_classes(options, "btn btn-primary") )
+    options[:class] = "btn btn-primary #{options[:class]}"
+    link_to_function(name, ("add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}')").html_safe, options)
   end
 
   def field(f, attr, options = {})

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Architectures") %>
-<% title_actions display_link_if_authorized(_("New Architecture"), hash_for_new_architecture_path), help_path %>
+<% title_actions new_link(_("New Architecture")), help_path %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/architectures/welcome.html.erb
+++ b/app/views/architectures/welcome.html.erb
@@ -11,6 +11,6 @@
   </p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4.5Architectures")%></p>
   <div class="blank-slate-pf-main-action">
-      <%= link_to(_("New architecture"), new_architecture_path, :class => "btn btn-primary btn-lg") %>
+      <%= new_link(_("New architecture"), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/auth_source_ldaps/index.html.erb
+++ b/app/views/auth_source_ldaps/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title _("LDAP Authentication") %>
 
-<% title_actions(display_link_if_authorized(_("New LDAP Source"), hash_for_new_auth_source_ldap_path), documentation_button('4.1.1LDAPAuthentication')) %>
+<% title_actions(new_link(_("New LDAP Source")), documentation_button('4.1.1LDAPAuthentication')) %>
 
 <table class="<%= table_css_classes("table-two-pane table-hover") %>">
   <thead>

--- a/app/views/auth_source_ldaps/welcome.html.erb
+++ b/app/views/auth_source_ldaps/welcome.html.erb
@@ -10,6 +10,6 @@
   </p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.1.1LDAPAuthentication")%></p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to(_("New authentication source"), new_auth_source_ldap_path, :class => 'btn btn-primary btn-lg') %>
+    <%= new_link(_("New authentication source"), :class => 'btn-lg') %>
   </div>
 </div>

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Global Parameters") %>
 
-<% title_actions display_link_if_authorized(_("New Parameter"), hash_for_new_common_parameter_path),
+<% title_actions new_link(_("New Parameter")),
                  documentation_button('4.2.3Parameters') %>
 
 

--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -1,6 +1,6 @@
 <% title _('Compute profiles') %>
 
-<% title_actions display_link_if_authorized(_('New Compute Profile'), hash_for_new_compute_profile_path),
+<% title_actions new_link(_('New Compute Profile')),
                  documentation_button('5.2.2UsingComputeProfiles') %>
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
@@ -14,7 +14,6 @@
       <tr>
         <td class="ellipsis"><%= link_to_if_authorized compute_profile.name, hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer, :auth_action => 'edit') %></td>
         <td><%= action_buttons(
-                  display_link_if_authorized(_('Edit'), hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer, :auth_action => 'edit')),
                   display_link_if_authorized(_('Rename'), hash_for_edit_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer)),
                   display_delete_if_authorized(hash_for_compute_profile_path(compute_profile).merge(:auth_object => compute_profile, :authorizer => authorizer), :data => { :confirm => _('Delete %s?') % compute_profile.name }))%>
         </td>

--- a/app/views/compute_profiles/show.html.erb
+++ b/app/views/compute_profiles/show.html.erb
@@ -1,7 +1,7 @@
 <%= javascript 'compute_resource' %>
 <% title(_("Edit Compute profile: %s") % @compute_profile.name) %>
 
-<% title_actions display_link_if_authorized(_("Back"), hash_for_compute_profiles_path) %>
+<% title_actions display_link_if_authorized(_("Back"), hash_for_compute_profiles_path, :class => 'btn btn-default') %>
 
 <p>
   <%= _("Click on the link of a compute resource to edit its default VM attributes.") %>

--- a/app/views/compute_resources/index.html.erb
+++ b/app/views/compute_resources/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Compute Resources") %>
-<% title_actions display_link_if_authorized(_("New Compute Resource"), hash_for_new_compute_resource_path),
+<% title_actions new_link(_("New Compute Resource")),
                  documentation_button('5.2ComputeResources') %>
 
 <table class="table table-bordered table-striped table-fixed">

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -45,7 +45,7 @@
   </div>
   <% if @compute_resource.capabilities.include?(:image) %>
     <div id="images" class="tab-pane">
-      <%= title_actions(display_link_if_authorized(_("New Image"), hash_for_new_compute_resource_image_path(:compute_resource_id => @compute_resource.id), :class => "btn btn-success", :data=>{:target=>"full-page"})) %>
+      <%= title_actions(new_link(_("New Image"), { :compute_resource_id => @compute_resource.id, :controller => :images }, { :data=>{:target=>"full-page"} })) %>
       <div id="images_list" data-url=<%= compute_resource_images_path(@compute_resource) %>>
         <%= spinner(_('Loading images information ...')) %>
       </div>

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title _('Config groups') %>
 
-<% title_actions display_link_if_authorized(_('New Config Group'), hash_for_new_config_group_path), help_path %>
+<% title_actions new_link(_('New Config Group')), help_path %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
@@ -22,7 +22,6 @@
         <td><%= link_to config_group.hosts_count, hosts_path(:search => %Q{config_group = "#{config_group}"}) %></td>
         <td><%= link_to config_group.hostgroups_count, hostgroups_path(:search => %Q{config_group = "#{config_group}"}) %></td>
         <td><%= action_buttons(
-                  display_link_if_authorized(_('Edit'), hash_for_edit_config_group_path(config_group).merge(:auth_object => config_group, :authorizer => authorizer)),
                   display_delete_if_authorized(hash_for_config_group_path(config_group).merge(:auth_object => config_group, :authorizer => authorizer), :data => { :confirm => _('Delete %s?') % config_group.name }))%>
         </td>
       </tr>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Domains") %>
 
-<% title_actions display_link_if_authorized(_("New Domain"), hash_for_new_domain_path), help_path %>
+<% title_actions new_link(_("New Domain")), help_path %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/domains/welcome.html.erb
+++ b/app/views/domains/welcome.html.erb
@@ -13,6 +13,6 @@
   </p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4Provisioning")%></p>
   <div class="blank-slate-pf-main-action">
-      <%= link_to _("New Domain"), new_domain_path, :class => "btn btn-primary btn-lg" %>
+      <%= new_link(_("New Domain"), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/environments/welcome.html.erb
+++ b/app/views/environments/welcome.html.erb
@@ -4,11 +4,11 @@
     <%= icon_text("th", "", :kind => "fa") %>
   </div>
   <h1><%= _('Environments') %></h1>
-  <p><%= _('If you are planning to use Foreman as an external node classifier you should provide information about one or more environments.') %></p>
-  <%= _('This information is commonly imported from a pre-existing puppet configuration by the use of the') %> <%= link_to  _('Puppet classes and environment importer'), documentation_url("4.2.2Classes"), :rel => "external" %> <%= _('Puppet classes and environment importer') %></a></br>
-  <%= _('Environments may be manually created and only require the name of the environment to be declared.') %></br>
+  <p><%= _("If you are planning to use Foreman as an external node classifier you should provide information about one or more environments. This information is commonly imported from a pre-existing Puppet configuration by the use of the %{link_start}Puppet classes and environment importer%{link_end}.").html_safe % { :link_start => tag(:a, :href => documentation_url("4.2.2Classes"), :rel => 'external'),
+                  :link_end => '</a>'.html_safe} %>
+  </p>
   <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url("4.2.1Environments")) %></p>
   <div class="blank-slate-pf-main-action">
-      <%= link_to _('New Puppet environment'), new_environment_path, :class => "btn btn-primary btn-lg" %>
+      <%= new_link(_('New Puppet environment'), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -4,7 +4,7 @@
      title _("Filters")
    end %>
 
-<% title_actions link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role)),
+<% title_actions new_link(_("New filter"), { :controller => :filters, :role_id => @role }),
                  documentation_button('4.1.2RolesandPermissions') %>
 
 <table class="table table-bordered table-striped" <%= "data-table='inline'".html_safe if params[:paginate] == 'client' %> >

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Host Groups") %>
 
-<% title_actions display_link_if_authorized(_("New Host Group"), hash_for_new_hostgroup_path), help_path %>
+<% title_actions new_link(_("New Host Group")), help_path %>
 
 <table class="table table-bordered table-striped">
   <thead>

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,2 +1,2 @@
-<% title_actions multiple_actions_select, button_group(display_link_if_authorized _("New Host"), hash_for_new_host_path) %>
+<% title_actions multiple_actions_select, button_group(new_link(_("New Host"))) %>
 <%= render 'list', :hosts => @hosts, :header => @title || _("Hosts")  %>

--- a/app/views/hosts/welcome.html.erb
+++ b/app/views/hosts/welcome.html.erb
@@ -7,6 +7,6 @@
   <p><%= _("You don't have any visible hosts. Hosts can be added and provisioned from Foreman, or configured to report to Foreman.") %></p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4Provisioning")%></p>
   <div class="blank-slate-pf-main-action">
-      <%= link_to _('New Host'), new_host_path, :class => "btn btn-primary btn-lg" %>
+      <%= new_link(_('New Host'), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,5 +1,4 @@
 <% title _("Images") %>
-<% title_actions display_link_if_authorized(_("New Image"), hash_for_new_compute_resource_image_path) %>
 <table class="table table-bordered table-striped" data-table='inline'>
   <thead>
     <tr>

--- a/app/views/locations/welcome.html.erb
+++ b/app/views/locations/welcome.html.erb
@@ -4,12 +4,15 @@
   </div>
   <h1><%= _('Locations') %></h1>
   <p>
-    <%= _("You must create a location before continuing") %></br>
-    <%= _("Locations are used to manage and differentiate the physical place where a system managed via Foreman is housed.") %></br>
-    <%= _("For example, there might be a data center in London and one in Virginia; these are locations.") %></br>
+    <%= _("You must create a location before continuing.") %>
+  </p>
+  <p>
+    <%= _("Locations are used to manage and differentiate the physical place where a system managed via Foreman is housed. For example, there might be a data center in London and one in Virginia; these are locations.") %>
+  </p>
+  <p>
     <%= (_('Locations also work nicely when used in tandem with %{organizations}.') % {:organizations => link_to(_("organizations"), :controller => "organizations", :action => "index")}).html_safe %>
   </p>
   <div class="blank-slate-pf-main-action">
-      <%= link_to(_("New location"), new_location_path, :class => "btn btn-primary btn-lg") %>
+      <%= new_link(_("New location"), {} , { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript "nfs_visibility" %>
 <% title _("Installation Media") %>
-<% title_actions display_link_if_authorized(_("New Medium"), hash_for_new_medium_path),
+<% title_actions new_link(_("New Medium")),
                  documentation_button('4.4.2InstallationMedia'),
                  help_path %>
 

--- a/app/views/media/welcome.html.erb
+++ b/app/views/media/welcome.html.erb
@@ -1,4 +1,4 @@
-<% title_actions link_to(_("New installation medium"), new_medium_path) %>
+<% title_actions new_link(_("New installation medium")) %>
 <% title _("Installation medium configuration") %>
 <div id="welcome">
   <p>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Hardware Models") %>
 
-<% title_actions display_link_if_authorized(_("New Model"), hash_for_new_model_path) %>
+<% title_actions new_link(_("New Model")) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Operating systems") %>
-<% title_actions display_link_if_authorized(_("New Operating system"), hash_for_new_operatingsystem_path),
+<% title_actions new_link(_("New Operating system")),
                  documentation_button('4.4.1OperatingSystems') %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">

--- a/app/views/organizations/welcome.html.erb
+++ b/app/views/organizations/welcome.html.erb
@@ -4,12 +4,15 @@
   </div>
   <h1><%= _('Organization') %></h1>
   <p>
-    <%= _("You must create an organization before continuing") %></br>
-    <%= _('Using the organization system provides a way to group resources together for easy management.') %></br>
-    <%= _('Organizations are particularly useful for Foreman installations where several customers or business units are managed with a single Foreman install.') %></br>
+    <%= _("You must create an organization before continuing.") %>
+  </p>
+  <p>
+    <%= _('Using the organization system provides a way to group resources together for easy management. Organizations are particularly useful for Foreman installations where several customers or business units are managed with a single Foreman install.') %>
+  </p>
+  <p>
     <%= (_('Organizations also work nicely in tandem with %{locations}.') % {:locations => link_to(_("locations"), :controller => "locations", :action => "index")}).html_safe %>
   </p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to(_("New organization"), new_organization_path, :class => 'btn btn-primary btn-lg') %>
+    <%= new_link(_("New organization"), {}, { :class => 'btn-lg' }) %>
   </div>
 </div>

--- a/app/views/provisioning_templates/index.html.erb
+++ b/app/views/provisioning_templates/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Provisioning Templates") %>
 
-<% title_actions display_link_if_authorized(_("New Template"), hash_for_new_provisioning_template_path),
+<% title_actions new_link(_("New Template")),
                  display_link_if_authorized(_("Build PXE Default"), { :controller => 'provisioning_templates', :action => :build_pxe_default },{
                    :confirm => _("You are about to change the default PXE menu on all configured TFTP servers - continue?"),
                    :class => "btn btn-info"}),

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Partition Tables") %>
-<% title_actions display_link_if_authorized(_("New Partition Table"), hash_for_new_ptable_path),
+<% title_actions new_link(_("New Partition Table")),
                  documentation_button('4.4.4PartitionTables'),
                  help_path %>
 

--- a/app/views/ptables/welcome.html.erb
+++ b/app/views/ptables/welcome.html.erb
@@ -1,5 +1,5 @@
 <% title _("Partition table configuration") %>
-<% title_actions link_to(_("New Partition Table"), new_ptable_path) %>
+<% title_actions new_link(_("New Partition Table")) %>
 <div id="welcome">
   <p> <%= _("A partition table entry represents either") %> </p>
   <ul>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -1,5 +1,5 @@
 <% title _('Realms') %>
-<% title_actions(display_link_if_authorized(_("New Realm"), hash_for_new_realm_path),
+<% title_actions(new_link(_("New Realm")),
                  documentation_button('4.3.8Realm')) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">

--- a/app/views/realms/welcome.html.erb
+++ b/app/views/realms/welcome.html.erb
@@ -10,6 +10,6 @@
     <%= link_to _('Learn more about this in the documentation.'), documentation_url("4.3.9Realm")%>
   </p>
   <div class="blank-slate-pf-main-action">
-    <%= display_link_if_authorized _('New Realm'), hash_for_new_realm_path, :class => "btn btn-primary btn-lg" %>
+    <%= new_link(_('New Realm'), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Roles") %>
-<% title_actions link_to_if_authorized(_("New role"), hash_for_new_role_path),
+<% title_actions new_link(_("New role")),
                  documentation_button('4.1.2RolesandPermissions') %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Smart Proxies") %>
 
-<% title_actions display_link_if_authorized(_("New Smart Proxy"), hash_for_new_smart_proxy_path),
+<% title_actions new_link(_("New Smart Proxy")),
                  documentation_button('4.3SmartProxies') %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">

--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Subnets") %>
 
 <%= javascript 'subnets' %>
-<% title_actions display_link_if_authorized(_("New Subnet"), hash_for_new_subnet_path) %>
+<% title_actions new_link(_("New Subnet")) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -1,6 +1,7 @@
 <% title taxonomy_upcase %>
-<% title_actions display_link_if_authorized(taxonomy_new, hash_for_new_taxonomy_path),
-                 display_link_if_authorized(_("Mismatches Report"), hash_for_mismatches_taxonomies_path), help_path %>
+<% title_actions new_link(taxonomy_new),
+                 display_link_if_authorized(_("Mismatches Report"), hash_for_mismatches_taxonomies_path, :class => 'btn btn-default'),
+                 help_path %>
 
 <% if @count_nil_hosts > 0 %>
   <%= alert :class => 'alert-warning', :header => '', :text => n_('There is', 'There are', @count_nil_hosts) + ' ' +

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Trends") %>
-<% title_actions display_link_if_authorized(_("Add Trend Counter"), hash_for_new_trend_path),
+<% title_actions new_link(_("Add Trend Counter")),
                  documentation_button('4.1.3Trends') %>
 
 <% if @trends.empty? %>

--- a/app/views/usergroups/index.html.erb
+++ b/app/views/usergroups/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("User Groups") %>
 
-<% title_actions display_link_if_authorized(_("New User group"), hash_for_new_usergroup_path) %>
+<% title_actions new_link(_("New User group")) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <%= javascript 'users', 'password_strength' %>
 <% title _("Users") %>
 
-<% title_actions  display_link_if_authorized(_("New User"), hash_for_new_user_path) %>
+<% title_actions new_link(_("New User")) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>


### PR DESCRIPTION
Previously the button classes were applied to new buttons using jQuery.
This commit creates a `new_link` helper that makes sure all new buttons
will receive the correct class and only display if authorized. Also a
little bit of cleanup.
