### PR TITLE
fixes #14865 - use waiting selector to search for checked boxes

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -222,10 +222,10 @@ class HostJSTest < IntegrationTestWithJavascript
   describe "hosts index multiple actions" do
     test 'show action buttons' do
       visit hosts_path
-      page.find('#check_all').click
+      page.find('#check_all').trigger('click')
 
-      # Ensure all hosts are checked
-      assert page.find('input.host_select_boxes').checked?
+      # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
+      assert page.has_no_selector?('input.host_select_boxes:not(:checked)')
 
       # Dropdown visible?
       assert multiple_actions_div.find('.dropdown-toggle').visible?


### PR DESCRIPTION
You can comment out the contents of the toggleCheck() JS function to verify that the test now waits ~30 seconds until they're all checked.
