### PR TITLE
Fixes #16104 - Use parameterizable for HW models

### DIFF
--- a/app/controllers/api/v2/models_controller.rb
+++ b/app/controllers/api/v2/models_controller.rb
@@ -49,12 +49,6 @@ module Api
       def destroy
         process_response @model.destroy
       end
-
-      private
-
-      def find_resource
-        @model = Model.friendly.find(params[:id]) || super
-      end
     end
   end
 end

--- a/app/controllers/concerns/find_common.rb
+++ b/app/controllers/concerns/find_common.rb
@@ -11,7 +11,10 @@ module FindCommon
   def resource_finder(scope, id)
     raise ActiveRecord::RecordNotFound if scope.empty?
     result = scope.from_param(id) if scope.respond_to?(:from_param)
-    result ||= scope.friendly.find(id) if scope.respond_to?(:friendly)
+    begin
+      result ||= scope.friendly.find(id) if scope.respond_to?(:friendly)
+    rescue ActiveRecord::RecordNotFound
+    end
     result || scope.find(id)
   end
 

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -27,7 +27,7 @@ module Parameterizable
       end
 
       def self.from_param(id_name)
-        self.find_by_id(id_name.to_i)
+        self.find_by_id(id_name.to_i) if id_name =~ /\A\d+-/
       end
     end
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -2,6 +2,7 @@ class Model < ActiveRecord::Base
   include Authorizable
   extend FriendlyId
   friendly_id :name
+  include Parameterizable::ByIdName
 
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many_hosts

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -16,7 +16,7 @@
     <% @models.each do |model| %>
       <tr>
         <td class="display-two-pane ellipsis">
-          <%= link_to_if_authorized trunc_with_tooltip(model.name),
+          <%= link_to_if_authorized model.name,
             hash_for_edit_model_path(:id => model).merge(:auth_object => model, :authorizer => authorizer) %></td>
         <td class="ellipsis"><%= model.vendor_class %></td>
         <td class="ellipsis"><%= model.hardware_model %></td>


### PR DESCRIPTION
Correctly escape HW model names that may contain url-unsafe characters.
Also removed unnecessary truncation of the model name.

Resource finder now works correctly for models that may contain either a
friendly name or a parameterized id-name.
