### PR TITLE
fixes #15355 - close interface modal at cr change

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -59,9 +59,7 @@ function computeResourceSelected(item){
       data: data,
       complete: function(){
         foreman.tools.hideSpinner();
-        update_nics(function() {
-          interface_subnet_selected(primary_nic_form().find('select.interface_subnet'));
-        });
+        handle_nic_updates();
       },
       error: function(jqXHR, status, error){
         $('#compute_resource').html(Jed.sprintf(__("Error loading virtual machine information: %s"), error));
@@ -74,6 +72,22 @@ function computeResourceSelected(item){
         update_capabilities($('#capabilities').val());
       }
     })
+  }
+}
+
+function handle_nic_updates() {
+  var modal_window = $('#interfaceModal');
+
+  var handler = function() {
+    update_nics(function() {
+      interface_subnet_selected(primary_nic_form().find('select.interface_subnet'));
+    });
+  };
+
+  if (modal_window.is(":visible")) {
+    modal_window.modal('hide').on('hidden.bs.modal', handler);
+  } else {
+    handler();
   }
 }
 


### PR DESCRIPTION
When creating a new host and selecting the compute resource, an XHR
request is initiated. When a user opens the interface modal before the
XHR request finishes, the open modal is destroyed at the time the
request finishes.
This does not close the modal correctly and the backdrop is not hidden.
The user is now locked in and can not click anything.
This commit closes the modal properly when the XHR finishes.
