### PR TITLE
fixes #14765 - exclude job templates from template sync

### DIFF
--- a/script/sync_templates.sh
+++ b/script/sync_templates.sh
@@ -24,6 +24,7 @@ rsync -r \
   --exclude '.*' \
   --exclude test \
   --exclude Rakefile \
+  --exclude 'jobs/' \
   $REPO/ct/ ./
 
 cd -


### PR DESCRIPTION
Because of https://github.com/theforeman/community-templates/pull/268
