### PR TITLE
fixes #15894 - retry intermittently failing integration tests

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -2,6 +2,7 @@ group :test do
   gem 'mocha', '~> 1.1'
   gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1.0'
+  gem 'minitest-optional_retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 2.5', :require => false

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -3,6 +3,10 @@ require 'integration/shared/host_finders'
 require 'integration/shared/host_orchestration_stubs'
 
 class HostJSTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   HostJSTest::edit page.test_0003_correctly override global params
+  extend Minitest::OptionalRetry
+
   include HostFinders
   include HostOrchestrationStubs
 

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class HostgroupJSTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   HostgroupJSTest.test_0001_submit updates taxonomy
+  extend Minitest::OptionalRetry
+
   test 'submit updates taxonomy' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     new_location = FactoryGirl.create(:location)

--- a/test/integration/provisioning_template_js_test.rb
+++ b/test/integration/provisioning_template_js_test.rb
@@ -1,6 +1,11 @@
 require 'integration_test_helper'
 
 class ProvisioningTemplateJSTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   ProvisioningTemplateJSTest.test_0001_edit template page
+  #   ProvisioningTemplateJSTest.test_0002_edit snippet page
+  extend Minitest::OptionalRetry
+
   test "edit template page" do
     template = FactoryGirl.create(:provisioning_template)
     visit provisioning_templates_path

--- a/test/integration/puppetclass_lookup_key_js_test.rb
+++ b/test/integration/puppetclass_lookup_key_js_test.rb
@@ -1,6 +1,11 @@
 require 'integration_test_helper'
 
 class PuppetclassLookupKeyJSTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   PuppetclassLookupKeyJSTest.test_0001_can hide value when overriden
+  #   PuppetclassLookupKeyJSTest.test_0002_uncheck override
+  extend Minitest::OptionalRetry
+
   test 'can hide value when overriden' do
     visit puppetclass_lookup_keys_path
     within(:xpath, "//table") do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -8,6 +8,7 @@ require 'capybara/poltergeist'
 require 'show_me_the_cookies'
 require 'database_cleaner'
 require 'active_support_test_case_helper'
+require 'minitest-optional_retry'
 
 DatabaseCleaner.strategy = :transaction
 


### PR DESCRIPTION
As tests are fixed (or new problems introduced), the use of the optional retry gem can be removed and added where appropriate.
