### PR TITLE
Fixes #16371 - Add support for login page dynamic text

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -9,7 +9,7 @@ class Setting < ActiveRecord::Base
   TYPES= %w{ integer boolean hash array string }
   FROZEN_ATTRS = %w{ name category full_name }
   NONZERO_ATTRS = %w{ puppet_interval idle_timeout entries_per_page max_trend outofsync_interval }
-  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret }
+  BLANK_ATTRS = %w{ trusted_puppetmaster_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text}
   ARRAY_HOSTNAMES = %w{ trusted_puppetmaster_hosts }
   URI_ATTRS = %w{ foreman_url unattended_url }
   URI_BLANK_ATTRS = %w{ login_delegation_logout_url }

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -22,7 +22,8 @@ class Setting::General < Setting
         self.set('use_gravatar', N_("Foreman will use gravatar to display user icons"), false, N_('Use Gravatar')),
         self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true, N_('DB pending migration')),
         self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true, N_('DB pending seed')),
-        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout'))
+        self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout')),
+        self.set('login_text', N_("Text to be shown on the login page"), nil, N_('Login page text'))
       ].each { |s| self.create! s.update(:category => "Setting::General")}
     end
 

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -32,6 +32,7 @@
     <div class="col-sm-5 col-md-6 col-lg-7 details">
       <p><strong><%= _("Welcome to Foreman") %></strong>
       <p id="version"><%= _("Version %{version}") % {:version => SETTINGS[:version]} %></p>
+      <p id="login_text"><%= Setting[:login_text] %></p>
     </div><!--/.col-*-->
   </div>
 </div>


### PR DESCRIPTION
Adds a new general setting called login_text. If this is set to a value, then the text is shown under the product and version information on the login page.
