### PR TITLE
Fixes #9169 - Add option to ignore supersede next-server statement

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -68,8 +68,10 @@ module Orchestration::DHCP
     # if we don't manage tftp at all, we dont create a next-server entry.
     return unless tftp?
 
-    # first try to ask our TFTP server for its boot server
-    bs = tftp.bootServer
+    # first try to ask our TFTP server and dont_pass_nextserver flag for its boot server
+    bs, flag = tftp.bootServer
+    # if the flag is set to true, we dont create a next-server entry.
+    return nil if flag
     # if that failed, trying to guess out tftp next server based on the smart proxy hostname
     bs ||= URI.parse(subnet.tftp.url).host
     # now convert it into an ip address (see http://theforeman.org/issues/show/1381)

--- a/lib/proxy_api/tftp.rb
+++ b/lib/proxy_api/tftp.rb
@@ -37,12 +37,12 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to fetch TFTP boot file"))
     end
 
-    # returns the TFTP boot server for this proxy
+    # returns the TFTP boot server and suppression flag for this proxy
     def bootServer
       if (response = parse(get("serverName"))) && response["serverName"].present?
-        return response["serverName"]
+        return response["serverName"], Foreman::Cast.to_bool(response["dont_pass_nextserver"])
       end
-      false
+      [false, Foreman::Cast.to_bool(response["dont_pass_nextserver"])]
     rescue RestClient::ResourceNotFound
       nil
     rescue => e


### PR DESCRIPTION
This patch introduces a new option "dont_pass_nextserver" into tftp.yml.

To set this option true, all new reservations for the subnet does not include "supersede server.next-server" statement into dhcpd.leases.
So, "next-server" value in each subnet specified in dhcpd.conf becomes valid.

It is necessary to modify both foreman and smart-proxy, I send the same titled PR to each.
