### PR TITLE
Fixes #17084 - Add webpack on welcome and unauthorized pages

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -113,6 +113,10 @@ class ActionDispatch::IntegrationTest
     set_request_user(:admin)
   end
 
+  def logout_admin
+    delete_cookie('test_user')
+  end
+
   def set_request_user(user)
     user = users(user) unless user.is_a?(User)
     create_cookie('test_user', user.login)


### PR DESCRIPTION
On pages where the welcome action in the app controller was triggered
the webpack server was not added due to welcome rendering before
