### PR TITLE
Fixes #10278 - don't replace . with - for oVirt VM anymore

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -143,8 +143,6 @@ module Foreman::Model
     end
 
     def create_vm(args = {})
-      #ovirt doesn't accept '.' in vm name.
-      args[:name] = args[:name].parameterize
       if (image_id = args[:image_id])
         args.merge!({:template => image_id})
       end


### PR DESCRIPTION
The version that supports . in VM names (v3.1.0-18) has been around
for almost 4 years
now (https://github.com/oVirt/ovirt-engine/commit/540a75e0f7bc4b9ed879471d3d830d575c6d6060).

Time to move one and make the VM names in oVirt a bit nicer now.
