### PR TITLE
Fixes #15527 - api/v2/hosts is slow loading permissions

### DIFF
--- a/app/services/authorizer_cache.rb
+++ b/app/services/authorizer_cache.rb
@@ -1,0 +1,14 @@
+module AuthorizerCache
+  def initialize_cache
+    @cache = HashWithIndifferentAccess.new do |h, k|
+      h[k] = HashWithIndifferentAccess.new
+    end
+  end
+
+  def collection_cache_lookup(subject, permission)
+    collection = @cache[subject.class.to_s][permission] ||=
+      find_collection(subject.class, :permission => permission)
+
+    collection.include?(subject)
+  end
+end

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -35,7 +35,7 @@ end
 node :permissions do |host|
   authorizer = Authorizer.new(User.current)
   Permission.where(:resource_type => "Host").all.inject({}) do |hash, permission|
-    hash[permission.name] = authorizer.can?(permission.name, host)
+    hash[permission.name] = authorizer.can?(permission.name, host, false)
     hash
   end
 end


### PR DESCRIPTION
The .eager_load call when called with [] generates a SELECT query that
selects all host attributes. This can cause it to take a lot longer when
there are large number of hosts involved. These attributes are
irrelevant in this context (when they are relevant, they're put in the
scope_components hash)

With 5700 hosts, it takes about 50% less time to run this than to run it
with eager_load.

This is the query I mean:

``` sql
SELECT `hosts`.`id` AS t0_r0, `hosts`.`name` AS t0_r1, `hosts`.`last_compile` AS t0_r2, `hosts`.`last_report` AS t0_r3, `hosts`.`updated_at` AS t0_r4, `hosts`.`created_at` AS t0_r5, `hosts`.`root_pass` AS t0_r6, `hosts`.`architecture_id` AS t0_r7, `hosts`.`operatingsystem_id` AS t0_r8, `hosts`.`environment_id` AS t0_r9, `hosts`.`ptable_id` AS t0_r10, `hosts`.`medium_id` AS t0_r11, `hosts`.`build` AS t0_r12, `hosts`.`comment` AS t0_r13, `hosts`.`disk` AS t0_r14, `hosts`.`installed_at` AS t0_r15, `hosts`.`model_id` AS t0_r16, `hosts`.`hostgroup_id` AS t0_r17, `hosts`.`owner_id` AS t0_r18, `hosts`.`owner_type` AS t0_r19, `hosts`.`enabled` AS t0_r20, `hosts`.`puppet_ca_proxy_id` AS t0_r21, `hosts`.`managed` AS t0_r22, `hosts`.`use_image` AS t0_r23, `hosts`.`image_file` AS t0_r24, `hosts`.`uuid` AS t0_r25, `hosts`.`compute_resource_id` AS t0_r26, `hosts`.`puppet_proxy_id` AS t0_r27, `hosts`.`certname` AS t0_r28, `hosts`.`image_id` AS t0_r29, `hosts`.`organization_id` AS t0_r30, `hosts`.`location_id` AS t0_r31, `hosts`.`type` AS t0_r32, `hosts`.`otp` AS t0_r33, `hosts`.`realm_id` AS t0_r34, `hosts`.`compute_profile_id` AS t0_r35, `hosts`.`provision_method` AS t0_r36, `hosts`.`grub_pass` AS t0_r37, `hosts`.`salt_proxy_id` AS t0_r38, `hosts`.`salt_environment_id` AS t0_r39, `hosts`.`discovery_rule_id` AS t0_r40, `hosts`.`global_status` AS t0_r41, `hosts`.`lookup_value_matcher` AS t0_r42, `hosts`.`chef_proxy_id` AS t0_r43 FROM `hosts` WHERE `hosts`.`type` IN ('Host::Managed')
```

vs just 

``` sql
SELECT `hosts`.* FROM `hosts` WHERE `hosts`.`type` IN ('Host::Managed')
```

In order to reproduce the issue, run the following script with a non-admin user with several roles, who's able to see many hosts (after 5k or so it becomes obviously slow)

```
  User.current = User.find(134)
  authorizer = Authorizer.new(User.current)
  host = Host.last
  puts Benchmark.measure {
    Permission.where(:resource_type => "Host").all.inject({}) do |hash, permission|                                                           puts permission
      puts Benchmark.measure { authorizer.can?(permission.name, host) }
    end
    puts 'total time'
  }
```

I've created this file to benchmark a few more things along the way, but it's tough since Rails delays running the query and chains them, anyone knows how to make it run the queries right away?
