### PR TITLE
Fixes #4477 - Host[group] form only show authorized resources

### DIFF
--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -12,6 +12,7 @@ module HostgroupsHelper
   end
 
   def parent_hostgroups
+    accessible_hostgroups = accessible_resource_records(:hostgroup, :title).to_a
     if @hostgroup.new_record?
       accessible_hostgroups
     else

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -214,7 +214,7 @@ module HostCommon
   end
 
   def available_puppetclasses
-    return Puppetclass.where(nil) if environment.blank?
+    return Puppetclass.where(nil).authorized(:view_puppetclasses) if environment.blank?
     environment.puppetclasses - parent_classes
   end
 

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -41,8 +41,8 @@ module Taxonomix
 
     # default inner_method includes parents (path_ids)
     def with_taxonomy_scope_override(loc = nil, org = nil, inner_method = :path_ids)
-      # need to .unscoped or default_scope {with_taxonomy_scope} overrides inner_method
-      unscoped.with_taxonomy_scope(loc, org, inner_method)
+      # need to .unscope in case default_scope {with_taxonomy_scope} overrides inner_method
+      unscope(:where => :taxonomy).with_taxonomy_scope(loc, org, inner_method)
     end
 
     def used_taxonomy_ids

--- a/app/views/common/os_selection/_initial.html.erb
+++ b/app/views/common/os_selection/_initial.html.erb
@@ -1,5 +1,5 @@
 <%= fields_for item do |f| %>
-  <%= select_f f, :architecture_id, Architecture.all, :id, :to_label, {:include_blank => blank_or_inherit_f(f, :architecture)},
+  <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => blank_or_inherit_f(f, :architecture)},
     {:label => _("Architecture"), :onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected')} %>
 
   <span id="host_os">

--- a/app/views/config_groups/_config_groups_selection.html.erb
+++ b/app/views/config_groups/_config_groups_selection.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="col-md-6 classes">
         <ul class="config_group_group">
-          <% (ConfigGroup.includes(:puppetclasses).where(nil) - obj.parent_config_groups).each do |config_group| %>
+          <% (ConfigGroup.includes(:puppetclasses).authorized(:view_config_groups) - obj.parent_config_groups).each do |config_group| %>
             <% css_class = obj.config_groups.include?(config_group) ? "hide" : "" %>
             <%= render 'config_groups/config_group', :obj => obj, :config_group => config_group, :added => false, :css_class => css_class %>
           <% end %>

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -29,7 +29,7 @@
       <%= select_f(f, :compute_profile_id, ComputeProfile.visibles, :id, :name,
                        { :include_blank => blank_or_inherit_f(f, :compute_profile) },
                        { :label => _("Compute profile") }
-                  ) if ComputeProfile.visibles.any? %>
+                  ) if ComputeProfile.visibles.exists? %>
       <%= puppet_master_fields f %>
     </div>
 
@@ -37,7 +37,7 @@
 
     <div class="tab-pane" id="network">
       <fieldset>
-        <%= select_f f, :domain_id, accessible_domains, :id, :to_label, {:include_blank => blank_or_inherit_f(f, :domain)},
+        <%= select_f f, :domain_id, accessible_resource(@hostgroup, :domain), :id, :to_label, {:include_blank => blank_or_inherit_f(f, :domain)},
           {:help_inline => :indicator, :label => _("Domain"),
            :onchange => 'interface_domain_selected(this);', :'data-url' => method_path('domain_selected') } %>
         <%= select_f f, :subnet_id, domain_subnets, :id, :to_label,
@@ -47,7 +47,7 @@
                                       :subnets => subnets_ipam_data.to_json },
                        :label    => _("Subnet"),
                        :help_inline => :indicator } %>
-        <%= select_f f, :realm_id, Realm.with_taxonomy_scope_override(@location,@organization).authorized(:view_realms), :id, :to_label,
+        <%= select_f f, :realm_id, accessible_resource(@hostgroup, :realms), :id, :to_label,
                         {:include_blank => blank_or_inherit_f(f, :realm)}, {:label => _("Realm")} %>
       </fieldset>
     </div>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -10,7 +10,7 @@
 
     <ul class="nav nav-tabs" data-tabs="tabs">
       <li class="active"><a href="#primary" data-toggle="tab"><%= _('Host') %></a></li>
-      <% if SmartProxy.with_features("Puppet").count > 0 %>
+      <% if accessible_puppet_proxies(@host).present? %>
         <li><a href="#puppet_klasses" data-toggle="tab"><%= _('Puppet Classes') %></a></li>
       <% end %>
       <li id="network_tab" data-refresh-url="<%= interfaces_hosts_path %>"><a href="#network" data-toggle="tab"><%= _('Interfaces') %></a></li>
@@ -38,7 +38,7 @@
           <%= host_taxonomy_select(f, Location) %>
         <% end %>
 
-        <%= select_f f, :hostgroup_id, accessible_hostgroups, :id, :to_label,
+        <%= select_f f, :hostgroup_id, accessible_resource(@host, :hostgroup, :title), :id, :to_label,
           { :include_blank => true},
           { :onchange => 'hostgroup_changed(this);',
             :data => {
@@ -48,13 +48,13 @@
             },
             :help_inline => :indicator } %>
 
-        <%= select_f f, :compute_resource_id, ComputeResource.with_taxonomy_scope_override(@location,@organization).authorized(:view_compute_resources).order('compute_resources.name'), :id, :to_label,
+        <%= select_f f, :compute_resource_id, accessible_resource(@host, :compute_resource), :id, :to_label,
           { :include_blank => _('Bare Metal') },
           {:label => _('Deploy on'), :disabled => !@host.new_record?, :'data-url' => compute_resource_selected_hosts_path,
             :onchange => 'computeResourceSelected(this);',
             :help_inline => :indicator } if SETTINGS[:unattended] && @host.new_record? || @host.compute_resource_id %>
 
-        <% if @host.new_record? && ComputeProfile.visibles.any? %>
+        <% if @host.new_record? && ComputeProfile.visibles.exists? %>
         <%# only show compute_profile select box for new hosts. It is not relevant for existing hosts as the VM attributes defined could
          be different from the defaults, or the defaults could have changed after the vm was created. %>
         <div id="compute_profile" <%= display?(!@host.compute_resource_id) %> >
@@ -107,7 +107,7 @@
       <div class="tab-pane"  id="info">
         <% if SETTINGS[:login] %>
           <%= selectable_f f, :is_owned_by, option_groups_from_collection_for_select(
-            [User, Usergroup], :visible, :table_name, :id_and_type, :select_title,
+            [User.authorized(:view_users), Usergroup.authorized(:view_usergroups)], :visible, :table_name, :id_and_type, :select_title,
             @host.is_owned_by || User.current.id_and_type), { :include_blank => _("select an owner") }, { :label => _("Owned By") }
           %>
         <% end %>
@@ -115,7 +115,7 @@
           :help_inline => _("Include this host within Foreman reporting")
         %>
         <div id='model_name'>
-          <%= select_f f, :model_id, Model.all, :id, :to_label, { :include_blank => true }, {:label => _("Hardware Model")} unless @host.compute_resource_id%>
+          <%= select_f f, :model_id, accessible_resource(@host, :model), :id, :to_label, { :include_blank => true }, {:label => _("Hardware Model")} unless @host.compute_resource_id%>
         </div>
         <%= textarea_f f, :comment, :help_block => _("Additional information about this host"), :size => "col-md-8", :rows => "3", :class => "no-stretch" %>
       </div>

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -1,5 +1,5 @@
 
-<%= select_f f, :architecture_id, Architecture.all, :id, :to_label, {:include_blank => true},
+<%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => true},
     {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'),
     :help_inline => :indicator, :required => true} %>
 

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -22,15 +22,15 @@
               :class => :interface_name,
               :size => "col-md-8", :label_size => "col-md-3" %>
 <% if SETTINGS[:unattended] %>
-  <%= select_f f, :domain_id, accessible_domains, :id, :to_label,
-               { :include_blank => accessible_domains.any? ? true : _("No domains")},
-               { :disabled => accessible_domains.empty? ? true : false,
+  <%= select_f f, :domain_id, accessible_resource(f.object, :domain), :id, :to_label,
+               { :include_blank => accessible_resource(f.object, :domain).any? ? true : _("No domains")},
+               { :disabled => accessible_resource(f.object, :domain).empty? ? true : false,
                  :help_inline => :indicator,
                  :class => 'interface_domain', :'data-url' => domain_selected_hosts_path,
                  :size => "col-md-8", :label_size => "col-md-3" } %>
-  <%= select_f f, :subnet_id, accessible_subnets, :id, :to_label,
-               { :include_blank => accessible_subnets.any? ? true : _("No subnets")},
-               { :disabled => accessible_subnets.empty? ? true : false,
+  <%= select_f f, :subnet_id, accessible_resource(f.object, :subnet), :id, :to_label,
+               { :include_blank => accessible_resource(f.object, :subnet).any? ? true : _("No subnets")},
+               { :disabled => accessible_resource(f.object, :subnet).empty? ? true : false,
                  :help_inline => :indicator,
                  :class => 'interface_subnet', :'data-url' => freeip_subnets_path,
                  :size => "col-md-8", :label_size => "col-md-3" } %>

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -3,7 +3,7 @@
               :text => obj.errors[:puppetclasses].map { |e| "<li>#{e}</li>" }.join.html_safe %>
   <% end %>
 
-  <%= render("config_groups/config_groups_selection", :obj => obj, :type => obj_type(obj)) if (controller_name != 'config_groups' && ConfigGroup.count > 0) %>
+  <%= render("config_groups/config_groups_selection", :obj => obj, :type => obj_type(obj)) if (controller_name != 'config_groups' && accessible_resource_records(:config_group).exists?) %>
 
 <div class="row">
   <div class="col-md-4 classes">

--- a/test/unit/helpers/host_and_hostgroups_helper_test.rb
+++ b/test/unit/helpers/host_and_hostgroups_helper_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class HostAndHostGroupsHelperTest < ActionView::TestCase
+  include HostsAndHostgroupsHelper
+
+  setup do
+    permission = Permission.find_by_name('view_domains')
+    filter = FactoryGirl.create(:filter, :on_name_starting_with_a,
+                                :permissions => [permission])
+    @user = FactoryGirl.create(:user)
+    @user.update_attribute :roles, [filter.role]
+    @domain1 = FactoryGirl.create(:domain, :name => 'a-domain.to-be-found.com')
+    @domain2 = FactoryGirl.create(:domain, :name => 'domain-not-to-be-found.com')
+  end
+
+  test "accessible_resource_records returns only authorized records" do
+    as_user @user do
+      records = accessible_resource_records(:domain)
+      assert records.include? @domain1
+      refute records.include? @domain2
+    end
+  end
+
+  test "accessible_resource includes current value even if not authorized" do
+    host = FactoryGirl.create(:host, :domain => @domain2)
+    domain3 = FactoryGirl.create(:domain, :name => 'one-more-not-to-be-found.com')
+    as_user @user do
+      resources = accessible_resource(host, :domain)
+      assert resources.include? @domain1
+      assert resources.include? @domain2
+      refute resources.include? domain3
+    end
+  end
+
+  test "accessible_related_resource shows only authorized related records" do
+    permission = Permission.find_by_name('view_subnets')
+    filter = FactoryGirl.create(:filter, :on_name_starting_with_a,
+                                :permissions => [permission])
+    @user.roles << filter.role
+    subnet1 = FactoryGirl.create(:subnet_ipv4, :name => 'a subnet', :domains => [@domain1])
+    subnet2 = FactoryGirl.create(:subnet_ipv4, :name => 'some other subnet', :domains => [@domain1])
+    subnet3 = FactoryGirl.create(:subnet_ipv4, :name => 'a subnet in anoter domain', :domains => [@domain2])
+    as_user @user do
+      resources = accessible_related_resource(@domain1, :subnets)
+      assert resources.include? subnet1
+      refute resources.include? subnet2
+      refute resources.include? subnet3
+    end
+  end
+end


### PR DESCRIPTION
Previously, most dropdowns in the host and hostgroup edit forms 
displayed all of the existing resources, including some that a user may
not have been authorized to view.
This commit makes sure only authorized resources are displayed, with the
exception of the current resource - so that editing a host will not
cause changes to its current associations in case the user is not
allowed to see them. This also includes a refactoring of the code to
reduce duplication.
I have also included a change to `with_taxonomy_scope_override` that
allows its use for relations. This was not previously possible due to
the `.unscoped` which was used to remove the default scope and has been
replaced with `.unscope(:where => :taxonomy)` that only removes any
previous taxonomy scopes.
