### PR TITLE
refs #16725 - initialize smart_proxies for models

### DIFF
--- a/app/models/concerns/belongs_to_proxies.rb
+++ b/app/models/concerns/belongs_to_proxies.rb
@@ -3,6 +3,7 @@ module BelongsToProxies
 
   included do
     class_attribute :registered_smart_proxies
+    self.registered_smart_proxies ||= {}
     register_smart_proxies_from_plugins
   end
 
@@ -14,7 +15,7 @@ module BelongsToProxies
     end
 
     def register_smart_proxy(name, options)
-      self.registered_smart_proxies = (registered_smart_proxies || {}).merge(name => options)
+      self.registered_smart_proxies = registered_smart_proxies.merge(name => options)
       belongs_to name, :class_name => 'SmartProxy'
       validates name, :proxy_features => { :feature => options[:feature] }
     end

--- a/test/models/concerns/belongs_to_proxies_test.rb
+++ b/test/models/concerns/belongs_to_proxies_test.rb
@@ -12,12 +12,20 @@ class BelongsToProxiesTest < ActiveSupport::TestCase
     belongs_to_proxy :foo, :feature => 'Foo'
   end
 
+  class EmptySampleModel
+    include BelongsToProxies
+  end
+
   setup do
     Foreman::Plugin.clear
   end
 
   teardown do
     Foreman::Plugin.clear
+  end
+
+  test '#registered_smart_proxies has default value' do
+    assert_equal({}, EmptySampleModel.registered_smart_proxies)
   end
 
   test '#registered_smart_proxies contains foo proxy' do


### PR DESCRIPTION
This is needed for discovery where we have to add the concern "BelongsToProxies" to a model without any smart_proxies.
