### PR TITLE
Fixes #15285 - save browser timezone in User

### DIFF
--- a/app/controllers/concerns/foreman/controller/users_mixin.rb
+++ b/app/controllers/concerns/foreman/controller/users_mixin.rb
@@ -31,6 +31,12 @@ module Foreman::Controller::UsersMixin
     sub_hg.each { |hg| hg.users << @user }
   end
 
+  def update_timezone
+    if @user.timezone.blank? && cookies[:timezone]
+      @user.update(timezone: cookies[:timezone])
+    end
+  end
+
   def set_current_taxonomies(user, options = {})
     session ||= options.fetch(:session, {})
     ['location', 'organization'].each do |taxonomy|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,6 +38,7 @@ class UsersController < ApplicationController
     editing_self?
     @user = find_resource(:edit_users)
     if @user.update_attributes(user_params)
+      update_timezone
       update_sub_hostgroups_owners
 
       process_success((editing_self? && !current_user.allowed_to?({:controller => 'users', :action => 'index'})) ? { :success_redirect => hosts_path } : {})

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -446,4 +446,24 @@ class UsersControllerTest < ActionController::TestCase
     post :login, {:login => {'login' => users(:admin).login, 'password' => 'secret'}}
     assert_redirected_to realms_path
   end
+
+  test "Browser timezone should be saved" do
+    user = FactoryGirl.create(:user, :with_mail)
+    cookies[:timezone] = "Europe/Athens"
+    put :update, { :id   => user.id,
+                   :user => { :timezone => "" } }, set_session_user
+
+    updated_user = User.find(user.id)
+    assert_equal(cookies[:timezone], updated_user.timezone)
+  end
+
+  test "Browser timezone should not override timezone param" do
+    user = FactoryGirl.create(:user, :with_mail)
+    cookies[:timezone] = "Europe/Athens"
+    put :update, { :id   => user.id,
+                   :user => { :timezone => "Europe/Amsterdam" } }, set_session_user
+
+    updated_user = User.find(user.id)
+    refute_equal(cookies[:timezone], updated_user.timezone)
+  end
 end


### PR DESCRIPTION
Not sure about this pull request:
Currently when a user chooses "Browser timezone" it is set to nil in the User model. And because it is empty we set it to the [cookie's timezone](https://github.com/theforeman/foreman/blob/2aa15bf1f40fff77a50bb9907fa993e067dd6346/app/controllers/concerns/application_shared.rb#L10-L18).
The change in this pull request will enforce that the cookie's timezone will be saved for the user.

Would love to hear your comments
