### PR TITLE
Fixes #15090 - Add scrolling to taxonomy selection

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -307,3 +307,8 @@ a.btn-info span{
     text-overflow: ellipsis;
   }
 }
+
+.dropdown-submenu > .dropdown-menu {
+  max-height: 80vh;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Having more then ~30 locations or organizations will cause the dropdown
to overflow the view.
