### PR TITLE
Fixes #16599 - Shrinkwrap npm modules

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,16 @@
+{
+  "name": "TheForemanDevDeps",
+  "version": "1.14.0",
+  "dependencies": {
+    "postcss-svgo": {
+      "version": "2.1.4",
+      "from": "postcss-svgo@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.4.tgz"
+    },
+    "svgo": {
+      "version": "0.6.6",
+      "from": "svgo@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz"
+    }
+  }
+}


### PR DESCRIPTION
This is a temporary workaround to pin the entire npm module tree until
we can upgrade node and npm on jenkins to newer versions.
