### PR TITLE
templates - sync from community-templates

### DIFF
--- a/app/views/unattended/kickstart/finish.erb
+++ b/app/views/unattended/kickstart/finish.erb
@@ -5,6 +5,14 @@ oses:
 - CentOS
 - Fedora
 %>
+  <%#
+  This template accepts the following parameters:
+  - bootloader-append: string (default="nofb quiet splash=quiet")
+  - force-puppet: boolean (default=false)
+  - ntp-server: string (default="0.fedora.pool.ntp.org")
+  - package_upgrade: boolean (default=true)
+  - salt_master: string (default=undef)
+  %>
 <% if @host.subnet.respond_to?(:dhcp_boot_mode?) -%>
 <%= snippet 'kickstart_networking_setup' %>
 service network restart
@@ -37,12 +45,14 @@ echo "updating system time"
 <%= snippet 'freeipa_register' %>
 <% end -%>
 
+<% unless @host.param_false?('package_upgrade') -%>
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update
 else
   yum -t -y update
 fi
+<% end -%>
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/app/views/unattended/kickstart/provision.erb
+++ b/app/views/unattended/kickstart/provision.erb
@@ -21,6 +21,7 @@ This template accepts the following parameters:
 - ntp-server: string (default="0.fedora.pool.ntp.org")
 - bootloader-append: string (default="nofb quiet splash=quiet")
 - disable-firewall: boolean (default=false)
+- package_upgrade: boolean (default=true)
 %>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -56,7 +57,7 @@ firewall --disable
 <% else -%>
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 <% end -%>
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
 timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 <% if rhel_compatible && os_major > 4 -%>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
@@ -183,12 +184,14 @@ echo "updating system time"
 echo 'proxy = <%= proxy_uri %>' >> /etc/yum.conf
 <% end -%>
 
+<% unless @host.param_false?('package_upgrade') -%>
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update
 else
   yum -t -y update
 fi
+<% end -%>
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/app/views/unattended/kickstart/provision_rhel.erb
+++ b/app/views/unattended/kickstart/provision_rhel.erb
@@ -20,6 +20,7 @@ This template accepts the following parameters:
 - ntp-server: string (default="0.fedora.pool.ntp.org")
 - bootloader-append: string (default="nofb quiet splash=quiet")
 - disable-firewall: boolean (default=false)
+- package_upgrade: boolean (default=true)
 %>
 <%
   os_major = @host.operatingsystem.major.to_i
@@ -54,7 +55,7 @@ firewall --disable
 <% else -%>
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 <% end -%>
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
 timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 <% if os_major > 4 -%>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
@@ -161,12 +162,14 @@ echo "updating system time"
 echo 'proxy = <%= proxy_uri %>' >> /etc/yum.conf
 <% end -%>
 
+<% unless @host.param_false?('package_upgrade') -%>
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update
 else
   yum -t -y update
 fi
+<% end -%>
 
 <%= snippet('remote_execution_ssh_keys') %>
 

--- a/app/views/unattended/snippets/_puppet.conf.erb
+++ b/app/views/unattended/snippets/_puppet.conf.erb
@@ -20,6 +20,9 @@ name: puppet.conf
   end
 %>
 [main]
+<%- unless @host.params['dns_alt_names'].to_s.empty? -%>
+dns_alt_names = <%= @host.params['dns_alt_names'] %>
+<%- end -%>
 vardir = <%= var_dir %>
 logdir = <%= log_dir %>
 rundir = <%= run_dir %>

--- a/app/views/unattended/snippets/_puppet_setup.erb
+++ b/app/views/unattended/snippets/_puppet_setup.erb
@@ -12,7 +12,7 @@ if os_family == 'Freebsd'
   freebsd_package = @host.param_true?('enable-puppet4') ? 'puppet4' : 'puppet38'
   etc_path = '/usr/local/etc/puppet'
   bin_path = '/usr/local/bin'
-elsif @host.param_true?('enable-puppetlabs-pc1-repo')
+elsif @host.param_true?('enable-puppetlabs-pc1-repo') || @host.param_true?('enable-puppet4')
   linux_package = 'puppet-agent'
   etc_path = '/etc/puppetlabs/puppet'
   bin_path = '/opt/puppetlabs/bin'

--- a/script/sync_templates.sh
+++ b/script/sync_templates.sh
@@ -13,11 +13,17 @@ trap "rm -rf $REPO" EXIT
 git clone -q -b $(git symbolic-ref -q HEAD --short) \
   https://github.com/theforeman/community-templates $REPO/ct
 
+# add underscore prefix to snippets
+if [ -d $REPO/ct/snippets ];
+then
+  for i in $REPO/ct/snippets/*;
+  do
+    mv $i $REPO/ct/snippets/_$(basename $i)
+  done
+fi
+
 # move into destination dir if run from Foreman root
 [ -d app/views/unattended ] && cd app/views/unattended
-
-# add underscore prefix to snippets
-(cd $REPO/ct/snippets && prename -f 's/^([^_])/_$1/' *)
 
 rsync -r \
   --exclude .gitignore \


### PR DESCRIPTION
Would like to sync community-templates so the change from https://github.com/theforeman/community-templates/pull/299 is included.  We need it so provisioning works in katello nightly.

Note, I also changed the sync script to remove the requirement on `prename` which doesn't exist on Fedora/Red Hat out of the box.
