### PR TITLE
fixes #14640 - add missing whitespace to template text

### DIFF
--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -66,11 +66,11 @@ module ProvisioningTemplatesHelper
 
   def how_templates_are_determined
     alert(:class => 'alert-info', :header => 'How templates are determined',
-          :text => '<p>' + _("When editing a template, you must assign a list\
-of operating systems which this template can be used with. Optionally, you can\
+          :text => '<p>' + _("When editing a template, you must assign a list \
+of operating systems which this template can be used with. Optionally, you can \
 restrict a template to a list of host groups and/or environments.") + '</p>' +
-'<p>'+ _("When a Host requests a template (e.g. during provisioning), Foreman\
-will select the best match from the available templates of that type, in the\
+'<p>'+ _("When a Host requests a template (e.g. during provisioning), Foreman \
+will select the best match from the available templates of that type, in the \
 following order:") + '</p>' + '<ul>' +
     '<li>' + _("Host group and Environment") + '</li>' +
     '<li>' + _("Host group only") + '</li>' +


### PR DESCRIPTION
provisioning template association text was missing whitespaces.
