### PR TITLE
fixes #16805 - reload host parameters on host group change

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -5,7 +5,7 @@
 
 <% Taxonomy.as_taxonomy @organization , @location do %>
 
-  <%= form_for @host,  :html => {:data => {:id => @host.try(:id), :type_changed => @host.type_changed?, :submit => 'progress_bar'}} do |f| %>
+  <%= form_for @host,  :html => {:data => {:id => @host.try(:id), :type_changed => !!@host.type_changed?, :submit => 'progress_bar'}} do |f| %>
     <%= base_errors_for @host %>
 
     <ul class="nav nav-tabs" data-tabs="tabs">

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -450,6 +450,7 @@ FactoryGirl.define do
     trait :with_parameter do
       after(:create) do |hg,evaluator|
         FactoryGirl.create(:hostgroup_parameter, :hostgroup => hg)
+        hg.group_parameters.reload
       end
     end
 


### PR DESCRIPTION
On Rails 4.2, `Host#type_changed?` may return nil due to bug #24220
causing data-type-changed to be missing from the host form and the JS
in handleHostgroupChangeEdit to assume host#edit is a hostgroup form.
Now that data-type-changed is always present, the full reload of
parameters occurs when the host group is changed on a host.
