### PR TITLE
Fixes #14778 - Ensure parsing complex settings keep target type

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -131,7 +131,7 @@ BANNER
     def typecast_value(type, value)
       if complex_type?(type)
         # we used JSON over custom format for input because it's easier to parse
-        JSON.parse(value).inspect
+        JSON.parse(value)
       else
         value
       end


### PR DESCRIPTION
As mentioned in [#14778](http://projects.theforeman.org/issues/14778), running `/usr/sbin/foreman-rake -- config -k ignored_interface_identifiers -v '["lo","awdl*"]'` doesn't seem to perform the expected behavior.

Without this patch, the config task would send complex types as strings to the setting model.

The array passed as argument is parsed as JSON but the parsed value is converted to `string`. Internally, the setting model in https://github.com/theforeman/foreman/blob/develop/app/models/setting.rb#L104 converts the value object to yaml so it's smart enough to handle an array input as object.

It looks simple but maybe I'm missing some side-effect...
