### PR TITLE
Fixes #15150 - expire topbar cache when session id changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
   before_filter :session_expiry, :update_activity_time, :unless => proc {|c| !SETTINGS[:login] || c.remote_user_provided? || c.api_request? }
   before_filter :set_taxonomy, :require_mail, :check_empty_taxonomy
   before_filter :authorize
+  before_filter :check_session_cache, :unless => :api_request?
   before_filter :welcome, :only => :index, :unless => :api_request?
   around_filter :set_timezone
   layout :display_layout?

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -1,6 +1,11 @@
 module Foreman::Controller::Session
   extend ActiveSupport::Concern
 
+  # expire the topbar cache when accessing under different session id
+  def check_session_cache
+    TopbarSweeper.check_user_session(User.current.id, session.id) if User.current
+  end
+
   def session_expiry
     return if ignore_api_request?
     if session[:expires_at].blank? || (Time.at(session[:expires_at]).utc - Time.now.utc).to_i < 0


### PR DESCRIPTION
Two independent session of the same user should not influence each
other via the topbar cache.
