### PR TITLE
Fixes #15284 - reload settings when dev env reload occurs

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -4,7 +4,7 @@ module SettingsHelper
       {:title => _("This setting is defined in the configuration file 'settings.yaml' and is read-only."), :helper => :show_value}) if setting.readonly?
 
     return edit_select(setting, :value,
-      {:select_values => self.send("#{setting.name}_collection").to_json }) if self.respond_to? "#{setting.name}_collection"
+      {:select_values => setting.send("#{setting.name}_collection").to_json }) if setting.respond_to? "#{setting.name}_collection"
 
     case setting.settings_type
       when "boolean"

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -274,9 +274,7 @@ class Setting < ActiveRecord::Base
 
   def self.set(name, description, default, full_name = nil, value = nil, options = {})
     if options.has_key? :collection
-      SettingsHelper.module_eval do
-        define_method("#{name}_collection".to_sym){ options[:collection].call }
-      end
+      define_method("#{name}_collection"){ options[:collection].call }
     end
     {:name => name, :value => value, :description => description, :default => default, :full_name => full_name}
   end

--- a/test/unit/helpers/settings_helper_test.rb
+++ b/test/unit/helpers/settings_helper_test.rb
@@ -3,29 +3,11 @@ require 'test_helper'
 class SettingsHelperTest < ActionView::TestCase
   include SettingsHelper
 
-  test "create a setting with values collection " do
-    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {{:a => "a", :b => "b"}} })
-    setting = Setting.create(options)
-    assert_equal self.send("#{setting.name}_collection"), { :a => "a", :b => "b" }
-    self.expects(:edit_select).with(setting, :value, :select_values => { :a => "a", :b => "b" }.to_json)
-    value(setting)
-  end
-
   test "readonly setting with values collection returns readonly field" do
     options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {{:a => "a", :b => "b"}} })
     setting = Setting.create(options)
     setting.readonly!
     self.expects(:readonly_field)
-    value(setting)
-  end
-
-  test "create a setting with a dynamic collection" do
-    expected_hostgroup_count = Hostgroup.all.count + 1
-    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {Hash[:size => Hostgroup.all.count]} })
-    FactoryGirl.create(:hostgroup, :root_pass => '12345678')
-    setting = Setting.create(options)
-    assert_equal self.send("#{setting.name}_collection"), { :size => expected_hostgroup_count }
-    self.expects(:edit_select).with(setting, :value, :select_values => { :size => expected_hostgroup_count }.to_json)
     value(setting)
   end
 end

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -425,6 +425,20 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal /\Aa.*\Z|\Ab.*\Z/, Setting.convert_array_to_regexp(['a*', 'b*'])
   end
 
+  test "create a setting with values collection " do
+    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {{:a => "a", :b => "b"}} })
+    setting = Setting.create(options)
+    assert_equal setting.send("#{setting.name}_collection"), { :a => "a", :b => "b" }
+  end
+
+  test "create a setting with a dynamic collection" do
+    expected_hostgroup_count = Hostgroup.all.count + 1
+    options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {Hash[:size => Hostgroup.all.count]} })
+    FactoryGirl.create(:hostgroup, :root_pass => '12345678')
+    setting = Setting.create(options)
+    assert_equal setting.send("#{setting.name}_collection"), { :size => expected_hostgroup_count }
+  end
+
   private
 
   def check_parsed_value(settings_type, expected_value, string_value)


### PR DESCRIPTION
Also I've moved the  setting collection logic from `SettingHelper` to `Setting` 
