### PR TITLE
 Fixes #14927 - correct override value requirment

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -31,7 +31,7 @@ module Api
       def_param_group :override_value do
         param :override_value, Hash, :required => true, :action_aware => true do
           param :match, String, :required => true, :desc => N_("Override match")
-          param :value, String, :required => true, :desc => N_("Override value")
+          param :value, String, :required => false, :desc => N_("Override value, required if use_puppet_default is false")
           param :use_puppet_default, :bool
         end
       end

--- a/test/functional/api/v2/override_values_controller_test.rb
+++ b/test/functional/api/v2/override_values_controller_test.rb
@@ -90,4 +90,22 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test "should create override value without when use_puppet_default is true" do
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
+
+    assert_difference('LookupValue.count', 1) do
+      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => true}}
+    end
+    assert_response :success
+  end
+
+  test "should not create override value without when use_puppet_default is false" do
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
+
+    assert_difference('LookupValue.count', 0) do
+      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => false}}
+    end
+    assert_response :error
+  end
 end


### PR DESCRIPTION
override value should only be required when use_puppet_default is false.

This should be tested with hammer since the issue was documenting `value` as required which led to hammer requiring it.
