### PR TITLE
Fixes #14316 - use inherited_by_default when possible

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -46,13 +46,13 @@ module HostsAndHostgroupsHelper
     @operatingsystem.ptables
   end
 
-  def puppet_master_fields(f, can_override = false, override = false)
-    "#{puppet_ca(f, can_override, override)} #{puppet_master(f, can_override, override)}".html_safe
+  def puppet_master_fields(f, can_override = false)
+    "#{puppet_ca(f, can_override)} #{puppet_master(f, can_override)}".html_safe
   end
 
   INHERIT_TEXT = N_("inherit")
 
-  def puppet_ca(f, can_override, override)
+  def puppet_ca(f, can_override = false)
     # Don't show this if we have no CA proxies, otherwise always include blank
     # so the user can choose not to sign the puppet cert on this host
     proxies = SmartProxy.unscoped.with_features("Puppet CA").with_taxonomy_scope(@location,@organization,:path_ids)
@@ -60,14 +60,14 @@ module HostsAndHostgroupsHelper
     select_f f, :puppet_ca_proxy_id, proxies, :id, :name,
              { :include_blank => blank_or_inherit_f(f, :puppet_ca_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-               :disable_button_enabled => override && !explicit_value?(:puppet_ca_proxy_id),
+               :disable_button_enabled => inherited_by_default?(:puppet_ca_proxy_id, @host),
                :user_set => user_set?(:puppet_ca_proxy_id)
              },
              { :label       => _("Puppet CA"),
                :help_inline => _("Use this puppet server as a CA server") }
   end
 
-  def puppet_master(f, can_override, override)
+  def puppet_master(f, can_override = false)
     # Don't show this if we have no Puppet proxies, otherwise always include blank
     # so the user can choose not to use puppet on this host
     proxies = SmartProxy.unscoped.with_features("Puppet").with_taxonomy_scope(@location,@organization,:path_ids)
@@ -75,7 +75,7 @@ module HostsAndHostgroupsHelper
     select_f f, :puppet_proxy_id, proxies, :id, :name,
              { :include_blank => blank_or_inherit_f(f, :puppet_proxy),
                :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-               :disable_button_enabled => override && !explicit_value?(:puppet_proxy_id),
+               :disable_button_enabled => inherited_by_default?(:puppet_proxy_id, @host),
                :user_set => user_set?(:puppet_proxy_id)
 
              },
@@ -83,7 +83,7 @@ module HostsAndHostgroupsHelper
                :help_inline => _("Use this puppet server as an initial Puppet Server or to execute puppet runs") }
   end
 
-  def realm_field(f, can_override = false, override = false)
+  def realm_field(f, can_override = false)
     # Don't show this if we have no Realms, otherwise always include blank
     # so the user can choose not to use a Realm on this host
     return if Realm.count == 0
@@ -93,7 +93,7 @@ module HostsAndHostgroupsHelper
                 :id, :to_label,
                 { :include_blank => true,
                   :disable_button => can_override ? _(INHERIT_TEXT) : nil,
-                  :disable_button_enabled => override && !explicit_value?(:realm_id),
+                  :disable_button_enabled => inherited_by_default?(:realm_id, @host),
                   :user_set => user_set?(:realm_id)
                 },
                 { :help_inline   => :indicator }
@@ -108,12 +108,6 @@ module HostsAndHostgroupsHelper
     klasses    = (smart_vars + class_vars).uniq
 
     classes.where(:id => klasses)
-  end
-
-  def explicit_value?(field)
-    return true if params[:action] == 'clone'
-    return false unless params[:host]
-    !!params[:host][field]
   end
 
   def user_set?(field)

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -490,7 +490,8 @@ module HostsHelper
   end
 
   def inherited_by_default?(field, host)
-    return false unless host.hostgroup && host.hostgroup_id_was.nil?
+    return true if @force_inherited_params
+    return false if host && !(host.hostgroup && host.hostgroup_id_was.nil?)
     return false if params[:action] == 'clone'
     return true unless params[:host]
     !params[:host][field]

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -78,9 +78,9 @@
            {:onchange => 'update_puppetclasses(this)', :'data-url' => hostgroup_or_environment_selected_hosts_path,
             :'data-host-id' => @host.id, :help_inline => :indicator} %>
 
-        <%= puppet_master_fields f, true, @host.hostgroup && @host.hostgroup_id_was.nil? %>
+        <%= puppet_master_fields f, true %>
 
-        <%= realm_field f, true, @host.hostgroup && @host.hostgroup_id_was.nil? %>
+        <%= realm_field f, true %>
 
       </div>
 

--- a/test/unit/helpers/hosts_helper_test.rb
+++ b/test/unit/helpers/hosts_helper_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class FormHelperTest < ActionView::TestCase
+  class SubjectMock
+    include HostsHelper
+    attr_accessor :params, :force_inherited_params
+  end
+
+  before do
+    @subject = SubjectMock.new
+    @subject.params = {}
+    @subject.force_inherited_params = false
+    @host = mock()
+    @host.stubs(:hostgroup).returns(true)
+    @host.stubs(:hostgroup_id_was).returns(true)
+  end
+
+  test 'field not inherited for host with changed hostgroup' do
+    refute @subject.inherited_by_default?(:some_field, @host)
+  end
+
+  test 'field inheritance can be forced' do
+    @subject.force_inherited_params = true
+    assert @subject.inherited_by_default?(:some_field, @host)
+  end
+end


### PR DESCRIPTION
Edit host page renders Inherit buttons in "pressed" state only if there is a
hostgroup set and the value is blank. Discovery plugin uses the Edit Host form
to provision discovered hosts and when the form is rendered, hostgroup is not
yet selected, therefore buttons are in incorrect state causing bad UX.

In this patch, I propose new parameter "inherit_all" (couldn't find a better
name) which overrides all the tests and renders the buttons in "pressed" state.

https://github.com/theforeman/foreman_discovery/pull/262
