### PR TITLE
Fixes #15409 - Separated puppet facts from core

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -285,8 +285,8 @@ Return the host's compute attributes that can be used to create a clone of this 
       param :type, String,     :desc => N_("optional: the STI type of host to create")
 
       def facts
-        @host = detect_host_type.import_host params[:name], params[:facts][:_type] || 'puppet', params[:certname], detected_proxy.try(:id)
-        state = @host.import_facts(params[:facts].to_unsafe_h)
+        @host = detect_host_type.import_host params[:name], params[:certname]
+        state = @host.import_facts(params[:facts].to_unsafe_h, detected_proxy)
         process_response state
       rescue ::Foreman::Exception => e
         render_message(e.to_s, :status => :unprocessable_entity)

--- a/app/models/concerns/facets/base.rb
+++ b/app/models/concerns/facets/base.rb
@@ -44,7 +44,7 @@ module Facets
 
       # Use this method to populate host's fields based on fact values exposed by the importer.
       # You can populate fields in the associated host's facets too.
-      def populate_fields_from_facts(host, importer, type, proxy_id)
+      def populate_fields_from_facts(host, parser, type, proxy)
       end
     end
   end

--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -94,6 +94,12 @@ module Facets
       attributes
     end
 
+    def populate_facet_fields(parser, type, source_proxy)
+      Facets.registered_facets.values.each do |facet_config|
+        facet_config.model.populate_fields_from_facts(self, parser, type, source_proxy)
+      end
+    end
+
     private
 
     def forward_property_call(property, args, facet)

--- a/app/models/concerns/puppet_host_extensions.rb
+++ b/app/models/concerns/puppet_host_extensions.rb
@@ -1,0 +1,18 @@
+module PuppetHostExtensions
+  def populate_fields_from_facts(parser, type, source_proxy)
+    super
+
+    type ||= 'puppet'
+    return unless type == 'puppet'
+
+    if Setting[:update_environment_from_facts]
+      set_non_empty_values parser, [:environment]
+    else
+      self.environment ||= parser.environment unless parser.environment.blank?
+    end
+
+    # if proxy authentication is enabled and we have no puppet proxy set and the upload came from puppet,
+    # use it as puppet proxy.
+    self.puppet_proxy ||= source_proxy
+  end
+end

--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -3,14 +3,16 @@ class FactImporter
   attr_reader :counters
 
   def self.importer_for(type)
-    importers[type.to_s] || importers[:puppet]
+    importers[type.to_s]
   end
 
   def self.importers
-    @importers ||= { :puppet => PuppetFactImporter }.with_indifferent_access
+    @importers ||= {}.with_indifferent_access
   end
 
-  def self.register_fact_importer(key, klass)
+  def self.register_fact_importer(key, klass, default = false)
+    importers.default = klass if default
+
     importers[key.to_sym] = klass
   end
 

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -6,14 +6,15 @@ class FactParser
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
   def self.parser_for(type)
-    parsers[type.to_s] || parsers[:puppet]
+    parsers[type.to_s]
   end
 
   def self.parsers
-    @parsers ||= { :puppet => PuppetFactParser }.with_indifferent_access
+    @parsers ||= {}.with_indifferent_access
   end
 
-  def self.register_fact_parser(key, klass)
+  def self.register_fact_parser(key, klass, default = false)
+    parsers.default = klass if default
     parsers[key.to_sym] = klass
   end
 

--- a/config/initializers/puppet.rb
+++ b/config/initializers/puppet.rb
@@ -11,3 +11,11 @@ Pagelets::Manager.with_key "hosts/_form" do |mgr|
     :partial => "hosts/puppet/main_tab_fields",
     :priority => 100
 end
+
+FactImporter.register_fact_importer :puppet, PuppetFactImporter, true
+FactParser.register_fact_parser :puppet, PuppetFactParser, true
+
+# The module should be included after the class is constructed,
+# since it tries to alias_method_chain a method that is defined
+# in the class itself.
+Host::Managed.send :prepend, PuppetHostExtensions

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -94,6 +94,14 @@ class FacetTest < ActiveSupport::TestCase
 
       @host.apply_inherited_attributes(attributes)
     end
+
+    test 'facts are parsed by facets too' do
+      TestFacet.expects(:populate_fields_from_facts)
+      @host.stubs(:save)
+      facts_json = read_json_fixture('facts/brslc022.facts.json')
+
+      @host.parse_facts(facts_json['facts'], nil, nil)
+    end
   end
 
   context "managed host facet behavior" do

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -25,8 +25,11 @@ class FactParserTest < ActiveSupport::TestCase
   test ".register_custom_parser" do
     chef_parser = Struct.new(:my_method)
     FactParser.register_fact_parser :chef, chef_parser
-
-    assert_equal chef_parser, FactParser.parser_for(:chef)
+    begin
+      assert_equal chef_parser, FactParser.parser_for(:chef)
+    ensure
+      FactParser.parsers.delete :chef
+    end
   end
 
   test "#parse_interfaces? should answer based on current setttings" do


### PR DESCRIPTION
Refactored facts import mechanism so, that puppet facts could be separated.
1. Moved SmartProxy reference from `#import_host` to `#import_facts` - the source is relevant for fact retrieval process, not to host creation.
2. Moved `#import_host` to `Host::Base`: it's base service and it is not limited to managed hosts.
3. Redesigned `#populate_fields_from_facts` to be responsible for filling host's fields from a predefined fact parser.
4. Refactored `FactParser` and `FactImporter` registries to expose a default option and removed references to puppet from there.
