### PR TITLE
Disabled frozen_string_literal in Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -623,3 +623,7 @@ Style/WordArray:
 # Cop supports --auto-correct.
 Style/ZeroLengthPredicate:
   Enabled: false
+
+# http://projects.theforeman.org/issues/16564
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
Due to bug in Rubocop, this kills some our PRs with false warnings:

https://github.com/bbatsov/rubocop/issues/3285

E.g. https://github.com/theforeman/foreman/pull/3667
