### PR TITLE
Fixes #15653 - CVE-2016-5390 fix API permissions for host interfaces

### DIFF
--- a/app/controllers/concerns/find_common.rb
+++ b/app/controllers/concerns/find_common.rb
@@ -48,10 +48,10 @@ module FindCommon
   end
 
   def resource_class_for(resource)
-    begin
-      return resource.classify.constantize
-    rescue NameError
-      return nil
-    end
+    klass = resource.classify.constantize
+    return Host::Managed if klass == Host
+    klass
+  rescue NameError
+    nil
   end
 end

--- a/test/functional/api/v2/interfaces_controller_test.rb
+++ b/test/functional/api/v2/interfaces_controller_test.rb
@@ -64,4 +64,18 @@ class Api::V2::InterfacesControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  context 'permissions' do
+    test 'user with permissions to view host can also view its interfaces' do
+      setup_user 'view', 'hosts', "name = #{@host.name}"
+      get :index, { :host_id => @host.name }, set_session_user
+      assert_response :success
+    end
+
+    test 'user without permissions to view host cannot view interfaces' do
+      setup_user 'view', 'hosts', "name = some.other.host"
+      get :index, { :host_id => @host.name }, set_session_user
+      assert_response :not_found
+    end
+  end
 end

--- a/test/functional/api/v2/parameters_controller_test.rb
+++ b/test/functional/api/v2/parameters_controller_test.rb
@@ -285,4 +285,20 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
       assert_filtering_works :operatingsystem, operatingsystems(:redhat).to_param
     end
   end
+
+  context 'permissions' do
+    test 'user with permissions to view host can also view its parameters' do
+      setup_user 'view', 'params'
+      setup_user 'view', 'hosts', "name = #{@host.name}"
+      get :index, { :host_id => @host.name }, set_session_user
+      assert_response :success
+    end
+
+    test 'user without permissions to view host cannot view parameters' do
+      setup_user 'view', 'params'
+      setup_user 'view', 'hosts', "name = some.other.host"
+      get :index, { :host_id => @host.name }, set_session_user
+      assert_response :not_found
+    end
+  end
 end


### PR DESCRIPTION
Non-admin users with the view_hosts permission containing a filter are
able to access API routes beneath "hosts" such as GET
/api/v2/hosts/secrethost/interfaces without the filter being taken into
account. This allows users to access network interface details
(including BMC login details) for any host.

The filter is only correctly used when accessing the main host details
(/api/v2/hosts/secrethost). Access to the "nested" routes, which
includes interfaces, reports, parameters, audits, facts and Puppet
classes, is not authorized beyond requiring any view_hosts permission.

---

Honestly I'm not very happy with the way we've historically tested find_common and permissions in controllers, if you have any suggestions about tests I'd be happy to hear it. cc @ares 
