### PR TITLE
Fixes #15657 - Correct import button styling

### DIFF
--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -12,7 +12,7 @@ module PuppetclassesAndEnvironmentsHelper
   end
 
   def import_proxy_select(hash)
-    select_action_button(_('Import'), {}, import_proxy_links(hash, 'btn btn-default'))
+    select_action_button(_('Import'), {}, import_proxy_links(hash))
   end
 
   def import_proxy_links(hash, classes = nil)


### PR DESCRIPTION
Remove duplicate button styling from puppet class and environment import
button when only one puppet smart proxy is available.
