### PR TITLE
Fixes #16881 - Pass information from proxy error response

### DIFF
--- a/lib/proxy_api/proxy_exception.rb
+++ b/lib/proxy_api/proxy_exception.rb
@@ -8,7 +8,15 @@ module ProxyAPI
     end
 
     def message
-      super + ' ' + _('for proxy') + ' ' + url
+      super + proxy_exception_response(exception) +
+        ' ' + _('for proxy') + ' ' + url
+    end
+
+    private
+
+    def proxy_exception_response(exception)
+      return '' unless exception.respond_to?(:response)
+      ": #{exception.response}"
     end
   end
 end

--- a/test/unit/proxy_api/proxy_exception_test.rb
+++ b/test/unit/proxy_api/proxy_exception_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ProxyApiExceptionTest < ActiveSupport::TestCase
+  test 'exception response body is added if available' do
+    fake_exception = OpenStruct.new(:response => 'useful message from proxy',
+                                    :message => 'useful message from proxy',
+                                    :code => 400)
+    proxy_exception = ProxyAPI::ProxyException.new(
+      'fakeurl',
+      fake_exception,
+      'unable to do something')
+    assert_match(
+      /ERF.*ProxyException.*unable to do something.*useful message from proxy.*/,
+      proxy_exception.message
+    )
+  end
+
+  test 'does not fail if response body is not available' do
+    proxy_exception = ProxyAPI::ProxyException.new('fakeurl',
+                                                   NoMethodError.new,
+                                                   'unable to do something')
+    assert_equal 'fakeurl', proxy_exception.url
+    assert_match(/unable to do something.*NoMethodError.*proxy fakeurl/,
+      proxy_exception.message)
+  end
+end


### PR DESCRIPTION
Certain information that could be important during creation of hosts
should be displayed - currently the ProxyAPI abstracts the entire
exception message away.

This commit appends the message that comes from the proxy if there is
one to show it whenever a ProxyAPI::ProxyException is thrown

![screenshot from 2016-10-12 17-58-13](https://cloud.githubusercontent.com/assets/598891/19317713/38bd6cf6-90a6-11e6-9369-4481296a3ed5.png) an example of an error that  normally get's hidden under just '400 bad request' 
