### PR TITLE
fixes #16512 - remove Setting#respond_to_missing?

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -78,7 +78,7 @@ module Api
       end
 
       def metadata_per_page
-        @per_page ||= params[:per_page].present? ? params[:per_page].to_i : Setting::General.entries_per_page
+        @per_page ||= params[:per_page].present? ? params[:per_page].to_i : Setting[:entries_per_page]
       end
 
       # For the purpose of ADDING/REMOVING associations in CHILD node on POST/PUT payload

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -14,7 +14,7 @@ module TrendsHelper
   def trend_days_filter
     form_tag @trend, :id => 'days_filter', :method => :get, :class=>"form form-inline" do
       content_tag(:span, (_("Trend of the last %s days.") %
-                          select(nil, 'range', 1..Setting.max_trend, {:selected => range},
+                          select(nil, 'range', 1..Setting[:max_trend], {:selected => range},
                                  {:onchange =>"$('#days_filter').submit();$(this).attr('disabled','disabled');;"})).html_safe)
     end
   end
@@ -27,7 +27,7 @@ module TrendsHelper
     end
   end
 
-  def chart_data(trend, from = Setting.max_trend, to = Time.now.utc)
+  def chart_data(trend, from = Setting[:max_trend], to = Time.now.utc)
     chart_colors = ['#4572A7','#AA4643','#89A54E','#80699B','#3D96AE','#DB843D','#92A8CD','#A47D7C','#B5CA92']
     values = trend.values
     labels = {}
@@ -49,6 +49,6 @@ module TrendsHelper
   end
 
   def range
-    params["range"].empty? ? Setting.max_trend : params["range"].to_i
+    params["range"].empty? ? Setting[:max_trend] : params["range"].to_i
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -47,7 +47,7 @@ class Domain < ActiveRecord::Base
   # return the primary name server for our domain based on DNS lookup
   # it first searches for SOA record, if it failed it will search for NS records
   def nameservers
-    return [] if Setting.query_local_nameservers
+    return [] if Setting[:query_local_nameservers]
     dns = Resolv::DNS.new
     ns = dns.getresources(name, Resolv::DNS::Resource::IN::SOA).collect {|r| r.mname.to_s}
     ns = dns.getresources(name, Resolv::DNS::Resource::IN::NS).collect {|r| r.name.to_s} if ns.empty?

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -95,15 +95,14 @@ class Setting < ActiveRecord::Base
 
     #setter method
     if method_name =~ /=\Z/
-      self[method_name.chomp("=")] = args.first
+      setting_name = method_name.chomp("=")
+      Foreman::Deprecation.deprecation_warning('1.16', "Setting.#{method_name} must be replaced with Setting[:#{setting_name}]= to write settings")
+      self[setting_name] = args.first
       #getter
     else
+      Foreman::Deprecation.deprecation_warning('1.16', "Setting.#{method_name} must be replaced with Setting[:#{method_name}] to read settings")
       self[method_name]
     end
-  end
-
-  def self.respond_to_missing?(method_name, include_private = false)
-    true
   end
 
   def value=(v)

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -4,12 +4,12 @@
 
 <% if @trends.empty? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter defined"),
-            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting.puppet_interval) %>
+            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting[:puppet_interval]) %>
 <% end %>
 
 <% if @trends.any? and TrendCounter.unconfigured? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter found"),
-            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting.puppet_interval) %>
+            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting[:puppet_interval]) %>
 <% end %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -118,7 +118,7 @@ class ActiveRecord::Base
     # Foreman.in_rake? prevents the failure of db:migrate for postgresql
     # don't query settings table if in rake
     return 20 if Foreman.in_rake?
-    Setting.entries_per_page rescue 20
+    Setting[:entries_per_page] rescue 20
   end
 
   def self.audited(*args)

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1067,7 +1067,7 @@ class HostTest < ActiveSupport::TestCase
       assert h.save
       h.root_pass = nil
       assert h.save!
-      assert_equal h.root_pass, Setting.root_pass
+      assert_equal h.root_pass, Setting[:root_pass]
     end
 
     test "should crypt the password and update it in the database" do

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -26,16 +26,24 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   def test_should_find_setting_via_method_missing_too
+    Foreman::Deprecation.expects(:deprecation_warning).twice
     assert Setting.create(:name => "bar", :value => "baz", :default => "x", :description => "test bar")
     assert_equal Setting["bar"], Setting.bar
     assert_equal "baz", Setting.bar
+  end
+
+  def test_should_write_setting_via_method_missing_too
+    Foreman::Deprecation.expects(:deprecation_warning)
+    assert Setting.create(:name => "bar", :value => "baz", :default => "x", :description => "test bar")
+    Setting.bar = 'foo'
+    assert_equal 'foo', Setting.find_by_name('bar').value
   end
 
   def test_settings_with_the_same_value_as_default_should_not_save_the_value
     assert Setting.create(:name => "foo", :value => "bar", :default => "bar", :description => "x")
     s = Setting.find_by_name "foo"
     assert_nil s.read_attribute(:value)
-    assert_equal "bar", Setting.foo
+    assert_equal "bar", Setting[:foo]
   end
 
   def test_should_not_allow_to_change_frozen_attributes


### PR DESCRIPTION
respond_to_missing? changed how AR handles group_by calls on
collections, causing group_by to be interpreted as a scope on the model.
Rather than adding a database call to determine known setting names,
it's been removed again.

The method_missing implementation has been deprecated in favour of the
hash [] style method calls which are more idiomatic and avoids making
the respond_to? behaviour any more complex.
