### PR TITLE
fixes #14913 - configure Hirb/Wirb via irbrc

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -206,11 +206,7 @@ module Foreman
   end
 
   def self.setup_console
-    Wirb.start
-    Hirb.enable
-  rescue
-    warn "Failed to load console gems, starting anyway"
-  ensure
+    ENV['IRBRC'] = File.expand_path('../irbrc', __FILE__)
     puts "For some operations a user must be set, try User.current = User.first"
   end
 end

--- a/config/irbrc
+++ b/config/irbrc
@@ -1,0 +1,6 @@
+begin
+  Wirb.start
+  Hirb.enable
+rescue
+  warn 'Failed to load console gems, starting anyway'
+end


### PR DESCRIPTION
Wirb 2.x can't be started before the IRB session itself, so use an irbrc
file per its docs to activate it and Hirb when starting a console.
