### PR TITLE
Fixes #6492 - ipmi_boot permission renamed to ipmi_boot_hosts

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -242,6 +242,8 @@ Return the host's compute attributes that can be used to create a clone of this 
         else
           render :json => { :error => _("Unknown device: available devices are %s") % valid_devices.join(', ') }, :status => :unprocessable_entity
         end
+      rescue ::Foreman::Exception => e
+        render_message(e.to_s, :status => :unprocessable_entity)
       end
 
       api :POST, "/hosts/facts", N_("Upload facts for a host, creating the host if required")
@@ -351,7 +353,7 @@ Return the host's compute attributes that can be used to create a clone of this 
       end
 
       def permissions_check
-        permission = "#{params[:action]}_hosts".to_sym
+        permission = "#{action_permission}_hosts".to_sym
         deny_access unless Host.authorized(permission, Host).find(@host.id)
       end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -761,6 +761,8 @@ class Host::Managed < Host::Base
   end
 
   def ipmi_boot(booting_device)
+    raise Foreman::Exception.new(
+      _("No BMC NIC available for host %s") % self) unless bmc_available?
     bmc_proxy.boot({:function => 'bootdevice', :device => booting_device})
   end
 

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -402,8 +402,8 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :power_hosts,   {:hosts          => [:power],
                                     :"api/v2/hosts" => [:power] }
     map.permission :console_hosts, {:hosts => [:console] }
-    map.permission :ipmi_boot, { :hosts          => [:ipmi_boot],
-                                 :"api/v2/hosts" => [:boot] }
+    map.permission :ipmi_boot_hosts, { :hosts          => [:ipmi_boot],
+                                       :"api/v2/hosts" => [:boot] }
     map.permission :puppetrun_hosts, {:hosts => [:puppetrun, :multiple_puppetrun, :update_multiple_puppetrun],
                                       :"api/v2/hosts" => [:puppetrun] }
   end

--- a/db/migrate/20161007115719_rename_ipmi_boot_permission.rb
+++ b/db/migrate/20161007115719_rename_ipmi_boot_permission.rb
@@ -1,0 +1,11 @@
+class RenameIpmiBootPermission < ActiveRecord::Migration
+  def up
+    Permission.where(:name => 'ipmi_boot').
+      update_all(:name => 'ipmi_boot_hosts')
+  end
+
+  def down
+    Permission.where(:name => 'ipmi_boot_hosts').
+      update_all(:name => 'ipmi_boot')
+  end
+end

--- a/db/seeds.d/03-permissions.rb
+++ b/db/seeds.d/03-permissions.rb
@@ -69,7 +69,7 @@ permissions = [
   ['Host', 'build_hosts'],
   ['Host', 'power_hosts'],
   ['Host', 'console_hosts'],
-  ['Host', 'ipmi_boot'],
+  ['Host', 'ipmi_boot_hosts'],
   ['Host', 'puppetrun_hosts'],
   ['Image', 'view_images'],
   ['Image', 'create_images'],

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -294,8 +294,8 @@
     resource_type: Host
     created_at: "2013-12-04 08:41:04.931564"
     updated_at: "2013-12-04 08:41:04.931564"
-  ipmi_boot:
-    name: ipmi_boot
+  ipmi_boot_hosts:
+    name: ipmi_boot_hosts
     resource_type: Host
     created_at: "2013-12-04 08:41:04.940695"
     updated_at: "2013-12-04 08:41:04.940695"

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3375,6 +3375,26 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#ipmi_boot' do
+    setup do
+      @host = FactoryGirl.build_stubbed(:host)
+    end
+
+    test 'throws exception when host does not have BMC proxy' do
+      assert_raises(Foreman::Exception) do
+        @host.ipmi_boot('bios')
+      end
+    end
+
+    test 'calls the proxy with the right function and device' do
+      bmc_proxy_stub = stub('bmc_proxy')
+      @host.expects(:bmc_available?).returns(true)
+      @host.expects(:bmc_proxy).returns(bmc_proxy_stub)
+      bmc_proxy_stub.expects(:boot).with(:function => 'bootdevice', :device => 'bios').returns(true)
+      assert @host.ipmi_boot('bios')
+    end
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)


### PR DESCRIPTION
Authorizer expects permission names to follow a convention
'action'_'controller'. However this permission was not following it, and
this prevented the permission from being applied properly.

Before this fix, only admins could call ipmi_boot. I've also added a
small fix to the controller to check whether the BMC interface is
available before making the IPMI call - otherwise the error that Foreman
threw did not make much sense for the end user (NoMethodError on
bmc_proxy).
