### PR TITLE
Fixes #16384 - Localize the names for email prefs

### DIFF
--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -1,5 +1,5 @@
 <%= f.hidden_field :mail_notification_id, :value => f.object.mail_notification.id %>
 <% values = f.object.mail_notification.subscription_type == 'alert' ? f.object.mail_notification.subscription_options : MailNotification::INTERVALS %>
-<%= select_f(f, :interval, values, :to_s, :to_translation, { :include_blank => _('No emails') }, {:label => f.object.mail_notification.name.humanize,
+<%= select_f(f, :interval, values, :to_s, :to_translation, { :include_blank => _('No emails') }, {:label => _(f.object.mail_notification.name.humanize),
              :help_inline => _(f.object.mail_notification.description)}) %>
 <%= mail_notification_query_builder(f.object.mail_notification, f) %>

--- a/db/seeds.d/16-mail_notifications.rb
+++ b/db/seeds.d/16-mail_notifications.rb
@@ -2,6 +2,16 @@
 # and method, and need to define the corresponding ActionMailer and method.
 # For system notifications, set subscriptable to false.  For recurring reports,
 # set subscription_type to 'report', and for ad hoc mails, use 'alert'
+
+# The names below are shown as humanized labels in the UI, so these should be
+# localized
+N_('Puppet summary')
+N_('Welcome')
+N_('Audit summary')
+N_('Host built')
+N_('Tester')
+N_('Puppet error state')
+
 notifications = [
   {
     :name              => 'puppet_summary',


### PR DESCRIPTION
Two changes were made to support this:

1) The seed file which loads the notifications to the db was
augmented to add in the translated forms of the name.
2) The ui was enhanced to use gettext to look up the translations.
