### PR TITLE
Fixes #16565 - Correct host search by parameters

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -152,12 +152,12 @@ module Hostext
       def search_by_params(key, operator, value)
         key_name = key.sub(/^.*\./,'')
         condition = sanitize_sql_for_conditions(["name = ? and value #{operator} ?", key_name, value_to_sql(operator, value)])
-        p = Parameter.where(condition).order(:priority)
+        p = Parameter.where(condition).reorder(:priority)
         return {:conditions => '1 = 0'} if p.blank?
 
         max         = p.first.priority
         condition   = sanitize_sql_for_conditions(["name = ? and NOT(value #{operator} ?) and priority > ?",key_name,value_to_sql(operator, value), max])
-        n           = Parameter.where(condition).order(:priority)
+        n           = Parameter.where(condition).reorder(:priority)
 
         conditions = param_conditions(p)
         negate = param_conditions(n)
@@ -225,7 +225,7 @@ module Hostext
               conditions << "nics.subnet_id = #{param.reference_id} OR nics.subnet6_id = #{param.reference_id}"
           end
         end
-        conditions.empty? ? [] : "( #{conditions.join(' OR ')} )"
+        conditions.empty? ? "" : "( #{conditions.join(' OR ')} )"
       end
 
       #override these if needed to add connection in plugin

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -13,22 +13,26 @@ class Parameter < ActiveRecord::Base
 
   default_scope -> { order("parameters.name") }
 
-  after_initialize :set_priority
+  before_create :set_priority
 
-  PRIORITY = {:common_parameter => 0, :domain_parameter => 1, :subnet_parameter => 2, :os_parameter => 3, :group_parameter => 4, :host_parameter => 5}
+  PRIORITY = { :common_parameter => 0,
+               :organization_parameter => 10,
+               :location_parameter => 20,
+               :domain_parameter => 30,
+               :subnet_parameter => 40,
+               :os_parameter => 50,
+               :group_parameter => 60,
+               :host_parameter => 70
+             }
 
-  def self.reassign_priorities
-    # priorities will be reassigned because of after_initialize
-    find_in_batches do |params|
-      params.each { |param| param.update_attribute(:priority, param.priority) }
-    end
+  def self.type_priority(type)
+    PRIORITY.fetch(type.to_s.underscore.to_sym, nil) unless type.nil?
   end
 
   private
 
   def set_priority
-    t = read_attribute(:type)
-    self.priority = PRIORITY[t.to_s.underscore.to_sym] unless t.blank?
+    self.priority = Parameter.type_priority(type)
   end
 
   def skip_strip_attrs

--- a/db/migrate/20110327123639_add_priority_to_parameter.rb
+++ b/db/migrate/20110327123639_add_priority_to_parameter.rb
@@ -2,7 +2,7 @@ class AddPriorityToParameter < ActiveRecord::Migration
   def up
     add_column :parameters, :priority, :integer
     Parameter.reset_column_information
-    Parameter.reassign_priorities
+    Rake::Task['parameters:reset_priorities'].invoke
   end
 
   def down

--- a/db/migrate/20160914125418_update_parameter_priorities.rb
+++ b/db/migrate/20160914125418_update_parameter_priorities.rb
@@ -1,0 +1,5 @@
+class UpdateParameterPriorities < ActiveRecord::Migration
+  def up
+    Rake::Task['parameters:reset_priorities'].invoke
+  end
+end

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -1,0 +1,9 @@
+desc 'Reset parameter priorities in case they were changed'
+namespace :parameters do
+  task :reset_priorities => :environment do
+    Parameter.reorder('').uniq.pluck(:type).each do |type|
+      priority = Parameter.type_priority(type)
+      Parameter.reorder('').where(type: type).update_all(priority: priority)
+    end
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1856,6 +1856,21 @@ class HostTest < ActiveSupport::TestCase
       assert_equal parameter.value, results.find(host.id).params[parameter.name]
     end
 
+    test "Correctly find hosts with overridden parameter values" do
+      host1 = FactoryGirl.create(:host)
+      host2 = FactoryGirl.create(:host)
+      parameter = FactoryGirl.create(:parameter)
+      override = FactoryGirl.create(:host_parameter, name: parameter.name, value: "different", host: host1)
+
+      results = Host.search_for(%{params.#{parameter.name} = "#{parameter.value}"})
+      assert results.include?(host2)
+      refute results.include?(host1)
+
+      results = Host.search_for(%{params.#{parameter.name} = "#{override.value}"})
+      assert results.include?(host1)
+      refute results.include?(host2)
+    end
+
     test "can search hosts by smart proxy" do
       host = FactoryGirl.create(:host)
       proxy = FactoryGirl.create(:puppet_and_ca_smart_proxy)


### PR DESCRIPTION
Overrides for parameters values caused incorrect results for when
searching by parameter value. This commit fixes those results, and
improves the handling of parameter priorities in general. A new rake
task, `parameters:reset_priorities` is introduced that should be invoked
every time priorities are changed to update to the correct values.
