### PR TITLE
fixes #15416 - update untouched templates during seed

### DIFF
--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -114,6 +114,13 @@ class SeedsTest < ActiveSupport::TestCase
     seed
   end
 
+  test "does update template that was not modified by user" do
+    seed
+    ProvisioningTemplate.without_auditing { ProvisioningTemplate.find_by_name('Kickstart default').update_attributes(:template => 'test') }
+    seed
+    refute_equal ProvisioningTemplate.find_by_name('Kickstart default').template, 'test'
+  end
+
   test "doesn't add a template back that was deleted" do
     seed
     assert_equal 1, ProvisioningTemplate.destroy_all(:name => 'Kickstart default').size


### PR DESCRIPTION
During upgrades, we run db:seeds again, but provisioning templates
are never updated again after the first time.  This causes issues
like when those templates cease working with the newer versions of
Foreman.  So, this PR updates the contents of the templates if a
user has never modified them.
