### PR TITLE
Fixes #15763 - added test:plugins rake task

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,5 +1,3 @@
-require 'rake/testtask'
-
 namespace :test do
   desc "Test API"
   Rake::TestTask.new(:api) do |t|
@@ -7,6 +5,19 @@ namespace :test do
     t.pattern = 'test/functional/api/**/*_test.rb'
     t.verbose = true
     t.warning = false
+  end
+
+  desc "Test lib source"
+  Rake::TestTask.new(:lib) do |t|
+    t.libs << "test"
+    t.pattern = 'test/lib/**/*_test.rb'
+    t.verbose = true
+    t.warning = false
+  end
+
+  desc "Test all enabled plugins"
+  task :plugins do
+    # intentionally empty - enhancement point for plugins
   end
 end
 


### PR DESCRIPTION
Everytime I do rake test in core, this also runs all plugin tests. This makes

  rake test test/unit/some_test.rb

unusable.

Let's create an enhancement point test:plugins so plugins can take advantage of
that. Part of this ticket is to modify

https://github.com/theforeman/foreman_plugin_template/blob/master/lib/tasks/foreman_plugin_template_tasks.rake

and file PRs for other plugins.
