### PR TITLE
Fixes #15712 - Pinning rabl to less than 0.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'ancestry', '~> 2.0'
 gem 'scoped_search', '>= 3.2.2', '< 4'
 gem 'ldap_fluff', '>= 0.3.5', '< 1.0'
 gem 'apipie-rails', '~> 0.3.4'
-gem 'rabl', '~> 0.11'
+gem 'rabl', '>= 0.11', "< 0.13"
 gem 'oauth', '~> 0.4'
 gem 'deep_cloneable', '~> 2.0'
 gem 'validates_lengths_from_database', '~> 0.5'


### PR DESCRIPTION
Not sure if rabl intentionally dropped support for ruby 2.0 but I opened https://github.com/nesquena/rabl/issues/669
