### PR TITLE
Fixed #15675 - Improve report expiry performance

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -74,10 +74,10 @@ class Report < ActiveRecord::Base
     cond = "reports.created_at < \'#{(Time.now.utc - timerange).to_formatted_s(:db)}\'"
     cond += " and reports.status = #{status}" unless status.nil?
 
-    Log.joins(:report).where(:report_id => where(cond)).delete_all
+    Log.where(:report_id => where(cond)).reorder('').delete_all
     Message.where("id not IN (#{Log.unscoped.select('DISTINCT message_id').to_sql})").delete_all
     Source.where("id not IN (#{Log.unscoped.select('DISTINCT source_id').to_sql})").delete_all
-    count = where(cond).delete_all
+    count = where(cond).reorder('').delete_all
     logger.info Time.now.utc.to_s + ": Expired #{count} #{to_s.underscore.humanize.pluralize}"
     count
   end


### PR DESCRIPTION
Slowness was being caused by an un-needed `.joins` method, which led
rails to creating suboptimal queries. Also removed default ordering for
a bit of extra performance.

I tested on a largeish DB with 3M reports and 6M logs, time was cut by a
factor of 13.

Before:

``` sql
explain analyze DELETE FROM "logs" WHERE "logs"."id" IN (SELECT "logs"."id" FROM "logs" INNER JOIN "reports" ON "reports"."id" = "logs"."report_id" WHERE "logs"."report_id" IN (SELECT "reports"."id" FROM "reports" WHERE "reports"."type" IN ('ConfigReport') AND (reports.created_at < '2016-07-13 10:15:44'))  ORDER BY logs.id);
                       QUERY PLAN
---------------------------------------------------------------------
 Delete on logs  (cost=642783.98..778314.18 rows=30900 width=34) (actual time=486967.018..486967.018 rows=0 loops=1)
   ->  Hash Semi Join  (cost=642783.98..778314.18 rows=30900 width=34) (actual time=17094.802..24939.511 rows=5614051 loops=1)
         Hash Cond: (logs.id = "ANY_subquery".id)
         ->  Seq Scan on logs  (cost=0.00..113311.00 rows=6180600 width=10) (actual time=0.019..1085.179 rows=6180600 loops=1)
         ->  Hash  (cost=642397.73..642397.73 rows=30900 width=32) (actual time=17090.868..17090.868 rows=5614051 loops=1)
               Buckets: 4096  Batches: 128 (originally 1)  Memory Usage: 4097kB
               ->  Subquery Scan on "ANY_subquery" (cost=642011.48..642397.73 rows=30900 width=32) (actual time=14401.229..16208.478 rows=5614051  loops=1)
                     ->  Sort  (cost=642011.48..642088.73 rows=30900 width=4) (actual time=14401.214..15517.160 rows=5614051 loops=1)
                           Sort Key: logs_1.id
                           Sort Method: external merge  Disk: 76792kB
                           ->  Hash Join  (cost=456555.32..639707.07 rows=30900 width=4) (actual time=6872.378..11094.825 rows=5614051 loops=1)
                                 Hash Cond: (logs_1.report_id = reports.id)
                                 ->  Seq Scan on logs logs_1 (cost=0.00..113311.00 rows=6180600 width=8) (actual time=0.003..446.289 rows=6180600  loops=1)
                                 ->  Hash  (cost=456374.66..456374.66 rows=14453 width=8) (actual time=6871.650..6871.650 rows=2890885 loops=1)
                                       Buckets: 2048  Batches: 32 (originally 1)  Memory Usage: 4097kB
                                       ->  Nested Loop (cost=0.43..456374.66 rows=14453 width=8) (actual time=0.321..6386.737 rows=2890885 loops=1)
                                             ->  Seq Scan on reports reports_1  (cost=0.00..364438.28 rows=14453 width=4) (actual time=0.012..1210 .655 rows=2890885 loops=1)
                                                   Filter: ((created_at < '2016-07-13 10:15:44'::timestamp without time zone) AND ((type)::text = 'ConfigReport'::text))
                                             ->  Index Only Scan using reports_pkey on reports  (cost=0.43..6.35 rows=1 width=4) (actual time=0.00 1..0.002 rows=1 loops=2890885) 
                                                   Index Cond: (id = reports_1.id)
                                                   Heap Fetches: 2890885
 Planning time: 2.020 ms
 Execution time: 486977.025 ms
(23 rows)
```

After:

``` sql
explain analyze DELETE FROM "logs" WHERE "logs"."report_id" IN (SELECT "reports"."id" FROM "reports" WHERE "reports"."type" IN ('ConfigReport') AND (reports.created_at < '2016-07-13 11:05:23'));
              QUERY PLAN
--------------------------------------------------------------------------
 Delete on logs  (cost=364618.94..547770.69 rows=3005154 width=12) (actual time=35701.974..35701.974 rows=0 loops=1)
   ->  Hash Join  (cost=364618.94..547770.69 rows=3005154 width=12) (actual time=1647.135..6981.071 rows=5614051 loops=1)
         Hash Cond: (logs.report_id = reports.id)
         ->  Seq Scan on logs  (cost=0.00..113311.00 rows=6180600 width=10) (actual time=0.013..1015.652 rows=6180600 loops=1)
         ->  Hash  (cost=364438.28..364438.28 rows=14453 width=10) (actual time=1646.429..1646.429 rows=2890885 loops=1)
               Buckets: 2048  Batches: 32 (originally 1)  Memory Usage: 4097kB
               ->  Seq Scan on reports  (cost=0.00..364438.28 rows=14453 width=10) (actual time=0.006..1182.048 rows=2890885 loops=1)
                     Filter: ((created_at < '2016-07-13 11:05:23'::timestamp without time zone) AND ((type)::text = 'ConfigReport'::text))
 Planning time: 0.264 ms
 Execution time: 35701.999 ms
(10 rows)
```
