### PR TITLE
fixes #16243 - make Host::Managed.new's options arg optional

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -42,9 +42,9 @@ class Host::Managed < Host::Base
   before_save :clear_data_on_build
   before_save :clear_puppetinfo, :if => :environment_id_changed?
 
-  def initialize(attributes = nil, options = {})
-    attributes = apply_inherited_attributes(attributes, false)
-    super(attributes, options)
+  def initialize(*args)
+    args.unshift(apply_inherited_attributes(args.shift, false))
+    super(*args)
   end
 
   def build_hooks


### PR DESCRIPTION
The options argument no longer exists on Rails 5 as it was part of the
support for protected_attrs. The argument list to .new should be handled
more defensively, like Host::Base.
