### PR TITLE
Fixes #16752 - Extract template code from Host::Managed

### DIFF
--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -1,0 +1,60 @@
+module Hostext
+  module OperatingSystem
+    extend ActiveSupport::Concern
+
+    included do
+      scope :with_os, -> { where('hosts.operatingsystem_id IS NOT NULL') }
+      alias_attribute :os, :operatingsystem
+      validates :operatingsystem_id, :presence => true,
+        :if => ->(host) { host.managed }
+    end
+
+    # returns a configuration template (such as kickstart) to a given host
+    def provisioning_template(opts = {})
+      opts[:kind]               ||= "provision"
+      opts[:operatingsystem_id] ||= operatingsystem_id
+      opts[:hostgroup_id]       ||= hostgroup_id
+      opts[:environment_id]     ||= environment_id
+
+      Taxonomy.as_taxonomy(self.organization, self.location) do
+        ProvisioningTemplate.find_template opts
+      end
+    end
+
+    def available_template_kinds(provisioning = nil)
+      kinds = template_kinds(provisioning)
+      kinds.map do |kind|
+        ProvisioningTemplate.find_template({ :kind               => kind.name,
+                                             :operatingsystem_id => operatingsystem_id,
+                                             :hostgroup_id       => hostgroup_id,
+                                             :environment_id     => environment_id
+        })
+      end.compact
+    end
+
+    def template_kinds(provisioning = nil)
+      return TemplateKind.all unless provisioning == 'image'
+      cr     = ComputeResource.find_by_id(self.compute_resource_id)
+      images = cr.try(:images)
+      if images.blank?
+        [TemplateKind.friendly.find('finish')]
+      else
+        uuid       = self.compute_attributes[cr.image_param_name]
+        image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
+        [TemplateKind.friendly.find(image_kind)]
+      end
+    end
+
+    def templates_used
+      result = {}
+      available_template_kinds.map do |template|
+        result[template.template_kind_name] = template.name
+      end
+      result
+    end
+
+    def jumpstart?
+      operatingsystem.family == "Solaris" && architecture.name =~/Sparc/i rescue false
+    end
+  end
+end

--- a/test/models/concerns/hostext/operating_system_test.rb
+++ b/test/models/concerns/hostext/operating_system_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+module Hostext
+  class OperatingSystemTest < ActiveSupport::TestCase
+    context 'associated config templates' do
+      setup do
+        @host = Host.create(:name => "host.mydomain.net", :mac => "aabbccddeaff",
+                            :ip => "2.3.04.03",           :medium => media(:one),
+                            :subnet => subnets(:one), :hostgroup => Hostgroup.find_by_name("Common"),
+                            :architecture => Architecture.first, :disk => "aaa",
+                            :environment => Environment.find_by_name("production"))
+      end
+
+      test "retrieves iPXE template if associated to the correct env and host group" do
+        assert_equal ProvisioningTemplate.find_by_name("MyString"), @host.provisioning_template({:kind => "iPXE"})
+      end
+
+      test "retrieves provision template if associated to the correct host group only" do
+        assert_equal ProvisioningTemplate.find_by_name("MyString2"), @host.provisioning_template({:kind => "provision"})
+      end
+
+      test "retrieves script template if associated to the correct OS only" do
+        assert_equal ProvisioningTemplate.find_by_name("MyScript"), @host.provisioning_template({:kind => "script"})
+      end
+
+      test "retrieves finish template if associated to the correct environment only" do
+        assert_equal ProvisioningTemplate.find_by_name("MyFinish"), @host.provisioning_template({:kind => "finish"})
+      end
+
+      test "available_template_kinds finds templates for a PXE host" do
+        os_dt = FactoryGirl.create(:os_default_template,
+                                   :template_kind=> TemplateKind.friendly.find('finish'))
+        host  = FactoryGirl.create(:host, :operatingsystem => os_dt.operatingsystem)
+
+        assert_equal [os_dt.provisioning_template], host.available_template_kinds('build')
+      end
+
+      test "available_template_kinds finds templates for an image host" do
+        Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
+        os_dt = FactoryGirl.create(:os_default_template,
+                                   :template_kind=> TemplateKind.friendly.find('finish'))
+        host  = FactoryGirl.create(:host, :on_compute_resource,
+                                   :operatingsystem => os_dt.operatingsystem)
+        FactoryGirl.create(:image, :uuid => 'abcde',
+                           :compute_resource => host.compute_resource)
+        host.compute_attributes = {:image_id => 'abcde'}
+
+        assert_equal [os_dt.provisioning_template], host.available_template_kinds('image')
+      end
+
+      test "#render_template" do
+        provision_template = @host.provisioning_template({:kind => "provision"})
+        @host.expects(:load_template_vars)
+        rendered_template = @host.render_template(provision_template)
+        assert(rendered_template.include?("http://foreman.some.host.fqdn/unattended/finish"), "rendred template should parse foreman_url")
+      end
+    end
+
+    test '#jumpstart? should return true for Solaris and SPARC hosts' do
+      host = FactoryGirl.create(:host,
+                                :operatingsystem => FactoryGirl.create(:solaris),
+                                :architecture => FactoryGirl.create(:architecture, :name => 'SPARC-T2'))
+      assert host.jumpstart?
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -930,59 +930,6 @@ class HostTest < ActiveSupport::TestCase
       assert_equal domain, host.domain
     end
 
-    context 'associated config templates' do
-      setup do
-        @host = Host.create(:name => "host.mydomain.net", :mac => "aabbccddeaff",
-                            :ip => "2.3.04.03",           :medium => media(:one),
-                            :subnet => subnets(:one), :hostgroup => Hostgroup.find_by_name("Common"),
-                            :architecture => Architecture.first, :disk => "aaa",
-                            :environment => Environment.find_by_name("production"))
-      end
-
-      test "retrieves iPXE template if associated to the correct env and host group" do
-        assert_equal ProvisioningTemplate.find_by_name("MyString"), @host.provisioning_template({:kind => "iPXE"})
-      end
-
-      test "retrieves provision template if associated to the correct host group only" do
-        assert_equal ProvisioningTemplate.find_by_name("MyString2"), @host.provisioning_template({:kind => "provision"})
-      end
-
-      test "retrieves script template if associated to the correct OS only" do
-        assert_equal ProvisioningTemplate.find_by_name("MyScript"), @host.provisioning_template({:kind => "script"})
-      end
-
-      test "retrieves finish template if associated to the correct environment only" do
-        assert_equal ProvisioningTemplate.find_by_name("MyFinish"), @host.provisioning_template({:kind => "finish"})
-      end
-
-      test "available_template_kinds finds templates for a PXE host" do
-        os_dt = FactoryGirl.create(:os_default_template,
-                                   :template_kind=> TemplateKind.friendly.find('finish'))
-        host  = FactoryGirl.create(:host, :operatingsystem => os_dt.operatingsystem)
-
-        assert_equal [os_dt.provisioning_template], host.available_template_kinds('build')
-      end
-
-      test "available_template_kinds finds templates for an image host" do
-        os_dt = FactoryGirl.create(:os_default_template,
-                                   :template_kind=> TemplateKind.friendly.find('finish'))
-        host  = FactoryGirl.create(:host, :on_compute_resource,
-                                   :operatingsystem => os_dt.operatingsystem)
-        FactoryGirl.create(:image, :uuid => 'abcde',
-                           :compute_resource => host.compute_resource)
-        host.compute_attributes = {:image_id => 'abcde'}
-
-        assert_equal [os_dt.provisioning_template], host.available_template_kinds('image')
-      end
-
-      test "#render_template" do
-        provision_template = @host.provisioning_template({:kind => "provision"})
-        @host.expects(:load_template_vars)
-        rendered_template = @host.render_template(provision_template)
-        assert(rendered_template.include?("http://foreman.some.host.fqdn/unattended/finish"), "rendred template should parse foreman_url")
-      end
-    end
-
     test "handle_ca must not perform actions when the manage_puppetca setting is false" do
       h = FactoryGirl.create(:host)
       Setting[:manage_puppetca] = false
@@ -2986,13 +2933,6 @@ class HostTest < ActiveSupport::TestCase
     refute(host.valid?)
     host.domain_id = last_domain_id
     assert(host.valid?)
-  end
-
-  test '#jumpstart? should return true for Solaris and SPARC hosts' do
-    host = FactoryGirl.create(:host,
-                              :operatingsystem => FactoryGirl.create(:solaris),
-                              :architecture => FactoryGirl.create(:architecture, :name => 'SPARC-T2'))
-    assert host.jumpstart?
   end
 
   test '#fqdn returns the FQDN from the primary interface' do


### PR DESCRIPTION
Host::Managed contains a lot of code related with determining the
template that a host should have. Other Host objects such as
Host::Discovered might need that logic, without becoming a
Host::Managed.

This commit extracts that into Hostext::OperatingSystem so it can
be used on plugins.
