### PR TITLE
Fixes #14313 - improve facts navigation and URL

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -15,24 +15,19 @@ module FactValuesHelper
       else
         if value_name != memo || value.compose
           parameters = { :parent_fact => memo }
-          if params[:host_id]
-            url = host_facts_path(parameters.merge({ :host_id => params[:host_id] }))
-          else
-            url = fact_values_path(parameters)
-          end
+          url = host_parent_fact_facts_path(parameters.merge({ :host_id => params[:host_id] || value.host.name }))
           link_to(current_name, url,
                   :title => _("Show all %s children fact values") % memo)
         else
-          link_to(current_name, fact_values_path("search" => "name = #{value_name}"),
-                  :title => _("Show all %s fact values") % value_name)
+          link_to(current_name, fact_values_path(:search => "name = #{value_name}"),
+                  :title => _("Show %s fact values for all hosts") % value_name)
         end
       end
     end.join(FactName::SEPARATOR).html_safe
 
     if value.compose
-      link_to(icon_text('plus-sign','', :title => _('Expand nested items')),
-              fact_values_path(:parent_fact => value_name)) + ' ' +
-          content_tag(:span, name)
+      url = host_parent_fact_facts_path(:parent_fact => value_name, :host_id => params[:host_id] || value.host.name)
+      link_to(icon_text('plus-sign','', :title => _('Expand nested items')), url) + ' ' + content_tag(:span, name)
     else
       name
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Foreman::Application.routes.draw do
         resources :audits, :only => :index
         resources :facts, :only => :index, :controller => :fact_values
         resources :puppetclasses, :only => :index
+
+        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts'
       end
     end
 
@@ -116,6 +118,7 @@ Foreman::Application.routes.draw do
       end
     end
 
+    get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts'
     resources :facts, :only => [:index, :show] do
       constraints(:id => /[^\/]+/) do
         resources :values, :only => :index, :controller => :fact_values, :as => "host_fact_values"


### PR DESCRIPTION
This brings several improvements:
- title on leave fact link changed to better describe the target
- clicking plus icon leads to the same path as last compose fact (keeping selected host)
- url contains parent fact name `/parent_facts/laguage::ruby/facts` instead of query param like `?parent_fact=laguage::ruby`
