### PR TITLE
fixes #15751 - replace spork with spring in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ custom_plan.rb
 pkg/
 config/hooks
 *.csv
+.envrc

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
+    gem 'spring', match[1]
+    require 'spring/binstub'
+  end
+end

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -12,4 +12,5 @@ group :development do
 
   gem 'bullet'
   gem "parallel_tests"
+  gem 'spring', '~> 1.0'
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,6 +1,5 @@
 group :test do
   gem 'mocha', '~> 1.1'
-  gem 'spork-minitest', '0.0.3'
   gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1.0'
   gem 'minitest-spec-rails', '~> 5.3'
@@ -9,7 +8,6 @@ group :test do
   gem 'show_me_the_cookies', '~> 3.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'
-  gem 'spork-rails', '~> 4.0.0'
   gem 'factory_girl_rails', '~> 4.5', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem "poltergeist", :require => false

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -23,6 +23,11 @@
 #   note when you log outside of standard rails path you won't see log output in WEBrick
 #   STDOUT (usually not wanted in development), to use Rails default path, don't set path
 #
+# :truncate:
+#   Truncate the log file to a zero byte length on each startup to reduce size, only
+#   supported with type: file
+#   values: true, false (default)
+#
 # :log_trace:
 #   Include caller tracing information in generated log events (this
 #   includes filename and line number of the log message)
@@ -62,3 +67,4 @@
 :test:
   :level: debug
   :filename: "test.log"
+  :truncate: true

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,0 +1,10 @@
+%w(
+  .ruby-version
+  .rbenv-vars
+  config/email.yaml
+  config/ignored_environments.yml
+  config/logging.yaml
+  config/settings.yaml
+  tmp/restart.txt
+  tmp/caching-dev.txt
+) + Dir["config/settings.plugins.d/*.yaml"].each { |path| Spring.watch(path) }

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -142,6 +142,7 @@ module Foreman
 
     def build_file_appender(name, options)
       log_filename = "#{@log_directory}/#{@config[:filename]}"
+      File.truncate(log_filename, 0) if @config[:truncate] && File.exist?(log_filename)
       begin
         ::Logging.appenders.file(
           name,

--- a/test/facet_test_helper.rb
+++ b/test/facet_test_helper.rb
@@ -1,14 +1,12 @@
-Spork.prefork do
-  unless ActiveRecord::Base.connection.table_exists?(:test_facets)
-    ActiveRecord::Base.connection.create_table :test_facets do |t|
-      # :id is created automatically
-      t.integer :host_id
-    end
+unless ActiveRecord::Base.connection.table_exists?(:test_facets)
+  ActiveRecord::Base.connection.create_table :test_facets do |t|
+    # :id is created automatically
+    t.integer :host_id
   end
-  unless ActiveRecord::Base.connection.table_exists?(:module_test_facets)
-    ActiveRecord::Base.connection.create_table :module_test_facets do |t|
-      # :id is created automatically
-      t.integer :host_id
-    end
+end
+unless ActiveRecord::Base.connection.table_exists?(:module_test_facets)
+  ActiveRecord::Base.connection.create_table :module_test_facets do |t|
+    # :id is created automatically
+    t.integer :host_id
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,73 +1,57 @@
 require 'rubygems'
-require 'fileutils'
-require 'spork'
 
-Spork.prefork do
-  # Loading more in this block will cause your tests to run faster. However,
-  # if you change any configuration or code from libraries loaded here, you'll
-  # need to restart spork for it take effect.
+ENV["RAILS_ENV"] = "test"
+require File.expand_path('../../config/environment', __FILE__)
+require 'rails/test_help'
+require 'mocha/mini_test'
+require 'factory_girl_rails'
+require 'functional/shared/basic_rest_response_test'
+require 'facet_test_helper'
+require 'active_support_test_case_helper'
 
-  # Remove previous test log to speed tests up
-  # Comment out these lines to enable test logging
-  test_log = File.expand_path('../../log/test.log', __FILE__)
-  FileUtils.rm(test_log) if File.exist?(test_log)
-
-  ENV["RAILS_ENV"] = "test"
-  require File.expand_path('../../config/environment', __FILE__)
-  require 'rails/test_help'
-  require 'mocha/mini_test'
-  require 'factory_girl_rails'
-  require 'functional/shared/basic_rest_response_test'
-  require 'facet_test_helper'
-  require 'active_support_test_case_helper'
-
-  # Use our custom test runner, and register a fake plugin to skip a specific test
-  Foreman::Plugin.register :skip_test do
-    tests_to_skip "CustomRunnerTest" => [ "custom runner is working" ]
-  end
-
-  # Turn of Apipie validation for tests
-  Apipie.configuration.validate = false
-
-  # To prevent Postgres' errors "permission denied: "RI_ConstraintTrigger"
-  if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
-    ActiveRecord::Migration.execute "SET CONSTRAINTS ALL DEFERRED;"
-  end
-
-  class ActionView::TestCase
-    helper Rails.application.routes.url_helpers
-  end
-
-  ::Rails::Engine.subclasses.map(&:instance).each do |engine|
-    support_file = "#{engine.root}/test/support/foreman_test_helper_additions.rb"
-    require support_file if File.exist?(support_file)
-  end
+# Use our custom test runner, and register a fake plugin to skip a specific test
+Foreman::Plugin.register :skip_test do
+  tests_to_skip "CustomRunnerTest" => [ "custom runner is working" ]
 end
 
-Spork.each_run do
-  # This code will be run each time you run your specs.
-  class ActionController::TestCase
-    include ::BasicRestResponseTest
-    setup :setup_set_script_name, :set_api_user, :turn_of_login
+# Turn of Apipie validation for tests
+Apipie.configuration.validate = false
 
-    def turn_of_login
-      SETTINGS[:require_ssl] = false
-    end
+# To prevent Postgres' errors "permission denied: "RI_ConstraintTrigger"
+if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+  ActiveRecord::Migration.execute "SET CONSTRAINTS ALL DEFERRED;"
+end
 
-    def setup_set_script_name
-      @request.env["SCRIPT_NAME"] = @controller.config.relative_url_root
-    end
+class ActionView::TestCase
+  helper Rails.application.routes.url_helpers
+end
 
-    def set_api_user
-      return unless self.class.to_s[/api/i]
-      set_basic_auth(users(:apiadmin), "secret")
-    end
+::Rails::Engine.subclasses.map(&:instance).each do |engine|
+  support_file = "#{engine.root}/test/support/foreman_test_helper_additions.rb"
+  require support_file if File.exist?(support_file)
+end
 
-    def set_basic_auth(user, password)
-      login = user.is_a?(User) ? user.login : user
-      @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(login, password)
-      @request.env['CONTENT_TYPE'] = 'application/json'
-      @request.env['HTTP_ACCEPT'] = 'application/json'
-    end
+class ActionController::TestCase
+  include ::BasicRestResponseTest
+  setup :setup_set_script_name, :set_api_user, :turn_of_login
+
+  def turn_of_login
+    SETTINGS[:require_ssl] = false
+  end
+
+  def setup_set_script_name
+    @request.env["SCRIPT_NAME"] = @controller.config.relative_url_root
+  end
+
+  def set_api_user
+    return unless self.class.to_s[/api/i]
+    set_basic_auth(users(:apiadmin), "secret")
+  end
+
+  def set_basic_auth(user, password)
+    login = user.is_a?(User) ? user.login : user
+    @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(login, password)
+    @request.env['CONTENT_TYPE'] = 'application/json'
+    @request.env['HTTP_ACCEPT'] = 'application/json'
   end
 end


### PR DESCRIPTION
To make use of it, run bin/rails and bin/rake rather than plain
rails or rake commands, and run `spring status` or `spring stop` to
check and stop current background processes.

Test log removal has moved to the logging framework as the file would
not be recreated after being deleted in the test helper, since the
Rails environment and logger are not reloaded on each `rake test`.

Lots more useful usage info is at https://github.com/rails/spring#readme.
