### PR TITLE
fixes #14415 - check CR availability with Fog, not SETTINGS

### DIFF
--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -21,6 +21,10 @@ module Foreman::Model
       super.merge({ :ip => :vm_ip_address })
     end
 
+    def self.available?
+      Fog::Compute.providers.include?(:aws)
+    end
+
     def self.model_name
       ComputeResource.model_name
     end

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -8,6 +8,10 @@ module Foreman::Model
 
     delegate :flavors, :to => :client
 
+    def self.available?
+      Fog::Compute.providers.include?(:google)
+    end
+
     def to_label
       "#{name} (#{zone}-#{provider_friendly_name})"
     end

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -6,6 +6,10 @@ module Foreman::Model
 
     attr_accessible :display_type, :uuid
 
+    def self.available?
+      Fog::Compute.providers.include?(:libvirt)
+    end
+
     # Some getters/setters for the attrs Hash
     def display_type
       self.attrs[:display].present? ? self.attrs[:display] : 'vnc'

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -16,6 +16,10 @@ module Foreman::Model
       super.merge({ :ip => :floating_ip_address })
     end
 
+    def self.available?
+      Fog::Compute.providers.include?(:openstack)
+    end
+
     def self.model_name
       ComputeResource.model_name
     end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -12,6 +12,10 @@ module Foreman::Model
 
     delegate :clusters, :quotas, :templates, :to => :client
 
+    def self.available?
+      Fog::Compute.providers.include?(:ovirt)
+    end
+
     def self.model_name
       ComputeResource.model_name
     end

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -11,6 +11,10 @@ module Foreman::Model
       super.merge({ :ip => :public_ip_address })
     end
 
+    def self.available?
+      Fog::Compute.providers.include?(:rackspace)
+    end
+
     def self.model_name
       ComputeResource.model_name
     end

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -9,6 +9,10 @@ module Foreman::Model
     before_create :update_public_key
     attr_accessible :pubkey_hash, :datacenter, :uuid, :server
 
+    def self.available?
+      Fog::Compute.providers.include?(:vsphere)
+    end
+
     def self.model_name
       ComputeResource.model_name
     end

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -4,9 +4,8 @@ end
 Fog::Model.send(:include, FogExtensions::Model) if defined? Fog::Model
 
 # Fog is required by bundler, and depending on the group configuration,
-# different providers will be available - determined in config/application.rb
-# and noted in SETTINGS.
-if SETTINGS[:ec2]
+# different providers will be available.
+if Foreman::Model::EC2.available?
   require 'fog/aws'
   require 'fog/aws/models/compute/flavor'
   Fog::Compute::AWS::Flavor.send(:include, FogExtensions::AWS::Flavor)
@@ -14,7 +13,7 @@ if SETTINGS[:ec2]
   Fog::Compute::AWS::Server.send(:include, FogExtensions::AWS::Server)
 end
 
-if SETTINGS[:gce]
+if Foreman::Model::GCE.available?
   require 'fog/google'
   require 'fog/google/models/compute/image'
   Fog::Compute::Google::Image.send(:include, FogExtensions::Google::Image)
@@ -24,14 +23,14 @@ if SETTINGS[:gce]
   Fog::Compute::Google::Flavor.send(:include, FogExtensions::Google::Flavor)
 end
 
-if SETTINGS[:libvirt]
+if Foreman::Model::Libvirt.available?
   require 'fog/libvirt'
   require 'fog/libvirt/compute'
   require 'fog/libvirt/models/compute/server'
   Fog::Compute::Libvirt::Server.send(:include, FogExtensions::Libvirt::Server)
 end
 
-if SETTINGS[:ovirt]
+if Foreman::Model::Ovirt.available?
   require 'fog/ovirt'
   require 'fog/ovirt/models/compute/server'
   Fog::Compute::Ovirt::Server.send(:include, FogExtensions::Ovirt::Server)
@@ -42,7 +41,7 @@ if SETTINGS[:ovirt]
   Fog::Compute::Ovirt::Volume.send(:include, FogExtensions::Ovirt::Volume)
 end
 
-if SETTINGS[:openstack]
+if Foreman::Model::Openstack.available?
   require 'fog/openstack'
   require 'fog/openstack/compute'
   Fog::Compute::OpenStack::Real.send(:include, FogExtensions::Openstack::Core)
@@ -52,7 +51,7 @@ if SETTINGS[:openstack]
   Fog::Compute::OpenStack::Flavor.send(:include, FogExtensions::Openstack::Flavor)
 end
 
-if SETTINGS[:vmware]
+if Foreman::Model::Vmware.available?
   require 'fog/vsphere'
   require 'fog/vsphere/compute'
   require 'fog/vsphere/models/compute/server'
@@ -62,7 +61,7 @@ if SETTINGS[:vmware]
   Fog::Compute::Vsphere::Folder.send(:include, FogExtensions::Vsphere::Folder)
 end
 
-if SETTINGS[:rackspace]
+if Foreman::Model::Rackspace.available?
   require 'fog/rackspace'
   require 'fog/rackspace/models/compute_v2/server'
   Fog::Compute::RackspaceV2::Server.send(:include, FogExtensions::RackspaceV2::Server)

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,21 +35,9 @@ else
   end
 end
 
-# For standalone CR bundler groups, check that the fog-* provider is registered
-SETTINGS[:ec2]       = Fog::Compute.providers.include?(:aws)
-SETTINGS[:gce]       = Fog::Compute.providers.include?(:google)
-SETTINGS[:libvirt]   = Fog::Compute.providers.include?(:libvirt)
-SETTINGS[:openstack] = Fog::Compute.providers.include?(:openstack)
-SETTINGS[:ovirt]     = false
-SETTINGS[:rackspace] = Fog::Compute.providers.include?(:rackspace)
-SETTINGS[:vmware]    = Fog::Compute.providers.include?(:vsphere)
-
 # CRs in fog core with extra dependencies will have those deps loaded, so then
 # load the corresponding bit of fog
-if defined?(::OVIRT)
-  require 'fog/ovirt'
-  SETTINGS[:ovirt] = Fog::Compute.providers.include?(:ovirt)
-end
+require 'fog/ovirt' if defined?(::OVIRT)
 
 require File.expand_path('../../lib/foreman.rb', __FILE__)
 require File.expand_path('../../lib/timed_cached_store.rb', __FILE__)

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -9,6 +9,7 @@ require 'foreman/provision' if SETTINGS[:unattended]
 require 'foreman'
 require 'filters_helper_overrides'
 require 'English'
+require 'fog_extensions'
 
 # We may be executing something like rake db:migrate:reset, which destroys this table
 # only continue if the table exists

--- a/test/functional/about_controller_test.rb
+++ b/test/functional/about_controller_test.rb
@@ -8,7 +8,9 @@ class AboutControllerTest < ActionController::TestCase
   end
 
   def test_registered_providers_list
-    klass_string = mock('ExampleClass', :constantize => mock('ExampleClass', :provider_friendly_name => 'Example Service'))
+    klass = mock('ExampleClass', :available? => true, :provider_friendly_name => 'Example Service')
+    klass_string = mock('ExampleClass')
+    klass_string.expects(:constantize).at_least_once.returns(klass)
     ComputeResource.expects(:registered_providers).at_least_once.returns('Example' => klass_string)
     ComputeResource.expects(:supported_providers).at_least_once.returns({})
 

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -127,9 +127,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   test '.providers returns merge of loaded builtin and registered providers' do
     ComputeResource.expects(:registered_providers).returns({'Libvirt' => 'Best::Provider::Libvirt', 'MyBest' => 'Best::Provider::MyBest'})
     ComputeResource.expects(:supported_providers).returns({'Libvirt' => 'Foreman::Model::Libvirt', 'EC2' => 'Foreman::Model::EC2', 'GCE' => 'Foreman::Model::GCE'})
-    SETTINGS.expects(:[]).with(:libvirt).returns(true)
-    SETTINGS.expects(:[]).with(:ec2).returns(true)
-    SETTINGS.expects(:[]).with(:gce).returns(false)
+    Fog::Compute.expects(:providers).twice.returns([:aws, :libvirt])
     assert_equal(
       {
         'EC2' => 'Foreman::Model::EC2',


### PR DESCRIPTION
Simplifies the code for checking compute resource availability, which
can easily be determined with the registered Fog providers instead of
being stored in SETTINGS in app initialisation. Plugins should always be
loaded, so should not need to override this class method.
