### PR TITLE
Fixes #16264 - Template combinations cannot be created

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/template_combination.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template_combination.rb
@@ -4,8 +4,12 @@ module Foreman::Controller::Parameters::TemplateCombination
   class_methods do
     def template_combination_params_filter
       Foreman::ParameterFilter.new(::TemplateCombination).tap do |filter|
-        filter.permit :environment_id, :environment_name, :environment,
-          :hostgroup_id, :hostgroup_name, :hostgroup
+        filter.permit_by_context :environment_id, :environment_name, :environment,
+          :hostgroup_id, :hostgroup_name, :hostgroup,
+          :nested => true
+
+        filter.permit_by_context :id, :_destroy,
+          :ui => false, :api => false, :nested => true
       end
     end
   end

--- a/app/views/provisioning_templates/_custom_tabs.html.erb
+++ b/app/views/provisioning_templates/_custom_tabs.html.erb
@@ -11,7 +11,7 @@
   <%= snippet_message(@template) %>
   <div id="association" <%= display? @template.snippet %> >
     <%= how_templates_are_determined %>
-    <%= multiple_selects f, :operatingsystems, Operatingsystem, @operatingsystems.try(:map, &:id), :label => _("Applicable<br>Operating Systems").html_safe %>
+    <%= multiple_selects f, :operatingsystems, Operatingsystem, @operatingsystems.try(:map, &:id), :label => _("Applicable Operating Systems") %>
     <%= render "provisioning_templates/combinations", :f => f %>
   </div>
 </div>


### PR DESCRIPTION
Currently, strong parameters is not allowing passing the nested
attributes required to ProvisioningTemplate to create
TemplateCombinations through the UI.
The fix is as simple as permitting those parameters in a 'nested'
context.
