### PR TITLE
fixes #16578 - make keep_param idempotent, remove duplicate call

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
@@ -6,9 +6,15 @@
 # working around https://github.com/rails/rails/issues/9454.
 module Foreman::Controller::Parameters::KeepParam
   def keep_param(params, top_level_hash, *keys)
+    # Delete keys being kept from the `params` hash, so the block yielded to filters the others
     old_params = keys.inject({}) do |op,(key,val)|
       params[top_level_hash].has_key?(key) ? op.update(key => params[top_level_hash].delete(key)) : op
     end
-    yield.update old_params
+
+    # Restore the deleted (kept) keys to the filtered hash of params from the block
+    filtered = yield.update(old_params)
+    # Restore the deleted (kept) keys to the original params hash so it remains unchanged
+    params[top_level_hash].update old_params
+    filtered
   end
 end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -682,8 +682,7 @@ class HostsController < ApplicationController
   # renders only resulting templates set so the rest of form is unaffected
   def template_used
     host = params[:id] ? Host.readonly.find(params[:id]) : Host.new
-    association_keys = host_params.keys.select { |k| k =~ /.*_ids\Z/ }
-    host.attributes = host_params.except(:host_parameters_attributes).except(*association_keys)
+    host.attributes = host_params.select { |k,v| !k.end_with?('_ids') }.except(:host_parameters_attributes)
     templates = host.available_template_kinds(params[:provisioning])
     return not_found if templates.empty?
     render :partial => 'provisioning', :locals => { :templates => templates }

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -1126,6 +1126,17 @@ class HostsControllerTest < ActionController::TestCase
     assert_template :partial => '_provisioning'
   end
 
+  test 'template_used does not save has_many relations on existing hosts' do
+    @host.setBuild
+    attrs = host_attributes(@host)
+    attrs[:config_group_ids] = [config_groups(:one).id]
+    ActiveRecord::Base.any_instance.expects(:destroy).never
+    ActiveRecord::Base.any_instance.expects(:save).never
+    xhr :put, :template_used, {:provisioning => 'build', :host => attrs, :id => @host.id }, set_session_user
+    assert_response :success
+    assert_template :partial => '_provisioning'
+  end
+
   test 'process_taxonomy renders a host from the params correctly' do
     nic = FactoryGirl.build(:nic_managed, :host => @host)
     attrs = host_attributes(@host)

--- a/test/unit/concerns/parameters/keep_param_test.rb
+++ b/test/unit/concerns/parameters/keep_param_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class KeepParamParametersTest < ActiveSupport::TestCase
+  include Foreman::Controller::Parameters::KeepParam
+
+  test "retains parameter within top-level hash" do
+    params = ActionController::Parameters.new(:user => {:login => 'foo'})
+    returned = keep_param(params, 'user', :login) { {} }
+    assert_equal 'foo', returned[:login]
+  end
+
+  test "retains multiple parameters" do
+    params = ActionController::Parameters.new(:user => {:login => 'foo', :other => 'bar'})
+    returned = keep_param(params, 'user', :login, :other) { {} }
+    assert_equal 'foo', returned[:login]
+    assert_equal 'bar', returned[:other]
+  end
+
+  test "ignores unknown parameters" do
+    params = ActionController::Parameters.new(:user => {:login => 'foo'})
+    returned = keep_param(params, 'user', :login, :other) { {} }
+    assert_equal 'foo', returned[:login]
+    refute returned.has_key?(:other)
+  end
+
+  test "doesn't modify input hash" do
+    params = ActionController::Parameters.new(:user => {:login => 'foo'})
+    returned = keep_param(params, 'user', :login) { {:login => 'foo'} }
+    assert_equal 'foo', returned[:login]
+    assert_equal 'foo', params[:user][:login]
+  end
+end


### PR DESCRIPTION
Using host_params (and keep_param) twice was causing compute_attributes
to be deleted permanently out of `params`. keep_param now restores
elements it deletes, and the controller now only calls host_params once
for efficiency.
