### PR TITLE
[WIP] Fixes #16982 - "No taxonomies" fix for Host default scope

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -122,7 +122,7 @@ class UnattendedController < ApplicationController
     if (result = token.match(/^([a-z0-9-]+)(.slax)$/i))
       token, _suffix = result.captures
     end
-    Host.for_token(token).first
+    Host.unscoped.for_token(token).first
   end
 
   def find_host_by_ip_or_mac
@@ -148,7 +148,7 @@ class UnattendedController < ApplicationController
     # we try to match first based on the MAC, falling back to the IP
     # host is readonly because of association so we reload it if we find it
     host = Host.joins(:provision_interface).where(mac_list.empty? ? {:nics => {:ip => ip}} : ["lower(nics.mac) IN (?)", mac_list]).first
-    host ? Host.find(host.id) : nil
+    host ? Host.unscoped.find(host.id) : nil
   end
 
   def allowed_to_install?

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -79,12 +79,12 @@ module Orchestration::SSHProvision
     logger.info "SSH connection established to #{provision_ip} - executing template"
     if client.deploy!
       # since we are in a after_commit callback, we need to fetch our host again, and clean up puppet ca on our own
-      Host.find(id).built
+      Host.unscoped.find(id).built
       respond_to?(:initialize_puppetca,true) && initialize_puppetca && delAutosign if puppetca?
     else
       if Setting[:clean_up_failed_deployment]
         logger.info "Deleting host #{name} because of non zero exit code of deployment script."
-        Host.find(id).destroy
+        Host.unscoped.find(id).destroy
       end
       raise ::Foreman::Exception.new(N_("Provision script had a non zero exit"))
     end

--- a/test/controllers/api/v1/hosts_controller_test.rb
+++ b/test/controllers/api/v1/hosts_controller_test.rb
@@ -42,7 +42,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
 
   test "should create host" do
     disable_orchestration
-    assert_difference('Host.count') do
+    assert_difference('Host.unscoped.count') do
       post :create, { :host => valid_attrs }
     end
     assert_response :success
@@ -51,7 +51,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
   test "should create host with host_parameters_attributes" do
     disable_orchestration
     Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
-    assert_difference('Host.count') do
+    assert_difference('Host.unscoped.count') do
       attrs = [{"name" => "compute_resource_id", "value" => "1", "nested" => "true"}]
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
     end
@@ -61,7 +61,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
   test "should create host with host_parameters_attributes sent in a hash" do
     disable_orchestration
     Foreman::Deprecation.expects(:api_deprecation_warning).with('Field host_parameters_attributes.nested ignored')
-    assert_difference('Host.count') do
+    assert_difference('Host.unscoped.count') do
       attrs = {"0" => {"name" => "compute_resource_id", "value" => "1", "nested" => "true"}}
       post :create, { :host => valid_attrs.merge(:host_parameters_attributes => attrs) }
     end
@@ -96,7 +96,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
 
   test "should be able to create hosts even when restricted" do
     disable_orchestration
-    assert_difference('Host.count') do
+    assert_difference('Host.unscoped.count') do
       post :create, { :host => valid_attrs }
     end
     assert_response :success
@@ -119,7 +119,7 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
 
   test "should allow destroy for restricted user who owns the hosts" do
     host = FactoryGirl.create(:host, :owner => users(:scoped), :organization => taxonomies(:organization1), :location => taxonomies(:location1))
-    assert_difference('Host.count', -1) do
+    assert_difference('Host.unscoped.count', -1) do
       setup_user 'destroy', 'hosts', "owner_type = User and owner_id = #{users(:scoped).id}", :scoped
       delete :destroy, { :id => host.to_param }
     end

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -14,15 +14,21 @@ class AuditExtensionsTest < ActiveSupport::TestCase
     assert_equal audit.username, @user.name
   end
 
-  test "host scoped search for audit works" do
-    resource = FactoryGirl.create(:host, :managed)
-    assert Audit.search_for("host = #{resource.name}").count > 0
-  end
+  context 'audit search for hosts' do
+    setup do
+      @resource = FactoryGirl.create(:host, :managed)
+      Organization.current = @resource.organization
+      Location.current = @resource.location
+    end
 
-  test "host autocomplete works in audit search" do
-    FactoryGirl.create(:host, :managed)
-    hosts = Audit.complete_for("host = ", {:controller => 'audits'})
-    assert hosts.count > 0
+    test "host scoped search for audit works" do
+      assert Audit.search_for("host = #{@resource.name}").count > 0
+    end
+
+    test "host autocomplete works in audit search" do
+      hosts = Audit.complete_for("host = ", {:controller => 'audits'})
+      assert hosts.count > 0
+    end
   end
 
   test "audit's change is filtered when data is encrypted" do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -131,7 +131,9 @@ class HostTest < ActiveSupport::TestCase
     h = FactoryGirl.create(:host, :managed)
     setup_user('view', 'hosts', 'name ~ *')
 
-    assert_includes Host.authorized('view_hosts'), h
+    Organization.current = h.organization
+    Location.current = h.location
+    assert_includes Host.unscoped.authorized('view_hosts'), h
   end
 
   context "when unattended is false" do
@@ -589,12 +591,13 @@ class HostTest < ActiveSupport::TestCase
     assert_includes hosts, host2
     refute_includes hosts, host3
 
+    # User 'one' has no organizations/locations, shouldn't see anything
     as_user(:one) do
       hosts = Host::Managed.all
     end
-    assert_includes hosts, host1
-    assert_includes hosts, host2
-    assert_includes hosts, host3
+    refute_includes hosts, host1
+    refute_includes hosts, host2
+    refute_includes hosts, host3
   end
 
   context "location or organizations are not enabled" do
@@ -3284,9 +3287,8 @@ class HostTest < ActiveSupport::TestCase
 
   describe 'taxonomy scopes' do
     test 'no_location overrides default scope' do
-      location = FactoryGirl.create(:location)
       host = FactoryGirl.create(:host, :location => nil)
-      Location.stubs(:current).returns(location)
+      Location.stubs(:current).returns(taxonomies(:location1))
 
       assert_nil Host.where(:id => host.id).first
       assert_not_nil Host.no_location.where(:id => host.id).first
@@ -3294,13 +3296,52 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'no_organization overrides default scope' do
-      organization = FactoryGirl.create(:organization)
       host = FactoryGirl.create(:host, :organization => nil)
-      Organization.stubs(:current).returns(organization)
+      Organization.stubs(:current).returns(taxonomies(:organization1))
 
       assert_nil Host.where(:id => host.id).first
       assert_not_nil Host.no_organization.where(:id => host.id).first
       Organization.unstub(:current)
+    end
+
+    test 'default scope returns hosts in current taxonomies' do
+      visible_host = FactoryGirl.create(
+        :host,
+        :organization => taxonomies(:organization1),
+        :location => taxonomies(:location1))
+      hidden_host = FactoryGirl.create(
+        :host,
+        :organization => taxonomies(:organization2),
+        :location => taxonomies(:location2))
+
+      Organization.current = taxonomies(:organization1)
+      Location.current = taxonomies(:location1)
+      assert_empty Host.where(:id => hidden_host.id)
+      assert_includes Host.where(:id => visible_host.id), visible_host
+    end
+
+    test 'default scope returns no hosts in current user has no taxonomies' do
+      unaccessible_host = FactoryGirl.create(
+        :host,
+        :organization => taxonomies(:organization1),
+        :location => taxonomies(:location1))
+
+      as_user(:one) do
+        Organization.current = nil
+        Location.current = nil
+        assert_empty Host.where(:id => unaccessible_host.id)
+      end
+    end
+
+    test 'default scope returns all hosts for an admin with no taxonomies' do
+      accessible_host = FactoryGirl.create(
+        :host,
+        :organization => taxonomies(:organization1),
+        :location => taxonomies(:location1))
+
+      Organization.current = nil
+      Location.current = nil
+      assert_includes Host.where(:id => accessible_host), accessible_host
     end
   end
 

--- a/test/unit/association_authorizer_test.rb
+++ b/test/unit/association_authorizer_test.rb
@@ -13,6 +13,8 @@ class AssociationAuthorizerTest < ActiveSupport::TestCase
     @user.update_attribute :roles, [role]
 
     as_user @user do
+      Organization.current = @host.organization
+      Location.current = @host.location
       authorized = AssociationAuthorizer.authorized_associations(Hostgroup.reflect_on_association(:hosts).klass, :hosts)
       assert authorized.include?(@host)
     end
@@ -20,6 +22,8 @@ class AssociationAuthorizerTest < ActiveSupport::TestCase
 
   test "user without permissions can't view host" do
     as_user @user do
+      Organization.current = @host.organization
+      Location.current = @host.location
       authorized = AssociationAuthorizer.authorized_associations(Hostgroup.reflect_on_association(:hosts).klass, :hosts)
       refute authorized.include?(@host)
     end

--- a/test/unit/ensure_not_used_by_test.rb
+++ b/test/unit/ensure_not_used_by_test.rb
@@ -17,8 +17,11 @@ class EnsureNotUsedByTest < ActiveSupport::TestCase
 
     as_user @user do
       in_taxonomy @org1 do
-        refute hostgroup.destroy
-        assert_equal "#{hostgroup.name} is used by #{host.name}", hostgroup.errors.full_messages.first
+        in_taxonomy host.location do
+          refute hostgroup.destroy
+          assert_equal "#{hostgroup.name} is used by #{host.name}",
+            hostgroup.errors.full_messages.first
+        end
       end
     end
   end

--- a/test/unit/orchestration/ssh_test.rb
+++ b/test/unit/orchestration/ssh_test.rb
@@ -10,7 +10,7 @@ class SshOrchestrationTest < ActiveSupport::TestCase
     host = FactoryGirl.create(:host, :managed)
     host.expects(:client).returns(ssh)
     host.send(:setSSHProvision)
-    refute Host::Managed.find_by_id(host.id)
+    refute Host::Managed.unscoped.find_by_id(host.id)
   end
 
   test 'failed SSH deployment retains host if disabled' do
@@ -20,6 +20,6 @@ class SshOrchestrationTest < ActiveSupport::TestCase
     host = FactoryGirl.create(:host, :managed)
     host.expects(:client).returns(ssh)
     host.send(:setSSHProvision)
-    assert Host::Managed.find_by_id(host.id)
+    assert Host::Managed.unscoped.find_by_id(host.id)
   end
 end


### PR DESCRIPTION
The default scope for hosts did not restrict properly by taxonomies.
An user without organizations or locations, could do anything it's
permissions allow to. The list of hosts was unrestricted and showed
hosts in any location or organization.

This is fixed to work so that:
- Users without taxonomies, when set to 'any context' cannot see
  anything
- Users with taxonomies, when set to 'any context' can see everything
  within all of their taxonomies context.
- Admins set to 'any context' can see everything - regardless of
  whether it has a taxonomy or not.
- Users or admins set to some organization/location scope can only
  see stuff within scope.
