### PR TITLE
Fixes #14503 - don't join reports with the logs and resources explicitly in API

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -15,7 +15,6 @@ module Api
         @reports = ConfigReport.
           authorized(:view_config_reports).
           my_reports.
-          includes(:logs => [:source, :message]).
           search_for(*search_options).paginate(paginate_options)
       end
 

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -13,7 +13,7 @@ module Api
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
-        @config_reports = resource_scope_for_index.my_reports.includes(:logs => [:source, :message])
+        @config_reports = resource_scope_for_index.my_reports
         @total = ConfigReport.my_reports.count
       end
 

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -13,7 +13,7 @@ module Api
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
-        @reports = resource_scope_for_index.my_reports.includes(:logs => [:source, :message])
+        @reports = resource_scope_for_index.my_reports
         @total = resource_class.my_reports.count
       end
 


### PR DESCRIPTION
Using `.includes(:logs => [:message, :source])` in the search scope
for reports caused serious performance issues (ending up with server
taking all of its memory). I've found no reason for the `includes` to
actually be there (we don't render the logs in the views) and should
be safe to just remove it.
