### PR TITLE
Refs #12364 - Allow running webpack dev server on any hostname

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 # Run Rails & Webpack concurrently
 # If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
 rails: [ -n "$RAILS_STARTUP" ] && $RAILS_STARTUP || bin/rails server -b 0.0.0.0
-webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host=0.0.0.0
+webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -438,8 +438,10 @@ module ApplicationHelper
 
   def webpack_dev_server
     return unless Rails.env.development?
-    host = ::Rails.configuration.webpack.dev_server.host.call
     port = ::Rails.configuration.webpack.dev_server.port
-    javascript_include_tag "http://#{host}:#{port}/webpack-dev-server.js"
+    dev_server = "#{request.protocol}#{request.host}:#{port}"
+    response.headers['Content-Security-Policy']['script-src'] = "script-src #{dev_server}"
+    response.headers['Content-Security-Policy']['wss:'] = "wss: #{dev_server}"
+    javascript_include_tag "#{dev_server}/webpack-dev-server.js"
   end
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -18,10 +18,4 @@
     :script_src  => %w(eval inline self),
     :img_src     => %w(self *.gravatar.com)
   }
-  if Rails.env.development? #allow webpack dev server provided assets
-    dev_server = ["http://0.0.0.0:#{::Rails.configuration.webpack.dev_server.port}",
-                  "http://localhost:#{::Rails.configuration.webpack.dev_server.port}"]
-    config.csp[:script_src] += dev_server
-    config.csp[:connect_src] += dev_server
-  end
 end

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,6 +77,7 @@ if (production) {
   );
 } else {
   config.devServer = {
+    host: '0.0.0.0',
     port: devServerPort,
     headers: { 'Access-Control-Allow-Origin': '*' }
   };


### PR DESCRIPTION
Currently, SecureHeaders only allows running the webpack dev server from
localhost or 0.0.0.0, and only using http. This leads to issues when
attempting to run foreman inside a virtual machine or using https. This
patch will generate the correct headers during runtime, to allow the dev
server to be run on the same host and protocol as the request uses.
