### PR TITLE
fixes #16717 - input_group_btn option no longer added to field

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -367,8 +367,8 @@ module FormHelper
         content_tag(:div, :class => "#{wrapper_class} #{error.empty? ? '' : 'has-error'}",
                     :id => options.delete(:control_group_id)) do
           input = capture do
-            if options[:input_group_btn]
-              input_group(yield.html_safe, input_group_btn(options[:input_group_btn]))
+            if (group_btn = options.delete(:input_group_btn))
+              input_group(yield.html_safe, input_group_btn(group_btn))
             else
               yield.html_safe
             end


### PR DESCRIPTION
When input_group_btn was passed to text_f (as in the host name field),
it was added as an attribute to the textbox as well as being output.
