### PR TITLE
Fixes #15718 - Correctly display hash parameters

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -23,15 +23,15 @@ module CommonParametersHelper
     popover(link_title, _("Do not send this parameter via the ENC.<br>Puppet will use the value defined in the manifest."), :title => title)
   end
 
-  def hidden_value_field(f, field, value, disabled, options = {})
+  def hidden_value_field(f, field, disabled, options = {})
     hidden = options.delete(:hidden_value) || f.object.hidden_value?
     html_class = "form-control no-stretch"
     html_class += " masked-input" if hidden
 
     input = f.text_area(field, options.merge(:disabled => disabled,
-                                               :class => html_class,
-                                               :rows => 1,
-                                               :placeholder => _("Value")))
+                                             :class => html_class,
+                                             :rows => 1,
+                                             :placeholder => _("Value")))
 
     input_group(input, input_group_btn(hidden_toggle(f.object.hidden_value?), fullscreen_button("$(this).closest('.input-group').find('input,textarea')")))
   end

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -3,7 +3,7 @@
     <%= f.text_field(:name,  :class => "form-control", :disabled => !can_edit_params?, :placeholder => _("Name")) %>
   </td>
   <td>
-    <%= hidden_value_field(f, :value, f.object.value, !can_edit_params?) %>
+    <%= hidden_value_field(f, :value, !can_edit_params?) %>
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if can_edit_params? %>

--- a/app/views/lookup_keys/_value.html.erb
+++ b/app/views/lookup_keys/_value.html.erb
@@ -11,7 +11,7 @@
     </div>
   </td>
   <td>
-    <%= hidden_value_field(f, :value, f.object.value_before_type_cast, f.object.use_puppet_default, :'data-property' => 'value', :hidden_value => hidden_value) %>
+    <%= hidden_value_field(f, :value, f.object.use_puppet_default, :value => f.object.value_before_type_cast, :'data-property' => 'value', :hidden_value => hidden_value) %>
   </td>
   <% if is_param %>
     <td class="ca">


### PR DESCRIPTION
Lookup values should dispaly the value before type cast for hash type
keys. Rails 4.2.6 introduced a change to the form helpers that only used
the value before type cast for user-provided input, so we need to
specify the correct value for the field instead of relying on the rails
helper to do it.
