### PR TITLE
Fixes #16055 - Have webpack-dev-server bind to 0.0.0.0

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,6 +77,7 @@ if (production) {
   );
 } else {
   config.devServer = {
+    host: '0.0.0.0',
     port: devServerPort,
     headers: { 'Access-Control-Allow-Origin': '*' }
   };


### PR DESCRIPTION
I run foreman inside a VM and am unable to connect to the webpack-dev-server unless it's bound to 0.0.0.0 or the specific external ip.
