### PR TITLE
Fixes #15053 - Select AR `order` values for `uniq`

### DIFF
--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -23,5 +23,18 @@ class UserIntegrationTest < ActionDispatch::IntegrationTest
       click_button "Login"
       assert_current_path root_path
     end
+
+    test "login non-admin" do
+      User.current = User.new(roles: Role.all, login: 'non-admin', password: 'changeme',
+                      password_confirmation: 'changeme', auth_source: AuthSourceInternal.first,
+                      mail: 'non-admin@example.com')
+      User.current.save
+
+      visit "/"
+      fill_in "login_login", :with => "non-admin"
+      fill_in "login_password", :with => "changeme"
+      click_button "Login"
+      assert_current_path root_path
+    end
   end
 end


### PR DESCRIPTION
Bug 15053 occurs when we call `uniq` on an ActiveRecord::Relation that
orders on some number of columns without explicitly selecting those
columns. This bug is found using a PostgreSQL database with the DB
error: "SELECT DISTINCT, ORDER BY expressions must appear in select
list"
