### PR TITLE
Fixes #10592 - Add tests to validate the allowed_helpers passed into the renderer in ProvisioningTemplate.build_pxe_default contains the generic list

### DIFF
--- a/test/unit/provisioning_template_test.rb
+++ b/test/unit/provisioning_template_test.rb
@@ -209,5 +209,10 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
                                       :hostgroup_id => @hg3.id,
                                       :environment_id => @ev3.id}).name
     end
+
+    test "should call build_pxe_default with allowed_helpers containing the default helpers" do
+      TemplatesController.any_instance.expects(:render_safe).with(anything, includes(*Foreman::Renderer::ALLOWED_GENERIC_HELPERS), anything).returns(true)
+      ProvisioningTemplate.build_pxe_default(TemplatesController.new)
+    end
   end
 end


### PR DESCRIPTION
@domcleal can you please review?
