### PR TITLE
Fixes #16160 - added script/start-foreman helper

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # Run Rails & Webpack concurrently
 # If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
-rails: [ -n "$RAILS_STARTUP" ] && $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || bin/rails server
+rails: [ -n "$RAILS_STARTUP" ] && env PRY_WARNING=1 $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || env PRY_WARNING=1 bin/rails server
 # you can use WEBPACK_OPTS to customize webpack server, e.g. 'WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start '
 webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS

--- a/config/initializers/pry_warning.rb
+++ b/config/initializers/pry_warning.rb
@@ -1,0 +1,3 @@
+if ENV['PRY_WARNING'] && defined? pry
+  Rails.logger.warn "WARNING: Pry will not work with foreman gem, use script/foreman-start-dev"
+end

--- a/script/foreman-start-dev
+++ b/script/foreman-start-dev
@@ -1,0 +1,3 @@
+#!/bin/sh
+./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS &
+./bin/rails server -b 0.0.0.0 "$@"


### PR DESCRIPTION
I don't want to use "foreman" gem for my development environment, I need pry
without hacks. A simple shell script does the very same. When you hit Ctrl+C
enter, both processes are terminated. And pry does work just fine.

Second part of this improvement is ability to set logging settings per
environment. I want my test environment to have slightly different
configuration than what's defined in `config/settings.yml` but the file is in
git and I can't change it.
