### PR TITLE
Fixes #14702 - Monkey patch #destroy to mimic Rails 3/5

### DIFF
--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -11,6 +11,17 @@ class ActiveRecord::Base
     self.name <=> other.name
   end
 
+  # Backport the behavior of #destroy from Rails 5 (and imitate Rails 3)
+  # by returning false on failure instead of raising RecordNotDestroyed.
+  #
+  # From https://github.com/rails/rails/commit/d937a1175f10586b892842348c1d6ecaa47aad2e
+  # Fixes http://projects.theforeman.org/issues/14702
+  def destroy
+    super
+  rescue ActiveRecord::RecordNotDestroyed
+    false
+  end
+
   def update_single_attribute(attribute, value)
     connection.update(
       "UPDATE #{self.class.quoted_table_name} SET " +


### PR DESCRIPTION
This fixes a regression caused by the Rails 4 upgrade where if Host::Managed#destroy failed to destroy an associated object, Foreman would show `ActiveRecord::RecordNotDestroyed` via `generic_exception` page instead of the underlying exception in a flash. Wasn't sure the best place to put this, `lib/core_extensions.rb` and `config/initializers/active_record_extensions.rb` both seem like fitting homes. 

It seems like a change was made in Rails 4.1[1] that caused `#destroy` to raise `ActiveRecord::RecordNotDestroyed` when destroying an ActiveRecord object that was associated to other objects via `has_many` that failed to destroy. In Rails 5[2] the behavior has been changed to return `false` if `#destroy` is called and raise if `#destroy!` is called. 
- [1] https://github.com/rails/rails/commit/5aab0c053832ded70a3a4b58cb97f8f8bba796ba
- [2] https://github.com/rails/rails/commit/d937a1175f10586b892842348c1d6ecaa47aad2e
