### PR TITLE
Fixes #14226 - Adds warnings to hostgroup edit page

### DIFF
--- a/app/controllers/concerns/foreman/controller/taxonomy_warnings.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_warnings.rb
@@ -1,0 +1,25 @@
+module Foreman::Controller::TaxonomyWarnings
+  extend ActiveSupport::Concern
+
+  included do
+    before_filter :taxonomy_warnings, :only => [:edit]
+  end
+
+  def taxonomy_warnings
+    @warnings ||= []
+
+    Taxonomy.enabled_taxonomies.each do |taxonomy|
+      @warnings += single_taxonomy_warnings(taxonomy.singularize, @hostgroup)
+    end
+  end
+
+  private
+
+  def single_taxonomy_warnings(taxonomy, hostgroup)
+    warnings = []
+
+    taxonomies_count = hostgroup.hosts.unscoped.distinct.count("#{taxonomy}_id")
+    warnings << _('The hostgroup is used by hosts in multiple %s' % taxonomy.pluralize) if taxonomies_count > 1
+    warnings
+  end
+end

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -6,6 +6,8 @@ class HostgroupsController < ApplicationController
   before_filter :ajax_request,   :only => [:process_hostgroup, :puppetclass_parameters]
   before_filter :taxonomy_scope, :only => [:new, :edit, :process_hostgroup]
 
+  include Foreman::Controller::TaxonomyWarnings
+
   def index
     @hostgroups = resource_base.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
   end

--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -11,6 +11,14 @@ module HostgroupsHelper
     msg.join("\n")
   end
 
+  def editor_warnings
+    return unless @warnings
+
+    @warnings.map do |warning|
+      alert(:class => 'alert-warning', :text => warning)
+    end.join().html_safe
+  end
+
   def parent_hostgroups
     if @hostgroup.new_record?
       accessible_hostgroups

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -1,4 +1,6 @@
 <%= javascript 'host_edit', 'host_edit_interfaces', 'class_edit' %>
+<%= editor_warnings %>
+
 <%= form_for @hostgroup, :html => {:data => {:id => @hostgroup.try(:id), :submit => 'progress_bar' }} do |f| %>
   <%= base_errors_for @hostgroup %>
 

--- a/test/functional/hostgroups_controller_test.rb
+++ b/test/functional/hostgroups_controller_test.rb
@@ -152,6 +152,50 @@ class HostgroupsControllerTest < ActionController::TestCase
     assert_equal(1, (assigns(:hostgroup).puppetclasses.length))
   end
 
+  context 'warnings' do
+    test 'should show warning, if connected to hosts in multiple orgs' do
+      org1 = FactoryGirl.create(:organization)
+      org2 = FactoryGirl.create(:organization)
+
+      hg = FactoryGirl.create(:hostgroup)
+
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :organization => org1)
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :organization => org2)
+
+      get :edit, { :id => hg.id }, set_session_user
+
+      assert_select '.alert-warning', /organizations/
+    end
+
+    test 'should show warning, if connected to hosts in multiple locations' do
+      loc1 = FactoryGirl.create(:location)
+      loc2 = FactoryGirl.create(:location)
+
+      hg = FactoryGirl.create(:hostgroup)
+
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :location => loc1)
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :location => loc2)
+
+      get :edit, { :id => hg.id }, set_session_user
+
+      assert_select '.alert-warning', /locations/
+    end
+
+    test 'should not show warnings if all hosts belong to the same taxonomy' do
+      loc1 = FactoryGirl.create(:location)
+      org1 = FactoryGirl.create(:organization)
+
+      hg = FactoryGirl.create(:hostgroup)
+
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :location => loc1, :organization => org1)
+      FactoryGirl.create(:host, :managed, :hostgroup => hg, :location => loc1, :organization => org1)
+
+      get :edit, { :id => hg.id }, set_session_user
+
+      assert_select '.alert-warning', 0
+    end
+  end
+
   describe "parent attributes" do
     before do
       @base = FactoryGirl.create(:hostgroup)


### PR DESCRIPTION
Adds warnings if a hostgroup has hosts that belong to different organizations. Such changes are considered dangerous, and the user should know that this is the case.
