### PR TITLE
refs #14395 - change user-friendly template kind names

### DIFF
--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -8,15 +8,15 @@ class TemplateKind < ActiveRecord::Base
   scoped_search :on => :name
 
   def self.jar
-    @jar ||= { "PXELinux" => N_("PXE Linux Template"),
-               "PXEGrub" => N_("PXE Grub Template"),
-               "iPXE" => N_("iPXE Template"),
-               "provision" => N_("Provision Template"),
-               "finish" => N_("Finish Template"),
-               "script" => N_("Script Template"),
-               "user_data" => N_("User Data Template"),
-               "ZTP" => N_("ZTP Template"),
-               "POAP" => N_("POAP Template")
+    @jar ||= { "PXELinux" => N_("PXELinux template"),
+               "PXEGrub" => N_("PXEGrub template"),
+               "iPXE" => N_("iPXE template"),
+               "provision" => N_("Provisioning template"),
+               "finish" => N_("Finish template"),
+               "script" => N_("Script template"),
+               "user_data" => N_("User data template"),
+               "ZTP" => N_("ZTP template"),
+               "POAP" => N_("POAP template")
              }
   end
 


### PR DESCRIPTION
- PXELinux/PXEGrub to one word to match project names
- change "Provision" to "Provisioning" to read better
- change to sentence case to better match app

---

I'm a little unsure about the preferred capitalisation of PXELinux/PXEGrub. The former is often all upper case, while the latter is often all lower (as it's a filename) or upper. Without the space they at least match the regular project names and the seeded provisioning template names.
