### PR TITLE
Fixes #16649 - PXE helper pxe_kernel_options fixed

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -87,11 +87,11 @@ module Foreman
     end
 
     def pxe_kernel_options
-      return [] unless @host || @host.operatingsystem
-      @host.operatingsystem.pxe_kernel_options(@host.params)
+      return '' unless @host || @host.operatingsystem
+      @host.operatingsystem.pxe_kernel_options(@host.params).join(' ')
     rescue => e
       template_logger.warn "Unable to build PXE kernel options: #{e}"
-      []
+      ''
     end
 
     # provide embedded snippets support as simple erb templates

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -18,6 +18,17 @@ class RendererTest < ActiveSupport::TestCase
     assert_nothing_raised(NoMethodError) { foreman_url }
   end
 
+  test "pxe_kernel_options are not set when no OS is set" do
+    @host = FactoryGirl.build(:host)
+    assert_equal '', pxe_kernel_options
+  end
+
+  test "pxe_kernel_options returns blacklist option for Red Hat" do
+    @host = FactoryGirl.build(:host, :operatingsystem => Operatingsystem.find_by_name('Redhat'))
+    @host.params['blacklist'] = 'dirty_driver, badbad_driver'
+    assert_equal 'modprobe.blacklist=dirty_driver,badbad_driver', pxe_kernel_options
+  end
+
   [:normal_renderer, :safemode_renderer].each do |renderer_name|
     test "#{renderer_name} is properly configured" do
       send "setup_#{renderer_name}"


### PR DESCRIPTION
In PXE templates there should be pxe_kernel_options appended on each line, but
it renders as "[]" instead empty string (or "['element=xyz']") instead of
element=xyz.
