### PR TITLE
fixes #15863 - add short request UUID to logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,7 @@ require File.expand_path('../../lib/timed_cached_store.rb', __FILE__)
 require File.expand_path('../../lib/foreman/exception', __FILE__)
 require File.expand_path('../../lib/core_extensions', __FILE__)
 require File.expand_path('../../lib/foreman/logging', __FILE__)
+require File.expand_path('../../lib/middleware/tagged_logging', __FILE__)
 
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
@@ -155,6 +156,9 @@ module Foreman
 
     # Catching Invalid JSON Parse Errors with Rack Middleware
     config.middleware.insert_before ActionDispatch::ParamsParser, "Middleware::CatchJsonParseErrors"
+
+    # Record request ID in logging MDC storage
+    config.middleware.insert_before Rails::Rack::Logger, Middleware::TaggedLogging
 
     # Add apidoc hash in headers for smarter caching
     config.middleware.use "Apipie::Middleware::ChecksumInHeaders"

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -45,6 +45,8 @@
 #     [%F] filename where the logging request was issued
 #     [%L] line number where the logging request was issued
 #     [%M] method name where the logging request was issued
+#     [%X{request}] request-ID set in HTTP headers, or random UUID
+#     [%X{session}] session ID from cookies, else the request-ID
 #     [%X{string}] variable set using ::Logging.mdc['string'] =
 
 :default:
@@ -53,7 +55,7 @@
   :log_trace: false
   :level: info
   :type: file
-  :pattern: "%d [%c] [%.1l] %m\n"
+  :pattern: "%d %.8X{session} [%c] [%.1l] %m\n"
 
 :production:
   :filename: "production.log"

--- a/lib/middleware/tagged_logging.rb
+++ b/lib/middleware/tagged_logging.rb
@@ -1,0 +1,24 @@
+module Middleware
+  class TaggedLogging
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      ::Logging.mdc['request'] = env['action_dispatch.request_id']
+
+      request = ActionDispatch::Request.new(env)
+      session_id = request.cookie_jar['_session_id']
+      ::Logging.mdc['session'] = if session_id.present?
+                                   session_id.gsub(/[^\w\-]/, '').first(32)
+                                 else
+                                   env['action_dispatch.request_id']
+                                 end
+
+      @app.call(env)
+    ensure
+      ::Logging.mdc.delete('request')
+      ::Logging.mdc.delete('session')
+    end
+  end
+end


### PR DESCRIPTION
New middleware stores the request ID (either from X-Request-ID or a
UUID generated by Rails) in the logger's thread storage. A short UUID is
now logged by default to minimise size of the log messages.

---

Generates log messages such as:

<pre>
$ egrep "33b38af1.*(Started|Completed)" log/development.log 
2016-07-27T15:38:43 33b38af1 [app] [I] Started GET "/" for 127.0.0.1 at 2016-07-27 15:38:43 +0100
2016-07-27T15:38:45 33b38af1 [app] [I] Completed 200 OK in 1978ms (Views: 1695.6ms | ActiveRecord: 18.5ms)
</pre>
