### PR TITLE
fixes #16792 - don't modify AR record attributes in-place

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -333,7 +333,7 @@ class ComputeResource < ActiveRecord::Base
   end
 
   def sanitize_url
-    self.url.chomp!("/") unless url.empty?
+    self.url = url.chomp("/") unless url.empty?
   end
 
   def random_password

--- a/app/models/concerns/strip_whitespace.rb
+++ b/app/models/concerns/strip_whitespace.rb
@@ -7,8 +7,7 @@ module StripWhitespace
 
   def strip_spaces
     self.changes.each do |column, values|
-      # return string if RuntimeError: can't modify frozen String
-      self.send(column).strip! if (values.last.is_a?(String) && !skip_strip_attrs.include?(column)) rescue send(column)
+      write_attribute(column, read_attribute(column).strip) if (read_attribute(column).is_a?(String) && !skip_strip_attrs.include?(column))
     end
   end
 

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -118,7 +118,7 @@ module Host
       raise ::Foreman::Exception.new('Host is pending for Build') if build?
       facts = facts.with_indifferent_access
 
-      facts[:domain].try(:downcase!)
+      facts[:domain] = facts[:domain].downcase if facts[:domain].present?
 
       time = facts[:_timestamp]
       time = time.to_time if time.is_a?(String)

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -97,7 +97,7 @@ module Nic
     # this is done to ensure compatibility with puppet storeconfigs
     def normalize_name
       # Remove whitespace
-      self.name.gsub!(/\s/,'') if self.name
+      self.name = self.name.gsub(/\s/, '') if self.name
       # no hostname was given or a domain was selected, since this is before validation we need to ignore
       # it and let the validations to produce an error
       return if name.empty?
@@ -108,7 +108,7 @@ module Nic
         # if we've just updated the domain name, strip off the old one
         old_domain = Domain.find(changed_attributes["domain_id"])
         # Remove the old domain, until fqdn will be set as the full name
-        self.name.chomp!("." + old_domain.to_s)
+        self.name = self.name.chomp('.' + old_domain.to_s)
       end
       # name should be fqdn
       self.name = fqdn

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -268,7 +268,7 @@ class Operatingsystem < ActiveRecord::Base
   end
 
   def downcase_release_name
-    self.release_name.downcase! unless Foreman.in_rake? || release_name.nil? || release_name.empty?
+    self.release_name = release_name.downcase if release_name.present?
   end
 
   def reject_empty_provisioning_template(attributes)

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -32,7 +32,7 @@ class Debian < Operatingsystem
 
   def self.shorten_description(description)
     return "" if description.blank?
-    s=description
+    s = description.dup
     s.gsub!('GNU/Linux','')
     s.gsub!(/\(.+?\)/,'')
     s.squeeze! " "

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -44,7 +44,7 @@ class Redhat < Operatingsystem
 
   def self.shorten_description(description)
     return "" if description.blank?
-    s=description
+    s = description.dup
     s.gsub!('Red Hat Enterprise Linux','RHEL')
     s.gsub!('release','')
     s.gsub!(/\(.+?\)/,'')

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -28,7 +28,7 @@ class Suse < Operatingsystem
 
   def self.shorten_description(description)
     return "" if description.blank?
-    s=description
+    s = description.dup
     s.gsub!('SUSE Linux Enterprise Server','SLES')
     s.gsub!(/\(.+?\)/,'')
     s.squeeze! " "

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -107,7 +107,7 @@ class SmartProxy < ActiveRecord::Base
   private
 
   def sanitize_url
-    self.url.chomp!('/') unless url.empty?
+    self.url = url.chomp('/') unless url.empty?
   end
 
   def associate_features

--- a/app/models/subnet/ipv4.rb
+++ b/app/models/subnet/ipv4.rb
@@ -72,9 +72,8 @@ class Subnet::Ipv4 < Subnet
   private
 
   def cleanup_ip(address)
-    address.gsub!(/\.\.+/, ".")
-    address.gsub!(/2555+/, "255")
-    address
+    address.gsub(/\.\.+/, ".").
+            gsub(/2555+/, "255")
   end
 
   def normalize_ip(address)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -63,7 +63,7 @@ class Template < ActiveRecord::Base
   end
 
   def remove_trailing_chars
-    self.template.tr!("\r", '') unless template.blank?
+    self.template = template.tr("\r", '') unless template.blank?
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -468,7 +468,7 @@ class User < ActiveRecord::Base
   end
 
   def normalize_mail
-    self.mail.strip! unless mail.blank?
+    self.mail = mail.strip unless mail.blank?
   end
 
   def reject_empty_intervals(attributes)

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -230,6 +230,12 @@ class ComputeResourceTest < ActiveSupport::TestCase
     refute as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }.readonly?
   end
 
+  test "url has trailing slash removed on save" do
+    cr = FactoryGirl.build(:ec2_cr, url: 'http://example.com/')
+    cr.save!
+    assert_equal 'http://example.com', cr.url
+  end
+
   describe "find_vm_by_uuid" do
     before do
       servers = mock()

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -194,6 +194,12 @@ class OperatingsystemTest < ActiveSupport::TestCase
     end
   end
 
+  test "release name is changed to lower case on save" do
+    os = FactoryGirl.build(:operatingsystem, release_name: 'TEST')
+    os.save!
+    assert_equal 'test', os.release_name
+  end
+
   test "should find os name using free text search only" do
     operatingsystems = Operatingsystem.search_for('centos')
     assert_equal 1, operatingsystems.count

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -133,6 +133,12 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     provisioning_template.preview_host_collection
   end
 
+  test 'saving removes carriage returns' do
+    template = FactoryGirl.build(:provisioning_template, template: "a\r\nb\r\nc\n")
+    template.save!
+    assert_equal "a\nb\nc\n", template.template
+  end
+
   describe "Association cascading" do
     setup do
       @os1 = FactoryGirl.create(:operatingsystem)

--- a/test/models/subnet/ipv4_test.rb
+++ b/test/models/subnet/ipv4_test.rb
@@ -13,6 +13,7 @@ class Subnet::Ipv4Test < ActiveSupport::TestCase
   should_not allow_value('300.300.300.0').for(:network)
   should_not allow_value('100.101.102').for(:network)
   should allow_value('100.101.102.103.').for(:network) # clean invalid addresses
+  should allow_value('100.101.102.25555').for(:network) # clean invalid addresses
   # Test smart proxies from Subnet are inherited
   should belong_to(:tftp)
   should belong_to(:dns)


### PR DESCRIPTION
Rails 5 calls #freeze on any string passed in as an attribute during
validation, so attributes must not be edited in-place with gsub! and
similar methods.
