### PR TITLE
fixes #16749 - improve NIC update performance during fact imports

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -398,15 +398,17 @@ module Host
       update_virtuals(iface.identifier_was, name) if iface.identifier_changed? && !iface.virtual? && iface.persisted? && iface.identifier_was.present?
       iface.attrs = attributes
 
-      logger.debug "Saving #{name} NIC for host #{self.name}"
-      result = iface.save
+      if iface.new_record? || iface.changed?
+        logger.debug "Saving #{name} NIC for host #{self.name}"
+        result = iface.save
 
-      unless result
-        logger.warn "Saving #{name} NIC for host #{self.name} failed, skipping because:"
-        iface.errors.full_messages.each { |e| logger.warn " #{e}" }
+        unless result
+          logger.warn "Saving #{name} NIC for host #{self.name} failed, skipping because:"
+          iface.errors.full_messages.each { |e| logger.warn " #{e}" }
+        end
+
+        result
       end
-
-      result
     end
 
     def update_virtuals(old, new)

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -59,7 +59,7 @@ class FactParser
       result = {}
 
       interfaces = remove_ignored(normalize_interfaces(get_interfaces))
-      logger.debug "We have following interfaces '#{interfaces.join(', ')}' based on facts"
+      logger.debug { "We have following interfaces '#{interfaces.join(', ')}' based on facts" }
 
       interfaces.each do |interface|
         iface_facts = get_facts_for_interface(interface)
@@ -97,11 +97,11 @@ class FactParser
       if (ip = values[:ipaddress]).present?
         begin
           if Resolv::DNS.new.getnames(ip).any? { |name| name.to_s == host_name }
-            logger.debug "resolved #{host_name} for #{ip}, #{int} is selected as primary"
+            logger.debug { "resolved #{host_name} for #{ip}, #{int} is selected as primary" }
             return [int, values]
           end
         rescue Resolv::ResolvError => e
-          logger.debug "could not resolv name for #{ip} because of #{e} #{e.message}"
+          logger.debug { "could not resolv name for #{ip} because of #{e} #{e.message}" }
           nil
         end
       end
@@ -164,7 +164,7 @@ class FactParser
   def remove_ignored(interfaces)
     interfaces.clone.delete_if do |identifier|
       if (remove = identifier.match(ignored_interfaces))
-        logger.debug "skipping interface with identifier '#{identifier}' since it was matched by 'ignored_interface_identifiers' setting "
+        logger.debug { "skipping interface with identifier '#{identifier}' since it was matched by 'ignored_interface_identifiers' setting " }
       end
       remove
     end

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -119,10 +119,12 @@ class PuppetFactParser < FactParser
   end
 
   def get_facts_for_interface(interface)
-    iface_facts = @facts.select { |name, value| name =~ /.*_#{interface}\Z/ }
-    iface_facts = iface_facts.map { |name, value| [name.gsub("_#{interface}", ''), value] }
+    iface_facts = @facts.inject([]) do |facts, (name, value)|
+      facts << [name.chomp("_#{interface}"), value] if name.end_with?("_#{interface}")
+      facts
+    end
     iface_facts = HashWithIndifferentAccess[iface_facts]
-    logger.debug "Interface #{interface} facts: #{iface_facts.inspect}"
+    logger.debug { "Interface #{interface} facts: #{iface_facts.inspect}" }
     iface_facts
   end
 

--- a/test/benchmark/puppet_fact_parser_interfaces.rb
+++ b/test/benchmark/puppet_fact_parser_interfaces.rb
@@ -1,0 +1,33 @@
+require "benchmark/benchmark_helper"
+
+def generate_facts(total)
+  {}.tap do |facts|
+    facts['interfaces'] = (1..total).map { |i| "eth0_#{i}" }.join(',')
+    (1..total).each do |i|
+      facts["ipaddress_eth0_#{i}"] = "192.168.#{i / 255}.#{i % 255}"
+      facts["macaddress_eth0_#{i}"] = "00:10:10:10:#{sprintf('%02X', i / 255)}:#{sprintf('%02X', i % 255)}"
+      facts["mtu_eth0_#{i}"] = "255.255.255.0"
+      facts["netmask_eth0_#{i}"] = "255.255.255.0"
+      facts["network_eth0_#{i}"] = "192.168.#{i / 255}.0"
+    end
+  end
+end
+
+Rails.logger.level = Logger::ERROR
+
+Setting::Provisioning.load_defaults
+
+foreman_benchmark do
+  Benchmark.ips do |x|
+    x.config(:time => 10, :warmup => 0)
+
+    [::PuppetFactParser].each do |parser|
+      [1, 50, 500].each do |total_facts|
+        facts = generate_facts(total_facts)
+        x.report("#{parser} #{total_facts}") do
+          parser.new(facts).interfaces
+        end
+      end
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1310,6 +1310,18 @@ class HostTest < ActiveSupport::TestCase
       refute host.interfaces.where(:mac => '00:00:00:11:22:33').first.link
     end
 
+    test "#set_interfaces does not save when no changes made" do
+      host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:11:22:33', :virtual => false, :ipaddress => '10.0.0.1', :ipaddress6 => '2001:db8::1', :link => true})
+      host.primary_interface.update_attribute :mac, '00:00:00:11:22:33'
+      host.primary_interface.update_attribute :ip, '10.0.0.1'
+      host.primary_interface.update_attribute :ip6, '2001:db8::1'
+      host.primary_interface.update_attribute :identifier, 'eth0'
+      Nic::Base.any_instance.expects(:save).never
+      assert_no_difference 'Nic::Base.count' do
+        host.set_interfaces(parser)
+      end
+    end
+
     test "#set_interfaces updates existing physical interface by identifier" do
       host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:22:33:44', :identifier => 'eth0', :virtual => false, :ipaddress => '10.0.0.200', :ipaddress6 => '2001:db8::2', :link => false})
       host.managed = false


### PR DESCRIPTION
- In get_facts_for_interface, replace regexes in hash key filtering
  with simple String methods and simplify hash construction
- Change logger.debug to lazy evaluation for production performance,
  especially when calling #inspect

Before:

```
  PuppetFactParser 1      6.114k (±16.1%) i/s -     57.836k in   9.951523s
 PuppetFactParser 50     15.127  (±26.4%) i/s -    135.000  in  10.036620s
PuppetFactParser 500      0.143  (± 0.0%) i/s -      2.000  in  14.027935s
Memory stats
Total objects allocated: 61005590
Total heap pages allocated: 4218
```

After:

```
  PuppetFactParser 1      9.308k (±14.8%) i/s -     87.936k in   9.934396s
 PuppetFactParser 50    213.821  (±16.4%) i/s -      2.018k in  10.007988s
PuppetFactParser 500      2.610  (± 0.0%) i/s -     27.000  in  10.357182s
Total objects allocated: 149652784
Total heap pages allocated: 4221
```

(approximately 15x faster, and sub-second for the ~400 interfaces in the
bug report)

In Host#set_interface, unchanged interfaces are no longer saved to avoid
creating an unnecessary validation and DB transactions in most imports.
