### PR TITLE
Fixes #16139 - Add link to code contribution in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@ Before submitting a pull request, please verify that:
 * There are tests added to make sure the bug does not return/feature does not break in the future.
 * Any strings are extracted for [translation](http://projects.theforeman.org/projects/foreman/wiki/Translating).
 
-For more information regarding contributions, plese read the [Foreman Handbook](http://theforeman.org/handbook.html).
+For more information regarding contributions, plese read the [Foreman Handbook](http://theforeman.org/handbook.html) and [Foreman contributions](http://theforeman.org/contribute.html).


### PR DESCRIPTION
Just a little amendment to quickly find how to setup the testing environment 
