### PR TITLE
Fixes #15599 - Unattended controller can access host params

### DIFF
--- a/test/functional/unattended_controller_test.rb
+++ b/test/functional/unattended_controller_test.rb
@@ -263,6 +263,14 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "template with host parameters should return parameters values" do
+    host_param = FactoryGirl.create(:host_parameter, :host => @ub_host, :name => 'my_param')
+    @request.env["HTTP_X_RHN_PROVISIONING_MAC_0"] = "eth0 #{@ub_host.mac}"
+    ProvisioningTemplate.any_instance.stubs(:template).returns("param: <%= @host.params['my_param'] %>")
+    get :host_template, {:kind => 'provision'}
+    assert_match "param: #{host_param.value}", @response.body
+  end
+
   context "location or organizations are not enabled" do
     before do
       SETTINGS[:locations_enabled] = false


### PR DESCRIPTION
`host.params` authorizes according to the permission `view_params` that was added in: https://github.com/theforeman/foreman/commit/c7f55be1eff7519bf83327b23ad2f5e220f62dde.
Unattended controller renders templates without a user when provisioning so the permission can't be checked on the current user. As a result any kickstart template that  uses host.params can't access the parameters and receives an empty value for all host parameters.
This pr adds a user in case of calling `render_template` while provisioning.
