### PR TITLE
Fixes #16439 - Don't fail recreate if DNS is ok

### DIFF
--- a/app/models/concerns/dns_interface.rb
+++ b/app/models/concerns/dns_interface.rb
@@ -35,7 +35,8 @@ module DnsInterface
   end
 
   def recreate_dns_record(type)
-    set_dns_record(type) unless dns_record(type).nil? || dns_record(type).valid?
+    return true if dns_record(type).nil? || dns_record(type).valid?
+    set_dns_record(type)
   end
 
   def set_dns_record(type)

--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -42,11 +42,10 @@ module Orchestration::DNS
     results = {}
 
     DnsInterface::RECORD_TYPES.each do |record_type|
-      results[record_type] = true
       del_dns_record_safe(record_type)
 
       begin
-        results[record_type] = recreate_dns_record(record_type) if dns_feasible?(record_type)
+        results[record_type] = dns_feasible?(record_type) ? recreate_dns_record(record_type) : true
       rescue => e
         Foreman::Logging.exception "Failed to rebuild DNS record for #{name}(#{ip}/#{ip6})", e, :level => :error
         return false

--- a/test/unit/orchestration/dns_test.rb
+++ b/test/unit/orchestration/dns_test.rb
@@ -175,6 +175,15 @@ class DnsOrchestrationTest < ActiveSupport::TestCase
         assert_equal 4, tasks.size
       end
     end
+
+    context 'dns not feasible' do
+      test 'should not fail dns rebuild' do
+        Nic::Managed.any_instance.stubs(:dns_feasible?).returns(false)
+        Nic::Managed.any_instance.expects(:recreate_dns_record).never
+        @host.save!
+        assert @host.interfaces.first.rebuild_dns
+      end
+    end
   end
 
   context 'host with ipv6 dns' do


### PR DESCRIPTION
If rebuilding a host and DNS is not "feasible" we don't want to fail
that host but rather recreate what's currently feasible.

If a DNS record is still valid we don't want to fail that host but
rather take the still valid entry.
