### PR TITLE
fixes #15787 - update shoulda-matchers to 3.x

### DIFF
--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -119,7 +119,13 @@ module NestedAncestryCommon
       length_of_matcher = obj_type.length + 1
 
       # the parent title + "/" is added to the name to create the title
-      length_of_matcher += parent.title.length + 1 if parent.present?
+      # If the parent_id doesn't exist, don't let errors be raised by this validation
+      parent_model = begin
+                       parent
+                     rescue ActiveRecord::RecordNotFound
+                       nil
+                     end
+      length_of_matcher += parent_model.title.length + 1 if parent_model.present?
 
       max_length_for_name = 255 - length_of_matcher
       current_title_length = max_length_for_name - name.length

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -72,6 +72,12 @@ module Host
       update_primary_interface_attributes(values_for_primary_interface)
     end
 
+    def dup
+      super.tap do |host|
+        host.interfaces << self.primary_interface.dup if self.primary_interface.present?
+      end
+    end
+
     delegate :ip, :ip6, :mac,
              :subnet, :subnet_id, :subnet_name,
              :subnet6, :subnet6_id, :subnet6_name,

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -702,9 +702,7 @@ class Host::Managed < Host::Base
     # do not copy system specific attributes
     host = self.selective_clone
 
-    self.interfaces.each do |nic|
-      host.interfaces << nic.clone
-    end
+    host.interfaces = self.interfaces.map(&:clone)
     if self.compute_resource
       host.compute_attributes = host.compute_resource.vm_compute_attributes_for(self.uuid)
     end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -8,7 +8,6 @@ class Hostgroup < ActiveRecord::Base
   include NestedAncestryCommon
 
   validates :name, :presence => true, :uniqueness => {:scope => :ancestry, :case_sensitive => false}
-  validates :title, :presence => true, :uniqueness => true
 
   validate :validate_subnet_types
 

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -25,7 +25,6 @@ class Taxonomy < ActiveRecord::Base
   validate :check_for_orphans, :unless => Proc.new {|t| t.new_record?}
 
   validates :name, :presence => true, :uniqueness => {:scope => [:ancestry, :type], :case_sensitive => false}
-  validates :title, :presence => true, :uniqueness => {:scope => :type}
 
   before_validation :sanitize_ignored_types
   after_create :assign_default_templates

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -13,6 +13,6 @@ group :test do
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem "poltergeist", :require => false
   gem 'test_after_commit', '>= 0.4', '< 2.0'
-  gem 'shoulda-matchers', '2.8.0'
+  gem 'shoulda-matchers', '~> 3.0'
   gem 'shoulda-context', '~> 1.2'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,13 @@ require 'functional/shared/basic_rest_response_test'
 require 'facet_test_helper'
 require 'active_support_test_case_helper'
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :minitest_4
+    with.library :rails
+  end
+end
+
 # Use our custom test runner, and register a fake plugin to skip a specific test
 Foreman::Plugin.register :skip_test do
   tests_to_skip "CustomRunnerTest" => [ "custom runner is working" ]

--- a/test/unit/helpers/form_helper_test.rb
+++ b/test/unit/helpers/form_helper_test.rb
@@ -18,7 +18,6 @@ class FormHelperTest < ActionView::TestCase
   test "is_required?(f, attr) method returns true if attribute is required and false if not required" do
     f = ActionView::Helpers::FormBuilder.new(:hostgroup, Hostgroup.new, @hostgroup, {})
     assert is_required?(f, :name)
-    assert is_required?(f, :title)
     refute is_required?(f, :environment_id)
     refute is_required?(f, :parent_id)
     f = ActionView::Helpers::FormBuilder.new(:host, Host::Managed.new, @host, {})

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -6,7 +6,7 @@ class HostgroupTest < ActiveSupport::TestCase
   end
 
   should validate_presence_of(:name)
-  should validate_uniqueness_of(:name)
+  should validate_uniqueness_of(:name).scoped_to(:ancestry).case_insensitive
   should allow_value(nil).for(:root_pass)
   should validate_length_of(:root_pass).is_at_least(8).
     with_message('should be 8 characters or more')

--- a/test/unit/hosts/base_test.rb
+++ b/test/unit/hosts/base_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 module Host
   class BaseTest < ActiveSupport::TestCase
     should validate_presence_of(:name)
-    should validate_uniqueness_of(:name)
+    context "with new host" do
+      subject { Host::Base.new(:name => 'test') }
+      should validate_uniqueness_of(:name).case_insensitive
+    end
     should_not allow_value('hostname_with_dashes').for(:name)
     should allow_value('hostname.with.periods').for(:name)
 
@@ -61,6 +64,12 @@ module Host
       host.interfaces = [ FactoryGirl.build(:nic_managed, :primary => true, :host => host,
                                             :domain => FactoryGirl.create(:domain)) ]
       assert host.valid?
+    end
+
+    test '.dup should return host with primary interface' do
+      host = Host::Base.new.dup
+      assert host.primary_interface
+      assert_equal 1, host.interfaces.size
     end
 
     private

--- a/test/unit/taxonomy_test.rb
+++ b/test/unit/taxonomy_test.rb
@@ -7,9 +7,7 @@ class TaxonomyTest < ActiveSupport::TestCase
   end
 
   should validate_presence_of(:name)
-  should validate_uniqueness_of(:name).scoped_to(:type).case_insensitive
-  should validate_presence_of(:title)
-  should validate_uniqueness_of(:title).scoped_to(:type)
+  should validate_uniqueness_of(:name).scoped_to(:ancestry, :type).case_insensitive
 
   test '.enabled?' do
     assert Taxonomy.enabled?(:organization)

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -15,7 +15,10 @@ class UsergroupTest < ActiveSupport::TestCase
     refute usergroup.valid?
   end
 
-  should validate_uniqueness_of(:name)
+  context "with new usergroup" do
+    subject { Usergroup.new(:name => 'test') }
+    should validate_uniqueness_of(:name)
+  end
   should validate_presence_of(:name)
   should have_many(:usergroup_members).dependent(:destroy)
   should have_many(:users).dependent(:destroy)


### PR DESCRIPTION
Contains changes to models for the new behaviour of the uniqueness
validation test, which saves a model with one value and then attempts
to validate a second.

NestedAncestryCommon's validation now doesn't fail when the specified
ancestry/parent_id is non-existent (shoulda-matchers generates an
invalid value).

Validations of title on NestedAncestryCommon models have been removed
as it's derived automatically from the name field, and can't be tested
independently of the model name. This in any case was a duplicate
validation of the name which is scoped to ancestry.

Host::Base has #dup implemented so the copied model has a valid primary
interface for #name= to work, matching the behaviour of #initialize.
