### PR TITLE
fixes #15704 - use sendmail for email.yaml

### DIFF
--- a/config/email.yaml.example
+++ b/config/email.yaml.example
@@ -1,9 +1,4 @@
 # Outgoing email settings
 
 production:
-  delivery_method: :smtp
-  smtp_settings:
-    address: smtp.example.com
-    port: 25
-    domain: example.com
-    authentication: :none
+  delivery_method: :sendmail


### PR DESCRIPTION
Using sendmail instead of the smtp.example.com as a default gives
mail a chance of "just working" on a unix system. This example
file is copied to email.yaml in packaging, so with the current
settings, email always does not work as smtp.example.com does
not resolve.
