### PR TITLE
Fixes #14529 - disabled dropdown button style fixed

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,6 +58,10 @@ a.config_group_name {
   margin-left: 3px;
 }
 
+.dropdown-menu > li > a.disabled {
+  color:#aaa !important;
+}
+
 #settings li {
   list-style-type: none;
   padding: 0 0 8px;


### PR DESCRIPTION
It's because twitter only accepts "disabled" class on `<li>` items and we set it
on <a> tags. We could refactor our select_action_button code but since tags are
self-contained in Rails and we pass array of elements already htmlized, it's
easier to do this via CSS.
