### PR TITLE
fixes #15682 - don't save invalid attributes at login from LDAP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,10 +74,11 @@ class ApplicationController < ActionController::Base
 
   def require_mail
     if User.current && !User.current.hidden? && User.current.mail.blank?
-      msg = _("Email is Required")
+      msg = _("An email address is required, please update your account details")
       respond_to do |format|
         format.html do
           error msg
+          flash.keep # keep any warnings added by the user login process, they may explain why this occurred
           redirect_to edit_user_path(:id => User.current)
         end
         format.text do

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,7 +77,7 @@ class UsersController < ApplicationController
       else
         #valid user
         #If any of the user attributes provided by external auth source are invalid then throw a flash message to user on successful login.
-        notice _(user.errors.full_messages.join(", ")) unless user.errors.empty?
+        warning _("Some imported user account details cannot be saved: %s") % user.errors.full_messages.to_sentence unless user.errors.empty?
         login_user(user)
       end
     else

--- a/test/functional/application_controller_subclass_test.rb
+++ b/test/functional/application_controller_subclass_test.rb
@@ -50,6 +50,14 @@ class TestableResourcesControllerTest < ActionController::TestCase
       assert_equal '/testable_resources', session[:original_uri]
     end
 
+    it "requires an account with mail" do
+      user = FactoryGirl.create(:user)
+      get :index, {}, set_session_user.merge(:user => user.id)
+      assert_response :redirect
+      assert_redirected_to edit_user_path(user)
+      assert_equal "An email address is required, please update your account details", flash[:error]
+    end
+
     context "and SSO authenticates" do
       setup do
         @sso = mock('dummy_sso')


### PR DESCRIPTION
When a user logs in and their last_login_on attribute is updated, bypass
saving the whole model which may contain invalid, unpersisted data.

Also fixes the warning about invalid synced attributes to show during
first user login and not only subsequent logins, by restoring the
invalid attributes to the model after saving it.

---

Post-login with invalid synced details now looks like this:

![screenshot from 2016-07-14 11-49-19](https://cloud.githubusercontent.com/assets/482089/16839951/d0b32966-49c9-11e6-80e4-42eb3972a074.png)
