### PR TITLE
Fixes #14679 - Fix tabbing of puppet CA in proxy

### DIFF
--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -1,5 +1,8 @@
 $(document).on('ContentLoad', function() {
   $('.nav-tabs a').on('shown.bs.tab', refreshCharts);
+  $('a[data-toggle="tab"]').on('click', function(e) {
+    history.pushState(null, null, $(this).attr('href'));
+  });
   showProxies();
   loadTFTP();
   setTab();

--- a/app/views/smart_proxies/logs/_errors_card.html.erb
+++ b/app/views/smart_proxies/logs/_errors_card.html.erb
@@ -1,14 +1,14 @@
 <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-with-action">
   <h2 class="card-pf-title">
-    <a href="#logs" onclick="changeFilterSelection(0); setTab();" data-toggle="tooltip" data-placement="top"><%= n_('%s log message', '%s log messages', logs.info_or_debug_messages) % logs.info_or_debug_messages %></a>
+    <a href="#logs" onclick="changeFilterSelection(0)" data-toggle="tooltip" data-placement="top"><%= n_('%s log message', '%s log messages', logs.info_or_debug_messages) % logs.info_or_debug_messages %></a>
   </h2>
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
       <% icon_present = false; if logs.error_or_fatal_messages > 0; icon_present = true %>
-        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="changeFilterSelection(1); setTab();" data-toggle="tooltip" data-placement="top" title="<%= n_('%s error message', '%s error messages', logs.error_or_fatal_messages) % logs.error_or_fatal_messages %>"><span class="pficon pficon-error-circle-o"></span><%= logs.error_or_fatal_messages %></a></span>
+        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="changeFilterSelection(1)" data-toggle="tooltip" data-placement="top" title="<%= n_('%s error message', '%s error messages', logs.error_or_fatal_messages) % logs.error_or_fatal_messages %>"><span class="pficon pficon-error-circle-o"></span><%= logs.error_or_fatal_messages %></a></span>
       <% end %>
       <% if logs.warn_messages > 0; icon_present = true %>
-        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="changeFilterSelection(2); setTab();" data-toggle="tooltip" data-placement="top" title="<%= n_('%s warning message', '%s warning messages', logs.warn_messages) % logs.warn_messages %>"><span class="pficon pficon-warning-triangle-o"></span><%= logs.warn_messages %></a></span>
+        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="changeFilterSelection(2)" data-toggle="tooltip" data-placement="top" title="<%= n_('%s warning message', '%s warning messages', logs.warn_messages) % logs.warn_messages %>"><span class="pficon pficon-warning-triangle-o"></span><%= logs.warn_messages %></a></span>
       <% end %>
       <% unless icon_present %>
         <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>

--- a/app/views/smart_proxies/logs/_failed_modules.html.erb
+++ b/app/views/smart_proxies/logs/_failed_modules.html.erb
@@ -1,3 +1,3 @@
 <% modules.each do |module_name, error_message| %>
-  <a href="#logs" onclick="filterLogsByMessage('<%= module_name %>'); setTab();" data-toggle="tooltip" data-placement="top" title="<%= error_message %>"><%= Feature.name_map[module_name] || module_name.humanize %></a>
+  <a href="#logs" onclick="filterLogsByMessage('<%= module_name %>')" data-toggle="tooltip" data-placement="top" title="<%= error_message %>"><%= Feature.name_map[module_name] || module_name.humanize %></a>
 <% end %>

--- a/app/views/smart_proxies/logs/_modules_card.html.erb
+++ b/app/views/smart_proxies/logs/_modules_card.html.erb
@@ -5,7 +5,7 @@
   <div class="card-pf-body">
     <p class="card-pf-aggregate-status-notifications">
       <% if names.count > 0 %>
-        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="filterLogsByMessage('<%= names.join('|') %>'); setTab();" data-toggle="tooltip" data-placement="top" title="<%= n_('Failed features: %s', 'Failed features: %s', names.count) % names.join(', ') %>"><span class="pficon pficon-warning-triangle-o"></span><%= names.count %></a></span>
+        <span class="card-pf-aggregate-status-notification"><a href="#logs" onclick="filterLogsByMessage('<%= names.join('|') %>')" data-toggle="tooltip" data-placement="top" title="<%= n_('Failed features: %s', 'Failed features: %s', names.count) % names.join(', ') %>"><span class="pficon pficon-warning-triangle-o"></span><%= names.count %></a></span>
       <% else %>
         <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
       <% end %>

--- a/app/views/smart_proxies/plugins/_puppet_ca.html.erb
+++ b/app/views/smart_proxies/plugins/_puppet_ca.html.erb
@@ -1,10 +1,10 @@
 <ul id="proxy-puppetca-tab" class="nav nav-tabs nav-tabs-pf">
-  <li class="active"><a href="#ca_general"><%= _("General") %></a></li>
+  <li class="active"><a href="#ca_general" data-toggle="tab"><%= _("General") %></a></li>
   <% if authorized_for(:permission => :view_smart_proxies_puppetca, :auth_object => @smart_proxy, :authorizer => authorizer) %>
-  <li><a href="#certificates"><%= _("Certificates") %></a></li>
+  <li><a href="#certificates" data-toggle="tab"><%= _("Certificates") %></a></li>
   <% end %>
   <% if authorized_for(:permission => :view_smart_proxies_autosign, :auth_object => @smart_proxy, :authorizer => authorizer) %>
-  <li><a href="#autosign"><%= _("Autosign entries") %></a></li>
+  <li><a href="#autosign" data-toggle="tab"><%= _("Autosign entries") %></a></li>
   <% end %>
 </ul>
 <div id="proxy-puppetca-tab-content" class="tab-content">


### PR DESCRIPTION
The links were missing the `data-toggle="tab"` attribute, causing the
tabbing to break when using under katello.
