### PR TITLE
fixes #17068 - Duplicate "Smart Class Parameter" entries.

### DIFF
--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -40,6 +40,7 @@ module Api
         param :override, :bool, :desc => N_("Whether the smart class parameter value is managed by Foreman")
         param :description, String, :desc => N_("Description of smart class")
         param :default_value, String, :desc => N_("Value to use when there is no match")
+        param :puppetclass_id, :number, :desc => N_("Puppet class ID")
         param :hidden_value, :bool, :desc => N_("When enabled the parameter is hidden in the UI")
         param :use_puppet_default, :bool, :desc => N_("Deprecated, please use omit")
         param :omit, :bool, :desc => N_("Foreman will not send this parameter in classification output. Puppet will use the value defined in the Puppet manifest for this parameter")

--- a/app/controllers/concerns/foreman/controller/parameters/puppetclass_lookup_key.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/puppetclass_lookup_key.rb
@@ -5,7 +5,7 @@ module Foreman::Controller::Parameters::PuppetclassLookupKey
   class_methods do
     def puppetclass_lookup_key_params_filter
       Foreman::ParameterFilter.new(::PuppetclassLookupKey).tap do |filter|
-        filter.permit :environments => [], :environment_ids => [], :environment_names => [],
+        filter.permit :puppetclass, :environments => [], :environment_ids => [], :environment_names => [],
           :environment_classes => [], :environment_classes_ids => [], :environment_classes_names => [],
           :param_classes => [], :param_classes_ids => [], :param_classes_names => []
         filter.permit_by_context :required, :nested => true

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -2,7 +2,8 @@ class PuppetclassLookupKey < LookupKey
   has_many :environment_classes, :dependent => :destroy
   has_many :environments, -> { uniq }, :through => :environment_classes
   has_many :param_classes, :through => :environment_classes, :source => :puppetclass
-
+  belongs_to :puppetclass, :inverse_of => :puppetclass_lookup_keys
+  validates :puppetclass, :presence => true
   before_validation :cast_default_value, :if => :override?
   before_validation :check_override_selected, :if => -> { persisted? && @validation_context != :importer }
   validate :validate_default_value, :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default, :if => :override?

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -17,6 +17,8 @@ class Puppetclass < ActiveRecord::Base
   has_many :config_group_classes
   has_many :config_groups, :through => :config_group_classes, :dependent => :destroy
   has_many :lookup_keys, :inverse_of => :puppetclass, :dependent => :destroy, :class_name => 'VariableLookupKey'
+  has_many :puppetclass_lookup_keys, :inverse_of => :puppetclass, :dependent => :destroy
+
   accepts_nested_attributes_for :lookup_keys, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
   # param classes
   has_many :class_params, -> { where('environment_classes.puppetclass_lookup_key_id is NOT NULL').uniq },

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -273,6 +273,7 @@ class PuppetClassImporter
     klass.class_params.where(:key => param_name).first ||
       PuppetclassLookupKey.create!(:key => param_name, :required => value.nil?,
                                    :override => value.nil?, :default_value => value,
+                                   :puppetclass_id => klass.id,
                                    :key_type => Foreman::ImporterPuppetclass.suggest_key_type(value))
   end
 end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -29,9 +29,6 @@ FactoryGirl.define do
       end
 
       trait :as_smart_class_param do
-        transient do
-          puppetclass nil
-        end
         after(:create) do |lkey, evaluator|
           evaluator.puppetclass.environments.each do |env|
             FactoryGirl.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
@@ -90,7 +87,7 @@ FactoryGirl.define do
       after(:create) do |pc,evaluator|
         evaluator.parameter_count.times do
           evaluator.environments.each do |env|
-            lkey = FactoryGirl.create :puppetclass_lookup_key
+            lkey = FactoryGirl.create :puppetclass_lookup_key, :puppetclass_id => pc.id
             FactoryGirl.create :environment_class, :puppetclass_id => pc.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
           end
         end

--- a/test/fixtures/lookup_keys.yml
+++ b/test/fixtures/lookup_keys.yml
@@ -5,6 +5,7 @@ one:
   key_type: integer
   validator_type:
   default_value: 80
+  puppetclass: one
   type: PuppetclassLookupKey
 
 three:
@@ -31,6 +32,7 @@ five:
   default_value: 'abcdef'
   path: 'organization,location'
   override: true
+  puppetclass: one
   type: PuppetclassLookupKey
 
 five_same_name:
@@ -40,6 +42,7 @@ five_same_name:
   default_value: 'abcdef'
   path: 'organization,location'
   override: true
+  puppetclass: one
   type: PuppetclassLookupKey
 
 six:


### PR DESCRIPTION
Previously, there is no association between puppet class with smart class parameters i.e puppet class lookup keys directly, it is through environment class.
When someone tries to delete puppet class then dependent environment class objects also get deleted, but the smart class parameters remains in database.

Likewise association between puppet class and smart variables i.e variable lookup keys, there should be the association required between the puppet class and smart class parameters. 
