### PR TITLE
Fixes #14545 - Correctly parse y.z minor OS version from facts

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -179,10 +179,4 @@ class FactParser
   def not_implemented_error(method)
     "#{method} fact parsing not implemented in #{self.class}"
   end
-
-  def is_numeric?(string)
-    !!Integer(string)
-  rescue ArgumentError, TypeError
-    false
-  end
 end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -99,6 +99,17 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     refute @importer.operatingsystem.description
   end
 
+  test 'should accept y.z minor version' do
+    FactoryGirl.create(:operatingsystem, name: "CentOS",
+                                         major: "7",
+                                         minor: "2.1511",
+                                         description: "CentOS Linux 7.2.1511")
+    assert_valid PuppetFactParser.new({ "operatingsystem" => "CentOS",
+                                        "lsbdistdescription" => "CentOS Linux release 7.2.1511 (Core) ",
+                                        "operatingsystemrelease" => "7.2.1511"
+    }).operatingsystem
+  end
+
   test "should set os.major and minor correctly from AIX facts" do
     @importer = PuppetFactParser.new(aix_facts)
     assert_equal 'AIX', @importer.operatingsystem.family


### PR DESCRIPTION
Some OSes use y.z minor version, for example CentOS uses versions such
as 7.2.1511. Currently, the puppet fact parser will only take the 'y'
part of the version, 2 in this case, which can lead to conflicts if the
OS has been defined manually with the 2.1511 minor version (as the
description will still contain the entire version).
