### PR TITLE
Fixes #14508 - foreman-rake console can take arguments

### DIFF
--- a/lib/tasks/console.rake
+++ b/lib/tasks/console.rake
@@ -1,7 +1,9 @@
 task :console => :environment do
+  flags = (ARGV.drop_while { |s| s != "--" }) || []
+  flags.shift
   # Extra arguments make IRB attempt to open MagicFile('argument')
   # on Rails 4 when starting a console.
   ARGV = []
   require 'rails/commands/console'
-  Rails::Console.start(Rails.application)
+  Rails::Console.start(Rails.application, Rails::Console.parse_arguments(flags))
 end


### PR DESCRIPTION
Closes #14508, so that one can now say

```
foreman-rake console -- --sandbox
```

and get a console that rolls back everything upon exit.

(We need the --, otherwise foreman-rake itself tries to interpret the flags)
