### PR TITLE
Fixes #15576 - Pin GCE-client to < 0.9

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,5 +1,5 @@
 group :gce do
   gem 'fog-google', '<= 0.1.0'
-  gem 'google-api-client', '~> 0.7', :require => 'google/api_client'
+  gem 'google-api-client', '~> 0.8.2', :require => 'google/api_client'
   gem 'sshkey', '~> 1.3'
 end


### PR DESCRIPTION
0.9 is incompatible with fog-google, 0.8.x works, and 0.8.2 is the
latest release we have available in foreman-packaging currently
