### PR TITLE
Fixes #15066 - fix ovirt operating systems and ovirt < 3.6

### DIFF
--- a/app/views/compute_resources/show/_ovirt.html.erb
+++ b/app/views/compute_resources/show/_ovirt.html.erb
@@ -2,3 +2,7 @@
   <td><%= _("URL") %></td>
   <td><%= @compute_resource.url %></td>
 </tr>
+<tr>
+  <td><%= _("Operating systems API supported?") %></td>
+  <td><%= @compute_resource.supports_operating_systems? ? icon_text("ok", "", :kind => "pficon") : icon_text("error-circle-o", "", :kind => "pficon") %></td>
+</tr>


### PR DESCRIPTION
The operating systems endpoint was added in ovirt 3.6
https://bugzilla.redhat.com/show_bug.cgi?id=1050243. Older versions
were failing getting 404 when provisioning.

This patch adds a check for this case. We also cache the operating
system data in compute resource - it saves one request + avoids
overloading logs with 404 when the operating systems are not supported
on ovirt side.

Finally, we show the information about operating systems availability
in the compute resource show page.

If somebody cached the data with ovirt 3.5 and then updates the ovirt
instance, they need to save the compute resource again to refresh the cache.
