### PR TITLE
Fixes #14479 - removed unwanted check for token param

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -36,9 +36,9 @@ module Foreman
 
       # use template_url from the request if set, but otherwise look for a Template
       # feature proxy, as PXE templates are written without an incoming request.
-      url = if @template_url && @host.try(:token).present?
+      url = if @template_url
               @template_url
-            elsif proxy.present? && proxy.has_feature?('Templates') && @host.try(:token).present?
+            elsif proxy.present? && proxy.has_feature?('Templates')
               temp_url = ProxyAPI::Template.new(:url => proxy.url).template_url
               if temp_url.nil?
                 logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")


### PR DESCRIPTION
In function foreman_url we explicitly check for tokens and I can't find a
reason why we do that. This simply blocks provisioning when using Templating
Smart Proxy plugin.
