### PR TITLE
fixes #15625 - vmware: add cdrom only when selected

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -328,7 +328,8 @@ module Foreman::Model
         args[:scsi_controller] = {:type => args.delete(:scsi_controller_type)}
       end
 
-      args[:cdroms] = [new_cdrom] if args.delete(:add_cdrom)
+      add_cdrom = args.delete(:add_cdrom)
+      args[:cdroms] = [new_cdrom] if add_cdrom == '1'
 
       args.except!(:hardware_version) if args[:hardware_version] == 'Default'
 


### PR DESCRIPTION
Rails seems to add a hidden field per checkbox that sets the value to `0` if the checkbox is not checked. The code assumed the value would be `nil`.
