### PR TITLE
Fixes #16562 - Enable JS testing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "node"
+  - "4" # Fedora
+script: ./script/travis_run_js_tests.sh

--- a/script/travis_run_js_tests.sh
+++ b/script/travis_run_js_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ev
+if [[ $( git diff --name-only HEAD~1..HEAD webpack/ | wc -l ) -ne 0 ]]; then
+  npm run test;
+fi


### PR DESCRIPTION
This enables JS testing on every PR. 
I've enabled it on my local repo to test it: https://travis-ci.org/dLobatog/foreman/builds/159996940
https://github.com/dLobatog/foreman/pull/28

cc @gailsteiger @ohadlevy @tbrisker 
