### PR TITLE
fixes #14741 - translate template kind string, not object

### DIFF
--- a/app/views/hosts/_templates.html.erb
+++ b/app/views/hosts/_templates.html.erb
@@ -8,7 +8,7 @@
   <tbody>
     <% @templates.each do |tmpl| %>
       <tr>
-        <td><%= _(tmpl.template_kind) %></td>
+        <td><%= _(tmpl.template_kind.to_s) %></td>
         <td><%= action_buttons(display_link_if_authorized(_("Edit"),
                                  hash_for_edit_provisioning_template_path(:id => tmpl.to_param),
                                  :rel => "external"),

--- a/lib/foreman/gettext/debug.rb
+++ b/lib/foreman/gettext/debug.rb
@@ -9,35 +9,35 @@ module Foreman::Gettext::Debug
   def _(key)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.d_(domain, key) {nil}
-      return DL + result + DR unless result.nil?
+      return DL + result.to_s + DR unless result.nil?
     end
-    DL + key + DR
+    DL + key.to_s + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def n_(*keys)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.dn_(domain, *keys) {nil}
-      return DL + result + DR unless result.nil?
+      return DL + result.to_s + DR unless result.nil?
     end
-    DL + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last + DR
+    DL + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def s_(key, separator = nil)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) {nil}
-      return DL + result + DR unless result.nil?
+      return DL + result.to_s + DR unless result.nil?
     end
-    DL + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last + DR
+    DL + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
   end
 
   # slightly modified copy of fast_gettext D_* method
   def ns_(*keys)
     FastGettext.translation_repositories.each_key do |domain|
       result = FastGettext::TranslationMultidomain.dns_(domain, *keys) {nil}
-      return DL + result + DR unless result.nil?
+      return DL + result.to_s + DR unless result.nil?
     end
-    DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last + DR
+    DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
   end
 end


### PR DESCRIPTION
Also convert translation keys to strings in debug mode to prevent
concatenation errors.

Should more closely match the behaviour of the original, non-debug mode which returns the original object.
