### PR TITLE
Fixes #16828 - cloned-roles - role.builtin must be 0

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -94,7 +94,7 @@ class RolesController < ApplicationController
       new_role.name = params[:role][:name]
       new_role.organization_ids = params[:role][:organization_ids]
       new_role.location_ids = params[:role][:location_ids]
-      new_role.builtin = false
+      new_role.builtin = 0
     else
       new_role = Role.new(role_params)
     end

--- a/test/controllers/roles_controller_test.rb
+++ b/test/controllers/roles_controller_test.rb
@@ -122,6 +122,7 @@ class RolesControllerTest < ActionController::TestCase
       cloned_role = Role.find_by_name('clonedrole')
       assert_not_nil cloned_role
       assert_equal @role.permissions, cloned_role.permissions
+      assert_equal cloned_role.builtin, 0
     end
   end
 end


### PR DESCRIPTION
Though `roles.builtin` has [`:default => 0`](https://github.com/theforeman/foreman/blob/12612809c5deb885b13ceaf36b6a147c21688eb5/db/migrate/20160715131352_set_role_builtin_default.rb). This is to ensure cloned roles always have `builtin == 0`
