### PR TITLE
Fixes #9016 - improved fact loading performance

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -45,11 +45,6 @@ class FactValue < ActiveRecord::Base
     { :conditions => "fact_values.id IN(#{search.join(',')})" }
   end
 
-  # Todo: find a way to filter which values are logged,
-  # this generates too much useless data
-  #
-  # audited
-
   # returns the average of all facts
   # required only on facts that return a unit (e.g. MB, GB etc)
   # normal  facts could be used via the sum and AR average

--- a/app/services/structured_fact_importer.rb
+++ b/app/services/structured_fact_importer.rb
@@ -24,19 +24,21 @@ class StructuredFactImporter < FactImporter
     Hash[fact_name_class.where(:type => fact_name_class).reorder('').pluck(:name, :id, :compose).map { |fact| [fact.shift, fact] }]
   end
 
-  def create_fact_name(fact_names, name, fact_value)
+  def find_or_create_fact_name(name, value = nil)
     if name.include?(FactName::SEPARATOR)
       parent_name = /(.*)#{FactName::SEPARATOR}/.match(name)[1]
-      parent_fact = create_fact_name(fact_names, parent_name, nil)
+      parent_fact = find_or_create_fact_name(parent_name, nil)
+      fact_name = parent_fact.children.where(:name => name, :type => fact_name_class.to_s).first
     else
       parent_fact = nil
+      fact_name = fact_name_class.where(:name => name, :type => fact_name_class.to_s).first
     end
 
-    if fact_names[name]
-      fact_name_class.update(fact_names[name][0], :compose => fact_value.nil?) if fact_value.nil? && !fact_names[name][1]
+    if fact_name
+      fact_name.update_attribute(:compose, value.nil?) if value.nil? && !fact_name.compose?
     else
-      fact_names[name] = [fact_name_class.create!(:name => name, :compose => fact_value.nil?, :parent_id => parent_fact).id, fact_value.nil?]
+      fact_name = fact_name_class.create!(:name => name, :type => fact_name_class.to_s, :compose => value.nil?, :parent => parent_fact)
     end
-    fact_names[name][0]
+    fact_name
   end
 end

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -13,5 +13,6 @@ group :development do
   gem 'bullet'
   gem "parallel_tests"
   gem 'spring', '~> 1.0'
+  gem 'benchmark-ips'
   gem 'foreman'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -173,6 +173,7 @@ module Foreman
     # Check that the loggers setting exist to configure the app and sql loggers
     Foreman::Logging.add_loggers((SETTINGS[:loggers] || {}).reverse_merge(
       :app => {:enabled => true},
+      :audit => {:enabled => true},
       :ldap => {:enabled => false},
       :permissions => {:enabled => false},
       :sql => {:enabled => false},

--- a/config/initializers/audit_instrumentation.rb
+++ b/config/initializers/audit_instrumentation.rb
@@ -1,0 +1,36 @@
+# Audit logging from fact importer events sent via ActiveSupport::Notifications
+module Foreman
+  class FactImporterLogSubscriber < ActiveSupport::LogSubscriber
+    def logger
+      ::Foreman::Logging.logger('audit')
+    end
+
+    def filter_facts(event, collection)
+      if event.payload[collection]
+        event.payload[:facts].select {|k, v| event.payload[collection].include?(k)}.inspect
+      else
+        {}
+      end
+    end
+
+    def log_importer(event, action)
+      facts = filter_facts(event, action)
+      logger.info "[#{event.payload[:host_name]}] #{action} #{event.payload[:count]} (#{event.duration.round(1)}ms)"
+      logger.debug facts.inspect unless facts.empty?
+    end
+
+    def fact_importer_added(event)
+      log_importer(event, :added)
+    end
+
+    def fact_importer_updated(event)
+      log_importer(event, :updated)
+    end
+
+    def fact_importer_deleted(event)
+      log_importer(event, :deleted)
+    end
+  end
+end
+
+Foreman::FactImporterLogSubscriber.attach_to :foreman

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -41,6 +41,8 @@
 #:loggers:
 #  :app:
 #    :enabled: true
+#  :audit:
+#    :enabled: true
 #  :ldap:
 #    :enabled: false
 #  :permissions:

--- a/test/benchmark/benchmark_helper.rb
+++ b/test/benchmark/benchmark_helper.rb
@@ -1,0 +1,29 @@
+require 'benchmark/ips'
+
+require File.expand_path('../../../config/environment', __FILE__)
+require 'factory_girl_rails'
+
+unless Rails.env.production? && !Rails.configuration.database_configuration["production"]["migrate"]
+  puts "Rais must be in production and database must have migrations turned off!"
+  puts "Please add similar configuration to your config/database.yaml:"
+  puts <<EOS
+production:
+  adapter: sqlite3
+  database: ":memory:"
+  migrate: false
+  pool: 1
+  timeout: 1000
+EOS
+  exit 1
+end
+
+load "#{Rails.root}/db/schema.rb"
+
+def foreman_benchmark
+  GC.start
+  yield
+  stats = GC.stat
+  puts "Memory stats"
+  puts "Total objects allocated: #{stats[:total_allocated_objects]}"
+  puts "Total heap pages allocated: #{stats[:total_allocated_pages]}"
+end

--- a/test/benchmark/puppet_fact_importer_benchmark.rb
+++ b/test/benchmark/puppet_fact_importer_benchmark.rb
@@ -1,0 +1,43 @@
+require "benchmark/benchmark_helper"
+
+FactName.transaction do
+  (0..100000).each do |x|
+    FactName.connection.execute "INSERT INTO fact_names (name) values ('rand_fact_name_#{x}')"
+  end
+end
+
+class StructuredFactImporter
+  def fact_name_class
+    FactName
+  end
+end
+
+def generate_facts(total, unique_names = 0, structured_names = 0)
+  facts = Hash[(1..total).map{|i| ["fact_#{i}", "value_#{i}"]}]
+  (total..total+unique_names).map{|i| facts["fact_#{i}_#{Foreman.uuid}"] = "value_#{i}"}
+  (total..total+structured_names).map{|i| facts[(["f#{i}"] * (i % 10)).join('::') + i.to_s] = "value_#{i}"}
+  facts
+end
+
+Rails.logger.level = Logger::ERROR
+
+foreman_benchmark do
+  Benchmark.ips do |x|
+    x.config(:time => 10, :warmup => 0)
+
+    [::PuppetFactImporter, ::StructuredFactImporter].each do |importer|
+      [200, 500].each do |total_facts|
+        [0, 50].each do |unique_names|
+          [0, 25].each do |structured_names|
+            facts = generate_facts(total_facts, unique_names, structured_names)
+            x.report("#{importer} (#{total_facts}) - #{unique_names} UN #{structured_names} SN") do
+              host = FactoryGirl.create(:host, :name => "benchmark-#{Foreman.uuid}")
+              importer.new(host, facts).import!
+              importer.new(host, {}).import!
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change improves fact loading performance by order of magnitude on
SQLite mostly thanks to explicit transaction. An extra optimization was
done for the most important "update" method call which is mostly used
during fact uploads.

Updating of 500 existing facts is faster from 14.8 seconds to 2.7
seconds with this patch.

The patch utilizes find_each method with works in batches rather than creating
instance for each individual model object. More reading at:

http://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each
