### PR TITLE
Fixes #15364 - disable Style/ClassCheck cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,10 @@ AllCops:
 Rails:
   Enabled: true
 
+# Don't prefer is_a? over kind_of?
+Style/ClassCheck:
+  Enabled: false
+
 # Don't enforce documentation
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
@theforeman/core I'd like to disable this style cop, please don't hesitate to add +1 / -1, I'll send a message to foreman-dev too.

this cop enforces us using `is_a?` instead of `kind_of?`
