### PR TITLE
Fixes #14730 - Only search host proxies explicitly

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -40,8 +40,8 @@ module Hostext
       scoped_search :in => :realm,       :on => :id,      :complete_enabled => false,  :rename => :realm_id, :only_explicit => true
       scoped_search :in => :environment, :on => :name,    :complete_value => true,  :rename => :environment
       scoped_search :in => :architecture, :on => :name,    :complete_value => true, :rename => :architecture
-      scoped_search :in => :puppet_proxy, :on => :name,    :complete_value => true, :rename => :puppetmaster
-      scoped_search :in => :puppet_ca_proxy, :on => :name,    :complete_value => true, :rename => :puppet_ca
+      scoped_search :in => :puppet_proxy, :on => :name,    :complete_value => true, :rename => :puppetmaster, :only_explicit => true
+      scoped_search :in => :puppet_ca_proxy, :on => :name,    :complete_value => true, :rename => :puppet_ca, :only_explicit => true
       scoped_search :in => :puppet_proxy, :on => :name,   :complete_value => true, :rename => :smart_proxy, :ext_method => :search_by_proxy, :only_explicit => true
       scoped_search :in => :compute_resource, :on => :name,    :complete_value => true, :rename => :compute_resource
       scoped_search :in => :compute_resource, :on => :id,      :complete_enabled => false, :rename => :compute_resource_id, :only_explicit => true


### PR DESCRIPTION
When searching hosts with free text in a taxonomy scope, if the taxonomy
has "all smart proxies" associated, it leads to scoped search generating
an incorrect scope which causes an invalid query:
`SELECT smart_proxies.id FROM "smart_proxies" "puppet_ca_proxies_hosts"`
Making the puppet_ca search only explicitly prevents this at the cost of
not allowing to search by puppet_ca using free text. I believe this is a
reasonable tradeoff as I did not find a simpler way to handle this (might
require some deep tweeking in scoped search).
To maintain consistency I also made the puppetmaster search explicit
only.
