### PR TITLE
Fixes #13819 _timestamp collision in facts_to_create

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -69,8 +69,11 @@ class FactImporter
       method          = host.new_record? ? :build : :create!
       fact_names      = fact_name_class.group(:name).maximum(:id)
       facts_to_create.each do |name|
-        host.fact_values.send(method, :value => facts[name],
+        if name != "_timestamp" 
+          logger.info("Fact Importer facts_to_create called for new fact '#{name}'")
+          host.fact_values.send(method, :value => facts[name],
                               :fact_name_id  => fact_names[name] || fact_name_class.create!(:name => name).id)
+        end
       end
     end
 

--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -63,17 +63,15 @@ class FactImporter
   end
 
   def add_new_facts
-    facts_to_create = facts.keys - db_facts.keys
+    facts_to_create = facts.keys - db_facts.keys - [ '_timestamp' ]
     # if the host does not exists yet, we don't have an host_id to use the fact_values table.
     if facts_to_create.present?
       method          = host.new_record? ? :build : :create!
       fact_names      = fact_name_class.group(:name).maximum(:id)
       facts_to_create.each do |name|
-        if name != "_timestamp" 
-          logger.info("Fact Importer facts_to_create called for new fact '#{name}'")
+          logger.debug("#{self.class.to_s}#facts_to_create #{method} new fact with name '#{name}'")
           host.fact_values.send(method, :value => facts[name],
-                              :fact_name_id  => fact_names[name] || fact_name_class.create!(:name => name).id)
-        end
+                                :fact_name_id  => fact_names[name] || fact_name_class.create!(:name => name).id)
       end
     end
 


### PR DESCRIPTION
Refs #14761, _timestamp already existing (and used) by Foreman, but Puppet versions < 4 may also submit.  Causes facts to fail to upload.  Requesting inclusion for Foreman 1.10.4
