### PR TITLE
fixes #16798 - move scoped_search definitions to STI subclasses

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -35,13 +35,13 @@ module Api::V2::TaxonomiesController
   api :GET, '/:resource_id', N_('List all :resource_id')
   param_group :search_and_pagination, ::Api::V2::BaseController
   def index
-    if @nested_obj
-      @taxonomies = @nested_obj.send(taxonomies_plural).send(:completer_scope, :controller => taxonomies_plural).search_for(*search_options).paginate(paginate_options)
-      @total = @nested_obj.send(taxonomies_plural).send(:completer_scope, :controller => taxonomies_plural).count
-    else
-      @taxonomies = taxonomy_class.send("my_#{taxonomies_plural}").search_for(*search_options).paginate(paginate_options)
-      @total = taxonomy_class.send("my_#{taxonomies_plural}").count
-    end
+    taxonomy_scope = if @nested_obj
+                       taxonomy_class.where(:id => @nested_obj.send("#{taxonomy_single}_ids"))
+                     else
+                       taxonomy_class
+                     end
+    @taxonomies = taxonomy_scope.send("my_#{taxonomies_plural}").search_for(*search_options).paginate(paginate_options)
+    @total = taxonomy_scope.send("my_#{taxonomies_plural}").count
     instance_variable_set("@#{taxonomies_plural}", @taxonomies)
 
     @render_template ||= 'api/v2/taxonomies/index'

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -13,9 +13,6 @@ module NestedAncestryCommon
 
     validate :title_and_lookup_key_length
 
-    scoped_search :on => :title, :complete_value => true, :default_order => true
-    scoped_search :on => :name, :complete_value => :true
-
     # attribute used by *_names and *_name methods.  default is :name
     attr_name :title
     optional_attr_accessible :parent, :parent_id

--- a/app/models/concerns/nested_ancestry_common/search.rb
+++ b/app/models/concerns/nested_ancestry_common/search.rb
@@ -1,0 +1,8 @@
+module NestedAncestryCommon::Search
+  extend ActiveSupport::Concern
+
+  included do
+    scoped_search :on => :title, :complete_value => true, :default_order => true
+    scoped_search :on => :name, :complete_value => :true
+  end
+end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -6,6 +6,7 @@ class Hostgroup < ActiveRecord::Base
   include HostCommon
 
   include NestedAncestryCommon
+  include NestedAncestryCommon::Search
 
   validates :name, :presence => true, :uniqueness => {:scope => :ancestry, :case_sensitive => false}
 

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -9,7 +9,13 @@ class Parameter < ActiveRecord::Base
   include Authorizable
   validates :name, :presence => true, :no_whitespace => true
 
-  scoped_search :on => :name, :complete_value => true
+  def self.inherited(child)
+    child.instance_eval do
+      scoped_search :on => :name, :complete_value => true
+      scoped_search :on => :value, :complete_value => :true
+    end
+    super
+  end
 
   default_scope -> { order("parameters.name") }
 

--- a/app/models/parameters/common_parameter.rb
+++ b/app/models/parameters/common_parameter.rb
@@ -2,9 +2,6 @@ class CommonParameter < Parameter
   audited :except => [:priority]
   validates :name, :uniqueness => true
 
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :value, :complete_value => :true
-
   def associated_type
     N_('global')
   end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -29,8 +29,14 @@ class Taxonomy < ActiveRecord::Base
   before_validation :sanitize_ignored_types
   after_create :assign_default_templates
 
-  scoped_search :on => :description, :complete_enabled => :false, :only_explicit => true
-  scoped_search :on => :id
+  def self.inherited(child)
+    child.instance_eval do
+      scoped_search :on => :description, :complete_enabled => :false, :only_explicit => true
+      scoped_search :on => :id
+    end
+    child.send(:include, NestedAncestryCommon::Search)
+    super
+  end
 
   delegate :import_missing_ids, :inherited_ids, :used_and_selected_or_inherited_ids, :selected_or_inherited_ids,
            :non_inherited_ids, :used_or_inherited_ids, :used_ids, :to => :tax_host


### PR DESCRIPTION
scoped_search doesn't support class inheritance with STI, so registering
definitions on the subclass fixes various issues. This fixes an issue
where scoped_search on CommonParameter calls Parameter.all and is
returned a list of CommonParameters under Rails 4.2, as it relies on a
bug (#18806) for applying the type='CommonParameter' condition when
calling Parameter.all.

On Rails 5.0, this bug was fixed and calling Parameter.all within a
scope on CommonParameter now returns all types of parameters.
Registering all scoped_search definitions on the subclasses ensures that
scoped_search calls CommonParameter.all instead.

The taxonomies API changed as it called Taxonomix objects with scopes
such as `.locations.search_for`, which no longer existed when the
scoped_search definitions were removed from Taxonomy (.locations is a
Taxonomy association with a where clause). This now explicitly searches
via the appropriate Taxonomy subclass.
