### PR TITLE
[API] Add method to get ENC values of a host

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -126,6 +126,13 @@ module Api
         process_response @host.destroy
       end
 
+      api :GET, "/hosts/:id/enc", N_("Get ENC values of host")
+      param :id, :identifier_dottable, :required => true
+
+      def enc
+        render :json => { :data => @host.info }.to_json if @host
+      end
+
       api :GET, "/hosts/:id/status", N_("Get configuration status of host")
       param :id, :identifier_dottable, :required => true
       description <<-eos
@@ -307,7 +314,7 @@ Return the host's compute attributes that can be used to create a clone of this 
             :console
           when 'disassociate'
             :edit
-          when 'vm_compute_attributes', 'get_status', 'template'
+          when 'vm_compute_attributes', 'get_status', 'template', 'enc'
             :view
           when 'rebuild_config'
             :build

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -351,7 +351,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :dashboard => [:OutOfSync, :errors, :active],
                                     :unattended => [:host_template, :hostgroup_template],
                                      :"api/v1/hosts" => [:index, :show, :status],
-                                     :"api/v2/hosts" => [:index, :show, :status, :get_status, :vm_compute_attributes, :template],
+                                     :"api/v2/hosts" => [:index, :show, :status, :get_status, :vm_compute_attributes, :template, :enc],
                                      :"api/v2/interfaces" => [:index, :show],
                                      :locations =>  [:mismatches],
                                      :organizations =>  [:mismatches]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -307,6 +307,7 @@ Foreman::Application.routes.draw do
           resources :autosign, :only => [:index]
         end
         resources :hosts, :except => [:new, :edit] do
+          get :enc, :on => :member
           get :status, :on => :member
           get 'status/:type', :on => :member, :action => :get_status
           get :vm_compute_attributes, :on => :member


### PR DESCRIPTION
I really miss an easy way to get a host parameters/smart class parameters using API endpoints.

So I eventually created a new endpoint to provide the same information that we receive in _/host/<fqdn>/externalNodes_ URL but in JSON format and using API authentication.

Please feel free to adapt the route name (_/api/v2/host/:id/enc_) to whatever you consider, but I encourage you to merge this request :smile: 
