### PR TITLE
fixes #15720 - rename *_filter to *_action

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -116,14 +116,6 @@ Performance/StringReplacement:
 Performance/TimesMap:
   Enabled: false
 
-# Offense count: 252
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, Include.
-# SupportedStyles: action, filter
-# Include: app/controllers/**/*.rb
-Rails/ActionFilter:
-  Enabled: false
-
 # Offense count: 1
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: strict, flexible

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,5 +1,5 @@
 class AboutController < ApplicationController
-  skip_before_filter :authorize, :only => :index
+  skip_before_action :authorize, :only => :index
 
   def index
     @smart_proxies = SmartProxy.authorized(:view_smart_proxies).includes(:features)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,17 +5,17 @@ module Api
 
     protect_from_forgery
     force_ssl :if => :require_ssl?
-    skip_before_filter :verify_authenticity_token, :unless => :protect_api_from_forgery?
+    skip_before_action :verify_authenticity_token, :unless => :protect_api_from_forgery?
 
-    before_filter :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
-    before_filter :session_expiry, :update_activity_time
-    around_filter :set_timezone
+    before_action :set_default_response_format, :authorize, :add_version_header, :set_gettext_locale
+    before_action :session_expiry, :update_activity_time
+    around_action :set_timezone
 
     cache_sweeper :topbar_sweeper
 
     respond_to :json
 
-    after_filter :log_response_body
+    after_action :log_response_body
 
     rescue_from StandardError do |error|
       Foreman::Logging.exception("Action failed", error)

--- a/app/controllers/api/v1/architectures_controller.rb
+++ b/app/controllers/api/v1/architectures_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ArchitecturesController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/architectures/", "List all architectures."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/audits_controller.rb
+++ b/app/controllers/api/v1/audits_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class AuditsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
-      before_filter :setup_search_options, :only => :index
+      before_action :find_resource, :only => %w{show update destroy}
+      before_action :setup_search_options, :only => :index
 
       api :GET, "/audits/", "List all audits."
       api :GET, "/hosts/:host_id/audits/", "List all audits for a given host."

--- a/app/controllers/api/v1/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v1/auth_source_ldaps_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class AuthSourceLdapsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/auth_source_ldaps/", "List all authsource ldaps"
       param :page, String, :desc => "paginate results"

--- a/app/controllers/api/v1/autosign_controller.rb
+++ b/app/controllers/api/v1/autosign_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class AutosignController < V1::BaseController
-      before_filter :find_required_nested_object, :setup_proxy
+      before_action :find_required_nested_object, :setup_proxy
 
       api :GET, "/smart_proxies/smart_proxy_id/autosign", "List all autosign"
 

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -3,7 +3,7 @@ module Api
     class BookmarksController < V1::BaseController
       include Foreman::Controller::BookmarkCommon
 
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/bookmarks/", "List all bookmarks."
       param :page, String, :desc => "paginate results"

--- a/app/controllers/api/v1/common_parameters_controller.rb
+++ b/app/controllers/api/v1/common_parameters_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class CommonParametersController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/common_parameters/", "List all common parameters."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/compute_resources_controller.rb
+++ b/app/controllers/api/v1/compute_resources_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ComputeResourcesController < V1::BaseController
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/compute_resources/", "List all compute resources."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/config_templates_controller.rb
+++ b/app/controllers/api/v1/config_templates_controller.rb
@@ -4,11 +4,11 @@ module Api
       include Foreman::Renderer
       include Foreman::Controller::ProvisioningTemplates
 
-      before_filter :deprecated
+      before_action :deprecated
 
-      before_filter :find_resource, :only => %w{show update destroy}
-      before_filter :handle_template_upload, :only => [:create, :update]
-      before_filter :process_template_kind, :only => [:create, :update]
+      before_action :find_resource, :only => %w{show update destroy}
+      before_action :handle_template_upload, :only => [:create, :update]
+      before_action :process_template_kind, :only => [:create, :update]
 
       api :GET, "/config_templates/", "List templates"
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/domains_controller.rb
+++ b/app/controllers/api/v1/domains_controller.rb
@@ -13,7 +13,7 @@ module Api
         DOC
       end
 
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/domains/", "List of domains"
       param :search, String, :desc => "Filter results"

--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class EnvironmentsController < V1::BaseController
       include Api::ImportPuppetclassesCommonController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/environments/", "List all environments."
       param :search, String, :desc => "Filter results"

--- a/app/controllers/api/v1/fact_values_controller.rb
+++ b/app/controllers/api/v1/fact_values_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class FactValuesController < V1::BaseController
-      before_filter :setup_search_options, :only => :index
+      before_action :setup_search_options, :only => :index
 
       api :GET, "/fact_values/", "List all fact values."
       api :GET, "/hosts/:host_id/facts/", "List all fact values of a given host."

--- a/app/controllers/api/v1/home_controller.rb
+++ b/app/controllers/api/v1/home_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class HomeController < V1::BaseController
-      before_filter :require_admin, :only => [:index]
+      before_action :require_admin, :only => [:index]
 
       api :GET, "/", "Show available links."
 

--- a/app/controllers/api/v1/hostgroups_controller.rb
+++ b/app/controllers/api/v1/hostgroups_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class HostgroupsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/hostgroups/", "List all hostgroups."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -2,9 +2,9 @@ module Api
   module V1
     class HostsController < V1::BaseController
       include Api::CompatibilityChecker
-      before_filter :check_create_host_nested, :only => [:create, :update]
+      before_action :check_create_host_nested, :only => [:create, :update]
 
-      before_filter :find_resource, :only => %w{show update destroy status}
+      before_action :find_resource, :only => %w{show update destroy status}
 
       api :GET, "/hosts/", "List all hosts."
       param :search, String, :desc => "Filter results"

--- a/app/controllers/api/v1/images_controller.rb
+++ b/app/controllers/api/v1/images_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class ImagesController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
-      before_filter :find_compute_resource
+      before_action :find_resource, :only => %w{show update destroy}
+      before_action :find_compute_resource
 
       api :GET, "/compute_resources/:compute_resource_id/images/", "List all images for compute resource"
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/lookup_keys_controller.rb
+++ b/app/controllers/api/v1/lookup_keys_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class LookupKeysController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
-      before_filter :setup_search_options, :only => :index
+      before_action :find_resource, :only => %w{show update destroy}
+      before_action :setup_search_options, :only => :index
 
       api :GET, "/lookup_keys/", "List all lookup_keys."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class MediaController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       # TRANSLATORS: API documentation - do not translate
       PATH_INFO = <<-eos

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ModelsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/models/", "List all models."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/operatingsystems_controller.rb
+++ b/app/controllers/api/v1/operatingsystems_controller.rb
@@ -5,8 +5,8 @@ module Api
         name 'Operating systems'
       end
 
-      before_filter :rename_config_templates, :only => %w{update create}
-      before_filter :find_resource, :only => %w{show edit update destroy bootfiles}
+      before_action :rename_config_templates, :only => %w{update create}
+      before_action :find_resource, :only => %w{show edit update destroy bootfiles}
 
       api :GET, "/operatingsystems/", "List all operating systems."
       param :search, String, :desc => "filter results", :required => false

--- a/app/controllers/api/v1/ptables_controller.rb
+++ b/app/controllers/api/v1/ptables_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class PtablesController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/ptables/", "List all ptables."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/puppetclasses_controller.rb
+++ b/app/controllers/api/v1/puppetclasses_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class PuppetclassesController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
-      before_filter :setup_search_options, :only => :index
+      before_action :find_resource, :only => %w{show update destroy}
+      before_action :setup_search_options, :only => :index
 
       api :GET, "/puppetclasses/", "List all puppetclasses."
       api :GET, "/hosts/:host_id/puppetclasses/", "List all puppetclasses of a given host."

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V1
     class ReportsController < V1::BaseController
-      before_filter :deprecated
-      before_filter :find_resource, :only => %w{show destroy}
-      before_filter :setup_search_options, :only => [:index, :last]
+      before_action :deprecated
+      before_action :find_resource, :only => %w{show destroy}
+      before_action :setup_search_options, :only => [:index, :last]
 
       api :GET, "/reports/", "List all reports."
       param :search, String, :desc => "filter results"

--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class RolesController < V1::BaseController
-      before_filter :require_admin
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :require_admin
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/roles/", "List all roles."
       param :page, String, :desc => "paginate results"

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class SettingsController < V1::BaseController
-      before_filter :require_admin
-      before_filter :find_resource, :only => %w{show update}
+      before_action :require_admin
+      before_action :find_resource, :only => %w{show update}
 
       api :GET, "/settings/", "List all settings."
       param :search, String, :desc => "Filter results"

--- a/app/controllers/api/v1/smart_proxies_controller.rb
+++ b/app/controllers/api/v1/smart_proxies_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     class SmartProxiesController < V1::BaseController
       include Api::ImportPuppetclassesCommonController
-      before_filter :find_resource, :only => %w{show update destroy refresh}
-      before_filter :check_feature_type, :only => :index
+      before_action :find_resource, :only => %w{show update destroy refresh}
+      before_action :check_feature_type, :only => :index
 
       api :GET, "/smart_proxies/", "List all smart_proxies."
       param :type, String, :desc => "filter by type"

--- a/app/controllers/api/v1/subnets_controller.rb
+++ b/app/controllers/api/v1/subnets_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SubnetsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, '/subnets', 'List of subnets'
       param :search, String, :desc => 'Filter results'

--- a/app/controllers/api/v1/usergroups_controller.rb
+++ b/app/controllers/api/v1/usergroups_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class UsergroupsController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/usergroups/", "List all user groups."
       param :page, String, :desc => "paginate results"

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class UsersController < V1::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
       # find_resource needs to be defined prior to UsersMixin is included, it depends on @user
       include Foreman::Controller::UsersMixin
 

--- a/app/controllers/api/v2/architectures_controller.rb
+++ b/app/controllers/api/v2/architectures_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class ArchitecturesController < V2::BaseController
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/architectures/", N_("List all architectures")
       api :GET, "/operatingsystems/:operatingsystem_id/architectures", N_("List all architectures for operating system")

--- a/app/controllers/api/v2/audits_controller.rb
+++ b/app/controllers/api/v2/audits_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class AuditsController < V2::BaseController
-      before_filter :find_resource, :only => %w{show}
+      before_action :find_resource, :only => %w{show}
 
       api :GET, "/audits/", N_("List all audits")
       api :GET, "/hosts/:host_id/audits/", N_("List all audits for a given host")

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class AuthSourceLdapsController < V2::BaseController
-      before_filter :find_resource, :only => %w{show update destroy test}
+      before_action :find_resource, :only => %w{show update destroy test}
 
       api :GET, "/auth_source_ldaps/", N_("List all LDAP authentication sources")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/autosign_controller.rb
+++ b/app/controllers/api/v2/autosign_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class AutosignController < V2::BaseController
-      before_filter :find_required_nested_object, :setup_proxy
+      before_action :find_required_nested_object, :setup_proxy
 
       api :GET, "/smart_proxies/smart_proxy_id/autosign", N_("List all autosign entries")
 

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -29,10 +29,10 @@ module Api
         param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations") if SETTINGS[:organizations_enabled]
       end
 
-      before_filter :setup_has_many_params, :only => [:create, :update]
-      before_filter :check_content_type
+      before_action :setup_has_many_params, :only => [:create, :update]
+      before_action :check_content_type
       # ensure include_root_in_json = false for V2 only
-      around_filter :disable_json_root
+      around_action :disable_json_root
 
       layout 'api/v2/layouts/index_layout', :only => :index
 

--- a/app/controllers/api/v2/bookmarks_controller.rb
+++ b/app/controllers/api/v2/bookmarks_controller.rb
@@ -3,7 +3,7 @@ module Api
     class BookmarksController < V2::BaseController
       include Foreman::Controller::BookmarkCommon
 
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/bookmarks/", N_("List all bookmarks")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/common_parameters_controller.rb
+++ b/app/controllers/api/v2/common_parameters_controller.rb
@@ -2,7 +2,7 @@
 module Api
   module V2
     class CommonParametersController < V2::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/common_parameters/", N_("List all global parameters.")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/compute_attributes_controller.rb
+++ b/app/controllers/api/v2/compute_attributes_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class ComputeAttributesController < V2::BaseController
-      before_filter :find_resource, :only => :update
+      before_action :find_resource, :only => :update
 
       def_param_group :compute_attribute do
         param :compute_attribute, Hash, :required => true, :action_aware => true do

--- a/app/controllers/api/v2/compute_profiles_controller.rb
+++ b/app/controllers/api/v2/compute_profiles_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class ComputeProfilesController < V2::BaseController
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/compute_profiles", N_("List of compute profiles")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -12,7 +12,7 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,
+      before_action :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,
                                               :available_clusters, :available_flavors, :available_folders,
                                               :available_networks, :available_resource_pools, :available_security_groups, :available_storage_domains,
                                               :available_zones, :available_storage_pods]

--- a/app/controllers/api/v2/config_groups_controller.rb
+++ b/app/controllers/api/v2/config_groups_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class ConfigGroupsController < V2::BaseController
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       api :GET, "/config_groups", N_("List of config groups")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
 
-      before_filter :find_resource, :only => %w{show destroy}
-      before_filter :setup_search_options, :only => [:index, :last]
+      before_action :find_resource, :only => %w{show destroy}
+      before_action :setup_search_options, :only => [:index, :last]
 
       add_smart_proxy_filters :create, :features => Proc.new { ConfigReportImporter.authorized_smart_proxy_features }
 

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -6,14 +6,14 @@ module Api
       include Foreman::Renderer
       include Foreman::Controller::ProvisioningTemplates
 
-      before_filter :deprecated
+      before_action :deprecated
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy clone}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy clone}
 
-      before_filter :handle_template_upload, :only => [:create, :update]
-      before_filter :process_template_kind, :only => [:create, :update]
-      before_filter :process_operatingsystems, :only => [:create, :update]
+      before_action :handle_template_upload, :only => [:create, :update]
+      before_action :process_template_kind, :only => [:create, :update]
+      before_action :process_operatingsystems, :only => [:create, :update]
 
       api :GET, "/config_templates/", N_("List provisioning templates")
       api :GET, "/operatingsystems/:operatingsystem_id/config_templates", N_("List provisioning templates per operating system")

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -15,8 +15,8 @@ module Api
         DOC
       end
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/domains/", N_("List of domains")
       api :GET, "/subnets/:subnet_id/domains", N_("List of domains per subnet")

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -5,8 +5,8 @@ module Api
       include Api::TaxonomyScope
       include Api::ImportPuppetclassesCommonController
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/environments/", N_("List all environments")
       api :GET, "/puppetclasses/:puppetclass_id/environments", N_("List environments of Puppet class")

--- a/app/controllers/api/v2/external_usergroups_controller.rb
+++ b/app/controllers/api/v2/external_usergroups_controller.rb
@@ -3,9 +3,9 @@ module Api
     class ExternalUsergroupsController < V2::BaseController
       include Api::Version2
 
-      before_filter :find_resource, :only => [:show, :update, :destroy, :refresh]
-      before_filter :find_required_nested_object, :only => [:index, :show, :create]
-      after_filter :refresh_external_usergroup, :only => [:create, :update, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy, :refresh]
+      before_action :find_required_nested_object, :only => [:index, :show, :create]
+      after_action :refresh_external_usergroup, :only => [:create, :update, :destroy]
 
       api :GET, '/usergroups/:usergroup_id/external_usergroups', N_('List all external user groups for user group')
       api :GET, '/auth_source_ldaps/:auth_source_ldap_id/external_usergroups', N_('List all external user groups for LDAP authentication source')

--- a/app/controllers/api/v2/fact_values_controller.rb
+++ b/app/controllers/api/v2/fact_values_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class FactValuesController < V2::BaseController
-      before_filter :setup_search_options, :only => :index
+      before_action :setup_search_options, :only => :index
 
       api :GET, "/fact_values/", N_("List all fact values")
       api :GET, "/hosts/:host_id/facts/", N_("List all fact values of a given host")

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/filters/", N_("List all filters")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/home_controller.rb
+++ b/app/controllers/api/v2/home_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class HomeController < V2::BaseController
-      before_filter :require_admin, :only => [:index]
+      before_action :require_admin, :only => [:index]
       layout false
 
       api :GET, "/", N_("Show available API links")

--- a/app/controllers/api/v2/host_classes_controller.rb
+++ b/app/controllers/api/v2/host_classes_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_host, :only => [:index, :create, :destroy]
+      before_action :find_host, :only => [:index, :create, :destroy]
 
       api :GET, "/hosts/:host_id/puppetclass_ids/", N_("List all Puppet class IDs for host")
 

--- a/app/controllers/api/v2/hostgroup_classes_controller.rb
+++ b/app/controllers/api/v2/hostgroup_classes_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_hostgroup, :only => [:index, :create, :destroy]
+      before_action :find_hostgroup, :only => [:index, :create, :destroy]
 
       api :GET, "/hostgroups/:hostgroup_id/puppetclass_ids/", N_("List all Puppet class IDs for host group")
 

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy clone}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy clone}
 
       api :GET, "/hostgroups/", N_("List all host groups")
       api :GET, "/puppetclasses/:puppetclass_id/hostgroups", N_("List all host groups for a Puppet class")

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -8,11 +8,11 @@ module Api
       include Foreman::Controller::SmartProxyAuth
 
       include Api::CompatibilityChecker
-      before_filter :check_create_host_nested, :only => [:create, :update]
+      before_action :check_create_host_nested, :only => [:create, :update]
 
-      before_filter :find_optional_nested_object, :except => [:facts]
-      before_filter :find_resource, :except => [:index, :create, :facts]
-      before_filter :permissions_check, :only => %w{power boot puppetrun}
+      before_action :find_optional_nested_object, :except => [:facts]
+      before_action :find_resource, :except => [:index, :create, :facts]
+      before_action :permissions_check, :only => %w{power boot puppetrun}
 
       add_smart_proxy_filters :facts, :features => Proc.new { FactImporter.fact_features }
 

--- a/app/controllers/api/v2/images_controller.rb
+++ b/app/controllers/api/v2/images_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class ImagesController < V2::BaseController
-      before_filter :find_required_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_required_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/compute_resources/:compute_resource_id/images/", N_("List all images for a compute resource")
       api :GET, "/operatingsystems/:operatingsystem_id/images/", N_("List all images for operating system")

--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -6,9 +6,9 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_required_nested_object, :only => [:index, :show, :create, :destroy]
-      before_filter :find_resource, :only => [:show, :update, :destroy]
-      before_filter :convert_type, :only => [:create, :update]
+      before_action :find_required_nested_object, :only => [:index, :show, :create, :destroy]
+      before_action :find_resource, :only => [:show, :update, :destroy]
+      before_action :convert_type, :only => [:create, :update]
 
       api :GET, '/hosts/:host_id/interfaces', N_("List all interfaces for host")
       api :GET, '/domains/:domain_id/interfaces', N_('List all interfaces for domain')

--- a/app/controllers/api/v2/mail_notifications_controller.rb
+++ b/app/controllers/api/v2/mail_notifications_controller.rb
@@ -3,7 +3,7 @@ module Api
     class MailNotificationsController < V2::BaseController
       include Api::Version2
 
-      before_filter :find_resource, :only => %w{show}
+      before_action :find_resource, :only => %w{show}
 
       api :GET, "/mail_notifications/", N_("List of email notifications")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       PATH_INFO = <<-eos
 The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture).

--- a/app/controllers/api/v2/models_controller.rb
+++ b/app/controllers/api/v2/models_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class ModelsController < V2::BaseController
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/models/", N_("List all hardware models")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -5,10 +5,10 @@ module Api
         name 'Operating systems'
       end
 
-      before_filter :rename_config_templates, :only => %w{update create}
-      before_filter :rename_config_template, :only => %w{index}
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show edit update destroy bootfiles}
+      before_action :rename_config_templates, :only => %w{update create}
+      before_action :rename_config_template, :only => %w{index}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show edit update destroy bootfiles}
 
       api :GET, "/operatingsystems/", N_("List all operating systems")
       api :GET, "/architectures/:architecture_id/operatingsystems", N_("List all operating systems for nested architecture")

--- a/app/controllers/api/v2/os_default_templates_controller.rb
+++ b/app/controllers/api/v2/os_default_templates_controller.rb
@@ -6,9 +6,9 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :rename_config_template
-      before_filter :find_required_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :rename_config_template
+      before_action :find_required_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, '/operatingsystems/:operatingsystem_id/os_default_templates', N_('List default templates combinations for an operating system')
       api :GET, '/config_templates/:config_template_id/os_default_templates', N_('List operating systems where this template is set as a default')

--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -4,11 +4,11 @@ module Api
       include Api::Version2
       include Api::V2::LookupKeysCommonController
 
-      before_filter :find_override_values
-      before_filter :find_override_value, :only => [:show, :update, :destroy]
+      before_action :find_override_values
+      before_action :find_override_value, :only => [:show, :update, :destroy]
       # override return_if_smart_mismatch in LookupKeysCommonController to add :index, :create
-      before_filter :return_if_smart_mismatch, :only => [:index, :create, :show, :update, :destroy]
-      before_filter :return_if_override_mismatch, :only => [:show, :update, :destroy]
+      before_action :return_if_smart_mismatch, :only => [:index, :create, :show, :update, :destroy]
+      before_action :return_if_override_mismatch, :only => [:show, :update, :destroy]
 
       api :GET, "/smart_variables/:smart_variable_id/override_values", N_("List of override values for a specific smart variable")
       api :GET, "/smart_class_parameters/:smart_class_parameter_id/override_values", N_("List of override values for a specific smart class parameter")

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_required_nested_object
-      before_filter :find_parameter, :only => [:show, :update, :destroy]
+      before_action :find_required_nested_object
+      before_action :find_parameter, :only => [:show, :update, :destroy]
 
       resource_description do
         desc <<-DOC

--- a/app/controllers/api/v2/permissions_controller.rb
+++ b/app/controllers/api/v2/permissions_controller.rb
@@ -3,8 +3,8 @@ module Api
     class PermissionsController < V2::BaseController
       include Api::Version2
 
-      before_filter :find_resource, :only => %w{show}
-      before_filter :parameter_deprecation, :only => %w(index)
+      before_action :find_resource, :only => %w{show}
+      before_action :parameter_deprecation, :only => %w(index)
 
       api :GET, "/permissions/", N_("List all permissions")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -6,12 +6,12 @@ module Api
       include Foreman::Renderer
       include Foreman::Controller::ProvisioningTemplates
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy clone}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy clone}
 
-      before_filter :handle_template_upload, :only => [:create, :update]
-      before_filter :process_template_kind, :only => [:create, :update]
-      before_filter :process_operatingsystems, :only => [:create, :update]
+      before_action :handle_template_upload, :only => [:create, :update]
+      before_action :process_template_kind, :only => [:create, :update]
+      before_action :process_operatingsystems, :only => [:create, :update]
 
       api :GET, "/provisioning_templates/", N_("List provisioning templates")
       api :GET, "/operatingsystems/:operatingsystem_id/provisioning_templates", N_("List provisioning templates per operating system")

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class PtablesController < V2::BaseController
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy clone}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy clone}
 
       api :GET, "/ptables/", N_("List all partition tables")
       api :GET, "/operatingsystems/:operatingsystem_id/ptables", N_("List all partition tables for an operating system")

--- a/app/controllers/api/v2/puppetclasses_controller.rb
+++ b/app/controllers/api/v2/puppetclasses_controller.rb
@@ -4,8 +4,8 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/puppetclasses/", N_("List all Puppet classes")
       api :GET, "/hosts/:host_id/puppetclasses", N_("List all Puppet classes for a host")

--- a/app/controllers/api/v2/realms_controller.rb
+++ b/app/controllers/api/v2/realms_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/realms/", N_("List of realms")
       param_group :taxonomy_scope, ::Api::V2::BaseController

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -3,9 +3,9 @@ module Api
     class ReportsController < V2::BaseController
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
-      before_filter :deprecated
-      before_filter :find_resource, :only => %w{show destroy}
-      before_filter :setup_search_options, :only => [:index, :last]
+      before_action :deprecated
+      before_action :find_resource, :only => %w{show destroy}
+      before_action :setup_search_options, :only => [:index, :last]
 
       add_smart_proxy_filters :create, :features => Proc.new { ConfigReportImporter.authorized_smart_proxy_features }
 

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class RolesController < V2::BaseController
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/roles/", N_("List all roles")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class SettingsController < V2::BaseController
-      before_filter :require_admin
-      before_filter :find_resource, :only => %w{show update}
+      before_action :require_admin
+      before_action :find_resource, :only => %w{show update}
 
       api :GET, "/settings/", N_("List all settings")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
       include Api::ImportPuppetclassesCommonController
-      before_filter :find_resource, :only => %w{show update destroy refresh version logs}
+      before_action :find_resource, :only => %w{show update destroy refresh version logs}
 
       api :GET, "/smart_proxies/", N_("List all smart proxies")
       param_group :taxonomy_scope, ::Api::V2::BaseController

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -4,9 +4,9 @@ module Api
       include Api::Version2
       include Api::TaxonomyScope
 
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy freeip}
-      before_filter :find_ipam, :only => %w{freeip}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy freeip}
+      before_action :find_ipam, :only => %w{freeip}
 
       api :GET, '/subnets', N_("List of subnets")
       api :GET, "/domains/:domain_id/subnets", N_("List of subnets for a domain")

--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -1,9 +1,9 @@
 module Api
   module V2
     class TemplateCombinationsController < V2::BaseController
-      before_filter :rename_config_template
-      before_filter :find_required_nested_object
-      before_filter :find_resource, :only => [:show, :update, :destroy]
+      before_action :rename_config_template
+      before_action :find_required_nested_object
+      before_action :find_resource, :only => [:show, :update, :destroy]
 
       def_param_group :template_combination_identifiers do
         param :config_template_id, String, :desc => N_("ID of config template")

--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class UsergroupsController < V2::BaseController
-      before_filter :find_optional_nested_object
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/usergroups/", N_("List all user groups")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -3,12 +3,12 @@ module Api
     class UsersController < V2::BaseController
       wrap_parameters User, :include => User.accessible_attributes
 
-      before_filter :find_resource, :only => %w{show update destroy}
+      before_action :find_resource, :only => %w{show update destroy}
       # find_resource needs to be defined prior to UsersMixin is included, it depends on @user
       include Foreman::Controller::UsersMixin
       include Api::Version2
       include Api::TaxonomyScope
-      before_filter :find_optional_nested_object
+      before_action :find_optional_nested_object
 
       api :GET, "/users/", N_("List all users")
       api :GET, "/auth_source_ldaps/:auth_source_ldap_id/users", N_("List all users for LDAP authentication source")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,13 +14,13 @@ class ApplicationController < ActionController::Base
   helper 'layout'
   helper_method :authorizer
 
-  before_filter :require_login
-  before_filter :set_gettext_locale_db, :set_gettext_locale
-  before_filter :session_expiry, :update_activity_time, :unless => proc {|c| !SETTINGS[:login] || c.remote_user_provided? || c.api_request? }
-  before_filter :set_taxonomy, :require_mail, :check_empty_taxonomy
-  before_filter :authorize
-  before_filter :welcome, :only => :index, :unless => :api_request?
-  around_filter :set_timezone
+  before_action :require_login
+  before_action :set_gettext_locale_db, :set_gettext_locale
+  before_action :session_expiry, :update_activity_time, :unless => proc {|c| !SETTINGS[:login] || c.remote_user_provided? || c.api_request? }
+  before_action :set_taxonomy, :require_mail, :check_empty_taxonomy
+  before_action :authorize
+  before_action :welcome, :only => :index, :unless => :api_request?
+  around_action :set_timezone
   layout :display_layout?
 
   attr_reader :original_search_parameter

--- a/app/controllers/architectures_controller.rb
+++ b/app/controllers/architectures_controller.rb
@@ -1,6 +1,6 @@
 class ArchitecturesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     base = resource_base.includes(:operatingsystems).search_for(params[:search], :order => params[:order])

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,7 +1,7 @@
 class AuditsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :setup_search_options, :only => :index
+  before_action :setup_search_options, :only => :index
 
   def index
     Audit.unscoped { @audits = resource_base.includes(:user).search_for(params[:search], :order => params[:order]).paginate :page => params[:page] }

--- a/app/controllers/auth_source_ldaps_controller.rb
+++ b/app/controllers/auth_source_ldaps_controller.rb
@@ -1,5 +1,5 @@
 class AuthSourceLdapsController < ApplicationController
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @auth_source_ldaps = resource_base.all

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,7 +1,7 @@
 class BookmarksController < ApplicationController
   include Foreman::Controller::BookmarkCommon
 
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @bookmarks = resource_base.paginate(:page => params[:page])

--- a/app/controllers/common_parameters_controller.rb
+++ b/app/controllers/common_parameters_controller.rb
@@ -1,6 +1,6 @@
 class CommonParametersController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @common_parameters = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/compute_profiles_controller.rb
+++ b/app/controllers/compute_profiles_controller.rb
@@ -1,6 +1,6 @@
 class ComputeProfilesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:show, :edit, :update, :destroy]
+  before_action :find_resource, :only => [:show, :edit, :update, :destroy]
 
   def index
     @compute_profiles = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -1,8 +1,8 @@
 class ComputeResourcesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   AJAX_REQUESTS = [:template_selected, :cluster_selected, :resource_pools]
-  before_filter :ajax_request, :only => AJAX_REQUESTS
-  before_filter :find_resource, :only => [:show, :edit, :associate, :update, :destroy, :ping] + AJAX_REQUESTS
+  before_action :ajax_request, :only => AJAX_REQUESTS
+  before_action :find_resource, :only => [:show, :edit, :associate, :update, :destroy, :ping] + AJAX_REQUESTS
 
   #This can happen in development when removing a plugin
   rescue_from ActiveRecord::SubclassNotFound do |e|

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -2,9 +2,9 @@ module Api::ImportPuppetclassesCommonController
   extend ActiveSupport::Concern
 
   included do
-    before_filter :find_required_puppet_proxy, :only => [:import_puppetclasses]
-    before_filter :get_environment_id, :only => [:import_puppetclasses]
-    before_filter :find_optional_environment, :only => [:import_puppetclasses]
+    before_action :find_required_puppet_proxy, :only => [:import_puppetclasses]
+    before_action :get_environment_id, :only => [:import_puppetclasses]
+    before_action :find_optional_environment, :only => [:import_puppetclasses]
   end
 
   extend Apipie::DSL::Concern

--- a/app/controllers/concerns/api/taxonomy_scope.rb
+++ b/app/controllers/concerns/api/taxonomy_scope.rb
@@ -3,7 +3,7 @@ module Api
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_taxonomy_scope
+      before_action :set_taxonomy_scope
     end
 
     def set_taxonomy_scope

--- a/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
+++ b/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
@@ -2,21 +2,21 @@ module Api::V2::LookupKeysCommonController
   extend ActiveSupport::Concern
 
   included do
-    before_filter :find_environment, :if => :environment_id?
-    before_filter :find_puppetclass, :if => :puppetclass_id?
-    before_filter :find_host, :if => :host_id?
-    before_filter :find_hostgroup, :if => :hostgroup_id?
+    before_action :find_environment, :if => :environment_id?
+    before_action :find_puppetclass, :if => :puppetclass_id?
+    before_action :find_host, :if => :host_id?
+    before_action :find_hostgroup, :if => :hostgroup_id?
 
-    before_filter :find_smart_class_parameters, :if => :smart_class_parameter_id?
-    before_filter :find_smart_class_parameter, :if => :smart_class_parameter_id?
+    before_action :find_smart_class_parameters, :if => :smart_class_parameter_id?
+    before_action :find_smart_class_parameter, :if => :smart_class_parameter_id?
 
-    before_filter :find_smart_variables, :if => :smart_variable_id?
-    before_filter :find_smart_variable, :if => :smart_variable_id?
+    before_action :find_smart_variables, :if => :smart_variable_id?
+    before_action :find_smart_variable, :if => :smart_variable_id?
 
-    before_filter :find_smarts
-    before_filter :find_smart
+    before_action :find_smarts
+    before_action :find_smart
 
-    before_filter :return_if_smart_mismatch, :only => [:show, :update, :destroy]
+    before_action :return_if_smart_mismatch, :only => [:show, :update, :destroy]
   end
 
   def smart_variable_id?

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -2,12 +2,12 @@ module Api::V2::TaxonomiesController
   extend ActiveSupport::Concern
 
   included do
-    before_filter :rename_config_template, :only => %w{update create}
-    before_filter :find_optional_nested_object
-    before_filter :find_taxonomy, :only => %w(show update destroy settings
+    before_action :rename_config_template, :only => %w{update create}
+    before_action :find_optional_nested_object
+    before_action :find_taxonomy, :only => %w(show update destroy settings
                                               domain_ids subnet_ids hostgroup_ids config_template_ids ptable_ids compute_resource_ids
                                               medium_ids smart_proxy_ids environment_ids user_ids organization_ids realm_ids)
-    before_filter :params_match_database, :only => %w(create update)
+    before_action :params_match_database, :only => %w(create update)
   end
 
   extend Apipie::DSL::Concern

--- a/app/controllers/concerns/foreman/controller/auto_complete_search.rb
+++ b/app/controllers/concerns/foreman/controller/auto_complete_search.rb
@@ -2,8 +2,8 @@ module Foreman::Controller::AutoCompleteSearch
   extend ActiveSupport::Concern
 
   included do
-    before_filter :reset_redirect_to_url, :only => [:index, :show]
-    before_filter :store_redirect_to_url, :except => [:index, :show, :create, :update]
+    before_action :reset_redirect_to_url, :only => [:index, :show]
+    before_action :store_redirect_to_url, :except => [:index, :show, :create, :update]
   end
 
   def auto_complete_search

--- a/app/controllers/concerns/foreman/controller/migration_checker.rb
+++ b/app/controllers/concerns/foreman/controller/migration_checker.rb
@@ -2,7 +2,7 @@ module Foreman::Controller::MigrationChecker
   extend ActiveSupport::Concern
 
   included do
-    before_filter :check_pending_migrations
+    before_action :check_pending_migrations
   end
 
   def self.needs_migration?

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -6,12 +6,12 @@ module Foreman::Controller::SmartProxyAuth
 
   module ClassMethods
     def add_smart_proxy_filters(actions, options = {})
-      skip_before_filter :require_login, :only => actions
-      skip_before_filter :authorize, :only => actions
-      skip_before_filter :verify_authenticity_token, :only => actions
-      skip_before_filter :set_taxonomy, :only => actions
-      skip_before_filter :session_expiry, :update_activity_time, :only => actions
-      before_filter(:only => actions) { require_smart_proxy_or_login(options[:features]) }
+      skip_before_action :require_login, :only => actions
+      skip_before_action :authorize, :only => actions
+      skip_before_action :verify_authenticity_token, :only => actions
+      skip_before_action :set_taxonomy, :only => actions
+      skip_before_action :session_expiry, :update_activity_time, :only => actions
+      before_action(:only => actions) { require_smart_proxy_or_login(options[:features]) }
       attr_reader :detected_proxy
 
       define_method(:require_ssl_with_smart_proxy_filters?) do

--- a/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
@@ -2,11 +2,11 @@ module Foreman::Controller::TaxonomiesController
   extend ActiveSupport::Concern
 
   included do
-    before_filter :find_resource, :only => %w{edit update destroy clone_taxonomy assign_hosts
+    before_action :find_resource, :only => %w{edit update destroy clone_taxonomy assign_hosts
                                               assign_selected_hosts assign_all_hosts step2 select
                                               parent_taxonomy_selected}
-    before_filter :count_nil_hosts, :only => %w{index create step2}
-    skip_before_filter :authorize, :set_taxonomy, :only => %w{select clear}
+    before_action :count_nil_hosts, :only => %w{index create step2}
+    skip_before_action :authorize, :set_taxonomy, :only => %w{select clear}
   end
 
   def index

--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -3,7 +3,7 @@ module Foreman::Controller::TaxonomyMultiple
 
   included do
     #TODO: make this before filter work, its not working as the same filter is defined in the hosts controller
-    #before_filter :find_multiple, :only => [:select_multiple_organization, :update_multiple_organization,
+    #before_action :find_multiple, :only => [:select_multiple_organization, :update_multiple_organization,
     #                                        :select_multiple_location,     :update_multiple_location]
   end
 

--- a/app/controllers/concerns/foreman/controller/users_mixin.rb
+++ b/app/controllers/concerns/foreman/controller/users_mixin.rb
@@ -2,8 +2,8 @@ module Foreman::Controller::UsersMixin
   extend ActiveSupport::Concern
 
   included do
-    before_filter :set_admin_on_creation, :only => :create
-    before_filter :clear_params_on_update, :update_admin_flag, :only => :update
+    before_action :set_admin_on_creation, :only => :create
+    before_action :clear_params_on_update, :update_admin_flag, :only => :update
   end
 
   def resource_scope(options = {})

--- a/app/controllers/config_groups_controller.rb
+++ b/app/controllers/config_groups_controller.rb
@@ -1,6 +1,6 @@
 class ConfigGroupsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @config_groups = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/config_reports_controller.rb
+++ b/app/controllers/config_reports_controller.rb
@@ -1,7 +1,7 @@
 class ConfigReportsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :setup_search_options, :only => :index
+  before_action :setup_search_options, :only => :index
 
   def index
     @config_reports = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page]).includes(:host)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,8 +1,8 @@
 class DashboardController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :prefetch_data, :only => :index
-  before_filter :find_resource, :only => [:destroy]
-  skip_before_filter :welcome
+  before_action :prefetch_data, :only => :index
+  before_action :find_resource, :only => [:destroy]
+  skip_before_action :welcome
 
   def index
     respond_to do |format|

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,6 +1,6 @@
 class DomainsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @domains = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -2,7 +2,7 @@ class EnvironmentsController < ApplicationController
   include Foreman::Controller::Environments
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @environments = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/external_usergroups_controller.rb
+++ b/app/controllers/external_usergroups_controller.rb
@@ -1,5 +1,5 @@
 class ExternalUsergroupsController < ApplicationController
-  before_filter :find_resource, :only => [:refresh]
+  before_action :find_resource, :only => [:refresh]
 
   def refresh
     if @external_usergroup.refresh

--- a/app/controllers/fact_values_controller.rb
+++ b/app/controllers/fact_values_controller.rb
@@ -1,7 +1,7 @@
 class FactValuesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :setup_search_options, :only => :index
+  before_action :setup_search_options, :only => :index
 
   def index
     base = resource_base.no_timestamp_facts

--- a/app/controllers/facts_controller.rb
+++ b/app/controllers/facts_controller.rb
@@ -1,5 +1,5 @@
 class FactsController < ApplicationController
-  before_filter :valid_request?
+  before_action :valid_request?
 
   def index
     render :json => FactName.no_timestamp_fact

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -1,8 +1,8 @@
 class FiltersController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_role
-  before_filter :setup_search_options, :only => :index
+  before_action :find_role
+  before_action :setup_search_options, :only => :index
 
   def index
     @filters = resource_base.includes(:role, :permissions).search_for(params[:search], :order => params[:order])

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
-  skip_before_filter :require_login, :only => [:status]
-  skip_before_filter :authorize, :set_taxonomy, :only => [:status]
-  skip_before_filter :session_expiry, :update_activity_time, :only => :status
+  skip_before_action :require_login, :only => [:status]
+  skip_before_action :authorize, :set_taxonomy, :only => [:status]
+  skip_before_action :session_expiry, :update_activity_time, :only => :status
 
   def settings
   end

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -2,9 +2,9 @@ class HostgroupsController < ApplicationController
   include Foreman::Controller::HostDetails
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_resource,  :only => [:nest, :clone, :edit, :update, :destroy]
-  before_filter :ajax_request,   :only => [:process_hostgroup, :puppetclass_parameters]
-  before_filter :taxonomy_scope, :only => [:new, :edit, :process_hostgroup]
+  before_action :find_resource,  :only => [:nest, :clone, :edit, :update, :destroy]
+  before_action :ajax_request,   :only => [:process_hostgroup, :puppetclass_parameters]
+  before_action :taxonomy_scope, :only => [:new, :edit, :process_hostgroup]
 
   def index
     @hostgroups = resource_base.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -21,18 +21,18 @@ class HostsController < ApplicationController
 
   add_smart_proxy_filters PUPPETMASTER_ACTIONS, :features => ['Puppet']
 
-  before_filter :ajax_request, :only => AJAX_REQUESTS
-  before_filter :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :puppetrun, :review_before_build,
+  before_action :ajax_request, :only => AJAX_REQUESTS
+  before_action :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :puppetrun, :review_before_build,
                                           :setBuild, :cancelBuild, :power, :overview, :bmc, :vm,
                                           :runtime, :resources, :nics, :ipmi_boot, :console,
                                           :toggle_manage, :pxe_config, :storeconfig_klasses, :disassociate]
 
-  before_filter :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
-  before_filter :set_host_type, :only => [:update]
-  before_filter :find_multiple, :only => MULTIPLE_ACTIONS
-  before_filter :validate_power_action, :only => :update_multiple_power_state
-  before_filter :validate_multiple_puppet_proxy, :only => :update_multiple_puppet_proxy
-  before_filter :validate_multiple_puppet_ca_proxy, :only => :update_multiple_puppet_ca_proxy
+  before_action :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
+  before_action :set_host_type, :only => [:update]
+  before_action :find_multiple, :only => MULTIPLE_ACTIONS
+  before_action :validate_power_action, :only => :update_multiple_power_state
+  before_action :validate_multiple_puppet_proxy, :only => :update_multiple_puppet_proxy
+  before_action :validate_multiple_puppet_ca_proxy, :only => :update_multiple_puppet_ca_proxy
   helper :hosts, :reports, :interfaces
 
   def index(title = nil)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,6 @@
 class ImagesController < ApplicationController
-  before_filter :find_compute_resource
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_compute_resource
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     # Listing images in /hosts/new consumes this method as JSON

--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -1,7 +1,7 @@
 class LookupKeysController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :setup_search_options, :only => :index
-  before_filter :find_resource, :only => [:edit, :update, :destroy], :if => Proc.new { params[:id] }
+  before_action :setup_search_options, :only => :index
+  before_action :find_resource, :only => [:edit, :update, :destroy], :if => Proc.new { params[:id] }
 
   def index
     @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])

--- a/app/controllers/lookup_values_controller.rb
+++ b/app/controllers/lookup_values_controller.rb
@@ -1,7 +1,7 @@
 class LookupValuesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:update, :destroy]
-  before_filter :setup_search_options, :only => :index
+  before_action :find_resource, :only => [:update, :destroy]
+  before_action :setup_search_options, :only => :index
 
   def index
     begin

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,6 @@
 class MediaController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @media = resource_base.includes(:operatingsystems).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -1,6 +1,6 @@
 class ModelsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @models = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -1,6 +1,6 @@
 class OperatingsystemsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @operatingsystems = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/puppetclass_lookup_keys_controller.rb
+++ b/app/controllers/puppetclass_lookup_keys_controller.rb
@@ -1,5 +1,5 @@
 class PuppetclassLookupKeysController < LookupKeysController
-  before_filter :setup_search_options, :only => :index
+  before_action :setup_search_options, :only => :index
 
   def index
     @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -1,8 +1,8 @@
 class PuppetclassesController < ApplicationController
   include Foreman::Controller::Environments
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy, :override]
-  before_filter :setup_search_options, :only => :index
+  before_action :find_resource, :only => [:edit, :update, :destroy, :override]
+  before_action :setup_search_options, :only => :index
 
   def index
     @puppetclasses = resource_base.search_for(params[:search], :order => params[:order]).includes(:config_group_classes, :class_params, :environments, :hostgroups).paginate(:page => params[:page])

--- a/app/controllers/realms_controller.rb
+++ b/app/controllers/realms_controller.rb
@@ -1,6 +1,6 @@
 class RealmsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @realms = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -17,7 +17,7 @@
 
 class RolesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:clone, :edit, :update, :destroy]
+  before_action :find_resource, :only => [:clone, :edit, :update, :destroy]
 
   def index
     params[:order] ||= 'name'

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,6 @@
 class SettingsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :require_admin
+  before_action :require_admin
 
   #This can happen in development when removing a plugin
   rescue_from ActiveRecord::SubclassNotFound do |e|

--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -1,8 +1,8 @@
 class SmartProxiesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_resource, :only => [:show, :edit, :update, :refresh, :ping, :tftp_server, :destroy, :puppet_environments, :puppet_dashboard, :log_pane, :failed_modules, :errors_card, :modules_card, :expire_logs]
-  before_filter :find_status, :only => [:ping, :tftp_server, :puppet_environments]
+  before_action :find_resource, :only => [:show, :edit, :update, :refresh, :ping, :tftp_server, :destroy, :puppet_environments, :puppet_dashboard, :log_pane, :failed_modules, :errors_card, :modules_card, :expire_logs]
+  before_action :find_status, :only => [:ping, :tftp_server, :puppet_environments]
 
   def index
     @smart_proxies = resource_base.includes(:features).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -1,6 +1,6 @@
 class SubnetsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
     @subnets = resource_base.search_for(params[:search], :order => params[:order]).includes(:domains, :dhcp).paginate :page => params[:page]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
-  skip_before_filter :session_expiry, :update_activity_time, :set_taxonomy, :only => [:show]
-  before_filter :ajax_request
+  skip_before_action :session_expiry, :update_activity_time, :set_taxonomy, :only => [:show]
+  before_action :ajax_request
 
   def show
     id     = params[:id]

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -3,10 +3,10 @@ class TemplatesController < ApplicationController
   include Foreman::Controller::ProvisioningTemplates
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :handle_template_upload, :only => [:create, :update]
-  before_filter :find_resource, :only => [:edit, :update, :destroy, :clone_template, :lock, :unlock]
-  before_filter :load_history, :only => :edit
-  before_filter :type_name_plural, :type_name_singular, :resource_class
+  before_action :handle_template_upload, :only => [:create, :update]
+  before_action :find_resource, :only => [:edit, :update, :destroy, :clone_template, :lock, :unlock]
+  before_action :load_history, :only => :edit
+  before_action :type_name_plural, :type_name_singular, :resource_class
 
   include TemplatePathsHelper
 
@@ -79,7 +79,7 @@ class TemplatesController < ApplicationController
   end
 
   def preview
-    # Not using before_filter :find_resource method because we have enabled preview to work for unsaved templates hence no resource could be found in those cases
+    # Not using before_action :find_resource method because we have enabled preview to work for unsaved templates hence no resource could be found in those cases
     if params[:id]
       find_resource
     else

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,5 +1,5 @@
 class TrendsController < ApplicationController
-  before_filter :find_resource, :only => [:show, :edit, :update, :destroy]
+  before_action :find_resource, :only => [:show, :edit, :update, :destroy]
 
   def index
     @trends = Trend.types.includes(:trendable).sort_by {|e| e.type_name.downcase }.paginate(:page => params[:page])

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -13,14 +13,14 @@ class UnattendedController < ApplicationController
   end
 
   # We want to find out our requesting host
-  before_filter :get_host_details, :allowed_to_install?, :except => :hostgroup_template
-  before_filter :handle_ca, :if => Proc.new { params[:kind] == 'provision' }
-  before_filter :handle_realm, :if => Proc.new { params[:kind] == 'provision' }
+  before_action :get_host_details, :allowed_to_install?, :except => :hostgroup_template
+  before_action :handle_ca, :if => Proc.new { params[:kind] == 'provision' }
+  before_action :handle_realm, :if => Proc.new { params[:kind] == 'provision' }
   # load "helper" variables to be available in the templates
-  before_filter :load_template_vars, :only => :host_template
+  before_action :load_template_vars, :only => :host_template
   # all of our requests should be returned in text/plain
-  after_filter :set_content_type
-  before_filter :set_admin_user, :only => :built
+  after_action :set_content_type
+  before_action :set_admin_user, :only => :built
 
   # this actions is called by each operatingsystem post/finish script - it notify us that the OS installation is done.
   def built
@@ -156,7 +156,7 @@ class UnattendedController < ApplicationController
     (@host.build || @spoof) ? true : head(:method_not_allowed)
   end
 
-  # Cleans Certificate and enable autosign. This is run as a before_filter for provisioning templates.
+  # Cleans Certificate and enable autosign. This is run as a before_action for provisioning templates.
   # The host is requesting its build configuration so I guess we just send them some text so a post mortum can see what happened
   def handle_ca
     # The reason we do it here is to minimize the amount of time it is possible to automatically get a certificate
@@ -164,19 +164,19 @@ class UnattendedController < ApplicationController
     # We don't do anything if we are in spoof mode.
     return true if @spoof
 
-    # This should terminate the before_filter and the action. We return a HTTP
+    # This should terminate the before_action and the action. We return a HTTP
     # error so the installer knows something is wrong. This is tested with
     # Anaconda, but maybe Suninstall will choke on it.
     render(:text => _("Failed to clean any old certificates or add the autosign entry. Terminating the build!"), :status => :internal_server_error) unless @host.handle_ca
     #TODO: Email the user who initiated this build operation.
   end
 
-  # Reset realm OTP. This is run as a before_filter for provisioning templates.
+  # Reset realm OTP. This is run as a before_action for provisioning templates.
   def handle_realm
     # We don't do anything if we are in spoof mode.
     return true if @spoof
 
-    # This should terminate the before_filter and the action. We return a HTTP
+    # This should terminate the before_action and the action. We return a HTTP
     # error so the installer knows something is wrong. This is tested with
     # Anaconda, but maybe Suninstall will choke on it.
     render(:text => _("Failed to get a new realm OTP. Terminating the build!"), :status => :internal_server_error) unless @host.handle_realm

--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -1,8 +1,8 @@
 class UsergroupsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-  before_filter :find_resource, :only => [:edit, :update, :destroy]
-  before_filter :get_external_usergroups_to_refresh, :only => [:update]
-  after_filter  :refresh_external_usergroups, :only => [:create, :update]
+  before_action :find_resource, :only => [:edit, :update, :destroy]
+  before_action :get_external_usergroups_to_refresh, :only => [:update]
+  after_action  :refresh_external_usergroups, :only => [:create, :update]
 
   def index
     @usergroups = resource_base.includes(:usergroups).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,11 +2,11 @@ class UsersController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::UsersMixin
 
-  skip_before_filter :require_mail, :only => [:edit, :update, :logout]
-  skip_before_filter :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogout]
-  skip_before_filter :authorize, :only => :extlogin
-  after_filter       :update_activity_time, :only => :login
-  skip_before_filter :update_admin_flag, :only => :update
+  skip_before_action :require_mail, :only => [:edit, :update, :logout]
+  skip_before_action :require_login, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogout]
+  skip_before_action :authorize, :only => :extlogin
+  after_action       :update_activity_time, :only => :login
+  skip_before_action :update_admin_flag, :only => :update
 
   def index
     @users = User.authorized(:view_users).except_hidden.search_for(params[:search], :order => params[:order]).includes(:auth_source, :cached_usergroups).paginate(:page => params[:page])

--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -21,7 +21,7 @@ module Foreman
       extend ActiveSupport::Concern
 
       included do
-        around_filter :clear_thread
+        around_action :clear_thread
       end
 
       def clear_thread

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class Api::TestableController < Api::V1::BaseController
-  before_filter :find_required_nested_object, :only => [:required_nested_values, :nested_values]
-  before_filter :find_optional_nested_object, :only => [:optional_nested_values]
-  before_filter :find_resource, :only => [:nested_values]
+  before_action :find_required_nested_object, :only => [:required_nested_values, :nested_values]
+  before_action :find_optional_nested_object, :only => [:optional_nested_values]
+  before_action :find_resource, :only => [:nested_values]
 
   def index
     render :text => Time.zone.name, :status => 200

--- a/test/unit/concerns/api_taxonomy_scope_test.rb
+++ b/test/unit/concerns/api_taxonomy_scope_test.rb
@@ -5,7 +5,7 @@ class DummyController
   cattr_accessor :callbacks
   attr_accessor :organization, :location, :params
 
-  def self.before_filter(*args)
+  def self.before_action(*args)
     self.callbacks = args
   end
 


### PR DESCRIPTION
The older 'filter' name is changing in Rails to 'action' and is being
deprecated.
