### PR TITLE
fixes #15628 - activesupport/rdoc dep issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
 gem 'responders', '~> 2.0'
 gem 'roadie-rails', '~> 1.1'
+gem 'rdoc'
+gem 'rdoc-data'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))


### PR DESCRIPTION
Fixes the following error when installing Foreman from source:

```
/opt/foreman/vendor/ruby/2.1.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require': cannot load such file -- rdoc (LoadError)
    from /opt/foreman/vendor/ruby/2.1.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `block in require'
    from /opt/foreman/vendor/ruby/2.1.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:240:in `load_dependency'
    from /opt/foreman/vendor/ruby/2.1.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/markup.rb:8:in `initialize'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/configuration.rb:139:in `new'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/configuration.rb:139:in `initialize'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/apipie_module.rb:26:in `new'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/apipie_module.rb:26:in `configuration'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/extractor.rb:38:in `finish'
    from /opt/foreman/vendor/ruby/2.1.0/gems/apipie-rails-0.3.6/lib/apipie/extractor.rb:179:in `block in <top (required)>'
```
