### PR TITLE
Fixes #17006 - added SSH BMC provider

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -761,7 +761,7 @@ class Host::Managed < Host::Base
   def bmc_available?
     ipmi = bmc_nic
     return false if ipmi.nil?
-    ipmi.password.present? && ipmi.username.present? && ipmi.provider == 'IPMI'
+    (ipmi.password.present? && ipmi.username.present? && ipmi.provider == 'IPMI') || ipmi.provider == 'SSH'
   end
 
   def ipmi_boot(booting_device)

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -1,6 +1,6 @@
 module Nic
   class BMC < Managed
-    PROVIDERS = %w(IPMI)
+    PROVIDERS = %w(IPMI SSH)
     before_validation :ensure_physical
     before_validation { |nic| nic.provider.try(:upcase!) }
     validates :provider, :presence => true, :inclusion => { :in => PROVIDERS }

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -3,7 +3,21 @@ require 'test_helper'
 class BMCTest < ActiveSupport::TestCase
   test 'lowercase IPMI provider string gets set to uppercase' do
     host = FactoryGirl.build(:host, :managed)
-    assert FactoryGirl.build(:nic_bmc, :host => host, :provider => 'ipmi').valid?
+    assert FactoryGirl.build(:nic_bmc, :host => host, :provider => 'IPMI').valid?
+  end
+
+  test 'BMC IPMI availability' do
+    host = FactoryGirl.build(:host, :managed)
+    nic = FactoryGirl.build(:nic_bmc, :host => host, :provider => 'IPMI', :username => "user", :password => "pass")
+    host.expects(:bmc_nic).returns(nic)
+    assert host.bmc_available?
+  end
+
+  test 'BMC SSH availability' do
+    host = FactoryGirl.build(:host, :managed)
+    nic = FactoryGirl.build(:nic_bmc, :host => host, :provider => 'SSH')
+    host.expects(:bmc_nic).returns(nic)
+    assert host.bmc_available?
   end
 
   test 'upcasing provider does not fail if provider is not present' do
@@ -33,14 +47,14 @@ class BMCTest < ActiveSupport::TestCase
   end
 
   test 'BMC password is provided in #password' do
-    bmc_nic = FactoryGirl.build(:nic_bmc, :provider => 'ipmi', :password => 'secret')
+    bmc_nic = FactoryGirl.build(:nic_bmc, :provider => 'IPMI', :password => 'secret')
     assert_equal 'secret', bmc_nic.password
   end
 
   context 'with bmc_credentials_accessible => false' do
     setup do
       Setting[:bmc_credentials_accessible] = false
-      @bmc_nic = FactoryGirl.build(:nic_bmc, :provider => 'ipmi', :password => 'secret')
+      @bmc_nic = FactoryGirl.build(:nic_bmc, :provider => 'IPMI', :password => 'secret')
     end
 
     test 'BMC password is redacted in ENC output' do


### PR DESCRIPTION
Simple provider SSH was merged the other day (1.14+) in smart proxy repo. This
is Foreman core part of the feature. Username and password is ignored as SSH
keys are used (configured on the proxy).
