### PR TITLE
refs #14691 - user editing self should not change User.current

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -86,7 +86,7 @@ module Api
       private
 
       def find_resource
-        editing_self? ? @user = User.current : super
+        editing_self? ? @user = User.find(User.current.id) : super
       end
     end
   end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -95,7 +95,7 @@ module Api
       private
 
       def find_resource
-        editing_self? ? @user = User.current : super
+        editing_self? ? @user = User.find(User.current.id) : super
       end
 
       def allowed_nested_id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,7 +133,7 @@ class UsersController < ApplicationController
   private
 
   def find_resource(permission = :view_users)
-    editing_self? ? User.current : User.authorized(permission).except_hidden.find(params[:id])
+    editing_self? ? User.find(User.current.id) : User.authorized(permission).except_hidden.find(params[:id])
   end
 
   def login_user(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ class User < ActiveRecord::Base
   end
 
   def to_label
-    (firstname.present? || lastname.present?) ? "#{firstname_was} #{lastname_was}" : login
+    (firstname.present? || lastname.present?) ? "#{firstname} #{lastname}" : login
   end
   alias_method :name, :to_label
 

--- a/test/functional/api/v1/users_controller_test.rb
+++ b/test/functional/api/v1/users_controller_test.rb
@@ -182,4 +182,14 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test '#update should not be editing User.current' do
+    user = User.create :login => "foo", :mail => "foo@bar.com", :auth_source => auth_sources(:one)
+    as_user user do
+      put :update, { :id => user.id, :user => valid_attrs }
+    end
+    assert_equal user, assigns(:user)
+    refute_equal user.object_id, assigns(:user).object_id
+    assert_response :success
+  end
 end

--- a/test/functional/api/v2/users_controller_test.rb
+++ b/test/functional/api/v2/users_controller_test.rb
@@ -207,4 +207,14 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test '#update should not be editing User.current' do
+    user = User.create :login => "foo", :mail => "foo@bar.com", :auth_source => auth_sources(:one)
+    as_user user do
+      put :update, { :id => user.id, :user => valid_attrs }
+    end
+    assert_equal user, assigns(:user)
+    refute_equal user.object_id, assigns(:user).object_id
+    assert_response :success
+  end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -245,6 +245,15 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'user should not be editing User.current' do
+    user = users(:one)
+    User.expects(:current).at_least_once.returns(user)
+    get :edit, { :id => user.id }
+    assert_equal user, assigns(:user)
+    refute_equal user.object_id, assigns(:user).object_id
+    assert_response :success
+  end
+
   test 'non admin user should be able to update itself' do
     User.current = users(:one)
     put :update, { :id => users(:one).id, :user => { :firstname => 'test' } }

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -808,13 +808,4 @@ class UserTest < ActiveSupport::TestCase
     user.timezone = ''
     assert user.valid?
   end
-
-  test '.to_label should return persisted name' do
-    user = users(:one)
-    user.firstname = 'First'
-    user.lastname = 'Last'
-    refute_equal('First Last', user.to_label, 'User to_label should not change until saved')
-    user.save
-    assert_equal('First Last', user.to_label, 'User to_label should change after saved')
-  end
 end


### PR DESCRIPTION
Rather than changing the behaviour of #to_label to return persisted
data, the User.current object should not be modified with unsaved data
from the form submission or API update.

User.current is used for authz as well as for display purposes, so
shouldn't be changed. Parameter filtering protects privilege escalation
in this case.
