### PR TITLE
Fixes #14701: Mention image password in API docs and tests

### DIFF
--- a/app/controllers/api/v2/images_controller.rb
+++ b/app/controllers/api/v2/images_controller.rb
@@ -32,6 +32,7 @@ module Api
           param :name, String, :required => true
           param :username, String, :required => true
           param :uuid, String, :required => true
+          param :password, String, :required => false
           param :compute_resource_id, String, :desc => N_("ID of compute resource")
           param :architecture_id, String, :desc => N_("ID of architecture")
           param :operatingsystem_id, String, :desc => N_("ID of operating system")

--- a/test/functional/api/v2/images_controller_test.rb
+++ b/test/functional/api/v2/images_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V2::ImagesControllerTest < ActionController::TestCase
   def valid_attrs
-    { :name                => 'TestImage', :username => 'ec2-user', :uuid => 'abcdef',
+    { :name                => 'TestImage', :username => 'ec2-user', :uuid => 'abcdef', :password => "password",
       :operatingsystem_id  => Operatingsystem.first.id,
       :compute_resource_id => ComputeResource.first.id,
       :architecture_id     => Architecture.first.id,


### PR DESCRIPTION
Setting the image password is well supported but not documented.
