### PR TITLE
Fixes #15140 - enlarge editable input size after error

### DIFF
--- a/app/assets/javascripts/settings.js
+++ b/app/assets/javascripts/settings.js
@@ -7,7 +7,9 @@ $(document).ready(function() {
     submitdata  : {authenticity_token: AUTH_TOKEN, format : "json"},
     onblur      : 'nothing',
     oneditcomplete : function(){
-      onEnterEdit($(this).parents('.setting'))
+      if ($(this).parents().length > 0) {
+        onEnterEdit($(this).parents('.setting'))
+      }
     },
     callback: function(){
       onLeaveEdit($(this))
@@ -29,6 +31,7 @@ $(document).ready(function() {
       $(this).html(_.escape(editable_value));
     },
     onerror     : function(settings, original, xhr) {
+      onLeaveEdit($(original));
       original.reset();
       var error = $.parseJSON(xhr.responseText)["errors"];
       $.jnotify(error, { type: "error", sticky: true });

--- a/vendor/assets/javascripts/jquery.jeditable.js
+++ b/vendor/assets/javascripts/jquery.jeditable.js
@@ -154,20 +154,16 @@
                 
                 /* figure out how wide and tall we are, saved width and height */
                 /* are workaround for http://dev.jquery.com/ticket/2190 */
-                if (0 == $(self).width()) {
-                    //$(self).css('visibility', 'hidden');
-                    settings.width  = savedwidth;
-                    settings.height = savedheight;
-                } else {
-                    if (settings.width != 'none') {
-                        settings.width = 
-                            settings.autowidth ? $(self).width()  : settings.width;
-                    }
-                    if (settings.height != 'none') {
-                        settings.height = 
-                            settings.autoheight ? $(self).height() : settings.height;
-                    }
+
+                if (settings.width != 'none') {
+                    settings.width =
+                        settings.autowidth ? savedheight  : settings.width;
                 }
+                if (settings.height != 'none') {
+                    settings.height =
+                        settings.autoheight ? savedwidth : settings.height;
+                }
+
                 //$(this).css('visibility', '');
                 
                 /* remove placeholder text, replace is here because of IE */


### PR DESCRIPTION
When unsuccessful edit occurs in setting index, the input shrinks like this:
![in-place-setting](https://cloud.githubusercontent.com/assets/11807069/15751649/7db8845a-28f3-11e6-9f58-b185f5a46895.png)
