### PR TITLE
Fixes #14341 - List all images for compute resource

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -366,10 +366,9 @@ function update_provisioning_image(){
   var arch_id = $('[name$="[architecture_id]"]').val();
   var os_id = $('[name$="[operatingsystem_id]"]').val();
   if((compute_id == undefined) || (compute_id == "") || (arch_id == "") || (os_id == "")) return;
-  var term = 'operatingsystem=' + os_id + ' architecture=' + arch_id;
   var image_options = $('#image_selection select').empty();
   $.ajax({
-      data:'search=' + encodeURIComponent(term),
+      data: {'operatingsystem_id': os_id, 'architecture_id': arch_id},
       type:'get',
       url: foreman_url('/compute_resources/'+compute_id+'/images'),
       dataType: 'json',

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,10 +4,10 @@ class ImagesController < ApplicationController
 
   def index
     # Listing images in /hosts/new consumes this method as JSON
-    values = resource_base.where(:compute_resource_id => @compute_resource.id).search_for(params[:search], :order => params[:order]).includes(:operatingsystem)
+    @images = resource_base.where(:compute_resource_id => @compute_resource.id).includes(:operatingsystem)
     respond_to do |format|
-      format.html { @images = values.paginate :page => params[:page] }
-      format.json { render :json => values }
+      format.html { render :partial => 'images/list' }
+      format.json { render :json => @images.where(:operatingsystem_id => params[:operatingsystem_id], :architecture_id => params[:architecture_id]) }
     end
   end
 

--- a/app/views/images/_list.html.erb
+++ b/app/views/images/_list.html.erb
@@ -1,4 +1,3 @@
-<% title _("Images") %>
 <table class="table table-bordered table-striped" data-table='inline'>
   <thead>
     <tr>
@@ -24,4 +23,3 @@
     <% end %>
   </tbody>
 </table>
-<%= will_paginate_with_info @images %>

--- a/test/functional/images_controller_test.rb
+++ b/test/functional/images_controller_test.rb
@@ -49,7 +49,7 @@ class ImagesControllerTest < ActionController::TestCase
     # This value is tested by the deprecation warning in application_controller
     # so we need to set it or the test will crash
     request.env['REQUEST_URI']="compute_resources/#{@image.compute_resource_id}/images"
-    get :index, { :format => :json, :compute_resource_id => @image.compute_resource_id }, set_session_user
+    get :index, { :format => :json, :compute_resource_id => @image.compute_resource_id, :operatingsystem_id => @image.operatingsystem_id, :architecture_id => @image.architecture_id }, set_session_user
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal 2, body.size


### PR DESCRIPTION
Previously, the listing was paginated, but since the table is loaded
via ajax and handled by datatables, the pagination had no effect,
leading to a list limited to the max per page (20 usually).
Also, improved the lookup to only bring the needed data.
