### PR TITLE
Fixes #14583 - reworded orphan taxonomy validation error

### DIFF
--- a/app/services/tax_host.rb
+++ b/app/services/tax_host.rb
@@ -130,7 +130,7 @@ class TaxHost
       taxable_type = hash_key_to_class(key)
       unless array_values.empty?
         found_orphan = true
-        taxonomy.errors.add(taxable_type.tableize, _("you cannot remove %s that are used by hosts or inherited.") % taxable_type.tableize.humanize.downcase)
+        taxonomy.errors.add(taxable_type.tableize, _("expecting %s used by hosts or inherited (check mismatches report).") % _(taxable_type.tableize.humanize.downcase))
       end
     end
     !found_orphan

--- a/test/models/taxonomy_test.rb
+++ b/test/models/taxonomy_test.rb
@@ -4,6 +4,7 @@ class TaxonomyTest < ActiveSupport::TestCase
   def setup
     SETTINGS.stubs(:[]).with(:organizations_enabled).returns(true)
     SETTINGS.stubs(:[]).with(:locations_enabled).returns(false)
+    SETTINGS.stubs(:[]).with(:unattended).returns(false)
   end
 
   should validate_presence_of(:name)
@@ -80,5 +81,15 @@ class TaxonomyTest < ActiveSupport::TestCase
       assert_equal org1, Organization.expand(org1)
       assert_equal [org1, org2], Organization.expand([org1, org2])
     end
+  end
+
+  test "taxonomy cannot be saved with orphans" do
+    location = Location.create :name => "Velky Tynec"
+    organization = Organization.create :name => "Olomouc"
+    FactoryBot.create(:host, :organization => organization, :location => location)
+    organization.save
+    assert_match /expecting locations/, organization.errors.messages[:locations].first
+    location.save
+    assert_match /expecting organizations/, location.errors.messages[:organizations].first
   end
 end


### PR DESCRIPTION
This error can appear when new Lifecycle Environment or a Hostgroup is being
created. Therefore I suggest to reword it a bit to something more
appropriate. Currently it reads:

```
    hammer organization add-hostgroup --hostgroup-id="6" --id="144"
    Locations you cannot remove locations that are used by hosts or inherited.
```

In this patch, I suggest wording that fits both for UI and API/CLI.
