### PR TITLE
Fixes #14518, #14516 - status change ignores validations

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -846,7 +846,7 @@ class Host::Managed < Host::Base
 
   def refresh_global_status!
     refresh_global_status
-    save!
+    save!(:validate => false)
   end
 
   def refresh_statuses


### PR DESCRIPTION
I'm not fully convinced that this should be merged so I'd appreciate @theforeman/core opinions. The root of the problem is that host can be invalid which would prevent saving global status change. Users do not have a chance to notice it unless they look at logs or they use foreman-tasks. On the other hand I think that we should try to avoid situation where hosts are invalid.

Note that I intentionally kept `save!` with just validations skipping so the exception is raised if there's some other, e.g. DB, error.
