### PR TITLE
Fixes #16627 - Load puppet proxy dashboard

### DIFF
--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -61,7 +61,7 @@ class SmartProxiesController < ApplicationController
   end
 
   def puppet_dashboard
-    dashboard = Dashboard::Data.new("puppetmaster = \"#{@smart_proxy.name}\"")
+    dashboard = Dashboard::Data.new("puppet_proxy_id = \"#{@smart_proxy.id}\"")
     @hosts = dashboard.hosts
     @report = dashboard.report
     @latest_events = dashboard.latest_events

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -41,6 +41,7 @@ module Hostext
       scoped_search :in => :environment, :on => :name,    :complete_value => true,  :rename => :environment
       scoped_search :in => :architecture, :on => :name,    :complete_value => true, :rename => :architecture
       scoped_search :in => :puppet_proxy, :on => :name,    :complete_value => true, :rename => :puppetmaster, :only_explicit => true
+      scoped_search :on => :puppet_proxy_id, :complete_value => false, :only_explicit => true
       scoped_search :in => :puppet_ca_proxy, :on => :name, :complete_value => true, :rename => :puppet_ca, :only_explicit => true
       scoped_search :in => :puppet_proxy, :on => :name, :complete_value => true, :rename => :smart_proxy, :ext_method => :search_by_proxy, :only_explicit => true
       scoped_search :in => :compute_resource, :on => :name,    :complete_value => true, :rename => :compute_resource


### PR DESCRIPTION
This is a backport of f33402e21bd693b353d99a80049242c9fcee4dc0 for the 1.12 branch
