### PR TITLE
Fixes #15833 - remove duplicities in smart params listings

### DIFF
--- a/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
+++ b/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
@@ -82,21 +82,23 @@ module Api::V2::LookupKeysCommonController
 
   def smart_class_parameters_resource_scope
     base = PuppetclassLookupKey.authorized(:view_external_parameters)
-    return base.smart_class_parameters unless (@puppetclass || @environment || @host || @hostgroup)
-    if @puppetclass && @environment
-      base.smart_class_parameters_for_class(@puppetclass.id, @environment.id)
-    elsif @puppetclass && !@environment
-      environment_ids = @puppetclass.environment_classes.pluck(:environment_id).uniq
-      base.smart_class_parameters_for_class(@puppetclass.id, environment_ids)
-    elsif !@puppetclass && @environment
-      puppetclass_ids = @environment.environment_classes.pluck(:puppetclass_id).uniq
-      base.smart_class_parameters_for_class(puppetclass_ids, @environment.id)
-    elsif @host || @hostgroup
-      puppetclass_ids = (@host || @hostgroup).all_puppetclasses.map(&:id)
-      environment_id  = (@host || @hostgroup).environment_id
-      # scope :parameters_for_class uses .override
-      base.parameters_for_class(puppetclass_ids, environment_id)
-    end
+    params = if !@puppetclass && !@environment && !@host && !@hostgroup
+               base.smart_class_parameters
+             elsif @puppetclass && @environment
+               base.smart_class_parameters_for_class(@puppetclass.id, @environment.id)
+             elsif @puppetclass && !@environment
+               environment_ids = @puppetclass.environment_classes.pluck(:environment_id).uniq
+               base.smart_class_parameters_for_class(@puppetclass.id, environment_ids)
+             elsif !@puppetclass && @environment
+               puppetclass_ids = @environment.environment_classes.pluck(:puppetclass_id).uniq
+               base.smart_class_parameters_for_class(puppetclass_ids, @environment.id)
+             elsif @host || @hostgroup
+               puppetclass_ids = (@host || @hostgroup).all_puppetclasses.map(&:id)
+               environment_id  = (@host || @hostgroup).environment_id
+               # scope :parameters_for_class uses .override
+               base.parameters_for_class(puppetclass_ids, environment_id)
+             end
+    params.distinct
   end
 
   def find_smarts

--- a/test/functional/api/v2/smart_class_parameters_controller_test.rb
+++ b/test/functional/api/v2/smart_class_parameters_controller_test.rb
@@ -10,6 +10,19 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     assert_equal 2, results['results'].length
   end
 
+  test "should get same smart class parameters in multiple environments once" do
+    @env_class = FactoryGirl.create(:environment_class,
+                               :puppetclass => puppetclasses(:one),
+                               :environment => environments(:testing),
+                               :puppetclass_lookup_key => lookup_keys(:complex))
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:smart_class_parameters)
+    results = ActiveSupport::JSON.decode(@response.body)
+    assert !results['results'].empty?
+    assert_equal 2, results['results'].length
+  end
+
   test "should get smart class parameters for a specific host" do
     @host = FactoryGirl.create(:host,
                                :puppetclasses => [puppetclasses(:one)],
@@ -57,6 +70,20 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     assert !results['results'].empty?
     assert_equal 1, results['results'].count
     assert_equal "custom_class_param", results['results'][0]['parameter']
+  end
+
+  test "should get same smart class parameters in multiple environments once for a specific puppetclass" do
+    @env_class = FactoryGirl.create(:environment_class,
+                               :puppetclass => puppetclasses(:one),
+                               :environment => environments(:testing),
+                               :puppetclass_lookup_key => lookup_keys(:complex))
+    get :index, {:puppetclass_id => puppetclasses(:one).id}
+    assert_response :success
+    assert_not_nil assigns(:smart_class_parameters)
+    results = ActiveSupport::JSON.decode(@response.body)
+    assert !results['results'].empty?
+    assert_equal 1, results['results'].count
+    assert_equal "cluster", results['results'][0]['parameter']
   end
 
   test "should get :not_found for a non-existing puppetclass" do


### PR DESCRIPTION
To reproduce this issue:
1/ install same puppet class to two different enviroments
2/ import the class to Foreman
3/ hammer sc-param list --puppet-class <class>
With this patch the params should be listed once and the pagination total (can be checked in debug output (-d)) should be correct
