### PR TITLE
Fixes #16652 - UEFI Grub2 support for non-intel archs

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -16,14 +16,16 @@ class Architecture < ActiveRecord::Base
 
   scoped_search :on => :name, :complete_value => :true
 
-  def intel_precision
+  def bootfilename_efi
     case name
     when /i.86/
       'ia32'
     when /x86[_-]64/
       'x64'
-    else
-      ''
+    when /aarch64|aa64/
+      'aa64'
+    else # ppc64, ppc64le and others
+      name.parameterize.gsub(/[^\w\.-]/, '_')
     end
   end
 end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -206,7 +206,7 @@ class Operatingsystem < ActiveRecord::Base
 
   def boot_filename(host = nil)
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
-    self.class.all_loaders_map(host.arch.nil? ? '' : host.arch.intel_precision)[host.pxe_loader]
+    self.class.all_loaders_map(host.arch.nil? ? '' : host.arch.bootfilename_efi)[host.pxe_loader]
   end
 
   # Does this OS family use release_name in its naming scheme

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -25,28 +25,53 @@ class ArchitectureTest < ActiveSupport::TestCase
     assert_not architecture.destroy
   end
 
-  test "should return intel precision for i386" do
+  test "should return EFI filename for i386" do
     architecture = Architecture.new :name => "i386"
-    assert_equal "ia32", architecture.intel_precision
+    assert_equal "ia32", architecture.bootfilename_efi
   end
 
-  test "should return intel precision for i686" do
+  test "should return EFI filename for i686" do
     architecture = Architecture.new :name => "i686"
-    assert_equal "ia32", architecture.intel_precision
+    assert_equal "ia32", architecture.bootfilename_efi
   end
 
-  test "should return intel precision for x86-64" do
+  test "should return EFI filename for x86-64" do
     architecture = Architecture.new :name => "x86-64"
-    assert_equal "x64", architecture.intel_precision
+    assert_equal "x64", architecture.bootfilename_efi
   end
 
-  test "should return intel precision for x86_64" do
+  test "should return EFI filename for x86_64" do
     architecture = Architecture.new :name => "x86_64"
-    assert_equal "x64", architecture.intel_precision
+    assert_equal "x64", architecture.bootfilename_efi
   end
 
-  test "should not return intel precision for unknown arch" do
-    architecture = Architecture.new :name => "unknown"
-    assert_equal "", architecture.intel_precision
+  test "should return EFI filename for aarch64" do
+    architecture = Architecture.new :name => "aarch64"
+    assert_equal "aa64", architecture.bootfilename_efi
+  end
+
+  test "should return EFI filename for aa64" do
+    architecture = Architecture.new :name => "aa64"
+    assert_equal "aa64", architecture.bootfilename_efi
+  end
+
+  test "should return EFI filename for ppc64" do
+    architecture = Architecture.new :name => "ppc64"
+    assert_equal "ppc64", architecture.bootfilename_efi
+  end
+
+  test "should return EFI filename for ppc64le" do
+    architecture = Architecture.new :name => "ppc64le"
+    assert_equal "ppc64le", architecture.bootfilename_efi
+  end
+
+  test "should return EFI filename for an unknown arch" do
+    architecture = Architecture.new :name => "Weird Árchitecturé 88"
+    assert_equal "weird-architecture-88", architecture.bootfilename_efi
+  end
+
+  test "should return EFI filename for a cracker" do
+    architecture = Architecture.new :name => "../../etc/shadow"
+    assert_equal "etc-shadow", architecture.bootfilename_efi
   end
 end


### PR DESCRIPTION
This small patch should enable GRUB2 UEFI booting of:
- ARM 64
- IBM POWER
- IBM POWER Little Endian
