### PR TITLE
Fixes #17035 - removes webpack provider plugin

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -63,10 +63,6 @@ var config = {
       modules: false,
       assets: true
     }),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-    }),
     new ExtractTextPlugin(production ? '[name]-[chunkhash].css' : '[name].css', {
             allChunks: true
     })

--- a/webpack/assets/javascripts/jquery.ui.custom_spinners.js
+++ b/webpack/assets/javascripts/jquery.ui.custom_spinners.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 const megabyte = 1024 * 1024;
 const gigabyte = 1024 * megabyte;
 

--- a/webpack/assets/javascripts/react_app/API.js
+++ b/webpack/assets/javascripts/react_app/API.js
@@ -1,4 +1,5 @@
 import ServerActions from './actions/ServerActions';
+import $ from 'jquery';
 
 export default {
   get(url) {


### PR DESCRIPTION
Webpack is currently configured to automatically load 'jquery' when the '$' or 'jquery' is used as free variable in a module. The identifier is filled with the exports of the loaded module.

This practice is not sufficient for our testing infrastructure.
