### PR TITLE
Fixes #16532 - fixed hostgroup architecture params

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -346,11 +346,13 @@ function subnet_contains(network, cidr, ip) {
 }
 
 function architecture_selected(element){
-  var attrs   = attribute_hash(['architecture_id', 'organization_id', 'location_id']);
   var url = $(element).attr('data-url');
+  var type = $(element).attr('data-type');
+  var attrs = {};
+  attrs[type] = attribute_hash(['architecture_id', 'organization_id', 'location_id']);
   tfm.tools.showSpinner();
   $.ajax({
-    data: {host: attrs},
+    data: attrs,
     type:'post',
     url: url,
     complete: function(){
@@ -363,11 +365,13 @@ function architecture_selected(element){
 }
 
 function os_selected(element){
-  var attrs = attribute_hash(['operatingsystem_id', 'organization_id', 'location_id']);
   var url = $(element).attr('data-url');
+  var type = $(element).attr('data-type');
+  var attrs = {};
+  attrs[type] = attribute_hash(['operatingsystem_id', 'organization_id', 'location_id']);
   tfm.tools.showSpinner();
   $.ajax({
-    data: {host: attrs},
+    data: attrs,
     type:'post',
     url: url,
     complete: function(){
@@ -416,10 +420,9 @@ function update_provisioning_image(){
 function medium_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
-  var obj = (type == "hosts" ? "host" : "hostgroup");
   var attrs = {};
-  attrs[obj] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id']);
-  attrs[obj]["use_image"] = $('*[id*=use_image]').attr('checked') == "checked";
+  attrs[type] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id']);
+  attrs[type]["use_image"] = $('*[id*=use_image]').attr('checked') == "checked";
   $.ajax({
     data: attrs,
     type:'post',
@@ -433,22 +436,21 @@ function medium_selected(element){
 function use_image_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
-  var obj = (type == "hosts" ? "host" : "hostgroup");
   var attrs = {};
-  attrs[obj] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']);
-  attrs[obj]['use_image'] = ($(element).attr('checked') == "checked");
+  attrs[type] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']);
+  attrs[type]['use_image'] = ($(element).attr('checked') == "checked");
   $.ajax({
     data: attrs,
     type: 'post',
     url:  url,
     success: function(response) {
       var field = $('*[id*=image_file]');
-      if (attrs[obj]["use_image"]) {
+      if (attrs[type]["use_image"]) {
         if (field.val() == "") field.val(response["image_file"]);
       } else
         field.val("");
 
-      field.attr("disabled", !attrs[obj]["use_image"]);
+      field.attr("disabled", !attrs[type]["use_image"]);
     }
   });
 }

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -59,8 +59,6 @@ module Host
                                     :domain, :domain_id, :domain_name,
                                     :lookup_values_attributes].freeze
 
-    after_initialize :suggest_default_pxe_loader
-
     # primary interface is mandatory because of delegated methods so we build it if it's missing
     # similar for provision interface
     # we can't set name attribute until we have primary interface so we don't pass it to super

--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -4,6 +4,6 @@
     { :label => _("Operating system"),
       :disabled => arch_oss.empty? ? true : false,
       :help_inline => :indicator,
-      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :required => true}
+      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize, :required => true}
   %>
 <% end %>

--- a/app/views/common/os_selection/_image_details.html.erb
+++ b/app/views/common/os_selection/_image_details.html.erb
@@ -1,7 +1,7 @@
 <%= fields_for item do |f| %>
   <span id="image_details">
     <%= checkbox_f f, :use_image, :label => _("OS Image"), :help_inline => _("Build from OS image"),
-                   :onchange => 'use_image_selected(this)', :'data-url'=> method_path('use_image_selected'), :'data-type' => controller_name %>
+                   :onchange => 'use_image_selected(this)', :'data-url'=> method_path('use_image_selected'), :'data-type' => controller_name.singularize %>
     <%= text_f f, :image_file, :disabled => !item.use_image, :class => "col-md-6" %>
   </span>
 <% end %>

--- a/app/views/common/os_selection/_initial.html.erb
+++ b/app/views/common/os_selection/_initial.html.erb
@@ -1,6 +1,6 @@
 <%= fields_for item do |f| %>
   <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => blank_or_inherit_f(f, :architecture)},
-    {:label => _("Architecture"), :onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected')} %>
+    {:label => _("Architecture"), :onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' => controller_name.singularize} %>
 
   <span id="host_os">
     <span id="os_select">

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -3,7 +3,7 @@
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
     {:label => _("Media"), :disabled => os_media.empty?,
      :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' =>  method_path('medium_selected'),
-     :'data-type' => controller_name, :required => true }
+     :'data-type' => controller_name.singularize, :required => true }
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -1,6 +1,6 @@
 
 <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => true},
-    {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'),
+    {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' => controller_name.singularize,
     :help_inline => :indicator, :required => true} %>
 
 <span id="os_select">

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -5,6 +5,31 @@ class HostgroupJSTest < IntegrationTestWithJavascript
   #   HostgroupJSTest.test_0001_submit updates taxonomy
   extend Minitest::OptionalRetry
 
+  test 'creates a hostgroup with provisioning data' do
+    env = FactoryGirl.create(:environment)
+    os = FactoryGirl.create(:ubuntu14_10, :with_associations)
+    visit new_hostgroup_path
+
+    fill_in 'hostgroup_name', :with => 'myhostgroup1'
+    select2 env.name, :from => 'hostgroup_environment_id'
+    click_link 'Operating System'
+    wait_for_ajax
+    select2 os.architectures.first.name, :from => 'hostgroup_architecture_id'
+    wait_for_ajax
+    select2 os.title, :from => 'hostgroup_operatingsystem_id'
+    wait_for_ajax
+    select2 os.media.first.name, :from => 'hostgroup_medium_id'
+    wait_for_ajax
+    select2 os.ptables.first.name, :from => 'hostgroup_ptable_id'
+    fill_in 'hostgroup_root_pass', :with => '12345678'
+    assert_submit_button(new_hostgroup_path)
+    wait_for_ajax
+
+    host = Hostgroup.where(:name => "myhostgroup1").first
+    assert host
+    assert_equal env.name, host.environment.name
+  end
+
   test 'submit updates taxonomy' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     new_location = FactoryGirl.create(:location)


### PR DESCRIPTION
We changed the `assign_parameter` implementation to accept the parameters as
regular hash with root element, but the JavaScript part was hardcoded to always
send `host`.

This patch changes the behavior to send `host` or `hostgroup` accordingly the
same way as in `medium_selected` which fixes the issue in hostgroup form (it
was not possible to set architecture).

Regression in 1.13 RC1 introduced by UEFI PXE loader implementation.
