### PR TITLE
Fixes #12225 - invalidate topbar cache after restart

### DIFF
--- a/app/controllers/topbar_sweeper.rb
+++ b/app/controllers/topbar_sweeper.rb
@@ -24,4 +24,8 @@ class TopbarSweeper < ActionController::Caching::Sweeper
   def self.expire_cache(controller)
     controller.expire_fragment(TopbarSweeper.fragment_name) if User.current
   end
+
+  def self.expire_cache_all_users
+    Rails.cache.delete_matched(/#{fragment_name('\d+')}/)
+  end
 end

--- a/config/initializers/expire_cache.rb
+++ b/config/initializers/expire_cache.rb
@@ -1,0 +1,6 @@
+# During restart, newly enabled or disabled plugins may modify topbar menu. For this reason,
+# cache is invalidated for all users. This will work for the default cache provider (files)
+# but might not work with other providers (memcached). On these installations, users need
+# to logout and re-login in order to update the top menu.
+
+TopbarSweeper.expire_cache_all_users


### PR DESCRIPTION
This is my third attempt. Replaces:

https://github.com/theforeman/foreman/pull/3496
