### PR TITLE
Fixes #15151 - properly convert Fog VMs to_s

### DIFF
--- a/app/models/concerns/fog_extensions/ovirt/server.rb
+++ b/app/models/concerns/fog_extensions/ovirt/server.rb
@@ -12,6 +12,10 @@ module FogExtensions
         alias_method_chain :locked?, :refresh
       end
 
+      def to_s
+        name
+      end
+
       def locked_with_refresh?
         @volumes = nil # force reload volumes
         locked_without_refresh?

--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -19,6 +19,10 @@ module FogExtensions
         @state == "poweredOn"
       end
 
+      def to_s
+        name
+      end
+
       private
 
       attr_reader :raw


### PR DESCRIPTION
Useful for power action pop up alerts to avoid the nasty inspection
strings.
