### PR TITLE
Fixes #14326 - Limit compute resource description length to 255

### DIFF
--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -17,11 +17,11 @@
 
 <div class="tab-content">
   <div class="tab-pane active" id="primary">
-    <table class="table table-bordered table-striped">
+    <table class="table table-bordered table-striped table-fixed">
       <thead>
         <tr>
-          <th><%= _("Details") %></th>
-          <th><%= _("Actions") %></th>
+          <th class="col-md-1"><%= _('Property') %></th>
+          <th class="col-md-11"><%= _('Value') %></th>
         </tr>
       </thead>
       <tbody>
@@ -32,7 +32,7 @@
         <% unless @compute_resource.description.empty? %>
           <tr>
             <td><%= _("Description") %></td>
-            <td><%= @compute_resource.description %></td>
+            <td class="ellipsis"><%= @compute_resource.description %></td>
           </tr>
         <% end %>
         <% # optional extra display elements based on type %>


### PR DESCRIPTION
Since we're setting the limit back to 255, would it make sense to:
1. do not modify existing descriptions, enforce the limit on new compute resources
2. change the column type back to `string` (and thus rollback part of this [issue](http://projects.theforeman.org/issues/9357))
3. keep the `text` type and add a length constraint to the db

2 and 3 would require to write a migration which would (probably) truncate long descriptions
