### PR TITLE
Fixes #16222 - Make HoundCI round ESLint on new JS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# node_modules is ignored by default
+app/assets/javascripts/**/*.js
+vendor/assets/javascripts/**/*.js

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,15 @@
+scss:
+  enabled: false
+
+ruby:
+  enabled: false
+
+jshint:
+  enabled: false
+
+eslint:
+  enabled: true
+  config_file: .eslintrc
+  ignore_file: .eslintignore
+
+fail_on_violations: true


### PR DESCRIPTION
15806 adds support for ESLint on new JS code via 'npm run lint'
This contains the configuration to make HoundCI run these linting checks
and comment on the pull request with any warnings. It'll ignore the old
javascript in app/assets/javascript

Depends on https://github.com/theforeman/foreman/pull/3673
