### PR TITLE
Fixes #12634 - New HW Model flag pxe_loader

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -350,7 +350,7 @@ function architecture_selected(element){
   var url = $(element).attr('data-url');
   tfm.tools.showSpinner();
   $.ajax({
-    data: attrs,
+    data: {host: attrs},
     type:'post',
     url: url,
     complete: function(){
@@ -367,7 +367,7 @@ function os_selected(element){
   var url = $(element).attr('data-url');
   tfm.tools.showSpinner();
   $.ajax({
-    data: attrs,
+    data: {host: attrs},
     type:'post',
     url: url,
     complete: function(){

--- a/app/controllers/api/v1/hostgroups_controller.rb
+++ b/app/controllers/api/v1/hostgroups_controller.rb
@@ -53,6 +53,7 @@ module Api
         param :operatingsystem_id, :number
         param :architecture_id, :number
         param :medium_id, :number
+        param :pxe_loader, Operatingsystem.all_loaders, :desc => N_("DHCP filename option")
         param :ptable_id, :number
         param :puppet_ca_proxy_id, :number
         param :subnet_id, :number

--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -41,6 +41,7 @@ module Api
         param :puppetclass_ids, Array
         param :operatingsystem_id, String, :desc => "required if host is managed and value is not inherited from host group"
         param :medium_id, String, :desc => "required if not imaged based provisioning and host is managed and value is not inherited from host group"
+        param :pxe_loader, Operatingsystem.all_loaders, :desc => N_("DHCP filename option")
         param :ptable_id, :number, :desc => "required if host is managed and custom partition has not been defined"
         param :subnet_id, :number, :desc => "IPv4 subnet"
         param :subnet6_id, :number, :desc => "IPv6 subnet"

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -34,6 +34,7 @@ module Api
           param :compute_profile_id, :number, :desc => N_('Compute profile ID')
           param :operatingsystem_id, :number, :desc => N_('Operating system ID')
           param :architecture_id, :number, :desc => N_('Architecture ID')
+          param :pxe_loader, Operatingsystem.all_loaders, :desc => N_("DHCP filename option (Grub2/PXELinux by default)")
           param :medium_id, :number, :desc => N_('Media ID')
           param :ptable_id, :number, :desc => N_('Partition table ID')
           param :puppet_ca_proxy_id, :number, :desc => N_('Puppet CA proxy ID')

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -56,6 +56,7 @@ module Api
           param :puppetclass_ids, Array
           param :operatingsystem_id, String, :desc => N_("required if host is managed and value is not inherited from host group")
           param :medium_id, String, :desc => N_("required if not imaged based provisioning and host is managed and value is not inherited from host group")
+          param :pxe_loader, Operatingsystem.all_loaders, :desc => N_("DHCP filename option (Grub2/PXELinux by default)")
           param :ptable_id, :number, :desc => N_("required if host is managed and custom partition has not been defined")
           param :subnet_id, :number, :desc => N_("required if host is managed and value is not inherited from host group")
           param :compute_resource_id, :number, :desc => N_("nil means host is bare metal")

--- a/app/controllers/concerns/foreman/controller/host_details.rb
+++ b/app/controllers/concerns/foreman/controller/host_details.rb
@@ -45,10 +45,14 @@ module Foreman::Controller::HostDetails
   def assign_parameter(name, root = "")
     taxonomy_scope
     Taxonomy.as_taxonomy @organization, @location do
-      instance_variable_set("@#{name}",name.classify.constantize.where(:id => params["#{name}_id"]).first)
-      item = instance_variable_get("@#{controller_name.singularize}") || controller_name.classify.constantize.new(params[controller_name.singularize])
+      item = instance_variable_get("@#{controller_name.singularize}") || controller_name.classify.constantize.new(item_params)
+      instance_variable_set("@#{name}", item.send(name.to_sym))
       render :partial => root + name, :locals => { :item => item }
     end
+  end
+
+  def item_params
+    send("#{item_name}_params".to_sym)
   end
 
   def item_name

--- a/app/controllers/concerns/foreman/controller/parameters/host_base.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/host_base.rb
@@ -20,6 +20,7 @@ module Foreman::Controller::Parameters::HostBase
         :root_pass,
         :start,
         :type,
+        :pxe_loader,
         # Model relations sorted in alphabetical order
         :architecture, :architecture_id, :architecture_name,
         :domain, :domain_id, :domain_name,

--- a/app/controllers/concerns/foreman/controller/parameters/hostgroup.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/hostgroup.rb
@@ -12,6 +12,7 @@ module Foreman::Controller::Parameters::Hostgroup
           :root_pass,
           :title,
           :vm_defaults,
+          :pxe_loader,
           # Relations in alphabetical order
           :arch, :arch_id, :arch_name,
           :architecture_id, :architecture_name,

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -71,7 +71,7 @@ class UnattendedController < ApplicationController
     type = 'iPXE' if type == 'gPXE'
 
     if (config = @host.provisioning_template({ :kind => type }))
-      logger.debug "rendering DB template #{config.name} - #{type}"
+      logger.debug "Rendering #{type} template '#{config.name}'"
       if !preview?
         User.as_anonymous_admin do
           safe_render config
@@ -211,18 +211,18 @@ class UnattendedController < ApplicationController
   end
 
   def safe_render(template)
-    @template_name = 'Unnamed'
     if template.is_a?(String)
-      @unsafe_template  = template
+      @unsafe_template_content = template
+      @template_name = 'Unnamed'
     elsif template.is_a?(ProvisioningTemplate)
-      @unsafe_template  = template.template
+      @unsafe_template_content = template.template
       @template_name = template.name
     else
       raise "unknown template"
     end
 
     begin
-      render :inline => "<%= unattended_render(@unsafe_template, @template_name).html_safe %>"
+      render :inline => "<%= unattended_render(@unsafe_template_content, @template_name).html_safe %>"
     rescue => error
       msg = _("There was an error rendering the %s template: ") % (@template_name)
       Foreman::Logging.exception(msg, error)

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -261,6 +261,7 @@ module HostsHelper
     fields += [[_("Puppet Environment"), (link_to(host.environment, hosts_path(:search => "environment = #{host.environment}")))]] if host.environment.present?
     fields += [[_("Host Architecture"), (link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}")))]] if host.arch.present?
     fields += [[_("Operating System"), (link_to(host.operatingsystem.to_label, hosts_path(:search => "os_description = #{host.operatingsystem.description}")))]] if host.operatingsystem.present?
+    fields += [[_("PXE Loader"), host.pxe_loader]] if host.operatingsystem.present? && host.pxe_build?
     fields += [[_("Host group"), (link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"})))]] if host.hostgroup.present?
     fields += [[_("Location"), (link_to(host.location.title, hosts_path(:search => "location = #{host.location}")) if host.location)]] if SETTINGS[:locations_enabled]
     fields += [[_("Organization"), (link_to(host.organization.title, hosts_path(:search => "organization = #{host.organization}")) if host.organization)]] if SETTINGS[:organizations_enabled]

--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -15,4 +15,15 @@ class Architecture < ActiveRecord::Base
   audited
 
   scoped_search :on => :name, :complete_value => :true
+
+  def intel_precision
+    case name
+    when /i.86/
+      'ia32'
+    when /x86[_-]64/
+      'x64'
+    else
+      ''
+    end
+  end
 end

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -102,7 +102,9 @@ module Orchestration::DHCP
     }
 
     if provision?
-      dhcp_attr.merge!({:filename => operatingsystem.boot_filename(self), :nextServer => boot_server})
+      dhcp_attr.merge!(:nextServer => boot_server)
+      filename = operatingsystem.boot_filename(self.host)
+      dhcp_attr.merge!(:filename => filename) if filename.present?
       if jumpstart?
         jumpstart_arguments = os.jumpstart_params self.host, model.vendor_class
         dhcp_attr.merge! jumpstart_arguments unless jumpstart_arguments.empty?
@@ -137,7 +139,7 @@ module Orchestration::DHCP
   # do we need to update our dhcp reservations
   def dhcp_update_required?
     # IP Address / name changed, or 'rebuild' action is triggered and DHCP record on the smart proxy is not present/identical.
-    return true if ((old.ip != ip) || (old.hostname != hostname) || (old.mac != mac) || (old.subnet != subnet) ||
+    return true if ((old.ip != ip) || (old.hostname != hostname) || (old.mac != mac) || (old.subnet != subnet) || (operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(self.host)) ||
                     (!old.build? && build? && !dhcp_record.valid?))
     # Handle jumpstart
     #TODO, abstract this way once interfaces are fully used

--- a/app/models/concerns/pxe_loader_suggestion.rb
+++ b/app/models/concerns/pxe_loader_suggestion.rb
@@ -1,0 +1,11 @@
+module PxeLoaderSuggestion
+  extend ActiveSupport::Concern
+
+  included do
+    after_initialize :suggest_default_pxe_loader
+  end
+
+  def suggest_default_pxe_loader
+    self.pxe_loader ||= self.try(:operatingsystem).try(:preferred_loader) if self.respond_to?(:pxe_loader)
+  end
+end

--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -1,0 +1,55 @@
+module PxeLoaderSupport
+  extend ActiveSupport::Concern
+
+  PXE_KINDS = {
+    :PXELinux => /^(pxelinux|PXELinux).*/,
+    :PXEGrub => /^(grub\/|Grub ).*/,
+    :PXEGrub2 => /^(grub2|Grub2).*/
+  }.with_indifferent_access.freeze
+
+  PREFERRED_KINDS = {
+    :PXEGrub2 => "Grub2 UEFI",
+    :PXELinux => "PXELinux BIOS",
+    :PXEGrub => "Grub UEFI"
+  }.with_indifferent_access.freeze
+
+  class_methods do
+    def all_loaders_map(precision = 'x64')
+      {
+        "None" => "",
+        "PXELinux BIOS" => "pxelinux.0",
+        "PXELinux UEFI" => "pxelinux.efi",
+        "Grub UEFI" => "grub/boot#{precision}.efi",
+        "Grub UEFI SecureBoot" => "grub/shim.efi",
+        "Grub2 UEFI" => "grub2/grub#{precision}.efi",
+        "Grub2 UEFI SecureBoot" => "grub2/shim.efi"
+      }.freeze
+    end
+
+    def all_loaders
+      all_loaders_map.keys.freeze
+    end
+
+    def valid_loader_name?(pxe_loader)
+      self.all_loaders.include?(pxe_loader)
+    end
+  end
+
+  def default_boot_filename
+    "pxelinux.0"
+  end
+
+  # Finds template kind for given loader filename or name or nil for "None" or ""
+  def pxe_loader_kind(host)
+    PXE_KINDS.find{|k, v| v.match(host.pxe_loader)}.try(:first).try(:to_sym)
+  end
+
+  # Suggested PXE loader when template kind is available (PXEGrub2, then PXELinux, then PXEGrub in this order)
+  def preferred_loader
+    associated_templates = os_default_templates.map(&:template_kind).compact.map(&:name)
+    template_kinds.each do |loader|
+      return PREFERRED_KINDS[loader] if associated_templates.include? loader
+    end
+    nil
+  end
+end

--- a/app/models/concerns/pxe_loader_validator.rb
+++ b/app/models/concerns/pxe_loader_validator.rb
@@ -1,0 +1,13 @@
+module PxeLoaderValidator
+  extend ActiveSupport::Concern
+
+  included do
+    validate :validate_pxe_loader
+  end
+
+  def validate_pxe_loader
+    return unless operatingsystem && pxe_loader.present?
+    loaders = operatingsystem.available_loaders
+    errors.add(:pxe_loader, _("'%{loader}' is not one of %{loaders}") % {:loader => pxe_loader, :loaders => loaders.join(', ')}) unless Operatingsystem.valid_loader_name?(pxe_loader)
+  end
+end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -35,6 +35,7 @@ module Host
     validate :host_has_required_interfaces
     validate :uniq_interfaces_identifiers
     validate :build_managed_only
+    include PxeLoaderSuggestion
 
     default_scope -> { where(taxonomy_conditions) }
 
@@ -55,6 +56,8 @@ module Host
                                     :subnet6, :subnet6_id, :subnet6_name,
                                     :domain, :domain_id, :domain_name,
                                     :lookup_values_attributes].freeze
+
+    after_initialize :suggest_default_pxe_loader
 
     # primary interface is mandatory because of delegated methods so we build it if it's missing
     # similar for provision interface

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -42,6 +42,8 @@ class Host::Managed < Host::Base
   before_save :clear_data_on_build
   before_save :clear_puppetinfo, :if => :environment_id_changed?
 
+  include PxeLoaderValidator
+
   def initialize(*args)
     args.unshift(apply_inherited_attributes(args.shift, false))
     super(*args)
@@ -620,7 +622,7 @@ class Host::Managed < Host::Base
       inherited_attributes = %w{operatingsystem_id architecture_id}
       inherited_attributes << "subnet_id" unless compute_provides?(:ip)
       inherited_attributes << "subnet6_id" unless compute_provides?(:ip6)
-      inherited_attributes.concat(%w{medium_id ptable_id}) if pxe_build?
+      inherited_attributes.concat(%w{medium_id ptable_id pxe_loader}) if pxe_build?
       assign_hostgroup_attributes(inherited_attributes)
     end
   end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -22,6 +22,8 @@ class Hostgroup < ActiveRecord::Base
   has_many :group_parameters, :dependent => :destroy, :foreign_key => :reference_id, :inverse_of => :hostgroup
   accepts_nested_attributes_for :group_parameters, :allow_destroy => true
   include ParameterValidators
+  include PxeLoaderValidator
+  include PxeLoaderSuggestion
   alias_attribute :hostgroup_parameters, :group_parameters
   has_many_hosts
   has_many :template_combinations, :dependent => :destroy
@@ -38,7 +40,7 @@ class Hostgroup < ActiveRecord::Base
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
 
   nested_attribute_for :compute_profile_id, :environment_id, :domain_id, :puppet_proxy_id, :puppet_ca_proxy_id,
-                       :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id, :realm_id
+                       :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id, :realm_id, :pxe_loader
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -16,14 +16,12 @@ class Junos < Operatingsystem
     "ZTP"
   end
 
-  # The variant to use when communicating with the proxy. Syslinux are pxegrub currently supported
-  def pxe_variant
-    "ZTP"
+  def available_loaders
+    ["None"]
   end
 
-  # The kind of PXE configuration template used. PXELinux and PXEGrub are currently supported
-  def template_kind
-    "ZTP"
+  def template_kinds
+    ["ZTP"]
   end
 
   def pxedir
@@ -34,7 +32,6 @@ class Junos < Operatingsystem
     pxedir + "/" + PXEFILES[file]
   end
 
-  #handle things like gpxelinux/ gpxe / pxelinux here
   def boot_filename(host = nil)
     "ztp.cfg/"+host.mac.gsub(/:/,"").upcase
   end

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -11,14 +11,12 @@ class NXOS < Operatingsystem
     Operatingsystem
   end
 
-  # The variant to use when communicating with the proxy. We also need a new type here.
-  def pxe_variant
-    "poap"
+  def template_kinds
+    ["POAP"]
   end
 
-  # The kind of PXE configuration template used. POAP is used for Cisco POAP scripts.
-  def template_kind
-    "POAP"
+  def available_loaders
+    ["None"]
   end
 
   def pxedir
@@ -29,7 +27,6 @@ class NXOS < Operatingsystem
     raise ::Foreman::Exception.new(N_("Function not available for %s"), self.display_family)
   end
 
-  # where to create the boot file on the TFTP server
   def boot_filename(host = nil)
     "poap.cfg/"+host.mac.gsub(/:/,"").upcase
   end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -20,6 +20,11 @@ class Redhat < Operatingsystem
     end
   end
 
+  # Redhat supports all PXE loaders
+  def available_loaders
+    self.class.all_loaders
+  end
+
   # The PXE type to use when generating actions and evaluating attributes. jumpstart, kickstart and preseed are currently supported.
   def pxe_type
     "kickstart"

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -23,14 +23,12 @@ class Solaris < Operatingsystem
     "jumpstart"
   end
 
-  # The variant to use when communicating with the proxy. Syslinux are pxegrub currently supported
-  def pxe_variant
-    "pxegrub"
+  def available_loaders
+    ["None"]
   end
 
-  # The kind of PXE configuration template used. PXELinux and PXEGrub are currently supported
-  def template_kind
-    "PXEGrub"
+  def template_kinds
+    ["PXEGrub"]
   end
 
   def pxedir
@@ -42,7 +40,6 @@ class Solaris < Operatingsystem
   end
 
   def boot_filename(host)
-    #handle things like gpxelinux/ gpxe / pxelinux here
     if host.jumpstart?
       "Solaris-#{major}.#{minor}-#{release_name}-#{host.model.hardware_model}-inetboot"
     else

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -7,17 +7,20 @@ class TemplateKind < ActiveRecord::Base
   validates :name, :presence => true, :uniqueness => true
   scoped_search :on => :name
 
+  PXE = ["PXEGrub2", "PXELinux", "PXEGrub"]
+
   def self.default_template_labels
     {
       "PXELinux" => N_("PXELinux template"),
       "PXEGrub" => N_("PXEGrub template"),
+      "PXEGrub2" => N_("PXEGrub2 template"),
       "iPXE" => N_("iPXE template"),
       "provision" => N_("Provisioning template"),
       "finish" => N_("Finish template"),
       "script" => N_("Script template"),
       "user_data" => N_("User data template"),
-      "ZTP" => N_("ZTP template"),
-      "POAP" => N_("POAP template")
+      "ZTP" => N_("ZTP PXE template"),
+      "POAP" => N_("POAP PXE template")
     }
   end
 

--- a/app/services/host_build_status.rb
+++ b/app/services/host_build_status.rb
@@ -35,6 +35,7 @@ class HostBuildStatus
         valid_template = host.render_template(template.template)
         fail!(:templates, _('Template %s is empty.') % template.name, template.name) if valid_template.blank?
       rescue => exception
+        Foreman::Logging.exception("Review template error", exception)
         fail!(:templates, _('Failure parsing %{template}: %{error}.') % {:template => template.name, :error => exception}, template.name)
       end
     end

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -10,7 +10,11 @@
     {:label => _("Partition table"), :disabled => os_ptable.empty?, :required => true}
   %>
 
-  <% if @operatingsystem and @operatingsystem.supports_image %>
+  <% if @operatingsystem && @operatingsystem.supports_image %>
     <%= render "common/os_selection/image_details", {:item => item} %>
+  <% end %>
+
+  <% if @operatingsystem && @operatingsystem.available_loaders.count > 0 %>
+    <%= render "common/os_selection/pxe_loader", {:item => item} %>
   <% end %>
 <% end %>

--- a/app/views/common/os_selection/_pxe_loader.html.erb
+++ b/app/views/common/os_selection/_pxe_loader.html.erb
@@ -1,0 +1,10 @@
+<%= fields_for item do |f| -%>
+  <% loaders = @operatingsystem.available_loaders; if loaders.any? -%>
+    <%= selectable_f f, :pxe_loader,
+      loaders.to_a, {
+        :include_blank => blank_or_inherit_f(f, :pxe_loader),
+      },
+      :label => _('PXE Loader'),
+      :help_inline => popover(_(""), _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE)"), :data => { :placement => 'top' }) %>
+  <% end -%>
+<% end -%>

--- a/app/views/unattended/kickstart/PXEGrub.erb
+++ b/app/views/unattended/kickstart/PXEGrub.erb
@@ -1,0 +1,28 @@
+<%#
+kind: PXEGrub
+name: Kickstart default PXEGrub
+oses:
+- CentOS
+- Fedora
+- RedHat
+-%>
+# This file was deployed via '<%= template_name %>' template
+<%= snippet 'kickstart_cmdline' -%>
+
+default=0
+timeout=<%= @loader_timeout %>
+
+title <%= template_name %>
+  root (nd)
+  <% if @host.operatingsystem.name.match(/.*atomic.*/i) -%>
+  kernel (nd)/<%= @kernel %> <%= @ks_option %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
+  kernel (nd)/<%= @kernel %> <%= @ks_option %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
+  kernel (nd)/<%= @kernel %> <%= @ks_option %> network ks.sendmac <%= @options %>
+  <% else -%>
+  kernel (nd)/<%= @kernel %> <%= @ks_option %> ksdevice=bootif network kssendmac <%= @options %>
+  <% end -%>
+  initrd (nd)/<%= @initrd %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/kickstart/PXEGrub2.erb
+++ b/app/views/unattended/kickstart/PXEGrub2.erb
@@ -1,0 +1,28 @@
+<%#
+kind: PXEGrub2
+name: Kickstart default PXEGrub2
+oses:
+- CentOS
+- Fedora
+- RedHat
+-%>
+# This file was deployed via '<%= template_name %>' template
+<%= snippet 'kickstart_cmdline' -%>
+
+set default=0
+set timeout=<%= @loader_timeout %>
+
+menuentry '<%= template_name %>' {
+  <% if @host.operatingsystem.name.match(/.*atomic.*/i) -%>
+  linuxefi <%= @kernel %> <%= @ks_option %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
+  linuxefi <%= @kernel %> <%= @ks_option %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
+  linuxefi <%= @kernel %> <%= @ks_option %> network ks.sendmac <%= @options %>
+  <% else -%>
+  linuxefi <%= @kernel %> <%= @ks_option %> ksdevice=bootif network kssendmac <%= @options %>
+  <% end -%>
+  initrdefi <%= @initrd %>
+}
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/kickstart/PXELinux.erb
+++ b/app/views/unattended/kickstart/PXELinux.erb
@@ -5,34 +5,24 @@ oses:
 - CentOS
 - Fedora
 - RedHat
-%>
-#
-# This file was deployed via '<%= @template_name %>' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-<%
-  options = []
-  if @host.params['blacklist']
-    options << "modprobe.blacklist=" + @host.params['blacklist'].gsub(' ', '')
-  end
-  options = options.join(' ')
 -%>
+# This file was deployed via '<%= template_name %>' template
+<%= snippet 'kickstart_cmdline' -%>
 
+TIMEOUT <%= @loader_timeout * 10 %>
 DEFAULT linux
 
-LABEL linux
-    KERNEL <%= @kernel %>
-    <% if @host.operatingsystem.name.match(/.*atomic.*/i) %>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= options %>
-    <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac <%= options %>
-    <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <%= options %>
-    <% else -%>
-    APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac <%= options %>
-    <% end -%>
-    IPAPPEND 2
+LABEL <%= template_name %>
+  KERNEL <%= @kernel %>
+  <% if @host.operatingsystem.name.match(/.*atomic.*/i) -%>
+  APPEND initrd=<%= @initrd %> <%= @ks_option %> repo=<%= @host.operatingsystem.medium_uri(@host) %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
+  APPEND initrd=<%= @initrd %> <%= @ks_option %> ks.device=bootif network ks.sendmac <%= @options %>
+  <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
+  APPEND initrd=<%= @initrd %> <%= @ks_option %> network ks.sendmac <%= @options %>
+  <% else -%>
+  APPEND initrd=<%= @initrd %> <%= @ks_option %> ksdevice=bootif network kssendmac <%= @options %>
+  <% end -%>
+  IPAPPEND 2
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/preseed/PXELinux.erb
+++ b/app/views/unattended/preseed/PXELinux.erb
@@ -6,7 +6,7 @@ oses:
 - Ubuntu
 %>
 #
-# This file was deployed via '<%= @template_name %>' template
+# This file was deployed via '<%= template_name %>' template
 #
 # Supported host/hostgroup parameters:
 #

--- a/app/views/unattended/pxe/PXEGrub2_default.erb
+++ b/app/views/unattended/pxe/PXEGrub2_default.erb
@@ -1,0 +1,31 @@
+<%#
+kind: PXEGrub2
+name: PXEGrub2 global default
+%>
+<%# Used to boot unknown hosts, do not associate or change the name. %>
+
+default=0
+timeout=20
+
+<%= snippet "pxegrub2_chainload" %>
+
+<%= snippet "pxegrub2_discovery" %>
+
+<% for profile in @profiles
+  url = default_template_url(profile[:template], profile[:hostgroup])
+  case profile[:pxe_type]
+  when 'kickstart'
+    append = "ks=#{url} ksdevice=bootif network kssendmac"
+  when 'preseed'
+    locale = profile[:hostgroup].params['lang'] || 'en_US'
+    append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"
+  else
+    raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+  end %>
+menuentry '<%= "#{profile[:hostgroup]} - #{profile[:template]}" %>' {
+  linuxefi <%= profile[:kernel] %> <%= append %>
+  initrdefi <%= profile[:initrd] %>
+}
+<% end %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/pxe/PXEGrub2_local.erb
+++ b/app/views/unattended/pxe/PXEGrub2_local.erb
@@ -1,0 +1,12 @@
+<%#
+kind: PXEGrub2
+name: PXEGrub2 default local boot
+%>
+<%# Used to boot provisioned hosts, do not associate or change the name. %>
+
+set default=0
+set timeout=20
+
+<%= snippet "pxegrub2_chainload" %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/pxe/PXEGrub_default.erb
+++ b/app/views/unattended/pxe/PXEGrub_default.erb
@@ -1,0 +1,30 @@
+<%#
+kind: PXEGrub
+name: PXEGrub global default
+%>
+<%# Used to boot unknown hosts, do not associate or change the name. %>
+
+default=0
+timeout=20
+
+<%= snippet "pxegrub_chainload" %>
+
+<%= snippet "pxegrub_discovery" %>
+
+<% for profile in @profiles
+  url = default_template_url(profile[:template], profile[:hostgroup])
+  case profile[:pxe_type]
+  when 'kickstart'
+    append = "ks=#{url} ksdevice=bootif network kssendmac"
+  when 'preseed'
+    locale = profile[:hostgroup].params['lang'] || 'en_US'
+    append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"
+  else
+    raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+  end %>
+title <%= "#{profile[:hostgroup]} - #{profile[:template]}" %>
+  kernel <%= profile[:kernel] %> <%= append %>
+  initrd <%= profile[:initrd] %>
+<% end %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/pxe/PXEGrub_local.erb
+++ b/app/views/unattended/pxe/PXEGrub_local.erb
@@ -2,11 +2,11 @@
 kind: PXEGrub
 name: PXEGrub default local boot
 %>
-
-<%# This template has special name (do not change it) and it is used for booting already provisioned hosts. %>
+<%# Used to boot provisioned hosts, do not associate or change the name. %>
 
 default=0
-timeout=1
-title Chainload into bootloader on first disk
-root (hd0,0)
-chainloader +1
+timeout=20
+
+<%= snippet "pxegrub_chainload" %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/pxe/PXELinux_default.erb
+++ b/app/views/unattended/pxe/PXELinux_default.erb
@@ -2,8 +2,7 @@
 kind: PXELinux
 name: PXELinux global default
 %>
-
-<%# This template has special name (do not change it) and it is used for booting unknown hosts. %>
+<%# Used to boot unknown hosts, do not associate or change the name. %>
 
 DEFAULT menu
 PROMPT 0
@@ -12,21 +11,24 @@ TIMEOUT 200
 TOTALTIMEOUT 6000
 ONTIMEOUT local
 
-LABEL local
-     MENU LABEL (local)
-     MENU DEFAULT
-     LOCALBOOT 0
+<%= snippet "pxelinux_chainload" %>
 
 <%= snippet "pxelinux_discovery" %>
 
-<% for profile in @profiles -%>
+<% for profile in @profiles
+  url = default_template_url(profile[:template], profile[:hostgroup])
+  case profile[:pxe_type]
+  when 'kickstart'
+    append = "ks=#{url} ksdevice=bootif network kssendmac"
+  when 'preseed'
+    locale = profile[:hostgroup].params['lang'] || 'en_US'
+    append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"
+  else
+    raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+  end %>
 LABEL <%= "#{profile[:hostgroup]} - #{profile[:template]}" %>
-     KERNEL <%= profile[:hostgroup].operatingsystem.kernel(profile[:hostgroup].architecture) %>
-<% case profile[:hostgroup].operatingsystem.pxe_type -%>
-<% when 'kickstart' -%>
-     APPEND initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> ks=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ksdevice=bootif network kssendmac
-<% when 'preseed' -%>
-     APPEND initrd=<%= profile[:hostgroup].operatingsystem.initrd(profile[:hostgroup].architecture) %> interface=auto url=<%= default_template_url(profile[:template], profile[:hostgroup]) %> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=<%= profile[:hostgroup].params['lang'] || 'en_US' %> console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA
-<% end -%>
+  KERNEL <%= profile[:kernel] %>
+  APPEND initrd=<%= profile[:initrd] %> <%= append %>
+<% end %>
 
-<% end -%>
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/pxe/PXELinux_local.erb
+++ b/app/views/unattended/pxe/PXELinux_local.erb
@@ -2,8 +2,7 @@
 kind: PXELinux
 name: PXELinux default local boot
 %>
-
-<%# This template has special name (do not change it) and it is used for booting already provisioned hosts. %>
+<%# Used to boot provisioned hosts, do not associate or change the name. %>
 
 DEFAULT menu
 PROMPT 0
@@ -12,7 +11,6 @@ TIMEOUT 200
 TOTALTIMEOUT 6000
 ONTIMEOUT local
 
-LABEL local
-     MENU LABEL (local)
-     MENU DEFAULT
-     LOCALBOOT 0
+<%= snippet "pxelinux_chainload" %>
+
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_kickstart_cmdline.erb
+++ b/app/views/unattended/snippets/_kickstart_cmdline.erb
@@ -1,0 +1,21 @@
+<%#
+kind: snippet
+name: kickstart_cmdline
+-%>
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+<%
+  @options = []
+  if @host.params['blacklist']
+    @options << "modprobe.blacklist=" + @host.params['blacklist'].gsub(' ', '')
+  end
+  @options = @options.join(' ')
+  log_debug "Extra kernel options: #{@options}"
+  @ks_option = 'ks=' + foreman_url('provision')
+  @loader_timeout = (@host.params['loader_timeout'] || 10).to_i
+-%>
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxegrub2_chainload.erb
+++ b/app/views/unattended/snippets/_pxegrub2_chainload.erb
@@ -1,0 +1,37 @@
+<%#
+kind: snippet
+name: pxegrub2_chainload
+%>
+<%
+  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]
+-%>
+menuentry "Chainload Grub2 EFI from ESP" {
+  unset root
+  echo Chainloading Grub2 EFI from ESP, available devices:
+  ls
+  echo -n "Probing ESP partition ... "
+  search --file --no-floppy --set=root /EFI/BOOT/BOOTX64.EFI
+  echo found $root
+  sleep 2
+  if [ -f ($root)/EFI/BOOT/grubx64.efi ]; then
+    chainloader ($root)/EFI/BOOT/grubx64.efi
+  <% paths.each do |path| %>
+  elif [ -f ($root)/EFI/<%= path %>/grubx64.efi ]; then
+    chainloader ($root)/EFI/<%= path %>/grubx64.efi
+  <% end -%>
+  else
+    echo File grubx64.efi not found on ESP.
+    echo Update 'pxegrub2_chainload' paths array with:
+    ls ($root)/EFI
+    echo The system will halt in 2 minutes or
+    echo press ESC to halt immediately.
+    sleep -i 120
+    halt --no-apm
+  fi
+}
+
+menuentry "Chainload into BIOS bootloader on first disk" {
+  set root=(hd0,0)
+  chainloader +1
+}
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxegrub2_discovery.erb
+++ b/app/views/unattended/snippets/_pxegrub2_discovery.erb
@@ -1,0 +1,9 @@
+<%#
+kind: snippet
+name: pxegrub2_discovery
+-%>
+menuentry 'Foreman Discovery Image' {
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  initrdefi boot/fdi-image/initrd0.img
+}
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxegrub_chainload.erb
+++ b/app/views/unattended/snippets/_pxegrub_chainload.erb
@@ -1,0 +1,18 @@
+<%#
+kind: snippet
+name: pxegrub_chainload
+%>
+<%
+  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "Microsoft", "EFI"]
+-%>
+fallback=<%= (1..paths.size).to_a.join(' ') %>
+<% paths.each do |path| %>
+title Chainload Grub from /EFI/<%= path %>
+  rootnoverify (hd0,0)
+  chainloader /EFI/<%= path %>/grubx64.efi
+<% end -%>
+
+title Chainload into bootloader on first disk
+  root (hd0,0)
+  chainloader +1
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxegrub_discovery.erb
+++ b/app/views/unattended/snippets/_pxegrub_discovery.erb
@@ -1,0 +1,9 @@
+<%#
+kind: snippet
+name: pxegrub_discovery
+-%>
+# http://projects.theforeman.org/issues/15997
+title Foreman Discovery Image - not supported with Grub 1.x
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  initrd boot/fdi-image/initrd0.img
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxelinux_chainload.erb
+++ b/app/views/unattended/snippets/_pxelinux_chainload.erb
@@ -1,0 +1,9 @@
+<%#
+kind: snippet
+name: pxelinux_chainload
+%>
+LABEL local
+  MENU LABEL Chainload into bootloader on first disk
+  MENU DEFAULT
+  LOCALBOOT 0
+<%# vim:sw=2:ts=2:et -%>

--- a/app/views/unattended/snippets/_pxelinux_discovery.erb
+++ b/app/views/unattended/snippets/_pxelinux_discovery.erb
@@ -3,7 +3,8 @@ kind: snippet
 name: pxelinux_discovery
 -%>
 LABEL discovery
-     MENU LABEL (discovery)
-     KERNEL boot/fdi-image/vmlinuz0
-     APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
-     IPAPPEND 2
+  MENU LABEL Foreman Discovery Image
+  KERNEL boot/fdi-image/vmlinuz0
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
+  IPAPPEND 2
+<%# vim:sw=2:ts=2:et -%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -174,7 +174,8 @@ module Foreman
       :app => {:enabled => true},
       :ldap => {:enabled => false},
       :permissions => {:enabled => false},
-      :sql => {:enabled => false}
+      :sql => {:enabled => false},
+      :templates => {:enabled => true}
     ))
 
     config.logger = Foreman::Logging.logger('app')

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -47,3 +47,5 @@
 #    :enabled: false
 #  :sql:
 #    :enabled: false
+#  :templates:
+#    :enabled: true

--- a/db/migrate/20160725142557_add_pxe_loader_to_host.rb
+++ b/db/migrate/20160725142557_add_pxe_loader_to_host.rb
@@ -1,0 +1,11 @@
+class AddPxeLoaderToHost < ActiveRecord::Migration
+  def change
+    add_column :hosts, :pxe_loader, :string, :limit => 255
+
+    reversible do |dir|
+      dir.up do
+        Host.update_all(:pxe_loader => 'PXELinux BIOS')
+      end
+    end
+  end
+end

--- a/db/migrate/20160727142242_add_pxe_loader_to_hostgroup.rb
+++ b/db/migrate/20160727142242_add_pxe_loader_to_hostgroup.rb
@@ -1,0 +1,11 @@
+class AddPxeLoaderToHostgroup < ActiveRecord::Migration
+  def change
+    add_column :hostgroups, :pxe_loader, :string, :limit => 255
+
+    reversible do |dir|
+      dir.up do
+        Hostgroup.update_all(:pxe_loader => 'PXELinux BIOS')
+      end
+    end
+  end
+end

--- a/db/seeds.d/07-provisioning_templates.rb
+++ b/db/seeds.d/07-provisioning_templates.rb
@@ -18,10 +18,13 @@ locations = Location.all
 ProvisioningTemplate.without_auditing do
   [
     # Generic PXE files
-    { :name => 'PXELinux global default', :source => 'pxe/PXELinux_default.erb', :template_kind => kinds[:PXELinux] },
-    { :name => 'PXELinux default local boot', :source => 'pxe/PXELinux_local.erb', :template_kind => kinds[:PXELinux] },
+    { :name => 'PXELinux global default', :source => 'pxe/PXELinux_default.erb', :template_kind => kinds[:PXELinux], :locked => true },
+    { :name => 'PXEGrub global default', :source => 'pxe/PXEGrub_default.erb', :template_kind => kinds[:PXEGrub], :locked => true },
+    { :name => 'PXEGrub2 global default', :source => 'pxe/PXEGrub2_default.erb', :template_kind => kinds[:PXEGrub2], :locked => true },
+    { :name => 'PXELinux default local boot', :source => 'pxe/PXELinux_local.erb', :template_kind => kinds[:PXELinux], :locked => true },
+    { :name => 'PXEGrub default local boot', :source => 'pxe/PXEGrub_local.erb', :template_kind => kinds[:PXEGrub], :locked => true },
+    { :name => 'PXEGrub2 default local boot', :source => 'pxe/PXEGrub2_local.erb', :template_kind => kinds[:PXEGrub2], :locked => true },
     { :name => 'PXELinux default memdisk', :source => 'pxe/PXELinux_memdisk.erb', :template_kind => kinds[:PXELinux] },
-    { :name => 'PXEGrub default local boot', :source => 'pxe/PXEGrub_local.erb', :template_kind => kinds[:PXEGrub] },
     { :name => 'PXELinux chain iPXE', :source => 'pxe/PXELinux_chain_iPXE.erb', :template_kind => kinds[:PXELinux] },
     { :name => 'PXELinux chain iPXE UNDI', :source => 'pxe/PXELinux_chain_iPXE_UNDI.erb', :template_kind => kinds[:PXELinux] },
     # OS specific files
@@ -49,6 +52,8 @@ ProvisioningTemplate.without_auditing do
     { :name => 'Kickstart RHEL default', :source => 'kickstart/provision_rhel.erb', :template_kind => kinds[:provision] },
     { :name => 'Kickstart default finish', :source => 'kickstart/finish.erb', :template_kind => kinds[:finish] },
     { :name => 'Kickstart default PXELinux', :source => 'kickstart/PXELinux.erb', :template_kind => kinds[:PXELinux] },
+    { :name => 'Kickstart default PXEGrub', :source => 'kickstart/PXEGrub.erb', :template_kind => kinds[:PXEGrub] },
+    { :name => 'Kickstart default PXEGrub2', :source => 'kickstart/PXEGrub2.erb', :template_kind => kinds[:PXEGrub2] },
     { :name => 'Kickstart default iPXE', :source => 'kickstart/iPXE.erb', :template_kind => kinds[:iPXE] },
     { :name => 'Kickstart default user data', :source => 'kickstart/userdata.erb', :template_kind => kinds[:user_data] },
     { :name => 'NX-OS default POAP setup', :source => 'poap/provision.erb', :template_kind => kinds[:POAP] },
@@ -80,7 +85,14 @@ ProvisioningTemplate.without_auditing do
     { :name => 'redhat_register', :source => 'snippets/_redhat_register.erb', :snippet => true },
     { :name => 'remote_execution_ssh_keys', :source => 'snippets/_remote_execution_ssh_keys.erb', :snippet => true },
     { :name => 'saltstack_minion', :source => 'snippets/_saltstack_minion.erb', :snippet => true },
-    { :name => 'saltstack_setup', :source => 'snippets/_saltstack_setup.erb', :snippet => true }
+    { :name => 'saltstack_setup', :source => 'snippets/_saltstack_setup.erb', :snippet => true },
+    { :name => 'kickstart_cmdline', :source => 'snippets/_kickstart_cmdline.erb', :snippet => true },
+    { :name => 'pxelinux_chainload', :source => 'snippets/_pxelinux_chainload.erb', :snippet => true },
+    { :name => 'pxegrub_chainload', :source => 'snippets/_pxegrub_chainload.erb', :snippet => true },
+    { :name => 'pxegrub2_chainload', :source => 'snippets/_pxegrub2_chainload.erb', :snippet => true },
+    { :name => 'pxelinux_discovery', :source => 'snippets/_pxelinux_discovery.erb', :snippet => true },
+    { :name => 'pxegrub_discovery', :source => 'snippets/_pxegrub_discovery.erb', :snippet => true },
+    { :name => 'pxegrub2_discovery', :source => 'snippets/_pxegrub2_discovery.erb', :snippet => true }
   ].each do |input|
     contents = File.read(File.join("#{Rails.root}/app/views/unattended", input.delete(:source)))
 

--- a/lib/proxy_api/tftp.rb
+++ b/lib/proxy_api/tftp.rb
@@ -1,27 +1,28 @@
 module ProxyAPI
   class TFTP < ProxyAPI::Resource
     def initialize(args)
-      @url     = args[:url] + "/tftp"
-      @variant = args[:variant]
+      @url = args[:url] + "/tftp"
       super args
     end
 
     # Creates a TFTP boot entry
+    # [+kind+] : PXE template kind
     # [+mac+]  : MAC address
     # [+args+] : Hash containing
     #    :pxeconfig => String containing the configuration
     # Returns  : Boolean status
-    def set(mac, args)
-      parse(post(args, "#{@variant}/#{mac}"))
+    def set(kind, mac, args)
+      parse(post(args, "#{kind}/#{mac}"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to set TFTP boot entry for %s"), mac)
     end
 
     # Deletes a TFTP boot entry
+    # [+kind+] : PXE template kind
     # [+mac+] : String in coloned sextuplet format
     # Returns : Boolean status
-    def delete(mac)
-      parse(super("#{@variant}/#{mac}"))
+    def delete(kind, mac)
+      parse(super("#{kind}/#{mac}"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to delete TFTP boot entry for %s"), mac)
     end
@@ -53,8 +54,8 @@ module ProxyAPI
     # [+args+] : Hash containing
     #   :menu => String containing the menu text
     # Returns    : Boolean status
-    def create_default(args)
-      parse(post(args, "create_default"))
+    def create_default(kind, args)
+      parse(post(args, "#{kind}/create_default"))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to create default TFTP boot menu"))
     end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -6,9 +6,7 @@ namespace :test do
     t.verbose = true
     t.warning = false
   end
-end
 
-namespace :test do
   desc "Test lib source"
   Rake::TestTask.new(:lib) do |t|
     t.libs << "test"

--- a/script/sync_templates.sh
+++ b/script/sync_templates.sh
@@ -20,6 +20,7 @@ git clone -q -b $(git symbolic-ref -q HEAD --short) \
 (cd $REPO/ct/snippets && prename -f 's/^([^_])/_$1/' *)
 
 rsync -r \
+  --exclude .gitignore \
   --exclude README.md \
   --exclude '.*' \
   --exclude test \

--- a/test/factories/architecture.rb
+++ b/test/factories/architecture.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :architecture do
-    sequence(:name) {|n| "arm#{n}" }
+    sequence(:name) {|n| "x86_64-#{n}" }
   end
 end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -225,6 +225,7 @@ FactoryGirl.define do
 
     trait :managed do
       managed true
+      pxe_loader "Grub2 UEFI"
       architecture { operatingsystem.try(:architectures).try(:first) }
       medium { operatingsystem.try(:media).try(:first) }
       ptable { operatingsystem.try(:ptables).try(:first) }

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -25,6 +25,20 @@ FactoryGirl.define do
       with_os_defaults
     end
 
+    trait :with_pxelinux do
+      provisioning_templates do
+        [FactoryGirl.create(:provisioning_template, :template_kind => TemplateKind.find_by_name('PXELinux'))]
+      end
+      with_os_defaults
+    end
+
+    trait :with_grub do
+      provisioning_templates do
+        [FactoryGirl.create(:provisioning_template, :template_kind => TemplateKind.find_by_name('PXEGrub'))]
+      end
+      with_os_defaults
+    end
+
     trait :with_archs do
       architectures { [FactoryGirl.create(:architecture)] }
     end

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -15,3 +15,6 @@ finish:
 
 pxegrub:
   name: PXEGrub
+
+pxegrub2:
+  name: PXEGrub2

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -55,6 +55,7 @@ class HostsControllerTest < ActionController::TestCase
           :environment_id => environments(:production).id,
           :subnet_id => subnets(:one).id,
           :medium_id => media(:one).id,
+          :pxe_loader => "Grub2 UEFI",
           :realm_id => realms(:myrealm).id,
           :disk => "empty partition",
           :puppet_proxy_id => smart_proxies(:puppetmaster).id,
@@ -84,7 +85,7 @@ class HostsControllerTest < ActionController::TestCase
           :medium_id => media(:one).id,
           :realm_id => realms(:myrealm).id,
           :disk => "empty partition",
-          :root_pass           => "xybxa6JUkz63w",
+          :root_pass => "xybxa6JUkz63w",
           :location_id => taxonomies(:location1).id,
           :organization_id => taxonomies(:organization1).id
         }

--- a/test/functional/shared/pxe_loader_test.rb
+++ b/test/functional/shared/pxe_loader_test.rb
@@ -1,0 +1,31 @@
+module PxeLoaderTest
+  extend ActiveSupport::Concern
+  included do
+    context "pxe loader" do
+      setup do
+        disable_orchestration
+        Operatingsystem.any_instance.stubs(:preferred_loader).returns("Grub2 UEFI")
+        Redhat.any_instance.stubs(:preferred_loader).returns("Grub2 UEFI")
+      end
+
+      test "should be created for host or hostgroup using suggestion" do
+        post :create, valid_attrs_with_root(basic_attrs)
+        refute_nil last_record.operatingsystem
+        assert_equal "Grub2 UEFI", last_record.pxe_loader
+        assert_response :created
+      end
+
+      test "should be created for host or hostgroup with Grub2 UEFI" do
+        post :create, valid_attrs_with_root(:pxe_loader => "Grub2 UEFI SecureBoot")
+        assert_equal "Grub2 UEFI SecureBoot", last_record.pxe_loader
+        assert_response :created
+      end
+
+      test "should be created for host or hostgroup with non-PXE" do
+        post :create, valid_attrs_with_root(:pxe_loader => "None")
+        assert_equal "None", last_record.pxe_loader
+        assert_response :created
+      end
+    end
+  end
+end

--- a/test/lib/foreman/renderer_test.rb
+++ b/test/lib/foreman/renderer_test.rb
@@ -67,17 +67,17 @@ class RendererTest < ActiveSupport::TestCase
 
     test "#{renderer_name} should render unnamed template" do
       send "setup_#{renderer_name}"
-      tmpl = unattended_render('x<%= @template_name %>')
-      assert_equal 'xUnnamed', tmpl
+      tmpl = unattended_render('x <%= @template_name %> <%= template_name %>')
+      assert_equal 'x Unnamed Unnamed', tmpl
     end
 
     test "#{renderer_name} should render template name" do
       send "setup_#{renderer_name}"
       template = mock('template')
-      template.stubs(:template).returns('x<%= @template_name %>')
+      template.stubs(:template).returns('x <%= @template_name %> <%= template_name %>')
       template.stubs(:name).returns('abc')
       tmpl = unattended_render(template)
-      assert_equal 'xabc', tmpl
+      assert_equal 'x abc abc', tmpl
     end
 
     test "#{renderer_name} should render with AR relation method calls" do

--- a/test/lib/net/dhcp_test.rb
+++ b/test/lib/net/dhcp_test.rb
@@ -40,27 +40,29 @@ class DhcpTest < ActiveSupport::TestCase
   end
 
   test "record should be equal if their attrs are the same" do
-    record1 = Net::DHCP::Record.new(:hostname => "test", :mac => "aa:bb:cc:dd:ee:ff",
-                                 :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
-    record2 = Net::DHCP::Record.new(:hostname => "test", :mac => "aa:bb:cc:dd:ee:ff",
-                                 :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
+    record1 = make_record
+    record2 = make_record
     assert_equal record1, record2
+    assert_equal record2, record1
   end
 
   test "record should be equal if one record has no hostname" do
-    record1 = Net::DHCP::Record.new(:mac => "aa:bb:cc:dd:ee:ff",
-                                    :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
-    record2 = Net::DHCP::Record.new(:hostname => "test", :mac => "aa:bb:cc:dd:ee:ff",
-                                    :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
+    record1 = make_record
+    record2 = make_record :hostname => "test"
+    assert_equal record1, record2
+    assert_equal record2, record1
+  end
+
+  test "record should be equal if one record has no filename" do
+    record1 = make_record
+    record2 = make_record :filename => "pxelinux.0"
     assert_equal record1, record2
     assert_equal record2, record1
   end
 
   test "record should not be equal if their attrs are not the same" do
-    record1 = Net::DHCP::Record.new(:hostname => "test1", :mac => "aa:bb:cc:dd:ee:ff",
-                                    :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
-    record2 = Net::DHCP::Record.new(:hostname => "test2", :mac => "aa:bb:cc:dd:ee:ff",
-                                    :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one))
+    record1 = make_record :hostname => "test1"
+    record2 = make_record :hostname => "test2"
     refute_equal record1, record2
   end
 
@@ -133,5 +135,11 @@ class DhcpTest < ActiveSupport::TestCase
                                     "proxy" => subnets(:one).dhcp_proxy)
     assert record1.conflicts.empty?
     assert record1.valid?
+  end
+
+  private
+
+  def make_record(attrs = {})
+    Net::DHCP::Record.new({:mac => "aa:bb:cc:dd:ee:ff", :network => "127.0.0.0", :ip => "127.0.0.1", "proxy" => smart_proxies(:one)}.merge(attrs))
   end
 end

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -24,4 +24,29 @@ class ArchitectureTest < ActiveSupport::TestCase
 
     assert_not architecture.destroy
   end
+
+  test "should return intel precision for i386" do
+    architecture = Architecture.new :name => "i386"
+    assert_equal "ia32", architecture.intel_precision
+  end
+
+  test "should return intel precision for i686" do
+    architecture = Architecture.new :name => "i686"
+    assert_equal "ia32", architecture.intel_precision
+  end
+
+  test "should return intel precision for x86-64" do
+    architecture = Architecture.new :name => "x86-64"
+    assert_equal "x64", architecture.intel_precision
+  end
+
+  test "should return intel precision for x86_64" do
+    architecture = Architecture.new :name => "x86_64"
+    assert_equal "x64", architecture.intel_precision
+  end
+
+  test "should not return intel precision for unknown arch" do
+    architecture = Architecture.new :name => "unknown"
+    assert_equal "", architecture.intel_precision
+  end
 end

--- a/test/unit/concerns/pxe_loader_support_test.rb
+++ b/test/unit/concerns/pxe_loader_support_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+
+class DummyPxeLoader
+  include PxeLoaderSupport
+end
+
+class PxeLoaderSupportTest < ActiveSupport::TestCase
+  def setup
+    @subject = DummyPxeLoader.new
+    @host = FactoryGirl.create(:host)
+    @subject.stubs(:template_kinds).returns(Operatingsystem.new.template_kinds)
+  end
+
+  describe "template kind" do
+    test "is not found when PXE loader is not set" do
+      @host.pxe_loader = ""
+      assert_nil @subject.pxe_loader_kind(@host)
+    end
+
+    test "is not found when PXE loader is set to None" do
+      @host.pxe_loader = "None"
+      assert_nil @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXELinux is found for given filename" do
+      @host.pxe_loader = "pxelinux.0"
+      assert_equal :PXELinux, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub is found for given filename" do
+      @host.pxe_loader = "grub/bootx64.efi"
+      assert_equal :PXEGrub, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for given filename" do
+      @host.pxe_loader = "grub2/grubx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXELinux is found for given loader name" do
+      @host.pxe_loader = "PXELinux UEFI"
+      assert_equal :PXELinux, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub is found for given loader name" do
+      @host.pxe_loader = "Grub UEFI"
+      assert_equal :PXEGrub, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for given loader name" do
+      @host.pxe_loader = "Grub2 UEFI"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+  end
+
+  describe "preferred loader" do
+    setup do
+      @template_pxelinux = FactoryGirl.create(:provisioning_template, :template_kind => TemplateKind.find_by_name(:PXELinux))
+      @template_pxegrub = FactoryGirl.create(:provisioning_template, :template_kind => TemplateKind.find_by_name(:PXEGrub))
+      @template_pxegrub2 = FactoryGirl.create(:provisioning_template, :template_kind => TemplateKind.find_by_name(:PXEGrub2))
+    end
+
+    test "is none for zero template kinds and templates" do
+      @subject.expects(:template_kinds).returns([])
+      @subject.expects(:os_default_templates).returns([])
+      assert_nil @subject.preferred_loader
+    end
+
+    test "is none for zero templates" do
+      @subject.expects(:os_default_templates).returns([])
+      assert_nil @subject.preferred_loader
+    end
+
+    test "is none for zero template kinds" do
+      @subject.expects(:template_kinds).returns([])
+      @subject.expects(:os_default_templates).returns([@template_pxelinux, @template_pxegrub, @template_pxegrub2])
+      assert_nil @subject.preferred_loader
+    end
+
+    test "is PXEGrub2 for associated templates" do
+      @subject.expects(:os_default_templates).returns([@template_pxelinux, @template_pxegrub, @template_pxegrub2])
+      assert_equal "Grub2 UEFI", @subject.preferred_loader
+    end
+
+    test "is PXELinux for associated templates" do
+      @subject.expects(:os_default_templates).returns([@template_pxelinux, @template_pxegrub])
+      assert_equal "PXELinux BIOS", @subject.preferred_loader
+    end
+
+    test "is PXEGrub for associated templates" do
+      @subject.expects(:os_default_templates).returns([@template_pxegrub])
+      assert_equal "Grub UEFI", @subject.preferred_loader
+    end
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -927,7 +927,7 @@ class HostTest < ActiveSupport::TestCase
 
     test "custom_disk_partition_with_erb" do
       h = FactoryGirl.create(:host)
-      h.disk = "<%= @template_name %>"
+      h.disk = "<%= template_name %>"
       assert h.save
       assert h.disk.present?
       assert_equal "Custom disk layout", h.diskLayout
@@ -937,7 +937,7 @@ class HostTest < ActiveSupport::TestCase
       h = FactoryGirl.create(:host, :managed)
       h.disk = ''
       h.ptable.stubs(:name).returns("some_name")
-      h.ptable.stubs(:layout).returns("<%= @template_name %>")
+      h.ptable.stubs(:layout).returns("<%= template_name %>")
       assert h.save
       assert_equal "some_name", h.diskLayout
     end
@@ -1188,6 +1188,14 @@ class HostTest < ActiveSupport::TestCase
       assert h.root_pass.present?
       assert_equal Setting[:root_pass], h.root_pass
       assert_equal Setting[:root_pass], h.read_attribute(:root_pass), 'should copy root_pass to host'
+    end
+
+    test "should validate pxe loader when provided" do
+      host = Host.create :name => "myhostpxe", :mac => "aabbecddeeff", :ip => "2.3.4.3", :hostgroup => hostgroups(:common), :managed => true, :pxe_loader => "PXELinux BIOS"
+      assert_equal "x86_64", host.architecture.name
+      assert_equal "PXELinux BIOS", host.pxe_loader
+      assert_empty host.errors.messages
+      assert host.valid?
     end
 
     test "should save uuid on managed hosts" do

--- a/test/unit/host_token_test.rb
+++ b/test/unit/host_token_test.rb
@@ -30,6 +30,6 @@ class HostTokenTest < ActiveSupport::TestCase
     end
 
     assert host.token.try(:value).present?
-    assert_includes host.send(:generate_pxe_template), "token=#{host.token.value}"
+    assert_includes host.send(:generate_pxe_template, :PXELinux), "token=#{host.token.value}"
   end
 end

--- a/test/unit/operatingsystem_test.rb
+++ b/test/unit/operatingsystem_test.rb
@@ -236,6 +236,39 @@ class OperatingsystemTest < ActiveSupport::TestCase
     refute_valid operatingsystem
   end
 
+  test "provides available loaders" do
+    assert Operatingsystem.new.available_loaders.include? "None"
+    assert Operatingsystem.new.available_loaders.include? "PXELinux BIOS"
+  end
+
+  test "provides available loaders for Redhat" do
+    assert Redhat.new.available_loaders.include? "PXELinux BIOS"
+    assert Redhat.new.available_loaders.include? "Grub UEFI"
+    assert Redhat.new.available_loaders.include? "Grub2 UEFI"
+  end
+
+  test "provides available loaders for Solaris" do
+    assert Solaris.new.available_loaders.include? "None"
+  end
+
+  test "should not have preferred pxe loader for an OS without architecture associated" do
+    assert_nil Operatingsystem.new.preferred_loader
+  end
+
+  test "should have preferred pxe loader for an Solaris OS without any templates" do
+    assert_nil Solaris.new.preferred_loader
+  end
+
+  test "should have preferred pxe loader for OS with PXELinux template" do
+    os = FactoryGirl.create(:operatingsystem, :with_associations, :with_pxelinux)
+    assert_equal "PXELinux BIOS", os.preferred_loader
+  end
+
+  test "should have preferred pxe loader for OS with Grub template" do
+    os = FactoryGirl.create(:operatingsystem, :with_associations, :with_grub)
+    assert_equal "Grub UEFI", os.preferred_loader
+  end
+
   context 'os default templates' do
     setup do
       @template_kind = FactoryGirl.create(:template_kind)

--- a/test/unit/operatingsystems/solaris_test.rb
+++ b/test/unit/operatingsystems/solaris_test.rb
@@ -9,6 +9,7 @@ class SolarisTest < ActiveSupport::TestCase
                                              :ip => '2.3.4.10') ],
           :architecture => architectures(:sparc),
           :operatingsystem => operatingsystems(:solaris10),
+          :pxe_loader => '',
           :compute_resource => compute_resources(:one),
           :model => models(:V210),
           :medium => media(:solaris10),

--- a/test/unit/orchestration/dhcp_test.rb
+++ b/test/unit/orchestration/dhcp_test.rb
@@ -75,11 +75,27 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     assert_equal '<Sun-Fire-V210>', d.vendor
   end
 
-  test "provision interface DHCP records should contain filename/next-server attributes" do
+  test "provision interface DHCP records should contain default filename/next-server attributes" do
     ProxyAPI::TFTP.any_instance.expects(:bootServer).returns('192.168.1.1')
     subnet = FactoryGirl.build(:subnet_ipv4, :dhcp, :tftp)
     h = FactoryGirl.create(:host, :with_dhcp_orchestration, :with_tftp_orchestration, :subnet => subnet)
+    assert_equal 'grub2/grubx64.efi', h.provision_interface.dhcp_record.filename
+    assert_equal '192.168.1.1', h.provision_interface.dhcp_record.nextServer
+  end
+
+  test "provision interface DHCP records should contain explicit filename/next-server attributes" do
+    ProxyAPI::TFTP.any_instance.expects(:bootServer).returns('192.168.1.1')
+    subnet = FactoryGirl.build(:subnet_ipv4, :dhcp, :tftp)
+    h = FactoryGirl.create(:host, :with_dhcp_orchestration, :with_tftp_orchestration, :subnet => subnet, :pxe_loader => 'PXELinux BIOS')
     assert_equal 'pxelinux.0', h.provision_interface.dhcp_record.filename
+    assert_equal '192.168.1.1', h.provision_interface.dhcp_record.nextServer
+  end
+
+  test "provision interface DHCP records should not contain explicit filename attribute when PXE loader is set to None" do
+    ProxyAPI::TFTP.any_instance.expects(:bootServer).returns('192.168.1.1')
+    subnet = FactoryGirl.build(:subnet_ipv4, :dhcp, :tftp)
+    h = FactoryGirl.create(:host, :with_dhcp_orchestration, :with_tftp_orchestration, :subnet => subnet, :pxe_loader => 'None')
+    assert_nil h.provision_interface.dhcp_record.filename
     assert_equal '192.168.1.1', h.provision_interface.dhcp_record.nextServer
   end
 


### PR DESCRIPTION
Implementation of

https://github.com/theforeman/rfcs/blob/master/text/0001-PXE-Booting-UEFI.md

In short, new host/hostgroup flag PXE loader is added to specify TFTP
DHCP filename and Foreman now orchestrates _all_ PXE-capable templates
deployment (e.g. PXELinux, Grub1, Grub2 if associated to an OS).

Test this patch against develop smart proxy as it requires https://github.com/theforeman/smart-proxy/pull/443 (merged).

There are few test-related TODOs and the patch is missing:
- [x] Add the sane default to all hosts, pxe_loader should not be empty (migration)
- [x] Validate the pxe_loader field of a host
- [x] Add new templates - https://github.com/theforeman/community-templates/pull/291
- [x] Build PXE Default button deploys all templates on all proxies
- [x] Editing PXE loader on existing host should trigger DHCP orchestration (w/o conflicts)
- [x] PXE Loader field works fine with hostgroup
- [x] Ability to set blank PXE Loader field (for iPXE provisioning)
- [ ] Test host/hostgroup provisioning rendering
- [x] UI integration test
- [x] API

I will update the list as we start with review.
