### PR TITLE
Fixes #16197 - Host#smart_proxies returns only the host proxies

### DIFF
--- a/app/models/concerns/hostext/smart_proxy.rb
+++ b/app/models/concerns/hostext/smart_proxy.rb
@@ -1,0 +1,22 @@
+module Hostext
+  module SmartProxy
+    extend ActiveSupport::Concern
+
+    def smart_proxies
+      ::SmartProxy.where(:id => smart_proxy_ids)
+    end
+
+    def smart_proxy_ids
+      ids = []
+      [subnet, subnet6].compact.each do |s|
+        ids << s.dhcp_id
+        ids << s.tftp_id
+        ids << s.dns_id
+      end
+      ids << domain.dns_id if domain.present?
+      ids << realm.realm_proxy_id if realm.present?
+      ids += [puppet_proxy_id, puppet_ca_proxy_id]
+      ids.uniq.compact
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,6 +1,7 @@
 class Host::Managed < Host::Base
   include Hostext::PowerInterface
   include Hostext::Search
+  include Hostext::SmartProxy
   include Hostext::Token
   include SelectiveClone
   include HostParams
@@ -736,32 +737,6 @@ class Host::Managed < Host::Base
 
   def vm_compute_attributes
     compute_resource ? compute_resource.vm_compute_attributes_for(uuid) : nil
-  end
-
-  def smart_proxies
-    SmartProxy.where(:id => smart_proxy_ids)
-  end
-
-  def smart_proxy_ids
-    ids = []
-    [subnet, hostgroup.try(:subnet), subnet6, hostgroup.try(:subnet6)].compact.each do |s|
-      ids << s.dhcp_id
-      ids << s.tftp_id
-      ids << s.dns_id
-    end
-
-    [domain, hostgroup.try(:domain)].compact.each do |d|
-      ids << d.dns_id
-    end
-
-    [realm, hostgroup.try(:realm)].compact.each do |r|
-      ids << r.realm_proxy_id
-    end
-
-    [puppet_proxy_id, puppet_ca_proxy_id, hostgroup.try(:puppet_proxy_id), hostgroup.try(:puppet_ca_proxy_id)].compact.each do |p|
-      ids << p
-    end
-    ids.uniq.compact
   end
 
   def bmc_proxy


### PR DESCRIPTION
Doing the following:
- Create 2 smart proxies, one for dhcp/dns/tft/puppetca/puppet, another
  for realms. Let's keep the realms proxy off, so it's unreachable.
- Create a hostgroup A that sets domain, subnet, realm, puppet_proxy,
  puppet_ca_proxy
- Create a host that uses hostgroup A, but uncheck 'inherit' and
  remove the 'realm' attribute. The host is created just fine with no
  realm
- When I try to rebuild the host, `HostBuildStatus#check_all_statuses`
  is called. This checks the host_status (OK), templates_status(OK), and
  smart_proxies_status(FAIL). The host cannot be rebuilt.

The reason `smart_proxies_status` fails is that `smart_proxy_ids`
tries to find whether Realm is set.
- If it's set, it adds the proxy to 'Host#smart_proxies`
- If it's not set, it looks in the hostgroup to see if it's set there.
  However, I have overridden the option, because I don't want to set a
  Realm since I don't want to boot the Realm proxy I have.

Host#smart_proxies should not look in the host.hostgroup object to
retrieve values for the proxy, but instead retrieve those from itself
