### PR TITLE
Fixes #16380 - Eager load hosts attributes

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -29,7 +29,8 @@ module Api
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
-        @hosts = resource_scope_for_index.includes([ :host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token ])
+        @hosts = resource_scope_for_index
+                   .eager_load([:host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token])
         # SQL optimizations queries
         @last_report_ids = Report.where(:host_id => @hosts.map(&:id)).group(:host_id).maximum(:id)
         @last_reports = Report.where(:id => @last_report_ids.values)

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -78,6 +78,17 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert !hosts.empty?
   end
 
+  test "should get attributes in ordered index" do
+    last_record.update(ip: "127.13.0.1")
+    get :index, order: "mac"
+    assert_response :success
+    assert_not_nil assigns(:hosts)
+    hosts = ActiveSupport::JSON.decode(@response.body)
+    ip_addresses = hosts["results"].map { |host| host["ip"] }
+    refute ip_addresses.empty?
+    assert_includes(ip_addresses, "127.13.0.1")
+  end
+
   test "should show individual record" do
     get :show, { :id => @host.to_param }
     assert_response :success


### PR DESCRIPTION
Since Rails 4, in order to load delegated attributes,
we need to use 'eager_load' instead of 'includes'
