### PR TITLE
fixes #14874 - do not run path replace during vmware clone

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -376,24 +376,13 @@ module Foreman::Model
     #
     # Foreman will try and start this vm after clone in a seperate request.
     #
-    # === Clusters
-    #
-    # Fog adaptor is incompatable with foreman because foreman does not have
-    # concept of a resource pool.
-    #
-    #   "resource_pool" => [args["cluster"], "Resources"]
-    #
-    # Fog calls +cluster.resourcePool.find("Resources")+ that actually calls
-    # +searchIndex.FindChild("Resources")+ in RbVmomi that then returns nil
-    # because it has no children.
     def clone_vm(raw_args)
       args = parse_args(raw_args)
-      path_replace = %r{/[^/]+/#{datacenter}/vm(/|)}
 
       opts = {
         "datacenter" => datacenter,
         "template_path" => args[:image_id],
-        "dest_folder" => args[:path].gsub(path_replace, ''),
+        "dest_folder" => args[:path],
         "power_on" => false,
         "start" => args[:start],
         "name" => args[:name],


### PR DESCRIPTION
I can't see any reason why we run a regex on the path here and this leads to problems:

From the ticket:

```
So our datacenter is: 'Turitea ITS'
Our original path is '/Datacenters/Turitea/Turitea ITS/vm/Production/Foundation/Infrastructure'

After the path_replace has been done the path is: '/DatacentersProduction/Foundation/Infrastructure' - which obviously doesn't work.
```

I also cleaned the comment a bit.
