### PR TITLE
fixes #15040 - remove user fragment cache initializer

### DIFF
--- a/app/controllers/topbar_sweeper.rb
+++ b/app/controllers/topbar_sweeper.rb
@@ -26,6 +26,8 @@ class TopbarSweeper < ActionController::Caching::Sweeper
   end
 
   def self.expire_cache_all_users
-    Rails.cache.delete_matched(/#{fragment_name('\d+')}/)
+    User.unscoped.pluck(:id).each do |id|
+      Rails.cache.delete("views/tabs_and_title_records-#{id}")
+    end
   end
 end

--- a/config/initializers/expire_cache.rb
+++ b/config/initializers/expire_cache.rb
@@ -1,6 +1,0 @@
-# During restart, newly enabled or disabled plugins may modify topbar menu. For this reason,
-# cache is invalidated for all users. This will work for the default cache provider (files)
-# but might not work with other providers (memcached). On these installations, users need
-# to logout and re-login in order to update the top menu.
-
-TopbarSweeper.expire_cache_all_users

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -32,10 +32,5 @@ Menu::Loader.load
 Dashboard::Loader.load
 
 # clear our users topbar cache
-# The User model may not be loaded or the table may not exist in all cases
-# where this initializer is called such as during initial migration of the database
-if defined?(User)
-  User.unscoped.pluck(:id).each do |id|
-    Rails.cache.delete("views/tabs_and_title_records-#{id}")
-  end
-end
+# The users table may not be exist during initial migration of the database
+TopbarSweeper.expire_cache_all_users if User.table_exists?


### PR DESCRIPTION
The initializer added in c3e0fed caused the foreman initializer to fail
as loaded the User model, which it assumes meant the table was present.
This isn't the case when db:migrate runs for the first time.

The new initializer has been removed so as to only keep the existing
cache expiry in the foreman initializer, which now checks for presence
of the table instead. The existing initializer is also compatible with
memcache, preventing an exception starting Rails.

http://ci.theforeman.org/job/test_develop_pull_request/15404/ - running tests manually, due to test_develop failing.
