### PR TITLE
Fixes #8245 - Updates OS on Hostgroup update

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -973,7 +973,7 @@ class Host::Managed < Host::Base
     attrs.each do |attr|
       next if send(attr).to_i == -1
       value = hostgroup.send("inherited_#{attr}")
-      self.send("#{attr}=", value) unless send(attr).present?
+      self.send("#{attr}=", value) if new_record? || send(attr).blank?
     end
   end
 


### PR DESCRIPTION
Prior to this commit
On the new host page if host groups are updated
the hostgroup changes dont get reflected.

For example
If hostgroup A had Redhat 7.1 as OS
and hostgroup B had Redhat 7.2

Now on the New Host page if HG A got applied and then HG B
The operating system would still show up as RedHat 7.1

This commit addresses that issue by applying host group changes
completely for New Hosts.
