### PR TITLE
Fixes #15077 - Error HTML tags are shown

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -124,7 +124,7 @@ module LayoutHelper
         text ||= _("Error")
     end
     header = icon.to_s
-    header += "<strong>#{text}</strong> " if text.present?
+    header += content_tag(:strong, text + ' ') if text.present?
     header.html_safe
   end
 


### PR DESCRIPTION
On some custom errors we show, the alert_header helper is escaping the
HTML tags we put on the alert title.

http://imgur.com/cm6l5ZW

Obviously these shouldn't be escaped. Fix is as simple as marking the
string that puts the tags as html_safe
