### PR TITLE
fixes #14202 - enable select2 in interfaces modal

### DIFF
--- a/app/assets/javascripts/compute_resources/libvirt/nic_info.js
+++ b/app/assets/javascripts/compute_resources/libvirt/nic_info.js
@@ -1,7 +1,7 @@
 providerSpecificNICInfo = function(form) {
-  if (form.find('.libvirt_network').val() == 'network') {
-    return Jed.sprintf(__('physical @ NAT %s'), form.find('.libvirt_nat').val());
+  if (form.find('select.libvirt_network').val() == 'network') {
+    return Jed.sprintf(__('physical @ NAT %s'), form.find('select.libvirt_nat').val());
   } else {
-    return Jed.sprintf(__('physical @ bridge %s'), form.find('.libvirt_bridge').val());
+    return Jed.sprintf(__('physical @ bridge %s'), form.find('select.libvirt_bridge').val());
   }
 }

--- a/app/assets/javascripts/compute_resources/ovirt/nic_info.js
+++ b/app/assets/javascripts/compute_resources/ovirt/nic_info.js
@@ -1,3 +1,3 @@
 providerSpecificNICInfo = function(form) {
-  return form.find('.ovirt_name').val() + ' @ ' + form.find('.ovirt_network').text();
+  return form.find('select.ovirt_name').val() + ' @ ' + form.find('select.ovirt_network').text();
 }

--- a/app/assets/javascripts/compute_resources/vmware/nic_info.js
+++ b/app/assets/javascripts/compute_resources/vmware/nic_info.js
@@ -1,3 +1,3 @@
 providerSpecificNICInfo = function(form) {
-  return form.find('.vmware_type').val() + ' @ ' + form.find('.vmware_network').val();
+  return form.find('select.vmware_type').val() + ' @ ' + form.find('select.vmware_network').val();
 }

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -277,7 +277,7 @@ var providerSpecificNICInfo = null;
 function nic_info(form) {
   var info = "";
   var virtual_types = ['Nic::Bond', 'Nic::Bridge']
-  if (form.find('.virtual').is(':checked') || virtual_types.indexOf(form.find('.interface_type').val()) >= 0) {
+  if (form.find('.virtual').is(':checked') || virtual_types.indexOf(form.find('select.interface_type').val()) >= 0) {
 
     // common virtual
     var attached = form.find('.attached').val();

--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -6,21 +6,21 @@
                  { :label    => _('Network type'),
                    :disabled => !new_host,
                    :onchange => 'libvirt_network_selected(this)',
-                   :class => 'libvirt_network without_select2',
+                   :class => 'libvirt_network',
                    :label_size => "col-md-3"
                  } %>
 
 <div id='nat' class='<%= 'hide' if f.object.type != 'network' %>'>
   <%= selectable_f f, :network, nat.map(&:name),
                    { :include_blank => nat.any? ? false : _("No networks") },
-                   { :class => "libvirt_nat without_select2", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_host), :label_size => "col-md-3" } %>
+                   { :class => "libvirt_nat", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_host), :label_size => "col-md-3" } %>
 </div>
 
 <div id='bridge' class='<%= 'hide' if f.object.type && (f.object.type != 'bridge') %>'>
   <% if bridges.any? %>
     <%= selectable_f f, :bridge, bridges.map(&:name),
                      { :include_blank => bridges.any? ? false : _("No bridges") },
-                     { :class => "libvirt_bridge without_select2", :label => _("Network"), :disabled => !new_host, :label_size => "col-md-3" } %>
+                     { :class => "libvirt_bridge", :label => _("Network"), :disabled => !new_host, :label_size => "col-md-3" } %>
   <% else %>
     <%= text_f f, :bridge,
       :class => "libvirt_bridge",
@@ -36,4 +36,4 @@
 </div>
 
 <%= selectable_f f, :model, %w(virtio rtl8139 ne2k_pci pcnet e1000), {},
-                 { :label => _('NIC type'), :class => 'without_select2', :disabled => !new_host, :label_size => "col-md-3" } %>
+                 { :label => _('NIC type'), :disabled => !new_host, :label_size => "col-md-3" } %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -1,5 +1,5 @@
 <%= text_f f, :name, :disabled => !new_host, :class => "ovirt_name", :label => _('Name'), :label_size => "col-md-3" %>
 <% selected_cluster ||= compute_resource.clusters.first.id %>
 <%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
-             { }, :disabled => !new_host, :class => "ovirt_network without_select2",
+             { }, :disabled => !new_host, :class => "ovirt_network",
              :label         => _('Network'), :label_size => "col-md-3" %>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,9 +1,9 @@
 <% networks = compute_resource.networks %>
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
-                 :class => "col-md-3 vmware_type without_select2",
+                 :class => "col-md-3 vmware_type",
                  :label => _('NIC type'), :label_size => "col-md-3"
 %>
 <%= select_f f, :network, networks, :name, :name, { },
-                 :class => "col-md-3 vmware_network without_select2",
+                 :class => "col-md-3 vmware_network",
                  :label => _('Network'), :label_size => "col-md-3"
 %>

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -1,5 +1,5 @@
 <%= selectable_f f, :type, interfaces_types, {},
-                    :class => 'interface_type without_select2',
+                    :class => 'interface_type',
                     :disabled => !f.object.new_record?,
                     :size => "col-md-8", :label_size => "col-md-3" %>
 
@@ -26,7 +26,7 @@
                { :include_blank => accessible_domains.any? ? true : _("No domains")},
                { :disabled => accessible_domains.empty? ? true : false,
                  :help_inline => :indicator,
-                 :class => 'interface_domain without_select2', :'data-url' => domain_selected_hosts_path,
+                 :class => 'interface_domain', :'data-url' => domain_selected_hosts_path,
                  :size => "col-md-8", :label_size => "col-md-3" } %>
   <%= select_f f, :subnet_id, accessible_subnets, :id, :to_label,
                { :include_blank => accessible_subnets.any? ? true : _("No subnets")},

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -157,7 +157,7 @@ class HostJSTest < IntegrationTestWithJavascript
       fill_in 'host_root_pass', :with => '12345678'
       click_link 'Interfaces'
       click_button 'Edit'
-      select domains(:unuseddomain).name, :from => 'host_interfaces_attributes_0_domain_id'
+      select2 domains(:unuseddomain).name, :from => 'host_interfaces_attributes_0_domain_id'
       fill_in 'host_interfaces_attributes_0_mac', :with => '11:11:11:11:11:11'
       fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
       click_button 'Ok' #close interfaces
@@ -198,7 +198,7 @@ class HostJSTest < IntegrationTestWithJavascript
       fill_in 'host_root_pass', :with => '12345678'
       click_link 'Interfaces'
       click_button 'Edit'
-      select domains(:mydomain).name, :from => 'host_interfaces_attributes_0_domain_id'
+      select2 domains(:mydomain).name, :from => 'host_interfaces_attributes_0_domain_id'
       wait_for_ajax
       fill_in 'host_interfaces_attributes_0_mac', :with => '11:11:11:11:11:11'
       wait_for_ajax
@@ -387,7 +387,7 @@ class HostJSTest < IntegrationTestWithJavascript
         domain = domains(:mydomain)
 
         modal.find('.interface_name').set('name')
-        modal.find('.interface_domain').select(domain.name)
+        select2 domain.name, :from => 'host_interfaces_attributes_0_domain_id'
 
         subnet_and_domain_are_selected(modal, domain)
 
@@ -407,7 +407,7 @@ class HostJSTest < IntegrationTestWithJavascript
         table.first(:button, 'Edit').click
 
         domain = domains(:mydomain)
-        modal.find('.interface_domain').select(domain.name)
+        select2 domain.name, :from => 'host_interfaces_attributes_0_domain_id'
         subnet_and_domain_are_selected(modal, domain)
 
         subnet_id = modal.find('#host_interfaces_attributes_0_subnet_id',

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -83,7 +83,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def select2(value, attrs)
-    first("#s2id_#{attrs[:from]}").click
+    find("#s2id_#{attrs[:from]}").click
     find(".select2-input").set(value)
     within ".select2-results" do
       find("span", text: value).click


### PR DESCRIPTION
Reverts commit 44723b9 and re-enables select2 in the interfaces modal,
instead fixing the issue with the NIC table detail lines to read the
network information out of select2 dropdown menus correctly.

http://projects.theforeman.org/issues/12055 was the reason select2 was removed from the modal, please give the detail lines a good test to make sure they work properly.  26eeda8 should ensure that select2 is always correctly initialised too, so the dropdown menus should always function no matter what order you change attributes on the New Host form.
