### PR TITLE
Refs #16599 - Specify npm 3.x requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "GPL-3.0",
   "description": "Foreman isn't really a node module, these are just dependencies needed to build the webpack bundle. 'dependencies' are the asset libraries in use and 'devDependencies' are used for the build process.",
   "private": true,
+  "engines": { "npm" : ">=3.0.0" },
   "devDependencies": {
     "babel-core": "~6.7.2",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
npm >= 3 is required for npm-shrinkwrap to function correctly.
