### PR TITLE
Fixes #16704 - Allow filtering on dashboard

### DIFF
--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -20,9 +20,11 @@ class Dashboard::Data
   end
 
   def latest_events
+    #workaround to get the inner query working
+    ids = hosts.to_sql.sub(/SELECT.*FROM/, "SELECT #{Host.connection.quote_table_name('hosts')}.#{Host.connection.quote_column_name('id')} FROM")
     # 9 reports + header fits the events box nicely...
     @latest_events ||= ConfigReport.authorized(:view_config_reports).my_reports.interesting
-                                   .joins(:host).where(:host => hosts)
+                                   .where("host_id in (#{ids})")
                                    .search_for('reported > "7 days ago"')
                                    .limit(9).includes(:host)
   end

--- a/test/unit/dashboard_test.rb
+++ b/test/unit/dashboard_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class DashboardTest < ActiveSupport::TestCase
+  setup do
+    @env = FactoryGirl.create(:environment)
+    @host = FactoryGirl.create(:host, :with_reports, :environment => @env)
+  end
+
+  test 'hosts returns correct host' do
+    data = Dashboard::Data.new
+
+    as_admin do
+      assert_equal 1, data.hosts.length
+    end
+  end
+
+  test 'hosts works with environment filter' do
+    data = Dashboard::Data.new("environment = #{@env.name}")
+
+    as_admin do
+      assert_equal 1, data.hosts.length
+    end
+  end
+
+  test 'hosts works with free text filter' do
+    data = Dashboard::Data.new(@env.name)
+
+    as_admin do
+      assert_equal 1, data.hosts.length
+    end
+  end
+
+  test 'hosts works with a filter that returns no hosts' do
+    data = Dashboard::Data.new("name = DoesNotExist")
+
+    as_admin do
+      assert_equal 0, data.hosts.length
+    end
+  end
+
+  test 'latest_events does not return uneventful reports' do
+    data = Dashboard::Data.new
+
+    as_admin do
+      assert_equal 0, data.latest_events.length
+    end
+  end
+
+  context 'with eventful report' do
+    setup do
+      @host.reports.first.update_attribute(:status, 2)
+    end
+
+    test 'latest_events returns latest events' do
+      data = Dashboard::Data.new
+
+      as_admin do
+        assert_equal 1, data.latest_events.length
+      end
+    end
+
+    test 'latest_events works with environment filter' do
+      data = Dashboard::Data.new("environment = #{@env.name}")
+
+      as_admin do
+        assert_equal 1, data.latest_events.length
+      end
+    end
+
+    test 'latest_events works with free text filter' do
+      data = Dashboard::Data.new(@env.name)
+
+      as_admin do
+        assert_equal 1, data.latest_events.length
+      end
+    end
+
+    test 'latest_events works with a filter that returns no hosts' do
+      data = Dashboard::Data.new("name = DoesNotExist")
+
+      as_admin do
+        assert_equal 0, data.latest_events.length
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some filters on the dashboard caused the reports widget to break,
specifically searching using free text or on attributes that are not
part of the hosts table (such as environment name).
This is caused by an issue with Rails that digregards outer joins when a
query is used as an inner query for a where clause using hash syntax.
