### PR TITLE
Fixes #16899 - rename helper with conflicting path name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,7 +204,7 @@ module ApplicationHelper
     text_field_tag(name, val, options)
   end
 
-  def help_path
+  def help_button
     link_to(_("Help"), { :action => "welcome" }, { :class => 'btn btn-default' }) if File.exist?("#{Rails.root}/app/views/#{controller_name}/welcome.html.erb")
   end
 

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -1,5 +1,5 @@
 <% title _("Architectures") %>
-<% title_actions new_link(_("New Architecture")), help_path %>
+<% title_actions new_link(_("New Architecture")), help_button %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title _('Config groups') %>
 
-<% title_actions new_link(_('New Config Group')), help_path %>
+<% title_actions new_link(_('New Config Group')), help_button %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Domains") %>
 
-<% title_actions new_link(_("New Domain")), help_path %>
+<% title_actions new_link(_("New Domain")), help_button %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("Host Groups") %>
 
-<% title_actions new_link(_("New Host Group")), help_path %>
+<% title_actions new_link(_("New Host Group")), help_button %>
 
 <table class="<%= table_css_classes %>">
   <thead>

--- a/app/views/media/index.html.erb
+++ b/app/views/media/index.html.erb
@@ -2,7 +2,7 @@
 <% title _("Installation Media") %>
 <% title_actions new_link(_("New Medium")),
                  documentation_button('4.4.2InstallationMedia'),
-                 help_path %>
+                 help_button %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>

--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Partition Tables") %>
 <% title_actions new_link(_("New Partition Table")),
                  documentation_button('4.4.4PartitionTables'),
-                 help_path %>
+                 help_button %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -1,7 +1,7 @@
 <% title taxonomy_upcase %>
 <% title_actions new_link(taxonomy_new),
                  display_link_if_authorized(_("Mismatches Report"), hash_for_mismatches_taxonomies_path, :class => 'btn btn-default'),
-                 help_path %>
+                 help_button %>
 
 <% if @count_nil_hosts > 0 %>
   <%= alert :class => 'alert-warning', :header => '', :text => n_('There is', 'There are', @count_nil_hosts) + ' ' +


### PR DESCRIPTION
help_path is defined by [this](https://github.com/theforeman/foreman/blob/develop/config/routes.rb#L19), since the route helpers were included after application helper, so it re-replaced the method by which we had replaced the original method :-)
