### PR TITLE
Refs #13741 - Hidden values use masked input for default value

### DIFF
--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -17,17 +17,12 @@
                    :help_inline => popover('', _('Whether the class parameter value is managed by Foreman.'))
         ) if is_param %>
     <%= param_type_selector(f, :onchange => 'keyTypeChange(this)') %>
-    <% if f.object.hidden_value? %>
-        <%= password_f f, :default_value, :size => "col-md-8", :no_label => false, :value => f.object.default_value_before_type_cast,
-                       :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)), :fullscreen => true %>
-    <% else %>
-        <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
-                       :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)),
-                       :fullscreen => :true,
-                       :rows => :auto,
-                       :help_inline => popover('', _("Value to use when there is no match.")),
-                       :class => "no-stretch" %>
-    <% end %>
+    <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
+                   :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)),
+                   :fullscreen => :true,
+                   :rows => 1,
+                   :help_inline => popover('', _("Value to use when there is no match.")),
+                   :class => "no-stretch #{'masked-input' if f.object.hidden_value?}" %>
     <div class="form-group">
       <%= checkbox_f(f, :use_puppet_default, :label => _('Use Puppet default'),
                      :help_inline => use_puppet_default_help,


### PR DESCRIPTION
This was missed in the pervious commit. Opening a hidden lookup key led
to the default value being displayed using a password input instead of
as a masked text area.
