### PR TITLE
Fixes #12225 - topbar is invalidated on menu change

### DIFF
--- a/app/controllers/topbar_sweeper.rb
+++ b/app/controllers/topbar_sweeper.rb
@@ -18,7 +18,8 @@ class TopbarSweeper < ActionController::Caching::Sweeper
   end
 
   def self.fragment_name(id = User.current.id)
-    "tabs_and_title_records-#{id}"
+    @@top_menu_cache_hash ||= Menu::Manager.items(:top_menu).content_hash
+    "tabs_and_title_records-#{@@top_menu_cache_hash}-#{id}"
   end
 
   def self.expire_cache(controller)

--- a/app/services/menu/divider.rb
+++ b/app/services/menu/divider.rb
@@ -9,5 +9,13 @@ module Menu
     def authorized?
       true
     end
+
+    # Node#content_hash for more info
+    def content_hash
+      hash = Digest::MD5.new()
+      hash << super
+      hash << @caption.to_s if @caption
+      hash.hexdigest
+    end
   end
 end

--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -41,6 +41,20 @@ module Menu
       false
     end
 
+    # Node#content_hash for more info
+    def content_hash
+      hash = Digest::MD5.new()
+      hash << super
+      hash << @url.to_s if @url
+      hash << @url_hash.to_s if @url_hash
+      hash << @condition.to_s if @condition
+      hash << @caption.to_s if @caption
+      hash << @html_options.to_s if @html_options
+      hash << @turbolinks.to_s if @turbolinks
+      @child_menus.each{|x| hash << x.content_hash} if @child_menus
+      hash.hexdigest
+    end
+
     private
 
     def add_relative_path(path)

--- a/app/services/menu/node.rb
+++ b/app/services/menu/node.rb
@@ -95,5 +95,15 @@ module Menu
       root = root.parent while root.parent
       root
     end
+
+    # Recursive content hash. Everytime a menu is modified (item is added, html_options are changed)
+    # this value changes and top bar cache is invalidated. This usually happens during upgrades
+    # or plugin un/installations.
+    def content_hash
+      hash = Digest::MD5.new()
+      hash << @name.to_s if @name
+      @children.each{|x| hash << x.content_hash} if @children
+      hash.hexdigest
+    end
   end
 end

--- a/app/services/menu/toggle.rb
+++ b/app/services/menu/toggle.rb
@@ -8,5 +8,13 @@ module Menu
     def authorized?
       true
     end
+
+    # Node#content_hash for more info
+    def content_hash
+      hash = Digest::MD5.new()
+      hash << super
+      hash << @caption.to_s if @caption
+      hash.hexdigest
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -127,8 +127,7 @@ module Foreman
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # enables in memory cache store with ttl
-    #config.cache_store = TimedCachedStore.new
+    # By default use file store
     config.cache_store = :file_store, Rails.root.join("tmp", "cache")
 
     # enables JSONP support in the Rack middleware

--- a/test/unit/menu_mapper_test.rb
+++ b/test/unit/menu_mapper_test.rb
@@ -196,4 +196,48 @@ class MenuMapperTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_hash_consistency
+    m1 = Menu::Manager::Mapper.new(:test_menu1, {})
+    m1.item :test_item, :caption => "Some Item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    m1.divider
+    m1.sub_menu :test_sub_menu, :caption => "Some Sub-menu" do
+      m1.item :test_sub_item, :caption => "Some Sub-item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    end
+    m2 = Menu::Manager::Mapper.new(:test_menu2, {})
+    m2.item :test_item, :caption => "Some Item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    m2.divider
+    m2.sub_menu :test_sub_menu, :caption => "Some Sub-menu" do
+      m2.item :test_sub_item, :caption => "Some Sub-item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    end
+    assert_equal m1.find(:root).content_hash, m2.find(:root).content_hash
+  end
+
+  def test_hash_item_change
+    m1 = Menu::Manager::Mapper.new(:test_menu1, {})
+    m1.item :test_item, :caption => "Some Item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    m2 = Menu::Manager::Mapper.new(:test_menu2, {})
+    m2.item :test_item, :caption => "Some Changed Item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    assert_not_equal m1.find(:root).content_hash, m2.find(:root).content_hash
+  end
+
+  def test_hash_url_change
+    m1 = Menu::Manager::Mapper.new(:test_menu1, {})
+    m1.item :test_item, :caption => "Some Item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    m2 = Menu::Manager::Mapper.new(:test_menu2, {})
+    m2.item :test_item, :caption => "Some Item", :url_hash => { :controller => 'facts', :action => 'show'}
+    assert_not_equal m1.find(:root).content_hash, m2.find(:root).content_hash
+  end
+
+  def test_hash_submenu_change
+    m1 = Menu::Manager::Mapper.new(:test_menu1, {})
+    m1.sub_menu :test_sub_menu, :caption => "Some Sub-menu" do
+      m1.item :test_sub_item, :caption => "Some Sub-item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    end
+    m2 = Menu::Manager::Mapper.new(:test_menu2, {})
+    m2.sub_menu :test_sub_menu, :caption => "Renamed Sub-menu" do
+      m2.item :test_sub_item, :caption => "Some Sub-item", :url_hash => { :controller => 'hosts', :action => 'show'}
+    end
+    assert_not_equal m1.find(:root).content_hash, m2.find(:root).content_hash
+  end
 end


### PR DESCRIPTION
I initially ditched an old patch thinking that Rails 4 caching solved the problem, but I was wrong. The key concept is to calculate a hash from all menu entries each request and use the hash as the cache ("fragment") key to prevent "missing" menu items after plugin installation (sessions do survive server restarts).
