### PR TITLE
Fixes #14393 - Using patternfly icons instead of glyphicons

### DIFF
--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -61,7 +61,7 @@ module SmartProxiesHelper
   end
 
   def refresh_proxy_icon(proxy, authorizer)
-    display_link_if_authorized(icon_text("refresh"), hash_for_refresh_smart_proxy_path(:id => proxy).
+    display_link_if_authorized(icon_text("refresh", "", :kind => "pficon"), hash_for_refresh_smart_proxy_path(:id => proxy).
                                                      merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)
   end
 


### PR DESCRIPTION
This seems to take care of persistent routing error where glyphicon is required but not available. Simple change to Patternfly icon seems to work. 
