### PR TITLE
Fixes #16566 - Allow css inline images

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -6,6 +6,6 @@
     :connect_src => ["'self'", 'ws:', 'wss:'],
     :style_src   => ["'unsafe-inline'", "'self'"],
     :script_src  => ["'unsafe-eval'", "'unsafe-inline'", "'self'"],
-    :img_src     => ["'self'", '*.gravatar.com']
+    :img_src     => ["'self'", 'data:', '*.gravatar.com']
   }
 end

--- a/test/integration/middleware_test.rb
+++ b/test/integration/middleware_test.rb
@@ -8,7 +8,7 @@ class MiddlewareIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal page.response_headers['X-Content-Type-Options'], 'nosniff'
     assert_equal page.response_headers['Content-Security-Policy'], \
       "default-src 'self'; child-src 'self'; connect-src 'self' ws: wss:; "+
-      "img-src 'self' *.gravatar.com; script-src 'unsafe-eval' 'unsafe-inline' "+
+      "img-src 'self' data: *.gravatar.com; script-src 'unsafe-eval' 'unsafe-inline' "+
       "'self'; style-src 'unsafe-inline' 'self'"
   end
 


### PR DESCRIPTION
Secure headers currently prevents inlining images in CSS using the
'data:' method. This add that to the allowed image sources.
