### PR TITLE
Fixes #17038 - Improve js testing coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "identity-obj-proxy": "^3.0.0",
-    "jest-cli": "^15.1.1",
+    "jest-cli": "^16.0.1",
     "jsdom": "^9.5.0",
     "react-addons-test-utils": "^15.3.1",
     "stats-webpack-plugin": "^0.2.1",
@@ -61,13 +61,16 @@
   },
   "jest": {
     "automock": true,
+    "verbose": true,
+    "collectCoverage": true,
+    "collectCoverageFrom": ["webpack/**/*.js", "!webpack/**/bundle*"],
+    "coverageReporters": ["lcov"],
     "unmockedModulePathPatterns": [
       "react",
       "node_modules/"
     ],
     "moduleNameMapper": {
-      "^.+\\.(png|gif)$": "identity-obj-proxy",
-      "^.+\\.(css)$": "identity-obj-proxy"
+      "^.+\\.(png|gif|css)$": "identity-obj-proxy"
     }
   }
 }

--- a/webpack/assets/javascripts/react_app/components/charts/Chart.test.js
+++ b/webpack/assets/javascripts/react_app/components/charts/Chart.test.js
@@ -19,7 +19,6 @@ describe('Chart', () => {
       };
       const chart = shallow(<Chart config={config} noDataMsg={'No data here'}></Chart>);
 
-      expect(chart.node.type.name).toBe('MessageBox');
       expect(chart.node.props.msg).toBe('No data here');
       expect(chart.node.props.icontype).toBe('info');
     });
@@ -33,7 +32,6 @@ describe('Chart', () => {
 
       const chart = shallow(<Chart config={config}></Chart>);
 
-      expect(chart.node.type.name).toBe('MessageBox');
       expect(chart.node.props.msg).toBe('No data available');
       expect(chart.node.props.icontype).toBe('info');
     });
@@ -53,7 +51,13 @@ describe('Chart', () => {
   describe('draws chart', () => {
     let config;
 
-    c3.generate = jest.fn();
+    /*
+      unmount calls chart.destroy
+      set c3.generate return value property destroy to value
+      so that unmount will throw 'is not a function, error when calling chart.destroy()
+      this facilitates checking that 'destroy' is called
+    */
+    c3.generate = jest.fn().mockReturnValue({destroy: ''});
 
     beforeEach(() => {
       config = {
@@ -145,6 +149,12 @@ describe('Chart', () => {
         chart.update();
 
         expect(c3.generate).toHaveBeenCalled();
+      });
+      it('unmount', () => {
+        let chart = mount(<Chart id="operatingsystem" config={config}></Chart>);
+
+        // a very peculiar way to prove that chart is destroyed when unmounting
+        expect(()=> {chart.unmount();}).toThrowError('this.chart.destroy is not a function');
       });
     });
   });

--- a/webpack/assets/javascripts/react_app/constants.test.js
+++ b/webpack/assets/javascripts/react_app/constants.test.js
@@ -1,0 +1,9 @@
+jest.unmock('./constants');
+
+import {ACTIONS} from './constants';
+
+describe('exists', () => {
+  it('RECEIVED_STATISTICS action exists', () => {
+    expect(ACTIONS.RECEIVED_STATISTICS).not.toBeUndefined();
+  });
+});

--- a/webpack/assets/javascripts/react_app/dispatcher.test.js
+++ b/webpack/assets/javascripts/react_app/dispatcher.test.js
@@ -1,0 +1,10 @@
+jest.unmock('./dispatcher');
+
+import dispatcher from './dispatcher';
+
+describe('dispatcher', () => {
+  it('exists', () => {
+    expect(dispatcher).not.toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
collect coverage on all webpack/*_/_.js files except 'bundle' files.

use 'lcov' reporter
