### PR TITLE
fixes #15525 - always update facts

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -1,6 +1,6 @@
 module FactValuesHelper
   def fact_from(record)
-    _("%s ago") % time_ago_in_words(record.host.last_compile)
+    _("%s ago") % time_ago_in_words(record.updated_at)
   rescue
     _("N/A")
   end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -153,12 +153,7 @@ module Host
 
       time = facts[:_timestamp]
       time = time.to_time if time.is_a?(String)
-
-      # we are not doing anything we already processed this fact (or a newer one)
-      if time
-        return true unless last_compile.nil? or (last_compile + 1.minute < time)
-        self.last_compile = time
-      end
+      self.last_compile = time if time
 
       type = facts.delete(:_type) || 'puppet'
       importer = FactImporter.importer_for(type).new(self, facts)


### PR DESCRIPTION
Previously, last_compile was checked to see if facts were uploaded in the last
minute and if so, ignore processing them.  This code dates back to the very
first tagged version of Foreman in git - but these days we have multiple
providers so this check doesn't make sense.  It's quite conceivable that
Salt/Chef/Puppet/Subscription Manager could upload facts within such a short
window - in fact, it does happen during provisioning.
