### PR TITLE
Fixes #14636 - correctly search puppet class on host form

### DIFF
--- a/app/assets/javascripts/class_edit.js
+++ b/app/assets/javascripts/class_edit.js
@@ -1,15 +1,11 @@
 function filter_puppet_classes(item){
   var term = $(item).val().trim();
-  $('.puppetclass_group li.puppetclass.hide').addClass('hide-me');
+  var class_elems = $('.available_classes').find('.puppetclass_group, .puppetclass');
   if (term.length > 0) {
-    $('.puppetclass_group li.puppetclass').removeClass('filter-marker').hide();
-    $('.puppetclass_group li.puppetclass:not(.hide-me, .selected-marker) span:contains('+term+')').parent('li').addClass('filter-marker').show();
-  } else{
-    $('.puppetclass_group li.puppetclass:not(.hide-me, .selected-marker)').addClass('filter-marker').show();
+    class_elems.hide().has('[data-class-name*='+term+']').show();
+  } else {
+    class_elems.show();
   }
-  var groups = $('li.filter-marker').closest('.puppetclass_group');
-  $('.puppetclass_group').hide();
-  groups.show();
 }
 
 function add_puppet_class(item){
@@ -147,4 +143,3 @@ function removeIconIfEmpty(element, ul_id) {
     element.find('i').hide();
   }
 }
-

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -35,7 +35,7 @@
     <% end %>
   </div>
 
-  <div class="col-md-8">
+  <div class="col-md-8 available_classes">
     <h3><%= _('Available Classes') %></h3>
     <div class='clearfix'>
       <div class='form-group col-md-6'>


### PR DESCRIPTION
Searching for puppet classes that were ellipsized did not work as
expected on the host edit form. This was due to the search looking only
in the span content which was truncated and did not contain the entire
puppet class name. Also, cleaned up the js code to be clearer and more
efficiant.
