### PR TITLE
fixes #16900 - ensure interface mac address is unicast

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -18,6 +18,8 @@ module Nic
              :if => Proc.new { |nic| nic.managed? && nic.host && nic.host.managed? && !nic.host.compute? && !nic.virtual? && nic.mac.present? }
     validates :mac, :presence => true,
               :if => Proc.new { |nic| nic.managed? && nic.host_managed? && !nic.host.compute? && !nic.virtual? }
+    validate :validate_mac_is_unicast,
+              :if => Proc.new { |nic| nic.managed? && !nic.virtual? }
     validates :mac, :mac_address => true, :allow_blank => true
 
     validates :host, :presence => true, :if => Proc.new { |nic| nic.require_host? }
@@ -227,6 +229,10 @@ module Nic
 
     def mac_uniqueness
       interface_attribute_uniqueness(:mac, Nic::Base.physical.is_managed)
+    end
+
+    def validate_mac_is_unicast
+      errors.add(:mac, _('must be a unicast MAC address')) if Net::Validations.multicast_mac?(mac) || Net::Validations.broadcast_mac?(mac)
     end
 
     private

--- a/lib/net/validations.rb
+++ b/lib/net/validations.rb
@@ -63,6 +63,21 @@ module Net
       false
     end
 
+    def self.multicast_mac?(mac)
+      return false unless validate_mac(mac)
+
+      # Get the first byte
+      msb = mac.tr('.:-', '').slice(0..1).to_i(16)
+
+      # Is least significant bit set?
+      msb & 0b1 == 1
+    end
+
+    def self.broadcast_mac?(mac)
+      return false unless validate_mac(mac)
+      mac.downcase == 'ff:ff:ff:ff:ff:ff'
+    end
+
     # validates the mac and raises an error
     def self.validate_mac!(mac)
       raise Error, "Invalid MAC #{mac}" unless validate_mac(mac)

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -48,7 +48,7 @@ FactoryGirl.define do
   factory :nic_base, :class => Nic::Base do
     type 'Nic::Base'
     sequence(:identifier) { |n| "eth#{n}" }
-    sequence(:mac) { |n| "00:00:00:00:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
+    sequence(:mac) { |n| "00:23:45:ab:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
 
     trait :with_subnet do
       subnet do
@@ -65,7 +65,7 @@ FactoryGirl.define do
 
   factory :nic_managed, :class => Nic::Managed, :parent => :nic_interface do
     type 'Nic::Managed'
-    sequence(:mac) { |n| "01:23:45:ab:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
+    sequence(:mac) { |n| "00:33:45:ab:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
     sequence(:ip) { |n| IPAddr.new(n, Socket::AF_INET).to_s }
 
     trait :without_ipv4 do
@@ -79,7 +79,7 @@ FactoryGirl.define do
 
   factory :nic_bmc, :class => Nic::BMC, :parent => :nic_managed do
     type 'Nic::BMC'
-    sequence(:mac) { |n| "01:23:56:cd:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
+    sequence(:mac) { |n| "00:43:56:cd:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
     sequence(:ip) { |n| IPAddr.new(255 + n, Socket::AF_INET).to_s }
     provider 'IPMI'
     username 'admin'
@@ -98,7 +98,7 @@ FactoryGirl.define do
   factory :nic_primary_and_provision, :parent => :nic_managed, :class => Nic::Managed do
     primary true
     provision true
-    sequence(:mac) { |n| "01:23:67:ab:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
+    sequence(:mac) { |n| "00:53:67:ab:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
     sequence(:ip) { |n| IPAddr.new(n, Socket::AF_INET).to_s }
   end
 

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -163,7 +163,7 @@ class HostJSTest < IntegrationTestWithJavascript
       click_button 'Edit'
       select2 domains(:unuseddomain).name, :from => 'host_interfaces_attributes_0_domain_id'
       wait_for_ajax
-      fill_in 'host_interfaces_attributes_0_mac', :with => '11:11:11:11:11:11'
+      fill_in 'host_interfaces_attributes_0_mac', :with => '00:11:11:11:11:11'
       wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
       click_button 'Ok' #close interfaces
@@ -206,7 +206,7 @@ class HostJSTest < IntegrationTestWithJavascript
       click_button 'Edit'
       select2 domains(:mydomain).name, :from => 'host_interfaces_attributes_0_domain_id'
       wait_for_ajax
-      fill_in 'host_interfaces_attributes_0_mac', :with => '11:11:11:11:11:11'
+      fill_in 'host_interfaces_attributes_0_mac', :with => '00:11:11:11:11:11'
       wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '2.3.4.44'
       wait_for_ajax

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -219,15 +219,15 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "#associate_by returns host by MAC attribute" do
-    host = FactoryGirl.create(:host, :mac => '11:22:33:44:55:1a')
+    host = FactoryGirl.create(:host, :mac => '00:22:33:44:55:1a')
     cr = FactoryGirl.build(:compute_resource)
-    assert_equal host, as_admin { cr.send(:associate_by, 'mac', '11:22:33:44:55:1a') }
+    assert_equal host, as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }
   end
 
   test "#associated_by returns read/write host" do
-    FactoryGirl.create(:host, :mac => '11:22:33:44:55:1a')
+    FactoryGirl.create(:host, :mac => '00:22:33:44:55:1a')
     cr = FactoryGirl.build(:compute_resource)
-    refute as_admin { cr.send(:associate_by, 'mac', '11:22:33:44:55:1a') }.readonly?
+    refute as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }.readonly?
   end
 
   describe "find_vm_by_uuid" do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1752,7 +1752,7 @@ class HostTest < ActiveSupport::TestCase
         :provider => "IPMI", :username => "root", :password => "secret", :ip => "10.35.19.35",
         :identifier => 'eth2'
       as_user :one do
-        assert h.update_attributes!("interfaces_attributes" => {"0" => {"mac"=>"59:52:10:1e:45:16"}})
+        assert h.update_attributes!("interfaces_attributes" => {"0" => {"mac"=>"00:52:10:1e:45:16"}})
       end
     end
 

--- a/test/models/nics/base_test.rb
+++ b/test/models/nics/base_test.rb
@@ -1,9 +1,15 @@
 require 'test_helper'
 
-class NicBaseTest < ActiveSupport::TestCase
+class Nic::BaseTest < ActiveSupport::TestCase
   setup do
     disable_orchestration
   end
+
+  should allow_values('00:50:56:84:4e:e3', '00:01:44:55:66:77', '72:00:03:bd:3b:70').
+    for(:mac)
+
+  should_not allow_values('13-61-f1-de-71-73', '01-00-CC-CC-DD-DD', 'ff-ff-ff-ff-ff-ff').
+    for(:mac)
 
   test '#host_managed? returns false if interface does not have a host' do
     nic = FactoryGirl.build(:nic_base)

--- a/test/unit/net/validations_test.rb
+++ b/test/unit/net/validations_test.rb
@@ -40,6 +40,26 @@ class ValidationsTest < ActiveSupport::TestCase
     end
   end
 
+  describe 'multicast_mac?' do
+    test 'MAC address is multicast' do
+      assert_equal true, Net::Validations.multicast_mac?('13:61:f1:de:71:73')
+    end
+
+    test 'MAC address is not multicast' do
+      assert_equal false, Net::Validations.multicast_mac?('3c:15:c2:d2:f4:60')
+    end
+  end
+
+  describe 'broadcast_mac?' do
+    test 'MAC address is broadcast' do
+      assert_equal true, Net::Validations.broadcast_mac?('ff:ff:ff:ff:ff:ff')
+    end
+
+    test 'MAC address is not broadcast' do
+      assert_equal false, Net::Validations.broadcast_mac?('3c:15:c2:d2:f4:60')
+    end
+  end
+
   test "hostname should be valid" do
     assert_nothing_raised Net::Validations::Error do
       Net::Validations.validate_hostname! "this.is.an.example.com"


### PR DESCRIPTION
This should prevent manually entered addresses to be either multicast or broadcast.

@dLobatog : This should have saved you a lot of debugging, I guess.
