### PR TITLE
Fixes #15601 - to_ip_address cannot retrieve PTR4 record

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -912,8 +912,8 @@ class Host::Managed < Host::Base
   # otherwise, use normal systems dns settings to resolv
   def to_ip_address(name_or_ip)
     return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
-    if dns_ptr_record
-      lookup = dns_ptr_record.dns_lookup(name_or_ip)
+    if dns_record(:ptr4)
+      lookup = dns_record(:ptr4).dns_lookup(name_or_ip)
       return lookup.ip unless lookup.nil?
     end
     # fall back to normal dns resolution

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -3239,6 +3239,38 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#to_ip_address' do
+    setup do
+      @host = FactoryGirl.build(:host)
+    end
+
+    test 'uses host PTR4 record to lookup the IP when present' do
+      stub_dns_record = stub()
+      @host.expects(:dns_record).with(:ptr4).returns(stub_dns_record).twice
+      stub_dns_record.expects(:dns_lookup).with('foo').
+        returns(OpenStruct.new(:ip => '127.0.0.1'))
+      assert '127.0.0.1', @host.to_ip_address('foo')
+    end
+
+    test 'when IP is passed as argument, return it' do
+      assert '127.0.0.1', @host.to_ip_address('127.0.0.1')
+    end
+
+    test 'call host domain resolver if there is no PTR4 record' do
+      @host.domain = FactoryGirl.build(:domain)
+      @host.domain.expects(:nameservers).returns('8.8.8.8')
+      Resolv::DNS.any_instance.expects(:getaddress).with('foo')
+        .returns('127.0.0.1')
+      assert '127.0.0.1', @host.to_ip_address('foo')
+    end
+
+    test 'raises exception when any error happens (no domain)' do
+      assert_raises(::Foreman::WrappedException) do
+        @host.to_ip_address('foo')
+      end
+    end
+  end
+
   private
 
   def parse_json_fixture(relative_path)


### PR DESCRIPTION
After some changes on the DNS orchestration, we removed `dns_ptr_record`
in favor of `dns_record(:ptr4)`. However, `host.to_ip_address` still
calls the old API. We should change that method to use the new API,
otherwise it doesn't work. Furthermore, DHCP orchestration relies
on `to_ip_address` so DHCP orchestration is broken if that method
doesn't work.
