### PR TITLE
Fixes #14566 - remove show_console_action function

### DIFF
--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -1,10 +1,6 @@
 module ComputeResourcesHelper
   include LookupKeysHelper
 
-  def show_console_action(state, link)
-    state ? link : ""
-  end
-
   def vm_state(vm)
     if vm.state == 'PAUSED'
       ' ' + _("Paused")

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -20,7 +20,7 @@
       </td>
       <td>
         <%= action_buttons(vm_power_action(vm, authorizer),
-                         show_console_action(vm.ready?, display_link_if_authorized("Console", hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer))),
+                         (display_link_if_authorized("Console", hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer)) if vm.ready?),
                          display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer))) %>
       </td>
     </tr>

--- a/app/views/compute_resources_vms/show.html.erb
+++ b/app/views/compute_resources_vms/show.html.erb
@@ -4,8 +4,7 @@
 
 <%
   all_actions = available_actions(@vm).push(
-                  show_console_action(@vm.ready?,
-                  link_to_if_authorized(_("Console"), hash_for_console_compute_resource_vm_path.merge(:auth_object => @compute_resource), {:disabled => @vm.nil? || !@vm.ready?, :class => "btn btn-info"})),
+                  (link_to_if_authorized(_("Console"), hash_for_console_compute_resource_vm_path.merge(:auth_object => @compute_resource), {:disabled => @vm.nil? || !@vm.ready?, :class => "btn btn-info"}) if @vm.ready?),
                   display_link_if_authorized(_("Associate VM"), hash_for_associate_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => @vm.identity).merge(:auth_object => @compute_resource, :permission => 'edit_compute_resources'), :title=> _("Associate VM to a Foreman host"), :method => :put, :class=>"btn btn-default"),
                   link_to(_("Back"), compute_resource_path(@compute_resource), :class=>'btn btn-default'))
   title_actions *all_actions


### PR DESCRIPTION
The `show_console_action` function is just a trenary operator, no sense
making this a function. This also causes the link to be generated even
if it is not needed, as it is passed to the function as a parameter.
