### PR TITLE
Fixes #16091 - Fixed association Foreman host with Compute VM

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -158,7 +158,7 @@ module Foreman::Model
     end
 
     def associated_host(vm)
-      associate_by("ip", [vm.floating_ip_address, vm.private_ip_address])
+      associate_by("ip", [vm.floating_ip_address, vm.private_ip_address] - [nil])
     end
 
     def flavor_name(flavor_ref)

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -158,7 +158,7 @@ module Foreman::Model
     end
 
     def associated_host(vm)
-      associate_by("ip", [vm.floating_ip_address, vm.private_ip_address] - [nil])
+      associate_by("ip", [vm.floating_ip_address, vm.private_ip_address].compact)
     end
 
     def flavor_name(flavor_ref)


### PR DESCRIPTION
fixes #16091 - association Foreman host with Compute VM
 when no floating ip is assigned to VM.
