### PR TITLE
fixes #4528 - import structured Puppet facts

### DIFF
--- a/app/services/puppet_fact_importer.rb
+++ b/app/services/puppet_fact_importer.rb
@@ -1,4 +1,4 @@
-class PuppetFactImporter < FactImporter
+class PuppetFactImporter < StructuredFactImporter
   def self.authorized_smart_proxy_features
     'Puppet'
   end

--- a/app/services/structured_fact_importer.rb
+++ b/app/services/structured_fact_importer.rb
@@ -1,0 +1,37 @@
+class StructuredFactImporter < FactImporter
+  def normalize(facts)
+    # Remove empty values first, so nil facts added by normalize_recurse imply compose
+    facts = facts.select { |k, v| v.present? }
+    normalize_recurse({}, facts)
+  end
+
+  # expand {'a' => {'b' => 'c'}} to {'a' => nil, 'a::b' => 'c'}
+  def normalize_recurse(memo, facts, prefix = '')
+    facts.each do |k, v|
+      k = prefix.empty? ? k.to_s : prefix + FactName::SEPARATOR + k.to_s
+      if v.is_a?(Hash)
+        memo[k] = nil
+        normalize_recurse(memo, v, k)
+      else
+        memo[k] = v.to_s
+      end
+    end
+    memo
+  end
+
+  def create_fact_name(fact_names, name, fact_value)
+    if name.include?(FactName::SEPARATOR)
+      parent_name = /(.*)#{FactName::SEPARATOR}/.match(name)[1]
+      parent_fact = create_fact_name(fact_names, parent_name, nil)
+    else
+      parent_fact = nil
+    end
+
+    if fact_names[name]
+      fact_names[name].update_attribute(:compose, fact_value.nil?) if fact_value.nil? && !fact_names[name].compose?
+    else
+      fact_names[name] = fact_name_class.create!(:name => name, :compose => fact_value.nil?, :parent => parent_fact)
+    end
+    fact_names[name]
+  end
+end

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -1,12 +1,15 @@
 require 'test_helper'
 
 class FactImporterTest < ActiveSupport::TestCase
+  attr_reader :importer
   class CustomFactName < FactName; end
   class CustomImporter < FactImporter
     def fact_name_class
       CustomFactName
     end
   end
+
+  let(:host) { FactoryGirl.create(:host) }
 
   test "default importers" do
     assert_includes FactImporter.importers.keys, 'puppet'
@@ -34,12 +37,6 @@ class FactImporterTest < ActiveSupport::TestCase
     end
 
     context 'importing facts' do
-      setup do
-        disable_orchestration
-        User.current = users :admin
-        @host = FactoryGirl.create(:host)
-      end
-
       test 'facts of other type do not collide even if they inherit from FactName' do
         assert_nothing_raised do
           custom_import '_timestamp' => '234'
@@ -49,13 +46,110 @@ class FactImporterTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#import!' do
+    setup do
+      FactoryGirl.create(:fact_value, :value => '2.6.9',:host => host,
+                         :fact_name => FactoryGirl.create(:fact_name, :name => 'kernelversion'))
+      FactoryGirl.create(:fact_value, :value => '10.0.19.33',:host => host,
+                         :fact_name => FactoryGirl.create(:fact_name, :name => 'ipaddress'))
+    end
+
+    test 'importer imports everything as strings' do
+      default_import 'kernelversion' => '2.6.9', 'vda_size' => 4242, 'structured' => {'key' => 'value'}
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '4242', value('vda_size')
+      assert_equal '{"key"=>"value"}', value('structured')
+      refute FactName.find_by_name('structured').compose?
+    end
+
+    test 'importer adds new facts' do
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      default_import 'foo' => 'bar', 'kernelversion' => '2.6.9', 'ipaddress' => '10.0.19.33'
+      assert_equal 'bar', value('foo')
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal 0, importer.counters[:deleted]
+      assert_equal 0, importer.counters[:updated]
+      assert_equal 1, importer.counters[:added]
+    end
+
+    test 'importer removes deleted facts' do
+      default_import 'ipaddress' => '10.0.19.33'
+      assert_nil value('kernelversion')
+
+      assert_equal 1, importer.counters[:deleted]
+      assert_equal 0, importer.counters[:updated]
+      assert_equal 0, importer.counters[:added]
+    end
+
+    test 'importer updates fact values' do
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      default_import 'kernelversion' => '3.8.11', 'ipaddress' => '10.0.19.33'
+      assert_equal '3.8.11', value('kernelversion')
+
+      assert_equal 0, importer.counters[:deleted]
+      assert_equal 1, importer.counters[:updated]
+      assert_equal 0, importer.counters[:added]
+    end
+
+    test "importer shouldn't set nil values" do
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      default_import('kernelversion' => nil, 'ipaddress' => '10.0.19.33')
+      assert_nil value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+
+      assert_equal 1, importer.counters[:deleted]
+      assert_equal 0, importer.counters[:updated]
+      assert_equal 0, importer.counters[:added]
+    end
+
+    test "importer adds, removes and deletes facts" do
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      default_import('kernelversion' => nil, 'ipaddress' => '10.0.19.5', 'uptime' => '1 picosecond')
+      assert_nil value('kernelversion')
+      assert_equal '10.0.19.5', value('ipaddress')
+      assert_equal '1 picosecond', value('uptime')
+
+      assert_equal 1, importer.counters[:deleted]
+      assert_equal 1, importer.counters[:updated]
+      assert_equal 1, importer.counters[:added]
+    end
+
+    test "importer retains 'other' facts" do
+      assert_equal '2.6.9', value('kernelversion')
+      FactoryGirl.create(:fact_value, :value => 'othervalue',:host => host,
+                         :fact_name => FactoryGirl.create(:fact_name_other, :name => 'otherfact'))
+      default_import('ipaddress' => '10.0.19.5', 'uptime' => '1 picosecond')
+      assert_equal 'othervalue', value('otherfact')
+      assert_nil value('kernelversion')
+      assert_equal '10.0.19.5', value('ipaddress')
+      assert_equal '1 picosecond', value('uptime')
+      assert_equal 1, importer.counters[:deleted]
+      assert_equal 1, importer.counters[:updated]
+      assert_equal 1, importer.counters[:added]
+    end
+  end
+
+  def default_import(facts)
+    @importer = FactImporter.new(host, facts)
+    @importer.stubs(:fact_name_class).returns(FactName)
+    @importer.import!
+  end
+
   def custom_import(facts)
-    importer = CustomImporter.new(@host, facts)
-    importer.import!
+    @importer = CustomImporter.new(host, facts)
+    @importer.import!
   end
 
   def puppet_import(facts)
-    importer = PuppetFactImporter.new(@host, facts)
-    importer.import!
+    @importer = PuppetFactImporter.new(host, facts)
+    @importer.import!
+  end
+
+  def value(fact)
+    FactValue.joins(:fact_name).where(:host_id => host.id, :fact_names => { :name => fact }).first.try(:value)
   end
 end

--- a/test/unit/structured_fact_importer_test.rb
+++ b/test/unit/structured_fact_importer_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class StructuredFactImporterTest < ActiveSupport::TestCase
+  attr_reader :importer
+
+  let(:host) { FactoryGirl.create(:host) }
+
+  describe '#import!' do
+    test 'hash facts are imported' do
+      import 'structured' => {'one' => 'value', 'two' => {'two-deep' => 'nested'}}
+      assert_nil value('structured')
+      assert_equal 'value', value('structured::one')
+      assert_equal 'nested', value('structured::two::two-deep')
+    end
+
+    test 'creates compose (parent) facts' do
+      import 'structured' => {'one' => {'two' => 'value'}}
+
+      assert fact_value('structured').compose
+      assert_nil value('structured')
+      assert_nil fact_value('structured').fact_name.parent
+
+      assert fact_value('structured::one').compose
+      assert_nil value('structured::one')
+      assert_equal fact_value('structured').fact_name, fact_value('structured::one').fact_name.parent
+
+      refute fact_value('structured::one::two').compose
+      assert_equal 'value', value('structured::one::two')
+      assert_equal fact_value('structured::one').fact_name, fact_value('structured::one::two').fact_name.parent
+    end
+
+    test 'updates fact values within hashes' do
+      import 'structured' => {'one' => 'value'}
+      assert_equal 'value', value('structured::one')
+      import 'structured' => {'one' => 'changed'}
+      assert_equal 'changed', value('structured::one')
+
+      assert_equal 0, importer.counters[:deleted]
+      assert_equal 1, importer.counters[:updated]
+      assert_equal 0, importer.counters[:added]
+    end
+
+    test 'enables compose attribute of previously string facts' do
+      import 'structured' => 'value'
+      refute fact_value('structured').compose
+      assert_equal 'value', value('structured')
+
+      import 'structured' => {'one' => 'value'}
+      assert fact_value('structured').compose
+      assert_nil value('structured')
+    end
+  end
+
+  describe 'normalize' do
+    test 'has no effect on unstructured facts' do
+      importer = StructuredFactImporter.new(nil, 'a' => 'b')
+      assert_equal({'a' => 'b'}, importer.send(:facts))
+    end
+
+    test 'removes nil fact values' do
+      importer = StructuredFactImporter.new(nil, 'a' => nil)
+      assert_equal({}, importer.send(:facts))
+    end
+
+    test 'changes symbol keys to strings' do
+      importer = StructuredFactImporter.new(nil, :a => 'b')
+      assert_equal({'a' => 'b'}, importer.send(:facts))
+    end
+
+    test 'expands nested hash keys with separators' do
+      importer = StructuredFactImporter.new(nil, 'a' => {'b' => 'c'})
+      assert_equal({'a' => nil, 'a::b' => 'c'}, importer.send(:facts))
+    end
+
+    test 'changes non-string values to strings' do
+      importer = StructuredFactImporter.new(nil, :a => 1)
+      assert_equal({'a' => '1'}, importer.send(:facts))
+    end
+  end
+
+  def import(facts)
+    @importer = StructuredFactImporter.new(host, facts)
+    @importer.stubs(:fact_name_class).returns(FactName)
+    @importer.import!
+  end
+
+  def fact_value(fact)
+    FactValue.joins(:fact_name).where(:host_id => host.id, :fact_names => { :name => fact }).first
+  end
+
+  def value(fact)
+    fact_value(fact).try(:value)
+  end
+end


### PR DESCRIPTION
A new structured fact importer converts nested hashes into the
FactName::SEPARATOR layout used for internal structured fact storage and
extends the regular fact importer to create the hierarchy of FactNames.
This can be used by other plugins requiring structured storage. It does
not support storage of arrays beyond current conversion to strings (http://projects.theforeman.org/issues/15522).
