### PR TITLE
fixes #16592 - keep consistent for headline capitalization

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -11,11 +11,11 @@ module Menu
 
       Manager.map :user_menu do |menu|
         menu.item :my_account,
-                  :caption => N_('My account'),
+                  :caption => N_('My Account'),
                   :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
         menu.divider
         menu.item :logout,
-                  :caption => N_('Log out'),
+                  :caption => N_('Log Out'),
                   :html => {:method => :post},
                   :url_hash => {:controller => '/users', :action => 'logout'}
       end
@@ -26,9 +26,9 @@ module Menu
           menu.item :organizations,      :caption => N_('Organizations') if SETTINGS[:organizations_enabled]
           menu.divider
           if SETTINGS[:login]
-            menu.item :auth_source_ldaps,:caption => N_('LDAP authentication')
+            menu.item :auth_source_ldaps,:caption => N_('LDAP Authentication')
             menu.item :users,            :caption => N_('Users')
-            menu.item :usergroups,       :caption => N_('User groups')
+            menu.item :usergroups,       :caption => N_('User Groups')
             menu.item :roles,            :caption => N_('Roles')
           end
           menu.divider
@@ -46,45 +46,45 @@ module Menu
           menu.item :trends,            :caption => N_('Trends')
           menu.item :audits,            :caption => N_('Audits')
           menu.divider                  :caption => N_('Reports')
-          menu.item :reports,           :caption => N_('Config management'),
+          menu.item :reports,           :caption => N_('Config Management'),
                     :url_hash => {:controller => '/config_reports', :action => 'index', :search => 'eventful = true'}
           menu.divider
         end
 
         menu.sub_menu :hosts_menu,      :caption => N_('Hosts') do
-          menu.item :hosts,             :caption => N_('All hosts')
-          menu.item :newhost,           :caption => N_('Create host'),
+          menu.item :hosts,             :caption => N_('All Hosts')
+          menu.item :newhost,           :caption => N_('Create Host'),
                     :url_hash => {:controller => '/hosts', :action => 'new'}
           if SETTINGS[:unattended]
             menu.divider                :caption => N_('Provisioning Setup')
             menu.item :architectures,   :caption => N_('Architectures')
-            menu.item :models,          :caption => N_('Hardware models')
-            menu.item :media,           :caption => N_('Installation media')
-            menu.item :operatingsystems,:caption => N_('Operating systems')
+            menu.item :models,          :caption => N_('Hardware Models')
+            menu.item :media,           :caption => N_('Installation Media')
+            menu.item :operatingsystems,:caption => N_('Operating Systems')
             menu.divider                :caption => N_('Templates')
-            menu.item :partition_tables, :caption => N_('Partition tables'),
+            menu.item :partition_tables, :caption => N_('Partition Tables'),
                       :url_hash => { :controller => 'ptables', :action => 'index' }
-            menu.item :provisioning_templates, :caption => N_('Provisioning templates'),
+            menu.item :provisioning_templates, :caption => N_('Provisioning Templates'),
                       :url_hash => { :controller => 'provisioning_templates', :action => 'index' }
           end
         end
 
         menu.sub_menu :configure_menu,  :caption => N_('Configure') do
-          menu.item :hostgroups,        :caption => N_('Host groups')
-          menu.item :common_parameters, :caption => N_('Global parameters')
+          menu.item :hostgroups,        :caption => N_('Host Groups')
+          menu.item :common_parameters, :caption => N_('Global Parameters')
           menu.divider                  :caption => N_('Puppet')
           menu.item :environments,      :caption => N_('Environments')
           menu.item :puppetclasses,     :caption => N_('Classes')
-          menu.item :config_groups,     :caption => N_('Config groups')
-          menu.item :variable_lookup_keys, :caption => N_('Smart variables')
-          menu.item :puppetclass_lookup_keys, :caption => N_('Smart class parameters')
+          menu.item :config_groups,     :caption => N_('Config Groups')
+          menu.item :variable_lookup_keys, :caption => N_('Smart Variables')
+          menu.item :puppetclass_lookup_keys, :caption => N_('Smart Class Parameters')
         end
 
         menu.sub_menu :infrastructure_menu, :caption => N_('Infrastructure') do
-          menu.item :smart_proxies, :caption => N_('Smart proxies')
+          menu.item :smart_proxies, :caption => N_('Smart Proxies')
           if SETTINGS[:unattended]
-            menu.item :compute_resources, :caption => N_('Compute resources')
-            menu.item :compute_profiles,  :caption => N_('Compute profiles')
+            menu.item :compute_resources, :caption => N_('Compute Resources')
+            menu.item :compute_profiles,  :caption => N_('Compute Profiles')
             menu.item :subnets,           :caption => N_('Subnets')
             menu.item :domains,           :caption => N_('Domains')
             menu.item :realms,            :caption => N_('Realms')

--- a/app/services/statistics.rb
+++ b/app/services/statistics.rb
@@ -8,8 +8,8 @@ module Statistics
       CountHosts.new(:count_by => :compute_resource, :title => _("Compute Resource Distribution"), :search => "compute_resource=~VAL~"),
       CountFacts.new(:count_by => :processorcount, :unit => Nn_('%s core', '%s cores'), :title => _("Number of CPUs"), :search => "facts.processorcount=~VAL1~"),
       CountFacts.new(:count_by => :manufacturer, :title => _("Hardware"), :search => "facts.manufacturer~~VAL~"),
-      CountNumericalFactPair.new(:count_by => :memory, :title => _("Average memory usage")),
-      CountNumericalFactPair.new(:count_by => :swap, :title => _("Average swap usage")),
+      CountNumericalFactPair.new(:count_by => :memory, :title => _("Average Memory Usage")),
+      CountNumericalFactPair.new(:count_by => :swap, :title => _("Average Swap Usage")),
       CountPuppetClasses.new(:id => :puppetclass, :title => _("Class Distribution"), :search => "class=~VAL1~")
     ]
 

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -7,7 +7,7 @@
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},
-    {:label => _("Partition table"), :disabled => os_ptable.empty?, :required => true}
+    {:label => _("Partition Table"), :disabled => os_ptable.empty?, :required => true}
   %>
 
   <% if @operatingsystem && @operatingsystem.supports_image %>

--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript 'compute_resource' %>
 
-<% title _('Compute profiles') %>
+<% title _('Compute Profiles') %>
 
 <% title_actions new_link(_('Create Compute Profile')),
                  documentation_button('5.2.2UsingComputeProfiles') %>

--- a/app/views/compute_resources/form/_gce.html.erb
+++ b/app/views/compute_resources/form/_gce.html.erb
@@ -1,6 +1,6 @@
 <%= text_f f, :project, :label => _("Google Project ID"), :help_inline => documentation_button('5.2.4GoogleComputeEngineNotes') %>
 <%= text_f f, :email, :label => _("Client Email"), :class => 'col-md-8' %>
-<%= text_f f, :key_path, :label => _("Certificate path"), :help_inline => _('The file path where your p12 file is located'), :class => 'col-md-8' %>
+<%= text_f f, :key_path, :label => _("Certificate Path"), :help_inline => _('The file path where your p12 file is located'), :class => 'col-md-8' %>
 
 <% zones = f.object.zones rescue [] %>
 <%= selectable_f(f, :zone, zones, {}, {:label => _('Zone'), :disabled => zones.empty?,

--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,8 +1,8 @@
 <%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
 
-<%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display type") %>
+<%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display Type") %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
-                  :label => _("Console passwords"),
+                  :label => _("Console Passwords"),
                   :help_inline => _("Set a randomly generated password on the display connection") %>
 
 <% hypervisor = f.object.hypervisor.uuid rescue nil%>

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -5,8 +5,8 @@
 <%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'), :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) })%>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
-                  :label => _("Console passwords"),
+                  :label => _("Console Passwords"),
                   :help_inline => _("Set a randomly generated password on the display connection") %>
-<%= checkbox_f f, :caching_enabled, :label => _("Enable caching"),
+<%= checkbox_f f, :caching_enabled, :label => _("Enable Caching"),
                   :help_inline => _("Cache slow calls to VMWare to speed up page rendering") %>
 <%= f.hidden_field(:pubkey_hash) if f.object.uuid.present? %>

--- a/app/views/compute_resources/show/_libvirt.html.erb
+++ b/app/views/compute_resources/show/_libvirt.html.erb
@@ -3,10 +3,10 @@
   <td><%= @compute_resource.url %></td>
 </tr>
 <tr>
-  <td><%= _("Display type") %></td>
+  <td><%= _("Display Type") %></td>
   <td><%= @compute_resource.display_type %></td>
 </tr>
 <tr>
-  <td><%= _("Console passwords") %></td>
+  <td><%= _("Console Passwords") %></td>
   <td><%= @compute_resource.set_console_password? ? _("Enabled") : _("Disabled") %></td>
 </tr>

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript 'class_edit' %>
 
-<% title _('Config groups') %>
+<% title _('Config Groups') %>
 
 <% title_actions new_link(_('Create Config Group')), help_button %>
 
@@ -8,9 +8,9 @@
   <thead>
     <tr>
       <th class="col-md-6"><%= sort :name %></th>
-      <th><%= _('Puppet classes') %></th>
+      <th><%= _('Puppet Classes') %></th>
       <th><%= _('Hosts') %></th>
-      <th><%= _('Host groups') %></th>
+      <th><%= _('Host Groups') %></th>
       <th><%= _('Actions') %></th>
     </tr>
   </thead>

--- a/app/views/dashboard/_new_hosts_widget_host_list.html.erb
+++ b/app/views/dashboard/_new_hosts_widget_host_list.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-striped table-fixed">
   <thead>
     <th width="30%"><%= _('Host') %></th>
-    <th><%= _('Operating system') %></th>
+    <th><%= _('Operating System') %></th>
     <th><%= _('Owner') %></th>
     <th><%= _('Created') %></th>
     <th><%= _('Installed') %></th>

--- a/app/views/domains/_form.html.erb
+++ b/app/views/domains/_form.html.erb
@@ -16,7 +16,7 @@
   <div class="tab-content">
 
     <div class="tab-pane active" id="primary">
-      <%= text_f   f, :name, :help_inline => _("The full DNS domain name") %>
+      <%= text_f   f, :name, :label => _("DNS Domain"), :help_inline => _("The full DNS domain name") %>
       <%= text_f   f, :fullname, :help_inline => _("Full name describing the domain") %>
       <%= smart_proxy_fields f %>
     </div>

--- a/app/views/fact_values/welcome.html.erb
+++ b/app/views/fact_values/welcome.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:title, _("Fact values")) %>
+<% content_for(:title, _("Fact Values")) %>
 <div class="blank-slate-pf">
   <div class="blank-slate-pf-icon">
     <%= icon_text("list-alt", "", :kind => "fa") %>
   </div>
-  <h1><%= _('Fact values') %></h1>
+  <h1><%= _('Fact Values') %></h1>
   <%= _("You don't seem to have any facts yet. If you wish to configure fact pushing, please follow the documentation.") %>
   <div class="blank-slate-pf-main-action">
     <%= link_to _('Documentation'), documentation_url("3.5.5FactsandtheENC"), :rel => "external",

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -66,18 +66,18 @@
     <div class="tab-pane" id="params">
 
       <fieldset>
-        <h2><%= _('Puppet class parameters') %></h2>
+        <h2><%= _('Puppet Class Parameters') %></h2>
         <%= render 'puppetclasses/classes_parameters', :obj => @hostgroup  %>
       </fieldset>
       <br/>
       <% if authorized_for(:controller => "host_editing", :action => "view_params") %>
         <fieldset>
-          <h2><%= _('Global parameters') %></h2>
+          <h2><%= _('Global Parameters') %></h2>
           <% if @hostgroup.parent.present? %>
-              <h4><%= _('Parent parameters') %></h4>
+              <h4><%= _('Parent Parameters') %></h4>
               <%= render "common_parameters/inherited_parameters", { :inherited_parameters => @hostgroup.parent_params(true), :parameters => @hostgroup.group_parameters } %>
           <% end %>
-          <h4><%= _('Host group parameters') %></h4>
+          <h4><%= _('Host Group Parameters') %></h4>
           <%= render "common_parameters/parameters", { :f => f, :type => :group_parameters } %>
         </fieldset>
       <% end %>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -7,7 +7,7 @@
     <tr>
       <th><%= sort :label, :as => _('Hostgroup|Name') %></th>
       <th><%= _('Hosts') %></th>
-      <th><%= _('Hosts including sub-groups') %></th>
+      <th><%= _('Hosts including Sub-groups') %></th>
       <th><%= _('Actions') %></th>
     </tr>
   </thead>

--- a/app/views/hostgroups/welcome.html.erb
+++ b/app/views/hostgroups/welcome.html.erb
@@ -1,5 +1,5 @@
 <% title_actions new_link(_("Create Host Group")) %>
-<% title _("Host group configuration") %>
+<% title _("Host Group Configuration") %>
 <div id="welcome">
   <p>
   <%= _('A host group is in some ways similar to an inherited node declaration, in that it is a high level grouping of classes that can be named and treated as a unit. This is then treated as a template and  is selectable during the creation of a new host and ensures that the host is configured in one of your pre-defined states.') %>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -51,7 +51,7 @@
 
         <%= select_f f, :compute_resource_id, accessible_resource(@host, :compute_resource), :id, :to_label,
           { :include_blank => _('Bare Metal') },
-          {:label => _('Deploy on'), :disabled => (!@host.new_record? || @host.uuid.present?), :'data-url' => compute_resource_selected_hosts_path,
+          {:label => _('Deploy On'), :disabled => (!@host.new_record? || @host.uuid.present?), :'data-url' => compute_resource_selected_hosts_path,
             :onchange => 'computeResourceSelected(this);',
             :help_inline => :indicator } if SETTINGS[:unattended] && @host.new_record? || @host.compute_resource_id %>
 
@@ -100,15 +100,15 @@
 
       <div class="tab-pane"  id="params">
         <fieldset>
-          <h2><%= _('Puppet class parameters') %></h2>
+          <h2><%= _('Puppet Class Parameters') %></h2>
           <%= render "puppetclasses/classes_parameters", :obj => @host %>
         </fieldset>
         <br/>
         <% if authorized_for(:controller => "host_editing", :action => "view_params") %>
           <fieldset>
-            <h2><%= _('Global parameters') %></h2>
+            <h2><%= _('Global Parameters') %></h2>
             <%= render "common_parameters/inherited_parameters", { :inherited_parameters => @host.host_inherited_params(true), :parameters => @host.host_parameters } %>
-            <h2><%= _('Host parameters') %></h2>
+            <h2><%= _('Host Parameters') %></h2>
             <%= render "common_parameters/parameters", { :f => f, :type => :host_parameters } %>
           </fieldset>
         <% end %>

--- a/app/views/hosts/_interfaces.html.erb
+++ b/app/views/hosts/_interfaces.html.erb
@@ -12,9 +12,9 @@
         <th class="hidden-xs" width="6%"></th>
         <th class="ellipsis"><%= _('Identifier') %></th>
         <th class="hidden-xs"><%= _('Type') %></th>
-        <th class="hidden-xs"><%= _("MAC address") %></th>
-        <th class="hidden-xs"><%= _("IPv4 address") %></th>
-        <th class="hidden-xs"><%= _("IPv6 address") %></th>
+        <th class="hidden-xs"><%= _("MAC Address") %></th>
+        <th class="hidden-xs"><%= _("IPv4 Address") %></th>
+        <th class="hidden-xs"><%= _("IPv6 Address") %></th>
         <th class="hidden-xs"><%= _("FQDN") %></th>
         <th><%= _('Actions') %></th>
       </tr>

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -26,7 +26,7 @@
 </div>
 <!-- this section is used for displaying the provisioning scripts-->
 <div class="form-group">
-  <label class="col-xs-2 control-label"><%= _('Provisioning templates') %></label>
+  <label class="col-xs-2 control-label"><%= _('Provisioning Templates') %></label>
   <div class="col-xs-10">
     <%= link_to_function icon_text("refresh", _("Resolve")), "template_info('#templates_info','#{template_used_hosts_url(:id => @host.id)}')", :class => "btn btn-default" %>
     <div class="help-block">

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -3,7 +3,7 @@
 
   <%= remove_child_link(_("Remove %s?") % (f.object.new_record? ? _("Variable") : f.object), f, { :class => 'btn btn-danger hide' }) if controller_name ==  "puppetclasses" && !is_param %>
   <fieldset>
-    <h2><%= _("Parameter details") %></h2>
+    <h2><%= _("Parameter Details") %></h2>
     <%= text_f f, :key, :disabled => is_param, :size => "col-md-8" %>
     <%= f.hidden_field :key if is_param %>
     <%= textarea_f f, :description, :rows => :auto, :size => "col-md-8", :class => "no-stretch" %>
@@ -11,7 +11,7 @@
     <%= show_puppet_class f %>
   </fieldset>
   <fieldset>
-    <h2><%= _("Default behavior") %></h2>
+    <h2><%= _("Default Behavior") %></h2>
     <h6><%= _("Override the default value of the Puppet class parameter.") if is_param%></h6>
     <%= checkbox_f(f, :override, :onchange => 'toggleOverrideValue(this)', :size => "col-md-8",
                    :label_help => _('Whether the class parameter value is managed by Foreman.')
@@ -30,7 +30,7 @@
                      :size => "col-md-1", :label_size => "col-md-2", :table_field => true,
                      :onchange => 'toggleOmitValue(this, "default_value")',
                      :disabled => (is_param && !f.object.override)) if is_param %>
-      <%= checkbox_f(f, :hidden_value, :label => _('Hidden value'),
+      <%= checkbox_f(f, :hidden_value, :label => _('Hidden Value'),
                      :class => 'hidden_value_textarea_switch', :onchange => 'toggle_lookupkey_hidden(this)',
                      :checked => f.object.hidden_value?,
                      :label_help => _("Hide all values for this parameter."),
@@ -39,7 +39,7 @@
     </div>
   </fieldset>
   <fieldset>
-    <%= collapsing_header _("Optional input validator"), "#optional_input_validators_#{f.object.id}", "collapsed" %>
+    <%= collapsing_header _("Optional Input Validator"), "#optional_input_validators_#{f.object.id}", "collapsed" %>
     <div id="optional_input_validators_<%= f.object.id %>" class="collapse out">
       <h6><%= _('If ERB is used in a parameter value, the validation of the value will happen during the ENC request. If the value is invalid, the ENC request will fail.') %></h6>
 
@@ -53,7 +53,7 @@
   </br>
   <div class="matcher-parent" <%= "id=#{(f.object.key || 'new_lookup_keys').to_s.gsub(' ', '_')}_lookup_key_override_value" %> style=<%= "display:none;" if (is_param && !f.object.override) %>>
     <fieldset>
-      <h2><%= _("Prioritize attribute order") %></h2>
+      <h2><%= _("Prioritize Attribute Order") %></h2>
       <h6><%= _("Set the order in which values are resolved.") %></h6>
       <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :id => 'order', :size => "col-md-8", :onchange => 'fill_in_matchers()', :value => f.object.path, :class => "no-stretch",
                         :label_help => _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>").html_safe %>
@@ -68,7 +68,7 @@
     </fieldset>
     </br>
     <fieldset>
-      <h2><%= _("Specify matchers") %>  <%= documentation_button('4.2.6SmartMatchers') %></h2>
+      <h2><%= _("Specify Matchers") %>  <%= documentation_button('4.2.6SmartMatchers') %></h2>
       <div class="children_fields lookup_values">
         <%= render 'lookup_keys/values', :f => f, :is_param => is_param %>
       </div>

--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -22,7 +22,7 @@
           <%= text_f f, :config_path, :size => "col-md-8", :help_inline => _("The NFS path to the jumpstart control files.") %>
           <%= text_f f, :image_path,  :size => "col-md-8", :help_inline => _("The NFS path to the image directory.") %>
         </span>
-        <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family") }, { :label => _("Operating system family") } %>
+        <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family") }, { :label => _("Operating System Family") } %>
     </div>
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @medium %>
     <%= submit_or_cancel f %>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -9,7 +9,7 @@
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("Medium|Name") %></th>
       <th class="col-md-6"><%= sort :path, :as => s_("Medium|Path") %></th>
-      <th class="col-md-1"><%= sort :family, :as => s_("Medium|Os family") %></th>
+      <th class="col-md-1"><%= sort :family, :as => s_("Medium|Os Family") %></th>
       <th class="col-md-2"><%= _("Operating Systems") %></th>
       <th><%= _('Actions') %></th>
     </tr>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -6,8 +6,8 @@
   <thead>
     <tr>
       <th class="col-md-4"><%= sort :name, :as => s_("Model|Name") %></th>
-      <th class="col-md-3"><%= sort :vendor_class, :as => _("Vendor class") %></th>
-      <th class="col-md-3"><%= sort :hardware_model, :as => s_("Model|Hardware model") %></th>
+      <th class="col-md-3"><%= sort :vendor_class, :as => _("Vendor Class") %></th>
+      <th class="col-md-3"><%= sort :hardware_model, :as => s_("Model|Hardware Model") %></th>
       <th class="col-md-1"><%= _("Hosts") %></th>
       <th><%= _('Actions') %></th>
     </tr>

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -4,11 +4,12 @@
                     :size => "col-md-8", :label_size => "col-md-3" %>
 
 <%= text_f f, :mac,
+              :label => _("MAC Address"),
               :label_help => _("Media access control address for this interface. Format must be six groups of two hexadecimal digits <br/> separated by colons (:), e.g. 00:11:22:33:44:55. Most virtualization compute resources (e.g. VMware, oVirt, libvirt) <br/> will overwrite the provided value with new random MAC address.").html_safe,
               :label_help_options => { :rel => 'popover-modal' },
               :class => :interface_mac, :'data-url' => random_name_interfaces_path, :size => "col-md-8", :label_size => "col-md-3" %>
 <%= text_f f, :identifier,
-              :label => _("Device identifier"),
+              :label => _("Device Identifier"),
               :label_help => _("Device identifier for this interface. This may be different on various platforms and environments, here are some common examples.<br/><ul>" +
                                 "<li>Use the basic name for physical interface identifiers, e.g. <strong>eth0</strong> or <strong>em0</strong> with biosdevname.</li>" +
                                 "<li>For virtual interfaces, use either alias notation (<strong>eth0:1</strong>, name:index) or VLAN notation (<strong>eth0.15</strong>, name.tag).</li>" +
@@ -16,7 +17,7 @@
               :label_help_options => { :rel => 'popover-modal', :'data-placement' => "top" },
               :class => :interface_identifier,
               :size => "col-md-8", :label_size => "col-md-3" %>
-<%= text_f f, :name, :label => _("DNS name"), :value => f.object.shortname,
+<%= text_f f, :name, :label => _("DNS Name"), :value => f.object.shortname,
               :label_help => _("Primary interface's DNS name and domain define host's FQDN"),
               :label_help_options => { :rel => 'popover-modal' },
               :class => :interface_name,
@@ -37,7 +38,7 @@
 <% end %>
 <%= text_f f, :ip,
               :class => :interface_ip,
-              :label => _("IPv4 address"),
+              :label => _("IPv4 Address"),
               :autocomplete => 'off',
               :help_block => suggest_new_link(f, :subnet , 'suggest_new_ip'),
               :label_help => _("An IP address will be auto-suggested if you have enabled IPAM on the IPv4 subnet selected above.<br/><br/>The IP address can be left blank when:<br/><ul><li>provisioning tokens are enabled</li><li>the domain does not manage DNS</li><li>the subnet does not manage reverse DNS</li><li>and the subnet does not manage DHCP reservations</li></ul>").html_safe,
@@ -49,7 +50,7 @@
               :size => "col-md-8", :label_size => "col-md-3" %>
 
 <%= text_f f, :ip6,
-              :label => _("IPv6 address"),
+              :label => _("IPv6 Address"),
               :class => :interface_ip6,
               :autocomplete => 'off',
               :help_block => suggest_new_link(f, :subnet6, 'suggest_new_ip6'),

--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -3,8 +3,8 @@
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("Operating System") %></a></li>
     <% if SETTINGS[:unattended] %>
-      <li><a href="#ptable" data-toggle="tab"><%= _("Partition table") %></a></li>
-      <li><a href="#media" data-toggle="tab"><%= _("Installation media") %></a></li>
+      <li><a href="#ptable" data-toggle="tab"><%= _("Partition Table") %></a></li>
+      <li><a href="#media" data-toggle="tab"><%= _("Installation Media") %></a></li>
       <li><a href="#templates" data-toggle="tab"><%= _("Templates") %></a></li>
     <% end -%>
     <% if authorized_for(:controller => "host_editing", :action => "view_params") %>
@@ -24,7 +24,7 @@
       <div id="release_name" <%= display?(!@operatingsystem.use_release_name?) %>>
         <%= text_f f, :release_name, :help_inline => _("e.g. karmic, lucid, hw0910 etc") %>
       </div>
-      <%= select_f f, :password_hash, PasswordCrypt::ALGORITHMS.keys, :to_s, :to_s, {}, { :label => _("Root password hash"), :help_inline => _("Hash function to use. Change takes effect for new or updated hosts.")} %>
+      <%= select_f f, :password_hash, PasswordCrypt::ALGORITHMS.keys, :to_s, :to_s, {}, { :label => _("Root Password Hash"), :help_inline => _("Hash function to use. Change takes effect for new or updated hosts.")} %>
       <%= multiple_checkboxes f, :architectures, @operatingsystem, Architecture, :label => _("Architectures") %>
     </div>
 
@@ -32,10 +32,10 @@
       <%= render('template_defaults', :f => f) %>
 
       <div class="tab-pane" id="ptable">
-        <%= multiple_checkboxes f, :ptables, @operatingsystem, os_habtm_family(Ptable, f.object), :label => _("Partition tables") %>
+        <%= multiple_checkboxes f, :ptables, @operatingsystem, os_habtm_family(Ptable, f.object), :label => _("Partition Tables") %>
       </div>
       <div class="tab-pane" id="media">
-        <%= multiple_checkboxes f, :media, @operatingsystem,   os_habtm_family(Medium, f.object), :label => _("Installation media") %>
+        <%= multiple_checkboxes f, :media, @operatingsystem,   os_habtm_family(Medium, f.object), :label => _("Installation Media") %>
       </div>
     <% end %>
     <% if authorized_for(:controller => "host_editing", :action => "view_params") %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -1,4 +1,4 @@
-<% title _("Operating systems") %>
+<% title _("Operating Systems") %>
 <% title_actions new_link(_("Create Operating System")),
                  documentation_button('4.4.1OperatingSystems') %>
 

--- a/app/views/operatingsystems/welcome.html.erb
+++ b/app/views/operatingsystems/welcome.html.erb
@@ -2,12 +2,12 @@
   <div class="blank-slate-pf-icon">
     <%= icon_text("lightbulb-o", "", :kind => "fa") %>
   </div>
-  <h1><%= _('Operating systems') %></h1>
+  <h1><%= _('Operating Systems') %></h1>
   <p>
     <%= _("The Operating systems detail the OSs known to Foreman, and is the central point that the other required components tie into.") %></br>
   </p>
   <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4.1OperatingSystems")%></p>
   <div class="blank-slate-pf-main-action">
-      <%= new_link(_("Create Operating system"), {}, { :class => "btn-lg" }) %>
+      <%= new_link(_("Create Operating System"), {}, { :class => "btn-lg" }) %>
   </div>
 </div>

--- a/app/views/provisioning_templates/index.html.erb
+++ b/app/views/provisioning_templates/index.html.erb
@@ -11,7 +11,7 @@
   <thead>
     <tr>
       <th class="col-md-3"><%= sort :name, :as => s_("ProvisioningTemplate|Name") %></th>
-      <th class="col-md-4"><%= _("Host group / Environment") %></th>
+      <th class="col-md-4"><%= _("Host Group / Environment") %></th>
       <th class="col-md-2"><%= sort :kind, :as => _("Kind") %></th>
       <th class="col-md-1"><%= sort :snippet, :as => s_("ProvisioningTemplate|Snippet") %></th>
       <th class="col-md-1"><%= sort :locked, :as => s_("ProvisioningTemplate|Locked"), :default => "DESC" %></th>

--- a/app/views/ptables/_custom_tabs.html.erb
+++ b/app/views/ptables/_custom_tabs.html.erb
@@ -2,6 +2,6 @@
   <%= checkbox_f f, :snippet, :onchange => "tfm.editor.snippetChanged(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
   <%= snippet_message(@template) %>
   <div id="association" <%= display? @template.snippet %> >
-    <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family")  }, { :label => _("Operating system family") } %>
+    <%= select_f f, :os_family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family")  }, { :label => _("Operating System Family") } %>
   </div>
 </div>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -7,8 +7,8 @@
   <thead>
     <tr>
       <th class="col-md-4"><%= sort :name, :as => s_("Ptable|Name") %></th>
-      <th class="col-md-1"><%= sort :family, :as => s_("Ptable|Os family") %></th>
-      <th class="col-md-4"><%= _("Operating systems") %></th>
+      <th class="col-md-1"><%= sort :family, :as => s_("Ptable|Os Family") %></th>
+      <th class="col-md-4"><%= _("Operating Systems") %></th>
       <th class="col-md-1"><%= sort :snippet, :as => s_("Ptable|Snippet") %></th>
       <th class="col-md-1"><%= sort :locked, :as => s_("Ptable|Locked"), :default => "DESC" %></th>
       <th class="col-md-1"><%= _('Actions') %></th>

--- a/app/views/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/puppetclass_lookup_keys/index.html.erb
@@ -1,11 +1,11 @@
-<% title _("Smart class parameters") %>
+<% title _("Smart Class Parameters") %>
 <% title_actions documentation_button('4.2.5ParameterizedClasses') %>
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>
     <tr>
       <th class="col-md-5"><%= sort :key, :as => _("Parameter") %></th>
-      <th class="col-md-5"><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-      <th><%= _('Number of overrides') %></th>
+      <th class="col-md-5"><%= sort :puppetclass, :as => _("Puppet Class") %></th>
+      <th><%= _('Number of Overrides') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/puppetclasses/_classes_parameters.html.erb
+++ b/app/views/puppetclasses/_classes_parameters.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-fixed" id="inherited_puppetclasses_parameters">
   <thead class="white-header">
     <tr>
-      <th class='col-md-3'><%= _('Puppet class') %></th>
+      <th class='col-md-3'><%= _('Puppet Class') %></th>
       <th class='col-md-2'><%= _('Name') %></th>
       <th class='col-md-6'><%= _('Value') %></th>
       <th class='col-md-1 ca'><%= _("Omit") %>&nbsp;<%= omit_help %></th>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -1,4 +1,4 @@
-<% title _("Puppet classes") %>
+<% title _("Puppet Classes") %>
 
 <% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path),
                  documentation_button('4.2.2Classes') %>
@@ -8,7 +8,7 @@
     <tr>
       <th class="col-md-3"><%= sort :name, :as => s_("Puppetclass|Name") %></th>
       <th class="col-md-3"><%= sort :environment, :as => _("Environments") %></th>
-      <th class="col-md-2"><%= _('Host groups') %></th>
+      <th class="col-md-2"><%= _('Host Groups') %></th>
       <th class="col-md-1"><%= _('Hosts') %></th>
       <th class="col-md-1"><%= _('Parameters') %></th>
       <th class="col-md-1"><%= _('Variables') %></th>

--- a/app/views/realms/_form.html.erb
+++ b/app/views/realms/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="tab-pane active" id="primary">
       <%= text_f   f, :name, :help_inline => _("Realm name, e.g. EXAMPLE.COM") %>
       <%= select_f f, :realm_type, Realm::TYPES, :to_s, :to_s, { },
-          {:label => _("Realm type"), :help_inline => _("Type of realm, e.g. FreeIPA")}
+          {:label => _("Realm Type"), :help_inline => _("Type of realm, e.g. FreeIPA")}
       %>
       <%= smart_proxy_fields f %>
     </div>

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -2,12 +2,12 @@
 <%= textarea_f f, :description, :rows => :auto  %>
 
 <%= subnet_type_f f %>
-<%= text_f f, :network %>
-<%= text_f f, :cidr, :label => _("Network prefix"), :help_inline => _("Suffix or prefix length for this subnet, e.g. 32") %>
-<%= text_f f, :mask, :help_inline => _("Netmask for this subnet"), :wrapper_class => "form-group #{'hide' unless f.object.show_mask?}" %>
-<%= text_f f, :gateway, :help_inline => _("Optional: Gateway for this subnet") %>
-<%= text_f f, :dns_primary, :help_inline => _("Optional: Primary DNS for this subnet") %>
-<%= text_f f, :dns_secondary, :help_inline => _("Optional: Secondary DNS for this subnet") %>
+<%= text_f f, :network, :label => _("Network Address") %>
+<%= text_f f, :cidr, :label => _("Network Prefix"), :help_inline => _("Suffix or prefix length for this subnet, e.g. 32") %>
+<%= text_f f, :mask, :label => _("Network Mask"), :help_inline => _("Netmask for this subnet"), :wrapper_class => "form-group #{'hide' unless f.object.show_mask?}" %>
+<%= text_f f, :gateway, :label => _("Gateway Address"), :help_inline => _("Optional: Gateway for this subnet") %>
+<%= text_f f, :dns_primary, :label => _("Primary DNS Server"), :help_inline => _("Optional: Primary DNS for this subnet") %>
+<%= text_f f, :dns_secondary, :label => _("Secondary DNS Server"), :help_inline => _("Optional: Secondary DNS for this subnet") %>
 <%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64]]},
                  :label => _('IPAM'),
                  :label_help => _("You can select one of the IPAM modes supported by the selected IP protocol:<br/>" +
@@ -22,5 +22,5 @@
 </div>
 <%= number_f f, :vlanid, :min => 0, :max => 4095, :help_inline => _("Optional: VLAN ID for this subnet") %>
 <%= selectable_f f, :boot_mode, Subnet.boot_modes_with_translations, {},
-                 :help_inline => _("Default boot mode for interfaces assigned to this subnet, applied to hosts from provisioning templates") %>
+                 :label => _("Boot Mode"), :help_inline => _("Default boot mode for interfaces assigned to this subnet, applied to hosts from provisioning templates") %>
 <%= hidden_field_tag :redirect, params[:redirect] %>

--- a/app/views/variable_lookup_keys/index.html.erb
+++ b/app/views/variable_lookup_keys/index.html.erb
@@ -1,11 +1,11 @@
-<% title _("Smart variables") %>
+<% title _("Smart Variables") %>
 <% title_actions new_link(_("Create Smart Variable")), documentation_button('4.2.4SmartVariables') %>
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>
     <tr>
       <th class="col-md-5"><%= sort :key, :as => _("Variable") %></th>
-      <th class="col-md-4"><%= sort :puppetclass, :as => _("Puppetclass") %></th>
-      <th class="col-md-2"><%= _('Number of overrides') %></th>
+      <th class="col-md-4"><%= sort :puppetclass, :as => _("Puppet Class") %></th>
+      <th class="col-md-2"><%= _('Number of Overrides') %></th>
       <th><%= _('Actions') %></th>
     </tr>
   </thead>

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -180,14 +180,14 @@ class HostgroupsControllerTest < ActionController::TestCase
     setup_user "view", "params"
     hg = FactoryGirl.create(:hostgroup, :with_parameter)
     get :edit, {:id => hg.id}, set_session_user.merge(:user => users(:one).id)
-    assert_not_nil response.body['Global parameters']
+    assert_not_nil response.body['Global Parameters']
   end
 
   test 'user without view_params rights should not see parameters in a hostgroup' do
     setup_user "edit"
     hg = FactoryGirl.create(:hostgroup, :with_parameter)
     get :edit, {:id => hg.id}, set_session_user.merge(:user => users(:one).id)
-    assert_nil response.body['Global parameters']
+    assert_nil response.body['Global Parameters']
   end
 
   describe "parent attributes" do

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -355,14 +355,14 @@ class HostsControllerTest < ActionController::TestCase
     setup_user "view", "params"
     host = FactoryGirl.create(:host, :with_parameter)
     get :edit, {:id => host.id}, set_session_user.merge(:user => users(:one).id)
-    assert_not_nil response.body['Global parameters']
+    assert_not_nil response.body['Global Parameters']
   end
 
   test 'user without view_params rights should not see parameters in a host' do
     setup_user "edit"
     host = FactoryGirl.create(:host, :with_parameter)
     get :edit, {:id => host.id}, set_session_user.merge(:user => users(:one).id)
-    assert_nil response.body['Global parameters']
+    assert_nil response.body['Global Parameters']
   end
 
   test 'multiple without hosts' do

--- a/test/integration/compute_profile_test.rb
+++ b/test/integration/compute_profile_test.rb
@@ -10,7 +10,7 @@ class ComputeProfileIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "index page" do
-    assert_index_page(compute_profiles_path,"Compute profiles","Create Compute Profile")
+    assert_index_page(compute_profiles_path,"Compute Profiles","Create Compute Profile")
   end
 
   test "create new page" do

--- a/test/integration/operatingsystem_test.rb
+++ b/test/integration/operatingsystem_test.rb
@@ -2,7 +2,7 @@ require 'integration_test_helper'
 
 class OperatingsystemIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
-    assert_index_page(operatingsystems_path,"Operating systems","Create Operating System")
+    assert_index_page(operatingsystems_path,"Operating Systems","Create Operating System")
   end
 
   test "create new page" do

--- a/test/integration/puppetclass_lookup_key_test.rb
+++ b/test/integration/puppetclass_lookup_key_test.rb
@@ -2,7 +2,7 @@ require 'integration_test_helper'
 
 class PuppetclassLookupKeyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
-    assert_index_page(puppetclass_lookup_keys_path,"Smart class parameters",false)
+    assert_index_page(puppetclass_lookup_keys_path,"Smart Class Parameters",false)
   end
 
   test "edit page" do

--- a/test/integration/statistic_test.rb
+++ b/test/integration/statistic_test.rb
@@ -10,7 +10,7 @@ class StatisticIntegrationTest < IntegrationTestWithJavascript
     assert page.has_selector?('h3', :text => "Number of CPUs")
     assert page.has_selector?('h3', :text => "Hardware")
     assert page.has_selector?('h3', :text => "Class Distribution")
-    assert page.has_selector?('h3', :text => "Average memory usage")
-    assert page.has_selector?('h3', :text => "Average swap usage")
+    assert page.has_selector?('h3', :text => "Average Memory Usage")
+    assert page.has_selector?('h3', :text => "Average Swap Usage")
   end
 end

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -13,8 +13,8 @@ class TopBarIntegrationTest < ActionDispatch::IntegrationTest
     end
     within("div.navbar-inner") do
       assert page.has_link?("Dashboard", :href => "/")
-      assert page.has_link?("All hosts", :href => "/hosts")
-      assert page.has_link?("Config management", :href => "/config_reports?search=eventful+%3D+true")
+      assert page.has_link?("All Hosts", :href => "/hosts")
+      assert page.has_link?("Config Management", :href => "/config_reports?search=eventful+%3D+true")
       assert page.has_link?("Facts", :href => "/fact_values")
       assert page.has_link?("Audits", :href => "/audits")
       assert page.has_link?("Statistics", :href => "/statistics")
@@ -33,7 +33,7 @@ class TopBarIntegrationTest < ActionDispatch::IntegrationTest
   test "Hosts link" do
     visit root_path
     within("div.navbar-inner") do
-      click_link("All hosts")
+      click_link("All Hosts")
     end
     assert page.has_selector?('h1', :text => "Hosts")
   end

--- a/test/integration/variable_lookup_key_test.rb
+++ b/test/integration/variable_lookup_key_test.rb
@@ -2,7 +2,7 @@ require 'integration_test_helper'
 
 class VariableLookupKeyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
-    assert_index_page(variable_lookup_keys_path,"Smart variables",false)
+    assert_index_page(variable_lookup_keys_path,"Smart Variables",false)
   end
 
   test "edit page" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -37,14 +37,14 @@ class ActionDispatch::IntegrationTest
   def assert_index_page(index_path,title_text,new_link_text = nil,has_search = true,has_pagination = true)
     visit index_path
     assert page.has_selector?('h1', :text => title_text), "#{title_text} was expected in the <h1> tag, but was not found"
-    (assert find_link(new_link_text).visible?, "#{new_link_text} is not visible") if new_link_text
+    (assert first(:link, new_link_text).visible?, "#{new_link_text} is not visible") if new_link_text
     (assert find_button('Search').visible?, "Search button is not visible") if has_search
     (assert has_content?("Displaying"), "Pagination 'Display ...' does not appear") if has_pagination
   end
 
   def assert_new_button(index_path,new_link_text,new_path)
     visit index_path
-    click_link new_link_text
+    first(:link, new_link_text).click
     assert_current_path new_path
   end
 


### PR DESCRIPTION
Based on PatternFly Outlines Headline Style Capitalization, http://www.patternfly.org/styles/terminology-and-wording/#capitalization
We suggested to keep consistent in headline capitalization, capitalize the first letter of every word in headline.

As last PR #3841, I fixed the menu case, @ohadlevy suggested me to fix all the labels in one PR.
So I re-created one PR for updating all labels capitalization in Foreman.

Please have a review.
Thanks.
