### PR TITLE
Fixes #16633 - AuthSourceLDAP uses *_authenticators filters

### DIFF
--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -86,6 +86,10 @@ module Api
             super
         end
       end
+
+      def controller_permission
+        'authenticators'
+      end
     end
   end
 end

--- a/app/controllers/auth_source_ldaps_controller.rb
+++ b/app/controllers/auth_source_ldaps_controller.rb
@@ -47,4 +47,10 @@ class AuthSourceLdapsController < ApplicationController
     Foreman::Logging.exception("Failed to connect to LDAP server", exception)
     render :json => {:message => exception.message}, :status => :unprocessable_entity
   end
+
+  private
+
+  def controller_permission
+    'authenticators'
+  end
 end

--- a/test/functional/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/functional/api/v2/auth_source_ldaps_controller_test.rb
@@ -53,4 +53,20 @@ class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response[:success]
   end
+
+  # This controller overrides 'controller_permission' in order to use
+  # view_authenticators (& friends) instead of view_auth_source_ldaps
+  context '*_authenticators filters' do
+    test 'restrict access to authenticators properly' do
+      setup_user('view', 'auth_source_ldaps')
+      get :index, { }
+      assert_response :forbidden
+    end
+
+    test 'allow access to auth source LDAP objects' do
+      setup_user('view', 'authenticators')
+      get :show, { :id => auth_sources(:one).to_param }
+      assert_response :success
+    end
+  end
 end


### PR DESCRIPTION
Prior to this, non-admin users who were granted *_authenticators
permissions were not able to use them, as the controllers were looking
for *_auth_source_ldaps permissions instead.
