### PR TITLE
refs #13968 - use existing feature to ensure reliable comparison

### DIFF
--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -76,11 +76,10 @@ class SmartProxyTest < ActiveSupport::TestCase
   end
 
   test "should be saved if features exist" do
-    feature = FactoryGirl.create(:feature, :tftp)
     proxy = FactoryGirl.build(:smart_proxy)
     ProxyAPI::Features.any_instance.stubs(:features =>["tftp"])
     assert proxy.save
-    assert_include(proxy.features, feature)
+    assert_include(proxy.features, features(:tftp))
   end
 
   test "should not be saved if features do not exist" do


### PR DESCRIPTION
Feature.name_map may have returned either the new factory-based feature
or the existing fixture-based feature for the name 'TFTP', causing
intermittent failures.
