### PR TITLE
Fixes #5785 - override class parameter by subnet name

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -101,6 +101,10 @@ class Subnet < ActiveRecord::Base
     "#{name} (#{network_address})"
   end
 
+  def to_s
+    name
+  end
+
   # Subnets are sorted on their priority value
   # [+other+] : Subnet object with which to compare ourself
   # +returns+ : Subnet object with higher precedence

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -173,7 +173,9 @@ module Classification
         next if (options[:skip_fqdn] && element=="fqdn")
         value_method = %w(yaml json).include?(lookup_value.lookup_key.key_type) ? :value_before_type_cast : :value
         computed_lookup_value = {:value => lookup_value.send(value_method), :element => element,
-                                 :element_name => element_name, :managed => lookup_value.use_puppet_default}
+                                 :element_name => element_name}
+
+        computed_lookup_value.merge!({ :managed => lookup_value.use_puppet_default }) if lookup_value.lookup_key.puppet?
         break
       end
       computed_lookup_value


### PR DESCRIPTION
I didn't change `to_label` in case anyone was using it so the simplest thing was adding `to_s` in addition to `to_label`.
