### PR TITLE
refs #16689 - expand array of eager load tables

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -224,8 +224,8 @@ class ApplicationController < ActionController::Base
   end
 
   def resource_base_search_and_page(tables = [])
-    resource_base_with_search.eager_load(tables).
-      paginate(:page => params[:page], :per_page => params[:per_page])
+    base = tables.empty? ? resource_base_with_search : resource_base_with_search.eager_load(*tables)
+    base.paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
   private


### PR DESCRIPTION
Previously an array of tables (e.g. on Puppetclasses, SubnetsController)
triggered false positive warnings from Bullet:

```
| Unused Eager Loading detected
|   Subnet::Ipv4 => [[:domains, :dhcp]]
```

and when no tables were passed on most index pages:

```
| Unused Eager Loading detected
|   Domain => [[]]
```
