### PR TITLE
Fixes #14476 - Correctly handle casting of invalid real param values

### DIFF
--- a/app/services/foreman/parameters/caster.rb
+++ b/app/services/foreman/parameters/caster.rb
@@ -81,7 +81,7 @@ module Foreman
           if value =~ /\A[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?\Z/
             value.to_f
           else
-            cast_value_integer value
+            cast_integer
           end
         end
       end

--- a/test/lib/parameters/caster_test.rb
+++ b/test/lib/parameters/caster_test.rb
@@ -84,5 +84,12 @@ class CasterTest < ActiveSupport::TestCase
         Foreman::Parameters::Caster.new(item, :attribute_name => :foo, :to => :hash).cast!
       end
     end
+
+    test "caster raises TypeError on invalid real" do
+      item = OpenStruct.new(:foo => "blah")
+      assert_raises(TypeError) do
+        Foreman::Parameters::Caster.new(item, :attribute_name => :foo, :to => :real).cast!
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously an incorrect `NoMethodError` was thrown due to remains of old code.
