### PR TITLE
Fixes #16646 - Add ability to plugins to modify index scope

### DIFF
--- a/app/controllers/concerns/scopes_per_action.rb
+++ b/app/controllers/concerns/scopes_per_action.rb
@@ -1,0 +1,48 @@
+# This module will hold a registry of scope directives that should be
+# part of the query per specific action in a controller. This is required by
+# plugins that add *_to_many relations to foreman core models like
+# `Host::Managed` and want to add some includes or eager_load directives to
+# the query.
+
+module ScopesPerAction
+  extend ActiveSupport::Concern
+
+  # returns a scope that includes all directives registered via add_scope_for
+  def action_scope_for(action, base_scope)
+    scope = base_scope
+    self.class.scopes_for(action).each do |scope_func|
+      scope = scope_func.call(scope) || scope
+    end
+    scope
+  end
+
+  module ClassMethods
+    # Add a new scope directive to action specified by action parameter using
+    # block statement. It will receive the base scope as a first parameter.
+    # example: add_scope_for(:my_action) { |base_scope| base_scope.includes(:my_new_table) }
+    def add_scope_for(action, &block)
+      local_scopes_for(action) << block
+    end
+
+    def scopes_for(action)
+      all_scopes = scopes_per_action.merge(scopes_per_action_from_plugins) { |k, left_v, right_v| left_v + right_v }
+      all_scopes[action] || []
+    end
+
+    def local_scopes_for(action)
+      scopes_per_action[action] ||= []
+    end
+
+    private
+
+    def scopes_per_action
+      @scopes_per_action ||= {}
+    end
+
+    def scopes_per_action_from_plugins
+      Foreman::Plugin.all.map {|plugin| plugin.action_scopes_hash_for(self) }.inject({}) do |memo, actions_hash|
+        memo.merge(actions_hash) { |k, left_v, right_v| left_v + right_v }
+      end
+    end
+  end
+end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -1,4 +1,5 @@
 class HostsController < ApplicationController
+  include ScopesPerAction
   include Foreman::Controller::HostDetails
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::TaxonomyMultiple
@@ -38,7 +39,7 @@ class HostsController < ApplicationController
 
   def index(title = nil)
     begin
-      search = resource_base_with_search
+      search = action_scope_for(:index, resource_base_with_search)
     rescue => e
       error e.to_s
       search = resource_base.search_for ''

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -105,6 +105,7 @@ module Foreman #:nodoc:
       @parameter_filters = {}
       @smart_proxies = {}
       @permissions = {}
+      @controller_action_scopes = {}
     end
 
     def after_initialize
@@ -368,6 +369,18 @@ module Foreman #:nodoc:
 
     def smart_proxies(klass)
       @smart_proxies.fetch(klass.name, {})
+    end
+
+    def add_controller_action_scope(controller_class, action, &block)
+      controller_actions = @controller_action_scopes[controller_class.name] || {}
+      actions_list = controller_actions[action] || []
+      actions_list << block
+      controller_actions[action] = actions_list
+      @controller_action_scopes[controller_class.name] = controller_actions
+    end
+
+    def action_scopes_hash_for(controller_class)
+      @controller_action_scopes[controller_class.name] || {}
     end
 
     private

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -78,6 +78,26 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert !hosts.empty?
   end
 
+  test "should include registered scope on index" do
+    # remember the previous state
+    old_scopes = Api::V2::HostsController.scopes_for(:index).dup
+
+    scope_accessed = false
+    Api::V2::HostsController.add_scope_for(:index) do |base_scope|
+      scope_accessed = true
+      base_scope
+    end
+    get :index, { }
+    assert_response :success
+    assert_not_nil assigns(:hosts)
+    hosts = ActiveSupport::JSON.decode(@response.body)
+    assert !hosts.empty?
+
+    #restore the previous state
+    new_scopes = Api::V2::HostsController.scopes_for(:index)
+    new_scopes.keep_if { |s| old_scopes.include?(s) }
+  end
+
   test "should get attributes in ordered index" do
     last_record.update(ip: "127.13.0.1")
     get :index, order: "mac"

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -31,6 +31,25 @@ class HostsControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
+  test "should include registered scope on index" do
+    # remember the previous state
+    old_scopes = HostsController.scopes_for(:index).dup
+
+    scope_accessed = false
+    HostsController.add_scope_for(:index) do |base_scope|
+      scope_accessed = true
+      base_scope
+    end
+    get :index, {}, set_session_user
+    assert_response :success
+    assert_template 'index'
+    assert scope_accessed
+
+    #restore the previous state
+    new_scopes = HostsController.scopes_for(:index)
+    new_scopes.keep_if { |s| old_scopes.include?(s) }
+  end
+
   test "should render 404 when host is not found" do
     get :show, {:id => "no.such.host"}, set_session_user
     assert_response :missing

--- a/test/unit/concerns/scopes_per_action_test.rb
+++ b/test/unit/concerns/scopes_per_action_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class ScopesPerActionTest < ActiveSupport::TestCase
+  include ScopesPerAction
+
+  setup do
+    self.class.send(:scopes_per_action).clear
+
+    self.class.add_scope_for(:test_action) { |base_scope| base_scope.includes(:my_table1) }
+
+    @scope = mock('scope')
+    @scope_expectation = @scope.expects(:includes).with(:my_table1)
+  end
+
+  test 'returns the same scope if callback returns nil' do
+    actual = action_scope_for(:test_action, @scope)
+
+    assert_equal @scope, actual
+  end
+
+  test 'can be called in chain' do
+    new_scope = mock('new_scope')
+    final_scope = mock('final_scope')
+    @scope_expectation.returns(new_scope)
+    new_scope.expects(:includes).with(:my_table2).returns(final_scope)
+
+    self.class.add_scope_for(:test_action) { |base_scope| base_scope.includes(:my_table2) }
+
+    actual = action_scope_for(:test_action, @scope)
+    assert_equal final_scope, actual
+  end
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -383,6 +383,27 @@ class PluginTest < ActiveSupport::TestCase
     assert_equal({:foo => {:feature => 'Foo'}}, Foreman::Plugin.find(:test_smart_proxy).smart_proxies(Awesome))
   end
 
+  def test_hosts_controller_action_scope
+    mock_scope = ->(scope) { scope }
+    Foreman::Plugin.register :test_hosts_controller_action_scope do
+      add_controller_action_scope HostsController, :test_action, &mock_scope
+    end
+    scopes = HostsController.scopes_for(:test_action)
+    assert_equal mock_scope, scopes.last
+  end
+
+  def test_hosts_controller_action_scope_added_to_local
+    mock_scope = ->(scope) { scope }
+    HostsController.add_scope_for(:test_action) do |scope|
+      scope
+    end
+    Foreman::Plugin.register :test_hosts_controller_action_scope_added_to_local do
+      add_controller_action_scope HostsController, :test_action, &mock_scope
+    end
+    scopes = HostsController.scopes_for(:test_action)
+    assert_equal 2, scopes.count
+  end
+
   context "adding permissions" do
     teardown do
       permission = Foreman::AccessControl.permission(:test_permission)


### PR DESCRIPTION
Added the ability for plugins to modify the scope used to get hosts for `#index` action. This is needed if a plugin wants to add more `includes` or `eager_load` statements, so Active Record won't try to lazy load additional relations and create N+1 queries.
