### PR TITLE
fixes #15847 - change mailer helpers from paths to URLs

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,6 +12,11 @@ class ApplicationMailer < ActionMailer::Base
     super
   end
 
+  def default_url_options
+    set_url
+    {:host => @url.host, :port => @url.port, :protocol => @url.scheme}
+  end
+
   protected
 
   def roadie_options
@@ -32,7 +37,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def set_url
-    unless (@url = URI.parse(Setting[:foreman_url])).present?
+    unless (@url ||= URI.parse(Setting[:foreman_url])).present?
       raise Foreman::Exception.new(N_(":foreman_url is not set, please configure in the Foreman Web UI (Administer -> Settings -> General)"))
     end
   end

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -18,7 +18,6 @@ class HostMailer < ApplicationMailer
     @timerange = time
     @out_of_sync = hosts.out_of_sync.sort
     @disabled = hosts.alerts_disabled.sort
-    set_url
 
     set_locale_for(user) do
       subject = _("Puppet Summary Report - F:%{failed} R:%{restarted} S:%{skipped} A:%{applied} FR:%{failed_restarts} T:%{total}") % {
@@ -39,7 +38,6 @@ class HostMailer < ApplicationMailer
   def error_state(report, options = {})
     @report = report
     @host = @report.host
-    set_url
     set_locale_for(options[:user]) do
       mail(:to => options[:user].mail, :subject => (_("Puppet error on %s") % @host)) do |format|
         format.html { render :layout => 'application_mailer' }

--- a/app/views/audit_mailer/summary.html.erb
+++ b/app/views/audit_mailer/summary.html.erb
@@ -8,10 +8,10 @@
         <% login = audit.user.login rescue nil
            user_search_param = login ? "user = #{login}" : %Q{username = "#{audit.username}"} %>
         <b>
-          <%= link_to(audit.username, audits_path(:search => user_search_param)) %>
+          <%= link_to(audit.username, audits_url(:search => user_search_param)) %>
           <span style="color: #cccccc"><%= audit_remote_address audit %></span>
           <%= audit_action_name audit%> <%= audited_type audit %>:
-          <%= link_to(audit_title(audit), audit_path(:id => audit), {:style => 'color: #2a6496'}) %>
+          <%= link_to(audit_title(audit), audit_url(:id => audit), {:style => 'color: #2a6496'}) %>
         </b>
         <ul style="list-style-type: none;">
           <% details(audit).each do |detail| -%>
@@ -29,5 +29,5 @@
   <% end %>
 </ul>
 <p>
-  <%= link_to(_('Full audits list'), audits_path(:search => @query)) %>
+  <%= link_to(_('Full audits list'), audits_url(:search => @query)) %>
 </p>

--- a/app/views/audit_mailer/summary.text.erb
+++ b/app/views/audit_mailer/summary.text.erb
@@ -5,10 +5,10 @@
          'Displaying %{num_audits} of %{total_audits} audits', @count) % {:num_audits => @limit, :total_audits => @count} %>
   <% @audits.each do |audit| %>
     <%= audit.username %> (<%= audit.remote_address %>) <%= audit_action_name audit%> <%= audited_type audit %>: <%= audit_title(audit) %>
-    (<%= audit_path(:id => audit) %>)
+    (<%= audit_url(:id => audit) %>)
   <% end %>
 <% else %>
   <%= _('No audit changes for this period') %>
 <% end %>
 
-<%= audits_path(:search => @query) %>
+<%= audits_url(:search => @query) %>

--- a/app/views/host_mailer/_active_hosts.html.erb
+++ b/app/views/host_mailer/_active_hosts.html.erb
@@ -31,7 +31,7 @@
         <td class="hosts-rows">
       <% end %>
       <% if v > 0 %>
-        <%= link_to v, config_reports_path(:search=>"host = #{host} and #{m} > 0") %>
+        <%= link_to v, config_reports_url(:search=>"host = #{host} and #{m} > 0") %>
       <% else %>
         <%= v %>
       <% end %>

--- a/app/views/host_mailer/_link_to_host.html.erb
+++ b/app/views/host_mailer/_link_to_host.html.erb
@@ -1,3 +1,3 @@
 <td class="hosts-rows">
-  <%= link_to host, host_path(:id => host) %>
+  <%= link_to host, host_url(:id => host) %>
 </td>

--- a/app/views/host_mailer/error_state.html.erb
+++ b/app/views/host_mailer/error_state.html.erb
@@ -2,5 +2,5 @@
 <div class="dashboard">
   <%= render :partial => 'error_states', :locals => {:logs => @report.logs} %>
   <br>
-  <%= link_to _("For more information"), config_report_path(@report) %>
+  <%= link_to _("For more information"), config_report_url(@report) %>
 </div>

--- a/app/views/host_mailer/host_built.html.erb
+++ b/app/views/host_mailer/host_built.html.erb
@@ -3,7 +3,7 @@
   <table>
     <tr>
       <td width="18%" class="hosts-rows"><b><%= _("Hostname") %></b></td>
-      <td width="82%" class="hosts-rows"><%= link_to @host, host_path(:id => @host) %></td>
+      <td width="82%" class="hosts-rows"><%= link_to @host, host_url(:id => @host) %></td>
     </tr>
     <tr>
       <td width="18%" class="hosts-rows"><b><%= _("IP") %></b></td>

--- a/app/views/host_mailer/host_built.text.erb
+++ b/app/views/host_mailer/host_built.text.erb
@@ -5,4 +5,4 @@
   <%= _("IP:") %>       <%= @host.ip %>
 
 <%= _("View in Foreman:") %>
-  <%= host_path(:id => @host) %>
+  <%= host_url(:id => @host) %>

--- a/test/unit/application_mailer_test.rb
+++ b/test/unit/application_mailer_test.rb
@@ -18,6 +18,7 @@ class ApplicationMailerTest < ActiveSupport::TestCase
           </head>
           <body>
             <h2 class="headline"><b>Foreman</b> test email</h2>
+            <a href="#{hosts_url}">Hosts list</a>
           </body>
         </html>|.html_safe
     end
@@ -47,5 +48,10 @@ class ApplicationMailerTest < ActiveSupport::TestCase
     new_from = 'foreman@widgets.example.com'
     Setting[:email_reply_address] = new_from
     assert_equal mail.from.first, new_from
+  end
+
+  test 'URL helpers use options from foreman_url setting' do
+    Setting[:foreman_url] = 'https://another.example.com:444'
+    assert mail.body.include? 'href="https://another.example.com:444/hosts"'
   end
 end


### PR DESCRIPTION
Use of path helpers in mailers (with Roadie to rewrite to URLs) is
deprecated in Rails 4 and removed in Rails 5, so prefer URL helpers. To
replace URL rewriting and reduce duplication, default_url_options is now
configured. Roadie URL rewriting may still be used for assets.
