### PR TITLE
Fixes #14432 - Removing scoped search on value for smart class parameter

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -41,7 +41,6 @@ class LookupKey < ActiveRecord::Base
       scoped_search :on => :merge_overrides, :complete_value => {:true => true, :false => false}
       scoped_search :on => :merge_default, :complete_value => {:true => true, :false => false}
       scoped_search :on => :avoid_duplicates, :complete_value => {:true => true, :false => false}
-      scoped_search :in => :lookup_values, :on => :value, :rename => :value, :complete_value => true
     end
     super
   end


### PR DESCRIPTION
This works for strings but not arrays.
or example the value ["a"], if I search on `lookup_values.where(:value =>  ["a"].to_yaml)` 
it will return the lookup_value.
`["a"].to_yaml` is:`"---\n- a\n"` 
but in `search_by_value` the `value` (that returns from autocomplete) will be `"[\"a\"]"` and `"[\"a\"]".to_yaml` will return: `"--- '[\"a\"]'\n"`, so the lookup_value is not found.
