### PR TITLE
fixes #15223 - query parameters are now correct.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -255,7 +255,7 @@ function template_info(div, url) {
   // Use a post to avoid request URI too large issues with big forms
   $.ajax({
     type: "POST",
-    url: url + "?provisioning=" + build,
+    url: url + "&provisioning=" + build,
     data: form,
     success: function(response, status, xhr) {
       $(div).html(response);


### PR DESCRIPTION
before this patch, there were two query
parameters (/hosts/template_used?id=47?provisioning=build).
since the view always prepand the hosts ID parameter, it is safe
to assume the URL always contain a leading parameter (e.g.
 /hosts/template_used?id=47).
