### PR TITLE
Fixes #16887 - Display errors from compute resource in VM tab

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -67,7 +67,7 @@ function computeResourceSelected(item){
         handle_nic_updates();
       },
       error: function(jqXHR, status, error){
-        $('#compute_resource').html(Jed.sprintf(__("Error loading virtual machine information: %s"), error));
+        $('#compute_resource').html(jqXHR.responseText);
         $('#compute_resource_tab a').addClass('tab-error');
       },
       success: function(result){

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -141,6 +141,8 @@ class HostsController < ApplicationController
       render :partial => "compute", :locals => { :compute_resource => compute_resource,
                                                  :vm_attrs         => compute_resource.compute_profile_attributes_for(compute_profile_id) }
     end
+  rescue ActionView::Template::Error => exception
+    process_ajax_error exception, 'render compute resource template'
   end
 
   def scheduler_hint_selected


### PR DESCRIPTION
This commit allows these errors to show up in the VM tab. Without it
just a standard, unstyled 'internal server error' message shows up while
the error is only logged on Foreman's log.

I thought about either moving this to `webpack/` or write an integration test for this but it might be excessive for such a small change. Feel free to ask for it if you disagree.

![screenshot from 2016-10-12 17-13-44](https://cloud.githubusercontent.com/assets/598891/19316088/6c1f8cb0-90a0-11e6-9512-981648c142e3.png) is how it looks now
