### PR TITLE
Fixes #16044 - Load dashboard widgets via ajax

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,8 +2,8 @@ class DashboardController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::Parameters::Widget
 
-  before_action :prefetch_data, :only => :index
-  before_action :find_resource, :only => [:destroy]
+  before_action :prefetch_data, :only => :show
+  before_action :find_resource, :only => [:show, :destroy]
   skip_before_action :welcome
 
   def index
@@ -12,6 +12,16 @@ class DashboardController < ApplicationController
       format.yaml { render :text => @report.to_yaml }
       format.json
     end
+  end
+
+  def show
+    if @widget.present? && @widget.user == User.current
+      render(:partial => @widget.template, :locals => @widget.data)
+    else
+      render_403 "User #{User.current} attempted to access another user's widget"
+    end
+  rescue ActionView::MissingTemplate, ActionView::Template::Error => exception
+    process_ajax_error exception, "load widget"
   end
 
   def create

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -35,12 +35,6 @@ module DashboardHelper
     end
   end
 
-  def render_widget(widget)
-    render(:partial => widget.template, :locals => widget.data)
-  rescue ActionView::MissingTemplate
-    ::Foreman::Exception.new(N_("Missing template '%{template}' for widget '%{widget}'."), :widget => _(widget.name), :template => widget.template)
-  end
-
   def widget_data(widget)
     { :data => { :id    => widget.id,    :name  => _(widget.name), :row  => widget.row, :col => widget.col,
                  :sizex => widget.sizex, :sizey =>  widget.sizey,  :hide => widget.hide } }

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -732,7 +732,7 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :dashboard do |map|
-    map.permission :access_dashboard, {:dashboard => [:index, :save_positions, :reset_default, :create, :destroy],
+    map.permission :access_dashboard, {:dashboard => [:index, :show, :save_positions, :reset_default, :create, :destroy],
                                       :"api/v1/dashboard" => [:index],
                                       :"api/v2/dashboard" => [:index]
     }

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -17,7 +17,9 @@
               <a class='minimize'>&minus;</a>
             </div>
             <div class="widget <%= widget.name.parameterize %>">
-              <%= render_widget(widget) %>
+              <div data-ajax-url="<%= widget_path(widget) %>" data-on-complete="refreshCharts">
+                <%= spinner(_("%s widget loading...") % widget.name) %>
+              </div>
             </div>
           <% end %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -412,7 +412,7 @@ Foreman::Application.routes.draw do
 
   end
 
-  resources :widgets, :controller => 'dashboard', :only => [:create, :destroy] do
+  resources :widgets, :controller => 'dashboard', :only => [:show, :create, :destroy] do
     collection do
       post 'save_positions', :to => 'dashboard#save_positions'
       put 'reset_default', :to => 'dashboard#reset_default'

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -1,12 +1,13 @@
 require 'integration_test_helper'
 
-class DashboardIntegrationTest < ActionDispatch::IntegrationTest
+class DashboardIntegrationTest < IntegrationTestWithJavascript
   def setup
     Dashboard::Manager.reset_user_to_default(users(:admin))
   end
 
   def assert_dashboard_link(text)
     visit dashboard_path
+    wait_for_ajax
     assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
     within "li[data-name='Status table']" do
       click_link(text)
@@ -54,6 +55,6 @@ class DashboardIntegrationTest < ActionDispatch::IntegrationTest
     Capybara.reset_sessions!
     login_admin
     visit dashboard_path
-    assert_equal deleted_widget.name, page.find('li.widget-add a').text
+    assert_equal deleted_widget.name, page.find('li.widget-add a', :visible => :hidden).text(:all)
   end
 end


### PR DESCRIPTION
This speeds up dasboard loading as widgets are loaded in the background
and do not block rendering, as well as allow the dashboard to load
correctly even if some of the widgets are broken.
