### PR TITLE
Fixes #16397 - set nested objects to optional for template_combinations

### DIFF
--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Foreman::Controller::Parameters::TemplateCombination
 
       before_action :rename_config_template
-      before_action :find_required_nested_object
+      before_action :find_optional_nested_object
       before_action :find_resource, :only => [:show, :update, :destroy]
 
       def_param_group :template_combination_identifiers do

--- a/test/functional/api/v2/template_combinations_controller_test.rb
+++ b/test/functional/api/v2/template_combinations_controller_test.rb
@@ -100,4 +100,20 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
       refute TemplateCombination.exists?(template_combinations(:two).id)
     end
   end
+
+  context 'unnested combinations' do
+    test "should get template combination directly" do
+      get :show, { :id => template_combinations(:two).id }
+      assert_response :success
+      template_combination = ActiveSupport::JSON.decode(@response.body)
+      assert !template_combination.empty?
+      assert_equal template_combination["provisioning_template_id"], template_combinations(:two).provisioning_template_id
+    end
+
+    test "should destroy directly" do
+      delete :destroy, { :id => template_combinations(:two).id }
+      assert_response :ok
+      refute TemplateCombination.exists?(template_combinations(:two).id)
+    end
+  end
 end


### PR DESCRIPTION
Fixes a bug introduced in ee66b3af2f9497404734ef39f3d60a64a14b3928, nested objects are not required in this case: you should still be able to use `/template_combinations/:id` url.
