### PR TITLE
fixes #14905 - enable DHCP orchestration with any boot mode

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -11,8 +11,11 @@ module Orchestration::DHCP
   def dhcp?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
+    #
+    # The subnet boot mode is ignored as DHCP can be required for PXE or image provisioning
+    # steps, while boot mode can be used in templates later.
     (host.nil? || host.managed?) && managed? && hostname.present? && ip_available? && mac_available? &&
-        !subnet.nil? && subnet.dhcp? && subnet.dhcp_boot_mode? && SETTINGS[:unattended] && (!provision? || operatingsystem.present?)
+        !subnet.nil? && subnet.dhcp? && SETTINGS[:unattended] && (!provision? || operatingsystem.present?)
   end
 
   def dhcp_record

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -20,5 +20,5 @@
 </div>
 <%= number_f f, :vlanid, :min => 0, :max => 4095, :help_inline => _("Optional: VLAN ID for this subnet") %>
 <%= selectable_f f, :boot_mode, Subnet.boot_modes_with_translations, {},
-                 :help_inline => _("Default boot mode for interfaces assigned to this subnet") %>
+                 :help_inline => _("Default boot mode for interfaces assigned to this subnet, applied to hosts from provisioning templates") %>
 <%= hidden_field_tag :redirect, params[:redirect] %>

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -53,14 +53,14 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     end
   end
 
-  test 'static boot mode disables dhcp orchestration' do
+  test 'static boot mode still enables dhcp orchestration' do
     if unattended?
       h = FactoryGirl.build(:host, :with_dhcp_orchestration)
       i = FactoryGirl.build(:nic_managed, :ip => '10.0.0.10', :name => 'eth0:0')
       i.host   = h
       i.domain = domains(:mydomain)
       i.subnet = FactoryGirl.build(:subnet_ipv4, :dhcp, :boot_mode => 'Static', :ipam => 'Internal DB')
-      refute i.dhcp?
+      assert i.dhcp?
     end
   end
 


### PR DESCRIPTION
DHCP orchestration remains useful to set up PXE booting to start the
provisioning process, even when a static boot mode because the boot mode
is typically applied later through templates. It's also useful in image
provisioning to bring the host onto the network.

To disable DHCP orchestration, the DHCP Proxy should be unset instead
of changing the boot mode.

Reverts commit 85c6f53.
