### PR TITLE
fixes #16996 - reduce eager_load of tables

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -9,9 +9,7 @@ class PuppetclassesController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    eager_load_tables = [:config_group_classes, :class_params, :environments,
-                         :hostgroups]
-    @puppetclasses = resource_base_search_and_page(eager_load_tables)
+    @puppetclasses = resource_base_search_and_page
     @hostgroups_authorizer = Authorizer.new(User.current, :collection => HostgroupClass.where(:puppetclass_id => @puppetclasses.map(&:id)).uniq.pluck(:hostgroup_id))
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,8 @@ Foreman::Application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
     Bullet.counter_cache_enable = false
+    Bullet.add_whitelist :type => :n_plus_one_query, :class_name => "Puppetclass", :association => :environments
+    Bullet.add_whitelist :type => :n_plus_one_query, :class_name => "Puppetclass", :association => :class_params
   end if defined?(Bullet)
 
   #Allow disabling the webpack dev server from the settings


### PR DESCRIPTION
Not eager_loading all data speeds up response time and reduces ressource consumption in larger environments. (actually makes it work with our environment)
In smaller environments there may be a negative performance impact, but this should be negligible.

additional tests seem to be not needed, because no new functionality is introduced
