### PR TITLE
Fixes #14980 - fixed unused_ip API subnet param

### DIFF
--- a/app/services/ipam/dhcp.rb
+++ b/app/services/ipam/dhcp.rb
@@ -5,7 +5,7 @@ module IPAM
       return unless subnet.dhcp?
       # we have DHCP proxy so asking it for free IP
       logger.debug "Asking #{dhcp.url} for free IP"
-      ip = dhcp_proxy.unused_ip(self, mac)["ip"]
+      ip = dhcp_proxy.unused_ip(subnet, mac)["ip"]
       logger.debug("Found #{ip}")
       ip
     end


### PR DESCRIPTION
The code is passing IPAM object instead of Subnet object to the proxy proxy
class.
