### PR TITLE
Fixes #15644 - Move enable/skip_orchestration to Host::Managed

### DIFF
--- a/app/models/concerns/interface_cloning.rb
+++ b/app/models/concerns/interface_cloning.rb
@@ -1,0 +1,18 @@
+module InterfaceCloning
+  extend ActiveSupport::Concern
+  # we keep the before update host object in order to compare changes
+  def setup_clone(&block)
+    return if new_record?
+    @old = setup_object_clone(self, &block)
+  end
+
+  def setup_object_clone(object)
+    clone = object.dup
+    yield(clone) if block_given?
+    # we can't assign using #attributes= because of mass-assign protected attributes (e.g. type)
+    for key in (object.changed_attributes.keys - ["updated_at"])
+      clone.send "#{key}=", object.changed_attributes[key]
+    end
+    clone
+  end
+end

--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -195,22 +195,6 @@ module Orchestration
     end
   end
 
-  # we keep the before update host object in order to compare changes
-  def setup_clone(&block)
-    return if new_record?
-    @old = setup_object_clone(self, &block)
-  end
-
-  def setup_object_clone(object)
-    clone = object.dup
-    yield(clone) if block_given?
-    # we can't assign using #attributes= because of mass-assign protected attributes (e.g. type)
-    for key in (object.changed_attributes.keys - ["updated_at"])
-      clone.send "#{key}=", object.changed_attributes[key]
-    end
-    clone
-  end
-
   def orchestration_errors?
     overwrite? ? errors.are_all_conflicts? : errors.empty?
   end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -5,6 +5,7 @@ module Nic
     include Orchestration::DNS
     include Orchestration::TFTP
     include DnsInterface
+    include InterfaceCloning
 
     include Exportable
     include Foreman::Renderer
@@ -82,7 +83,8 @@ module Nic
       return unless primary?
       return unless fqdn_changed?
       return unless host.present?
-      LookupValue.where(:match => "fqdn=#{fqdn_was}").update_all(:match => host.send(:lookup_value_match))
+      LookupValue.where(:match => "fqdn=#{fqdn_was}").
+        update_all(:match => host.lookup_value_match)
     end
 
     def drop_host_cache

--- a/test/unit/hosts/base_test.rb
+++ b/test/unit/hosts/base_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+module Host
+  class BaseTest < ActiveSupport::TestCase
+    should validate_presence_of(:name)
+    should validate_uniqueness_of(:name)
+    should_not allow_value('hostname_with_dashes').for(:name)
+    should allow_value('hostname.with.periods').for(:name)
+
+    test "should import facts from json stream" do
+      host = Host::Base.new(:name => "sinn1636.lan")
+      assert host.import_facts(JSON.parse(facts_sample_json)['facts'])
+    end
+
+    test "should make hostname lowercase" do
+      host = Host::Base.new(:name => 'MYHOST',
+                            :domain => FactoryGirl.create(:domain, :name => "mydomainlowercase.net"))
+      host.valid?
+      assert_equal "myhost.mydomainlowercase.net", host.name
+    end
+
+    test "should update name when domain is changed" do
+      host = Host::Base.new(:name => 'foo')
+      refute_equal "#{host.shortname}.yourdomain.net", host.name
+      host.domain_name = "yourdomain.net"
+      host.save!
+      assert_equal "#{host.shortname}.yourdomain.net", host.name
+    end
+
+    test '.new should build host with primary interface' do
+      host = Host::Base.new
+      assert host.primary_interface
+      assert_equal 1, host.interfaces.size
+    end
+
+    test '.new should mark one interfaces as primary if none was chosen explicitly' do
+      host = Host::Base.new(:interfaces_attributes => [ {:ip => '192.168.0.1' }, { :ip => '192.168.1.2' } ])
+      assert host.primary_interface
+      assert_equal 2, host.interfaces.size
+    end
+
+    test '.new does not reset primary flag if it was set explicitly' do
+      host = Host::Base.new(:interfaces_attributes => [ {:ip => '192.168.0.1' }, { :ip => '192.168.1.2', :primary => true } ])
+      assert_equal 2, host.interfaces.size
+      assert_equal '192.168.1.2', host.primary_interface.ip
+    end
+
+    test "host should not save without primary interface" do
+      host = Host::Base.new(:name => 'foo')
+      host.interfaces = []
+      refute host.valid?
+      assert_includes host.errors.keys, :interfaces
+
+      host.interfaces = [ FactoryGirl.build(:nic_managed, :primary => true, :host => host,
+                                            :domain => FactoryGirl.create(:domain)) ]
+      assert host.valid?
+    end
+
+    private
+
+    def facts_sample_json
+      File.read(File.expand_path(File.dirname(__FILE__) + "/../facts.json"))
+    end
+  end
+end


### PR DESCRIPTION
# skip_orchestration and enable_orchestration were called in Host::Base

when importing facts. These two methods could not be called there
because they come from the Orchestration mixin which Host::Base does not
have. This blocked importing facts for a Host::Discovered or a Host::Base.

To test this, I've moved the tests that import the facts to a separate
test class just for Host::Base. Notice I've moved a few other tests
which also belong there. There are probably more, but I didn't want to
make this more complicated.

Lastly, Nic::Managed called lookup_value_match on save, so importing
facts didn't work for Host::Base as that method wasn't there either, so
I moved it. Same logic applies to 'setup_clone'.

@lzap you wanted to be notified, so :bell: :smile: 

I think this PR is symptomatic of very blurry lines between `Host::Managed` and `Host::Base`. I think we should define the boundaries for each class, and then document it and enforce it.
