### PR TITLE
Fixes #16020 - Prevent reflective XSS on form validation

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -265,7 +265,7 @@ module FormHelper
   end
 
   def help_inline(inline, error)
-    help_inline = error.empty? ? inline : content_tag(:span, error.to_sentence.html_safe, :class => 'error-message')
+    help_inline = error.empty? ? inline : content_tag(:span, error.to_sentence, :class => 'error-message')
     case help_inline
       when blank?
         ""


### PR DESCRIPTION
Error messages for various form fields were not properly escaped to
prevent HTML from being insert into them. This caused a possible
reflective XSS in smart class parameter/varaible default value
validations.
