### PR TITLE
Fixes #16239 - Enable rubocop checks on HoundCI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,7 +2,7 @@ scss:
   enabled: false
 
 ruby:
-  enabled: false
+  config_file: .rubocop.yml
 
 jshint:
   enabled: false


### PR DESCRIPTION
This allows HoundCI to use our rubocop rules to lint our Ruby files
and comment on them.

Without the _todo file, it comments about every rule:
https://github.com/dLobatog/foreman/pull/25/files

With the _todo file, it only comments on violations of our rules
https://github.com/dLobatog/foreman/pull/26/files
