### PR TITLE
Fixes #16358 - Load dashboard on puppet proxy view

### DIFF
--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -62,7 +62,7 @@ class SmartProxiesController < ApplicationController
   end
 
   def puppet_dashboard
-    dashboard = Dashboard::Data.new("puppetmaster = \"#{@smart_proxy.name}\"")
+    dashboard = Dashboard::Data.new("puppet_proxy_id = \"#{@smart_proxy.id}\"")
     @hosts = dashboard.hosts
     @report = dashboard.report
     @latest_events = dashboard.latest_events

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -41,6 +41,7 @@ module Hostext
       scoped_search :in => :environment, :on => :name,    :complete_value => true,  :rename => :environment
       scoped_search :in => :architecture, :on => :name,    :complete_value => true, :rename => :architecture
       scoped_search :in => :puppet_proxy, :on => :name,    :complete_value => true, :rename => :puppetmaster, :only_explicit => true
+      scoped_search :on => :puppet_proxy_id, :complete_value => false, :only_explicit => true
       scoped_search :in => :puppet_ca_proxy, :on => :name, :complete_value => true, :rename => :puppet_ca, :only_explicit => true
       scoped_search :in => :puppet_proxy, :on => :name, :complete_value => true, :rename => :smart_proxy, :ext_method => :search_by_proxy, :only_explicit => true
       scoped_search :in => :compute_resource, :on => :name,    :complete_value => true, :rename => :compute_resource

--- a/app/views/dashboard/_reports_widget.html.erb
+++ b/app/views/dashboard/_reports_widget.html.erb
@@ -1,9 +1,7 @@
 <h4 class="header">
   <%= _("Latest Events") %>
 </h4>
-<% if @latest_events.empty? %>
-  <p class="ca"><%= _("No interesting reports received in the last week") %></p>
-<% else %>
+<% if @latest_events.exists? %>
   <table class="<%= table_css_classes 'table-fixed reports-table' %>">
     <thead>
       <tr>
@@ -24,4 +22,6 @@
       <% end %>
     </tbody>
   </table>
+<% else %>
+  <p class="ca"><%= _("No interesting reports received in the last week") %></p>
 <% end %>


### PR DESCRIPTION
Some changes made to the main dashboard caused the puppet dashboard on
the smart proxy page to break.
This commit also includes small improvements to the dashboard loading
performance.
