### PR TITLE
Fixes #16472 - Pin gettext_i18n_rails to < 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'friendly_id', '~> 5.0'
 gem 'secure_headers', '~> 1.3'
 gem 'safemode', '~> 1.2', '>= 1.2.4'
 gem 'fast_gettext', '>= 0.8', '< 1.2.0'
-gem 'gettext_i18n_rails', '~> 1.0'
+gem 'gettext_i18n_rails', '~> 1.7.2' # 1.8.0 only supports ruby 2.1+
 gem 'rails-i18n', '~> 4.0.0'
 gem 'turbolinks', '~> 2.5'
 gem 'logging', '>= 1.8.0', '< 3.0.0'


### PR DESCRIPTION
gettext_i18n_rails 1.8.0 only supports Ruby 2.1+
