### PR TITLE
Fixes #14340 - specify the default icon sizes to prevent intermittent layout changes

### DIFF
--- a/test/integration/support/poltergeist_onload_extensions.js
+++ b/test/integration/support/poltergeist_onload_extensions.js
@@ -5,8 +5,16 @@ var disableAnimationStyles = '-webkit-transition: none !important;' +
                              'transition: none !important;'
 
 window.onload = function() {
+  // disable animations to speed up the tests and make them more deterministic
   var animationStyles = document.createElement('style');
   animationStyles.type = 'text/css';
   animationStyles.innerHTML = '* {' + disableAnimationStyles + '}';
   document.head.appendChild(animationStyles);
+
+  // make sure the icon elements have size specified before the icons
+  // get loaded to prevent unexpected layout changes
+  var fixedIconSizes = document.createElement('style');
+  fixedIconSizes.type = 'text/css';
+  fixedIconSizes.innerHTML = '.pficon, .fa { width: 12px; height: 12px; }';
+  document.head.appendChild(fixedIconSizes);
 };

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -18,8 +18,7 @@ Capybara.register_driver :poltergeist do |app|
     # :inspector => true
     :js_errors => true,
     :timeout => 60,
-    #disable animations to speed up the tests
-    :extensions => ["#{Rails.root}/test/integration/support/disable_animations.js"],
+    :extensions => ["#{Rails.root}/test/integration/support/poltergeist_onload_extensions.js"]
   }
   Capybara::Poltergeist::Driver.new(app, opts)
 end


### PR DESCRIPTION
Defining the sizes for icons prevents the layout to change while loading the icons.

Compare the layout change before the fix:

![without-icons](https://cloud.githubusercontent.com/assets/190443/14013111/ba73595e-f1aa-11e5-9be8-508a6d781b4d.png)
![with-icons](https://cloud.githubusercontent.com/assets/190443/14013114/c1013430-f1aa-11e5-97d9-0a02f7585feb.png)

and after the fix:
![fixed-without-icons](https://cloud.githubusercontent.com/assets/190443/14013136/d86a8694-f1aa-11e5-8e4f-e919dc9affa9.png)
![fixed-with-icons](https://cloud.githubusercontent.com/assets/190443/14013139/deb461be-f1aa-11e5-8e1b-7cfceb94bff6.png)
