### PR TITLE
Refs #16689 - Missing DRY index action controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -223,8 +223,9 @@ class ApplicationController < ActionController::Base
     resource_base.search_for(params[:search], :order => params[:order])
   end
 
-  def resource_base_search_and_page
-    resource_base_with_search.paginate(:page => params[:page])
+  def resource_base_search_and_page(tables = [])
+    resource_base_with_search.eager_load(tables).
+      paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
   private

--- a/app/controllers/config_reports_controller.rb
+++ b/app/controllers/config_reports_controller.rb
@@ -4,7 +4,7 @@ class ConfigReportsController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    @config_reports = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page]).includes(:host)
+    @config_reports = resource_base_search_and_page(:host)
   end
 
   def show

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -38,7 +38,7 @@ class HostsController < ApplicationController
 
   def index(title = nil)
     begin
-      search = resource_base.search_for(params[:search], :order => params[:order])
+      search = resource_base_with_search
     rescue => e
       error e.to_s
       search = resource_base.search_for ''

--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -4,9 +4,7 @@ class LookupKeysController < ApplicationController
   before_action :find_resource, :only => [:edit, :update, :destroy], :if => Proc.new { params[:id] }
 
   def index
-    @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])
-                                .includes(:puppetclass)
-                                .paginate(:page => params[:page])
+    @lookup_keys = resource_base_search_and_page(:puppetclass)
     @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map(&:puppetclass_id).compact.uniq)
   end
 

--- a/app/controllers/puppetclass_lookup_keys_controller.rb
+++ b/app/controllers/puppetclass_lookup_keys_controller.rb
@@ -4,9 +4,7 @@ class PuppetclassLookupKeysController < LookupKeysController
   before_action :setup_search_options, :only => :index
 
   def index
-    @lookup_keys = resource_base.search_for(params[:search], :order => params[:order])
-                                .paginate(:page => params[:page])
-                                .includes(:param_classes)
+    @lookup_keys = resource_base_search_and_page(:param_classes)
     @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map{|key| key.param_class.try(:id)}.compact.uniq)
   end
 

--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -9,7 +9,9 @@ class PuppetclassesController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    @puppetclasses = resource_base.search_for(params[:search], :order => params[:order]).includes(:config_group_classes, :class_params, :environments, :hostgroups).paginate(:page => params[:page])
+    eager_load_tables = [:config_group_classes, :class_params, :environments,
+                         :hostgroups]
+    @puppetclasses = resource_base_search_and_page(eager_load_tables)
     @hostgroups_authorizer = Authorizer.new(User.current, :collection => HostgroupClass.where(:puppetclass_id => @puppetclasses.map(&:id)).uniq.pluck(:hostgroup_id))
   end
 

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -5,7 +5,7 @@ class SubnetsController < ApplicationController
   before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
-    @subnets = resource_base.search_for(params[:search], :order => params[:order]).includes(:domains, :dhcp).paginate :page => params[:page]
+    @subnets = resource_base_search_and_page([:domains, :dhcp])
   end
 
   def new

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -11,7 +11,7 @@ class TemplatesController < ApplicationController
   include TemplatePathsHelper
 
   def index
-    @templates = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+    @templates = resource_base_search_and_page
     @templates = @templates.includes(resource_base.template_includes)
   end
 


### PR DESCRIPTION
Some of the controllers that could have used the refactor in #16689 were
not added in that commit.

Additionally, I've fixed the '.includes' leftover in those controllers
from Rails 3 to be '.eager_load' now. '.includes' does not change the
query in _any_ way unless you call '.references' afterwards.
