### PR TITLE
Fixes #15372 - Merge the correct hash when adding new volumes

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -86,7 +86,7 @@ module Foreman::Model
     end
 
     def new_volume(attr = { })
-      client.volumes.new(attrs.merge(:allocation => '0G'))
+      client.volumes.new(attr.merge(:allocation => '0G'))
     end
 
     def storage_pools


### PR DESCRIPTION
Use 'attr' passed into the method and not the attrs hash on the cr.
