### PR TITLE
Fixes #15667 - Passing nested array to 'IN' is deprecated

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -38,7 +38,11 @@ class SmartProxy < ActiveRecord::Base
     end
   }
 
-  scope :with_features, ->(*feature_names) { where(:features => { :name => feature_names }).joins(:features) if feature_names.any? }
+  scope :with_features, lambda { |*feature_names|
+    if feature_names.any?
+      where(:features => { :name => feature_names.flatten }).joins(:features)
+    end
+  }
 
   def hostname
     URI(url).host


### PR DESCRIPTION
Rails 5 will remove the option of passing nested arrays that are used in
SQL 'IN' conditions. You can see several warnings running
test/functional/subnets_controller.rb
