### PR TITLE
Fixes #16260 - Wait for dashboard to fully load in test

### DIFF
--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -55,6 +55,7 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
     Capybara.reset_sessions!
     login_admin
     visit dashboard_path
+    wait_for_ajax
     assert_equal deleted_widget.name, page.find('li.widget-add a', :visible => :hidden).text(:all)
   end
 end


### PR DESCRIPTION
This will hopefully prevent intermittent db deadlocks.
