### PR TITLE
Fixes #15570 #14879 - Fixed query syntax in ForemanTrend#find_hosts

### DIFF
--- a/app/models/trends/foreman_trend.rb
+++ b/app/models/trends/foreman_trend.rb
@@ -32,6 +32,6 @@ class ForemanTrend < Trend
   end
 
   def find_hosts
-    trendable.hosts.find(:all, :order => 'name')
+    trendable.hosts.order(:name)
   end
 end


### PR DESCRIPTION
I think the fix in b4fd0508565dad5d8afb646d933498d42ad4307a is incomplete, this should fix it I think :) You should maybe consider backporting it to 1.11 aswell.
