### PR TITLE
Fixes #16624 - Make AuthSourceLDAP taxable

### DIFF
--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -1,11 +1,21 @@
 module Api
   module V2
     class AuthSourceLdapsController < V2::BaseController
+      include Api::TaxonomyScope
       include Foreman::Controller::Parameters::AuthSourceLdap
+
+      wrap_parameters AuthSourceLdap,
+        :include => auth_source_ldap_params_filter.
+                      accessible_attributes(parameter_filter_context)
 
       before_action :find_resource, :only => %w{show update destroy test}
 
       api :GET, "/auth_source_ldaps/", N_("List all LDAP authentication sources")
+      api :GET, '/locations/:location_id/auth_source_ldaps/',
+        N_('List LDAP authentication sources per location')
+      api :GET, '/organizations/:organization_id/auth_source_ldaps/',
+        N_('List LDAP authentication sources per organization')
+      param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 
       def index
@@ -37,6 +47,7 @@ module Api
           param :groups_base, String, :desc => N_("groups base DN")
           param :server_type, AuthSourceLdap::SERVER_TYPES.keys, :desc => N_("type of the LDAP server")
           param :ldap_filter, String, :desc => N_("LDAP filter")
+          param_group :taxonomies, ::Api::V2::BaseController
         end
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,7 +153,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # not all models includes Authorizable so we detect whether we should apply authorized scope or not
+  # Not all models include Authorizable so we detect whether we should apply authorized scope or not
   def resource_base
     @resource_base ||= if model_of_controller.respond_to?(:authorized)
                          model_of_controller.authorized(current_permission)

--- a/app/controllers/concerns/foreman/controller/parameters/auth_source_ldap.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/auth_source_ldap.rb
@@ -1,5 +1,6 @@
 module Foreman::Controller::Parameters::AuthSourceLdap
   extend ActiveSupport::Concern
+  include Foreman::Controller::Parameters::Taxonomix
 
   class_methods do
     def auth_source_ldap_params_filter
@@ -21,6 +22,8 @@ module Foreman::Controller::Parameters::AuthSourceLdap
           :server_type,
           :tls,
           :usergroup_sync
+
+        add_taxonomix_params_filter(filter)
       end
     end
   end

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -30,8 +30,6 @@ class AuthSource < ActiveRecord::Base
   scope :non_internal, -> { where("type NOT IN (?)", ['AuthSourceInternal', 'AuthSourceHidden']) }
   scope :except_hidden, -> { where('type <> ?', 'AuthSourceHidden') }
 
-  scoped_search :on => :name, :complete_value => :true
-
   def authenticate(login, password)
   end
 

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -27,6 +27,7 @@ class AuthSourceLdap < AuthSource
   include Parameterizable::ByIdName
   include Encryptable
   encrypts :account_password
+  include Taxonomix
 
   validates :host, :presence => true, :length => {:maximum => 60}
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :presence => true, :if => Proc.new { |auth| auth.onthefly_register? }
@@ -38,6 +39,14 @@ class AuthSourceLdap < AuthSource
 
   before_validation :strip_ldap_attributes
   after_initialize :set_defaults
+
+  scoped_search :on => :name, :complete_value => :true
+
+  default_scope lambda {
+    with_taxonomy_scope do
+      order("#{AuthSourceLdap.table_name}.name")
+    end
+  }
 
   DEFAULT_PORTS = {:ldap => 389, :ldaps => 636 }
   # Loads the LDAP info for a user and authenticates the user with their password

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -219,7 +219,7 @@ module Taxonomix
   end
 
   def used_taxonomy_ids(type)
-    return [] if new_record?
+    return [] if new_record? || !self.respond_to?(:hosts)
     Host::Base.where(taxonomy_foreign_key_conditions).uniq.pluck(type).compact
   end
 

--- a/app/views/api/v2/auth_source_ldaps/show.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/show.json.rabl
@@ -2,6 +2,10 @@ object @auth_source_ldap
 
 extends "api/v2/auth_source_ldaps/main"
 
+node do |auth_source_ldap|
+  partial("api/v2/taxonomies/children_nodes", :object => auth_source_ldap)
+end
+
 child :external_usergroups do
   extends "api/v2/external_usergroups/base"
 end

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -6,6 +6,12 @@
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("LDAP server") %></a></li>
     <li><a href="#account" data-toggle="tab"><%= _("Account") %></a></li>
     <li><a href="#attributes" data-toggle="tab"><%= _("Attribute mappings") %></a></li>
+    <% if show_location_tab? %>
+      <li><a href="#locations" data-toggle="tab"><%= _("Locations") %></a></li>
+    <% end %>
+    <% if show_organization_tab? %>
+      <li><a href="#organizations" data-toggle="tab"><%= _("Organizations") %></a></li>
+    <% end %>
   </ul>
 
   <div class="tab-content">
@@ -38,7 +44,8 @@
       <%= text_f f, :attr_mail, :help_inline => _("e.g. mail") %>
       <%= text_f f, :attr_photo, :label => _("Photo attribute"), :help_inline => _("e.g. jpegPhoto") %>
     </div>
-  </div>
+    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @auth_source_ldap %>
+</div>
 
   <%= submit_or_cancel f %>
 <% end %>

--- a/test/controllers/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/api/v2/auth_source_ldaps_controller_test.rb
@@ -69,4 +69,16 @@ class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
       assert_response :success
     end
   end
+
+  test 'taxonomies can be set' do
+    put :update, { :id => auth_sources(:one).to_param,
+                   :organization_names => [taxonomies(:organization1).name],
+                   :location_ids => [taxonomies(:location1).id] }
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_response :success
+    assert_equal taxonomies(:location1).id,
+      show_response['locations'].first['id']
+    assert_equal taxonomies(:organization1).id,
+      show_response['organizations'].first['id']
+  end
 end

--- a/test/controllers/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/auth_source_ldaps_controller_test.rb
@@ -94,4 +94,17 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     put :test_connection, {:id => AuthSourceLdap.first, :auth_source_ldap => {:name => AuthSourceLdap.first.name} }, set_session_user
     assert_response :unprocessable_entity
   end
+
+  test 'organizations/locations can be assigned to it' do
+    auth_source_ldap_params = { :name => AuthSourceLdap.first.name,
+                                :organization_ids => [taxonomies(:organization1).id],
+                                :location_names => [taxonomies(:location1).name] }
+    put :update, { :id => AuthSourceLdap.first,
+                   :auth_source_ldap => auth_source_ldap_params },
+                   set_session_user
+    assert_equal [taxonomies(:organization1)],
+      AuthSourceLdap.first.organizations.to_a
+    assert_equal [taxonomies(:location1)],
+      AuthSourceLdap.first.locations.to_a
+  end
 end

--- a/test/models/auth_source_test.rb
+++ b/test/models/auth_source_test.rb
@@ -1,35 +1,14 @@
 require 'test_helper'
 
 class AuthSourceTest < ActiveSupport::TestCase
-  def setup
-    @auth_source = AuthSource.new
-  end
-
   should validate_presence_of(:name)
   should validate_uniqueness_of(:name)
   should validate_length_of(:name).is_at_most(60)
 
   test "when auth_method_name is applied should return 'Abstract'" do
-    @auth_source.name = "connection"
-    @auth_source.save
-
-    assert_equal "Abstract", @auth_source.auth_method_name
-  end
-
-# the self.authenticate method can't be tested yet, cause use the authenticate method which it isn't implemented yet
-
-  test "should return search results if search free text is auth source name" do
-    @auth_source.name = 'remote'
-    @auth_source.save
-    results = AuthSource.search_for('remote')
-    assert_equal(1, results.count)
-  end
-
-  test "should return search results for name = auth source name" do
-    @auth_source.name = 'my_ldap'
-    @auth_source.save
-    results = AuthSource.search_for('name = my_ldap')
-    assert_equal(1, results.count)
-    assert_equal 'my_ldap', results.first.name
+    auth_source = AuthSource.new
+    auth_source.name = "connection"
+    auth_source.save
+    assert_equal "Abstract", auth_source.auth_method_name
   end
 end

--- a/test/models/auth_sources/auth_source_ldap_test.rb
+++ b/test/models/auth_sources/auth_source_ldap_test.rb
@@ -27,6 +27,8 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
   should validate_length_of(:attr_firstname).is_at_most(30)
   should validate_length_of(:attr_lastname).is_at_most(30)
   should validate_length_of(:attr_mail).is_at_most(30)
+  should have_many(:organizations)
+  should have_many(:locations)
 
   test "after initialize if port == 0 should automatically change to 389" do
     other_auth_source_ldap = AuthSourceLdap.new
@@ -215,6 +217,23 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
       ensure
         FileUtils.remove_entry temp_dir
       end
+    end
+  end
+
+  context 'scoped search' do
+    test "should return search results if search free text is auth source name" do
+      @auth_source_ldap.name = 'remote'
+      @auth_source_ldap.save
+      results = AuthSourceLdap.search_for('remote')
+      assert_equal(1, results.count)
+    end
+
+    test "should return search results for name = auth source name" do
+      @auth_source_ldap.name = 'my_ldap'
+      @auth_source_ldap.save
+      results = AuthSourceLdap.search_for('name = my_ldap')
+      assert_equal(1, results.count)
+      assert_equal 'my_ldap', results.first.name
     end
   end
 


### PR DESCRIPTION
This allows users to set organizations/locations on AuthSourceLDAP
objects. That in itself might not be that useful, but it allows us to
follow on and assign the AuthSourceLDAP taxonomies to the users
autocreated through it.
