### PR TITLE
Fixes #17083 - log skipped orchestration steps

### DIFF
--- a/app/models/concerns/orchestration/common.rb
+++ b/app/models/concerns/orchestration/common.rb
@@ -5,4 +5,12 @@ module Orchestration::Common
     logger.debug "Error occured during validations of #{self.class.name}: #{e.message}"
     nil
   end
+
+  def log_orchestration_errors
+    logged_errors = []
+    logged_errors << errors.full_messages if self.respond_to?(:errors) && errors.any?
+    logged_errors << host.errors.full_messages if self.respond_to?(:host) && host.respond_to?(:errors) && host.errors.any?
+    logger.warn("Not queueing #{self.class.name}: #{logged_errors.to_sentence}") if logged_errors.any?
+    false
+  end
 end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -3,6 +3,7 @@ require 'timeout'
 
 module Orchestration::Compute
   extend ActiveSupport::Concern
+  include Orchestration::Common
 
   included do
     attr_accessor :compute_attributes, :vm
@@ -36,7 +37,7 @@ module Orchestration::Compute
   protected
 
   def queue_compute
-    return unless compute? && errors.empty?
+    return log_orchestration_errors unless compute? && errors.empty?
     # Create a new VM if it doesn't already exist or update an existing vm
     vm_exists? ? queue_compute_create : queue_compute_update
   end

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -135,7 +135,7 @@ module Orchestration::DHCP
   end
 
   def queue_dhcp
-    return unless (dhcp? || (old && old.dhcp?)) && orchestration_errors?
+    return log_orchestration_errors unless (dhcp? || (old && old.dhcp?)) && orchestration_errors?
     queue_remove_dhcp_conflicts
     new_record? ? queue_dhcp_create : queue_dhcp_update
   end

--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -55,7 +55,7 @@ module Orchestration::DNS
   end
 
   def queue_dns
-    return unless (dns? || dns6? || reverse_dns? || reverse_dns6?) && errors.empty?
+    return log_orchestration_errors unless (dns? || dns6? || reverse_dns? || reverse_dns6?) && errors.empty?
     queue_remove_dns_conflicts if overwrite?
     new_record? ? queue_dns_create : queue_dns_update
   end

--- a/app/models/concerns/orchestration/puppetca.rb
+++ b/app/models/concerns/orchestration/puppetca.rb
@@ -1,5 +1,6 @@
 module Orchestration::Puppetca
   extend ActiveSupport::Concern
+  include Orchestration::Common
 
   included do
     attr_reader :puppetca
@@ -43,7 +44,7 @@ module Orchestration::Puppetca
   private
 
   def queue_puppetca
-    return unless puppetca? && errors.empty?
+    return log_orchestration_errors unless puppetca? && errors.empty?
     return unless Setting[:manage_puppetca]
     new_record? ? queue_puppetca_create : queue_puppetca_update
   end

--- a/app/models/concerns/orchestration/realm.rb
+++ b/app/models/concerns/orchestration/realm.rb
@@ -1,5 +1,6 @@
 module Orchestration::Realm
   extend ActiveSupport::Concern
+  include Orchestration::Common
 
   included do
     after_validation  :queue_realm
@@ -45,7 +46,7 @@ module Orchestration::Realm
   private
 
   def queue_realm
-    return unless realm? && errors.empty?
+    return log_orchestration_errors unless realm? && errors.empty?
     new_record? ? queue_realm_create : queue_realm_update
   end
 

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -1,5 +1,6 @@
 module Orchestration::TFTP
   extend ActiveSupport::Concern
+  include Orchestration::Common
 
   included do
     after_validation :validate_tftp, :unless => :skip_orchestration?
@@ -150,7 +151,7 @@ module Orchestration::TFTP
   end
 
   def queue_tftp
-    return unless (tftp? || tftp6?) && no_errors
+    return log_orchestration_errors unless (tftp? || tftp6?) && no_errors
     # Jumpstart builds require only minimal tftp services. They do require a tftp object to query for the boot_server.
     return true if host.jumpstart?
     new_record? ? queue_tftp_create : queue_tftp_update


### PR DESCRIPTION
If there is an ActiveRecord error during unattended/built orchestration
(queue_tftp), the method silently does not enqueue TFTP orchestration. We
should print the error in logs, otherwise it is impossible to investigate the
root cause.

Symptoms are even more difficult to spot because due to bug RM/17082 no error
is reported when unattended "built" REST API call fails, so the TFTP
orchestration is silently ignored and hosts stays in provisioning loop.

The patch aims only to add logging, note this is currently sent into SQL logger
due to limitation of our logging stack.
