### PR TITLE
Fixes #16318 - PXE templates now work in safemode

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -71,7 +71,6 @@ class UnattendedController < ApplicationController
     type = 'iPXE' if type == 'gPXE'
 
     if (config = @host.provisioning_template({ :kind => type }))
-      logger.debug "Rendering #{type} template '#{config.name}'"
       if !preview?
         User.as_anonymous_admin do
           safe_render config

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -277,4 +277,9 @@ class Operatingsystem < ActiveRecord::Base
     attributes.merge!({:_destroy => 1}) if template_exists && provisioning_template_id_empty
     (!template_exists && provisioning_template_id_empty)
   end
+
+  # overriden by operating systems
+  def pxe_kernel_options(params)
+    []
+  end
 end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -52,4 +52,10 @@ class Redhat < Operatingsystem
     s.strip!
     s.blank? ? description : s
   end
+
+  def pxe_kernel_options(params)
+    options = super
+    options << "modprobe.blacklist=#{params['blacklist'].gsub(' ', '')}" if params['blacklist']
+    options
+  end
 end

--- a/app/services/host_build_status.rb
+++ b/app/services/host_build_status.rb
@@ -32,7 +32,8 @@ class HostBuildStatus
 
     available_template_kinds.each do |template|
       begin
-        valid_template = host.render_template(template.template)
+        Rails.logger.info "Rendering #{template}"
+        valid_template = host.render_template(template)
         fail!(:templates, _('Template %s is empty.') % template.name, template.name) if valid_template.blank?
       rescue => exception
         Foreman::Logging.exception("Review template error", exception)


### PR DESCRIPTION
The PXE loader patch included some template changes which were not tested
appropriately in safemode. This fixes it, introduces helper method per
particular OS with common kernel command line options.

So far Red Hat family is supported, I am working on Debian/Ubuntu support
already.

Please merge https://github.com/theforeman/community-templates/pull/295 after
this patch and sync templates.

Note the file `snippets/kickstart_cmdline.erb` was dropped, shall I remove it
in this patch or do you prefer to remove it during template sync?

Raising attention as PXE is currently broken in nighlty @dLobato @domcleal
@mhulan
