### PR TITLE
Fixes #12488 - Add admin flag to usergroup param group description

### DIFF
--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -22,6 +22,7 @@ module Api
       def_param_group :usergroup do
         param :usergroup, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
+          param :admin, :bool, :required => false, :desc => N_("is an admin user group")
           param :user_ids, Array, :require => false
           param :usergroup_ids, Array, :require => false
           param :role_ids, Array, :require => false


### PR DESCRIPTION
To verify run 
`hammer -r user-group create --help`
and check the --admin option is in the output.
You may need to regenerate apipie cache on the server `rake apipie:cache:index`. 
