### PR TITLE
Refs #13164 - Consistent parameters authorization in api

### DIFF
--- a/app/models/concerns/host_params.rb
+++ b/app/models/concerns/host_params.rb
@@ -61,7 +61,7 @@ module HostParams
 
     def host_params_objects
       # Host parameters should always be first for the uniq order
-      (host_parameters + host_inherited_params_objects.to_a.reverse!).uniq {|param| param.name}
+      (host_parameters.authorized(:view_params) + host_inherited_params_objects.to_a.reverse!).uniq {|param| param.name}
     end
   end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -191,7 +191,7 @@ class Taxonomy < ActiveRecord::Base
   # returns self and parent parameters as a hash
   def parameters(include_source = false)
     hash = parent_params(include_source)
-    self.send("#{type.downcase}_parameters".to_sym).each {|p| hash[p.name] = include_source ? {:value => p.value, :source => sti_name, :safe_value => p.safe_value, :source_name => el.title} : p.value }
+    self.send("#{type.downcase}_parameters".to_sym).authorized(:view_params).each {|p| hash[p.name] = include_source ? {:value => p.value, :source => sti_name, :safe_value => p.safe_value, :source_name => el.title} : p.value }
     hash
   end
 
@@ -211,7 +211,7 @@ class Taxonomy < ActiveRecord::Base
   end
 
   def params_objects
-    (self.send("#{type.downcase}_parameters".to_sym) + taxonomy_inherited_params_objects.to_a.reverse!).uniq {|param| param.name}
+    (self.send("#{type.downcase}_parameters".to_sym).authorized(:view_params) + taxonomy_inherited_params_objects.to_a.reverse!).uniq {|param| param.name}
   end
 
   private

--- a/app/views/api/v2/domains/show.json.rabl
+++ b/app/views/api/v2/domains/show.json.rabl
@@ -6,8 +6,8 @@ child :subnets do
   extends "api/v2/subnets/base"
 end
 
-child :parameters => :parameters do
-  extends "api/v2/parameters/base"
+node do |domain|
+  { :parameters => partial("api/v2/parameters/base", :object => domain.parameters.authorized) }
 end
 
 node do |domain|

--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -2,8 +2,8 @@ object @hostgroup
 
 extends "api/v2/hostgroups/main"
 
-child :group_parameters => :parameters do
-  extends "api/v2/parameters/base"
+node do |hostgroup|
+  { :parameters => partial("api/v2/parameters/base", :object => hostgroup.group_parameters.authorized) }
 end
 
 child :template_combinations do

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -2,8 +2,8 @@ object @host
 
 extends "api/v2/hosts/main"
 
-child :host_parameters => :parameters do
-  extends "api/v2/parameters/base"
+node do |host|
+  { :parameters => partial("api/v2/parameters/base", :object => host.host_parameters.authorized) }
 end
 
 node do |host|

--- a/app/views/api/v2/operatingsystems/show.json.rabl
+++ b/app/views/api/v2/operatingsystems/show.json.rabl
@@ -2,8 +2,8 @@ object @operatingsystem
 
 extends "api/v2/operatingsystems/main"
 
-child :parameters => :parameters do
-  extends "api/v2/parameters/base"
+node do |os|
+  { :parameters => partial("api/v2/parameters/base", :object => os.parameters.authorized) }
 end
 
 child :media do

--- a/app/views/api/v2/subnets/show.json.rabl
+++ b/app/views/api/v2/subnets/show.json.rabl
@@ -6,8 +6,8 @@ child :domains do
   extends "api/v2/domains/base"
 end
 
-child :parameters => :parameters do
-  extends "api/v2/parameters/base"
+node do |subnet|
+  { :parameters => partial("api/v2/parameters/base", :object => subnet.parameters.authorized) }
 end
 
 node do |subnet|

--- a/test/functional/api/v2/domains_controller_test.rb
+++ b/test/functional/api/v2/domains_controller_test.rb
@@ -86,4 +86,19 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
       assert show_response.keys.include?(node), "'#{node}' child node should be in response but was not"
     end
   end
+
+  test "user without view_params permission can't see domain parameters" do
+    setup_user "view", "domains"
+    domain_with_parameter = FactoryGirl.create(:domain, :with_parameter)
+    get :show, {:id => domain_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see domain parameters" do
+    setup_user "view", "domains"
+    setup_user "view", "params"
+    domain_with_parameter = FactoryGirl.create(:domain, :with_parameter)
+    get :show, {:id => domain_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -65,4 +65,19 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal hostgroups(:common).id.to_s, Hostgroup.find_by_name("db").ancestry
   end
+
+  test "user without view_params permission can't see hostgroup parameters" do
+    setup_user "view", "hostgroups"
+    hostgroup_with_parameter = FactoryGirl.create(:hostgroup, :with_parameter)
+    get :show, {:id => hostgroup_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see hostgroup parameters" do
+    setup_user "view", "hostgroups"
+    setup_user "view", "params"
+    hostgroup_with_parameter = FactoryGirl.create(:hostgroup, :with_parameter)
+    get :show, {:id => hostgroup_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -622,4 +622,19 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       assert_equal [@managed_host], assigns(:hosts)
     end
   end
+
+  test "user without view_params permission can't see host parameters" do
+    setup_user "view", "hosts"
+    host_with_parameter = FactoryGirl.create(:host, :with_parameter)
+    get :show, {:id => host_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see host parameters" do
+    setup_user "view", "hosts"
+    setup_user "view", "params"
+    host_with_parameter = FactoryGirl.create(:host, :with_parameter)
+    get :show, {:id => host_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/api/v2/locations_controller_test.rb
+++ b/test/functional/api/v2/locations_controller_test.rb
@@ -273,4 +273,19 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
 
     assert_equal expected_metadata, response.except('results')
   end
+
+  test "user without view_params permission can't see location parameters" do
+    setup_user "view", "locations"
+    location_with_parameter = FactoryGirl.create(:location, :with_parameter)
+    get :show, {:id => location_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see location parameters" do
+    setup_user "view", "locations"
+    setup_user "view", "params"
+    location_with_parameter = FactoryGirl.create(:location, :with_parameter)
+    get :show, {:id => location_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/api/v2/operatingsystems_controller_test.rb
+++ b/test/functional/api/v2/operatingsystems_controller_test.rb
@@ -107,6 +107,21 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_equal operatingsystems(:redhat), assigns(:operatingsystem)
   end
 
+  test "user without view_params permission can't see os parameters" do
+    setup_user "view", "operatingsystems"
+    os_with_parameter = FactoryGirl.create(:operatingsystem, :with_parameter)
+    get :show, {:id => os_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see os parameters" do
+    setup_user "view", "operatingsystems"
+    setup_user "view", "params"
+    os_with_parameter = FactoryGirl.create(:operatingsystem, :with_parameter)
+    get :show, {:id => os_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
+
   private
 
   def os_params

--- a/test/functional/api/v2/organizations_controller_test.rb
+++ b/test/functional/api/v2/organizations_controller_test.rb
@@ -21,4 +21,19 @@ class Api::V2::OrganizationsControllerTest < ActionController::TestCase
       refute_includes assigns(:organizations), org2
     end
   end
+
+  test "user without view_params permission can't see organization parameters" do
+    setup_user "view", "organizations"
+    org_with_parameter = FactoryGirl.create(:organization, :with_parameter)
+    get :show, {:id => org_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see organization parameters" do
+    setup_user "view", "organizations"
+    setup_user "view", "params"
+    org_with_parameter = FactoryGirl.create(:organization, :with_parameter)
+    get :show, {:id => org_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/api/v2/subnets_controller_test.rb
+++ b/test/functional/api/v2/subnets_controller_test.rb
@@ -120,4 +120,19 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test "user without view_params permission can't see subnet parameters" do
+    setup_user "view", "subnets"
+    subnet_with_parameter = FactoryGirl.create(:subnet_ipv4, :with_parameter)
+    get :show, {:id => subnet_with_parameter.to_param, :format => 'json'}
+    assert_empty JSON.parse(response.body)['parameters']
+  end
+
+  test "user with view_params permission can see subnet parameters" do
+    setup_user "view", "subnets"
+    setup_user "view", "params"
+    subnet_with_parameter = FactoryGirl.create(:subnet_ipv4, :with_parameter)
+    get :show, {:id => subnet_with_parameter.to_param, :format => 'json'}
+    assert_not_empty JSON.parse(response.body)['parameters']
+  end
 end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -309,15 +309,15 @@ class HostsControllerTest < ActionController::TestCase
   test 'user with view_params rights should see parameters in a host' do
     setup_user "edit"
     setup_user "view", "params"
-    subnet = FactoryGirl.create(:host, :with_parameter)
-    get :edit, {:id => subnet.id}, set_session_user.merge(:user => users(:one).id)
+    host = FactoryGirl.create(:host, :with_parameter)
+    get :edit, {:id => host.id}, set_session_user.merge(:user => users(:one).id)
     assert_not_nil response.body['Global parameters']
   end
 
   test 'user without view_params rights should not see parameters in a host' do
     setup_user "edit"
-    subnet = FactoryGirl.create(:host, :with_parameter)
-    get :edit, {:id => subnet.id}, set_session_user.merge(:user => users(:one).id)
+    host = FactoryGirl.create(:host, :with_parameter)
+    get :edit, {:id => host.id}, set_session_user.merge(:user => users(:one).id)
     assert_nil response.body['Global parameters']
   end
 


### PR DESCRIPTION
When fetching a host from the api the permission `view_params` was added to `all_parameters` in the response but not to `parameters`. To be consistent `view_params` should be added to both.
