### PR TITLE
Fixes #15050 - Scoped search host name without field no longer ISEs

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -67,7 +67,7 @@ module Hostext
         scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true
       end
       if SETTINGS[:organizations_enabled]
-        scoped_search :in => :organization, :on => :title, :rename => :organization, :complete_value => true
+        scoped_search :in => :organization, :on => :title, :rename => :organization, :complete_value => true, :only_explicit => true
         scoped_search :on => :organization_id, :complete_enabled => false, :only_explicit => true
       end
       scoped_search :in => :config_groups, :on => :name, :complete_value => true, :rename => :config_group, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_config_group


### PR DESCRIPTION
Searching for an existing host's name without any fields specified
results in an SQL error: missing FROM-clause entry for
table \"organizations_hosts\"

setting the field to explicit_only fixes this issue.

This can be reproduced using
`curl -X GET -u admin 'http://localhost:3000/api/v2/hosts?organization_id=2&search=<hostname>'`
where `<hostname>` is an existing hostname

My guess of what the larger issue is:
This has to do with scoped search using AR's [includes](https://git.io/vrVqg)
which generates a sql query with a non-existing table, organization_hosts

This is shown on the command line

`Host.includes([:location, :organization]).where("taxonomies.name" => "org1")
.to_sql.include?("organizations_hosts")`
evaluates to true

I am not sure about what to do for a more permanent fix,
it looks like its the same issue as
https://github.com/theforeman/foreman/commit/5185335248abd0104ec0b791df5e641eeae9da6b
