### PR TITLE
Fixes #15276 - View only role will have permissions

### DIFF
--- a/db/seeds.d/03-roles.rb
+++ b/db/seeds.d/03-roles.rb
@@ -1,6 +1,6 @@
 # Roles
 def view_permissions
-  Permission.all.map(&:name).select { |permission_name| permission_name.match /view/ }.map(&:to_sym)
+  Permission.all.map(&:name).select { |permission_name| permission_name.match /^view/ }.map(&:to_sym)
 end
 
 default_permissions =


### PR DESCRIPTION
starting with view.

As is it filters for any permissions containing the word view. This means that those with the view roles will also receive permissions for everything involving something like content-views. I think it's better to stick by the convention of starting all view permissions with view_ and filtering by that.
