### PR TITLE
fixes #16547 - handle nil value from get_interface_scope

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -173,7 +173,7 @@ module Host
       end
 
       parser.interfaces.each do |name, attributes|
-        iface = get_interface_scope(name, attributes).first || interface_class(name).new(:managed => false)
+        iface = get_interface_scope(name, attributes).try(:first) || interface_class(name).new(:managed => false)
         # create or update existing interface
         set_interface(attributes, name, iface)
       end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1324,7 +1324,7 @@ class HostTest < ActiveSupport::TestCase
       refute host.interfaces.where(:mac => '00:00:00:22:33:44').first.link
     end
 
-    test "#set_interfaces creates new physical interface" do
+    test "#set_interfaces updates existing physical interface by MAC address" do
       host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:11:22:33', :virtual => false, :ipaddress => '10.10.0.1', :ipaddress6 => '2001:db8::1'})
 
       # primary already existed so it's updated
@@ -1333,6 +1333,17 @@ class HostTest < ActiveSupport::TestCase
       end
       assert_equal '10.10.0.1', host.interfaces.where(:mac => '00:00:00:11:22:33').first.ip
       assert_equal '2001:db8::1', host.interfaces.where(:mac => '00:00:00:11:22:33').first.ip6
+    end
+
+    test "#set_interfaces creates new physical interface if none exists" do
+      host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:11:22:34', :virtual => false, :ipaddress => '10.10.0.1', :ipaddress6 => '2001:db8::1'})
+      host.managed = true
+
+      assert_difference 'host.interfaces(true).count' do
+        host.set_interfaces(parser)
+      end
+      assert_equal '10.10.0.1', host.interfaces.where(:mac => '00:00:00:11:22:34').first.ip
+      assert_equal '2001:db8::1', host.interfaces.where(:mac => '00:00:00:11:22:34').first.ip6
     end
 
     test "#set_interfaces creates new interface with link up if no link fact specified" do


### PR DESCRIPTION
Since 7b75a6a, get_interface_scope may return no scope for managed hosts
when importing a physical interface not already known by MAC address.

---

Replaces #3856 with tests and review comments addressed.
