### PR TITLE
fixes #16892 - secureheaders expects img_src parameter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -410,7 +410,7 @@ class ApplicationController < ActionController::Base
     port = Rails.configuration.webpack.dev_server.port
     @dev_server = "#{request.protocol}#{request.host}:#{port}"
     append_content_security_policy_directives(script_src: [@dev_server], connect_src: [@dev_server],
-                                              style_src: [@dev_server], image_src: [@dev_server])
+                                              style_src: [@dev_server], img_src: [@dev_server])
   end
 
   class << self


### PR DESCRIPTION
This fixes the following:

```
2016-10-12T21:03:33 e6772d1e [app] [F]
21:03:33 rails.1   |  | SecureHeaders::ContentSecurityPolicyConfigError (Unknown config directive: image_src=["http://localhost:3808"]):
21:03:33 rails.1   |  |   app/controllers/application_controller.rb:412:in `allow_webpack'
21:03:33 rails.1   |  |   app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
21:03:33 rails.1   |  |   lib/middleware/catch_json_parse_errors.rb:8:in `call'
21:03:33 rails.1   |  |   lib/middleware/tagged_logging.rb:18:in `call'
```
