### PR TITLE
fixes #16046 - run webpack:compile as pre-req to test rake tasks

### DIFF
--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -3,7 +3,7 @@ begin
 
   namespace :jenkins do
     task :unit => ['jenkins:setup:minitest', 'rake:test:units', 'rake:test:lib', 'rake:test:functionals']
-    task :integration => ["jenkins:setup:minitest", 'rake:test:integration']
+    task :integration => ['webpack:compile', 'jenkins:setup:minitest', 'rake:test:integration']
     task :lib => ["jenkins:setup:minitest", 'rake:test:lib']
     task :functionals => ["jenkins:setup:minitest", 'rake:test:functionals']
     task :units => ["jenkins:setup:minitest", 'rake:test:units']
@@ -13,7 +13,7 @@ begin
         ENV["CI_REPORTS"] = 'jenkins/reports/unit/'
         gem 'ci_reporter'
       end
-      task :minitest  => [:pre_ci, "ci:setup:minitest"]
+      task :minitest  => [:pre_ci, 'webpack:try_compile', 'ci:setup:minitest']
     end
 
     task :rubocop do

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -17,3 +17,6 @@ namespace :test do
     t.warning = false
   end
 end
+
+# Ensure webpack files are compiled in case integration tests are executed
+Rake::Task[:test].enhance ['webpack:try_compile']

--- a/lib/tasks/webpack_try_compile.rake
+++ b/lib/tasks/webpack_try_compile.rake
@@ -1,0 +1,10 @@
+namespace :webpack do
+  desc 'Try to compile webpack assets for integration tests, fails only with a warning'
+  task :try_compile do
+    begin
+      Rake::Task['webpack:compile'].invoke
+    rescue => e
+      puts "WARNING: `rake webpack:compile` failed to run. This is only important if running integration tests. (cause: #{e})"
+    end
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -27,8 +27,6 @@ end
 Capybara.default_max_wait_time = 30
 Capybara.javascript_driver = :poltergeist
 
-Rake::Task["webpack:compile"].invoke
-
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL


### PR DESCRIPTION
The webpack:compile task is now run before all rake test tasks,
including jenkins:*. Except for jenkins:integration, a failure in
webpack:compile is issued as a warning as unit tests don't require
webpack assets to run.

Using webpack:compile from the task definitions avoids the need to load
tasks from railties in test helpers and keeps rake task dependencies
defined together.
