### PR TITLE
Refs #16222 - remove no-global-assign rule from eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,7 +91,6 @@
     "no-fallthrough": "error",
     "no-floating-decimal": "error",
     "no-func-assign": "error",
-    "no-global-assign": "error",
     "no-implied-eval": "error",
     "no-inline-comments": "off",
     "no-inner-declarations": ["error", "functions"],


### PR DESCRIPTION
Hound uses an older version of eslint that does not support this rule
leading to confusing comments on PRs. The rule is not crucial and can be
removed.
