### PR TITLE
Fixes #14957 - Use a temporary status file to store exit status

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -53,7 +53,8 @@ class Foreman::Provision::SSH
   def command
     # Use the users home to store the provision script since we can't reliably
     # tell if other locations are writeable or executable by the user.
-    "#{command_prefix} sh -c '(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script}) 2>&1 | tee #{remote_script}.log; exit ${PIPESTATUS[0]}'"
+    main_execution="(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script} ; echo $? >#{remote_script}.status) 2>&1"
+    "#{command_prefix} sh -c '#{main_execution} | tee #{remote_script}.log; exit $(cat #{remote_script}.status)'"
   end
 
   def defaults


### PR DESCRIPTION
Based on http://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another/14272#14272, I've sent the exit status of the remote script to a temp file and then read it back. I wasn't sure if `mktemp` could be relied upon to be present, so I've re-used the `remote_script`.\* convention.

Untested locally, as yet - I should have time to test on my production instance tonight.
