### PR TITLE
Fixes #14319 - removes unused media_path template helper

### DIFF
--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -21,10 +21,6 @@ module HostTemplateHelpers
     operatingsystem.initrd(architecture)
   end
 
-  def media_path
-    operatingsystem.medium_uri(self)
-  end
-
   #returns the URL for Foreman based on the required action
   def foreman_url(action = "provision")
     # Get basic stuff


### PR DESCRIPTION
please see comments in the issue http://projects.theforeman.org/issues/14319 if you're concerned about deprecation warnings
