### PR TITLE
Fixes #15621 - WebUI: Cloned roles saved with nil builtin

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -81,7 +81,7 @@ class RolesController < ApplicationController
       new_role = Role.find(params[:original_role_id]).
                    deep_clone(:include => [:filters => :filterings])
       new_role.name    = params[:role][:name]
-      new_role.builtin = false
+      new_role.builtin = 0
     else
       new_role = Role.new(params[:role])
     end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -23,7 +23,7 @@ class Role < ActiveRecord::Base
   include Parameterizable::ByIdName
 
   # Built-in roles
-  BUILTIN_DEFAULT_ROLE = 2
+  BUILTIN_DEFAULT_ROLE = 1
   audited :allow_mass_assignment => true
 
   attr_accessible :name, :permissions
@@ -50,7 +50,7 @@ class Role < ActiveRecord::Base
   has_many :permissions, :through => :filters
 
   validates :name, :presence => true, :uniqueness => true
-  validates :builtin, :inclusion => { :in => 0..2 }
+  validates :builtin, :inclusion => { :in => 0..1 }
 
   scoped_search :on => :name, :complete_value => true
 

--- a/db/migrate/20160718114501_update_existing_builtin_to_boolean1_in_roles.rb
+++ b/db/migrate/20160718114501_update_existing_builtin_to_boolean1_in_roles.rb
@@ -1,0 +1,9 @@
+class UpdateExistingBuiltinToBoolean1InRoles < ActiveRecord::Migration
+  def up
+    roles = Role.where(:builtin => 2)
+    roles.each do |role|
+      role.builtin = 1
+      role.save!
+    end
+  end
+end

--- a/db/migrate/20160718114649_change_builtin_to_boolean_in_roles.rb
+++ b/db/migrate/20160718114649_change_builtin_to_boolean_in_roles.rb
@@ -1,0 +1,9 @@
+class ChangeBuiltinToBooleanInRoles < ActiveRecord::Migration
+  def self.up
+	change_column :roles, :builtin, 'boolean USING CAST(builtin AS boolean)'
+  end
+
+  def self.down
+	change_column :roles, :builtin,  'integer USING CAST(builtin AS integer)'
+  end
+end

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -27,7 +27,7 @@ viewer:
 default_role:
   name: Default role
   id: "7"
-  builtin: "2"
+  builtin: true
 
 destroy_hosts:
   name: Destroy hosts

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -80,6 +80,7 @@ class RolesControllerTest < ActionController::TestCase
       cloned_role = Role.find_by_name('clonedrole')
       assert_not_nil cloned_role
       assert_equal @role.permissions, cloned_role.permissions
+      assert_equal 0, cloned_role.builtin
     end
   end
 end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -63,6 +63,16 @@ class RoleTest < ActiveSupport::TestCase
         assert_equal Role::BUILTIN_DEFAULT_ROLE, role.builtin
       end
     end
+
+    should "have zero or one builtin" do
+      role = Role.new(:name => 'role name')
+      [0, 1, 2].each do |i|
+        role.builtin = i
+        role.save
+        # role should be valid in case of builtin is 0 or 1 else not
+        (i != 2) ? (role.must_be :valid?) : (assert_not role.valid?)
+      end
+    end
   end
 
   describe ".for_current_user" do


### PR DESCRIPTION
The above fix will prevent nil value for 'builtin' attribute for Role while cloning it. The changed files are-

/app/controllers/roles_controller.rb#L84

/test/functional/roles_controller_test.rb#L83
