### PR TITLE
fixes #12746 - list compute resources from plugin definitions

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -5,5 +5,14 @@ class AboutController < ApplicationController
     @smart_proxies = SmartProxy.authorized(:view_smart_proxies).includes(:features)
     @compute_resources = ComputeResource.authorized(:view_compute_resources)
     @plugins = Foreman::Plugin.all
+
+    enabled_providers = ComputeResource.providers.keys
+    @providers = ComputeResource.all_providers.map do |provider_name, provider_class|
+      {
+        :friendly_name => provider_class.constantize.provider_friendly_name,
+        :name => provider_name,
+        :status => enabled_providers.include?(provider_name) ? :installed : :absent,
+      }
+    end
   end
 end

--- a/app/controllers/api/v1/compute_resources_controller.rb
+++ b/app/controllers/api/v1/compute_resources_controller.rb
@@ -24,7 +24,7 @@ module Api
       api :POST, "/compute_resources/", "Create a compute resource."
       param :compute_resource, Hash, :required => true do
         param :name, String, :required => true
-        param :provider, String, :desc => "Providers include #{ComputeResource.providers.join(', ')}"
+        param :provider, String, :desc => "Providers include #{ComputeResource.providers.keys.join(', ')}"
         param :url, String, :desc => "URL for Libvirt, oVirt, and OpenStack"
         param :description, String
         param :user, String, :desc => "Username for oVirt, EC2, VMware, OpenStack. Access Key for EC2."
@@ -45,7 +45,7 @@ module Api
       param :id, String, :required => true
       param :compute_resource, Hash, :required => true do
         param :name, String
-        param :provider, String, :desc => "Providers include #{ComputeResource.providers.join(', ')}"
+        param :provider, String, :desc => "Providers include #{ComputeResource.providers.keys.join(', ')}"
         param :url, String, :desc => "URL for Libvirt, oVirt, and OpenStack"
         param :description, String
         param :user, String, :desc => "Username for oVirt, EC2, VMware, OpenStack. Access Key for EC2."

--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -60,9 +60,10 @@ module ComputeResourcesHelper
   end
 
   def list_providers
-    ComputeResource.providers.map do |provider|
-      [ComputeResource.provider_class(provider).constantize.provider_friendly_name, provider]
+    providers = ComputeResource.providers.map do |provider_name, provider_class|
+      [provider_class.constantize.provider_friendly_name, provider_name]
     end
+    providers.sort_by { |provider| provider.first }
   end
 
   def unset_password?

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -50,10 +50,10 @@
                 </tr>
               </thead>
               <tbody>
-              <% ComputeResource.supported_providers.each do |provider,klass| %>
+              <% @providers.sort_by { |prov| prov[:friendly_name].downcase }.each do |provider| %>
                 <tr>
-                  <td><%= klass.constantize.provider_friendly_name %></td>
-                  <% if ComputeResource.providers.include?(provider) %>
+                  <td><%= provider[:friendly_name] %></td>
+                  <% if provider[:status] == :installed %>
                     <td><div class="label label-success"><%= _('Installed') %></div></td>
                   <% else %>
                     <td><div class="label label-default"><%= _('Not Installed') %></div></td>

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -17,7 +17,7 @@ Apipie.configure do |config|
 
   substitutions = {
     :operatingsystem_families => Operatingsystem.families.join(", "),
-    :providers => ComputeResource.providers.join(', '),
+    :providers => -> { ComputeResource.providers.keys.join(', ') },
     :default_nic_type => InterfaceTypeMapper::DEFAULT_TYPE.humanized_name.downcase,
     :template_kinds => -> { Rails.cache.fetch("template_kind_names", expires_in: 1.hour) {TemplateKind.pluck(:name).join(", ")} },
     :provision_methods => -> { Host::Managed.provision_methods.map { |method, friendly_name| "#{method} (#{_(friendly_name)})" }.join(', ') },

--- a/test/functional/about_controller_test.rb
+++ b/test/functional/about_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class AboutControllerTest < ActionController::TestCase
+  def test_index
+    get :index, {}, set_session_user
+    assert_response :success
+    assert_template 'index'
+  end
+
+  def test_registered_providers_list
+    klass_string = mock('ExampleClass', :constantize => mock('ExampleClass', :provider_friendly_name => 'Example Service'))
+    ComputeResource.expects(:registered_providers).at_least_once.returns('Example' => klass_string)
+    ComputeResource.expects(:supported_providers).at_least_once.returns({})
+
+    get :index, {}, set_session_user
+    assert_response :success
+
+    assert_kind_of Array, assigns(:providers)
+    example = assigns(:providers).find { |p| p[:name] == 'Example' }
+    assert_equal({:friendly_name => 'Example Service', :name => 'Example', :status => :installed}, example)
+  end
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -213,11 +213,21 @@ class PluginTest < ActiveSupport::TestCase
       name 'Awesome compute'
       compute_resource Awesome::Provider::MyAwesome
     end
-    assert ComputeResource.providers.must_include 'MyAwesome'
+    assert ComputeResource.providers.keys.must_include 'MyAwesome'
+    assert ComputeResource.providers.values.must_include 'Awesome::Provider::MyAwesome'
     assert_equal ComputeResource.provider_class('MyAwesome'), 'Awesome::Provider::MyAwesome'
-    assert ComputeResource.supported_providers.keys.must_include 'MyAwesome'
-    assert ComputeResource.supported_providers.values.must_include 'Awesome::Provider::MyAwesome'
-    assert SETTINGS[:myawesome]
+    assert ComputeResource.registered_providers.keys.must_include 'MyAwesome'
+    assert ComputeResource.registered_providers.values.must_include 'Awesome::Provider::MyAwesome'
+  end
+
+  def test_invalid_compute_resource
+    e = assert_raise(Foreman::Exception) do
+      Foreman::Plugin.register :awesome_compute do
+        name 'Awesome compute'
+        compute_resource String
+      end
+    end
+    assert_match /wrong type supplied/, e.message
   end
 
   def test_add_search_path_override


### PR DESCRIPTION
Load the full list of known CRs from plugins on the fly, instead of
modifying the class-level list of supported plugins. Since plugin
definitions don't get reloaded, this allows the ComputeResource class to
be reloaded without affecting the registered list.

Changes the apipie translation use of ComputeResource.providers to a
lambda to prevent foreman/plugin being autoloaded before it's required
in config/initializers/foreman.rb, and to ensure CRs from plugins are
listed.

Previously registered provider names are no longer rejected, instead
they are merged with preference given to plugins, allowing them to
override existing provider names in Foreman.
