### PR TITLE
fixes #15762 - move flash testing out of integration test

### DIFF
--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -385,8 +385,9 @@ class HostsControllerTest < ActionController::TestCase
     post :update_multiple_environment, { :host_ids => [@host1.id, @host2.id],
       :environment => { :id => environments(:global_puppetmaster).id}},
       set_session_user.merge(:user => users(:admin).id)
-    assert Host.find(@host1.id).environment == environments(:global_puppetmaster)
-    assert Host.find(@host2.id).environment == environments(:global_puppetmaster)
+    assert_equal environments(:global_puppetmaster), Host.find(@host1.id).environment
+    assert_equal environments(:global_puppetmaster), Host.find(@host2.id).environment
+    assert_equal "Updated hosts: changed environment", flash[:notice]
   end
 
   test "should inherit the hostgroup environment if *inherit from hostgroup* selected" do

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -245,8 +245,8 @@ class HostJSTest < IntegrationTestWithJavascript
 
       # remove hosts cookie on submit
       index_modal.find('.btn-primary').click
+      assert_current_path hosts_path
       assert_empty(page.driver.cookies['_ForemanSelectedhosts'])
-      assert has_selector?("div", :text => "Updated hosts: changed environment")
     end
   end
 


### PR DESCRIPTION
The flash div is only present momentarily before jnotify removes the
element and re-displays it as a popup, so only check that it's set in
the response from functional tests.
