### PR TITLE
fixes #14291 - replace integration test logins with SSO

### DIFF
--- a/app/services/sso.rb
+++ b/app/services/sso.rb
@@ -7,6 +7,16 @@ module SSO
   end
 
   def self.all
-    METHODS
+    METHODS + (@registered_methods || [])
+  end
+
+  def self.register_method(klass)
+    @registered_methods ||= []
+    @registered_methods << klass
+    klass
+  end
+
+  def self.deregister_method(klass)
+    @registered_methods.delete(klass) if @registered_methods
   end
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,6 +6,7 @@ group :test do
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 2.5', :require => false
+  gem 'show_me_the_cookies', '~> 3.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'
   gem 'spork-rails', '~> 4.0.0'

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -12,4 +12,16 @@ class UserIntegrationTest < ActionDispatch::IntegrationTest
     assert_submit_button(users_path)
     assert page.has_link? 'user12345'
   end
+
+  context "without automatic login" do
+    def login_admin; end
+
+    test "login" do
+      visit "/"
+      fill_in "login_login", :with => users(:admin).login
+      fill_in "login_password", :with => "secret"
+      click_button "Login"
+      assert_current_path hosts_path
+    end
+  end
 end

--- a/test/unit/sso.rb
+++ b/test/unit/sso.rb
@@ -23,4 +23,21 @@ class SSOTest < ActiveSupport::TestCase
     available = SSO.get_available(Object.new)
     assert available.present?
   end
+
+  def test_register_method
+    assert_difference 'SSO.all.count', 1 do
+      SSO.register_method(DummyMethod)
+    end
+    assert_includes SSO.all, DummyMethod
+  ensure
+    SSO.deregister_method(DummyMethod)
+  end
+
+  def test_deregister_method
+    SSO.register_method(DummyMethod)
+    assert_difference 'SSO.all.count', -1 do
+      SSO.deregister_method(DummyMethod)
+    end
+    refute_includes SSO.all, DummyMethod
+  end
 end


### PR DESCRIPTION
Replace the loading and form-filling on the user login page with a
test-only SSO method, which automatically logs in the test user on
every request. This uses a cookie sent in the request to specify the
user.

---

This seems to lower the integration test wall time by 83 seconds locally, a saving of 11%.
