### PR TITLE
Fixes #15785 - make sure the selector is visible before clicking

### DIFF
--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -39,6 +39,8 @@ class HostgroupJSTest < IntegrationTestWithJavascript
   private
 
   def select_from_list(list_id, item)
-    page.find(:xpath, "//div[@id='ms-#{list_id}']//li/span[text() = '#{item.name}']").click
+    selector = "//div[@id='ms-#{list_id}']//li/span[text() = '#{item.name}']"
+    assert page.has_xpath?(selector, :visible => true)
+    page.find(:xpath, selector).click
   end
 end


### PR DESCRIPTION
It seems the `has_xpath?` assertion could help. I was able to reproduce
the original issue, but it was pretty rare. I'm still trying the
fix at my setup and will be more confided about the change really fixing
the issue later today after some reasonable amount of iterations.
