### PR TITLE
Fixes #11749 - puppet env jquery selector more restrictive

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -387,17 +387,17 @@ $(function() {
 });
 
 function update_puppetclasses(element) {
-  var host_id = $("form").data('id')
-  var env_id = $('select[name*=environment_id]').val();
+  var host_id = $("form").data('id');
   var url = $(element).attr('data-url');
   var data = $("form").serialize().replace('method=patch', 'method=post');
+
+  if (element.value == '') return;
   if (url.match('hostgroups')) {
     data = data + '&hostgroup_id=' + host_id
   } else {
     data = data + '&host_id=' + host_id
   }
 
-  if (env_id == "") return;
   foreman.tools.showSpinner();
   $.ajax({
     type: 'post',


### PR DESCRIPTION
This current jquery selector for puppet environment
selection would match any select box where name
included environment_id.  This caused issues with
katello as we put a field containing lifecycle_environment_id
in the form
