### PR TITLE
Fixes #14837 - Reword import buttons

### DIFF
--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -12,12 +12,13 @@ module PuppetclassesAndEnvironmentsHelper
   end
 
   def import_proxy_select(hash)
-    select_action_button(_('Import'), {}, import_proxy_links(hash))
+    select_action_button(_('Import'), {}, import_proxy_links(hash, true))
   end
 
-  def import_proxy_links(hash, classes = nil)
+  def import_proxy_links(hash, import_env_text = false, classes = nil)
+    import_from_text = import_env_text ? _("Import environments from %s") : _("Import classes from %s")
     SmartProxy.with_features("Puppet").map do |proxy|
-      display_link_if_authorized(_("Import from %s") % proxy.name, hash.merge(:proxy => proxy), {:class=>classes})
+      display_link_if_authorized(import_from_text % proxy.name, hash.merge(:proxy => proxy), {:class=>classes})
     end.flatten
   end
 


### PR DESCRIPTION
Import buttons now say where they import from.

In /environments it looks like:
![image](https://cloud.githubusercontent.com/assets/433583/18615386/5b2c274c-7dae-11e6-92bf-12f6952a9598.png)

In /puppetclasses, it would state "Import environments from..." as it is what it is doing
and would look like:

![image](https://cloud.githubusercontent.com/assets/433583/18615395/9f545da4-7dae-11e6-92e1-becfae5076dc.png)
