### PR TITLE
fixes #14742 - retrieve template kind labels from plugin regs

### DIFF
--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -7,24 +7,25 @@ class TemplateKind < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
   scoped_search :on => :name
 
-  def self.jar
-    @jar ||= { "PXELinux" => N_("PXELinux template"),
-               "PXEGrub" => N_("PXEGrub template"),
-               "iPXE" => N_("iPXE template"),
-               "provision" => N_("Provisioning template"),
-               "finish" => N_("Finish template"),
-               "script" => N_("Script template"),
-               "user_data" => N_("User data template"),
-               "ZTP" => N_("ZTP template"),
-               "POAP" => N_("POAP template")
-             }
+  def self.default_template_labels
+    {
+      "PXELinux" => N_("PXELinux template"),
+      "PXEGrub" => N_("PXEGrub template"),
+      "iPXE" => N_("iPXE template"),
+      "provision" => N_("Provisioning template"),
+      "finish" => N_("Finish template"),
+      "script" => N_("Script template"),
+      "user_data" => N_("User data template"),
+      "ZTP" => N_("ZTP template"),
+      "POAP" => N_("POAP template")
+    }
   end
 
-  def self.add_to_jar(hash)
-    jar.merge!(hash) { |key| raise Foreman::Exception.new(N_("Cannot add template with key %s, it already exists"), key) }
+  def self.plugin_template_labels
+    Foreman::Plugin.all.map(&:get_template_labels).inject({}, :merge)
   end
 
   def to_s
-    TemplateKind.jar[name] || name
+    self.class.default_template_labels[name] || self.class.plugin_template_labels[name] || name
   end
 end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -101,6 +101,7 @@ module Foreman #:nodoc:
       @provision_methods = {}
       @compute_resources = []
       @to_prepare_callbacks = []
+      @template_labels = {}
     end
 
     def after_initialize
@@ -331,7 +332,11 @@ module Foreman #:nodoc:
 
     # add human readable label for plugin's template kind with i18n support: template_labels "kind_name" => N_("Nice Name")
     def template_labels(hash)
-      TemplateKind.add_to_jar hash
+      @template_labels.merge!(hash)
+    end
+
+    def get_template_labels
+      @template_labels
     end
 
     private

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -341,4 +341,13 @@ class PluginTest < ActiveSupport::TestCase
 
     Host::Managed.cloned_parameters[:include].delete(:fake_facet)
   end
+
+  def test_add_template_label
+    kind = FactoryGirl.build(:template_kind)
+    Foreman::Plugin.register :test_template_kind do
+      name 'Test template kind'
+      template_labels kind.name => 'Test plugin template kind'
+    end
+    assert_equal 'Test plugin template kind', kind.to_s
+  end
 end

--- a/test/unit/template_kind_test.rb
+++ b/test/unit/template_kind_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class TemplateKindTest < ActiveSupport::TestCase
+  test '#to_s returns English string for default template kinds' do
+    assert_equal 'iPXE template', TemplateKind.find_by_name('iPXE').to_s
+  end
+
+  test '#to_s returns English string from plugin registration' do
+    kind = FactoryGirl.build(:template_kind)
+    Foreman::Plugin.expects(:all).returns([mock('plugin', :get_template_labels => {kind.name => 'Plugin kind'})])
+    assert_equal 'Plugin kind', kind.to_s
+  end
+
+  test '#to_s returns name for unknown kinds' do
+    kind = FactoryGirl.build(:template_kind)
+    assert_equal kind.name, kind.to_s
+  end
+end


### PR DESCRIPTION
Ensures plugin kinds registered in class variables aren't lost when the
TemplateKind class is reloaded.
