### PR TITLE
fixes #16198 - remove therubyracer Bundler group

### DIFF
--- a/bundler.d/therubyracer.rb
+++ b/bundler.d/therubyracer.rb
@@ -1,3 +1,0 @@
-group :therubyracer do
-  gem 'therubyracer', '0.11.3', :require => 'v8'
-end


### PR DESCRIPTION
NodeJS must be installed instead, which ExecJS will use automatically.
