### PR TITLE
fixes #14820 - override Rails log level with Foreman::Logging config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -163,6 +163,8 @@ module Foreman
     ))
 
     config.logger = Foreman::Logging.logger('app')
+    # Explicitly set the log_level from our config, overriding the Rails env default
+    config.log_level = Foreman::Logging.logger_level('app').to_sym
     config.active_record.logger = Foreman::Logging.logger('sql')
 
     if config.serve_static_files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,9 +48,6 @@ Foreman::Application.configure do |app|
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Set to :debug to see everything in the log.
-  config.log_level = :info
-
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -54,6 +54,11 @@ module Foreman
       fail "Trying to use logger #{name} which has not been configured."
     end
 
+    def logger_level(name)
+      level_int = logger(name).level
+      ::Logging::LEVELS.find { |n,i| i == level_int }.first
+    end
+
     # Standard way for logging exceptions to get the most data in the log.
     # The behaviour can be influenced by this options:
     #   * :logger - the name of the logger to put the exception in ('app' by default)

--- a/test/lib/foreman/logging_test.rb
+++ b/test/lib/foreman/logging_test.rb
@@ -35,4 +35,9 @@ class ForemanLoggingTest < ActiveSupport::TestCase
       Foreman::Logging.send(:load_config, 'development')
     end
   end
+
+  def test_logger_level
+    Foreman::Logging.add_logger('test_logger', {:enabled => true, :level => :debug})
+    assert_equal 'debug', Foreman::Logging.logger_level('test_logger')
+  end
 end


### PR DESCRIPTION
The log_level is expected to be explicitly configured in the Rails
config in the production environment.
