### PR TITLE
Fixes #16092 - Test connection buttons don't disapper on error

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -573,3 +573,12 @@ table {
 .masked-input {
   font-family: 'AllBullets';
 }
+
+.btn-spinner {
+  .spinner {
+    margin: 0.3em;
+  }
+  .caption {
+    float: right;
+  }
+}

--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -65,4 +65,25 @@ module ComputeResourcesHelper
   def unset_password?
     action_name == "edit" || action_name == "test_connection"
   end
+
+  def test_connection_button_f(f, success, caption = nil)
+    caption ||= _("Test Connection")
+    btn_class = success ? 'btn-success' : 'btn-default'
+    spinner_class = success ? 'spinner-inverse' : nil
+    spinner_button_f(f, caption, "testConnection(this)",
+                     :id => 'test_connection_button',
+                     :spinner_id => 'test_connection_indicator',
+                     :class => btn_class,
+                     :spinner_class => spinner_class,
+                     :'data-url' => test_connection_compute_resources_path)
+  end
+
+  def load_button_f(f, success, failure_caption)
+    caption = success ? _("Test Connection") : failure_caption
+    test_connection_button_f(f, success, caption)
+  end
+
+  def load_datacenters_button_f(f, success)
+    load_button_f(f, success, _("Load Datacenters"))
+  end
 end

--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -70,12 +70,17 @@ module ComputeResourcesHelper
     caption ||= _("Test Connection")
     btn_class = success ? 'btn-success' : 'btn-default'
     spinner_class = success ? 'spinner-inverse' : nil
-    spinner_button_f(f, caption, "testConnection(this)",
-                     :id => 'test_connection_button',
-                     :spinner_id => 'test_connection_indicator',
-                     :class => btn_class,
-                     :spinner_class => spinner_class,
-                     :'data-url' => test_connection_compute_resources_path)
+
+    content_tag(:div, :class => "form-group") do
+      content_tag(:div, :class => "col-md-4 col-md-offset-2") do
+        spinner_button_f(f, caption, "testConnection(this)",
+                         :id => 'test_connection_button',
+                         :spinner_id => 'test_connection_indicator',
+                         :class => btn_class,
+                         :spinner_class => spinner_class,
+                         :'data-url' => test_connection_compute_resources_path)
+      end
+    end
   end
 
   def load_button_f(f, success, failure_caption)

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -172,6 +172,14 @@ module FormHelper
     end
   end
 
+  def spinner_button_f(f, caption, action, html_options = {})
+    html_options[:class] ||= 'btn-default'
+    html_options[:class] = "btn btn-spinner #{html_options[:class]}"
+    caption = '<div class="caption">' + caption + '</div>'
+    caption += hidden_spinner('', :id => html_options[:spinner_id], :class => html_options[:spinner_class])
+    link_to_function(caption.html_safe, action, html_options)
+  end
+
   def file_field_f(f, attr, options = {})
     field(f, attr, options) do
       f.file_field attr, options
@@ -310,6 +318,7 @@ module FormHelper
     table_field = options.delete(:table_field)
     error       = options.delete(:error) || f.object.errors[attr] if f && f.object.respond_to?(:errors)
     help_inline = help_inline(options.delete(:help_inline), error)
+    help_inline += options[:help_inline_permanent] unless options[:help_inline_permanent].nil?
     size_class  = options.delete(:size) || "col-md-4"
     wrapper_class = options.delete(:wrapper_class) || "form-group"
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -318,7 +318,6 @@ module FormHelper
     table_field = options.delete(:table_field)
     error       = options.delete(:error) || f.object.errors[attr] if f && f.object.respond_to?(:errors)
     help_inline = help_inline(options.delete(:help_inline), error)
-    help_inline += options[:help_inline_permanent] unless options[:help_inline_permanent].nil?
     size_class  = options.delete(:size) || "col-md-4"
     wrapper_class = options.delete(:wrapper_class) || "form-group"
 

--- a/app/views/compute_resources/form/_ec2.html.erb
+++ b/app/views/compute_resources/form/_ec2.html.erb
@@ -2,5 +2,5 @@
 <%= password_f f, :password, :label => _("Secret Key"), :unset => unset_password? %>
 
 <% regions = f.object.regions rescue [] %>
-<%= selectable_f(f, :region, regions, {}, {:label => _('Region'), :disabled => regions.empty?,
-                 :help_inline_permanent => load_button_f(f, !regions.empty?, _("Load Regions")) }) %>
+<%= selectable_f(f, :region, regions, {}, {:label => _('Region'), :disabled => regions.empty? }) %>
+<%= load_button_f(f, !regions.empty?, _("Load Regions")) %>

--- a/app/views/compute_resources/form/_ec2.html.erb
+++ b/app/views/compute_resources/form/_ec2.html.erb
@@ -3,6 +3,4 @@
 
 <% regions = f.object.regions rescue [] %>
 <%= selectable_f(f, :region, regions, {}, {:label => _('Region'), :disabled => regions.empty?,
-                 :help_inline => link_to_function(regions.empty? ? _("Load Regions") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{regions.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline_permanent => load_button_f(f, !regions.empty?, _("Load Regions")) }) %>

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -4,6 +4,4 @@
 
 <% zones = f.object.zones rescue [] %>
 <%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?,
-                 :help_inline => link_to_function(zones.empty? ? _("Load zones") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{zones.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline_permanent => load_button_f(f, !zones.empty?, _("Load Zones")) }) %>

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -3,5 +3,5 @@
 <%= text_f f, :key_path, :label => _("Certificate path"), :help_inline => _('The file path where your p12 file is located'), :class => 'col-md-8' %>
 
 <% zones = f.object.zones rescue [] %>
-<%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?,
-                 :help_inline_permanent => load_button_f(f, !zones.empty?, _("Load Zones")) }) %>
+<%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty? }) %>
+<%= load_button_f(f, !zones.empty?, _("Load Zones")) %>

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -10,6 +10,4 @@
   <%= f.hidden_field :uuid, :value => hypervisor %>
 <% end %>
 
-<div class="col-md-offset-2">
-  <%= test_connection_button_f(f, !hypervisor.nil?) %>
-</div>
+<%= test_connection_button_f(f, !hypervisor.nil?) %>

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -9,6 +9,7 @@
 <% if hypervisor %>
   <%= f.hidden_field :uuid, :value => hypervisor %>
 <% end %>
-<%= link_to_function _("Test Connection"), "testConnection(this)", :class => "btn + #{hypervisor.nil? ? "btn-default" : "btn-success"}", :'data-url' => test_connection_compute_resources_path %>
 
-<%= hidden_spinner('', :id => 'test_connection_indicator') %>
+<div class="col-md-offset-2">
+  <%= test_connection_button_f(f, !hypervisor.nil?) %>
+</div>

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -3,6 +3,6 @@
 <%= password_f f, :password, :unset => unset_password? %>
 
 <% tenants = f.object.tenants rescue [] %>
-<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty?,
-                 :help_inline_permanent => load_button_f(f, !tenants.empty?, _("Load Tenants")) }) %>
+<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty? }) %>
+<%= load_button_f(f, !tenants.empty?, _("Load Tenants")) %>
 <%= checkbox_f f, :allow_external_network, {:checked => f.object.allow_external_network, :label => _("Allow external network as main network")} %>

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -4,7 +4,5 @@
 
 <% tenants = f.object.tenants rescue [] %>
 <%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty?,
-                 :help_inline => link_to_function(tenants.empty? ? _("Load Tenants") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{tenants.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline_permanent => load_button_f(f, !tenants.empty?, _("Load Tenants")) }) %>
 <%= checkbox_f f, :allow_external_network, {:checked => f.object.allow_external_network, :label => _("Allow external network as main network")} %>

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -4,10 +4,7 @@
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
 <%= selectable_f(f, :uuid, datacenters, {}, {:label => _('Datacenter'),
                  :onchange => 'ovirt_datacenterSelected();',
-                 :help_inline => link_to_function(datacenters.empty? ? _("Load Datacenters") : _("Test Connection"), "testConnection(this)",
-                 :id => 'test_connection_button',
-                 :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) }) %>
 <% quotas = (f.object.uuid.nil? && controller.action_name != 'test_connection') ? [] : f.object.quotas.all rescue []%>
 <%= select_f f, :ovirt_quota, quotas, :id, :name, {}, :label => _("Quota ID") %>
 <%= textarea_f f, :public_key, :label => _("X509 Certification Authorities"), :size => "col-md-8",

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -3,8 +3,8 @@
 <%= password_f f, :password, :unset => unset_password? %>
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
 <%= selectable_f(f, :uuid, datacenters, {}, {:label => _('Datacenter'),
-                 :onchange => 'ovirt_datacenterSelected();',
-                 :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) }) %>
+                 :onchange => 'ovirt_datacenterSelected();' }) %>
+<%= load_datacenters_button_f(f, !datacenters.empty?) %>
 <% quotas = (f.object.uuid.nil? && controller.action_name != 'test_connection') ? [] : f.object.quotas.all rescue []%>
 <%= select_f f, :ovirt_quota, quotas, :id, :name, {}, :label => _("Quota ID") %>
 <%= textarea_f f, :public_key, :label => _("X509 Certification Authorities"), :size => "col-md-8",

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -3,6 +3,4 @@
 <%= password_f f, :password, :label => _("API Key"), :unset => unset_password? %>
 <% flavors = f.object.flavors rescue [] %>
 <%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region'),
-                 :help_inline => link_to_function(_("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{flavors.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+                 :help_inline_permanent => test_connection_button_f(f, !flavors.empty?) }) %>

--- a/app/views/compute_resources/form/_rackspace.html.erb
+++ b/app/views/compute_resources/form/_rackspace.html.erb
@@ -2,5 +2,5 @@
 <%= text_f f, :user %>
 <%= password_f f, :password, :label => _("API Key"), :unset => unset_password? %>
 <% flavors = f.object.flavors rescue [] %>
-<%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region'),
-                 :help_inline_permanent => test_connection_button_f(f, !flavors.empty?) }) %>
+<%= selectable_f(f, :region, f.object.regions, {}, {:label => _('Region') }) %>
+<%= test_connection_button_f(f, !flavors.empty?) %>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -2,7 +2,8 @@
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
 <% datacenters = list_datacenters f.object%>
-<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'), :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) })%>
+<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter') })%>
+<%= load_datacenters_button_f(f, !datacenters.empty?) %>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console passwords"),

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -2,10 +2,7 @@
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
 <% datacenters = list_datacenters f.object%>
-<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'),
-                 :help_inline => link_to_function(datacenters.empty? ? _("Load Datacenters") : _("Test Connection"), "testConnection(this)",
-                 :class => "btn + #{datacenters.empty? ? "btn-default" : "btn-success"}",
-                 :'data-url' => test_connection_compute_resources_path) + hidden_spinner('', :id => 'test_connection_indicator').html_safe }) %>
+<%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'), :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) })%>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console passwords"),


### PR DESCRIPTION
Adds new type of inline help that doesn't disappear when there is a validation error for the field.
It also moves the spinner onto the "Test connection" button. Previously it was placed right next to the field and validation errors were displayed between the spinner and the button.
