### PR TITLE
Fixes #15471 - Find CA expiry even if some dates are missing

### DIFF
--- a/app/services/proxy_status/puppetca.rb
+++ b/app/services/proxy_status/puppetca.rb
@@ -17,7 +17,7 @@ module ProxyStatus
     end
 
     def expiry
-      ca_cert = find_by_state('valid').sort_by!(&:valid_from).first
+      ca_cert = find_by_state('valid').select{|c| c.valid_from.present?}.min_by(&:valid_from)
       if ca_cert.present?
         ca_cert.expires_at
       else

--- a/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
@@ -12,6 +12,7 @@ class ProxyStatusPuppetcaTest < ActiveSupport::TestCase
       certificates = { "proxy.host2"=>{"state"=>"valid", "fingerprint"=>"SHA256", "serial"=>3, "not_before"=>"2015-12-25T14:33:10UTC", "not_after"=>"2020-12-25T14:33:10UTC"},
                        "secure.proxy"=>{"state"=>"valid", "fingerprint"=>"SHA256", "serial"=>1, "not_before"=>"2015-12-12T14:33:10UTC", "not_after"=>"2020-12-11T14:33:10UTC"},
                        "proxy.host"=>{"state"=>"valid", "fingerprint"=>"SHA256", "serial"=>2, "not_before"=>"2015-12-22T14:33:10UTC", "not_after"=>"2020-12-22T14:33:10UTC"},
+                       "proxy.host.with_no_dates"=>{"state"=>"valid", "fingerprint"=>"SHA256", "serial"=>5, "not_before"=>nil, "not_after"=>nil},
                        "refuted.host"=>{"state"=>"refuted", "fingerprint"=>"SHA256", "serial"=>4, "not_before"=>"2015-12-22T14:33:10UTC", "not_after"=>"2020-12-22T14:33:10UTC"},
                        "pending.host"=>{"state"=>"pending", "fingerprint"=>"SHA256", "serial"=>6}}
       ProxyAPI::Puppetca.any_instance.expects(:all).returns(certificates)
@@ -19,7 +20,7 @@ class ProxyStatusPuppetcaTest < ActiveSupport::TestCase
 
     test 'it returns all certificates' do
       certs = @proxy_status.certs
-      assert_equal(5, certs.length)
+      assert_equal(6, certs.length)
     end
 
     test 'it returns CA certificate by hostname with all fields parsed' do


### PR DESCRIPTION
If some certificates in the puppet CA proxy are missing dates, the proxy
view for puppet CA will be broken as the comparison used to find the CA
certficate's expiry date will fail. This change also adds a minor
optimization - running in O(n) instead of O(nlogn).
