### PR TITLE
fixes #14350 - replace selector to ensure Capybara wait is used

### DIFF
--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -15,7 +15,7 @@ class HostgroupJSTest < IntegrationTestWithJavascript
 
     group.locations.reload
 
-    assert_not_nil group.locations.first{ |l| l.name == new_location.name }
+    assert_includes group.locations, new_location
   end
 
   test 'parameters change after parent update' do
@@ -39,7 +39,6 @@ class HostgroupJSTest < IntegrationTestWithJavascript
   private
 
   def select_from_list(list_id, item)
-    span = page.all(:css, "#ms-#{list_id} .ms-selectable ul li span").first{ |i| i.text == item.name }
-    span.click
+    page.find(:xpath, "//div[@id='ms-#{list_id}']//li/span[text() = '#{item.name}']").click
   end
 end


### PR DESCRIPTION
The CSS selector using .all wouldn't wait for a matching element to be
rendered, so any delay could cause it to match nothing. Since text can't
be matched in a CSS selector, it's been replaced with an XPath selector.

The test was also passing a block to Array#first, which was ignored
causing the wrong item to be selected.
