### PR TITLE
Fixes #16072 - Fixes compute profile two pane

### DIFF
--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -141,6 +141,7 @@ function hide_columns(){
 
 // place the content into the right pane
 function right_pane_content(response){
+  var contentId;
   if (handle_redirect(response)) return; //session expired redirect to login
 
   if (!$("#content", response).length){
@@ -150,7 +151,14 @@ function right_pane_content(response){
     fix_multi_checkbox();
   } else {
     // response is not a form use the entire page
-    $('#content').replaceWith($("#content", response));
+    if ($('#two_pane_content', response).length) {
+      // replace only #two_pane_content if it's present in the response
+      contentId = '#two_pane_content';
+      two_pane_close();
+    } else {
+      contentId = '#content';
+    }
+    $(contentId).replaceWith($(contentId, response));
   }
   $(document.body).trigger('ContentLoad');
 }

--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -131,4 +131,8 @@ class ComputeResourcesController < ApplicationController
         super
     end
   end
+
+  def two_pane?
+    super && params[:action] != 'show'
+  end
 end

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -51,7 +51,7 @@
     </div>
   <% end %>
   <div id="compute_profiles" class="tab-pane">
-    <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
+    <table class="<%= table_css_classes 'table-two-pane table-fixed' %>" id="two_pane_content">
       <thead>
         <tr>
           <th class="col-md-8"><%= _("Compute profile") %></th>
@@ -67,7 +67,7 @@
                             new_compute_profile_compute_resource_compute_attribute_path(compute_profile.to_param, @compute_resource.to_param)
                           end %>
           <tr>
-            <td class="ellipsis"><%= link_to(compute_profile.name, which_path, :class => compute_attribute.try(:id) ? '' : 'new_two_pane') %></td>
+            <td class="display-two-pane ellipsis"><%= link_to(compute_profile.name, which_path) %></td>
             <td>
               <% set = @compute_resource.compute_attributes.where(:compute_profile_id => compute_profile.id).first %>
               <%= set ? set.name : content_tag(:span, _("unspecified"), :class => 'gray') %>

--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -1,0 +1,38 @@
+require 'integration_test_helper'
+
+class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
+  setup do
+    Fog.mock!
+  end
+
+  teardown do
+    Fog.unmock!
+  end
+
+  def check_two_pane(compute_resource, compute_profile)
+    profile_name = compute_profile.name
+
+    visit compute_resource_path(compute_resource)
+
+    # Select Compute profiles tab and open two pane for the compute profile
+    click_link("Compute profiles")
+    click_link(profile_name)
+
+    assert page.has_selector?('div.two-pane-right'), "Right pane didn't open"
+
+    # Hit Submit and check the original table is displayed again
+    click_button('Submit')
+    assert has_link?(profile_name), "Compute profile table wasn't displayed again"
+
+    # Check the pane is closed
+    assert page.has_no_selector?('div.two-pane-right'), "Right pane didn't close"
+  end
+
+  test "edit compute attributes two pane" do
+    check_two_pane(compute_resources(:ec2), compute_profiles(:one))
+  end
+
+  test "add new compute attributes two pane" do
+    check_two_pane(compute_resources(:ec2), compute_profiles(:three))
+  end
+end


### PR DESCRIPTION
Fixes compute profile two-pane behaviour in compute resource detail page and
adds support for using id '#two_pane_content' for element that should be
replaced after closing the right pane. '#content' is still used by default.
