### PR TITLE
Fixes #9584 - User email address length can be longer than 60

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,7 @@ class User < ActiveRecord::Base
 
   validates :mail, :format => { :with => /\A(([\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~]+((\.\"[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+(\.[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+)*\")*\.[\w!#\$%&\'\*\+\-\/=\?\^`\{\|\}~]+)*)|(\"[\w !#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+(\.[\w !#\$%&\'\*\+\-\/=\?\^`\{\|\}~\"\(\),:;<>@\[\\\] ]+)*\"))
                                           @[a-z0-9]+((\.[a-z0-9]+)*|(\-[a-z0-9]+)*)*\z/ix },
-                   :length => { :maximum => 60 },
+                   :length => { :maximum => 254 },
                    :allow_blank => true
   validates :mail, :presence => true, :on => :update,
                    :if => Proc.new { |u| !AuthSourceHidden.where(:id => u.auth_source_id).any? && u.mail_was.present? }

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -17,7 +17,7 @@ class UserTest < ActiveSupport::TestCase
   should validate_length_of(:login).is_at_most(100)
   should validate_length_of(:firstname).is_at_most(50)
   should validate_length_of(:lastname).is_at_most(50)
-  should validate_length_of(:mail).is_at_most(60)
+  should validate_length_of(:mail).is_at_most(254)
   # Format
   should allow_value('').for(:mail).on(:create)
   should allow_value('é ô à', "C_r'a-z.y( )<,Na=me;>").for(:firstname)


### PR DESCRIPTION
As far as I know, there's no need for this artificial limitation.
