### PR TITLE
Fixes #16218 - override settings per environment

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -33,9 +33,12 @@
 :fqdn: 'localhost.localdomain.net'
 
 # Log settings for the current environment can be adjusted by adding them
-# here. For example, if you want to increase the log level.
+# here. It is also possible to override settings per environment. See
+# logging.yaml for more details and examples.
 #:logging:
 #  :level: debug
+#  :production:
+#    :type: syslog
 
 # Individual logging types can be toggled on/off here
 #:loggers:

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -80,6 +80,7 @@ module Foreman
     def load_config(environment, overrides = {})
       fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?('config/logging.yaml')
       overrides ||= {}
+      overrides = overrides[environment.to_sym] if overrides.has_key?(environment.to_sym)
       @config = YAML.load_file('config/logging.yaml')
       @config = @config[:default].deep_merge(@config[environment.to_sym]).deep_merge(overrides)
     end


### PR DESCRIPTION
This is a small change that will add possibility to setup loggers for test
environment. I don't like the hardcoded defaults and there is no way to change
that only for test environment. I want separate setups for development and
test.
