### PR TITLE
Fixes #14965 - turn off auditing during DB migrations

### DIFF
--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -5,18 +5,3 @@ require 'audit_extensions'
 
 Audit = Audited.audit_class
 Audit.send(:include, AuditExtensions)
-
-module Foreman
-  module DisableAudited
-    extend ActiveSupport::Concern
-
-    included do
-      def self.audited(*args)
-        super
-        self.auditing_enabled = false if Foreman.in_rake?('db:migrate')
-      end
-    end
-  end
-end
-
-::ActiveRecord::Base.send :include, Foreman::DisableAudited

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -120,6 +120,12 @@ class ActiveRecord::Base
     return 20 if Foreman.in_rake?
     Setting.entries_per_page rescue 20
   end
+
+  def self.audited(*args)
+    # do not audit data changes during db migrations
+    super
+    self.auditing_enabled = false if Foreman.in_rake?('db:migrate')
+  end
 end
 
 module ExemptedFromLogging


### PR DESCRIPTION
Move code turning off auditing during db:migrations so that it is
executed earlier than initializers
