### PR TITLE
Fixes #14575 - fix domain ENC info

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -377,7 +377,8 @@ class Host::Managed < Host::Base
     param = {}
     # maybe these should be moved to the common parameters, leaving them in for now
     param["puppetmaster"] = puppetmaster
-    param["domainname"]   = domain.fullname unless domain.nil? or domain.fullname.nil?
+    param["domainname"]   = domain.name unless domain.nil? or domain.name.nil?
+    param["foreman_domain_description"] = domain.fullname unless domain.nil? or domain.fullname.nil?
     param["realm"]        = realm.name unless realm.nil?
     param["hostgroup"]    = hostgroup.to_label unless hostgroup.nil?
     if SETTINGS[:locations_enabled]

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -2267,6 +2267,13 @@ class HostTest < ActiveSupport::TestCase
     refute_includes enc.keys, 'environment'
   end
 
+  test '#info ENC YAML contains domain name and description' do
+    host = FactoryGirl.build(:host, :domain => FactoryGirl.build(:domain, :name => 'example.tst', :fullname => 'custom text'))
+    enc = host.info
+    assert_equal 'example.tst', enc['parameters']['domainname']
+    assert_equal 'custom text', enc['parameters']['foreman_domain_description']
+  end
+
   test "#info ENC YAML returns no puppet classes if no environment" do
     puppetclass = FactoryGirl.create(:puppetclass)
     host             = FactoryGirl.create(:host, :puppetclasses => [puppetclass])


### PR DESCRIPTION
I know this is a bit of API change but I don't think many people would use domain description. It's still available under different, foreman prefixed, global parameter.
