### PR TITLE
Refs #3809 - Turning on the AndOr cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Metrics/ClassLength:
 Performance/FixedSize:
   Exclude:
     - 'test/**/*'
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -200,13 +200,6 @@ Style/AlignHash:
 Style/AlignParameters:
   Enabled: false
 
-# Offense count: 263
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: always, conditionals
-Style/AndOr:
-  Enabled: false
-
 # Offense count: 1075
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -127,7 +127,7 @@ module Api
       end
 
       def process_operatingsystems
-        return unless (ct = params[:config_template]) and (operatingsystems = ct.delete(:operatingsystems))
+        return unless (ct = params[:config_template]) && (operatingsystems = ct.delete(:operatingsystems))
         ct[:operatingsystem_ids] = operatingsystems.collect {|os| os[:id]}
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -198,7 +198,7 @@ class ApplicationController < ActionController::Base
 
   def remote_user_provided?
     return false unless Setting["authorize_login_delegation"]
-    return false if api_request? and !(Setting["authorize_login_delegation_api"])
+    return false if api_request? && !(Setting["authorize_login_delegation_api"])
     (@remote_user = request.env["REMOTE_USER"]).present?
   end
 

--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -18,7 +18,7 @@ module Foreman::Controller::Environments
       end
     end
 
-    if @changed["new"].size > 0 or @changed["obsolete"].size > 0 or @changed["updated"].size > 0
+    if @changed["new"].size > 0 || @changed["obsolete"].size > 0 || @changed["updated"].size > 0
       render "common/_puppetclasses_or_envs_changed"
     else
       notice _("No changes to your environments detected")

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -32,14 +32,14 @@ module Foreman::Controller::SmartProxyAuth
     features = features.call if features.respond_to?(:call)
     allowed_smart_proxies = features.blank? ? SmartProxy.all : SmartProxy.with_features(*features)
 
-    if !Setting[:restrict_registered_smart_proxies] or auth_smart_proxy(allowed_smart_proxies, Setting[:require_ssl_smart_proxies])
+    if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies, Setting[:require_ssl_smart_proxies])
       set_admin_user
       return true
     end
 
     require_login
     unless User.current
-      render_error 'access_denied', :status => :forbidden unless performed? and api_request?
+      render_error 'access_denied', :status => :forbidden unless performed? && api_request?
       return false
     end
     authorize

--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -29,7 +29,7 @@ module Foreman::Controller::TaxonomyMultiple
 
   def update_multiple_taxonomies(type)
     # simple validations
-    if (params[type].nil?) or (id=params[type][:id]).blank?
+    if (params[type].nil?) || (id=params[type][:id]).blank?
       error "No #{type.to_s.classify} selected!"
       redirect_to(hosts_path) and return
     end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -50,7 +50,7 @@ class HostsController < ApplicationController
         @last_reports = ConfigReport.where(:id => @last_report_ids.values)
         # rendering index page for non index page requests (out of sync hosts etc)
         @hostgroup_authorizer = Authorizer.new(User.current, :collection => @hosts.map(&:hostgroup_id).compact.uniq)
-        render :index if title and (@title = title)
+        render :index if title && (@title = title)
       end
       format.yaml { render :text => search.all(:select => "hosts.name").map(&:name).to_yaml }
       format.json
@@ -399,7 +399,7 @@ class HostsController < ApplicationController
 
   def update_multiple_environment
     # simple validations
-    if (params[:environment].nil?) or (id=params["environment"]["id"]).nil?
+    if (params[:environment].nil?) || (id=params["environment"]["id"]).nil?
       error _('No environment selected!')
       redirect_to(select_multiple_environment_hosts_path) and return
     end
@@ -421,7 +421,7 @@ class HostsController < ApplicationController
 
   def update_multiple_owner
     # simple validations
-    if (params[:owner].nil?) or (id=params["owner"]["id"]).nil?
+    if (params[:owner].nil?) || (id=params["owner"]["id"]).nil?
       error _('No owner selected!')
       redirect_to(select_multiple_owner_hosts_path) and return
     end
@@ -720,7 +720,7 @@ class HostsController < ApplicationController
   end
 
   def set_host_type
-    return unless params[:host] and params[:host][:type]
+    return unless params[:host] && params[:host][:type]
     type = params[:host].delete(:type) #important, otherwise mass assignment will save the type.
     if type.constantize.new.is_a?(Host::Base)
       @host      = @host.becomes(type.constantize)
@@ -778,7 +778,7 @@ class HostsController < ApplicationController
 
   def find_multiple
   # Lets search by name or id and make sure one of them exists first
-    if params[:host_names].present? or params[:host_ids].present?
+    if params[:host_names].present? || params[:host_ids].present?
       @hosts = resource_base.where("hosts.id IN (?) or hosts.name IN (?)", params[:host_ids], params[:host_names])
       if @hosts.empty?
         error _('No hosts were found with that id or name')
@@ -827,7 +827,7 @@ class HostsController < ApplicationController
   # if a save failed and the only reason was network conflicts then flag this so that the view
   # is rendered differently and the next save operation will be forced
   def offer_to_overwrite_conflicts
-    @host.overwrite = "true" if @host.errors.any? and @host.errors.are_all_conflicts?
+    @host.overwrite = "true" if @host.errors.any? && @host.errors.are_all_conflicts?
   end
 
   def validate_power_action

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -30,11 +30,11 @@ class UnattendedController < ApplicationController
   end
 
   def hostgroup_template
-    return head(:not_found) unless (params.has_key?("id") and params.has_key?(:hostgroup))
+    return head(:not_found) unless (params.has_key?("id") && params.has_key?(:hostgroup))
 
     template = ProvisioningTemplate.find_by_name(params['id'])
     @host = Hostgroup.find_by_title(params['hostgroup'])
-    return head(:not_found) unless template and @host
+    return head(:not_found) unless template && @host
 
     load_template_vars if template.template_kind.name == 'provision'
     safe_render template.template
@@ -146,7 +146,7 @@ class UnattendedController < ApplicationController
   end
 
   def allowed_to_install?
-    (@host.build or @spoof) ? true : head(:method_not_allowed)
+    (@host.build || @spoof) ? true : head(:method_not_allowed)
   end
 
   # Cleans Certificate and enable autosign. This is run as a before_filter for provisioning templates.
@@ -196,7 +196,7 @@ class UnattendedController < ApplicationController
     ip = request.env['REMOTE_ADDR']
 
     # check if someone is asking on behalf of another system (load balance etc)
-    if request.env['HTTP_X_FORWARDED_FOR'].present? and (ip =~ Regexp.new(Setting[:remote_addr]))
+    if request.env['HTTP_X_FORWARDED_FOR'].present? && (ip =~ Regexp.new(Setting[:remote_addr]))
       ip = request.env['HTTP_X_FORWARDED_FOR']
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,7 +105,7 @@ class UsersController < ApplicationController
     TopbarSweeper.expire_cache(self)
     sso_logout_path = get_sso_method.try(:logout_url)
     session[:user] = @user = User.current = nil
-    if flash[:notice] or flash[:error]
+    if flash[:notice] || flash[:error]
       flash.keep
     else
       session.clear

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
     else
       options = args[1] || {}
       html_options = args[2] || {}
-      unless html_options.has_key?(:'data-id') || (options.is_a?(String) and options.starts_with?("mailto:"))
+      unless html_options.has_key?(:'data-id') || (options.is_a?(String) && options.starts_with?("mailto:"))
         begin
           path = URI.split(url_for(options) || html_options['href'])[5].split(/\//).select {|x| !x.empty?}
           if path.size > 0
@@ -188,7 +188,7 @@ module ApplicationHelper
 
   def searchable?
     return false if (SETTINGS[:login] && !User.current) || @welcome
-    if (controller.action_name == "index") or (defined?(SEARCHABLE_ACTIONS) and (SEARCHABLE_ACTIONS.include?(controller.action_name)))
+    if (controller.action_name == "index") || (defined?(SEARCHABLE_ACTIONS) && (SEARCHABLE_ACTIONS.include?(controller.action_name)))
       controller.respond_to?(:auto_complete_search)
     end
   end

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -26,7 +26,7 @@ module AuditsHelper
         (id_to_label audit.audited_changes.keys[0], audit.audited_changes.values[0]).to_s
       else
         name = audit.auditable_name.blank? ? audit.revision.to_label : audit.auditable_name
-        name += " / #{audit.associated_name}" if audit.associated_id and !audit.associated_name.blank?
+        name += " / #{audit.associated_name}" if audit.associated_id && !audit.associated_name.blank?
         name
     end
   rescue
@@ -37,7 +37,7 @@ module AuditsHelper
     if audit.action == 'update'
       return [] unless audit.audited_changes.present?
       audit.audited_changes.map do |name, change|
-        next if change.nil? or change.to_s.empty?
+        next if change.nil? || change.to_s.empty?
         if name == 'template'
           (_("Provisioning Template content changed %s") % (link_to 'view diff', audit_path(audit))).html_safe if audit_template? audit
         elsif name == "owner_id" || name == "owner_type"

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -29,7 +29,7 @@ module HostsAndHostgroupsHelper
   end
 
   def parent_classes(obj)
-    return obj.hostgroup.classes if obj.is_a?(Host::Base) and obj.hostgroup
+    return obj.hostgroup.classes if obj.is_a?(Host::Base) && obj.hostgroup
     return obj.is_root? ? [] : obj.parent.classes if obj.is_a?(Hostgroup)
     []
   end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -198,7 +198,7 @@ module HostsHelper
   end
 
   def selected?(host)
-    return false if host.nil? or !host.is_a?(Host::Base) or session[:selected].nil?
+    return false if host.nil? || !host.is_a?(Host::Base) || session[:selected].nil?
     session[:selected].include?(host.id.to_s)
   end
 
@@ -242,7 +242,7 @@ module HostsHelper
 
   def name_field(host)
     return if host.name.blank?
-    (SETTINGS[:unattended] and host.managed?) ? host.shortname : host.name
+    (SETTINGS[:unattended] && host.managed?) ? host.shortname : host.name
   end
 
   def overview_fields(host)

--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -2,7 +2,7 @@ module OperatingsystemsHelper
   include CommonParametersHelper
 
   def icon(record, opts = {})
-    return "" if record.blank? or record.name.blank?
+    return "" if record.blank? || record.name.blank?
     family = case record.name
              when /fedora/i
                "Fedora"

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -24,7 +24,7 @@ module SmartProxiesHelper
                                                            merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer, :anchor => 'autosign'))
     end
 
-    if SETTINGS[:unattended] and proxy.has_feature?('DHCP')
+    if SETTINGS[:unattended] && proxy.has_feature?('DHCP')
       actions << display_link_if_authorized(_("Import IPv4 subnets"), hash_for_import_subnets_path(:smart_proxy_id => proxy))
     end
 

--- a/app/helpers/unattended_helper.rb
+++ b/app/helpers/unattended_helper.rb
@@ -2,7 +2,7 @@ module UnattendedHelper
   include Foreman::Renderer
 
   def ks_console
-    (@port and @baud) ? "console=ttyS#{@port},#{@baud}": ""
+    (@port && @baud) ? "console=ttyS#{@port},#{@baud}": ""
   end
 
   def grub_pass

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -65,7 +65,7 @@ module Foreman::Model
     end
 
     def regions
-      return [] if user.blank? or password.blank?
+      return [] if user.blank? || password.blank?
       @regions ||= client.describe_regions.body["regionInfo"].map { |r| r["regionName"] }
     end
 

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -246,7 +246,7 @@ module Foreman::Model
     end
 
     def validate_volume_capacity(vol)
-      if vol.capacity.to_s.empty? or /\A\d+G?\Z/.match(vol.capacity.to_s).nil?
+      if vol.capacity.to_s.empty? || /\A\d+G?\Z/.match(vol.capacity.to_s).nil?
         raise Foreman::Exception.new(N_("Please specify volume size. You may optionally use suffix 'G' to specify volume size in gigabytes."))
       end
     end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -142,7 +142,7 @@ module Foreman::Model
 
     def test_connection(options = {})
       super
-      if errors[:url].empty? and errors[:username].empty? and errors[:password].empty?
+      if errors[:url].empty? && errors[:username].empty? && errors[:password].empty?
         update_public_key options
         datacenters && test_https_required
       end

--- a/app/models/concerns/fog_extensions/vsphere/folder.rb
+++ b/app/models/concerns/fog_extensions/vsphere/folder.rb
@@ -3,7 +3,7 @@ module FogExtensions
     module Folder
       extend ActiveSupport::Concern
       def to_label
-        if parent and parent != datacenter
+        if parent && parent != datacenter
           "#{parent} / #{name}"
         else
           name == "vm" ? "VM Folder" : name

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -68,7 +68,7 @@ module HostCommon
   end
 
   def puppetca?
-    return false if self.respond_to?(:managed?) and !managed?
+    return false if self.respond_to?(:managed?) && !managed?
     puppetca_exists?
   end
 
@@ -91,10 +91,10 @@ module HostCommon
   # Else if the host/hostgroup's operatingsystem has only one media then use the image_path from that as this is automatically displayed when there is only one item
   # Else we cannot provide a default and it is cut and paste time
   def default_image_file
-    return "" unless operatingsystem and operatingsystem.supports_image
+    return "" unless operatingsystem && operatingsystem.supports_image
     if medium
       nfs_path = medium.try :image_path
-      if operatingsystem.try(:media) and operatingsystem.media.size == 1
+      if operatingsystem.try(:media) && operatingsystem.media.size == 1
         nfs_path ||= operatingsystem.media.first.image_path
       end
       # We encode the hw_model into the image file name as not all Sparc flashes can contain all possible hw_models. The user can always
@@ -110,7 +110,7 @@ module HostCommon
   def image_file=(file)
     # We only save a value into the image_file field if the value is not the default path, (which was placed in the entry when it was displayed,)
     # and it is not a directory, (ends in /)
-    value = ((default_image_file == file) or (file =~ /\/\Z/) or file == "") ? nil : file
+    value = ((default_image_file == file) || (file =~ /\/\Z/) || file == "") ? nil : file
     write_attribute :image_file, value
   end
 
@@ -231,7 +231,7 @@ module HostCommon
 
   # fall back to our puppet proxy in case our puppet ca is not defined/used.
   def check_puppet_ca_proxy_is_required?
-    return true if puppet_ca_proxy_id.present? or puppet_proxy_id.blank?
+    return true if puppet_ca_proxy_id.present? || puppet_proxy_id.blank?
     if puppet_proxy.has_feature?('Puppet CA')
       self.puppet_ca_proxy ||= puppet_proxy
     end

--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -141,7 +141,7 @@ module Orchestration
 
     update_cache
     # if we have no failures - we are done
-    return true if q.failed.empty? and q.pending.empty? and q.conflict.empty? and orchestration_errors?
+    return true if q.failed.empty? && q.pending.empty? && q.conflict.empty? && orchestration_errors?
 
     logger.warn "Rolling back due to a problem: #{q.failed + q.conflict}"
     fail_queue(q)

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -15,7 +15,7 @@ module Orchestration::Compute
   end
 
   def compute_object
-    if uuid.present? and compute_resource_id.present?
+    if uuid.present? && compute_resource_id.present?
       compute_resource.find_vm_by_uuid(uuid) rescue nil
       # we don't want the fact that we failed to fetch the information to break foreman
       # this is mostly relevant when the orchestration had a failure, and later on in the ui we try to retrieve the server again.
@@ -44,7 +44,7 @@ module Orchestration::Compute
   protected
 
   def queue_compute
-    return unless compute? and errors.empty?
+    return unless compute? && errors.empty?
     new_record? ? queue_compute_create : queue_compute_update
   end
 
@@ -69,7 +69,7 @@ module Orchestration::Compute
   end
 
   def queue_compute_destroy
-    return unless errors.empty? and compute_resource_id.present? and uuid
+    return unless errors.empty? && compute_resource_id.present? && uuid
     queue.create(:name   => _("Removing compute instance %s") % self, :priority => 100,
                  :action => [self, :delCompute])
   end
@@ -196,7 +196,7 @@ module Orchestration::Compute
   private
 
   def compute_update_required?
-    return false unless compute_resource.supports_update? and !compute_attributes.nil?
+    return false unless compute_resource.supports_update? && !compute_attributes.nil?
     old.compute_attributes = compute_resource.find_vm_by_uuid(uuid).attributes
     compute_resource.update_required?(old.compute_attributes, compute_attributes.symbolize_keys)
   end

--- a/app/models/concerns/orchestration/puppetca.rb
+++ b/app/models/concerns/orchestration/puppetca.rb
@@ -43,7 +43,7 @@ module Orchestration::Puppetca
   private
 
   def queue_puppetca
-    return unless puppetca? and errors.empty?
+    return unless puppetca? && errors.empty?
     return unless Setting[:manage_puppetca]
     new_record? ? queue_puppetca_create : queue_puppetca_update
   end
@@ -54,14 +54,14 @@ module Orchestration::Puppetca
 
   def queue_puppetca_update
     # Host has been built --> remove auto sign
-    if old.build? and !build?
+    if old.build? && !build?
       queue.create(:name => _("Delete autosign entry for %s") % self, :priority => 50,
                    :action => [self, :delAutosign])
     end
   end
 
   def queue_puppetca_destroy
-    return unless puppetca? and errors.empty?
+    return unless puppetca? && errors.empty?
     return unless Setting[:manage_puppetca]
     queue.create(:name => _("Delete PuppetCA certificates for %s") % self, :priority => 50,
                  :action => [self, :delCertificate])

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -13,7 +13,7 @@ module Orchestration::SSHProvision
   protected
 
   def queue_ssh_provision
-    return unless ssh_provision? and errors.empty?
+    return unless ssh_provision? && errors.empty?
     new_record? ? queue_ssh_provision_create : queue_ssh_provision_update
   end
 
@@ -43,11 +43,11 @@ module Orchestration::SSHProvision
 
   def setSSHWaitForResponse
     logger.info "Starting SSH provisioning script - waiting for #{provision_ip} to respond"
-    if compute_resource.respond_to?(:key_pair) and compute_resource.key_pair.try(:secret)
+    if compute_resource.respond_to?(:key_pair) && compute_resource.key_pair.try(:secret)
       credentials = { :key_data => [compute_resource.key_pair.secret] }
-    elsif vm.respond_to?(:password) and vm.password.present?
+    elsif vm.respond_to?(:password) && vm.password.present?
       credentials = { :password => vm.password, :auth_methods => ["password", "keyboard-interactive"] }
-    elsif image.respond_to?(:password) and image.password.present?
+    elsif image.respond_to?(:password) && image.password.present?
       credentials = { :password => image.password, :auth_methods => ["password", "keyboard-interactive"] }
     else
       raise ::Foreman::Exception.new(N_('Unable to find proper authentication method'))

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -135,9 +135,9 @@ module Orchestration::TFTP
     # we switched build mode
     set_tftp = true if old.host.build? != host.build?
     # medium or arch changed
-    set_tftp = true if old.host.medium.try(:id) != host.medium.try(:id) or old.host.arch.try(:id) != host.arch.try(:id)
+    set_tftp = true if old.host.medium.try(:id) != host.medium.try(:id) || old.host.arch.try(:id) != host.arch.try(:id)
     # operating system changed
-    set_tftp = true if host.operatingsystem and old.host.operatingsystem and (old.host.operatingsystem.name != host.operatingsystem.name or old.host.operatingsystem.try(:id) != host.operatingsystem.try(:id))
+    set_tftp = true if host.operatingsystem && old.host.operatingsystem && (old.host.operatingsystem.name != host.operatingsystem.name || old.host.operatingsystem.try(:id) != host.operatingsystem.try(:id))
     # MAC address changed
     if mac != old.mac
       set_tftp = true

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -64,7 +64,7 @@ class Domain < ActiveRecord::Base
   end
 
   def proxy
-    ProxyAPI::DNS.new(:url => dns.url) if dns and !dns.url.blank?
+    ProxyAPI::DNS.new(:url => dns.url) if dns && !dns.url.blank?
   end
 
   def lookup(query)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -3,7 +3,7 @@ module Host
     type = "Host::Managed"
     case method.to_s
     when /create/, 'new'
-      if args.empty? or args[0].nil? # got no parameters
+      if args.empty? || args[0].nil? # got no parameters
         #set the default type
         args = [{:type => type}]
       else # got some parameters

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -140,7 +140,7 @@ class Host::Managed < Host::Base
   scope :alerts_enabled, -> { where(:enabled => true) }
 
   scope :run_distribution, lambda { |fromtime,totime|
-    if fromtime.nil? or totime.nil?
+    if fromtime.nil? || totime.nil?
       raise ::Foreman.Exception.new(N_("invalid time range"))
     else
       joins("INNER JOIN reports ON reports.host_id = hosts.id").where("reports.reported_at BETWEEN ? AND ?", fromtime, totime)
@@ -378,8 +378,8 @@ class Host::Managed < Host::Base
     param = {}
     # maybe these should be moved to the common parameters, leaving them in for now
     param["puppetmaster"] = puppetmaster
-    param["domainname"]   = domain.name unless domain.nil? or domain.name.nil?
-    param["foreman_domain_description"] = domain.fullname unless domain.nil? or domain.fullname.nil?
+    param["domainname"]   = domain.name unless domain.nil? || domain.name.nil?
+    param["foreman_domain_description"] = domain.fullname unless domain.nil? || domain.fullname.nil?
     param["realm"]        = realm.name unless realm.nil?
     param["hostgroup"]    = hostgroup.to_label unless hostgroup.nil?
     if SETTINGS[:locations_enabled]
@@ -393,8 +393,8 @@ class Host::Managed < Host::Base
       param["puppet_ca"]    = puppet_ca_server if puppetca_exists?
     end
     param["comment"]      = comment unless comment.blank?
-    param["foreman_env"]  = environment.to_s unless environment.nil? or environment.name.nil?
-    if SETTINGS[:login] and owner
+    param["foreman_env"]  = environment.to_s unless environment.nil? || environment.name.nil?
+    if SETTINGS[:login] && owner
       param["owner_name"]  = owner.name
       param["owner_email"] = owner.is_a?(User) ? owner.mail : owner.users.map(&:mail)
     end
@@ -501,7 +501,7 @@ class Host::Managed < Host::Base
       next unless value.is_a?(String)
 
       # we already have this parameter
-      next if myparams.has_key?(param) and myparams[param] == value
+      next if myparams.has_key?(param) && myparams[param] == value
 
       unless (hp = self.host_parameters.create(:name => param, :value => value))
         logger.warn "Failed to import #{param}/#{value} for #{name}: #{hp.errors.full_messages.join(', ')}"
@@ -607,7 +607,7 @@ class Host::Managed < Host::Base
     return unless hostgroup
     assign_hostgroup_attributes(%w{domain_id})
 
-    if SETTINGS[:unattended] and (new_record? or managed?)
+    if SETTINGS[:unattended] && (new_record? || managed?)
       inherited_attributes = %w{operatingsystem_id architecture_id}
       inherited_attributes << "subnet_id" unless compute_provides?(:ip)
       inherited_attributes << "subnet6_id" unless compute_provides?(:ip6)
@@ -980,7 +980,7 @@ class Host::Managed < Host::Base
         errors.add("#{e}_id".to_sym, _("%{value} does not belong to %{os} operating system") % { :value => value, :os => os })
         status = false
       end
-    end if SETTINGS[:unattended] and managed? and os and pxe_build?
+    end if SETTINGS[:unattended] && managed? && os && pxe_build?
 
     puppetclasses.select("puppetclasses.id,puppetclasses.name").uniq.each do |e|
       unless environment.puppetclasses.map(&:id).include?(e.id)
@@ -998,7 +998,7 @@ class Host::Managed < Host::Base
   end
 
   def set_certname
-    self.certname = Foreman.uuid if read_attribute(:certname).blank? or new_record?
+    self.certname = Foreman.uuid if read_attribute(:certname).blank? || new_record?
   end
 
   def provision_method_in_capabilities

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -65,7 +65,7 @@ class LookupValue < ActiveRecord::Base
   end
 
   def validate_and_cast_value
-    return true if self.marked_for_destruction? or !self.value.is_a? String
+    return true if self.marked_for_destruction? || !self.value.is_a?(String)
     begin
       unless self.lookup_key.contains_erb?(value)
         Foreman::Parameters::Caster.new(self, :attribute_name => :value, :to => lookup_key.key_type).cast!

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -277,7 +277,7 @@ class Operatingsystem < ActiveRecord::Base
   end
 
   def downcase_release_name
-    self.release_name.downcase! unless Foreman.in_rake? or release_name.nil? or release_name.empty?
+    self.release_name.downcase! unless Foreman.in_rake? || release_name.nil? || release_name.empty?
   end
 
   def reject_empty_provisioning_template(attributes)

--- a/app/models/parameters/location_parameter.rb
+++ b/app/models/parameters/location_parameter.rb
@@ -16,7 +16,7 @@ class LocationParameter < Parameter
 
   def enforce_permissions(operation)
     # We get called again with the operation being set to create
-    return true if operation == "edit" and new_record?
+    return true if operation == "edit" && new_record?
     return true if User.current.allowed_to?("#{operation}_locations".to_sym)
 
     errors.add(:base, _("You do not have permission to %s this location parameter") % operation)

--- a/app/models/parameters/organization_parameter.rb
+++ b/app/models/parameters/organization_parameter.rb
@@ -16,7 +16,7 @@ class OrganizationParameter < Parameter
 
   def enforce_permissions(operation)
     # We get called again with the operation being set to create
-    return true if operation == "edit" and new_record?
+    return true if operation == "edit" && new_record?
     return true if User.current.allowed_to?("#{operation}_organizations".to_sym)
 
     errors.add(:base, _("You do not have permission to %s this organization parameter") % operation)

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -87,7 +87,7 @@ class ProvisioningTemplate < Template
 
     # once a template has been matched, we no longer look for others.
 
-    if opts[:hostgroup_id] and opts[:environment_id]
+    if opts[:hostgroup_id] && opts[:environment_id]
       # try to find a full match to our host group and environment
       template ||= templates.joins(:template_combinations).where(
         "template_combinations.hostgroup_id" => opts[:hostgroup_id],
@@ -171,7 +171,7 @@ class ProvisioningTemplate < Template
     ProvisioningTemplate.joins(:template_kind).where("template_kinds.name" => "provision").includes(:template_combinations => [:environment, {:hostgroup => [ :operatingsystem, :architecture, :medium]}]).each do |template|
       template.template_combinations.each do |combination|
         hostgroup = combination.hostgroup
-        if hostgroup and hostgroup.operatingsystem and hostgroup.architecture and hostgroup.medium
+        if hostgroup && hostgroup.operatingsystem && hostgroup.architecture && hostgroup.medium
           combos << {:hostgroup => hostgroup, :template => template}
         end
       end

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -125,7 +125,7 @@ class Puppetclass < ActiveRecord::Base
     # Retrieve an optional http server's DocumentRoot from the settings.yaml file, and prepare it for writing
     doc_root = Pathname.new(Setting[:document_root])
     doc_root.mkpath
-    unless doc_root.directory? and doc_root.writable?
+    unless doc_root.directory? && doc_root.writable?
       puts "Unable to write html to #{doc_root}"
       return false
     end
@@ -158,7 +158,7 @@ class Puppetclass < ActiveRecord::Base
             sh cmd
           end
           # Relocate the paths for files and references if the manifests were relocated and sanitized
-          if relocated and (files = `find #{out} -exec grep -l '#{root}' {} \\;`.gsub(/\n/, " ")) != ""
+          if relocated && (files = `find #{out} -exec grep -l '#{root}' {} \\;`.gsub(/\n/, " ")) != ""
             puts "Rewriting..." if verbose
             cmd = "ruby -p -i -e 'rex=%r{#{root}};$_.gsub!(rex,\"\")' #{files}"
             puts cmd if debug

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -262,7 +262,7 @@ class Setting < ActiveRecord::Base
       self.settings_type = t
     else
       self.settings_type = "integer" if default.is_a?(Integer)
-      self.settings_type = "boolean" if default.is_a?(TrueClass) or default.is_a?(FalseClass)
+      self.settings_type = "boolean" if default.is_a?(TrueClass) || default.is_a?(FalseClass)
     end
   end
 

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -116,7 +116,7 @@ class SmartProxy < ActiveRecord::Base
 
     begin
       reply = ProxyAPI::Features.new(:url => url).features
-      if reply.is_a?(Array) and reply.any?
+      if reply.is_a?(Array) && reply.any?
         self.features = Feature.where(:name => reply.map{|f| Feature.name_map[f]})
       else
         self.features.clear

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -228,14 +228,14 @@ class Subnet < ActiveRecord::Base
   private
 
   def validate_ranges
-    if from.present? or to.present?
+    if from.present? || to.present?
       errors.add(:from, _("must be specified if to is defined"))   if from.blank?
       errors.add(:to,   _("must be specified if from is defined")) if to.blank?
     end
     return if errors.keys.include?(:from) || errors.keys.include?(:to)
-    errors.add(:from, _("does not belong to subnet"))     if from.present? and !self.contains?(f=IPAddr.new(from))
-    errors.add(:to, _("does not belong to subnet"))       if to.present?   and !self.contains?(t=IPAddr.new(to))
-    errors.add(:from, _("can't be bigger than to range")) if from.present? and t.present? and f > t
+    errors.add(:from, _("does not belong to subnet"))     if from.present? && !self.contains?(f=IPAddr.new(from))
+    errors.add(:to, _("does not belong to subnet"))       if to.present?   && !self.contains?(t=IPAddr.new(to))
+    errors.add(:from, _("can't be bigger than to range")) if from.present? && t.present? && f > t
   end
 
   def check_if_type_changed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,7 +191,7 @@ class User < ActiveRecord::Base
     # user is already in local database
     if (user = unscoped.find_by_login(login))
       # user has an authentication method and the authentication was successful
-      if user.auth_source and (attrs = user.auth_source.authenticate(login, password))
+      if user.auth_source && (attrs = user.auth_source.authenticate(login, password))
         logger.debug "Authenticated user #{user.login} against #{user.auth_source} authentication source"
 
         # update with returned attrs, maybe some info changed in LDAP
@@ -401,7 +401,7 @@ class User < ActiveRecord::Base
   end
 
   def self.try_to_auto_create_user(login, password)
-    return nil if login.blank? or password.blank?
+    return nil if login.blank? || password.blank?
 
     # user is not yet registered, try to authenticate with available sources
     logger.debug "Attempting to log into an auth source as #{login} for account auto-creation"

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -72,7 +72,7 @@ module Classification
     end
 
     def value_of_key(key, values)
-      value = if values[key.id] and values[key.id][key.to_s]
+      value = if values[key.id] && values[key.id][key.to_s]
                 {:value => values[key.id][key.to_s][:value], :managed => values[key.id][key.to_s][:managed] }
               else
                 default_value_method = %w(yaml json).include?(key.key_type) ? :default_value_before_type_cast : :default_value

--- a/app/services/config_report_importer.rb
+++ b/app/services/config_report_importer.rb
@@ -13,7 +13,7 @@ class ConfigReportImporter < ReportImporter
     super
     return report unless report.persisted?
     # we update our host record, so we won't need to lookup the report information just to display the host list / info
-    host.update_attribute(:last_report, time) if host.last_report.nil? or host.last_report.utc < time
+    host.update_attribute(:last_report, time) if host.last_report.nil? || host.last_report.utc < time
     # Store all Puppet message logs
     import_log_messages
     # Check for errors

--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -47,7 +47,7 @@ class Dashboard::Data
   end
 
   def percentage
-    return 0 if report[:ok_hosts_enabled] == 0 or report[:total_hosts] == 0
+    return 0 if report[:ok_hosts_enabled] == 0 || report[:total_hosts] == 0
     report[:ok_hosts_enabled] * 100 / report[:total_hosts]
   end
 

--- a/app/services/foreman/parameters/caster.rb
+++ b/app/services/foreman/parameters/caster.rb
@@ -88,7 +88,7 @@ module Foreman
 
       def cast_array
         return value if value.is_a? Array
-        return value.to_a if !value.is_a? String and value.is_a? Enumerable
+        return value.to_a if !value.is_a?(String) && value.is_a?(Enumerable)
         val = load_yaml_or_json
         raise TypeError unless val.is_a? Array
         val

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -55,13 +55,13 @@ class PuppetClassImporter
   def obsolete_and_new(changes = { })
     return if changes.empty?
     changes.values.map(&:keys).flatten.uniq.each do |env_name|
-      if changes['new'] and changes['new'][env_name].try(:>, '') # we got new classes
+      if changes['new'] && changes['new'][env_name].try(:>, '') # we got new classes
         add_classes_to_foreman(env_name, JSON.parse(changes['new'][env_name]))
       end
-      if changes['obsolete'] and changes['obsolete'][env_name].try(:>, '') # we need to remove classes
+      if changes['obsolete'] && changes['obsolete'][env_name].try(:>, '') # we need to remove classes
         remove_classes_from_foreman(env_name, JSON.parse(changes['obsolete'][env_name]))
       end
-      if changes['updated'] and changes['updated'][env_name].try(:>, '') # we need to update classes
+      if changes['updated'] && changes['updated'][env_name].try(:>, '') # we need to update classes
         update_classes_in_foreman(env_name, JSON.parse(changes['updated'][env_name]))
       end
     end

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -9,7 +9,7 @@ class PuppetFactParser < FactParser
       args = {:name => os_name, :major => "1", :minor => "0"}
       os = Operatingsystem.where(args).first || Operatingsystem.new(args)
     elsif orel.present?
-      if os_name == "Debian" and orel[/testing|unstable/i]
+      if os_name == "Debian" && orel[/testing|unstable/i]
         case facts[:lsbdistcodename]
           when /wheezy/i
             orel = "7"

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -11,8 +11,8 @@ module SSO
 
     def available?
       return false unless Setting['authorize_login_delegation']
-      return false if controller.api_request? and !(Setting['authorize_login_delegation_api'])
-      return false if controller.api_request? and !request.env[CAS_USERNAME].present?
+      return false if controller.api_request? && !(Setting['authorize_login_delegation_api'])
+      return false if controller.api_request? && !request.env[CAS_USERNAME].present?
       true
     end
 

--- a/app/views/api/v1/home/index.json.rabl
+++ b/app/views/api/v1/home/index.json.rabl
@@ -10,7 +10,7 @@ child(:links => "links") do
 
   # add additional actions
   %w(home#status).each do |additional_action|
-    if (description = Apipie.app[additional_action]) and
+    if (description = Apipie.app[additional_action]) &&
         (api = description.method_apis_to_json.first)
       index_method_description_apis << api
     end

--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -26,7 +26,7 @@ Rails.application.config.gettext_i18n_rails.msgmerge = %w[--no-fuzzy-matching]
 
 # When mark_translated setting is set, we will wrap all translated strings
 # which is useful when translating code base.
-if SETTINGS[:mark_translated] and !Rails.env.test?
+if SETTINGS[:mark_translated] && !Rails.env.test?
   include Foreman::Gettext::Debug
 else
   include Foreman::Gettext::AllDomains

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -36,7 +36,7 @@ Apipie.configure do |config|
   config.validate = false
   config.force_dsl = true
   config.reload_controllers = Rails.env.development?
-  config.markup = Apipie::Markup::Markdown.new if Rails.env.development? and defined? Maruku
+  config.markup = Apipie::Markup::Markdown.new if Rails.env.development? && defined? Maruku
   config.default_version = "v1"
   config.update_checksum = true
   config.checksum_path = ['/api/', '/apidoc/']

--- a/db/migrate/20090915030726_change_report_field_type_to_text.rb
+++ b/db/migrate/20090915030726_change_report_field_type_to_text.rb
@@ -1,12 +1,12 @@
 class ChangeReportFieldTypeToText < ActiveRecord::Migration
   def up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE reports MODIFY log text;"
     end
   end
 
   def down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       change_column :reports, :log, :text, :limit => 50.kilobytes, :null => false
     end
   end

--- a/db/migrate/20100115021803_change_mysql_reports_column.rb
+++ b/db/migrate/20100115021803_change_mysql_reports_column.rb
@@ -1,12 +1,12 @@
 class ChangeMysqlReportsColumn < ActiveRecord::Migration
   def up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE reports MODIFY log mediumtext;"
     end
   end
 
   def down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE reports MODIFY log text;"
     end
   end

--- a/db/migrate/20100325142616_update_fact_names_and_values_to_bin.rb
+++ b/db/migrate/20100325142616_update_fact_names_and_values_to_bin.rb
@@ -1,13 +1,13 @@
 class UpdateFactNamesAndValuesToBin < ActiveRecord::Migration
   def up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_names MODIFY name varchar(255) COLLATE utf8_bin NOT NULL}
       execute %{ALTER TABLE fact_values MODIFY value varchar(255) COLLATE utf8_bin NOT NULL}
     end
   end
 
   def down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_names MODIFY name varchar(255)}
       execute %{ALTER TABLE fact_values MODIFY value varchar(255)}
     end

--- a/db/migrate/20100419151910_add_owner_to_hosts.rb
+++ b/db/migrate/20100419151910_add_owner_to_hosts.rb
@@ -12,7 +12,7 @@ class AddOwnerToHosts < ActiveRecord::Migration
     email = SETTINGS[:administrator] || "root@#{Facter.value(:domain)}"
     owner = User.find_by_mail email
     owner ||= User.where(:admin => true).first
-    unless owner.nil? or owner.id.nil?
+    unless owner.nil? || owner.id.nil?
       say "setting default owner for all hosts"
       Host.update_all("owner_id = '#{owner.id}'")
     end

--- a/db/migrate/20100524080302_migrate_installation_medium_uri.rb
+++ b/db/migrate/20100524080302_migrate_installation_medium_uri.rb
@@ -3,7 +3,7 @@ class MigrateInstallationMediumUri < ActiveRecord::Migration
     Medium.unscoped.all.each do |medium|
       matches = /^([^:]+):(\/.+)/.match(medium.path)
 
-      if matches.size == 3 and ![ 'http', 'https', 'ftp', 'ftps', 'nfs' ].include?(matches[1])
+      if matches.size == 3 && ![ 'http', 'https', 'ftp', 'ftps', 'nfs' ].include?(matches[1])
         medium.path = 'nfs://' + matches[1] + matches[2]
         medium.save
       end

--- a/db/migrate/20100525094200_simplify_parameters.rb
+++ b/db/migrate/20100525094200_simplify_parameters.rb
@@ -13,12 +13,12 @@ class SimplifyParameters < ActiveRecord::Migration
     for parameter in Parameter.all
       # There should be no Parameter objects. That is an abstract class.
       # The type is probably nil because this table was imported by prod2dev
-      parameter.update_attribute :type, "HostParameter"   if column_exists? :parameters, :reference_id and parameter.type.nil? and parameter.reference_id
-      parameter.update_attribute :type, "GroupParameter"  if column_exists? :parameters, :hostgroup_id and parameter.type.nil? and parameter.hostgroup_id
-      parameter.update_attribute :type, "DomainParameter" if column_exists? :parameters, :domain_id and parameter.type.nil? and parameter.domain_id
+      parameter.update_attribute :type, "HostParameter"   if column_exists?(:parameters, :reference_id) && parameter.type.nil? && parameter.reference_id
+      parameter.update_attribute :type, "GroupParameter"  if column_exists?(:parameters, :hostgroup_id) && parameter.type.nil? && parameter.hostgroup_id
+      parameter.update_attribute :type, "DomainParameter" if column_exists?(:parameters, :domain_id) && parameter.type.nil? && parameter.domain_id
       parameter.update_attribute :type, "CommonParameter" if parameter.type.nil?
 
-      if parameter.reference_id.nil? and parameter.type != "CommonParameter"
+      if parameter.reference_id.nil? && parameter.type != "CommonParameter"
         parameter.reference_id = parameter.hostgroup_id || parameter.domain_id
         unless parameter.save
           say "Failed to migrate the parameter #{parameter.name}: " + parameter.errors.full_messages.join("\n")

--- a/db/migrate/20101018120548_create_messages.rb
+++ b/db/migrate/20101018120548_create_messages.rb
@@ -3,7 +3,7 @@ class CreateMessages < ActiveRecord::Migration
     create_table :messages do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE messages ENGINE = MYISAM"
       execute "ALTER TABLE messages ADD FULLTEXT (value)"
     else

--- a/db/migrate/20101018120603_create_sources.rb
+++ b/db/migrate/20101018120603_create_sources.rb
@@ -3,7 +3,7 @@ class CreateSources < ActiveRecord::Migration
     create_table :sources do |t|
       t.text :value
     end
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE sources ENGINE = MYISAM"
       execute "ALTER TABLE sources ADD FULLTEXT (value)"
     else

--- a/db/migrate/20110321070954_revert_face_names_and_values_to_text_records.rb
+++ b/db/migrate/20110321070954_revert_face_names_and_values_to_text_records.rb
@@ -1,12 +1,12 @@
 class RevertFaceNamesAndValuesToTextRecords < ActiveRecord::Migration
   def up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "ALTER TABLE fact_values MODIFY value text COLLATE utf8_bin NOT NULL;"
     end
   end
 
   def down
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute %{ALTER TABLE fact_values MODIFY value varchar(255) COLLATE utf8_bin NOT NULL}
     end
   end

--- a/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
+++ b/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
@@ -12,7 +12,7 @@ class AddAuditableNameAndAssociatedNameToAudit < ActiveRecord::Migration
         associated_name ||= audit.associated.try(:to_label) rescue nil
         attr[:auditable_name] = auditable_name  if auditable_name
         attr[:associated_name]= associated_name if associated_name
-        if audit.username.empty? and audit.user
+        if audit.username.empty? && audit.user
           username = audit.user.to_label rescue nil
           attr[:username] = username if !username.empty?
         end

--- a/db/migrate/20130121130826_add_digest_to_messages.rb
+++ b/db/migrate/20130121130826_add_digest_to_messages.rb
@@ -1,6 +1,6 @@
 class AddDigestToMessages < ActiveRecord::Migration
   def up
-    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" or ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
+    if ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql" || ActiveRecord::Base.connection.instance_values["config"][:adapter] == "mysql2"
       execute "DROP INDEX value ON messages" if index_exists?(:messages, :value, :name => 'value')
     else
       remove_index(:messages, :value) if index_exists?(:messages, :value)

--- a/db/seeds.d/08-partition_tables.rb
+++ b/db/seeds.d/08-partition_tables.rb
@@ -19,7 +19,7 @@ Ptable.without_auditing do
   ].each do |input|
     contents = File.read(File.join("#{Rails.root}/app/views/unattended", input.delete(:source)))
 
-    if (p = Ptable.find_by_name(input[:name])) and !audit_modified?(Ptable, input[:name])
+    if (p = Ptable.find_by_name(input[:name])) && !audit_modified?(Ptable, input[:name])
       if p.layout != contents
         p.layout = contents
         raise "Unable to update partition table: #{format_errors p}" unless p.save

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -6,7 +6,7 @@ module Foreman
     end
 
     def self.calculate_error_code(classname, message)
-      return 'ERF00-0000' if classname.nil? or message.nil?
+      return 'ERF00-0000' if classname.nil? || message.nil?
       basename = classname.split(':').last
       class_hash = Zlib.crc32(basename) % 100
       msg_hash = Zlib.crc32(message) % 10000

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -167,7 +167,7 @@ module Foreman
     end
 
     def jumpstart_attributes
-      if @host.operatingsystem.supports_image and @host.use_image
+      if @host.operatingsystem.supports_image && @host.use_image
         @install_type     = "flash_install"
         # We have an individual override for the host's image file
         @archive_location = @host.image_file ? @host.image_file : @host.default_image_file

--- a/lib/foreman/util.rb
+++ b/lib/foreman/util.rb
@@ -9,7 +9,7 @@ module Foreman
       path += ENV['PATH'].split(File::PATH_SEPARATOR)
       path.flatten.uniq.each do |dir|
         dest = File.join(dir, bin)
-        return dest if FileTest.file? dest and FileTest.executable? dest
+        return dest if FileTest.file?(dest) && FileTest.executable?(dest)
       end
       return false
     rescue StandardError => e

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -24,7 +24,7 @@ module ProxyAPI
       params = {}
       params.merge!({:mac => mac}) if mac.present?
 
-      params.merge!({:from => subnet.from, :to => subnet.to}) if subnet.from.present? and subnet.to.present?
+      params.merge!({:from => subnet.from, :to => subnet.to}) if subnet.from.present? && subnet.to.present?
       if params.any?
         params = "?" + params.map{|e| e.join("=")}.join("&")
       else

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -50,7 +50,7 @@ module ProxyAPI
     #      OR: false if a HTTP error is detected
     # TODO: add error message handling
     def parse(response)
-      if response and response.code >= 200 and response.code < 300
+      if response && response.code >= 200 && response.code < 300
         return response.body.present? ? JSON.parse(response.body) : true
       else
         false

--- a/lib/proxy_api/template.rb
+++ b/lib/proxy_api/template.rb
@@ -7,7 +7,7 @@ module ProxyAPI
 
     # returns the Template URL for this proxy
     def template_url
-      if (response = parse(get("templateServer"))) and response["templateServer"].present?
+      if (response = parse(get("templateServer"))) && response["templateServer"].present?
         return response["templateServer"]
       end
     rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,

--- a/lib/timed_cached_store.rb
+++ b/lib/timed_cached_store.rb
@@ -15,7 +15,7 @@ class TimedCachedStore < ActiveSupport::Cache::MemoryStore
   end
 
   def write(name, value, options = nil)
-    if options and options[:expires_in]
+    if options && options[:expires_in]
       time                  = Time.now.utc
       ttl                   = time + options[:expires_in].to_i
       @data[ts_field(name)] = { :created_at => time, :expires_at => ttl }

--- a/script/foreman-config
+++ b/script/foreman-config
@@ -38,7 +38,7 @@ rescue OptionParser::InvalidOption => e
   # don't fail on unknown attributes, rather pass it to the rake task
   e.recover argv
   rake_args << argv.shift
-  rake_args << argv.shift if !argv.empty? and argv.first !~ /^-/
+  rake_args << argv.shift if !argv.empty? && argv.first !~ /^-/
   retry
 end
 


### PR DESCRIPTION
Ruby style guide:

https://github.com/bbatsov/ruby-style-guide#no-and-or-or

Avdi Grimm sums up the differences between `and` and `or` vs `&&` and `||` rather succinctly here:

http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/

Also, this is one of the few cops that Rails enables:

https://github.com/rails/rails/blob/master/.rubocop.yml#L21-L23

We could also configure this cop to completely forbid use of `and` and `or`. Would like to hear some opinions.
