### PR TITLE
Fixes #11079 - Handle oVirt with missing template version name

### DIFF
--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem 'rbovirt', '~> 0.0.36'
+  gem 'rbovirt', '~> 0.0.37'
 end


### PR DESCRIPTION
rbovirt 0.0.37 fixes a bug that causes templates with a missing version
name to raise an exception.
