### PR TITLE
Fixes #16907 - Sorted proxy features on smart proxy display

### DIFF
--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -34,7 +34,7 @@
         <% if SETTINGS[:organizations_enabled] %>
           <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.organizations).html_safe %></td>
         <% end %>
-        <td class="ellipsis"><%= proxy.features.map(&:name).to_sentence %></td>
+        <td class="ellipsis"><%= proxy.features.map(&:name).sort.to_sentence %></td>
         <td>
           <span class="proxy-show-status"><%= spinner %></span>
         </td>


### PR DESCRIPTION
The current implementation displays a smart proxy's features in an unknown order. When there are many smart proxies this is visually distracting.

This change forces a sort by-name on the features.
