### PR TITLE
Fixes #16159 - Rename mail alerts to not be Puppet specific

### DIFF
--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -20,7 +20,7 @@ class HostMailer < ApplicationMailer
     @disabled = hosts.alerts_disabled.sort
 
     set_locale_for(user) do
-      subject = _("Puppet Summary Report - F:%{failed} R:%{restarted} S:%{skipped} A:%{applied} FR:%{failed_restarts} T:%{total}") % {
+      subject = _("Configuration Management Summary Report - F:%{failed} R:%{restarted} S:%{skipped} A:%{applied} FR:%{failed_restarts} T:%{total}") % {
         :failed => total_metrics["failed"],
         :restarted => total_metrics["restarted"],
         :skipped => total_metrics["skipped"],
@@ -39,7 +39,7 @@ class HostMailer < ApplicationMailer
     @report = report
     @host = @report.host
     set_locale_for(options[:user]) do
-      mail(:to => options[:user].mail, :subject => (_("Puppet error on %s") % @host)) do |format|
+      mail(:to => options[:user].mail, :subject => (_("Configuration Management Error on %s") % @host)) do |format|
         format.html { render :layout => 'application_mailer' }
       end
     end

--- a/app/models/mail_notifications/config_management_error.rb
+++ b/app/models/mail_notifications/config_management_error.rb
@@ -1,0 +1,10 @@
+class ConfigManagementError < MailNotification
+  scope :all_hosts, lambda {
+    ConfigManagementError.includes(:user_mail_notifications).
+    where(:user_mail_notifications => {:interval => 'Subscribe to all hosts'})
+  }
+
+  def subscription_options
+    [N_("Subscribe to my hosts"), N_("Subscribe to all hosts")]
+  end
+end

--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -23,7 +23,9 @@ class MailNotification < ApplicationRecord
 
   def initialize(*args)
     params = args.shift
-    params[:type] = "PuppetError" if params.is_a?(Hash) && params[:name] == 'puppet_error_state'
+    if params.is_a?(Hash) && params[:name] == 'config_error_state'
+      params[:type] = "ConfigManagementError"
+    end
     args.unshift(params)
     super(*args)
   end

--- a/app/models/mail_notifications/puppet_error.rb
+++ b/app/models/mail_notifications/puppet_error.rb
@@ -1,7 +1,0 @@
-class PuppetError < MailNotification
-  scope :all_hosts, -> { PuppetError.includes(:user_mail_notifications).where(:user_mail_notifications => {:interval => 'Subscribe to all hosts'}) }
-
-  def subscription_options
-    [N_("Subscribe to my hosts"), N_("Subscribe to all hosts")]
-  end
-end

--- a/app/services/config_report_importer.rb
+++ b/app/services/config_report_importer.rb
@@ -17,7 +17,7 @@ class ConfigReportImporter < ReportImporter
     # Store all Puppet message logs
     import_log_messages
     # Check for errors
-    notify_on_report_error(:puppet_error_state)
+    notify_on_report_error(:config_error_state)
   end
 
   def report_status

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -98,8 +98,8 @@ class ReportImporter
         return
       end
 
-      owners = host.owner.present? ? host.owner.recipients_for(:puppet_error_state) : []
-      users = PuppetError.all_hosts.flat_map(&:users)
+      owners = host.owner.present? ? host.owner.recipients_for(:config_error_state) : []
+      users = ConfigManagementError.all_hosts.flat_map(&:users)
       users.select { |user| Host.authorized_as(user, :view_hosts).find(host.id).present? }
       owners.concat users
       if owners.present?

--- a/app/views/host_mailer/error_state.html.erb
+++ b/app/views/host_mailer/error_state.html.erb
@@ -1,4 +1,4 @@
-<h2 class="headline"><%= _("<b>Foreman</b> Puppet error report").html_safe %></h2>
+<h2 class="headline"><%= _("<b>Foreman</b> Configuration Management Error Report").html_safe %></h2>
 <div class="dashboard">
   <%= render :partial => 'error_states', :locals => {:logs => @report.logs} %>
   <br>

--- a/app/views/host_mailer/summary.html.erb
+++ b/app/views/host_mailer/summary.html.erb
@@ -1,4 +1,4 @@
-<h2 class="headline"><%= _("<b>Foreman</b> Puppet summary").html_safe %></h2>
+<h2 class="headline"><%= _("<b>Foreman</b> Configuration Management Summary").html_safe %></h2>
 <h2 style="margin: 5px 0px;"><%= _("Summary from %{time} ago to now") % {:time => distance_of_time_in_words(Time.now - @timerange)} %></h2>
 <h3><%= _("Summary report from Foreman server at %{foreman_url}") % {:foreman_url => Setting[:foreman_url]} %></h3>
 <div class="dashboard">
@@ -6,6 +6,6 @@
 </div>
 <div class="hosts">
   <%= render :partial => 'list', :locals => {:state => 'active', :title => _("Hosts with interesting values (changed, failures etc)"), :list => @hosts} %>
-  <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which are currently not running Puppet"), :list => @out_of_sync} %>
+  <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which do not have recent reports from configuration management"), :list => @out_of_sync} %>
   <%= render :partial => 'list', :locals => {:state => 'nonactive', :title => _("Hosts which Foreman reporting is disabled"), :list => @disabled} %>
 </div>

--- a/db/migrate/20160818062936_rename_puppet_mail_notifications.rb
+++ b/db/migrate/20160818062936_rename_puppet_mail_notifications.rb
@@ -1,0 +1,20 @@
+class RenamePuppetMailNotifications < ActiveRecord::Migration
+  # We have to load this class in the migration so that existing mail
+  # notifications of 'type=PuppetError' can load
+  class ::PuppetError < ConfigManagementError
+  end
+
+  def up
+    MailNotification.where(:name => 'puppet_summary').
+      update_all(:name => 'config_summary')
+    MailNotification.where(:name => 'puppet_error_state').
+      update_all(:name => 'config_error_state', :type => ConfigManagementError)
+  end
+
+  def down
+    MailNotification.where(:name => 'config_summary').
+      update_all(:name => 'puppet_summary')
+    MailNotification.where(:name => 'config_error_state').
+      update_all(:name => 'puppet_error_state', :type => PuppetError)
+  end
+end

--- a/db/seeds.d/16-mail_notifications.rb
+++ b/db/seeds.d/16-mail_notifications.rb
@@ -14,8 +14,8 @@ N_('Puppet error state')
 
 notifications = [
   {
-    :name              => 'puppet_summary',
-    :description       => N_('A summary of eventful puppet reports'),
+    :name              => 'config_summary',
+    :description       => N_('A summary of eventful configuration management reports'),
     :mailer            => 'HostMailer',
     :method            => 'summary',
     :subscription_type => 'report'
@@ -56,8 +56,8 @@ notifications = [
   },
 
   {
-    :name               => 'puppet_error_state',
-    :description        => N_('A notification when a host reports a puppet error'),
+    :name               => 'config_error_state',
+    :description        => N_('A notification when a host reports a configuration error'),
     :mailer             => 'HostMailer',
     :method             => 'error_state',
     :subscription_type  => 'alert'

--- a/test/factories/mail_notification.rb
+++ b/test/factories/mail_notification.rb
@@ -8,11 +8,11 @@ FactoryGirl.define do
     subscription_type "report"
     queryable false
 
-    trait :puppet_error do
-      sequence(:name) {"puppet_error_state"}
+    trait :config_error do
+      sequence(:name) {"config_error_state"}
       mailer "HostMailer"
-      mailer_method "puppet"
-      type "PuppetError"
+      mailer_method "config"
+      type "ConfigManagementError"
     end
   end
 end

--- a/test/fixtures/mail_notifications.yml
+++ b/test/fixtures/mail_notifications.yml
@@ -1,18 +1,18 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
-puppet_summary:
-  name: puppet_summary
-  description: Puppet summary
+config_summary:
+  name: config_summary
+  description: config summary
   mailer: HostMailer
   method: summary
   subscription_type: report
 
-puppet_error_state:
-  name: puppet_error_state
-  description: A notification when a host reports a puppet error
+config_error_state:
+  name: config_error_state
+  description: A notification when a host reports a config error
   mailer: HostMailer
   method: error_state
   subscription_type: alert
-  type: PuppetError
+  type: ConfigManagementError
 
 welcome:
   name: welcome

--- a/test/models/mail_notification_test.rb
+++ b/test/models/mail_notification_test.rb
@@ -16,8 +16,8 @@ class MailNotificationTest < ActiveSupport::TestCase
 
   test "user with mail disabled doesn't get mail" do
     user = FactoryGirl.create(:user, :with_mail, :mail_enabled => false)
-    user.mail_notifications << MailNotification[:puppet_summary]
-    notification = user.user_mail_notifications.find_by_mail_notification_id(MailNotification[:puppet_summary])
+    user.mail_notifications << MailNotification[:config_summary]
+    notification = user.user_mail_notifications.find_by_mail_notification_id(MailNotification[:config_summary])
 
     assert_no_difference "ActionMailer::Base.deliveries.size" do
       notification.deliver
@@ -34,8 +34,8 @@ class MailNotificationTest < ActiveSupport::TestCase
     mailer.deliver(:foo, :users => users)
   end
 
-  test "when name is set to 'puppet_error_state', type should be set to PuppetError" do
-    mailer = MailNotification.new(:name => 'puppet_error_state')
-    assert_equal 'PuppetError', mailer.type
+  test "'config_error_state' type is ConfigManagementError" do
+    mailer = MailNotification.new(:name => 'config_error_state')
+    assert_equal 'ConfigManagementError', mailer.type
   end
 end

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -20,10 +20,10 @@ class ReportImporterTest < ActiveSupport::TestCase
     assert_empty r.logs
   end
 
-  context 'puppet error state notification' do
+  context 'config error state notification' do
     setup do
       @user = as_admin { FactoryGirl.create(:user, :admin, :with_mail) }
-      @user.mail_notifications << PuppetError.first
+      @user.mail_notifications << ConfigManagementError.first
       @host = FactoryGirl.create(:host)
     end
 
@@ -51,9 +51,9 @@ class ReportImporterTest < ActiveSupport::TestCase
       @host = FactoryGirl.create(:host, :owner => @owner)
     end
 
-    # Only ConfigReportImporter is set to send puppet error states
+    # Only ConfigReportImporter is set to send config error states
     test 'when owner is subscribed to notification, a mail should be sent on error' do
-      @owner.mail_notifications << PuppetError.first
+      @owner.mail_notifications << ConfigManagementError.first
       @owner.user_mail_notifications.all.each { |notification| notification.update_attribute(:interval, 'Subscribe to my hosts') }
       assert_difference 'ActionMailer::Base.deliveries.size' do
         report = read_json_fixture('reports/errors.json')
@@ -81,10 +81,10 @@ class ReportImporterTest < ActiveSupport::TestCase
     end
   end
 
-  # Only ConfigReportImporter is set to send puppet error states
+  # Only ConfigReportImporter is set to send config error states
   test 'when usergroup owner is subscribed to notification, a mail should be sent to all users on error' do
     ug = FactoryGirl.create(:usergroup, :users => FactoryGirl.create_pair(:user, :with_mail))
-    Usergroup.any_instance.expects(:recipients_for).with(:puppet_error_state).returns(ug.users)
+    Usergroup.any_instance.expects(:recipients_for).with(:config_error_state).returns(ug.users)
     host = FactoryGirl.create(:host, :owner => ug)
     report = read_json_fixture('reports/errors.json')
     report["host"] = host.name

--- a/test/unit/tasks/reports_test.rb
+++ b/test/unit/tasks/reports_test.rb
@@ -10,7 +10,7 @@ class ReportsTest < ActiveSupport::TestCase
     as_admin do
       ActionMailer::Base.deliveries = []
       @owner = FactoryGirl.create(:user, :admin, :with_mail)
-      @owner.mail_notifications << MailNotification[:puppet_summary]
+      @owner.mail_notifications << MailNotification[:config_summary]
       @owner.user_mail_notifications.all.each { |notification| notification.update_attribute(:interval, 'Daily') }
       @host = FactoryGirl.create(:host, :owner => @owner)
     end
@@ -18,7 +18,7 @@ class ReportsTest < ActiveSupport::TestCase
 
   test 'reports:daily sends mail' do
     Rake.application.invoke_task 'reports:daily'
-    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Puppet Summary/ }
+    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Configuration Management Summary/ }
     assert mail
     assert_match /Summary from/, mail.body.encoded
   end
@@ -33,7 +33,7 @@ class ReportsTest < ActiveSupport::TestCase
     end
 
     Rake.application.invoke_task 'reports:daily'
-    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Puppet Summary/ }
+    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Configuration Management Summary/ }
     assert mail
     assert_match /#{@host.name}/, mail.body.encoded
   end


### PR DESCRIPTION
Right now, under 'my account', users get emails with alerts about the
status of their hosts regarding configuration management (e.g: if there
was an error, get an alert, or get a weekly summary of all hosts
changes)

These emails gather info from reports that could come from Puppet,
Ansible, Salt or Chef, but there are references to Puppet all over
them.

I think these Puppet references should be removed as these reports
may not come from Puppet.
## 

Another step further in this direction would be to start storing a
'origin' or similar field in Reports and Facts that indicates where
they come from.
