### PR TITLE
Fixes #16962 - Typo on domains welcome page

### DIFF
--- a/app/controllers/api/v1/domains_controller.rb
+++ b/app/controllers/api/v1/domains_controller.rb
@@ -7,7 +7,7 @@ module Api
         # TRANSLATORS: API documentation - do not translate
         desc <<-DOC
           Foreman considers a domain and a DNS zone as the same thing. That is, if you
-          are planning to manage a site where all the machines are or the form
+          are planning to manage a site where all the machines are of the form
           <i>hostname</i>.<b>somewhere.com</b> then the domain is <b>somewhere.com</b>.
           This allows Foreman to associate a puppet variable with a domain/site
           and automatically append this variable to all external node requests made

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -8,7 +8,7 @@ module Api
       resource_description do
         desc <<-DOC
           Foreman considers a domain and a DNS zone as the same thing. That is, if you
-          are planning to manage a site where all the machines are or the form
+          are planning to manage a site where all the machines are of the form
           <i>hostname</i>.<b>somewhere.com</b> then the domain is <b>somewhere.com</b>.
           This allows Foreman to associate a puppet variable with a domain/site
           and automatically append this variable to all external node requests made

--- a/app/views/domains/welcome.html.erb
+++ b/app/views/domains/welcome.html.erb
@@ -5,7 +5,7 @@
   <h1><%= _('Domains') %></h1>
   <p>
     <%= _("Foreman considers a domain and a DNS zone as the same thing.") %></br>
-    <%= _("That is, if you are planning to manage a site where all the machines are or the form <i>hostname</i>.<b>somewhere.com</b>
+    <%= _("That is, if you are planning to manage a site where all the machines are of the form <i>hostname</i>.<b>somewhere.com</b>
     then the domain is <b>somewhere.com</b>.").html_safe %></br>
     <%= _('This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site.') %></br>
     <%= _("The <b>fullname</b> field is used for human readability in reports and other pages that refer to domains,


### PR DESCRIPTION
I am not sure how to apply this for `Satellite`.

``` ruby
Foreman considers a domain and a DNS zone as the same thing
```

should be

``` ruby
Satellite considers a domain and a DNS zone as the same thing
```

I suppose i18n must be doing it?
