### PR TITLE
Fixes #6977 - sorts default PXE menu's labels 

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -188,6 +188,6 @@ class ProvisioningTemplate < Template
         end
       end
     end
-    combos
+    combos.sort_by! { |profile| [profile[:hostgroup], profile[:template]] }
   end
 end


### PR DESCRIPTION
About the ordering in the label itself (hostgroup before template) you can see [here](https://github.com/theforeman/community-templates/pull/269)
