### PR TITLE
fixes #16580 - redact BMC password in ENC/templates with setting

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -12,7 +12,7 @@ module Nic
     end
     alias_method :virtual?, :virtual
 
-    attr_exportable :provider, :username, :password => ->(nic) { nic.decrypt_field(nic.password) }
+    attr_exportable :provider, :username, :password
 
     def proxy
       proxy = bmc_proxy
@@ -20,7 +20,7 @@ module Nic
       ProxyAPI::BMC.new({ :host_ip  => ip,
                           :url      => proxy.url,
                           :user     => username,
-                          :password => password })
+                          :password => password_unredacted })
     end
 
     def self.humanized_name
@@ -29,6 +29,11 @@ module Nic
 
     class Jail < Nic::Managed::Jail
       allow :provider, :username, :password
+    end
+
+    alias_method :password_unredacted, :password
+    def password
+      Setting[:bmc_credentials_accessible] ? password_unredacted : nil
     end
 
     private

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -33,11 +33,18 @@ class Setting::Auth < Setting
         self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'), nil, N_('Authorize login delegation auth source user autocreate')),
         self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"), false, N_('Authorize login delegation')),
         self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"), false, N_('Authorize login delegation API')),
-        self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60, N_('Idle timeout'))
+        self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60, N_('Idle timeout')),
+        self.set('bmc_credentials_accessible', N_("Permits access to BMC interface passwords through ENC YAML output and in templates"), true, N_('BMC credentials access'))
       ].compact.each { |s| self.create! s.update(:category => "Setting::Auth")}
     end
 
     true
+  end
+
+  def validate_bmc_credentials_accessible(record)
+    if !record.value && !Setting[:safemode_render]
+      record.errors[:base] << _("Unable to disable bmc_credentials_accessible when safemode_render is disabled")
+    end
   end
 
   def validate_websockets_encrypt(record)

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -29,4 +29,10 @@ class Setting::Provisioning < Setting
 
     true
   end
+
+  def validate_safemode_render(record)
+    if !record.value && !Setting[:bmc_credentials_accessible]
+      record.errors[:base] << _("Unable to disable safemode_render when bmc_credentials_accessible is disabled")
+    end
+  end
 end

--- a/app/views/nic/bmcs/_bmc.html.erb
+++ b/app/views/nic/bmcs/_bmc.html.erb
@@ -2,7 +2,17 @@
 
 <%= content_tag :span, :id => 'bmc_fields' do %>
   <%= text_f f, :username, :size => "col-md-8", :label_size => "col-md-3" %>
-  <%= password_f f, :password, :unset => action_name == "edit", :size => "col-md-8", :label_size => "col-md-3" %>
+  <%= password_f f, :password, :unset => action_name == "edit", :size => "col-md-8", :label_size => "col-md-3",
+                    :help_inline => popover('',
+                        _("The BMC password will be used by Foreman to access the host's BMC controller via a BMC-enabled smart proxy, if available.") + ' ' +
+                          (Setting[:bmc_credentials_accessible] ?
+                            _("The password will also be accessible to other users via templates and in the ENC YAML output; disable the bmc_credentials_accessible setting to prevent access.") :
+                            _("The password will not be accessible to other users; enable the bmc_credentials_accessible setting to permit access via templates and in the ENC YAML output.")),
+                        :title => _("BMC password usage"),
+                        :rel => 'popover-modal',
+                        :'data-placement' => "top"
+                      ).html_safe
+ %>
   <%= selectable_f f, :provider, Nic::BMC::PROVIDERS, {}, :size => "col-md-8", :label_size => "col-md-3" %>
 <% end %>
 

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -31,5 +31,9 @@ FactoryGirl.define do
     trait :puppet do
       name 'Puppet'
     end
+
+    trait :bmc do
+      name 'BMC'
+    end
   end
 end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -6,6 +6,10 @@ FactoryGirl.define do
       features { |sp| [sp.association(:template_feature), sp.association(:tftp_feature) ] }
     end
 
+    factory :bmc_smart_proxy do
+      features { |sp| [sp.association(:feature, :bmc)] }
+    end
+
     factory :dhcp_smart_proxy do
       features { |sp| [sp.association(:feature, :dhcp)] }
     end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -297,3 +297,8 @@ attributes61:
   category: Setting::Provisioning
   default: "Random-based"
   description: 'Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)'
+attributes62:
+  name: bmc_credentials_accessible
+  category: Setting::Auth
+  default: "true"
+  description: 'Permits access to BMC interface passwords through ENC YAML output and in templates'

--- a/test/unit/nic_bmc_jail_test.rb
+++ b/test/unit/nic_bmc_jail_test.rb
@@ -8,4 +8,12 @@ class NicBMCJailTest < ActiveSupport::TestCase
       assert Nic::BMC::Jail.allowed?(m), "Method #{m} is not available in Nic::BMC::Jail while should be allowed."
     end
   end
+
+  def test_jail_should_not_include_these_methods
+    denied = [:password_redacted]
+
+    denied.each do |m|
+      refute Nic::BMC::Jail.allowed?(m), "Method #{m} is available in Nic::BMC::Jail while should not be allowed."
+    end
+  end
 end

--- a/test/unit/setting_test.rb
+++ b/test/unit/setting_test.rb
@@ -526,4 +526,18 @@ class SettingTest < ActiveSupport::TestCase
     Setting[name] = options[:value]
     assert_nil Rails.cache.read(name)
   end
+
+  test 'bmc_credentials_accessible may not be disabled with safemode_render disabled' do
+    Setting[:safemode_render] = false
+    bmc = Setting.find_by_name('bmc_credentials_accessible')
+    bmc.value = false
+    refute_valid bmc, :base, 'Unable to disable bmc_credentials_accessible when safemode_render is disabled'
+  end
+
+  test 'safemode_render may not be disabled with bmc_credentials_accessible disabled' do
+    Setting[:bmc_credentials_accessible] = false
+    bmc = Setting.find_by_name('safemode_render')
+    bmc.value = false
+    refute_valid bmc, :base, 'Unable to disable safemode_render when bmc_credentials_accessible is disabled'
+  end
 end


### PR DESCRIPTION
Passwords stored against BMC NICs are accessible by default via
nic.password in a template, even in safe mode (861a03b), and are also
exported in the ENC output. A new bmc_credentials_accessible setting
allows the admin to redact the values in both locations, only allowing
the password to be used internally for BMC smart proxies.

Disabling BMC credential access requires safemode_render for complete
protection.
