### PR TITLE
Fixes #16378 - Move default_value casting to lookup_key children

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -20,14 +20,11 @@ class LookupKey < ActiveRecord::Base
                                 :allow_destroy => true
 
   alias_attribute :value, :default_value
-  before_validation :cast_default_value
 
   validates :key, :presence => true
   validates :validator_type, :inclusion => { :in => VALIDATOR_TYPES, :message => N_("invalid")}, :allow_blank => true, :allow_nil => true
   validates :key_type, :inclusion => {:in => KEY_TYPES, :message => N_("invalid")}, :allow_blank => true, :allow_nil => true
-  validate :validate_default_value
   validates_associated :lookup_values
-  validate :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default, :if =>  Proc.new { |lk| lk.override || !lk.puppet? }
 
   before_save :sanitize_path
   attr_name :key

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -2,7 +2,10 @@ class PuppetclassLookupKey < LookupKey
   has_many :environment_classes, :dependent => :destroy
   has_many :environments, -> { uniq }, :through => :environment_classes
   has_many :param_classes, :through => :environment_classes, :source => :puppetclass
+
+  before_validation :cast_default_value, :if => :override?
   before_validation :check_override_selected, :if => -> { persisted? && @validation_context != :importer }
+  validate :validate_default_value, :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default, :if => :override?
   after_validation :reset_override_params, :if => ->(key) { key.override_changed? && !key.override? }
 
   scoped_search :in => :param_classes, :on => :name, :rename => :puppetclass, :alias => :puppetclass_name, :complete_value => true

--- a/app/models/lookup_keys/variable_lookup_key.rb
+++ b/app/models/lookup_keys/variable_lookup_key.rb
@@ -1,8 +1,10 @@
 class VariableLookupKey < LookupKey
   belongs_to :puppetclass, :inverse_of => :lookup_keys
 
+  before_validation :cast_default_value
   validates :puppetclass, :presence => true
   validates :key, :uniqueness => true, :no_whitespace => true
+  validate :validate_default_value, :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default
 
   scoped_search :in => :puppetclass, :on => :name, :complete_value => true, :rename => :puppetclass
 

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -122,9 +122,9 @@ class ClassificationTest < ActiveSupport::TestCase
   test "#value_of_key should correctly typecast JSON and YAML default values" do
     env = FactoryGirl.create(:environment)
     pc = FactoryGirl.create(:puppetclass, :environments => [env])
-    yaml_lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
+    yaml_lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true,
                                    :puppetclass => pc, :key_type => 'yaml', :default_value => 'a: b')
-    json_lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
+    json_lkey = FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true,
                                    :puppetclass => pc, :key_type => 'json', :default_value => '{"a": "b"}')
     classparam = Classification::ClassParam.new
 

--- a/test/unit/lookup_key_test.rb
+++ b/test/unit/lookup_key_test.rb
@@ -134,6 +134,17 @@ class LookupKeyTest < ActiveSupport::TestCase
     assert_equal default, Classification::GlobalParam.new(:host=>@host3).enc['dns']
   end
 
+  test 'default_value value should not be casted if override is false' do
+    param = FactoryGirl.build(:puppetclass_lookup_key, :as_smart_class_param,
+                              :override => false, :key_type => 'boolean',
+                              :default_value => 't', :puppetclass => puppetclasses(:one))
+    param.save
+    assert_equal 't', param.default_value
+    param.override = true
+    param.save
+    assert_equal true, param.default_value
+  end
+
   describe '#default_value_before_type_cast' do
     test 'nil value should remain nil' do
       param = FactoryGirl.build(:puppetclass_lookup_key, :as_smart_class_param,


### PR DESCRIPTION
For puppetclass_lookup_key casting/validation should only be done when override is true so each child of lookup_key needs to decide when to call them.
