### PR TITLE
Fixes #15464 - Change keys for pagelets

### DIFF
--- a/app/helpers/pagelets_helper.rb
+++ b/app/helpers/pagelets_helper.rb
@@ -1,6 +1,13 @@
 module PageletsHelper
+  def virtual_path
+    @virtual_path
+  end
+
   def pagelets_for(mountpoint)
-    Pagelets::Manager.sorted_pagelets_at("#{controller_name}/#{action_name}", mountpoint)
+    result = ["#{controller_name}/#{action_name}", virtual_path].uniq.map do |key|
+      Pagelets::Manager.pagelets_at(key, mountpoint)
+    end
+    result.flatten.sort
   end
 
   def render_pagelets_for(mountpoint, opts = {})

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -181,7 +181,7 @@ module Foreman #:nodoc:
     # Extends page by adding custom pagelet to a mountpoint.
     # Usage:
     #
-    # extend_page("smart_proxies/show") do |context|
+    # extend_page("hosts/_form") do |context|
     #   context.add_pagelet :mountpoint,
     #                       :name => N_("Example Pagelet"),
     #                       :partial => "path/to/partial",
@@ -189,8 +189,8 @@ module Foreman #:nodoc:
     #                       :id => 'custom-html-id',
     #                       :onlyif => Proc.new { |subject| subject.should_show_pagelet? }
     # end
-    def extend_page(page_name, &block)
-      yield Pagelets::Manager.new(page_name) if block_given?
+    def extend_page(virtual_path, &block)
+      yield Pagelets::Manager.new(virtual_path) if block_given?
     end
 
     def tests_to_skip(hash)

--- a/app/services/pagelets/manager.rb
+++ b/app/services/pagelets/manager.rb
@@ -1,35 +1,31 @@
 module Pagelets
   class Manager
-    def initialize(page_name)
-      @page_name = page_name
+    def initialize(key)
+      @key = key
     end
 
     def add_pagelet(mountpoint, opts)
-      self.class.add_pagelet(@page_name, mountpoint, opts)
+      self.class.add_pagelet(@key, mountpoint, opts)
     end
 
     class << self
-      def add_pagelet(page_name, mountpoint, opts)
-        handle_empty_keys_for page_name, mountpoint
-        raise ::Foreman::Exception.new(N_("Cannot add pagelet to page %s without partial"), page_name) unless opts[:partial]
-        raise ::Foreman::Exception.new(N_("Cannot add pagelet to page %s without mountpoint"), page_name) if mountpoint.nil?
-        priority = opts[:priority] || default_pagelet_priority(page_name, mountpoint)
+      def add_pagelet(key, mountpoint, opts)
+        handle_empty_keys_for key, mountpoint
+        raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without partial"), key) unless opts[:partial]
+        raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without mountpoint"), key) if mountpoint.nil?
+        priority = opts[:priority] || default_pagelet_priority(key, mountpoint)
         pagelet = Pagelets::Pagelet.new(opts.delete(:name), opts.delete(:partial), priority, opts)
-        @pagelets[page_name][mountpoint] << pagelet
+        @pagelets[key][mountpoint] << pagelet
       end
 
-      def default_pagelet_priority(page_name, mountpoint)
+      def default_pagelet_priority(key, mountpoint)
         # We need a default priority value for the first pagelet if it is not specified
-        @pagelets[page_name][mountpoint].map(&:priority).push(0).max + 100
+        @pagelets[key][mountpoint].map(&:priority).push(0).max + 100
       end
 
-      def pagelets_at(page_name, mountpoint)
-        handle_empty_keys_for page_name, mountpoint
-        @pagelets[page_name][mountpoint]
-      end
-
-      def sorted_pagelets_at(page_name, mountpoint)
-        pagelets_at(page_name, mountpoint).sort
+      def pagelets_at(key, mountpoint)
+        handle_empty_keys_for key, mountpoint
+        @pagelets[key][mountpoint]
       end
 
       def clear
@@ -38,10 +34,10 @@ module Pagelets
 
       private
 
-      def handle_empty_keys_for(page_name, mountpoint)
+      def handle_empty_keys_for(key, mountpoint)
         @pagelets ||= {}.with_indifferent_access
-        @pagelets[page_name] ||= {}
-        @pagelets[page_name][mountpoint] ||= []
+        @pagelets[key] ||= {}
+        @pagelets[key][mountpoint] ||= []
       end
     end
   end

--- a/test/unit/pagelet_manager_test.rb
+++ b/test/unit/pagelet_manager_test.rb
@@ -6,21 +6,12 @@ class PageletManagerTest < ActiveSupport::TestCase
     assert_equal 100, ::Pagelets::Manager.pagelets_at("test", :test_point).first.priority
   end
 
-  test 'should return sorted pagelets at mountpoint' do
-    assert_equal 0, ::Pagelets::Manager.sorted_pagelets_at("test", :mountpoint).count
-    ::Pagelets::Manager.add_pagelet("test", :mountpoint, :partial => "tests", :priority => 20)
-    ::Pagelets::Manager.add_pagelet("test", :mountpoint, :partial => "tests", :priority => 15)
-    ::Pagelets::Manager.add_pagelet("test", :mountpoint, :partial => "tests", :priority => 5)
-    assert_equal 3, ::Pagelets::Manager.sorted_pagelets_at("test", :mountpoint).count
-    assert_equal 5, ::Pagelets::Manager.sorted_pagelets_at("test", :mountpoint).first.priority
-  end
-
   test 'should add default priority' do
     ::Pagelets::Manager.add_pagelet("test", :point, :partial => "tests")
     ::Pagelets::Manager.add_pagelet("test", :point, :partial => "tests")
 
-    assert_equal 100, ::Pagelets::Manager.sorted_pagelets_at("test", :point).first.priority
-    assert_equal 200, ::Pagelets::Manager.sorted_pagelets_at("test", :point).last.priority
+    assert_equal 100, ::Pagelets::Manager.pagelets_at("test", :point).sort.first.priority
+    assert_equal 200, ::Pagelets::Manager.pagelets_at("test", :point).sort.last.priority
   end
 
   test '.add_pagelet should raise error when partial is missing' do

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -325,8 +325,8 @@ class PluginTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal 1, ::Pagelets::Manager.sorted_pagelets_at("tests/show", :main_tabs).count
-    assert_equal "My Tab", ::Pagelets::Manager.sorted_pagelets_at("tests/show", :main_tabs).first.name
+    assert_equal 1, ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).count
+    assert_equal "My Tab", ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).first.name
   end
 
   def test_register_facet


### PR DESCRIPTION
Pagelets will be keyed as
"#{controller}/#{partial_name}". This removes
a necessity to register a pagelet multiple times if
a partial is reused for different actions.
