### PR TITLE
Refs #7233 - Fixing erroneous rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,9 +24,6 @@ Style/Documentation:
 # Support both ruby19 and hash_rockets
 Style/HashSyntax:
   Enabled: false
-  SupportedStyles:
-    - ruby19
-    - hash_rockets
 
 Metrics/ClassLength:
   Exclude:


### PR DESCRIPTION
SupportedStyles is not meant to be configured and configuring it in this way does nothing.
