### PR TITLE
fixes #17041 - skips orchestration when importing facts

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -99,11 +99,15 @@ module Orchestration
   end
 
   def skip_orchestration?
+    return true if skip_orchestration_for_testing?
+    !!@skip_orchestration
+  end
+
+  def skip_orchestration_for_testing?
     # The orchestration should be disabled in tests in order to avoid side effects.
     # If a test needs to enable orchestration, it should be done explicitly by stubbing
     # this method.
-    return true if Rails.env.test?
-    !!@skip_orchestration
+    Rails.env.test?
   end
 
   private

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -313,6 +313,10 @@ module Host
       @old = super { |clone| clone.interfaces = self.interfaces.map {|i| setup_object_clone(i) } }
     end
 
+    def skip_orchestration?
+      false
+    end
+
     private
 
     def owner_taxonomies_match

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -22,7 +22,7 @@ module Nic
              :operatingsystem, :provisioning_template, :jumpstart?, :build, :build?, :os, :arch,
              :image_build?, :pxe_build?, :pxe_build?, :token, :to_ip_address, :model, :to => :host
     delegate :operatingsystem_id, :hostgroup_id, :environment_id,
-             :overwrite?, :skip_orchestration!, :to => :host, :allow_nil => true
+             :overwrite?, :skip_orchestration?, :skip_orchestration!, :to => :host, :allow_nil => true
 
     attr_exportable :ip, :mac, :name, :attrs, :virtual, :link, :identifier, :managed, :primary, :provision, :subnet, :subnet6,
       :tag => ->(nic) { nic.tag if nic.virtual? },

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -251,9 +251,9 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "should not trigger dhcp orchestration when importing facts" do
-    host = Host.new(:name => "sinn1636.lan")
-    host.stubs(:skip_orchestration?).returns(false)
-    host.primary_interface.expects(:dhcp_conflict_detected?).never
+    host = FactoryGirl.create(:host, :managed, :with_dhcp_orchestration, :name => "sinn1636.lan")
+    host.stubs(:skip_orchestration_for_testing?).returns(false) # Explicitly enable orchestration
+    Nic::Managed.any_instance.expects(:dhcp_conflict_detected?).never
     assert host.import_facts(read_json_fixture('facts/facts.json')['facts'])
   end
 


### PR DESCRIPTION
This is a regression in 1.13. The orchestration callbacks only run if `unless :skip_orchestration?`, however `skip_orchestration?` is not a method for `Nic::Managed` causing the callbacks to always run, even if importing facts.

This leads to a chain reaction: Smart Proxy gets unresponsive, all Foreman threads start to wait for a response from Smart Proxy and the UI gets completely unresponsive.
