### PR TITLE
fixes #14887 - remove unused test-unit dep

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -14,7 +14,6 @@ group :test do
   gem 'parser', '2.3.0.2'
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem "poltergeist", :require => false
-  gem 'test-unit' if RUBY_VERSION >= '2.2'
   gem 'test_after_commit', '~> 0.4.0'
   gem 'shoulda-matchers', '2.8.0'
   gem 'shoulda-context', '~> 1.2'


### PR DESCRIPTION
Rails 4 removes the hard dep on test-unit in rails/rails@aa7857b6.
