### PR TITLE
Fixes #16238 - Speed up dashboard loading time.

### DIFF
--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -17,7 +17,10 @@ class Dashboard::Data
 
   def latest_events
     # 9 reports + header fits the events box nicely...
-    @latest_events ||= ConfigReport.authorized(:view_config_reports).my_reports.interesting.where(:host_id => hosts.pluck(:id)).search_for('reported > "7 days ago"').limit(9).includes(:host)
+    @latest_events ||= ConfigReport.authorized(:view_config_reports).my_reports.interesting
+                                   .joins(:host).where(:host => hosts.reorder(''))
+                                   .search_for('reported > "7 days ago"')
+                                   .limit(9).includes(:host)
   end
 
   private


### PR DESCRIPTION
I've change report host to inner query and used a join, in
my testing, this speed up dramaticilly dashboard loading
time, on my setup from 60 seconds to under 10 seconds.
