### PR TITLE
Fixes #16965 - renamed title to Foreman Smart Proxy

### DIFF
--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -16,7 +16,7 @@ class Setting::Auth < Setting
         self.set('oauth_consumer_key', N_("OAuth consumer key"), '', N_('OAuth consumer key'), nil, {:encrypted => true}),
         self.set('oauth_consumer_secret', N_("OAuth consumer secret"), '', N_("OAuth consumer secret"), nil, {:encrypted => true}),
         self.set('oauth_map_users', N_("Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."), true, N_('OAuth map users')),
-        self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
+        self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Foreman Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
         self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
         self.set('trusted_puppetmaster_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted puppetmaster hosts')),
         self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert, N_('SSL certificate')),

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -125,7 +125,7 @@ class SmartProxy < ActiveRecord::Base
         self.features.clear
         if reply.any?
           errors.add :base, _('Features "%s" in this proxy are not recognized by Foreman. '\
-                              'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.') % reply.to_sentence
+                              'If these features come from a Foreman Smart Proxy plugin, make sure Foreman has the plugin installed too.') % reply.to_sentence
         else
           errors.add :base, _('No features found on this proxy, please make sure you enable at least one feature')
         end

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -1,4 +1,4 @@
-<% title _("Smart Proxies") %>
+<% title _("Foreman Smart Proxies") %>
 <%= javascript 'proxy_status', 'charts' %>
 <% title_actions new_link(_("New Smart Proxy")),
                  documentation_button('4.3SmartProxies') %>

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -1,4 +1,4 @@
-<% title(_('Smart Proxy: %s') % @smart_proxy.to_label) %>
+<% title(_('Foreman Smart Proxy: %s') % @smart_proxy.to_label) %>
 <%= javascript 'proxy_status', 'charts' %>
 <%= smart_proxy_title_actions(@smart_proxy, authorizer) %>
 <% service_features = services_tab_features(@smart_proxy) %>

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -65,7 +65,7 @@ namespace :puppet do
 
       proxies = SmartProxy.with_features("Puppet")
       if proxies.empty?
-        puts "ERROR: We did not find at least one configured Smart Proxy with the Puppet feature"
+        puts "ERROR: We did not find at least one configured Foreman Smart Proxy with the Puppet feature"
         exit 1
       end
       if ENV["proxy"]
@@ -153,7 +153,7 @@ namespace :puppet do
 
       proxies = SmartProxy.with_features("Puppet")
       if proxies.empty?
-        puts "ERROR: We did not find at least one configured Smart Proxy with the Puppet feature"
+        puts "ERROR: We did not find at least one configured Foreman Smart Proxy with the Puppet feature"
         exit 1
       end
       if ENV["proxy"]

--- a/man/foreman-debug.8.asciidoc
+++ b/man/foreman-debug.8.asciidoc
@@ -22,7 +22,7 @@ Collects configuration and log data for Foreman, Smart Proxies, backend
 services and system information while removing security information like
 passwords, tokens and keys.
 
-This program can be used on Foreman instances, Smart Proxy instances or
+This program can be used on Foreman instances, Foreman Smart Proxy instances or
 backend services separately.
 
 SENDING INFORMATION

--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -15,7 +15,7 @@ Collects configuration and log data for Foreman, Smart Proxies, backend
 services and system information while removing security information like
 passwords, tokens and keys.
 
-This program can be used on Foreman instances, Smart Proxy instances or
+This program can be used on Foreman instances, Foreman Smart Proxy instances or
 backend services separately.
 
 OPTIONS:

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -2,7 +2,7 @@ require 'integration_test_helper'
 
 class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
-    assert_index_page(smart_proxies_path,"Smart Proxies","New Smart Proxy",false)
+    assert_index_page(smart_proxies_path, "Foreman Smart Proxies", "New Smart Proxy", false)
     visit smart_proxies_path
     if SETTINGS[:locations_enabled]
       assert page.has_selector?('th', :text => 'Locations')
@@ -13,7 +13,7 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
 
   test "create new page" do
     ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
-    assert_new_button(smart_proxies_path,"New Smart Proxy",new_smart_proxy_path)
+    assert_new_button(smart_proxies_path, "New Smart Proxy", new_smart_proxy_path)
     fill_in "smart_proxy_name", :with => "DNS Worldwide"
     fill_in "smart_proxy_url", :with => "http://dns.example.com"
     assert_submit_button(smart_proxies_path)

--- a/test/models/concerns/belongs_to_proxies_test.rb
+++ b/test/models/concerns/belongs_to_proxies_test.rb
@@ -35,7 +35,7 @@ class BelongsToProxiesTest < ActiveSupport::TestCase
   test '#registered_smart_proxies contains foo proxy and bar proxy from plugin' do
     class SampleModelOne < SampleModel; end
     Foreman::Plugin.register :test_smart_proxy do
-      name 'Smart Proxy test'
+      name 'Foreman Smart Proxy test'
       smart_proxy_for SampleModelOne, :bar, :feature => 'Bar'
     end
     expected = {
@@ -53,7 +53,7 @@ class BelongsToProxiesTest < ActiveSupport::TestCase
   test '#registered_smart_proxies can be extended for subclass only' do
     class SampleModelThree < SampleModel; end
     Foreman::Plugin.register :test_smart_proxy do
-      name 'Smart Proxy test'
+      name 'Foreman Smart Proxy test'
       smart_proxy_for SampleModelThree, :baz, :feature => 'Baz'
     end
 

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -86,7 +86,7 @@ class SmartProxyTest < ActiveSupport::TestCase
   test "should not be saved if features do not exist" do
     proxy = SmartProxy.new(:name => 'Proxy', :url => 'https://some.where.net:8443')
     error_message = 'Features "feature" in this proxy are not recognized by Foreman. '\
-    'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.'
+    'If these features come from a Foreman Smart Proxy plugin, make sure Foreman has the plugin installed too.'
     ProxyAPI::Features.any_instance.stubs(:features =>["feature"])
     refute proxy.save
     assert_equal(error_message, proxy.errors[:base].first)

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -376,7 +376,7 @@ class PluginTest < ActiveSupport::TestCase
 
   def test_add_smart_proxy_for
     Foreman::Plugin.register :test_smart_proxy do
-      name 'Smart Proxy test'
+      name 'Foreman Smart Proxy test'
       smart_proxy_for Awesome, :foo, :feature => 'Foo'
     end
     assert_equal({}, Foreman::Plugin.find(:test_smart_proxy).smart_proxies(User))


### PR DESCRIPTION
We have Smart Proxy in the Foreman Core, WebUI/API/CLI and also in our Core
documentation, but in the installer and package name it's foreman-proxy. This
creates confusion.

This patch is an attempt to "communicate" it using new name term "Foreman Smart
Proxy" (where appropriate). Short versions stays as "Smart Proxy" or "Smart
Proxies" (e.g. in the main menu).

Noticeable changes are:
- Foreman Smart Proxies (list page)
- Foreman Smart Proxy (new/edit form)
- two more occurrences in Setting help or error message
- foreman debug man page

I will follow up with changes in the manual.
