### PR TITLE
fixes #15250 - ignore current controller from link_to/hash_for

### DIFF
--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -23,7 +23,7 @@ module Menu
     end
 
     def url
-      add_relative_path(@url || @context.routes.url_for(url_hash.merge(:only_path=>true)))
+      add_relative_path(@url || @context.routes.url_for(url_hash.merge(:only_path=>true).except(:use_route)))
     end
 
     def url_hash

--- a/config/initializers/routing_hash_for.rb
+++ b/config/initializers/routing_hash_for.rb
@@ -19,7 +19,7 @@ module ActionDispatch
                           {},
                           inner_options || {},
                           args,
-                          opts.dup,
+                          opts.merge(:use_route => route_key),
                           route.segment_keys.uniq)
             end
           end

--- a/test/unit/hash_for_test.rb
+++ b/test/unit/hash_for_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class HashForTest < ActionView::TestCase
+  test "hash_for_*_path returns expected elements" do
+    assert_equal({:controller => 'hosts', :action => 'new', :use_route => 'new_host'}, hash_for_new_host_path)
+  end
+
+  test "hash_for_* doesn't memorize options" do
+    assert_equal({:controller => 'audits', :action => 'index', :use_route => 'audits', :search => 'foo'}, hash_for_audits_path(:search => 'foo'))
+    assert_equal({:controller => 'audits', :action => 'index', :use_route => 'audits'}, hash_for_audits_path)
+  end
+
+  test "hash_for_* causes link_to to generate links to root from within nested controller" do
+    opts = url_options.merge(:_recall => {:controller=>"foreman_example/examples", :action=>"index"})
+    expects(:url_options).returns(opts)
+    assert_includes link_to('test', hash_for_hosts_path), 'href="/hosts"'
+  end
+end


### PR DESCRIPTION
When link_to generates a link on a page served from a nested controller
(e.g. foreman_example/examples) with a hash of controller/action from
our hash_for_*_path extension, it calls url_for which added the current
controller prefix to the controller name, and this wouldn't exist.

When linking to hash_for_hosts_path (`:controller => 'hosts', :action =>
'index'`), this would attempt to link to `:controller =>
'foreman_example/hosts'` instead. By returning :use_route from hash_for
as in Rails 4.1, actionpack assumes the controller name is absolute and
will not add the current controller prefix.

Rails source where relative controller is assumed by url_for if no named
route was given (the :use_route option):
https://github.com/rails/rails/blob/v4.2.6/actionpack/lib/action_dispatch/routing/route_set.rb#L695-L698

Rails 4.1 source where :use_route was always added:
https://github.com/rails/rails/blob/v4.1.14.2/actionpack/lib/action_dispatch/routing/route_set.rb#L289-L294
