### PR TITLE
fixes #16592 - Update the menu labels with using initial caps

### DIFF
--- a/app/services/menu/loader.rb
+++ b/app/services/menu/loader.rb
@@ -13,11 +13,11 @@ module Menu
 
       Manager.map :user_menu do |menu|
         menu.item :my_account,
-                  :caption => N_('My account'),
+                  :caption => N_('My Account'),
                   :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
         menu.divider
         menu.item :logout,
-                  :caption => N_('Log out'),
+                  :caption => N_('Log Out'),
                   :html => {:method => :post},
                   :url_hash => {:controller => '/users', :action => 'logout'}
       end
@@ -28,9 +28,9 @@ module Menu
           menu.item :organizations,      :caption => N_('Organizations') if SETTINGS[:organizations_enabled]
           menu.divider
           if SETTINGS[:login]
-            menu.item :auth_source_ldaps,:caption => N_('LDAP authentication')
+            menu.item :auth_source_ldaps,:caption => N_('LDAP Authentication')
             menu.item :users,            :caption => N_('Users')
-            menu.item :usergroups,       :caption => N_('User groups')
+            menu.item :usergroups,       :caption => N_('User Groups')
             menu.item :roles,            :caption => N_('Roles')
           end
           menu.divider
@@ -48,45 +48,45 @@ module Menu
           menu.item :trends,            :caption => N_('Trends')
           menu.item :audits,            :caption => N_('Audits')
           menu.divider                  :caption => N_('Reports')
-          menu.item :reports,           :caption => N_('Config management'),
+          menu.item :reports,           :caption => N_('Config Management'),
                     :url_hash => {:controller => '/config_reports', :action => 'index', :search => 'eventful = true'}
           menu.divider
         end
 
         menu.sub_menu :hosts_menu,      :caption => N_('Hosts') do
-          menu.item :hosts,             :caption => N_('All hosts')
-          menu.item :newhost,           :caption => N_('New host'),
+          menu.item :hosts,             :caption => N_('All Hosts')
+          menu.item :newhost,           :caption => N_('New Host'),
                     :url_hash => {:controller => '/hosts', :action => 'new'}
           if SETTINGS[:unattended]
             menu.divider                :caption => N_('Provisioning Setup')
             menu.item :architectures,   :caption => N_('Architectures')
-            menu.item :models,          :caption => N_('Hardware models')
-            menu.item :media,           :caption => N_('Installation media')
-            menu.item :operatingsystems,:caption => N_('Operating systems')
+            menu.item :models,          :caption => N_('Hardware Models')
+            menu.item :media,           :caption => N_('Installation Media')
+            menu.item :operatingsystems,:caption => N_('Operating Systems')
             menu.divider                :caption => N_('Templates')
-            menu.item :partition_tables, :caption => N_('Partition tables'),
+            menu.item :partition_tables, :caption => N_('Partition Tables'),
                       :url_hash => { :controller => 'ptables', :action => 'index' }
-            menu.item :provisioning_templates, :caption => N_('Provisioning templates'),
+            menu.item :provisioning_templates, :caption => N_('Provisioning Templates'),
                       :url_hash => { :controller => 'provisioning_templates', :action => 'index' }
           end
         end
 
         menu.sub_menu :configure_menu,  :caption => N_('Configure') do
-          menu.item :hostgroups,        :caption => N_('Host groups')
-          menu.item :common_parameters, :caption => N_('Global parameters')
+          menu.item :hostgroups,        :caption => N_('Host Groups')
+          menu.item :common_parameters, :caption => N_('Global Parameters')
           menu.divider                  :caption => N_('Puppet')
           menu.item :environments,      :caption => N_('Environments')
           menu.item :puppetclasses,     :caption => N_('Classes')
-          menu.item :config_groups,     :caption => N_('Config groups')
-          menu.item :variable_lookup_keys, :caption => N_('Smart variables')
-          menu.item :puppetclass_lookup_keys, :caption => N_('Smart class parameters')
+          menu.item :config_groups,     :caption => N_('Config Groups')
+          menu.item :variable_lookup_keys, :caption => N_('Smart Variables')
+          menu.item :puppetclass_lookup_keys, :caption => N_('Smart Class Parameters')
         end
 
         menu.sub_menu :infrastructure_menu, :caption => N_('Infrastructure') do
-          menu.item :smart_proxies, :caption => N_('Smart proxies')
+          menu.item :smart_proxies, :caption => N_('Smart Proxies')
           if SETTINGS[:unattended]
-            menu.item :compute_resources, :caption => N_('Compute resources')
-            menu.item :compute_profiles,  :caption => N_('Compute profiles')
+            menu.item :compute_resources, :caption => N_('Compute Resources')
+            menu.item :compute_profiles,  :caption => N_('Compute Profiles')
             menu.item :subnets,           :caption => N_('Subnets')
             menu.item :domains,           :caption => N_('Domains')
             menu.item :realms,            :caption => N_('Realms')


### PR DESCRIPTION
Change the labels in the navigation menus which are using sentence capitalization to use initial caps.
