### PR TITLE
Refs #12364 - webpack server can serve assets on https

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 # Run Rails & Webpack concurrently
 # If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
 rails: [ -n "$RAILS_STARTUP" ] && $RAILS_STARTUP || bin/rails server -b 0.0.0.0
-webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js
+# you can use WEBPACK_OPTS to customize webpack server, e.g. 'WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start '
+webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,5 @@ Foreman::Application.configure do
 
   #Allow disabling the webpack dev server from the settings
   config.webpack.dev_server.enabled = SETTINGS.fetch(:webpack_dev_server, true)
+  config.webpack.dev_server.https = SETTINGS.fetch(:webpack_dev_server_https, false)
 end

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -21,6 +21,11 @@
 # Make sure to run `rake webpack:compile` if disabled.
 :webpack_dev_server: true
 
+# If you run Foreman in development behind some proxy or use HTTPS you need
+# to enable HTTPS for webpack dev server too, otherwise you'd get mixed content
+# errors in your browser
+:webpack_dev_server_https: false
+
 # Local administrative settings for application domain, fqdn, foreman URL,
 # administrator email address etc. If you don't have a Puppet provisioning
 # system you may want to change to setup your project on your local machine.


### PR DESCRIPTION
https://github.com/theforeman/foreman/commit/42ba771cc8bfc09257c15c5d388542d4d1b69358 does not fix the issue completely, the policy is required but is not sufficient if the webpack server runs on the same domain as the Foreman. Browser refuses content from both `https://$domain` and `http://$domain` if the domain is same in both urls. With this patch, webpack server can be started in https mode and we can configure the client to use https too in settings.yaml.

There's one gotcha though, webpack_rails only supports verify_none ssl mode, I plan to send them patch and after that we can expose this option too.
