### PR TITLE
Fixes #14521 - better error on missing PXELinux template

### DIFF
--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -48,7 +48,9 @@ module Orchestration::TFTP
     # work around for ensuring that people can use @host as well, as tftp templates were usually confusing.
     @host = self.host
     if build?
-      pxe_render host.provisioning_template({:kind => host.operatingsystem.template_kind})
+      pxe_template = host.provisioning_template({:kind => host.operatingsystem.template_kind})
+      failure_missing_template unless pxe_template
+      pxe_render pxe_template
     else
       if host.operatingsystem.template_kind == "PXEGrub"
         pxe_render ProvisioningTemplate.find_by_name("PXEGrub default local boot")
@@ -94,14 +96,20 @@ module Orchestration::TFTP
 
   private
 
+  def template_kind_missing?(kind = host.operatingsystem.template_kind)
+    host.provisioning_template({:kind => kind}).nil?
+  end
+
+  def failure_missing_template
+    failure _("No %{template_kind} template were found for this host, make sure you define at least one in your %{os} settings") %
+      { :template_kind => host.operatingsystem.template_kind, :os => host.operatingsystem }
+  end
+
   def validate_tftp
     return unless tftp?
     return unless host.operatingsystem
     return if Rails.env == "test"
-    if host.provisioning_template({:kind => host.operatingsystem.template_kind}).nil? && host.provisioning_template({:kind => "iPXE"}).nil?
-      failure _("No %{template_kind} templates were found for this host, make sure you define at least one in your %{os} settings") %
-                { :template_kind => host.operatingsystem.template_kind, :os => host.operatingsystem }
-    end
+    failure_missing_template if (template_kind_missing? && template_kind_missing?("iPXE"))
   end
 
   def queue_tftp

--- a/test/unit/orchestration/tftp_test.rb
+++ b/test/unit/orchestration/tftp_test.rb
@@ -60,6 +60,15 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     assert h.interfaces.first.rebuild_tftp
   end
 
+  def test_should_fail_rebuilding_when_template_is_missing
+    h = FactoryGirl.create(:host, :with_tftp_orchestration)
+    as_admin { h.update_attribute :operatingsystem, operatingsystems(:centos5_3) }
+    h.build = true
+    h.stubs(:provisioning_template).returns(nil)
+    refute h.interfaces.first.rebuild_tftp
+    assert_match /No PXELinux template were found/, h.errors[:base].first
+  end
+
   def test_should_fail_rebuild_tftp_with_exception
     h = FactoryGirl.create(:host, :with_tftp_orchestration)
     Nic::Managed.any_instance.expects(:setTFTP).raises(StandardError, 'TFTP rebuild failed')


### PR DESCRIPTION
For a host with OS with iPXE template but no PXELinux template, we still
attempt to render PXELinux template which leads to "Failed to generate PXELinux
template: undefined method `encoding' for nil:NilClass" orchestration error.

This patch gives nicer error instead.

I can move it one step further - if there is no PXELinux template associated,
there is no point in scheduling TFTP orchestration and we could just skip it.
