### PR TITLE
Fixes #15038 - reset User cache during migration

### DIFF
--- a/db/migrate/20150612105614_rename_taxonomy_ignored_type_to_provisioning_templates.rb
+++ b/db/migrate/20150612105614_rename_taxonomy_ignored_type_to_provisioning_templates.rb
@@ -16,6 +16,7 @@ class RenameTaxonomyIgnoredTypeToProvisioningTemplates < ActiveRecord::Migration
   private
 
   def swap_name(old, new)
+    User.reset_column_information
     FakeTaxonomy.where("ignore_types LIKE '%#{old}%'").all.each do |taxonomy|
       taxonomy.ignore_types.delete(old)
       taxonomy.ignore_types.push(new)


### PR DESCRIPTION
This commit will update the cache information about columns on the User table.  This is needed due to errors observed during certain upgrades involving the Katello plugin.

@iNecas, This is to address the issue that we discussed earlier today where the following error was observed while this migration was being executed:

```
PG::Error: ERROR:  column users.helptips_enabled does not exist
```
