### PR TITLE
fixes #16545 - correctly search for classes from YAML import

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -487,7 +487,9 @@ class Host::Managed < Host::Base
   def importNode(nodeinfo)
     myklasses= []
     # puppet classes
-    nodeinfo["classes"].each do |klass|
+    classes = nodeinfo["classes"]
+    classes = classes.keys if classes.is_a?(Hash)
+    classes.each do |klass|
       if (pc = Puppetclass.find_by_name(klass))
         myklasses << pc
       else

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -784,6 +784,15 @@ class HostTest < ActiveSupport::TestCase
       assert_equal '3.3.4.12', parameters['foreman_interfaces'].first['ip']
     end
 
+    test "should import from non-parameterized external nodes output" do
+      host = FactoryGirl.create(:host, :environment => environments(:production))
+      host.importNode("environment" => "production", "classes" => ["apache", "base"], "parameters" => {})
+
+      Setting[:Parametrized_Classes_in_ENC] = true
+      Setting[:Enable_Smart_Variables_in_ENC] = true
+      assert_equal ['apache', 'base'], host.info['classes'].keys
+    end
+
     test "show be enabled by default" do
       host = Host.create :name => "myhost", :mac => "aabbccddeeff"
       assert host.enabled?


### PR DESCRIPTION
Prevents a full class hash of name => parameters being passed to the AR
finder when using a parameterized (hash-style) YAML format.
