### PR TITLE
Fixes #16463 - Fix with_taxonomy_scope when taxable_ids = []

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -36,12 +36,7 @@ module Taxonomix
       self.which_location        = Location.expand(loc) if SETTINGS[:locations_enabled]
       self.which_organization    = Organization.expand(org) if SETTINGS[:organizations_enabled]
       scope = block_given? ? yield : where('1=1')
-      tax_ids = taxable_ids
-      # we need to generate part of SQL query as a string, otherwise the default scope would set id on each
-      # new instance and the same taxable_id on taxable_taxonomy objects
-      if tax_ids.present?
-        scope = scope.where("#{self.table_name}.id IN (#{tax_ids.join(',')})")
-      end
+      scope = scope_by_taxable_ids(scope)
       scope.readonly(false)
     end
 
@@ -115,6 +110,21 @@ module Taxonomix
 
     def admin_ids
       User.unscoped.where(:admin => true).pluck(:id) if self == User
+    end
+
+    def scope_by_taxable_ids(scope)
+      case (cached_ids = taxable_ids)
+      when nil
+        scope
+      when []
+        # If *no* taxable ids were found, then don't show any resources
+        scope.where(:id => [])
+      else
+        # We need to generate the WHERE part of the SQL query as a string,
+        # otherwise the default scope would set id on each new instance
+        # and the same taxable_id on taxable_taxonomy objects
+        scope.where("#{self.table_name}.id IN (#{cached_ids.join(',')})")
+      end
     end
   end
 


### PR DESCRIPTION
The old implementation of taxonomy_scope was relying on calling
`scope.where(:id => [])`, it did it 'if taxable_ids'. A recent change
introduced more checking into that condition (taxable_ids.present?)
which made the case when taxable_ids == [] not run any scope.

That results in objects not being scoped at all when taxable_ids
is an empty array.

To reproduce, simply go to any page with scoped content, like
smart proxies or compute resources, and see how the scoped content
still shows up when choosing the wrong taxonomy.

![](http://i.imgur.com/Qu4zSk6.png)
