### PR TITLE
Fixes #15925 - pin audited gem to allow tests to pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.6'
 gem 'rest-client', '>= 1.8.0', '< 3', :require => 'rest_client'
-gem 'audited-activerecord', '~> 4.0'
+gem 'audited-activerecord', '4.2.0'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '~> 2.0'
 gem 'scoped_search', '>= 3.2.2', '< 4'


### PR DESCRIPTION
Audited gem changed internal implementation of auditing_enabled causing
CI test to fail when attempting to run rake db:migrate.
This is a temporary workaround to unblock CI until permanent fix is
made.
