### PR TITLE
Fixes #15439 - improved error reporting for media

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -251,8 +251,9 @@ class Operatingsystem < ActiveRecord::Base
   end
 
   def boot_files_uri(medium, architecture, host = nil)
-    raise ::Foreman::Exception.new(N_("Invalid medium for %s"), self) unless media.include?(medium)
-    raise ::Foreman::Exception.new(N_("Invalid architecture for %s"), self) unless architectures.include?(architecture)
+    raise ::Foreman::Exception.new(N_("%{os} medium was not set for host '%{host}'"), :host => host, :os => self) if medium.nil?
+    raise ::Foreman::Exception.new(N_("Invalid medium '%{medium}' for '%{os}'"), :medium => medium, :os => self) unless media.include?(medium)
+    raise ::Foreman::Exception.new(N_("Invalid architecture '%{arch}' for '%{os}'"), :arch => architecture, :os => self) unless architectures.include?(architecture)
     eval("#{self.family}::PXEFILES").values.collect do |img|
       medium_vars_to_uri("#{medium.path}/#{pxedir}/#{img}", architecture.name, self)
     end

--- a/lib/tasks/exports.rake
+++ b/lib/tasks/exports.rake
@@ -42,6 +42,17 @@ exporter_template(:enabled, :managed_hosts_provisioning_summary) do |header, dat
   end
 end
 
+exporter_template(:enabled, :managed_hosts_bootfiles) do |header, data|
+  header << ["Host", "Boot files"]
+  Host::Managed.all.find_each do |host|
+    bootfiles = host.operatingsystem.send(:boot_files_uri, host.medium, host.architecture, host) rescue []
+    data << [
+      host.name,
+      bootfiles.join(' + ')
+    ]
+  end
+end
+
 exporter_template(:disabled, :discovered_hosts_summary) do |header, data|
   header << ["Host", "CPUs", "Memory", "Disks", "Subnet", "Booted IF", "MACs", "IPs", "Created", "Last report"]
   Host::Discovered.all.find_each do |record|


### PR DESCRIPTION
When Katello plugin is installed, it sets media flag according to Content Views
and sometimes it can be nil. Then ugly error message NoMethodError: undefined
method `path' for nil:NilClass is shown. This improves the error message.

Also adds new exporter that shows media URLs - very useful when Katello is
installed.
