### PR TITLE
Fixes #15846 - Renamed use_puppet_default to skip_foreman in LookupValue.

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -140,14 +140,14 @@ function undo_remove_child_node(item){
 function toggleOverrideValue(item) {
   var override = $(item).is(':checked');
   var fields = $(item).closest('.fields');
-  var fields_to_disable = fields.find("[name$='[required]'],[id$='_key_type'],[id$='_validator_type'],[name$='[use_puppet_default]'],[name$='[hidden_value]']");
-  var use_puppet_default = $(item).closest('fieldset').find("[id$='use_puppet_default']").is(':checked');
+  var fields_to_disable = fields.find("[name$='[required]'],[id$='_key_type'],[id$='_validator_type'],[name$='[omit]'],[name$='[hidden_value]']");
+  var omit = $(item).closest('fieldset').find("[id$='omit']").is(':checked');
   var default_value_field = fields.find("[id$='_default_value']");
   var pill_icon = $('#pill_' + fields[0].id +' i');
   var override_value_div = fields.find("[id$='lookup_key_override_value']");
 
   fields_to_disable.prop('disabled', !override);
-  default_value_field.prop('disabled', !override || use_puppet_default);
+  default_value_field.prop('disabled', !override || omit);
   override ? pill_icon.addClass('fa-flag') : pill_icon.removeClass('fa-flag');
   override_value_div.toggle(override);
 }
@@ -188,9 +188,9 @@ function mergeOverridesChanged(item) {
   changeCheckboxEnabledStatus(mergeDefault, item.checked);
 }
 
-function toggleUsePuppetDefaultValue(item, value_field) {
-  var use_puppet_default = $(item).is(':checked');
-  $(item).closest('.fields').find('[id$=' + value_field + ']').prop('disabled', use_puppet_default);
+function toggleOmitValue(item, value_field) {
+  var omit = $(item).is(':checked');
+  $(item).closest('.fields').find('[id$=' + value_field + ']').prop('disabled', omit);
 }
 
 function filterByEnvironment(item){

--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -11,6 +11,8 @@ module Api
       before_action :return_if_smart_mismatch, :only => [:index, :create, :show, :update, :destroy]
       before_action :return_if_override_mismatch, :only => [:show, :update, :destroy]
 
+      before_action :rename_use_puppet_default, :only => [:create, :update]
+
       api :GET, "/smart_variables/:smart_variable_id/override_values", N_("List of override values for a specific smart variable")
       api :GET, "/smart_class_parameters/:smart_class_parameter_id/override_values", N_("List of override values for a specific smart class parameter")
       param :smart_variable_id, :identifier, :required => false
@@ -32,8 +34,9 @@ module Api
       def_param_group :override_value do
         param :override_value, Hash, :required => true, :action_aware => true do
           param :match, String, :required => true, :desc => N_("Override match")
-          param :value, String, :required => false, :desc => N_("Override value, required if use_puppet_default is false")
-          param :use_puppet_default, :bool
+          param :value, String, :required => false, :desc => N_("Override value, required if omit is false")
+          param :use_puppet_default, :bool, :required => false, :desc => N_("Deprecated, please use omit")
+          param :omit, :bool, :required => false, :desc => N_("Foreman will not send this parameter in classification output, replaces use_puppet_default")
         end
       end
 
@@ -93,6 +96,13 @@ module Api
       # overwrite Api::BaseController
       def resource_class
         LookupValue
+      end
+
+      def rename_use_puppet_default
+        return unless params[:override_value] && params[:override_value].key?(:use_puppet_default)
+
+        params[:override_value][:omit] = params[:override_value].delete(:use_puppet_default)
+        Foreman::Deprecation.api_deprecation_warning('"use_puppet_default" was renamed to "omit"')
       end
     end
   end

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -5,6 +5,8 @@ module Api
       include Api::V2::LookupKeysCommonController
       include Foreman::Controller::Parameters::PuppetclassLookupKey
 
+      before_action :rename_use_puppet_default, :only => [:update]
+
       alias_method :resource_scope, :smart_class_parameters_resource_scope
 
       api :GET, "/smart_class_parameters", N_("List all smart class parameters")
@@ -39,7 +41,8 @@ module Api
         param :description, String, :desc => N_("Description of smart class")
         param :default_value, String, :desc => N_("Value to use when there is no match")
         param :hidden_value, :bool, :desc => N_("When enabled the parameter is hidden in the UI")
-        param :use_puppet_default, :bool, :desc => N_("Do not send this parameter via the ENC. Puppet will use the value defined in the Puppet manifest for this parameter")
+        param :use_puppet_default, :bool, :desc => N_("Deprecated, please use omit")
+        param :omit, :bool, :desc => N_("Foreman will not send this parameter in classification output. Puppet will use the value defined in the Puppet manifest for this parameter")
         param :path, String, :desc => N_("The order in which values are resolved")
         param :validator_type, LookupKey::VALIDATOR_TYPES, :desc => N_("Types of validation values")
         param :validator_rule, String, :desc => N_("Used to enforce certain values for the parameter values")
@@ -60,6 +63,13 @@ module Api
       # overwrite Api::BaseController
       def resource_class
         LookupKey
+      end
+
+      def rename_use_puppet_default
+        return unless params[:smart_class_parameter] && params[:smart_class_parameter].key?(:use_puppet_default)
+
+        params[:smart_class_parameter][:omit] = params[:smart_class_parameter].delete(:use_puppet_default)
+        Foreman::Deprecation.api_deprecation_warning('"use_puppet_default" was renamed to "omit"')
       end
     end
   end

--- a/app/controllers/concerns/foreman/controller/parameters/lookup_key.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/lookup_key.rb
@@ -17,7 +17,7 @@ module Foreman::Controller::Parameters::LookupKey
         :parameter_type,
         :path,
         :puppetclass_id,
-        :use_puppet_default,
+        :omit,
         :validator_rule,
         :validator_type,
         :variable,

--- a/app/controllers/concerns/foreman/controller/parameters/lookup_value.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/lookup_value.rb
@@ -8,7 +8,7 @@ module Foreman::Controller::Parameters::LookupValue
           :host_or_hostgroup,
           :lookup_key, :lookup_key_id,
           :match,
-          :use_puppet_default,
+          :omit,
           :value,
           :nested => true
 

--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -19,8 +19,10 @@ module CommonParametersHelper
     content_tag(:span, options[:popover], :class => "input-group-addon") + lookup_key_field(id, value, options)
   end
 
-  def use_puppet_default_help link_title = nil, title = _("Use Puppet default")
-    popover(link_title, _("Do not send this parameter via the ENC.<br>Puppet will use the value defined in the manifest."), :title => title)
+  def omit_help
+    title = _("Omit prameter from classification")
+    body = _("Foreman will not send this parameter in classification output.")
+    popover(nil, body, :title => title)
   end
 
   def hidden_value_field(f, field, disabled, options = {})

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -73,7 +73,7 @@ module LookupKeysHelper
       effective_value,
       :popover => diagnostic_popover(lookup_key, matcher, popover_value, warnings),
       :name => "#{lookup_value_name_prefix(lookup_key.id)}[value]",
-      :disabled => !lookup_key.overridden?(obj) || lookup_value.use_puppet_default || !can_edit_params?,
+      :disabled => !lookup_key.overridden?(obj) || lookup_value.omit || !can_edit_params?,
       :inherited_value => inherited_value,
       :lookup_key => lookup_key,
       :lookup_key_hidden_value? => lookup_key.hidden_value?,
@@ -118,7 +118,7 @@ module LookupKeysHelper
       { :text => _("Required parameter without value.<br/><b>Please override!</b><br/>"),
         :icon => "error-circle-o" }
     else
-      { :text => _("Optional parameter without value.<br/><i>Will not be sent to Puppet.</i><br/>"),
+      { :text => _("Optional parameter without value.<br/><i>Still managed by Foreman, the value will be empty.</i><br/>"),
         :icon => "warning-triangle-o" }
     end
   end
@@ -153,15 +153,15 @@ module LookupKeysHelper
     lookup_key.overridden_value(host_or_hostgroup) || LookupValue.new
   end
 
-  def use_puppet_default_check_box(lookup_key, lookup_value, disabled)
+  def omit_check_box(lookup_key, lookup_value, disabled)
     return unless lookup_key.type == "PuppetclassLookupKey"
-    check_box(lookup_value_name_prefix(lookup_key.id), :use_puppet_default,
+    check_box(lookup_value_name_prefix(lookup_key.id), :omit,
               :value    => lookup_value.id,
               :disabled => disabled || !can_edit_params?,
-              :onchange => "toggleUsePuppetDefaultValue(this, 'value')",
+              :onchange => "toggleOmitValue(this, 'value')",
               :hidden   => disabled,
-              :title    => _('Use Puppet default'),
-              :checked  => lookup_value.use_puppet_default)
+              :title    => _('Omit from classification output'),
+              :checked  => lookup_value.omit)
   end
 
   def hidden_lookup_value_fields(lookup_key, lookup_value, disabled)

--- a/app/models/concerns/puppet_lookup_value_extensions.rb
+++ b/app/models/concerns/puppet_lookup_value_extensions.rb
@@ -1,0 +1,11 @@
+module PuppetLookupValueExtensions
+  extend ActiveSupport::Concern
+
+  included do
+    validate :value_present?
+  end
+
+  def value_present?
+    self.errors.add(:value, :blank) if value.to_s.empty? && !omit && lookup_key.puppet?
+  end
+end

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -26,12 +26,12 @@ class PuppetclassLookupKey < LookupKey
   end
 
   def cast_default_value
-    super unless use_puppet_default
+    super unless omit
     true
   end
 
   def validate_default_value
-    super unless use_puppet_default
+    super unless omit
     true
   end
 

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -1,5 +1,6 @@
 class LookupValue < ActiveRecord::Base
   include Authorizable
+  include PuppetLookupValueExtensions
 
   validates_lengths_from_database
   audited :associated_with => :lookup_key
@@ -7,11 +8,10 @@ class LookupValue < ActiveRecord::Base
 
   belongs_to :lookup_key
   validates :match, :presence => true, :uniqueness => {:scope => :lookup_key_id}, :format => LookupKey::VALUE_REGEX
-  validate :value_present?
   delegate :key, :to => :lookup_key
   before_validation :sanitize_match
 
-  before_validation :validate_and_cast_value, :unless => Proc.new{|p| p.use_puppet_default }
+  before_validation :validate_and_cast_value, :unless => Proc.new{|p| p.omit }
   validate :validate_value, :ensure_fqdn_exists, :ensure_hostgroup_exists
 
   attr_accessor :host_or_hostgroup
@@ -24,10 +24,6 @@ class LookupValue < ActiveRecord::Base
   scoped_search :on => :value, :complete_value => true, :default_order => true
   scoped_search :on => :match, :complete_value => true
   scoped_search :in => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
-
-  def value_present?
-    self.errors.add(:value, :blank) if value.to_s.empty? && !use_puppet_default && lookup_key.puppet?
-  end
 
   def value=(val)
     if val.is_a?(HashWithIndifferentAccess)

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -74,7 +74,7 @@ module Classification
                 {:value => values[key.id][key.to_s][:value], :managed => values[key.id][key.to_s][:managed] }
               else
                 default_value_method = %w(yaml json).include?(key.key_type) ? :default_value_before_type_cast : :default_value
-                {:value => key.send(default_value_method), :managed => key.use_puppet_default}
+                {:value => key.send(default_value_method), :managed => key.omit}
               end
 
       return nil if value[:managed]
@@ -173,7 +173,7 @@ module Classification
         computed_lookup_value = {:value => lookup_value.send(value_method), :element => element,
                                  :element_name => element_name}
 
-        computed_lookup_value.merge!({ :managed => lookup_value.use_puppet_default }) if lookup_value.lookup_key.puppet?
+        computed_lookup_value.merge!({ :managed => lookup_value.omit }) if lookup_value.lookup_key.puppet?
         break
       end
       computed_lookup_value
@@ -192,7 +192,7 @@ module Classification
 
       lookup_values.each do |lookup_value|
         element, element_name = get_element_and_element_name(lookup_value)
-        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.use_puppet_default)
+        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.omit)
         elements << element
         element_names << element_name
         if should_avoid_duplicates
@@ -221,7 +221,7 @@ module Classification
       # and then merging with higher priority
       lookup_values.reverse_each do |lookup_value|
         element, element_name = get_element_and_element_name(lookup_value)
-        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.use_puppet_default)
+        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.omit)
         elements << element
         element_names << element_name
         values.deep_merge!(lookup_value.value)

--- a/app/views/api/v2/override_values/base.json.rabl
+++ b/app/views/api/v2/override_values/base.json.rabl
@@ -1,3 +1,5 @@
 object @override_value
 
-attributes :id, :match, :value, :use_puppet_default
+attributes :id, :match, :value, :omit
+# compatibility
+attribute :omit => :use_puppet_default

--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -11,7 +11,10 @@ node :override_values_count do |lk|
 end
 
 attributes :description, :override, :parameter_type, :default_value, :hidden_value?, :hidden_value,
-           :use_puppet_default, :required, :validator_type, :validator_rule, :merge_overrides,
+           :omit, :required, :validator_type, :validator_rule, :merge_overrides,
            :merge_default, :avoid_duplicates, :override_value_order, :created_at, :updated_at
+
+# compatibility
+attribute :omit => :use_puppet_default
 
 attribute :param_class, :as => :puppetclass_name

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -18,16 +18,16 @@
         ) if is_param %>
     <%= param_type_selector(f, :onchange => 'keyTypeChange(this)') %>
     <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
-                   :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)),
+                   :disabled => (is_param && (!f.object.override || f.object.omit)),
                    :input_group_btn => fullscreen_input,
                    :rows => 1,
                    :help_inline => popover('', _("Value to use when there is no match.")),
                    :class => "no-stretch #{'masked-input' if f.object.hidden_value?}" %>
     <div class="form-group">
-      <%= checkbox_f(f, :use_puppet_default, :label => _('Use Puppet default'),
-                     :help_inline => use_puppet_default_help,
+      <%= checkbox_f(f, :omit, :label => _('Omit'),
+                     :help_inline => omit_help,
                      :size => "col-md-1", :label_size => "col-md-2", :table_field => true,
-                     :onchange => 'toggleUsePuppetDefaultValue(this, "default_value")',
+                     :onchange => 'toggleOmitValue(this, "default_value")',
                      :disabled => (is_param && !f.object.override)) if is_param %>
       <%= checkbox_f(f, :hidden_value, :label => _('Hidden value'),
                      :class => 'hidden_value_textarea_switch', :onchange => 'toggle_lookupkey_hidden(this)',
@@ -58,7 +58,7 @@
       <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :id => 'order', :size => "col-md-8", :onchange => 'fill_in_matchers()', :value => f.object.path, :class => "no-stretch" %>
       <%= checkbox_f(f, :merge_overrides, :onchange => 'mergeOverridesChanged(this)', :table_field => true,
                         :disabled => !f.object.supports_merge?, :size => "col-md-1", :label_size => "col-md-2",
-                        :help_inline => popover("", _("Continue to look for matches after first find (only array/hash type)? Note: merging overrides ignores all matchers that use Puppet default."))) %>
+                        :help_inline => popover("", _("Continue to look for matches after first find (only array/hash type)? Note: merging overrides ignores all matchers that are omitted."))) %>
       <%= checkbox_f(f, :merge_default, :disabled =>  !f.object.merge_overrides, :size => "col-md-1", :table_field => true,
                         :label_size => "col-md-2", :help_inline => popover('',_("Include default value when merging all matching values."))) %>
       <%= checkbox_f(f, :avoid_duplicates, :disabled => (!f.object.supports_uniq? || !f.object.merge_overrides),

--- a/app/views/lookup_keys/_value.html.erb
+++ b/app/views/lookup_keys/_value.html.erb
@@ -11,13 +11,13 @@
     </div>
   </td>
   <td>
-    <%= hidden_value_field(f, :value, f.object.use_puppet_default, :value => f.object.value_before_type_cast, :'data-property' => 'value', :hidden_value => hidden_value) %>
+    <%= hidden_value_field(f, :value, f.object.omit, :value => f.object.value_before_type_cast, :'data-property' => 'value', :hidden_value => hidden_value) %>
   </td>
   <% if is_param %>
     <td class="ca">
-      <%= f.check_box :use_puppet_default, :'data-property' => 'use_puppet_default',
+      <%= f.check_box :omit, :'data-property' => 'omit',
                       :disabled => !is_param,
-                      :onchange => 'toggleUsePuppetDefaultValue(this, "value")' %>
+                      :onchange => 'toggleOmitValue(this, "value")' %>
     </td>
   <%end%>
   <td>

--- a/app/views/lookup_keys/_values.html.erb
+++ b/app/views/lookup_keys/_values.html.erb
@@ -8,8 +8,8 @@
       </span></th>
     <% if is_param %>
       <th class='col-md-4'><%= _('Value') %></th>
-      <th class='col-md-2 ca'><%= _('Use Puppet default') %>
-        <span class="help-inline"> <%= use_puppet_default_help() %></span>
+      <th class='col-md-2 ca'><%= _('Omit') %>
+        <span class="help-inline"> <%= omit_help %></span>
       </th>
     <% else %>
       <th class='col-md-6'><%= _('Value') %></th>

--- a/app/views/puppetclasses/_class_parameters.html.erb
+++ b/app/views/puppetclasses/_class_parameters.html.erb
@@ -30,7 +30,7 @@
       <%= content_tag(:span, error.full_messages.to_sentence, :class => "help-block") if error.present? %>
     </td>
     <td class="ca">
-      <%= use_puppet_default_check_box(lookup_key, lookup_value, !overridden) %>
+      <%= omit_check_box(lookup_key, lookup_value, !overridden) %>
       <%= hidden_lookup_value_fields(lookup_key, lookup_value, !overridden) %>
     </td>
   </tr>

--- a/app/views/puppetclasses/_classes_parameters.html.erb
+++ b/app/views/puppetclasses/_classes_parameters.html.erb
@@ -4,7 +4,7 @@
       <th class='col-md-3'><%= _('Puppet class') %></th>
       <th class='col-md-2'><%= _('Name') %></th>
       <th class='col-md-6'><%= _('Value') %></th>
-      <th class='col-md-1 ca'><%= _("Use Puppet default") %>&nbsp;<%= use_puppet_default_help %></th>
+      <th class='col-md-1 ca'><%= _("Omit") %>&nbsp;<%= omit_help %></th>
     </tr>
   </thead>
   <tbody>

--- a/db/migrate/20160726085358_rename_lookup_value_use_puppet_default.rb
+++ b/db/migrate/20160726085358_rename_lookup_value_use_puppet_default.rb
@@ -1,0 +1,6 @@
+class RenameLookupValueUsePuppetDefault < ActiveRecord::Migration
+  def change
+    # this method is revesible
+    rename_column :lookup_values, :use_puppet_default, :omit
+  end
+end

--- a/db/migrate/20160831121418_rename_lookup_key_use_puppet_default.rb
+++ b/db/migrate/20160831121418_rename_lookup_key_use_puppet_default.rb
@@ -1,0 +1,6 @@
+class RenameLookupKeyUsePuppetDefault < ActiveRecord::Migration
+  def change
+    # this method is revesible
+    rename_column :lookup_keys, :use_puppet_default, :omit
+  end
+end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
       end
       after(:create) do |lkey, evaluator|
         evaluator.overrides.each do |match, value|
-          FactoryGirl.create :lookup_value, :lookup_key_id => lkey.id, :value => value, :match => match, :use_puppet_default => false
+          FactoryGirl.create :lookup_value, :lookup_key_id => lkey.id, :value => value, :match => match, :omit => false
         end
         lkey.reload
       end
@@ -39,8 +39,8 @@ FactoryGirl.define do
         end
       end
 
-      trait :with_use_puppet_default do
-        use_puppet_default true
+      trait :with_omit do
+        omit true
       end
     end
 
@@ -66,8 +66,8 @@ FactoryGirl.define do
   factory :lookup_value do
     sequence(:value) {|n| "value#{n}" }
 
-    trait :with_use_puppet_default do
-      use_puppet_default true
+    trait :with_omit do
+      omit true
     end
   end
 

--- a/test/functional/api/v2/override_values_controller_test.rb
+++ b/test/functional/api/v2/override_values_controller_test.rb
@@ -91,7 +91,16 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should create override value without when use_puppet_default is true" do
+  test "should create override value without when omit is true" do
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
+
+    assert_difference('LookupValue.count', 1) do
+      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :omit => true}}
+    end
+    assert_response :success
+  end
+
+  test "should create override value without when use_puppet_default is true (compatibility test)" do
     lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
 
     assert_difference('LookupValue.count', 1) do
@@ -100,11 +109,20 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should not create override value without when use_puppet_default is false" do
+  test "should create override value when use_puppet_default is false (compatibility test)" do
+    lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two), :omit => true)
+
+    assert_difference('LookupValue.count', 1) do
+      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => false, :value => 'test_val'}}
+    end
+    assert_response :success
+  end
+
+  test "should not create override value without when omit is false" do
     lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
 
     assert_difference('LookupValue.count', 0) do
-      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => false}}
+      post :create, {:smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :omit => false}}
     end
     assert_response :error
   end

--- a/test/functional/api/v2/smart_class_parameters_controller_test.rb
+++ b/test/functional/api/v2/smart_class_parameters_controller_test.rb
@@ -159,6 +159,25 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     refute_equal orig_value, new_value
   end
 
+  test "should update smart class parameter with use_puppet_default (compatibility test)" do
+    orig_value = lookup_keys(:five).omit
+    refute lookup_keys(:five).omit # check that the initial value is false
+    put :update, { :id => lookup_keys(:five).to_param, :smart_class_parameter => { :use_puppet_default => "true" } }
+    assert_response :success
+    new_value = lookup_keys(:five).reload.omit
+    refute_equal orig_value, new_value
+  end
+
+  test "should update smart class parameter with use_puppet_default (compatibility test)" do
+    key = lookup_keys(:five)
+    key.omit = true
+    key.save!
+    put :update, { :id => lookup_keys(:five).to_param, :smart_class_parameter => { :use_puppet_default => "false" } }
+    assert_response :success
+    new_value = lookup_keys(:five).reload.omit
+    refute new_value
+  end
+
   test "should return error if smart class parameter if it does not belong to specified puppetclass" do
     get :show, {:id => lookup_keys(:five).id, :puppetclass_id => puppetclasses(:one).id}
     assert_response 404

--- a/test/functional/lookup_keys_controller_test.rb
+++ b/test/functional/lookup_keys_controller_test.rb
@@ -12,8 +12,8 @@ class LookupKeysControllerTest < ActionController::TestCase
     }
     @value = @key.override_values[1]
     @key.override_values = [@value]
-    @create = {"1462788609698"=>{"match"=>"hostgroup=db", "value"=>'4', "use_puppet_default"=>"0", "_destroy"=>"false"}}
-    @delete = {"0"=>{"match"=>@value.match, "value"=>@value.value, "use_puppet_default"=>"0", "_destroy"=>"1", "id"=>@value.id } }
+    @create = {"1462788609698"=>{"match"=>"hostgroup=db", "value"=>'4', "omit"=>"0", "_destroy"=>"false"}}
+    @delete = {"0"=>{"match"=>@value.match, "value"=>@value.value, "omit"=>"0", "_destroy"=>"1", "id"=>@value.id } }
   end
 
   test 'patch add valid override' do

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -36,7 +36,7 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
                           :value => 'test',
-                          :use_puppet_default => false
+                          :omit => false
     end
     enc = classification.enc
 
@@ -145,13 +145,13 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => ['test'],
-                          :use_puppet_default => false
+                          :omit => false
     end
     value2 = as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => ['test'],
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -170,13 +170,13 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => ['test'],
-                          :use_puppet_default => false
+                          :omit => false
     end
     value2 = as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => ['test'],
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -196,13 +196,13 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:example => {:a => 'test'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => {:b => 'test2'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -222,13 +222,13 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => 'test2'},
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:example => 'test'},
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -247,20 +247,20 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:a => 'test'},
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => {:b => 'test2'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "os=#{operatingsystems(:redhat)}",
                           :value => {:example => {:b => 'test3'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -280,19 +280,19 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:example => {:a => 'test'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => {:b => 'test2'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "os=#{operatingsystems(:redhat)}",
                           :value => {:example => {:a => 'test3'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -302,7 +302,7 @@ class ClassificationTest < ActiveSupport::TestCase
                  classification.send(:values_hash))
   end
 
-  test 'smart class parameter with use_puppet_default on specific matcher does not send a value to puppet' do
+  test 'smart class parameter with omit on specific matcher does not send a value to puppet' do
     key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
                              :override => true, :key_type => 'string',
                              :default_value => "123", :path => "organization\nos\nlocation",
@@ -312,7 +312,7 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => "345",
-                          :use_puppet_default => true
+                          :omit => true
     end
     enc = classification.enc
     refute enc['base'].has_key?(key.key)
@@ -467,11 +467,11 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:example => {:a => 'test'}},
-                          :use_puppet_default => false
+                          :omit => false
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => {:b => 'test2'}},
-                          :use_puppet_default => false
+                          :omit => false
     end
     key.reload
 
@@ -482,20 +482,20 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should not return class parameters when default value should use puppet default" do
-    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :with_use_puppet_default,
+    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :with_omit,
                               :puppetclass => puppetclasses(:one))
     enc = classification.enc
     assert enc['base'][lkey.key].nil?
   end
 
   test "#enc should not return class parameters when lookup_value should use puppet default" do
-    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :with_use_puppet_default,
+    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :with_omit,
                               :puppetclass => puppetclasses(:one), :path => "location")
     as_admin do
       LookupValue.create! :lookup_key_id => lkey.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => 'test',
-                          :use_puppet_default => true
+                          :omit => true
     end
 
     enc = classification.enc
@@ -503,20 +503,20 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return class parameters when default value and lookup_values should not use puppet default" do
-    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :use_puppet_default => false,
+    lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :omit => false,
                               :puppetclass => puppetclasses(:one), :path => "location")
     lvalue = as_admin do
       LookupValue.create! :lookup_key_id => lkey.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => 'test',
-                          :use_puppet_default => false
+                          :omit => false
     end
     enc = classification.enc
     assert_equal lvalue.value, enc['base'][lkey.key]
   end
 
   test "#enc should not return class parameters when merged lookup_values and default are all using puppet default" do
-    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :use_puppet_default => true,
+    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'hash', :merge_overrides => true,
                              :default_value => {}, :path => "organization\nos\nlocation",
                              :puppetclass => puppetclasses(:one))
@@ -525,20 +525,20 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => {:example => {:a => 'test'}},
-                          :use_puppet_default => true
+                          :omit => true
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => {:example => {:b => 'test2'}},
-                          :use_puppet_default => true
+                          :omit => true
     end
 
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "os=#{operatingsystems(:redhat)}",
                           :value => {:example => {:a => 'test3'}},
-                          :use_puppet_default => true
+                          :omit => true
     end
     enc = classification.enc
 
@@ -549,7 +549,7 @@ class ClassificationTest < ActiveSupport::TestCase
     FactoryGirl.create(:setting,
                        :name => 'host_group_matchers_inheritance',
                        :value => true)
-    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :use_puppet_default => true,
+    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nhostgroup\nlocation",
                              :puppetclass => puppetclasses(:two))
@@ -567,20 +567,20 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{parent_hostgroup}",
                           :value => "parent",
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{child_hostgroup}",
                           :value => "child",
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match =>"organization=#{taxonomies(:organization1)}",
                           :value => "org",
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     enc = classification.enc
@@ -592,7 +592,7 @@ class ClassificationTest < ActiveSupport::TestCase
     FactoryGirl.create(:setting,
                        :name => 'host_group_matchers_inheritance',
                        :value => true)
-    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :use_puppet_default => true,
+    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nhostgroup\nlocation",
                              :puppetclass => puppetclasses(:two))
@@ -610,20 +610,20 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{parent_hostgroup}",
                           :value => "parent",
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{child_hostgroup}",
                           :value => "child",
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match =>"location=#{taxonomies(:location1)}",
                           :value => "loc",
-                          :use_puppet_default => true
+                          :omit => true
     end
 
     enc = classification.enc
@@ -641,13 +641,13 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => 'test_incorrect',
-                          :use_puppet_default => false
+                          :omit => false
     end
     value2 = as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
                           :value => 'test_correct',
-                          :use_puppet_default => false
+                          :omit => false
     end
     enc = classification.enc
     key.reload
@@ -656,7 +656,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test 'enc should return correct values for multi-key matchers' do
-    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :use_puppet_default => true,
+    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "hostgroup,organization\nlocation",
                              :puppetclass => puppetclasses(:two))
@@ -674,20 +674,20 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{parent_hostgroup},organization=#{taxonomies(:organization1)}",
                           :value => "parent",
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "hostgroup=#{child_hostgroup},organization=#{taxonomies(:organization1)}",
                           :value => "child",
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match =>"location=#{taxonomies(:location1)}",
                           :value => "loc",
-                          :use_puppet_default => false
+                          :omit => false
     end
     enc = classification.enc
     key.reload
@@ -705,19 +705,19 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => '<%= [2,3] %>',
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "organization=#{taxonomies(:organization1)}",
                           :value => '<%= [3,4] %>',
-                          :use_puppet_default => false
+                          :omit => false
     end
     as_admin do
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "os=#{operatingsystems(:redhat)}",
                           :value => '<%= [4,5] %>',
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     key.reload
@@ -736,7 +736,7 @@ class ClassificationTest < ActiveSupport::TestCase
     host = classification.send(:host)
     host.update_attributes(:hostgroup => hostgroup)
 
-    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_use_puppet_default,
+    key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_omit,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "hostgroup,organization\nlocation",
                              :puppetclass => puppetclasses(:two))
@@ -774,7 +774,7 @@ class ClassificationTest < ActiveSupport::TestCase
       LookupValue.create! :lookup_key_id => key.id,
                           :match => "location=#{taxonomies(:location1)}",
                           :value => '<%= "c" %>',
-                          :use_puppet_default => false
+                          :omit => false
     end
 
     key.reload

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -363,15 +363,15 @@ EOF
     def setup
       @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
                                :override => true, :key_type => 'boolean',
-                               :default_value => 'whatever', :puppetclass => puppetclasses(:one), :use_puppet_default => true)
+                               :default_value => 'whatever', :puppetclass => puppetclasses(:one), :omit => true)
     end
 
-    test "default_value is not validated if use_puppet_default is true" do
+    test "default_value is not validated if omit is true" do
       assert @key.valid?
     end
 
-    test "default_value is validated if use_puppet_default is false" do
-      @key.use_puppet_default = false
+    test "default_value is validated if omit is false" do
+      @key.omit = false
       refute @key.valid?
     end
   end
@@ -379,7 +379,8 @@ EOF
   test "override params are reset after override changes back to false" do
     @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
                               :override => true, :key_type => 'array',
-                              :default_value => '[]', :puppetclass => puppetclasses(:one))
+                              :default_value => '[]', :puppetclass => puppetclasses(:one),
+                              :omit => true)
     override_params = [:merge_overrides, :merge_default, :avoid_duplicates]
 
     override_params.each { |param| @key.send("#{param}=", true) }

--- a/test/unit/lookup_value_test.rb
+++ b/test/unit/lookup_value_test.rb
@@ -167,10 +167,10 @@ class LookupValueTest < ActiveSupport::TestCase
     refute value.valid?
   end
 
-  test "boolean lookup value should allow nil value if use_puppet_default is true" do
+  test "boolean lookup value should allow nil value if omit is true" do
     #boolean key
     key = lookup_keys(:three)
-    value = LookupValue.new(:value => nil, :match => "hostgroup=Common", :lookup_key_id => key.id, :use_puppet_default => true)
+    value = LookupValue.new(:value => nil, :match => "hostgroup=Common", :lookup_key_id => key.id, :omit => true)
     assert_valid value
   end
 
@@ -210,16 +210,16 @@ class LookupValueTest < ActiveSupport::TestCase
     def setup
       @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
                                 :override => true, :key_type => 'boolean',
-                                :default_value => 'whatever', :puppetclass => puppetclasses(:one), :use_puppet_default => true)
-      @value = LookupValue.new(:value => 'abc', :match => "hostgroup=Common", :lookup_key_id => @key.id, :use_puppet_default => true)
+                                :default_value => 'whatever', :puppetclass => puppetclasses(:one), :omit => true)
+      @value = LookupValue.new(:value => 'abc', :match => "hostgroup=Common", :lookup_key_id => @key.id, :omit => true)
     end
 
-    test "value is not validated if use_puppet_default is true" do
+    test "value is not validated if omit is true" do
       assert_valid @value
     end
 
-    test "value is validated if use_puppet_default is false" do
-      @value.use_puppet_default = false
+    test "value is validated if omit is false" do
+      @value.omit = false
       refute_valid @value
     end
   end
@@ -227,21 +227,21 @@ class LookupValueTest < ActiveSupport::TestCase
   context "when key type is puppetclass lookup and value is empty" do
     def setup
       @key = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
-                                :with_override, :with_use_puppet_default,
+                                :with_override, :with_omit,
                                 :key_type => 'string',
                                 :puppetclass => puppetclasses(:one))
       @value = FactoryGirl.build_stubbed(:lookup_value, :value => "",
                                          :match => "hostgroup=Common",
                                          :lookup_key_id => @key.id,
-                                         :use_puppet_default => true)
+                                         :omit => true)
     end
 
-    test "value is validated if use_puppet_default is true" do
+    test "value is validated if omit is true" do
       assert_valid @value
     end
 
-    test "value is not validated if use_puppet_default is false" do
-      @value.use_puppet_default = false
+    test "value is not validated if omit is false" do
+      @value.omit = false
       refute_valid @value
     end
   end


### PR DESCRIPTION
As part of this commit added a helper concern for deprecation of API properties.
## Usage

In the controller include `Api::V2::ParameterDeprecation`, and call `deprecate_param`. 
Example:

``` ruby
class OverrideValuesController < V2::BaseController
  include Api::V2::ParameterDeprecation

  deprecate_param [:create, :update], [:override_value, :use_puppet_default], :skip_foreman
end
```

`deprecate_param` parameters:
- action: (array of symbols) What actions are affected by the deprecation
- property_path: (array of symbols) What is the path to the deprecated property in `params` hash. In our example, it represents the property `params[:override_value][:use_puppet_default]`
- new_name: (nillable string) If a property was not dropped but renamed, set this value to the new name, and it will be filled automatically by the framework.
