### PR TITLE
Fixes #15046 - Add possibility to use bmc_nic in provisioning templates

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -74,7 +74,7 @@ class Host::Managed < Host::Base
       :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :primary_interface,
       :provision_interface, :interfaces, :bond_interfaces, :bridge_interfaces, :interfaces_with_identifier,
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
-      :multiboot, :jumpstart_path, :install_path, :miniroot, :medium
+      :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic
   end
 
   scope :recent,      ->(*args) { where(["last_report > ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago)]) }

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -27,6 +27,10 @@ module Nic
       N_('BMC')
     end
 
+    class Jail < Nic::Managed::Jail
+      allow :provider, :username, :password
+    end
+
     private
 
     def ensure_physical

--- a/test/unit/host_jail_test.rb
+++ b/test/unit/host_jail_test.rb
@@ -6,7 +6,7 @@ class HostJailTest < ActiveSupport::TestCase
                :organization, :url_for_boot, :params, :info, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
                :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method, :image_build?,
                :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :facts,
-               :facts_hash]
+               :facts_hash, :bmc_nic]
 
     allowed.each do |m|
       assert Host::Managed::Jail.allowed?(m), "Method #{m} is not available in Host::Managed::Jail while should be allowed."

--- a/test/unit/nic_bmc_jail_test.rb
+++ b/test/unit/nic_bmc_jail_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class NicBMCJailTest < ActiveSupport::TestCase
+  def test_jail_should_include_these_methods
+    allowed = [:provider, :username, :password]
+
+    allowed.each do |m|
+      assert Nic::BMC::Jail.allowed?(m), "Method #{m} is not available in Nic::BMC::Jail while should be allowed."
+    end
+  end
+end


### PR DESCRIPTION
This will add some attributes to jails of managed hosts and bmc nic in order to use them in provisioning templates.
