### PR TITLE
Fixes #15336 - Enables proper deletion of Orgs

### DIFF
--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -6,6 +6,7 @@ class Location < Taxonomy
 
   has_and_belongs_to_many :organizations, :join_table => 'locations_organizations'
   has_many_hosts :dependent => :nullify
+  before_destroy EnsureNotUsedBy.new(:hosts)
 
   has_many :location_parameters, :class_name => 'LocationParameter', :foreign_key => :reference_id, :dependent => :destroy, :inverse_of => :location
   has_many :default_users,       :class_name => 'User',              :foreign_key => :default_location_id

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -6,6 +6,7 @@ class Organization < Taxonomy
 
   has_and_belongs_to_many :locations, :join_table => 'locations_organizations'
   has_many_hosts :dependent => :nullify
+  before_destroy EnsureNotUsedBy.new(:hosts)
 
   has_many :organization_parameters, :class_name => 'OrganizationParameter', :foreign_key => :reference_id,            :dependent => :destroy, :inverse_of => :organization
   has_many :default_users,           :class_name => 'User',                  :foreign_key => :default_organization_id, :dependent => :nullify

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -23,7 +23,6 @@ class Taxonomy < ActiveRecord::Base
     :user_ids, :users, :user_names
 
   belongs_to :user
-  before_destroy EnsureNotUsedBy.new(:hosts)
   after_create :assign_taxonomy_to_user
 
   has_many :taxable_taxonomies, :dependent => :destroy

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -28,7 +28,7 @@
             display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
             display_link_if_authorized(_("Nest"), hash_for_nest_taxonomy_path(taxonomy) ),
             display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy) ),
-            display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :data => { :confirm => _("Delete %s?") % taxonomy.name }, :action => :destroy),
+            display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :data => { :confirm => _("%s %s has %s Hosts and %s Hostgroups that will need to be reassociated post deletion. Delete %s?") % [taxonomy_title, taxonomy.name, taxonomy.hosts.count, taxonomy.hostgroups.count, taxonomy.name]}, :action => :destroy),
             (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
             (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,
                 assign_all_hosts_taxonomy_path(taxonomy),

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -84,12 +84,13 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     end
   end
 
-  test "should NOT destroy location if hosts use it" do
-    FactoryGirl.create(:host, :location => taxonomies(:location1))
-    assert_difference('Location.count', 0) do
+  test "should dissociate hosts from the destroyed location" do
+    host = FactoryGirl.create(:host, :location => taxonomies(:location1))
+    assert_difference('Location.count', -1) do
       delete :destroy, { :id => taxonomies(:location1).to_param }
     end
-    assert_response :unprocessable_entity
+    assert_response :success
+    assert_nil Host::Managed.find(host.id).location
   end
 
   test "should update *_ids. test for domain_ids" do


### PR DESCRIPTION
Prior to this commit if you had an Org/Location with a host and tried to
the delete the Org. You would end up with an error that looks like

<Org> is used by <Host> (RuntimeError)

Basic error is these 2 areas

https://github.com/theforeman/foreman/blob/develop/app/models/taxonomies/organization.rb#L8
and
https://github.com/theforeman/foreman/blob/develop/app/models/taxonomy.rb#L2

`before_destroy EnsureNotUsedBy.new(:hosts)`

The above code is in the super class Taxonomy. This checks to make sure
no associations are there for the organization before destroying.

`has_many_hosts :dependent => :nullify`
The above code is in the sub class Organization/Location. This nullifies
the host association on the deletion of organization/location object.

We basically need `has_many_hosts :dependent => :nullify` to run
before `before_destroy EnsureNotUsedBy.new(:hosts)`

For the proper ordering of these checks

This commit tries to address that ordering issue
