### PR TITLE
Fixes #14541 - foreman-rake must preserve environment variables

### DIFF
--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -13,5 +13,5 @@ CMD="$BUNDLER_CMD $RAKE_CMD"
 if [ $USERNAME = foreman ]; then
   RAILS_ENV=production $CMD "$@"
 else
-  su - foreman -s /bin/bash -c 'RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
+  su foreman -s /bin/bash -c 'RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
 fi


### PR DESCRIPTION
After extensive testing it seems that it's not possible to preserve the environment variables with su without also preserving HOME. This solution used sudo instead, would this be acceptable?
