### PR TITLE
Fixes #15374 - move progress_report_id to Host::Base

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -3,6 +3,7 @@ require 'orchestration/queue'
 
 module Orchestration
   extend ActiveSupport::Concern
+  include Orchestration::ProgressReport
 
   included do
     attr_reader :old

--- a/app/models/concerns/orchestration/progress_report.rb
+++ b/app/models/concerns/orchestration/progress_report.rb
@@ -1,0 +1,11 @@
+module Orchestration::ProgressReport
+  extend ActiveSupport::Concern
+
+  def progress_report_id
+    @progress_report_id ||= Foreman.uuid
+  end
+
+  def progress_report_id=(value)
+    @progress_report_id = value
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -660,14 +660,6 @@ class Host::Managed < Host::Base
     read_attribute(:certname) || name
   end
 
-  def progress_report_id
-    @progress_report_id ||= Foreman.uuid
-  end
-
-  def progress_report_id=(value)
-    @progress_report_id = value
-  end
-
   def capabilities
     compute_resource ? compute_resource.capabilities : bare_metal_capabilities
   end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -18,8 +18,7 @@ module Nic
 
     # Interface normally are not executed by them self, so we use the host queue and related methods.
     # this ensures our orchestration works on both a host and a managed interface
-    delegate :progress_report_id, :capabilities, :compute_resource,
-             :operatingsystem, :provisioning_template, :jumpstart?, :build, :build?, :os, :arch,
+    delegate :capabilities, :compute_resource, :operatingsystem, :provisioning_template, :jumpstart?, :build, :build?, :os, :arch,
              :image_build?, :pxe_build?, :pxe_build?, :token, :model, :to => :host
     delegate :operatingsystem_id, :hostgroup_id, :environment_id,
              :overwrite?, :skip_orchestration?, :skip_orchestration!, :to => :host, :allow_nil => true
@@ -42,6 +41,22 @@ module Nic
       end
     end
     alias_method_chain :queue, :host
+
+    def progress_report_id
+      if host && host.respond_to?(:progress_report_id)
+        host.progress_report_id
+      else
+        super
+      end
+    end
+
+    def progress_report_id=(value)
+      if host && host.respond_to?(:progress_report_id=)
+        host.progress_report_id = value
+      else
+        super
+      end
+    end
 
     def hostname
       if domain.present? && name.present?

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -56,6 +56,20 @@ class NicTest < ActiveSupport::TestCase
     assert_equal "123.1.2.3", interface.ip
   end
 
+  test "managed nic should generate progress report uuid" do
+    uuid = '710d4a8f-b1b6-47f5-9ef5-5892a19dabcd'
+    Foreman.stubs(:uuid).returns(uuid)
+    nic = FactoryGirl.build(:nic_managed)
+    assert_equal uuid, nic.progress_report_id
+  end
+
+  test "host with managed nic should delegate progress report creation" do
+    uuid = '710d4a8f-b1b6-47f5-9ef5-5892a19dabcd'
+    host = FactoryGirl.create(:host, :managed)
+    host.expects(:progress_report_id).returns(uuid)
+    assert_equal uuid, host.primary_interface.progress_report_id
+  end
+
   test "should delegate subnet attributes" do
     subnet = subnets(:two)
     domain = (subnet.domains.any? ? subnet.domains : subnet.domains << Domain.first).first

--- a/test/models/orchestration_test.rb
+++ b/test/models/orchestration_test.rb
@@ -52,38 +52,40 @@ class OrchestrationTest < ActiveSupport::TestCase
     end
   end
 
-  test "test host compensates queue if active record not saved" do
-    class Host::Test2 < Host::Base
-      include Orchestration
+  class Host::WithDummyAction < Host::Base
+    include Orchestration
+    after_validation :queue_test
 
-      attr_accessor :progress_report_id
-
-      after_validation :queue_test
-
-      def lookup_value_match
-        "fqdn=zzz"
-      end
-
-      def queue_test
-        queue.create(
-          :name => 'test action',
-          :priority => 1,
-          :action => [self, :setTestFlags]
-        )
-      end
-
-      def setTestFlags
-        true
-      end
+    def queue_test
+      queue.create(
+        :name => 'dummy action',
+        :priority => 1,
+        :action => [self, :setAction]
+      )
     end
 
-    h = Host::Test2.new(:name => 'test1')
+    def setAction
+      true
+    end
+  end
+
+  test "test dummy action host can be created and calls update_cache" do
+    uuid = '710d4a8f-b1b6-47f5-9ef5-5892a19dabcd'
+    Foreman.stubs(:uuid).returns(uuid)
+    h = Host::WithDummyAction.new(:name => "test1")
+    h.stubs(:skip_orchestration?).returns(false)
+    Rails.cache.expects(:write).with(uuid, any_parameters).at_least_once.returns(true)
+    h.save!
+  end
+
+  test "test dummy action host compensates queue if active record not saved" do
+    h = Host::WithDummyAction.new(:name => 'test1')
     h.stubs(:skip_orchestration?).returns(false)
     h.stubs(:update_cache).returns(true)
     h.stubs(:_create_record).raises(ActiveRecord::InvalidForeignKey, 'Fake foreign key exception')
 
     # rollback should be called
-    h.expects(:delTestFlags).returns(true)
+    h.expects(:delAction).returns(true)
 
     assert_raise ActiveRecord::InvalidForeignKey do
       h.save!


### PR DESCRIPTION
This solves issue when deleting Host::Discovered as the attribute is not
available in discovered hosts.
