### PR TITLE
Fixes #16525 - host/hostgroup - include _name fields for proxy

### DIFF
--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -4,5 +4,6 @@ extends "api/v2/hostgroups/base"
 
 attributes :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name, :domain_id, :domain_name,
            :environment_id, :environment_name, :compute_profile_id, :compute_profile_name, :ancestry, :parent_id, :parent_name,
-           :puppet_proxy_id, :puppet_ca_proxy_id, :ptable_id, :ptable_name, :medium_id, :medium_name,
+           :puppet_proxy_id, :puppet_proxy_name, :puppet_ca_proxy_id, :puppet_ca_proxy_name,
+           :ptable_id, :ptable_name, :medium_id, :medium_name,
            :architecture_id, :architecture_name, :realm_id, :realm_name, :created_at, :updated_at

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -11,9 +11,10 @@ attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :r
            :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
            :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
            :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_type,
-           :enabled, :puppet_ca_proxy_id, :managed, :use_image, :image_file, :uuid, :compute_resource_id, :compute_resource_name,
+           :enabled, :puppet_ca_proxy_id, :puppet_ca_proxy_name, :managed, :use_image, :image_file, :uuid,
+           :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
-           :puppet_proxy_id, :certname, :image_id, :image_name, :created_at, :updated_at,
+           :puppet_proxy_id, :puppet_proxy_name, :certname, :image_id, :image_name, :created_at, :updated_at,
            :last_compile, :global_status, :global_status_label
 attributes :organization_id, :organization_name if SETTINGS[:organizations_enabled]
 attributes :location_id, :location_name         if SETTINGS[:locations_enabled]


### PR DESCRIPTION
Adding the following attributes for consistency:
  puppet_proxy_name
  puppet_ca_proxy_name
