### PR TITLE
Fixes #15924 - Adding support for scheduler hints in openstack and server groups

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -36,6 +36,32 @@ var nic_update_handler = function() {
   });
 };
 
+function schedulerHintFilterSelected(item){
+  var filter = $(item).val();
+  if (filter == '') {
+    $('#scheduler_hint_wrapper').empty();
+  } else {
+    var url = $(item).attr('data-url');
+    var data = serializeForm().replace('method=patch', 'method=post');
+    foreman.tools.showSpinner();
+    $.ajax({
+      type:'post',
+      url: url,
+      data: data,
+      complete: function(){
+        foreman.tools.hideSpinner();
+      },
+      error: function(jqXHR, status, error){
+        $('#scheduler_hint_wrapper').html(Jed.sprintf(__("Error loading scheduler hint filters information: %s"), error));
+        $('#compute_resource_tab a').addClass('tab-error');
+      },
+      success: function(result){
+        $('#scheduler_hint_wrapper').html(result);
+      }
+    })
+  }
+}
+
 function computeResourceSelected(item){
   providerSpecificNICInfo = null;
   var compute = $(item).val();

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -136,6 +136,15 @@ class HostsController < ApplicationController
     end
   end
 
+  def scheduler_hint_selected
+    return not_found unless (params[:host])
+    @host = Host.new params[:host]
+    Taxonomy.as_taxonomy @organization, @location do
+      # compute_resource = ComputeResource.authorized(:view_compute_resources).find_by_id(id)
+      render :partial => "compute_resources_vms/form/scheduler_hint_filters"
+    end
+  end
+
   def interfaces
     @host = Host.new params[:host]
     @host.apply_compute_profile(InterfaceMerge.new)

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -1,6 +1,6 @@
 module Foreman::Model
   class Openstack < ComputeResource
-    attr_accessor :tenant
+    attr_accessor :tenant, :scheduler_hint_value
     has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy
     after_create :setup_key_pair
     after_destroy :destroy_key_pair
@@ -11,6 +11,8 @@ module Foreman::Model
 
     validates :user, :password, :presence => true
     validates :allow_external_network, inclusion: { in: [true, false] }
+
+    SEARCHABLE_ACTIONS = [:server_group_anti_affinity, :server_group_affinity, :raw]
 
     def provided_attributes
       super.merge({ :ip => :floating_ip_address })
@@ -93,12 +95,37 @@ module Foreman::Model
       } ]
     end
 
+    def possible_scheduler_hints
+      SEARCHABLE_ACTIONS.collect{|x| x.to_s.camelize }
+    end
+
+    def get_server_groups(policy)
+      server_groups = client.server_groups.select{ |sg| sg.policies.include?(policy) }
+      errors.add(:scheduler_hint_value, _("No matching servergroups found")) if server_groups.empty?
+      server_groups
+    end
+
+    def format_scheduler_hint_filter(args = {})
+      raise "Hint data is missing" if args[:scheduler_hint_data].nil?
+      name = args.delete(:scheduler_hint_filter).underscore.to_sym
+      data = args.delete(:scheduler_hint_data)
+      filter = {}
+      case name
+        when :server_group_anti_affinity, :server_group_affinity
+          filter[:group] = data[:scheduler_hint_value]
+        when :raw
+          filter = JSON.parse(data[:scheduler_hint_value])
+      end
+      args[:os_scheduler_hints] = filter
+    end
+
     def create_vm(args = {})
       boot_from_volume(args) if Foreman::Cast.to_bool(args[:boot_from_volume])
       network = args.delete(:network)
       # fix internal network format for fog.
       args[:nics].delete_if(&:blank?)
       args[:nics].map! {|nic| { 'net_id' => nic } }
+      format_scheduler_hint_filter(args) if args[:scheduler_hint_filter] != '' && !args[:scheduler_hint_filter].nil?
       vm = super(args)
       if network.present?
         address = allocate_address(network)

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -6,7 +6,7 @@ module FogExtensions
       included do
         alias_method_chain :security_groups, :no_id
         attr_reader :nics
-        attr_accessor :boot_from_volume, :size_gb
+        attr_accessor :boot_from_volume, :size_gb, :scheduler_hint_filter
         attr_writer :security_group, :network # floating IP
       end
 
@@ -55,6 +55,10 @@ module FogExtensions
 
       def size_gb
         attr[:size_gb]
+      end
+
+      def scheduler_hint_filter
+        attr[:scheduler_hint_filter]
       end
 
       def network

--- a/app/views/compute_resources_vms/form/_scheduler_hint_filters.erb
+++ b/app/views/compute_resources_vms/form/_scheduler_hint_filters.erb
@@ -1,0 +1,8 @@
+<%=
+  hint_name = params[:host][:compute_attributes][:scheduler_hint_filter].underscore
+  fields_for "#{type}[compute_attributes][scheduler_hint_data]", @host.compute_resource  do |f|
+    render :partial => provider_partial(@host.compute_resource, "scheduler_filters/#{hint_name}"),
+           :locals => { :f => f, :hint_name => hint_name }
+
+  end
+%>

--- a/app/views/compute_resources_vms/form/openstack/_base.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_base.html.erb
@@ -18,3 +18,10 @@
 <%= selectable_f f, :network, compute_resource.address_pools, { include_blank: 'None' }, { :label => _("Floating IP network"), :label_size => "col-md-2" } %>
 <%= checkbox_f f, :boot_from_volume, {:label => _("Boot from volume"), :label_size => "col-md-2", :help_inline => _("Create new boot volume from image")}, "true", "false" %>
 <%= text_f f, :size_gb, { :label => _("New boot volume size (GB)"), :label_size => "col-md-2", :help_inline => _("Defaults to image size if left blank") } %>
+<%= selectable_f f, :scheduler_hint_filter, compute_resource.possible_scheduler_hints, { include_blank: 'None' }, { :label => _("Scheduler hint filter"), :label_size => "col-md-2", :'data-url' => scheduler_hint_selected_hosts_path,
+                                                                                                              :onchange => 'schedulerHintFilterSelected(this);' } %>
+<div id="scheduler_hint_wrapper">
+  <%= if @host && @host.compute_attributes[:scheduler_hint_filter]
+        render :partial => "compute_resources_vms/form/scheduler_hint_filters", :locals => { :compute_resource => compute_resource, :host => @host }
+      end  %>
+</div>

--- a/app/views/compute_resources_vms/form/openstack/scheduler_filters/_raw.erb
+++ b/app/views/compute_resources_vms/form/openstack/scheduler_filters/_raw.erb
@@ -1,0 +1,2 @@
+<%=
+  textarea_f f, :scheduler_hint_value, :help_block => _("JSON object of the scheduler hint"), :size => "col-md-8", :rows => "6", :class => "no-stretch", :label => _("Server hint data") %>

--- a/app/views/compute_resources_vms/form/openstack/scheduler_filters/_server_group_affinity.erb
+++ b/app/views/compute_resources_vms/form/openstack/scheduler_filters/_server_group_affinity.erb
@@ -1,0 +1,5 @@
+<%=
+  server_groups = @host.compute_resource.get_server_groups(hint_name.gsub(/server_group_/, ''))
+  select_f f, :scheduler_hint_value, server_groups.to_a.sort_by { |sg| sg.name.downcase },
+           :id, :name, {}, :label => _('Server group'), :disabled => server_groups.empty?
+%>

--- a/app/views/compute_resources_vms/form/openstack/scheduler_filters/_server_group_anti_affinity.erb
+++ b/app/views/compute_resources_vms/form/openstack/scheduler_filters/_server_group_anti_affinity.erb
@@ -1,0 +1,5 @@
+<%=
+  server_groups = @host.compute_resource.get_server_groups(hint_name.gsub(/server_group_/, ''))
+  select_f f, :scheduler_hint_value, server_groups.to_a.sort_by { |sg| sg.name.downcase },
+           :id, :name, {}, :label => _('Server group'), :disabled => server_groups.empty?
+%>

--- a/bundler.d/openstack.rb
+++ b/bundler.d/openstack.rb
@@ -1,3 +1,3 @@
 group :openstack do
-  gem 'fog-openstack', '~> 0.1', '>= 0.1.7'
+  gem 'fog-openstack', '~> 0.1', '>= 0.1.10'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Foreman::Application.routes.draw do
         post 'domain_selected'
         post 'use_image_selected'
         post 'compute_resource_selected'
+        post 'scheduler_hint_selected'
         post 'interfaces'
         post 'medium_selected'
         get  'select_multiple_organization'

--- a/test/unit/compute_resources/openstack_test.rb
+++ b/test/unit/compute_resources/openstack_test.rb
@@ -26,6 +26,78 @@ class OpenstackTest < ActiveSupport::TestCase
                                 :flavor_ref => 'foo_flavor', :image_ref => 'foo_image')
   end
 
+  describe "formatting hints" do
+    it "formats well when set to ServerGroupAntiAffinity" do
+      args = {
+          :scheduler_hint_filter => "ServerGroupAntiAffinity",
+          :scheduler_hint_data => {
+              :scheduler_hint_value => "some-uuid"
+          }
+      }
+      desired = {
+          :os_scheduler_hints => {
+              :group => "some-uuid"
+          }
+      }
+      @compute_resource.format_scheduler_hint_filter(args)
+      assert_equal(desired, args)
+    end
+
+    it "formats well when set to ServerGroupAffinity" do
+      args = {
+          :scheduler_hint_filter => "ServerGroupAffinity",
+          :scheduler_hint_data => {
+              :scheduler_hint_value => "some-uuid"
+          }
+      }
+      desired = {
+          :os_scheduler_hints => {
+              :group => "some-uuid"
+          }
+      }
+      @compute_resource.format_scheduler_hint_filter(args)
+      assert_equal(desired, args)
+    end
+
+    it "formats well when set to Raw" do
+      args = {
+          :scheduler_hint_filter => "Raw",
+          :scheduler_hint_data => {
+              :scheduler_hint_value => '{"key": "value"}'
+          }
+      }
+      desired = {
+          :os_scheduler_hints => {
+              'key' => "value"
+          }
+      }
+      @compute_resource.format_scheduler_hint_filter(args)
+      assert_equal(desired, args)
+    end
+
+    it "Should raise exception if set to Raw and malformed json" do
+      args = {
+          :scheduler_hint_filter => "Raw",
+          :scheduler_hint_data => {
+              :scheduler_hint_value => '{"key": }'
+          }
+      }
+      assert_raise ::JSON::ParserError do
+        @compute_resource.format_scheduler_hint_filter(args)
+      end
+    end
+
+    it "Should raise exception if no hint data provided" do
+      args = {
+          :scheduler_hint_filter => "Raw",
+      }
+      e = assert_raise(::RuntimeError)  do
+        @compute_resource.format_scheduler_hint_filter(args)
+      end
+      assert_equal("Hint data is missing", e.message)
+    end
+  end
+
   describe "find_vm_by_uuid" do
     it "raises RecordNotFound when the vm does not exist" do
       cr = mock_cr_servers(Foreman::Model::Openstack.new, empty_servers)


### PR DESCRIPTION
Note that this PR requires fog-openstack 1.10 (not released yet) in order to support server groups (Merged here: https://github.com/fog/fog-openstack/commit/04a2beffcf0633db735b152a1e7d9fc4c95a8d0b)
