### PR TITLE
Fixes #14401 - Refreshing Host's global status not persisting to the database

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -860,13 +860,18 @@ class Host::Managed < Host::Base
     self.global_status = build_global_status.status
   end
 
+  def refresh_global_status!
+    refresh_global_status
+    save!
+  end
+
   def refresh_statuses
     HostStatus.status_registry.each do |status_class|
       status = get_status(status_class)
       status.refresh! if status.relevant?
     end
     host_statuses.reload
-    refresh_global_status
+    refresh_global_status!
   end
 
   def get_status(type)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -546,6 +546,28 @@ class HostTest < ActiveSupport::TestCase
     refute host.get_status(HostStatus::ConfigurationStatus).new_record?
   end
 
+  test 'host #refresh_global_status! updates global status in database' do
+    host = FactoryGirl.build(:host)
+    config_status = host.get_status(HostStatus::ConfigurationStatus)
+    config_status.status = 1
+    config_status.save!
+    config_status.stubs(:relevant?).returns(true)
+    HostStatus::ConfigurationStatus.any_instance.stubs(:error?).returns(true)
+
+    assert_equal 0, host.global_status
+    host.refresh_global_status!
+    assert_equal 2, host.reload.global_status
+  end
+
+  test 'host #refresh_statuses updates global status in database' do
+    host = FactoryGirl.build(:host)
+    host.update_attribute(:global_status, 1)
+
+    assert_equal 1, host.global_status
+    host.refresh_statuses
+    assert_equal 0, host.reload.global_status
+  end
+
   test 'build status is updated on host validation' do
     host = FactoryGirl.build(:host)
     host.build = false


### PR DESCRIPTION
The refresh_global_status method does not save to the database which is [causing problems in Katello](http://projects.theforeman.org/issues/14372) having an additional refresh_global_status! method would allow plugins to use this and ensure that global_status is correct. Changing the original method would break [here.](https://github.com/theforeman/foreman/blob/c7d9169d12e16bcd5f4e3466e5cf99ca963eeea7/app/models/host/managed.rb#L723) I also added a test for the new method that replicates the issue I was seeing.
