### PR TITLE
Fixes #15406 - Moved puppet outside hosts helper

### DIFF
--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -1,0 +1,141 @@
+module HostDescriptionHelper
+  UI.register_host_description do
+    multiple_actions_provider :base_multiple_actions
+    overview_fields_provider :base_status_overview_fields
+    overview_fields_provider :base_host_overview_fields
+    overview_buttons_provider :base_host_overview_buttons
+    title_actions_provider :base_host_title_actions
+  end
+
+  def base_multiple_actions
+    actions = []
+    if authorized_for(:controller => :hosts, :action => :edit)
+      actions.concat [
+        { :action => [_('Change Group'), select_multiple_hostgroup_hosts_path], :priority => 100 },
+        { :action => [_('Change Environment'), select_multiple_environment_hosts_path], :priority => 200 },
+        { :action => [_('Edit Parameters'), multiple_parameters_hosts_path], :priority => 300 },
+        { :action => [_('Disable Notifications'), multiple_disable_hosts_path], :priority => 400 },
+        { :action => [_('Enable Notifications'), multiple_enable_hosts_path], :priority => 500 },
+        { :action => [_('Disassociate Hosts'), multiple_disassociate_hosts_path], :priority => 600 },
+        { :action => [_('Rebuild Config'), rebuild_config_hosts_path], :priority => 700 },
+      ]
+      actions << { :action => [_('Build Hosts'), multiple_build_hosts_path], :priority => 110 } if SETTINGS[:unattended]
+      actions <<  { :action => [_('Assign Organization'), select_multiple_organization_hosts_path], :priority => 800 }
+      actions <<  { :action => [_('Assign Location'), select_multiple_location_hosts_path], :priority => 900 }
+      actions <<  { :action => [_('Change Owner'), select_multiple_owner_hosts_path], :priority => 1000 } if SETTINGS[:login]
+    end
+    actions << { :action => [_('Change Power State'), select_multiple_power_state_hosts_path], :priority => 1100 } if authorized_for(:controller => :hosts, :action => :power)
+    actions << { :action => [_('Delete Hosts'), multiple_destroy_hosts_path], :priority => 1200 } if authorized_for(:controller => :hosts, :action => :destroy)
+    actions
+  end
+
+  def base_status_overview_fields(host)
+    global_status = host.build_global_status
+    fields = [
+      {
+        :field => [
+          _("Status"),
+          content_tag(:span, ''.html_safe, :class => host_global_status_icon_class(global_status.status)) +
+            content_tag(:span, _(global_status.to_label), :class => host_global_status_class(global_status.status)),
+        ],
+        :priority => 10,
+      },
+    ]
+    fields += host_detailed_status_list(host)
+
+    fields
+  end
+
+  def host_detailed_status_list(host)
+    priority = 10
+    host.host_statuses.sort_by(&:type).map do |status|
+      next unless status.relevant? && !status.substatus?
+      { :field => [
+        _(status.name),
+        content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +
+          content_tag(:span, _(status.to_label), :class => host_global_status_class(status.to_global)),
+      ], :priority => priority += 1 }
+    end.compact
+  end
+
+  def base_host_overview_fields(host)
+    fields = []
+    fields << { :field => [_("Build duration"), build_duration(host)], :priority => 90 }
+    fields << { :field => [_("Build errors"), link_to("Logs from OS installer", build_errors_host_path(:id => host.id))], :priority => 91 } if host.build_errors.present?
+    fields << { :field => [_("Token"), host.token || _("N/A")], :priority => 92 } if User.current.admin
+    fields << { :field => [_("Domain"), link_to(host.domain, hosts_path(:search => "domain = #{host.domain}"))], :priority => 100 } if host.domain.present?
+    fields << { :field => [_("Realm"), link_to(host.realm, hosts_path(:search => "realm = #{host.realm}"))], :priority => 200 } if host.realm.present?
+    fields << { :field => [_("IP Address"), host.ip], :priority => 300 } if host.ip.present?
+    fields << { :field => [_("IPv6 Address"), host.ip6], :priority => 400 } if host.ip6.present?
+    fields << { :field => [_("Comment"), host.comment], :priority => 500 } if host.comment.present?
+    fields << { :field => [_("MAC Address"), host.mac], :priority => 600 } if host.mac.present?
+    fields << { :field => [_("Architecture"), link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}"))], :priority => 700 } if host.arch.present?
+    fields << { :field => [_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => "os_description = #{host.operatingsystem.description}"))], :priority => 800 } if host.operatingsystem.present?
+    fields << { :field => [_("PXE Loader"), host.pxe_loader], :priority => 900 } if host.operatingsystem.present? && !host.image_build?
+    fields << { :field => [_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))], :priority => 1000 } if host.hostgroup.present?
+    fields << { :field => [_("Boot time"), (boot_time = host&.reported_data&.boot_time) ? date_time_relative(boot_time) : _('Not reported')], :priority => 1100 }
+    fields << { :field => [_("Location"), link_to(host.location.title, hosts_path(:search => "location = #{host.location}"))], :priority => 1200 }
+    fields << { :field => [_("Organization"), link_to(host.organization.title, hosts_path(:search => "organization = #{host.organization}"))], :priority => 1300 }
+    if host.owner_type == _("User")
+      fields << { :field => [_("Owner"), (link_to(host.owner, hosts_path(:search => %{user.login = "#{host.owner.login}"})) if host.owner)], :priority => 1400 }
+    else
+      fields << { :field => [_("Owner"), host.owner], :priority => 1400 }
+    end
+    fields << { :field => [_("Certificate Name"), host.certname], :priority => 1500 } if Setting[:use_uuid_for_certificates]
+    fields
+  end
+
+  def base_host_title_actions(host)
+    [
+      {
+        :action => button_group(
+          link_to_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host),
+                                  :title    => _("Edit this host"), :id => "edit-button", :class => 'btn btn-default'),
+          display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host).merge(:auth_object => host, :permission => 'create_hosts'),
+                                  :title    => _("Clone this host"), :id => "clone-button", :class => 'btn btn-default'),
+          if host.build
+            link_to_if_authorized(_("Cancel build"), hash_for_cancelBuild_host_path(:id => host).merge(:auth_object => host, :permission => 'build_hosts'),
+                                  :disabled => host.can_be_built?,
+                                  :title    => _("Cancel build request for this host"), :id => "cancel-build-button", :class => 'btn btn-default')
+          else
+            link_to_if_authorized(_("Build"), hash_for_host_path(:id => host).merge(:auth_object => host, :permission => 'build_hosts', :anchor => "review_before_build"),
+                                  :disabled => !host.can_be_built?,
+                                  :title    => _("Enable rebuild on next host boot"),
+                                  :class    => "btn btn-default",
+                                  :id       => "build-review",
+                                  :data     => { :toggle => 'modal',
+                                                 :target => '#review_before_build',
+                                                 :url    => review_before_build_host_path(:id => host),
+                                               })
+          end
+        ),
+        :priority => 100 },
+      if host.supports_power?
+        {
+          :action => button_group(
+            link_to(_("Loading power state ..."), '#', :disabled => true, :class => 'btn btn-default', :id => :loading_power_state)
+          ),
+          :priority => 200,
+        }
+      end,
+      {
+        :action => button_group(
+          link_to_if_authorized(_("Delete"), hash_for_host_path(:id => host).merge(:auth_object => host, :permission => 'destroy_hosts'),
+                                :class => "btn btn-danger",
+                                :id => "delete-button",
+                                :data => { :message => delete_host_dialog(host) },
+                                :method => :delete)
+        ),
+        :priority => 300,
+      },
+    ].compact
+  end
+
+  def base_host_overview_buttons(host)
+    [
+      { :button => link_to_if_authorized(_("Audits"), hash_for_host_audits_path(:host_id => @host), :title => _("Host audit entries"), :class => 'btn btn-default'), :priority => 100 },
+      ({ :button => link_to_if_authorized(_("Facts"), hash_for_host_facts_path(:host_id => host), :title => _("Browse host facts"), :class => 'btn btn-default'), :priority => 200 } if host.fact_values.any?),
+      ({ :button => link_to_if_authorized(_("Reports"), hash_for_host_config_reports_path(:host_id => host), :title => _("Browse host config management reports"), :class => 'btn btn-default'), :priority => 300 } if host.reports.any?),
+    ].compact
+  end
+end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -126,7 +126,7 @@ module Foreman #:nodoc:
     def_field :name, :description, :url, :author, :author_url, :version, :path
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,
                 :facets, :rbac_registry, :dashboard_widgets, :info_providers, :smart_proxy_references,
-                :renderer_variable_loaders
+                :renderer_variable_loaders, :host_ui_description
 
     # Lists plugin's roles:
     # Foreman::Plugin.find('my_plugin').registered_roles
@@ -542,6 +542,10 @@ module Foreman #:nodoc:
 
     def register_graphql_mutation_field(field_name, mutation_class)
       graphql_types_registry.register_plugin_mutation_field(field_name, mutation_class)
+    end
+
+    def describe_host(&block)
+      @host_ui_description = UI.describe_host(&block)
     end
 
     private

--- a/app/services/ui.rb
+++ b/app/services/ui.rb
@@ -1,0 +1,26 @@
+module UI
+  module_function
+
+  def describe_host(&block)
+    description = HostDescription.new
+    description.instance_eval(&block)
+    description
+  end
+
+  def register_host_description(&block)
+    @local_host_descriptions ||= []
+    @local_host_descriptions << describe_host(&block)
+  end
+
+  def host_descriptions
+    host_descriptions_from_plugins + (@local_host_descriptions || [])
+  end
+
+  class << self
+    private
+
+    def host_descriptions_from_plugins
+      Foreman::Plugin.all.map {|plugin| plugin.host_ui_description}.compact
+    end
+  end
+end

--- a/app/services/ui/host_description.rb
+++ b/app/services/ui/host_description.rb
@@ -1,0 +1,19 @@
+module UI
+  class HostDescription
+    CUSTOMIZATION_POINTS = [:overview_fields, :overview_buttons, :multiple_actions, :title_actions]
+
+    def self.reduce_providers(customization_point)
+      UI.host_descriptions.map(&customization_point).flatten.compact
+    end
+
+    attr_reader(*CUSTOMIZATION_POINTS)
+
+    CUSTOMIZATION_POINTS.each do |customization_point|
+      define_method "#{customization_point}_provider" do |method_sym|
+        value = instance_variable_get("@#{customization_point}") || []
+        value << method_sym
+        instance_variable_set("@#{customization_point}", value)
+      end
+    end
+  end
+end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1464,6 +1464,152 @@ host_info['parameters'] # list of foreman properties that are associated with th
 host_info['environment'] # Host's environment
 
 ----
+[[extending-host-ui]]
+=== Extending host UI
+A plugin can add fields displayed in `Properties` tab on host overview page,
+add buttons to `Details` area on host overview page, add actions to the right
+side of the title area on host overview page and add actions for multiple
+selected hosts.
+
+Adding an item to one of those lists requires adding a helper with a method that
+returns relevant items to your plugin and registering that method in plugin
+description. The methods should return a list of hashes, where each hash will
+have two predefined fields: `:priority` and either `:field`, `:action` or `:button`
+according to the desired extension point. `:priority` value would be used by the
+system to define the order of the items to show. The lower the priority, the
+higher the item will show.
+
+[[extending-host-ui-overview-fields]]
+==== Adding overview fields
+In this case, the method that will contribute overview fields will receive a host
+instance for generating the field. Here are a couple of examples of fields added
+by the core. Notice the `:priority` setting, it will determine the order in which
+the fields are shown.
+
+In plugin helper (`my_plugin_helper.rb`):
+[source, ruby]
+----
+def my_plugin_host_overview_fields(host)
+  fields = []
+  fields << { :field => [_("Build duration"), build_duration(host)], :priority => 90 } # call to other helper method
+  fields << { :field => [_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => "os_description = #{host.operatingsystem.description}"))], :priority => 800 } # creating a linkable item
+  fields << { :field => [_("PXE Loader"), host.pxe_loader], :priority => 900 } # adding a simple value
+
+  fields
+end
+----
+
+Now we have to register our new helper in `engine.rb`:
+[source, ruby]
+----
+Foreman::Plugin.register :my_plugin do
+  describe_host do
+    overview_fields_provider :my_plugin_host_overview_fields
+  end
+end
+----
+
+[[extending-host-ui-overview-buttons]]
+==== Adding overview details buttons
+In this case, the method that will contribute buttons will also receive a host
+instance for generating the action. Here are a couple of examples of actions added
+by the core. Notice the `:priority` setting, it will determine the order in which
+the buttons are shown.
+
+In plugin helper (`my_plugin_helper.rb`):
+[source, ruby]
+----
+def my_plugin_host_overview_buttons(host)
+  [
+    { :button => link_to_if_authorized(_("Audits"), hash_for_host_audits_path(:host_id => host), :title => _("Host audit entries"), :class => 'btn btn-default'), :priority => 100 },
+    { :button => link_to_if_authorized(_("Facts"), hash_for_host_facts_path(:host_id => host), :title => _("Browse host facts"), :class => 'btn btn-default'), :priority => 200 },
+  ]
+end
+----
+
+Now we have to register our new helper in `engine.rb`:
+[source, ruby]
+----
+Foreman::Plugin.register :my_plugin do
+  describe_host do
+    overview_buttons_provider :my_plugin_host_overview_buttons
+  end
+end
+----
+
+[[extending-host-ui-title-actions]]
+==== Adding actions to title area
+In this case, the method that will contribute actions will also receive a host
+instance for generating the action. Here are a couple of examples of actions added
+by the core. Notice the `:priority` setting, it will determine the order in which
+the actions are shown.
+
+In plugin helper (`my_plugin_helper.rb`):
+[source, ruby]
+----
+def my_plugin_host_title_actions(host)
+  [
+    {
+      :action => button_group(
+        link_to_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host),
+                                :title    => _("Edit this host"), :id => "edit-button", :class => 'btn btn-default'),
+        display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host).merge(:auth_object => host, :permission => 'create_hosts'),
+                                :title    => _("Clone this host"), :id => "clone-button", :class => 'btn btn-default'),
+      ),
+      :priority => 100
+    },
+    {
+      :action => button_group(
+        link_to_if_authorized(_("Delete"), hash_for_host_path(:id => host).merge(:auth_object => host, :permission => 'destroy_hosts'),
+                              :class => "btn btn-danger",
+                              :id => "delete-button",
+                              :data => { :message => delete_host_dialog(host) },
+                              :method => :delete)
+      ),
+      :priority => 300,
+    },
+  ]
+end
+----
+
+Now we have to register our new helper in `engine.rb`:
+[source, ruby]
+----
+Foreman::Plugin.register :my_plugin do
+  describe_host do
+    title_actions_provider :my_plugin_host_title_actions
+  end
+end
+----
+
+[[extending-host-ui-multiple-actions]]
+==== Adding actions to multiple host select menu
+In this case, the method that will contribute actions will not receive any parameters.
+Here are a couple of examples of actions added by the core. Notice the `:priority`
+setting, it will determine the order in which the actions are shown.
+
+In plugin helper (`my_plugin_helper.rb`):
+[source, ruby]
+----
+def my_plugin_multiple_actions
+  [
+    { :action => [_('Assign Organization'), select_multiple_organization_hosts_path], :priority => 800 },
+    { :action => [_('Assign Location'), select_multiple_location_hosts_path], :priority => 900 }
+  ]
+end
+----
+
+Now we have to register our new helper in `engine.rb`:
+[source, ruby]
+----
+Foreman::Plugin.register :my_plugin do
+  describe_host do
+    multiple_actions_provider :my_plugin_multiple_actions
+  end
+end
+----
+
+
 [[settings]]
 === Settings
 


### PR DESCRIPTION
In order to make lists of items more extendable, I have changed the way our helpers generate lists of actions/fields.
1. Created a registry that will store a list of methods that are contributing to a each placeholder
2. Modified each item in the list to contain a priority field, so the items could be sorted differently than the order they are added to the list.
3. Kept backwards (plugins) compatibility as much as possible.
### Central registry

Added a singleton class instance that will be used as providers registry - each entry in this registry is a symbol that point to a method that will provide the relevant list items.
Now a helper can declare at module level which methods should be used from that module to provide different items.
Usage example:

``` ruby
module PuppetRelatedHelper
  UI.host_description.multiple_actions_provider :puppet_actions
  UI.host_description.overview_fields_provider :puppet_host_overview_fields

  def puppet_actions
  # ... snip ...
  end

  def puppet_host_overview_fields(host)
  # ... snip ...
  end
```

Files: `app/services/ui.rb` and `app/services/ui/host_description.rb`.
### Priority field

Most of our items lists like multiple_actions, overview_fields e.t.c. are using array of elements to declare the elements that will be used on different host screens. I have modified each item to be a hash that contains two fields: `:action` or `:field` that will contain the original item and `:priority` that will contain the priority of that item.
Instead of:

``` ruby
      actions << [_('Change Puppet Master'), select_multiple_puppet_proxy_hosts_path] if SmartProxy.unscoped.authorized.with_features("Puppet").exists?
```

The code looks like:

``` ruby
      actions << { :action => [_('Change Puppet Master'), select_multiple_puppet_proxy_hosts_path], :priority => 1050 } if SmartProxy.unscoped.authorized.with_features("Puppet").exists?
```
### Backwards (plugin) compatibility

The methods didn't change their name. Which means that other plugins still can `alias_method_chain` to add their items. Methods that implement sorting are aware of the fact that part of the items will be in old format.
