### PR TITLE
refs #13424 - add wait_for_ajax to statistics page load test

### DIFF
--- a/test/integration/statistic_test.rb
+++ b/test/integration/statistic_test.rb
@@ -3,6 +3,7 @@ require 'integration_test_helper'
 class StatisticIntegrationTest < IntegrationTestWithJavascript
   test "statistics page" do
     visit statistics_path
+    wait_for_ajax
     assert page.has_selector?('h3', :text => "OS Distribution")
     assert page.has_selector?('h3', :text => "Architecture Distribution")
     assert page.has_selector?('h3', :text => "Environment Distribution")


### PR DESCRIPTION
Prevents errors occurring when the AJAX calls continue beyond the end of the test.
