### PR TITLE
Fixes #13772 - orchestration now uses app logger

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,8 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  # Rails use Notifications for own sql logging so we can override sql logger for orchestration
+  def logger
+    Foreman::Logging.logger('app')
+  end
+end

--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -1,4 +1,4 @@
-class Architecture < ActiveRecord::Base
+class Architecture < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class AuthSource < ActiveRecord::Base
+class AuthSource < ApplicationRecord
   include Authorizable
 
   audited

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,4 @@
-class Bookmark < ActiveRecord::Base
+class Bookmark < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/cached_user_role.rb
+++ b/app/models/cached_user_role.rb
@@ -1,4 +1,4 @@
-class CachedUserRole < ActiveRecord::Base
+class CachedUserRole < ApplicationRecord
   belongs_to :user
   belongs_to :role
 

--- a/app/models/cached_usergroup_member.rb
+++ b/app/models/cached_usergroup_member.rb
@@ -1,4 +1,4 @@
-class CachedUsergroupMember < ActiveRecord::Base
+class CachedUsergroupMember < ApplicationRecord
   belongs_to :user
   belongs_to :usergroup
 end

--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -1,4 +1,4 @@
-class ComputeAttribute < ActiveRecord::Base
+class ComputeAttribute < ApplicationRecord
   audited :associated_with => :compute_profile
 
   belongs_to :compute_resource

--- a/app/models/compute_profile.rb
+++ b/app/models/compute_profile.rb
@@ -1,4 +1,4 @@
-class ComputeProfile < ActiveRecord::Base
+class ComputeProfile < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -1,4 +1,4 @@
-class ComputeResource < ActiveRecord::Base
+class ComputeResource < ApplicationRecord
   include Taxonomix
   include Encryptable
   include Authorizable

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -1,4 +1,4 @@
-class ConfigGroup < ActiveRecord::Base
+class ConfigGroup < ApplicationRecord
   audited
   include Authorizable
   include Parameterizable::ByIdName

--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -1,4 +1,4 @@
-class ConfigGroupClass < ActiveRecord::Base
+class ConfigGroupClass < ApplicationRecord
   include Authorizable
 
   audited :associated_with => :config_group

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,6 +1,6 @@
 require "resolv"
 # This models a DNS domain and so represents a site.
-class Domain < ActiveRecord::Base
+class Domain < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,4 +1,4 @@
-class Environment < ActiveRecord::Base
+class Environment < ApplicationRecord
   extend FriendlyId
   friendly_id :name, :reserved_words => []
   include Taxonomix

--- a/app/models/environment_class.rb
+++ b/app/models/environment_class.rb
@@ -1,4 +1,4 @@
-class EnvironmentClass < ActiveRecord::Base
+class EnvironmentClass < ApplicationRecord
   belongs_to :environment
   belongs_to :puppetclass
   belongs_to :puppetclass_lookup_key

--- a/app/models/external_usergroup.rb
+++ b/app/models/external_usergroup.rb
@@ -1,4 +1,4 @@
-class ExternalUsergroup < ActiveRecord::Base
+class ExternalUsergroup < ApplicationRecord
   extend FriendlyId
   friendly_id :name
 

--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -1,4 +1,4 @@
-class FactName < ActiveRecord::Base
+class FactName < ApplicationRecord
   include Parameterizable::ByIdName
 
   SEPARATOR = '::'

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -1,4 +1,4 @@
-class FactValue < ActiveRecord::Base
+class FactValue < ApplicationRecord
   include Authorizable
   include ScopedSearchExtensions
 

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,4 +1,4 @@
-class Feature < ActiveRecord::Base
+class Feature < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   has_and_belongs_to_many :smart_proxies

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,4 +1,4 @@
-class Filter < ActiveRecord::Base
+class Filter < ApplicationRecord
   include Taxonomix
   include Authorizable
   include TopbarCacheExpiry

--- a/app/models/filtering.rb
+++ b/app/models/filtering.rb
@@ -1,4 +1,4 @@
-class Filtering < ActiveRecord::Base
+class Filtering < ApplicationRecord
   belongs_to :filter
   belongs_to :permission
 end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -1,5 +1,5 @@
 module Host
-  class Base < ActiveRecord::Base
+  class Base < ApplicationRecord
     include Foreman::STI
     include Authorizable
     include Parameterizable::ByName

--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -1,4 +1,4 @@
-class HostClass < ActiveRecord::Base
+class HostClass < ApplicationRecord
   include Authorizable
 
   validates_lengths_from_database

--- a/app/models/host_config_group.rb
+++ b/app/models/host_config_group.rb
@@ -1,4 +1,4 @@
-class HostConfigGroup < ActiveRecord::Base
+class HostConfigGroup < ApplicationRecord
   include Authorizable
   audited :associated_with => :host
   audited :associated_with => :hostgroup

--- a/app/models/host_facets/base.rb
+++ b/app/models/host_facets/base.rb
@@ -1,5 +1,5 @@
 module HostFacets
-  class Base < ActiveRecord::Base
+  class Base < ApplicationRecord
     self.abstract_class = true
 
     include Facets::Base

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -1,5 +1,5 @@
 module HostStatus
-  class Status < ActiveRecord::Base
+  class Status < ApplicationRecord
     include Foreman::STI
 
     self.table_name = 'host_status'

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -1,4 +1,4 @@
-class Hostgroup < ActiveRecord::Base
+class Hostgroup < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :title

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -1,4 +1,4 @@
-class HostgroupClass < ActiveRecord::Base
+class HostgroupClass < ApplicationRecord
   include Authorizable
 
   audited :associated_with => :hostgroup

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,4 @@
-class Image < ActiveRecord::Base
+class Image < ApplicationRecord
   include Authorizable
 
   audited :except => [ :password ]

--- a/app/models/key_pair.rb
+++ b/app/models/key_pair.rb
@@ -1,4 +1,4 @@
-class KeyPair < ActiveRecord::Base
+class KeyPair < ApplicationRecord
   belongs_to :compute_resource
   validates_lengths_from_database
   validates :name, :secret, :presence => true

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,4 +1,4 @@
-class Log < ActiveRecord::Base
+class Log < ApplicationRecord
   belongs_to :message
   belongs_to :source
   belongs_to :report

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -1,4 +1,4 @@
-class LookupKey < ActiveRecord::Base
+class LookupKey < ApplicationRecord
   include Authorizable
   include HiddenValue
 

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -1,4 +1,4 @@
-class LookupValue < ActiveRecord::Base
+class LookupValue < ApplicationRecord
   include Authorizable
   include PuppetLookupValueExtensions
   include HiddenValue

--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -1,4 +1,4 @@
-class MailNotification < ActiveRecord::Base
+class MailNotification < ApplicationRecord
   include Authorizable
 
   INTERVALS = [N_("Daily"), N_("Weekly"), N_("Monthly")]

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,4 +1,4 @@
-class Medium < ActiveRecord::Base
+class Medium < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,4 @@
-class Message < ActiveRecord::Base
+class Message < ApplicationRecord
   has_many :reports, :through => :logs
   has_many :logs
   validates_lengths_from_database

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -1,4 +1,4 @@
-class Model < ActiveRecord::Base
+class Model < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -1,7 +1,7 @@
 # Represents a Host's network interface
 # This class is the both parent
 module Nic
-  class Base < ActiveRecord::Base
+  class Base < ApplicationRecord
     include Foreman::STI
     include Encryptable
     encrypts :password

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 # Stores the information related to serving the notification to multiple users
 # This class' responsibility is, given a notification blueprint, to determine
 # who are the notification recipients
-class Notification < ActiveRecord::Base
+class Notification < ApplicationRecord
   AUDIENCE_USER     = 'user'
   AUDIENCE_GROUP    = 'usergroup'
   AUDIENCE_TAXONOMY = 'taxonomy'

--- a/app/models/notification_blueprint.rb
+++ b/app/models/notification_blueprint.rb
@@ -6,7 +6,7 @@
 # actions that are notification-worthy. This keeps the responsibilities
 # separate, Notifications taking care of serving the content, and
 # NotificationBlueprint of storing it.
-class NotificationBlueprint < ActiveRecord::Base
+class NotificationBlueprint < ApplicationRecord
   has_many :notifications, :dependent => :destroy
   store :actions, :accessors => [:links], :coder => JSON
 

--- a/app/models/notification_recipient.rb
+++ b/app/models/notification_recipient.rb
@@ -1,4 +1,4 @@
-class NotificationRecipient < ActiveRecord::Base
+class NotificationRecipient < ApplicationRecord
   belongs_to :notification
   belongs_to :user
   has_one :notification_blueprint, :through => :notification

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 require 'uri'
 
-class Operatingsystem < ActiveRecord::Base
+class Operatingsystem < ApplicationRecord
   include Authorizable
   include ValidateOsFamily
   include PxeLoaderSupport

--- a/app/models/os_default_template.rb
+++ b/app/models/os_default_template.rb
@@ -1,4 +1,4 @@
-class OsDefaultTemplate < ActiveRecord::Base
+class OsDefaultTemplate < ApplicationRecord
   belongs_to :provisioning_template
   belongs_to :template_kind
   belongs_to :operatingsystem

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -1,4 +1,4 @@
-class Parameter < ActiveRecord::Base
+class Parameter < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,4 +1,4 @@
-class Permission < ActiveRecord::Base
+class Permission < ApplicationRecord
   validates_lengths_from_database
   validates :name, :presence => true, :uniqueness => true
 

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -1,4 +1,4 @@
-class Puppetclass < ActiveRecord::Base
+class Puppetclass < ApplicationRecord
   include Authorizable
   include ScopedSearchExtensions
   extend FriendlyId

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -1,4 +1,4 @@
-class Realm < ActiveRecord::Base
+class Realm < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,4 +1,4 @@
-class Report < ActiveRecord::Base
+class Report < ApplicationRecord
   LOG_LEVELS = %w[debug info notice warning err alert emerg crit]
 
   include Foreman::STI

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class Role < ActiveRecord::Base
+class Role < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,6 @@
 require 'resolv'
 
-class Setting < ActiveRecord::Base
+class Setting < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   include ActiveModel::Validations

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -1,4 +1,4 @@
-class SmartProxy < ActiveRecord::Base
+class SmartProxy < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,4 +1,4 @@
-class Source < ActiveRecord::Base
+class Source < ApplicationRecord
   validates_lengths_from_database
   has_many :reports, :through => :logs
   has_many :logs

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -1,4 +1,4 @@
-class SshKey < ActiveRecord::Base
+class SshKey < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :name

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,6 +1,6 @@
 require 'ipaddr'
 
-class Subnet < ActiveRecord::Base
+class Subnet < ApplicationRecord
   IP_FIELDS = [:network, :mask, :gateway, :dns_primary, :dns_secondary, :from, :to]
   REQUIRED_IP_FIELDS = [:network, :mask]
   SUBNET_TYPES = {:'Subnet::Ipv4' => N_('IPv4'), :'Subnet::Ipv6' => N_('IPv6')}

--- a/app/models/subnet_domain.rb
+++ b/app/models/subnet_domain.rb
@@ -1,4 +1,4 @@
-class SubnetDomain < ActiveRecord::Base
+class SubnetDomain < ApplicationRecord
   belongs_to :domain
   belongs_to :subnet
 

--- a/app/models/taxable_taxonomy.rb
+++ b/app/models/taxable_taxonomy.rb
@@ -1,4 +1,4 @@
-class TaxableTaxonomy < ActiveRecord::Base
+class TaxableTaxonomy < ApplicationRecord
   belongs_to :taxonomy
   belongs_to :taxable, :polymorphic => true
 

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,4 +1,4 @@
-class Taxonomy < ActiveRecord::Base
+class Taxonomy < ApplicationRecord
   validates_lengths_from_database
 
   include Authorizable

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,4 +1,4 @@
-class Template < ActiveRecord::Base
+class Template < ApplicationRecord
   include Exportable
   attr_accessor :modify_locked, :modify_default
 

--- a/app/models/template_combination.rb
+++ b/app/models/template_combination.rb
@@ -1,4 +1,4 @@
-class TemplateCombination < ActiveRecord::Base
+class TemplateCombination < ApplicationRecord
   belongs_to :provisioning_template
   belongs_to :environment
   belongs_to :hostgroup

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -1,4 +1,4 @@
-class TemplateKind < ActiveRecord::Base
+class TemplateKind < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   validates_lengths_from_database

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,4 +1,4 @@
-class Token < ActiveRecord::Base
+class Token < ApplicationRecord
   validates_lengths_from_database
   belongs_to_host :foreign_key => :host_id
 

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,4 +1,4 @@
-class Trend < ActiveRecord::Base
+class Trend < ApplicationRecord
   validates_lengths_from_database
   after_save :create_values, :if => ->(o) { o.fact_value.nil? }
   after_destroy :destroy_values, :if => ->(o) { o.fact_value.nil? }

--- a/app/models/trend_counter.rb
+++ b/app/models/trend_counter.rb
@@ -1,4 +1,4 @@
-class TrendCounter < ActiveRecord::Base
+class TrendCounter < ApplicationRecord
   belongs_to :trend
   validates :count, :numericality => {:greater_than_or_equal_to => 0}
   validates :created_at, :uniqueness => {:scope => :trend_id}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 require 'digest/sha1'
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   include Authorizable
   extend FriendlyId
   friendly_id :login

--- a/app/models/user_mail_notification.rb
+++ b/app/models/user_mail_notification.rb
@@ -1,4 +1,4 @@
-class UserMailNotification < ActiveRecord::Base
+class UserMailNotification < ApplicationRecord
   belongs_to :user
   belongs_to :mail_notification
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-class UserRole < ActiveRecord::Base
+class UserRole < ApplicationRecord
   include TopbarCacheExpiry
 
   belongs_to :owner, :polymorphic => true

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -1,4 +1,4 @@
-class Usergroup < ActiveRecord::Base
+class Usergroup < ApplicationRecord
   audited
   include Authorizable
   extend FriendlyId

--- a/app/models/usergroup_member.rb
+++ b/app/models/usergroup_member.rb
@@ -1,4 +1,4 @@
-class UsergroupMember < ActiveRecord::Base
+class UsergroupMember < ApplicationRecord
   belongs_to :member, :polymorphic => true
   belongs_to :usergroup
 

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -1,4 +1,4 @@
-class Widget < ActiveRecord::Base
+class Widget < ApplicationRecord
   belongs_to :user
 
   validates :user_id, :name, :template, :presence => true

--- a/db/migrate/20090730152224_create_ptables.rb
+++ b/db/migrate/20090730152224_create_ptables.rb
@@ -1,5 +1,5 @@
 class CreatePtables < ActiveRecord::Migration
-  class Ptable < ActiveRecord::Base; end
+  class Ptable < ApplicationRecord; end
   def up
     create_table :ptables do |t|
       t.string :name,   :limit => 64, :null => false

--- a/db/migrate/20100310080727_add_family_to_os.rb
+++ b/db/migrate/20100310080727_add_family_to_os.rb
@@ -1,5 +1,5 @@
 class AddFamilyToOs < ActiveRecord::Migration
-  class Operatingsystem < ActiveRecord::Base; end
+  class Operatingsystem < ApplicationRecord; end
 
   def up
     add_column :operatingsystems, :family_id, :integer

--- a/db/migrate/20100414125652_add_releasename_to_os.rb
+++ b/db/migrate/20100414125652_add_releasename_to_os.rb
@@ -1,5 +1,5 @@
 class AddReleasenameToOs < ActiveRecord::Migration
-  class Operatingsystem < ActiveRecord::Base; end
+  class Operatingsystem < ApplicationRecord; end
 
   def up
     add_column :operatingsystems, :release_name, :string, :limit => 64

--- a/db/migrate/20100419151910_add_owner_to_hosts.rb
+++ b/db/migrate/20100419151910_add_owner_to_hosts.rb
@@ -1,7 +1,7 @@
 require 'facter'
 class AddOwnerToHosts < ActiveRecord::Migration
-  class User < ActiveRecord::Base; end
-  class Host < ActiveRecord::Base; end
+  class User < ApplicationRecord; end
+  class Host < ApplicationRecord; end
 
   def up
     add_column :hosts, :owner_id,   :integer

--- a/db/migrate/20100523141204_create_media_operatingsystems_and_migrate_data.rb
+++ b/db/migrate/20100523141204_create_media_operatingsystems_and_migrate_data.rb
@@ -1,5 +1,5 @@
 class CreateMediaOperatingsystemsAndMigrateData < ActiveRecord::Migration
-  class Medium < ActiveRecord::Base; end
+  class Medium < ApplicationRecord; end
 
   def up
     medium_hash = {}

--- a/db/migrate/20100601221000_update_os_minor.rb
+++ b/db/migrate/20100601221000_update_os_minor.rb
@@ -1,5 +1,5 @@
 class UpdateOsMinor < ActiveRecord::Migration
-  class Operatingsystem < ActiveRecord::Base; end
+  class Operatingsystem < ApplicationRecord; end
 
   def up
     Operatingsystem.where(:minor => nil).update_all("minor = ''")

--- a/db/migrate/20100616114400_change_family_in_os.rb
+++ b/db/migrate/20100616114400_change_family_in_os.rb
@@ -1,5 +1,5 @@
 class ChangeFamilyInOs < ActiveRecord::Migration
-  class Operatingsystem < ActiveRecord::Base; end
+  class Operatingsystem < ApplicationRecord; end
 
   def up
     add_column :operatingsystems, :type, :string, :limit => 16

--- a/db/migrate/20110213104226_create_proxy_features.rb
+++ b/db/migrate/20110213104226_create_proxy_features.rb
@@ -1,5 +1,5 @@
 class CreateProxyFeatures < ActiveRecord::Migration
-  class Feature < ActiveRecord::Base; end
+  class Feature < ApplicationRecord; end
 
   def up
     # Create the tables

--- a/db/migrate/20120313081913_add_puppet_master_proxy_to_host_and_host_group.rb
+++ b/db/migrate/20120313081913_add_puppet_master_proxy_to_host_and_host_group.rb
@@ -1,5 +1,5 @@
 class AddPuppetMasterProxyToHostAndHostGroup < ActiveRecord::Migration
-  class SmartProxy < ActiveRecord::Base
+  class SmartProxy < ApplicationRecord
     has_and_belongs_to_many :features
   end
 

--- a/db/migrate/20120624094034_add_os_family_to_ptable.rb
+++ b/db/migrate/20120624094034_add_os_family_to_ptable.rb
@@ -1,5 +1,5 @@
 class AddOsFamilyToPtable < ActiveRecord::Migration
-  class FakePtableWithoutFamily < ActiveRecord::Base
+  class FakePtableWithoutFamily < ApplicationRecord
     self.table_name = 'ptables'
 
     has_and_belongs_to_many :operatingsystems

--- a/db/migrate/20120905095532_create_environment_classes.rb
+++ b/db/migrate/20120905095532_create_environment_classes.rb
@@ -1,5 +1,5 @@
 class CreateEnvironmentClasses < ActiveRecord::Migration
-  class EnvironmentClass < ActiveRecord::Base; end
+  class EnvironmentClass < ApplicationRecord; end
 
   def up
     rename_table :environments_puppetclasses, :environment_classes

--- a/db/migrate/20121118120028_migrate_hypervisors_to_compute_resources.rb
+++ b/db/migrate/20121118120028_migrate_hypervisors_to_compute_resources.rb
@@ -1,5 +1,5 @@
 class MigrateHypervisorsToComputeResources < ActiveRecord::Migration
-  class Hypervisor < ActiveRecord::Base; end
+  class Hypervisor < ApplicationRecord; end
 
   def up
     return unless Hypervisor.table_exists?

--- a/db/migrate/20130329195742_remove_duplicate_snippets.rb
+++ b/db/migrate/20130329195742_remove_duplicate_snippets.rb
@@ -1,5 +1,5 @@
 class RemoveDuplicateSnippets < ActiveRecord::Migration
-  class FakeConfigTemplate < ActiveRecord::Base
+  class FakeConfigTemplate < ApplicationRecord
     self.table_name = 'config_templates'
   end
 

--- a/db/migrate/20130908100439_delete_orphaned_records.rb
+++ b/db/migrate/20130908100439_delete_orphaned_records.rb
@@ -1,9 +1,9 @@
 class DeleteOrphanedRecords < ActiveRecord::Migration
-  class FakeConfigTemplate < ActiveRecord::Base
+  class FakeConfigTemplate < ApplicationRecord
     self.table_name = 'config_templates'
   end
 
-  class FakePtable < ActiveRecord::Base
+  class FakePtable < ApplicationRecord
     self.table_name = 'ptables'
   end
 

--- a/db/migrate/20131127112625_rename_seeded_templates.rb
+++ b/db/migrate/20131127112625_rename_seeded_templates.rb
@@ -35,11 +35,11 @@ class RenameSeededTemplates < ActiveRecord::Migration
     "Ubuntu Mirror" => "Ubuntu mirror"
   }
 
-  class FakeConfigTemplate < ActiveRecord::Base
+  class FakeConfigTemplate < ApplicationRecord
     self.table_name = 'config_templates'
   end
 
-  class FakePtable < ActiveRecord::Base
+  class FakePtable < ApplicationRecord
     self.table_name = 'ptables'
   end
 

--- a/db/migrate/20140219183343_migrate_permissions.rb
+++ b/db/migrate/20140219183343_migrate_permissions.rb
@@ -4,11 +4,11 @@ require Rails.root + 'db/seeds.d/03-permissions'
 # Fake models to make sure that this migration can be executed even when
 # original models changes later (e.g. add validation on columns that are not
 # present at this moment)
-class FakePermission < ActiveRecord::Base
+class FakePermission < ApplicationRecord
   self.table_name = 'permissions'
 end
 
-class FakeFilter < ActiveRecord::Base
+class FakeFilter < ApplicationRecord
   self.table_name = 'filters'
   # we need this for polymorphic relation to work, it has class name hardcoded in AR
   def self.name
@@ -30,25 +30,25 @@ class FakeFilter < ActiveRecord::Base
            :validate => false
 end
 
-class FakeUserRole < ActiveRecord::Base
+class FakeUserRole < ApplicationRecord
   self.table_name = 'user_roles'
   belongs_to :owner, :polymorphic => true
   belongs_to :role, :class_name => 'FakeRole'
 end
 
-class FakeRole < ActiveRecord::Base
+class FakeRole < ApplicationRecord
   self.table_name = 'roles'
   has_many :filters, :dependent => :destroy, :class_name => 'FakeFilter', :foreign_key => 'role_id'
   has_many :permissions, :through => :filters, :class_name => 'FakePermission', :foreign_key => 'permission_id'
 end
 
-class FakeFiltering < ActiveRecord::Base
+class FakeFiltering < ApplicationRecord
   self.table_name = 'filterings'
   belongs_to :filter, :class_name => 'FakeFilter'
   belongs_to :permission, :class_name => 'FakePermission'
 end
 
-class FakeUser < ActiveRecord::Base
+class FakeUser < ApplicationRecord
   self.table_name = 'users'
   # we need this for polymorphic relation to work, it has class name hardcoded in AR
   def self.name

--- a/db/migrate/20140630114339_add_boot_mode_to_subnet.rb
+++ b/db/migrate/20140630114339_add_boot_mode_to_subnet.rb
@@ -1,5 +1,5 @@
 class AddBootModeToSubnet < ActiveRecord::Migration
-  class FakeSubnet < ActiveRecord::Base
+  class FakeSubnet < ApplicationRecord
     self.table_name = 'subnets'
   end
 

--- a/db/migrate/20140710132249_extract_nic_attributes.rb
+++ b/db/migrate/20140710132249_extract_nic_attributes.rb
@@ -1,4 +1,4 @@
-class FakeBMCNic < ActiveRecord::Base
+class FakeBMCNic < ApplicationRecord
   self.table_name = 'nics'
   serialize :attrs, Hash
 

--- a/db/migrate/20140902102858_convert_ipam_to_string.rb
+++ b/db/migrate/20140902102858_convert_ipam_to_string.rb
@@ -1,5 +1,5 @@
 class ConvertIpamToString < ActiveRecord::Migration
-  class FakeSubnet < ActiveRecord::Base
+  class FakeSubnet < ApplicationRecord
     self.table_name = 'subnets'
   end
 

--- a/db/migrate/20140908082450_remove_signo_setting.rb
+++ b/db/migrate/20140908082450_remove_signo_setting.rb
@@ -1,5 +1,5 @@
 class RemoveSignoSetting < ActiveRecord::Migration
-  class FakeSetting < ActiveRecord::Base
+  class FakeSetting < ApplicationRecord
     self.table_name = 'settings'
   end
 

--- a/db/migrate/20140908192300_change_nil_admin_users_to_false.rb
+++ b/db/migrate/20140908192300_change_nil_admin_users_to_false.rb
@@ -1,4 +1,4 @@
-class FakeUser < ActiveRecord::Base
+class FakeUser < ApplicationRecord
   self.table_name = 'users'
 end
 

--- a/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
+++ b/db/migrate/20140910153654_move_host_nics_to_interfaces.rb
@@ -1,4 +1,4 @@
-class FakeNic < ActiveRecord::Base
+class FakeNic < ApplicationRecord
   self.table_name = 'nics'
 
   def type
@@ -6,7 +6,7 @@ class FakeNic < ActiveRecord::Base
   end
 end
 
-class FakeHost < ActiveRecord::Base
+class FakeHost < ApplicationRecord
   self.table_name = 'hosts'
 end
 

--- a/db/migrate/20141015164522_remove_failed_report_setting.rb
+++ b/db/migrate/20141015164522_remove_failed_report_setting.rb
@@ -1,5 +1,5 @@
 class RemoveFailedReportSetting < ActiveRecord::Migration
-  class FakeSetting < ActiveRecord::Base
+  class FakeSetting < ApplicationRecord
     self.table_name = 'settings'
   end
 

--- a/db/migrate/20141203082104_make_templates_default.rb
+++ b/db/migrate/20141203082104_make_templates_default.rb
@@ -1,5 +1,5 @@
 class MakeTemplatesDefault < ActiveRecord::Migration
-  class FakeConfigTemplate < ActiveRecord::Base
+  class FakeConfigTemplate < ApplicationRecord
     self.table_name = 'config_templates'
   end
 

--- a/db/migrate/20150312144232_migrate_websockets_setting.rb
+++ b/db/migrate/20150312144232_migrate_websockets_setting.rb
@@ -1,4 +1,4 @@
-class FakeSetting < ActiveRecord::Base
+class FakeSetting < ApplicationRecord
   self.table_name = 'settings'
 
   def default=(v)

--- a/db/migrate/20150508124600_copy_unmanaged_hosts_to_interfaces.rb
+++ b/db/migrate/20150508124600_copy_unmanaged_hosts_to_interfaces.rb
@@ -1,4 +1,4 @@
-class FakeNic < ActiveRecord::Base
+class FakeNic < ApplicationRecord
   self.table_name = 'nics'
 
   def type
@@ -6,7 +6,7 @@ class FakeNic < ActiveRecord::Base
   end
 end
 
-class FakeHost < ActiveRecord::Base
+class FakeHost < ApplicationRecord
   self.table_name = 'hosts'
 
   def type

--- a/db/migrate/20150514114044_migrate_ptables_to_templates.rb
+++ b/db/migrate/20150514114044_migrate_ptables_to_templates.rb
@@ -1,5 +1,5 @@
 class MigratePtablesToTemplates < ActiveRecord::Migration
-  class FakeOldPtable < ActiveRecord::Base
+  class FakeOldPtable < ApplicationRecord
     self.table_name = 'ptables'
 
     has_and_belongs_to_many :operatingsystems, :join_table => 'operatingsystems_ptables', :foreign_key => 'ptable_id'
@@ -7,7 +7,7 @@ class MigratePtablesToTemplates < ActiveRecord::Migration
     has_many_hosts :foreign_key => 'ptable_id'
   end
 
-  class FakeNewPtable < ActiveRecord::Base
+  class FakeNewPtable < ApplicationRecord
     self.table_name = 'templates'
 
     has_and_belongs_to_many :operatingsystems, :join_table => 'operatingsystems_ptables', :foreign_key => 'ptable_id'

--- a/db/migrate/20150605073820_fix_template_snippet_flag.rb
+++ b/db/migrate/20150605073820_fix_template_snippet_flag.rb
@@ -1,5 +1,5 @@
 class FixTemplateSnippetFlag < ActiveRecord::Migration
-  class FakeTemplate < ActiveRecord::Base
+  class FakeTemplate < ApplicationRecord
     self.table_name = 'templates'
   end
 

--- a/db/migrate/20150612105614_rename_taxonomy_ignored_type_to_provisioning_templates.rb
+++ b/db/migrate/20150612105614_rename_taxonomy_ignored_type_to_provisioning_templates.rb
@@ -1,5 +1,5 @@
 class RenameTaxonomyIgnoredTypeToProvisioningTemplates < ActiveRecord::Migration
-  class FakeTaxonomy < ActiveRecord::Base
+  class FakeTaxonomy < ApplicationRecord
     self.table_name = 'taxonomies'
 
     serialize :ignore_types, Array

--- a/db/migrate/20150714140850_remove_new_from_compute_attributes.rb
+++ b/db/migrate/20150714140850_remove_new_from_compute_attributes.rb
@@ -1,4 +1,4 @@
-class FakeComputeAttribute < ActiveRecord::Base
+class FakeComputeAttribute < ApplicationRecord
   self.table_name = 'compute_attributes'
   serialize :vm_attrs, Hash
 end

--- a/db/migrate/20160317070258_add_view_params_to_filters_with_edit.rb
+++ b/db/migrate/20160317070258_add_view_params_to_filters_with_edit.rb
@@ -1,9 +1,9 @@
 class AddViewParamsToFiltersWithEdit < ActiveRecord::Migration
-  class FakeFiltering < ActiveRecord::Base
+  class FakeFiltering < ApplicationRecord
     self.table_name = 'filterings'
   end
 
-  class FakeFilter < ActiveRecord::Base
+  class FakeFilter < ApplicationRecord
     self.table_name = 'filters'
   end
 

--- a/db/migrate/20160516070529_divide_lookup_key_permissions.rb
+++ b/db/migrate/20160516070529_divide_lookup_key_permissions.rb
@@ -1,16 +1,16 @@
 class DivideLookupKeyPermissions < ActiveRecord::Migration
-  class FakeFilter < ActiveRecord::Base
+  class FakeFilter < ApplicationRecord
     self.table_name = 'filters'
     belongs_to :role
     has_many :filterings
     has_many :permissions
   end
 
-  class FakeFiltering < ActiveRecord::Base
+  class FakeFiltering < ApplicationRecord
     self.table_name = 'filterings'
   end
 
-  class FakePermission < ActiveRecord::Base
+  class FakePermission < ApplicationRecord
     self.table_name = 'permissions'
   end
 

--- a/db/migrate/20160527093031_limit_os_description.rb
+++ b/db/migrate/20160527093031_limit_os_description.rb
@@ -1,5 +1,5 @@
 class LimitOsDescription < ActiveRecord::Migration
-  class FakeOperatingSystem < ActiveRecord::Base
+  class FakeOperatingSystem < ApplicationRecord
     self.table_name = 'operatingsystems'
   end
 

--- a/db/migrate/20160818091420_add_override_flag_to_filter.rb
+++ b/db/migrate/20160818091420_add_override_flag_to_filter.rb
@@ -1,5 +1,5 @@
 class AddOverrideFlagToFilter < ActiveRecord::Migration
-  class FakeFilter < ActiveRecord::Base
+  class FakeFilter < ApplicationRecord
     self.table_name = 'filters'
   end
 

--- a/db/migrate/20161006070258_migrate_common_parameter_permissions.rb
+++ b/db/migrate/20161006070258_migrate_common_parameter_permissions.rb
@@ -1,5 +1,5 @@
 class MigrateCommonParameterPermissions < ActiveRecord::Migration
-  class FakeFilter < ActiveRecord::Base
+  class FakeFilter < ApplicationRecord
     self.table_name = 'filters'
   end
 

--- a/lib/foreman/model.rb
+++ b/lib/foreman/model.rb
@@ -1,2 +1,3 @@
+# Module for Foreman-defined classes (e.g. Compute Resources)
 module Foreman::Model
 end

--- a/test/controllers/api/base_controller_subclass_test.rb
+++ b/test/controllers/api/base_controller_subclass_test.rb
@@ -31,7 +31,7 @@ class Api::TestableController < Api::V1::BaseController
   end
 end
 
-class Testable < ActiveRecord::Base
+class Testable < ApplicationRecord
   belongs_to :domain
 end
 

--- a/test/controllers/application_controller_subclass_test.rb
+++ b/test/controllers/application_controller_subclass_test.rb
@@ -14,7 +14,7 @@ class ::TestableResourcesController < ::ApplicationController
   end
 end
 
-class ::TestableResource < ActiveRecord::Base
+class ::TestableResource < ApplicationRecord
   # ugly hack - causing ActiveRecord to check the resource against "realms" table in the DB.
   # If removed, the ActiveRecord will fail to find a table with name "testable_resources" which will fail tests,
   # even if there are no actual calls to the find/select... methods.
@@ -34,7 +34,7 @@ module Testscope
     end
   end
 
-  class TestableResource < ActiveRecord::Base
+  class TestableResource < ApplicationRecord
     # ugly hack - causing ActiveRecord to check the resource against "realms" table in the DB.
     # If removed, the ActiveRecord will fail to find a table with name "testable_resources" which will fail tests,
     # even if there are no actual calls to the find/select... methods.

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TaxonomixDummy < ActiveRecord::Base
+class TaxonomixDummy < ApplicationRecord
   self.table_name = 'environments'
   include Taxonomix
 
@@ -13,7 +13,7 @@ class TaxonomixDummy < ActiveRecord::Base
   end
 end
 
-class UntaxedDummy < ActiveRecord::Base
+class UntaxedDummy < ApplicationRecord
   self.table_name = 'environments'
 end
 


### PR DESCRIPTION
Yeah, as simple as that. No more hidden orch issues in the flooded sql logger
which is turned off by default and in production environments it is almost
always turned off (while orch logging still provides a lot of very useful
messages at INFO/WARN level).

![image](https://cloud.githubusercontent.com/assets/49752/17623884/a1c688ce-60a2-11e6-82ac-6f7f3d6e9178.png)
