### PR TITLE
Fixes #14817 - load JS only in relevant pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,10 +11,6 @@
 //= require topbar
 //= require two-pane
 //= require vendor
-//= require about
-//= require proxy_status
-//= require proxy_status/puppet
-//= require proxy_status/logs
 //= require jquery.extentions
 //= require jquery.multi-select
 //= require settings

--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -1,3 +1,6 @@
+//= require proxy_status/puppet
+//= require proxy_status/logs
+
 $(document).on('ContentLoad', function() {
   $('.nav-tabs a').on('shown.bs.tab', refreshCharts);
   showProxies();

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -1,4 +1,5 @@
 <% title _("About") %>
+<%= javascript 'proxy_status', 'about' %>
 
 <div class="row" id="about">
   <div class="col-md-7">

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Smart Proxies") %>
-
+<%= javascript 'proxy_status' %>
 <% title_actions new_link(_("New Smart Proxy")),
                  documentation_button('4.3SmartProxies') %>
 

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -1,4 +1,5 @@
 <% title(_('Smart Proxy: %s') % @smart_proxy.to_label) %>
+<%= javascript 'proxy_status' %>
 <%= smart_proxy_title_actions(@smart_proxy, authorizer) %>
 <% service_features = services_tab_features(@smart_proxy) %>
 <% tab_features = tabbed_features(@smart_proxy) %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -49,6 +49,7 @@ Foreman::Application.configure do |app|
                   hidden_values
                   password_strength
                   proxy_status
+                  about
                   parameter_override)
 
   javascript += FastGettext.default_available_locales.map { |loc| "locale/#{loc}/app" }


### PR DESCRIPTION
The proxy_status.js and about.js files should only be loaded on relevant
pages.
