### PR TITLE
fixes #14338 - move session store configuration earlier

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -212,6 +212,9 @@ module Foreman
         child.helper helpers
       end
     end
+
+    # Use the database for sessions instead of the cookie-based default
+    config.session_store :active_record_store, :secure => !!SETTINGS[:require_ssl]
   end
 
   def self.setup_console

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Foreman::Application.config.session_store :cookie_store, :key => '_foreman_session'
-
-# Use the database for sessions instead of the cookie-based default,
-# which shouldn't be used to store highly confidential information
-# (create the session table with "rails generate session_migration")
-Foreman::Application.config.session_store :active_record_store, :secure => !!SETTINGS[:require_ssl]


### PR DESCRIPTION
When a plugin has an initializer relying on :build_middleware_stack, the
middleware stack is constructed with the default session store (cookies)
as the store hasn't been configured by config/initializers/ yet.  Moving
the config into the main app config ensures it's set before the
middleware stack is first loaded.
