### PR TITLE
fixes #15519 - speed up host edit page rendering on vmware

### DIFF
--- a/app/assets/javascripts/compute_resources/vmware/nic_info.js
+++ b/app/assets/javascripts/compute_resources/vmware/nic_info.js
@@ -1,3 +1,3 @@
 providerSpecificNICInfo = function(form) {
-  return form.find('select.vmware_type').val() + ' @ ' + form.find('select.vmware_network').val();
+  return form.find('.vmware_type').val() + ' @ ' + form.find('.vmware_network').val();
 }

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,9 +1,12 @@
-<% networks = compute_resource.networks %>
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
-                 :class => "col-md-3 vmware_type",
-                 :label => _('NIC type'), :label_size => "col-md-3"
+  :class => "col-md-3 vmware_type",
+  :label => _('NIC type'), :label_size => "col-md-3"
 %>
-<%= select_f f, :network, networks, :name, :name, { },
-                 :class => "col-md-3 vmware_network",
-                 :label => _('Network'), :label_size => "col-md-3"
-%>
+<% if new_host %>
+  <%= select_f f, :network, compute_resource.networks, :name, :name, { },
+    :class => "col-md-3 vmware_network",
+    :label => _('Network'), :label_size => "col-md-3"
+  %>
+<% else %>
+  <%= text_f f, :network, :class => 'col-md-3 vmware_network', :label => _("Network"), :label_size => "col-md-3" %>
+<% end %>

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -5,8 +5,12 @@
   :class => "span5",
   :label => _("Datastore Cluster"),
   :label_size => "col-md-2",
-  :onchange => 'vsphereStoragePodSelected(this)' if new_host and vsphere_storage_pods(compute_resource).any? %>
-<%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
+  :onchange => 'vsphereStoragePodSelected(this)' if new_host && vsphere_storage_pods(compute_resource).any? %>
+<% if new_host %>
+  <%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
+<% else %>
+  <%= text_f f, :datastore, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
+<% end %>
 <%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2" %>
 <%= text_f f, :size_gb,
            :class       => "col-md-2",


### PR DESCRIPTION
This commit speeds up rendering of the host edit page for hosts on
VMWare. The API calls to list networks and datastores are expensive.
When editing a host, these information is never showed to a user and
furthermore CR editing on VMWare is not supported.
So instead of displaying a select box, this commit shows a textbox.

On my local environment, rendering before this patch was ~ 20seconds. After the patch, it got down to approx. 4 seconds. This makes a huge difference to a user.

I talked to @iNecas and @tstrachota about this. There are more ways to improve this
- caching
- filtering the network list based on a the VMWware cluster (#3559)
- not displaying a form but some nice patternfly cards with VM information, ...

but I think, this is a good quick win.
