### PR TITLE
Fixes #14791 - Added callback ability to our taxonomy controller.

### DIFF
--- a/app/controllers/concerns/foreman/controller/callbacks_scope.rb
+++ b/app/controllers/concerns/foreman/controller/callbacks_scope.rb
@@ -1,0 +1,72 @@
+module Foreman::Controller::CallbacksScope
+  extend ActiveSupport::Concern
+
+  class ScopeClass
+    attr_reader :result, :result_options
+
+    def initialize
+      @result_options = {}
+    end
+
+    def process_success(options = {}, merge_direction = :right)
+      throw 'tried to set ambigous result' if @result == :error
+      @result = :success
+      merge_options options, merge_direction
+    end
+
+    def process_error(options = {}, merge_direction = :right)
+      throw 'tried to set ambigous result' if @result == :success
+      @result = :error
+      merge_options options, merge_direction
+    end
+
+    private
+
+    def merge_options(other, merge_direction)
+      if merge_direction == :right
+        @result_options.merge! other
+      elsif merge_direction == :left
+        @result_options = other.merge(@result_options)
+      else
+        throw "unknown direction: #{merge_direction}"
+      end
+    end
+  end
+
+  included do
+    alias_method_chain :process_success, :scope
+    alias_method_chain :process_error, :scope
+  end
+
+  def process_success_with_scope(options = {}, merge_direction = :right)
+    @result_scope ||= ScopeClass.new
+
+    @result_scope.process_success(options, merge_direction)
+  end
+
+  def process_error_with_scope(options = {}, merge_direction = :right)
+    @result_scope ||= ScopeClass.new
+
+    @result_scope.process_error(options, merge_direction)
+  end
+
+  def default_render(*args)
+    if @result_scope
+      if @result_scope.result == :success
+        process_success_without_scope @result_scope.result_options
+      else
+        process_error_without_scope @result_scope.result_options
+      end
+    end
+
+    super unless performed?
+  end
+
+  def successful?(callback_result)
+    if callback_result
+      @result_scope.nil? || @result_scope.result == :success
+    else
+      callback_result.nil? && (@result_scope.nil? || @result_scope.result == :success)
+    end
+  end
+end


### PR DESCRIPTION
Created a callback framework to extend foreman methods without using `#alias_method_chain`. Now the control over the flow will remain in Foreman, so if the flow changes like in case of [#14252](http://projects.theforeman.org/issues/14252) plugins like katello should not be updated.

If the PR will be accepted, we could expand the usage of this framework to other controllers that need to be overridden by plugins.

Now the plugins would be able to use regular callback semantics in order to extend/override the behavior of foreman (they will have `before`, `after` and `around` callbacks) and they could safely call `process_success` and `process_error` without double rendering problems.
