### PR TITLE
fixes #16700 - change CatchJsonParseErrors test to cleanup driver

### DIFF
--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -1,9 +1,16 @@
 require 'integration_test_helper'
 
-class AboutIntegrationTest < ActionDispatch::IntegrationTest
+class AboutIntegrationTest < IntegrationTestWithJavascript
+  setup do
+    ComputeResource.any_instance.expects(:ping).at_least_once.returns([])
+    proxy_status = mock('ProxyStatus::Version')
+    proxy_status.expects(:version).at_least_once.returns('version' => '1.13.0')
+    SmartProxy.any_instance.expects(:statuses).at_least_once.returns(:version => proxy_status)
+  end
+
   test "about page" do
-    visit about_index_path
     assert_index_page(about_index_path,"About", nil, false, false)
+    wait_for_ajax
     assert page.has_selector?('h4', :text => "System Status"), "System Status was expected in the <h4> tag, but was not found"
     assert page.has_selector?('h4', :text => "Support"), "Support was expected in the <h4> tag, but was not found"
     assert page.has_selector?('h4', :text => "System Information"), "System Information was expected in the <h4> tag, but was not found"
@@ -19,6 +26,7 @@ class AboutIntegrationTest < ActionDispatch::IntegrationTest
 
   test "about page proxies should have version" do
     visit about_index_path
+    wait_for_ajax
     assert page.has_selector?('th', :text => "Version")
   end
 end

--- a/test/integration/catch_json_parse_errors_test.rb
+++ b/test/integration/catch_json_parse_errors_test.rb
@@ -1,12 +1,7 @@
 require 'integration_test_helper'
 require 'rest-client'
-require 'capybara/rails'
 
-class CatchJsonParseErrorsTest < ActiveSupport::TestCase
-  def setup
-    Capybara.current_driver = Capybara.javascript_driver
-  end
-
+class CatchJsonParseErrorsTest < IntegrationTestWithJavascript
   test "submitting invalid JSON" do
     broken_json = "{notAJson"
     body = post_broken_json_to_api('/api/hosts', broken_json)


### PR DESCRIPTION
On completion, the Capybara driver was left unset causing the next test
to execute with the JS driver and introducing AJAX concurrency issues.
Using the integration test helpers ensures it's reset correctly.

The AboutIntegrationTest now uses the JS driver explicitly to test its
AJAX features, and stubs the network-based ping calls.
