### PR TITLE
Fixes #16219 - Interfaces API works with scoped view_hosts

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -56,7 +56,22 @@ module Api
       association = resource_class.reflect_on_all_associations.find {|assoc| assoc.plural_name == parent_name.pluralize}
       #if couldn't find an association by name, try to find one by class
       association ||= resource_class.reflect_on_all_associations.find {|assoc| assoc.class_name == parent_name.camelize}
-      resource_class.joins(association.name).merge(scope)
+      result_scope = resource_class.joins(association.name).merge(scope)
+      # Check that the scope resolves before return
+      result_scope if result_scope.to_a
+    rescue ActiveRecord::ConfigurationError
+      # Chaining SQL with a parent scope does not always work, as the
+      # parent scope might have attributes the resource_class does not have.
+      #
+      # For example, chaining 'interfaces' with a parent scope (hosts) that
+      # contains an authorization filter (hostgroup = foo), will not work
+      # as the resulting SQL has attributes (hostgroup) the
+      # resource_class does not have.
+      #
+      # In such cases, we resolve the scope first, and then call 'where'
+      # on the results
+      resource_class.joins(association.name).
+        where(association.name => scope.map(&:id))
     end
 
     def resource_scope_for_index(options = {})

--- a/test/functional/api/base_controller_subclass_test.rb
+++ b/test/functional/api/base_controller_subclass_test.rb
@@ -228,6 +228,7 @@ class Api::TestableControllerTest < ActionController::TestCase
         setup do
           @testable_scope1.expects(:find).with('1').returns(@testable_obj)
           @testable_scope1.expects(:empty?).returns(false)
+          @testable_scope1.expects(:to_a).returns([@testable_obj])
         end
 
         it 'should return nested resource for unauthorized resource' do

--- a/test/functional/api/v2/interfaces_controller_test.rb
+++ b/test/functional/api/v2/interfaces_controller_test.rb
@@ -77,5 +77,12 @@ class Api::V2::InterfacesControllerTest < ActionController::TestCase
       get :index, { :host_id => @host.name }, set_session_user
       assert_response :not_found
     end
+
+    test 'user with hostgroup-scoped view_hosts can view its interfaces' do
+      @host.update_attributes(:hostgroup => FactoryGirl.create(:hostgroup))
+      setup_user 'view', 'hosts', "hostgroup_title = #{@host.hostgroup.title}"
+      get :index, { :host_id => @host.name }, set_session_user
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
Before this commit, parent_scope called 'merge' on a scope that may
contain conditions that do not make sense on 'resource_class'.

In this case, when a user with a filter :view_hosts and search
'hostgroup_fullname = foo' tried to view
api/v2/hosts/somehost/interfaces, that would not work.

The SQL generated by `scope_for` contains
`AND ((hostgroups.title = 'base'))`, which clearly cannot be
merged with the Nic::Base scope, as 'hostgroups' isn't a field in
Nic::Base.

To avoid this problem, we resolve the scope and call 'where' on the
scope ids, instead of merging the parent and the child scope.

Notice this problem exists for any child/parent relationship where the
user has a filter :view_parent , search 'parent_attribute = foo' if
parent_attribute is not defined in the child.

---

The old parent scope was wrong, by the way. It was a simple '"SELECT \"hosts\".\* FROM \"hosts\" WHERE \"hosts\".\"type\" IN ('Host::Managed')"' which does NOT apply any authorization filters, the fix for the CVE fixed that.
