### PR TITLE
fixes #16821 - store plugin permissions in AccessControl in tests

### DIFF
--- a/app/services/foreman/access_control.rb
+++ b/app/services/foreman/access_control.rb
@@ -50,6 +50,11 @@ module Foreman
         permissions.detect {|p| p.name == name}
       end
 
+      # Removes the permission object given from the control list
+      def remove_permission(permission)
+        !!@permissions.delete(permission)
+      end
+
       # Returns the actions that are allowed by the permission of given name
       def allowed_actions(permission_name)
         perm = permission(permission_name)

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -373,3 +373,11 @@ crud_hosts_1_2:
 crud_hosts_1_3:
   filter: crud_hosts_1
   permission: view_hosts
+<% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).each do |role,permissions| %>
+<% role_id = role.tr(' ', '_').scan(/[a-z_]/i).join %>
+<% permissions.each do |permission| %>
+<%= role_id %>_<%= permission %>:
+  filter: <%= role_id %>
+  permission: <%= permission %>
+<% end %>
+<% end %>

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -108,3 +108,8 @@ view_compute_resources_1:
   role_id: 11
 crud_hosts_1:
   role_id: 12
+<% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).keys.each do |role| %>
+<% role_id = role.tr(' ', '_').scan(/[a-z_]/i).join %>
+<%= role_id %>:
+  role: <%= role_id %>
+<% end %>

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -714,4 +714,10 @@
     resource_type: Role
     created_at: "2014-01-07 15:09:32.783442"
     updated_at: "2014-01-07 15:09:32.783442"
-
+<% Foreman::Plugin.all.map(&:permissions).inject({}, :merge).each do |permission,attrs| %>
+  <%= permission %>:
+    name: <%= permission %>
+    <% attrs.each do |k,v| %>
+    <%= k %>: <%= v %>
+    <% end %>
+<% end %>

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -53,3 +53,9 @@ manage_hosts:
   name: CRUD hosts
   id: "12"
   builtin: "0"
+
+<% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).keys.each do |role| %>
+<%= role.tr(' ', '_').scan(/[a-z_]/i).join %>:
+  name: "<%= role %>"
+  builtin: "0"
+<% end %>


### PR DESCRIPTION
When initialising a new test database, the "permission" directive in a
plugin registration would skip the Foreman::AccessControl mapping so
later tests using the access control lists would fail (e.g.
AccessPermissionsTest, if a route added by a plugin to the main app
engine used a plugin permission.)

The AccessControl entry is now always created as it's safe to do so even
without a database, but the Permission resource is not created from the
initialiser in the test environment. Instead, permissions, roles and
filters are added to the database via fixtures so plugins can rely on
them for unit or functional tests.

---

Alternative to #3933, which I feel is unreliable (I spent a long time removing this hack once in f20c2a1). The issue is simply missing AccessControl mappings, which are added trivially by changing the `#permission` method for plugin registrations.

I've gone further by adding permissions and roles automatically to fixtures so plugin authors can rely on them inside the test environment too.
