### PR TITLE
fixes #15573 - support rest-client 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.6'
-gem 'rest-client', '~> 1.8.0', :require => 'rest_client'
+gem 'rest-client', '>= 1.8.0', '< 3', :require => 'rest_client'
 gem 'audited-activerecord', '~> 4.0'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '~> 2.0'

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -202,4 +202,16 @@ class ActiveSupport::TestCase
   def next_mac(mac)
     mac.tr(':','').to_i(16).succ.to_s(16).rjust(12, '0').scan(/../).join(':')
   end
+
+  def fake_rest_client_response(data)
+    net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
+    req = RestClient::Request.new(:method => 'get', :url => 'http://localhost:8443')
+    if RestClient::Response.method(:create).arity == 3 # 2.0.0+
+      RestClient::Response.create(data.to_json, net_http_resp, req)
+    elsif RestClient::Response.method(:create).arity == 4 # 1.8.x
+      RestClient::Response.create(data.to_json, net_http_resp, nil, req)
+    else
+      raise "unknown RestClient::Response.create version (#{RestClient.version}, arity #{RestClient::Response.method(:create).arity})"
+    end
+  end
 end

--- a/test/lib/proxy_api/bmc_test.rb
+++ b/test/lib/proxy_api/bmc_test.rb
@@ -2,25 +2,10 @@ require 'test_helper'
 require "mocha/setup"
 
 class ProxyApiBmcTest < ActiveSupport::TestCase
-  # Called before every test method runs. Can be used
-  # to set up fixture information.
   def setup
     @url="http://localhost:8443"
     @options = {:username => "testuser", :password => "fakepass"}
     @testbmc = ProxyAPI::BMC.new({:user => "admin", :password => "secretpass", :url => @url})
-  end
-
-  # Called after every test method runs. Can be used to tear
-  # down fixture information.
-
-  def teardown
-    # Do nothing
-  end
-
-  def fake_response(data)
-    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
-    net_http_resp.add_field 'Set-Cookie', 'Monster'
-    RestClient::Response.create(JSON(data), net_http_resp, nil, RestClient::Request.new(:method=>'get', :url=>'http://localhost:8443'))
   end
 
   test "constructor should complete" do
@@ -34,13 +19,13 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
 
   test "providers should get list of providers" do
     expected = ["freeipmi", "ipmitool"]
-    @testbmc.stubs(:get).returns(fake_response(expected))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(expected))
     assert_equal(expected, @testbmc.providers)
   end
 
   test "providers installed should get list of installed providers" do
     expected = ["freeipmi", "ipmitool"]
-    @testbmc.stubs(:get).returns(fake_response(expected))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(expected))
     assert_equal(expected, @testbmc.providers_installed)
   end
 
@@ -69,7 +54,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
   end
 
   test "boot function should not raise nomethod exception when function does exist" do
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.boot_pxe(@options)
   end
 
@@ -77,7 +62,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     device = "pxe"
     expected_path = "/127.0.0.1/chassis/config/bootdevice/#{device}"
     data = @options.merge({:function => "bootdevice", :device => device})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.boot_pxe(@options)
   end
@@ -86,7 +71,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     device = "disk"
     expected_path = "/127.0.0.1/chassis/config/bootdevice/#{device}"
     data = @options.merge({:function => "bootdevice", :device => device})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.boot_disk(@options)
   end
@@ -95,7 +80,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     device = "cdrom"
     expected_path = "/127.0.0.1/chassis/config/bootdevice/#{device}"
     data = @options.merge({:function => "bootdevice", :device => device})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.boot_cdrom(@options)
   end
@@ -104,7 +89,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     device = "bios"
     expected_path = "/127.0.0.1/chassis/config/bootdevice/#{device}"
     data = @options.merge({:function => "bootdevice", :device => device})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.boot_bios(@options)
   end
@@ -113,7 +98,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "off"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.power_off(@options)
   end
@@ -122,7 +107,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "on"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.power_on(@options)
   end
@@ -131,7 +116,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "cycle"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.power_cycle(@options)
   end
@@ -140,7 +125,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "soft"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response({"result" => true}))
+    @testbmc.stubs(:put).returns(fake_rest_client_response({"result" => true}))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.power_soft(@options)
   end
@@ -149,7 +134,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "off"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.power_off?(@options)
   end
@@ -157,7 +142,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "on"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.power_on?(@options)
   end
@@ -166,7 +151,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "status"
     expected_path = "/127.0.0.1/chassis/power/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.power_status(@options)
   end
@@ -175,7 +160,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "off"
     expected_path = "/127.0.0.1/chassis/identify/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.identify_off(@options)
   end
@@ -183,7 +168,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "on"
     expected_path = "/127.0.0.1/chassis/identify/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:put).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:put).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:put).with(data, expected_path).at_least_once
     @testbmc.identify_on(@options)
   end
@@ -192,7 +177,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "status"
     expected_path = "/127.0.0.1/chassis/identify/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.identify_status(@options)
   end
@@ -201,7 +186,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "ip"
     expected_path = "/127.0.0.1/lan/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.lan_ip(@options)
   end
@@ -210,7 +195,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "netmask"
     expected_path = "/127.0.0.1/lan/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.lan_netmask(@options)
   end
@@ -219,7 +204,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "gateway"
     expected_path = "/127.0.0.1/lan/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.lan_gateway(@options)
   end
@@ -228,7 +213,7 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
     action = "mac"
     expected_path = "/127.0.0.1/lan/#{action}"
     data = @options.merge({:action => action})
-    @testbmc.stubs(:get).returns(fake_response(["fakedata"]))
+    @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
     @testbmc.expects(:get).with(expected_path, data).at_least_once
     @testbmc.lan_mac(@options)
   end

--- a/test/lib/proxy_api/dhcp_test.rb
+++ b/test/lib/proxy_api/dhcp_test.rb
@@ -6,12 +6,6 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     @dhcp = ProxyAPI::DHCP.new({:url => @url})
   end
 
-  def fake_response(data)
-    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
-    net_http_resp.add_field 'Set-Cookie', 'Monster'
-    RestClient::Response.create(JSON(data), net_http_resp, nil, RestClient::Request.new(:method=>'get', :url=>'http://localhost:8443'))
-  end
-
   test "constructor should complete" do
     assert_not_nil(@dhcp)
   end
@@ -26,7 +20,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    @dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_response({:ip=>'192.168.0.50'}))
+    @dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
     assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
   end
 
@@ -47,7 +41,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
       path.include?('192.168.0.0/unused_ip?') &&
         path.include?('from=192.168.0.50') &&
         path.include?('to=192.168.0.150')
-    end.returns(fake_response({:ip=>'192.168.0.50'}))
+    end.returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
     assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
   end
 
@@ -56,7 +50,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    @dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_response({:ip=>'192.168.0.50'}))
+    @dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
     assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock, '00:11:22:33:44:55'))
   end
 end

--- a/test/lib/proxy_api/template_test.rb
+++ b/test/lib/proxy_api/template_test.rb
@@ -6,19 +6,13 @@ class ProxyApiTemplateTest < ActiveSupport::TestCase
     @template = ProxyAPI::Template.new({:url => @url})
   end
 
-  def fake_response(data)
-    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
-    net_http_resp.add_field 'Set-Cookie', 'Monster'
-    RestClient::Response.create(JSON(data), net_http_resp, nil, RestClient::Request.new(:method=>'get', :url=>'http://localhost:8443'))
-  end
-
   test "constructor sets url base path with /unattended" do
     expected = "#{@url}/unattended"
     assert_equal(expected, @template.url)
   end
 
   test "should get template server url" do
-    @template.expects(:get).with('templateServer').returns(fake_response({'templateServer'=>'mytemplateserver'}))
+    @template.expects(:get).with('templateServer').returns(fake_rest_client_response({'templateServer'=>'mytemplateserver'}))
     assert_equal('mytemplateserver', @template.template_url)
   end
 end

--- a/test/unit/smart_proxy_test.rb
+++ b/test/unit/smart_proxy_test.rb
@@ -73,12 +73,4 @@ class SmartProxyTest < ActiveSupport::TestCase
       assert_equal 1, proxy.hosts_count
     end
   end
-
-  private
-
-  def fake_response(data)
-    net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
-    net_http_resp.add_field 'Set-Cookie', 'Monster'
-    RestClient::Response.create(JSON(data), net_http_resp, nil)
-  end
 end


### PR DESCRIPTION
Add a test helper that understands how to create fake responses for both
supported 1.8 and 2.x versions.
