### PR TITLE
Fixes #13529 - Remove duplicate permissions

### DIFF
--- a/db/migrate/20160717125402_unify_permissions.rb
+++ b/db/migrate/20160717125402_unify_permissions.rb
@@ -1,0 +1,18 @@
+class UnifyPermissions < ActiveRecord::Migration
+  def up
+    names = Permission.group(:name).having("count(*) > 1").pluck(:name)
+    names.each do |name|
+      dup_permissions = Permission.where(:name => name).order(:id).pluck(:id).to_a
+      # Keeps one of the duplicates
+      saved_permission = dup_permissions.pop
+      Filtering.where(:permission_id => dup_permissions).update_all(:permission_id => saved_permission)
+      Permission.where(:id => dup_permissions).delete_all
+    end
+
+    add_index :permissions, :name, :unique => true
+  end
+
+  def down
+    remove_index :permissions, :name, :unique => true
+  end
+end


### PR DESCRIPTION
A migration which adds unique constraint
and removes duplicate permissions
