### PR TITLE
fixes #15610 - choose firmware for vsphere vms

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -127,6 +127,7 @@ class ComputeResource < ActiveRecord::Base
   def host_compute_attrs(host)
     { :name => host.vm_name,
       :provision_method => host.provision_method,
+      :firmware_type => host.firmware_type,
       "#{interfaces_attrs_name}_attributes" => host_interfaces_attrs(host) }.with_indifferent_access
   end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -141,6 +141,14 @@ module Foreman::Model
       }
     end
 
+    def firmware_types
+      {
+        "automatic" => N_("Automatic"),
+        "bios" => N_("BIOS"),
+        "efi" => N_("EFI")
+      }
+    end
+
     # vSphere guest OS type descriptions
     # list fetched from RbVmomi::VIM::VirtualMachineGuestOsIdentifier.values and
     # http://pubs.vmware.com/vsphere-60/topic/com.vmware.wssdk.apiref.doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
@@ -332,6 +340,9 @@ module Foreman::Model
 
       args.except!(:hardware_version) if args[:hardware_version] == 'Default'
 
+      firmware_type = args.delete(:firmware_type)
+      args[:firmware] = firmware_mapping(firmware_type) if args[:firmware] == 'automatic'
+
       args.reject! { |k, v| v.nil? }
       args
     end
@@ -503,8 +514,14 @@ module Foreman::Model
         :volumes    => [new_volume],
         :scsi_controller => { :type => scsi_controller_default_type },
         :datacenter => datacenter,
+        :firmware => 'automatic',
         :boot_order => ['network', 'disk']
       )
+    end
+
+    def firmware_mapping(firmware_type)
+      return 'efi' if firmware_type == :uefi
+      'bios'
     end
   end
 end

--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -33,6 +33,17 @@ module PxeLoaderSupport
     def valid_loader_name?(pxe_loader)
       self.all_loaders.include?(pxe_loader)
     end
+
+    def firmware_type(pxe_loader)
+      case pxe_loader
+      when 'None'
+        :none
+      when /UEFI/
+        :uefi
+      else
+        :bios
+      end
+    end
   end
 
   def default_boot_filename

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -916,6 +916,11 @@ class Host::Managed < Host::Base
     modification.run(self, compute_resource.try(:compute_profile_for, compute_profile_id))
   end
 
+  def firmware_type
+    return unless pxe_loader.present?
+    Operatingsystem.firmware_type(pxe_loader)
+  end
+
   private
 
   def compute_profile_present?

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -5,6 +5,11 @@
 
 <%= counter_f f, :corespersocket, :disabled => !new_host, :label => _('Cores per socket'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count, :value => f.object.corespersocket || 1 %>
 <%= text_f f, :memory_mb, :class => "col-md-2", :disabled => !new_host, :label => _("Memory (MB)") %>
+<%= field(f, :firmware, :label => _('Firmware'), :label_size => "col-md-2") do
+  compute_resource.firmware_types.collect do |type, name|
+    radio_button_f f, :firmware, {:disabled => !new_host, :value => type, :text => _(name)}
+  end.join(' ').html_safe
+end %>
 <%= selectable_f f, :cluster, compute_resource.clusters, { :include_blank => _('Please select a cluster') },
                     :class => "col-md-2", :disabled => !new_host,
                     :label => _('Cluster'), :onchange => 'vsphereGetResourcePools(this)',

--- a/app/views/compute_resources_vms/show/_vmware.html.erb
+++ b/app/views/compute_resources_vms/show/_vmware.html.erb
@@ -13,6 +13,7 @@
       <%= prop :mac %>
       <%= prop :cpus %>
       <%= prop :corespersocket, _('Cores per socket') %>
+      <%= prop :firmware, _('Firmware') %>
       <%= prop :hypervisor %>
       <%= prop :connection_state %>
       <%= prop :overall_status %>

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -144,6 +144,32 @@ class VmwareTest < ActiveSupport::TestCase
       assert_equal attrs_out, @cr.parse_args(attrs_in)
     end
 
+    context 'firmware' do
+      test 'chooses BIOS firmware when firmware type is None and firmware is automatic' do
+        attrs_in = HashWithIndifferentAccess.new(:firmware_type => :none, 'firmware' => 'automatic')
+        attrs_out = {:firmware => "bios"}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'chooses BIOS firmware when firmware type is bios and firmware is automatic' do
+        attrs_in = HashWithIndifferentAccess.new(:firmware_type => :bios, 'firmware' => 'automatic')
+        attrs_out = {:firmware => "bios"}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'chooses EFI firmware when pxe loader is set to UEFI and firmware is automatic' do
+        attrs_in = HashWithIndifferentAccess.new(:firmware_type => :uefi, 'firmware' => 'automatic')
+        attrs_out = {:firmware => "efi"}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'chooses BIOS firmware when no pxe loader is set and firmware is automatic' do
+        attrs_in = HashWithIndifferentAccess.new('firmware' => 'automatic')
+        attrs_out = {:firmware => "bios"}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+    end
+
     test "doesn't modify input hash" do
       # else compute profiles won't save properly
       attrs_in = HashWithIndifferentAccess.new("interfaces_attributes"=>{"0"=>{"network"=>"network-17"}})

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -92,4 +92,22 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
       assert_equal "Grub UEFI", @subject.preferred_loader
     end
   end
+
+  describe 'firmware_type' do
+    test 'detects none firmware' do
+      assert_equal :none, DummyPxeLoader.firmware_type('None')
+    end
+
+    test 'detects bios firmware' do
+      assert_equal :bios, DummyPxeLoader.firmware_type('PXELinux BIOS')
+    end
+
+    test 'detects uefi firmware' do
+      assert_equal :uefi, DummyPxeLoader.firmware_type('Grub2 UEFI')
+    end
+
+    test 'defaults to bios firmware' do
+      assert_equal :bios, DummyPxeLoader.firmware_type('Anything')
+    end
+  end
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3482,6 +3482,23 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#firmware_type' do
+    test 'should be :none for host with none loader' do
+      host = FactoryGirl.build(:host, :managed, :pxe_loader => "None")
+      assert_equal :none, host.firmware_type
+    end
+
+    test 'should be :bios for host with bios loader' do
+      host = FactoryGirl.build(:host, :managed, :pxe_loader => "PXELinux BIOS")
+      assert_equal :bios, host.firmware_type
+    end
+
+    test 'should be :uefi for host with uefi loader' do
+      host = FactoryGirl.build(:host, :managed, :pxe_loader => "Grub2 UEFI")
+      assert_equal :uefi, host.firmware_type
+    end
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)


### PR DESCRIPTION
I know efi support is still on it's way, but why not start with this.

We can then later either
- remove the radio buttons
- add an "auto" radio button that passed the correct parameter to fog

@lzap : Do you already have something in mind here?
