### PR TITLE
Fixes #14410 - Raise error on pending migrations on production

### DIFF
--- a/config/initializers/pending_migrations.rb
+++ b/config/initializers/pending_migrations.rb
@@ -1,0 +1,20 @@
+# Plugin migrations might not run during a failed run of foreman-installer.
+# However, the application can be started when there are missing migrations.
+# In that case,if the user checks the application, everything will look fine.
+# When migrations are pending, permissions from plugins will not be
+# loaded into Foreman::AccessControl - app/services/foreman/plugin.rb#L217
+#
+# This is a problem for plugins. I can set the 'view_activation_keys'
+# permissions because it's on the db, but if it's not loaded, it's
+# useless. This means the user won't be able to use these permissions and
+# won't be able to access any plugin resource.
+#
+# Rails has a helper to catch this automatically, but this initializer will
+# show the foreman-rake command we intend users to use to run migrations.
+
+if !Foreman.in_rake? &&
+    ActiveRecord::Migrator.needs_migration?(ActiveRecord::Base.connection)
+  raise Foreman::Exception.new(
+    N_('Some database migrations are pending. '\
+       'Please run `foreman-rake db:migrate` and restart the application to continue.'))
+end


### PR DESCRIPTION
_Problem_

During foreman-installer --upgrade, maybe there's some error that will
make migrations not run, such as proxy unavailable, etc.. In that case,
if the user checks the application, everything will look fine. However,
when migrations are pending, permissions from plugins will not be
loaded into Foreman::AccessControl:
(https://github.com/theforeman/foreman/blob/develop/app/services/foreman/plugin.rb#L217)

This is a problem for plugins. I can set the 'view_activation_keys'
permissions because it's on the db, but if it's not loaded, it's
useless. This means the user won't be able to use these permissions and
won't be able to access any plugin resource.

_Solution_

I looked at the source, and the only option is to show a 500. This
leaves these instructions to run the migrations. We should show a nicer
error IMO, so we can either catch pending_migrations or patch Rails to
allow redirecting to an URL when migrations are pending.
