### PR TITLE
fixes #13959 - add support to boot from volume snapshot in openstack

### DIFF
--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -6,7 +6,7 @@ module FogExtensions
       included do
         alias_method_chain :security_groups, :no_id
         attr_reader :nics
-        attr_accessor :boot_from_volume, :size_gb
+        attr_accessor :boot_from_volume, :size_gb, :clone_from_snapshot, :snapshot_id
         attr_writer :security_group, :network # floating IP
       end
 

--- a/app/views/compute_resources_vms/form/openstack/_base.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_base.html.erb
@@ -3,12 +3,20 @@
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)
+   snapshots = compute_resource.available_snapshots
+
 %>
 <%= selectable_f f, :availability_zone, compute_resource.zones, {:include_blank => _("No preference")}, :label => _('Availability zone'), :label_size => "col-md-2" %>
 <div id='image_selection'>
   <%= select_f f, :image_ref, images, :uuid, :name,
                { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
                { :disabled => images.empty?, :label => _("Image"), :label_size => "col-md-2" } %>
+</div>
+<div id='snapshot_selection'>
+  <%= checkbox_f f, :clone_from_snapshot, {:label => "Clone from snapshot", :help_inline => _("Use snapshot instead of image"), :id => 'use_snapshot_for_vm'}, "true", "false" %>
+  <%= select_f f, :snapshot_id, snapshots, :id, :name,
+               { :include_blank => (snapshots.empty? || snapshots.size == 1) ? false : _('Please select a snapshot') },
+               { :disabled => snapshots.empty?, :label => _("Snapsot") } %>
 </div>
 <%= select_f f, :tenant_id, compute_resource.tenants, :id, :name, {}, :label => _('Tenant'), :label_size => "col-md-2" %>
 

--- a/test/unit/compute_resources/openstack_test.rb
+++ b/test/unit/compute_resources/openstack_test.rb
@@ -18,12 +18,28 @@ class OpenstackTest < ActiveSupport::TestCase
     assert_equal host, as_admin { @compute_resource.associated_host(iface) }
   end
 
-  test "boot_from_volume does not get triggered when a string 'false' is passed as argument" do
+  test "boot_from_volume does not get triggered when boot_from_volume and boot_from_snapshot set to false" do
     Fog.mock!
     @compute_resource.stubs(:key_pair).returns(mocked_key_pair)
     @compute_resource.expects(:boot_from_volume).never
     @compute_resource.create_vm(:boot_from_volume => 'false', :nics => [""],
+                                :flavor_ref => 'foo_flavor', :image_ref => 'foo_image', :boot_from_snapshot => 'false')
+  end
+
+  test "boot_from_volume triggered when boot_from_volume set to true" do
+    Fog.mock!
+    @compute_resource.stubs(:key_pair).returns(mocked_key_pair)
+    @compute_resource.expects(:boot_from_volume).once
+    @compute_resource.create_vm(:boot_from_volume => 'true', :nics => [""],
                                 :flavor_ref => 'foo_flavor', :image_ref => 'foo_image')
+  end
+
+  test "boot_from_volume triggered when boot_from_snapshot set to true" do
+    Fog.mock!
+    @compute_resource.stubs(:key_pair).returns(mocked_key_pair)
+    @compute_resource.expects(:boot_from_volume).once
+    @compute_resource.create_vm(:nics => [""], :flavor_ref => 'foo_flavor', :image_ref => 'foo_image',
+                                :boot_from_snapshot => 'true')
   end
 
   describe "find_vm_by_uuid" do


### PR DESCRIPTION
Adding a checkbox to allow boot from snapshot.
NOTE - If the snapshot as an attached storage, the VM creation will fail
