### PR TITLE
Fixes #16379 - Improve layout of hostname randomize button

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -216,7 +216,6 @@ body.modal-open {
 .input-addon {
   color: black;
 }
-// eof form-control-feedback
 
 legend {
   margin-bottom: 10px;

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -15,17 +15,6 @@ module FormHelper
     end
   end
 
-  def button_input_group(content, options = {}, glyph = nil)
-    options[:type] ||= 'button'
-    options[:herf] ||= '#'
-    options[:class] ||= 'btn btn-default'
-    content_tag :span, class: 'input-group-btn' do
-      content_tag :button, content, options  do
-        content_tag :span,content, :class => glyph
-      end
-    end
-  end
-
   def password_f(f, attr, options = {})
     unset_button = options.delete(:unset)
     password_field_tag(:fakepassword, nil, :style => 'display: none') +
@@ -39,8 +28,8 @@ module FormHelper
              title="'.html_safe + _('Caps lock ON') +
               '" style="display:none"></span>'.html_safe
           if unset_button
-            button = button_input_group '', {:id => 'disable-pass-btn', :onclick => "toggle_input_group(this)", :title => _("Change the password")}, 'glyphicon glyphicon-pencil'
-            input_group pass, button
+            button = link_to_function(icon_text('pencil'), 'toggle_input_group(this)', {:id => 'disable-pass-btn', :class => 'btn btn-default', :title => _("Change the password")})
+            input_group(pass, input_group_btn(button))
           else
             pass
           end
@@ -337,8 +326,8 @@ module FormHelper
         content_tag(:div, :class => "#{wrapper_class} #{error.empty? ? '' : 'has-error'}",
                     :id => options.delete(:control_group_id)) do
           input = capture do
-            if options[:fullscreen]
-              content_tag(:div, yield.html_safe + fullscreen_input, :class => "input-group")
+            if options[:input_group_btn]
+              input_group(yield.html_safe, input_group_btn(options[:input_group_btn]))
             else
               yield.html_safe
             end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -474,8 +474,7 @@ module HostsHelper
   end
 
   def randomize_mac_link
-    link_class = "hide" unless NameGenerator.random_based?
-    link_to_function(icon_text("random", _("Randomize")), "randomizeName()",
-      :title => _('Generate new random name. Visit Settings to disable this feature.'), :'data-placement' => "right", :class => link_class)
+    link_to_function(icon_text('random'), 'randomizeName()', :class => 'btn btn-default',
+      :title => _('Generate new random name. Visit Settings to disable this feature.')) if NameGenerator.random_based?
   end
 end

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -28,7 +28,7 @@
 
       <div class="tab-pane active" id="primary">
         <%= text_f f, :name, :size => "col-md-4", :value => name_field(@host),
-            :help_block => randomize_mac_link,
+            :input_group_btn => randomize_mac_link,
             :help_inline => _("This value is used also as the host's primary interface name.") %>
 
         <% if show_organization_tab?  %>

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -19,7 +19,7 @@
     <%= param_type_selector(f, :onchange => 'keyTypeChange(this)') %>
     <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
                    :disabled => (is_param && (!f.object.override || f.object.use_puppet_default)),
-                   :fullscreen => :true,
+                   :input_group_btn => fullscreen_input,
                    :rows => 1,
                    :help_inline => popover('', _("Value to use when there is no match.")),
                    :class => "no-stretch #{'masked-input' if f.object.hidden_value?}" %>


### PR DESCRIPTION
This moves the button from being a line of its own to an icon inside the
input. Also added a form_feedback option to the field helper to allow
easy addition of more icons in inputs in the future.
