### PR TITLE
fixes #14502 - fix documentation of the hosts controller for puppetclass_ids

### DIFF
--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -36,7 +36,7 @@ module Api
         param :domain_id, :number, :desc => "required if host is managed and value is not inherited from host group"
         param :realm_id, :number
         param :puppet_proxy_id, :number
-        param :puppet_class_ids, Array
+        param :puppetclass_ids, Array
         param :operatingsystem_id, String, :desc => "required if host is managed and value is not inherited from host group"
         param :medium_id, String, :desc => "required if not imaged based provisioning and host is managed and value is not inherited from host group"
         param :ptable_id, :number, :desc => "required if host is managed and custom partition has not been defined"
@@ -82,7 +82,7 @@ module Api
         param :domain_id, :number
         param :puppet_proxy_id, :number
         param :operatingsystem_id, String
-        param :puppet_class_ids, Array
+        param :puppetclass_ids, Array
         param :medium_id, :number
         param :ptable_id, :number
         param :subnet_id, :number

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -52,7 +52,7 @@ module Api
           param :domain_id, :number, :desc => N_("required if host is managed and value is not inherited from host group")
           param :realm_id, :number
           param :puppet_proxy_id, :number
-          param :puppet_class_ids, Array
+          param :puppetclass_ids, Array
           param :operatingsystem_id, String, :desc => N_("required if host is managed and value is not inherited from host group")
           param :medium_id, String, :desc => N_("required if not imaged based provisioning and host is managed and value is not inherited from host group")
           param :ptable_id, :number, :desc => N_("required if host is managed and custom partition has not been defined")


### PR DESCRIPTION
previously it wrongly stated that the parameter is called puppet_class_ids, resulting in 500 errors when calling it
