### PR TITLE
Fixes #17042 - improved orchestration logging

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -151,6 +151,18 @@ module Orchestration
     fail_queue(q)
 
     rollback
+  ensure
+    unless q.nil?
+      logger.info("Processed queue '#{queue_name}', #{q.completed.count}/#{q.all.count} completed tasks") unless q.empty?
+      q.all.each do |task|
+        msg = "Task #{task.name} *#{task.status}*"
+        if task.status?(:completed) || task.status?(:pending)
+          logger.debug msg
+        else
+          logger.error msg
+        end
+      end
+    end
   end
 
   def fail_queue(q)

--- a/app/services/orchestration/task.rb
+++ b/app/services/orchestration/task.rb
@@ -19,6 +19,10 @@ module Orchestration
       end
     end
 
+    def status?(symbol)
+      @status == symbol.to_s
+    end
+
     def to_s
       "#{name}\t #{priority}\t #{status}\t #{action}"
     end


### PR DESCRIPTION
This improves orchestration logging, failed tasks were silently ignored (we
only logged those which failed due exception but not these that return false).

The patch adds this logging pattern:

```
[I] Processed 6/6 orchestration tasks
[D] Task Remove IPv4 DNS record for srv-192-168-122-148.local.lan *completed*
[D] Task Remove Reverse IPv4 DNS record for srv-192-168-122-148.local.lan *completed*
[D] Task Remove DHCP Settings for srv-192-168-122-148.local.lan *completed*
[D] Task Delete TFTP PXEGrub2 config for srv-192-168-122-148.local.lan *completed*
[D] Task Delete TFTP PXELinux config for srv-192-168-122-148.local.lan *completed*
[D] Task Delete TFTP PXEGrub config for srv-192-168-122-148.local.lan *completed*
```

Number of successful tasks (6) out of (6) is logged as INFO level, all tasks
are logged by their name along with the status (DEBUG only level).
