### PR TITLE
 Fixes #16548 - Changing user own password require current password 

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/user.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/user.rb
@@ -6,13 +6,14 @@ module Foreman::Controller::Parameters::User
   class_methods do
     def user_params_filter
       Foreman::ParameterFilter.new(::User).tap do |filter|
-        filter.permit :default_location_id,
+        filter.permit :current_password,
+          :default_location_id,
           :default_organization_id,
+          :description,
           :firstname,
           :lastname,
           :locale,
           :mail,
-          :description,
           :mail_enabled,
           :password,
           :password_confirmation,

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -35,6 +35,9 @@
                         :label => _('Authorized by') } ) unless @editing_self %>
 
       <div id='password' <%= display? !@user.manage_password? %>>
+        <% if User.current == @user  %>
+          <%= password_f f, :current_password, :label => _('Current password'), :placeholder => '' %>
+        <% end %>
         <%= password_f f, :password, :label => _('Password'), :error => @user.errors[:password_hash] %>
         <%= password_f f, :password_confirmation, :label => _('Verify') %>
       </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -117,9 +117,9 @@ class UsersControllerTest < ActionController::TestCase
                     :login => "johnsmith", :password => "dummy", :password_confirmation => "DUMMY"
                   }
                  }, set_session_user
-    mod_user = User.find_by_id(user.id)
 
-    assert mod_user.matching_password?("changeme")
+    user.reload
+    assert user.matching_password?("changeme")
     assert_template :edit
   end
 
@@ -133,6 +133,21 @@ class UsersControllerTest < ActionController::TestCase
                  }, set_session_user
 
     assert_redirected_to users_url
+  end
+
+  test "current user have to enter current password to change password" do
+    user = FactoryGirl.create(:user, :password => 'password')
+    User.current = user
+
+    put :update, {:id => user.id,
+                  :user => {
+                    :current_password => "password", :password => "newpassword", :password_confirmation => "newpassword"
+                  }
+    }, set_session_user
+
+    user.reload
+    assert user.matching_password?("newpassword")
+    assert_redirected_to users_path
   end
 
   test "should delete different user" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -43,6 +43,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "mail is required for own user" do
     user = FactoryGirl.create(:user)
+    user.password = nil
+    # refute_valid user can check only one field and due to we need to set password to nil after adding current_password field to verify password change
     as_user user do
       refute_valid user, :mail
     end
@@ -873,5 +875,32 @@ class UserTest < ActiveSupport::TestCase
     user = users(:one)
     user.timezone = ''
     assert user.valid?
+  end
+
+  test "changing user password as admin without setting current password" do
+    user = FactoryGirl.create(:user, :mail => "foo@bar.com")
+    as_admin do
+      user.password = "newpassword"
+      assert user.save
+    end
+  end
+
+  test "changing user's own password with incorrect current password" do
+    user = FactoryGirl.create(:user, :mail => "foo@bar.com")
+    as_user user do
+      user.current_password = "hatatitla"
+      user.password = "newpassword"
+      refute user.valid?
+      assert user.errors.messages.has_key? :current_password
+    end
+  end
+
+  test "changing user's own password with correct current password" do
+    user = FactoryGirl.create(:user, :password => "password", :mail => "foo@bar.com")
+    as_user user do
+      user.current_password = "password"
+      user.password = "newpassword"
+      assert user.save
+    end
   end
 end


### PR DESCRIPTION
Changing user own password require current password and adding changing password activity to Audit log
