### PR TITLE
Fixes #6958 - adds support for nested hostgroup in default PXE menu

### DIFF
--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -19,7 +19,7 @@ module Foreman::Controller::ProvisioningTemplates
     protocol = uri.scheme
 
     url_for(:only_path => false, :action => :hostgroup_template, :controller => '/unattended',
-            :id => template.name, :hostgroup => hostgroup.name, :protocol => protocol,
+            :id => template.name, :hostgroup => hostgroup.title, :protocol => protocol,
             :host => host, :port => port)
   end
 

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -33,8 +33,7 @@ class UnattendedController < ApplicationController
     return head(:not_found) unless (params.has_key?("id") and params.has_key?(:hostgroup))
 
     template = ProvisioningTemplate.find_by_name(params['id'])
-    @host = Hostgroup.find_by_name(params['hostgroup'])
-
+    @host = Hostgroup.find_by_title(params['hostgroup'])
     return head(:not_found) unless template and @host
 
     load_template_vars if template.template_kind.name == 'provision'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,9 +122,7 @@ Foreman::Application.routes.draw do
       end
     end
 
-    constraints(:hostgroup => /[^\/]+/) do
-      get 'unattended/template/:id/:hostgroup', :to => "unattended#hostgroup_template"
-    end
+    get 'unattended/template/:id/*hostgroup', :to => "unattended#hostgroup_template", hostgroup: /.+/
   end
 
   resources :settings, :only => [:index, :update] do

--- a/test/functional/provisioning_templates_controller_test.rb
+++ b/test/functional/provisioning_templates_controller_test.rb
@@ -124,6 +124,15 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
       get :build_pxe_default, {}, set_session_user
       assert_redirected_to provisioning_templates_path
     end
+
+    test "kickstart url should support in nested hostgroup " do
+      t1 = TemplateCombination.new :hostgroup => hostgroups(:inherited), :environment => environments(:production)
+      t1.provisioning_template = templates(:mystring2)
+      t1.save
+      ProxyAPI::TFTP.any_instance.expects(:create_default).with(has_entry(:menu, regexp_matches(/ks=http:\/\/foreman.unattended.url\/unattended\/template\/MyString2\/Parent\/inherited/))).returns(true)
+      get :build_pxe_default, {}, set_session_user
+      assert_redirected_to provisioning_templates_path
+    end
   end
 
   test 'preview' do

--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -200,6 +200,11 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :conflict
   end
 
+  test "template with nested hostgroup should be rendered" do
+    get :hostgroup_template, {:id => "MyString", :hostgroup => "Parent/inherited"}
+    assert_response :success
+  end
+
   test "template with hostgroup should be rendered" do
     get :hostgroup_template, {:id => "MyString", :hostgroup => "Common"}
     assert_response :success


### PR DESCRIPTION
The host group interface provides the opportunity to nest host groups, with host groups inheriting parameters from parents.when the default PXE menu is created however, this nesting is not replicated and only the final element of the hostgroup path is inserted into the kickstart URL.
