### PR TITLE
fixes #14781 - stub network calls for host_build_status_test

### DIFF
--- a/test/unit/host_build_status_test.rb
+++ b/test/unit/host_build_status_test.rb
@@ -4,6 +4,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
   attr_reader :build
 
   setup do
+    disable_orchestration
     User.current = users(:admin)
     @host = Host.new(:name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03", :ptable => FactoryGirl.create(:ptable), :medium => media(:one),
                     :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),


### PR DESCRIPTION
This makes tests a lot faster\* as they don't try to communicate with a non existing smart proxy on the internet.
- when you are on a corporate network that drops outgoing connections
