### PR TITLE
Fixes #13704 - Defensive association name setter

### DIFF
--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -82,7 +82,9 @@ module HasManyCommon
 
       # SETTER _name= method
       define_method "#{assoc_name}=" do |name_value|
-        assoc_id = assoc_klass(association).send("find_by_#{assoc_klass(association).attribute_name}", name_value).id
+        assoc_id = assoc_klass(association).send("find_by_#{assoc_klass(association).attribute_name}", name_value).try(:id)
+        raise ActiveRecord::RecordNotFound
+                .new(_("Could not find %{association} with name: %{name}") % { name: name_value, association: association }) unless assoc_id
         self.send("#{assoc}_id=", assoc_id)
       end
 

--- a/test/lib/has_many_common_test.rb
+++ b/test/lib/has_many_common_test.rb
@@ -79,6 +79,13 @@ class HasManyCommonTest < ActiveSupport::TestCase
     refute_equal orig_id, new_id
   end
 
+  test "should raise not found error if hostgroup name does not exist" do
+    host = FactoryGirl.build(:host)
+    assert_raise ActiveRecord::RecordNotFound do
+      host.hostgroup_name = "No such HG"
+    end
+  end
+
   ## Test name methods resolve for Plugin AR objects
   class ::FakePlugin; end
   class ::FakePlugin::FakeModel; end


### PR DESCRIPTION
When setting an association by name (e.g., hostgroup_name, organization_name)
and the name does not exist, we raise a not found error
