### PR TITLE
fixes #17071 - set ip after acquiring compute details

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -172,6 +172,8 @@ class Host::Managed < Host::Base
     delegate :dhcp?, :dhcp_record, :to => :primary_interface
     # DNS orchestration delegation
     delegate :dns?, :dns6?, :reverse_dns?, :reverse_dns6?, :dns_record, :to => :primary_interface
+    # IP delegation
+    delegate :mac_based_ipam?, :required_ip_addresses_set?, :compute_provides_ip?, :ip_available?, :ip6_available?, :to => :primary_interface
     include Orchestration::Compute
     include Rails.application.routes.url_helpers
     # TFTP orchestration delegation
@@ -643,8 +645,8 @@ class Host::Managed < Host::Base
   def set_ip_address
     return unless SETTINGS[:unattended] && (new_record? || managed?)
     self.interfaces.select { |nic| nic.managed }.each do |nic|
-      nic.ip  ||= nic.subnet.unused_ip.suggest_ip if nic.subnet.present?
-      nic.ip6 ||= nic.subnet6.unused_ip.suggest_ip if nic.subnet6.present?
+      nic.ip  = nic.subnet.unused_ip(mac).suggest_ip if nic.subnet.present? && nic.ip.blank?
+      nic.ip6 = nic.subnet6.unused_ip(mac).suggest_ip if nic.subnet6.present? && nic.ip6.blank?
     end
   end
 

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -55,17 +55,16 @@ module Nic
       N_('Interface')
     end
 
-    # Copied from compute orchestration
     def ip_available?
-      ip.present? || (host.present? && host.compute_provides?(:ip)) # TODO revist this for VMs
+      ip.present? || compute_provides_ip?(:ip)
     end
 
     def ip6_available?
-      ip6.present? || (host.present? && host.compute_provides?(:ip6)) # TODO revist this for VMs
+      ip6.present? || compute_provides_ip?(:ip6)
     end
 
     def mac_available?
-      mac.present? || (host.present? && host.compute_provides?(:mac)) # TODO revist this for VMs
+      mac.present? || (host.present? && host.compute_provides?(:mac))
     end
 
     protected

--- a/app/services/ipam/eui64.rb
+++ b/app/services/ipam/eui64.rb
@@ -4,6 +4,7 @@ module IPAM
       logger.debug("Suggesting ip for #{subnet} based on mac '#{mac}' (EUI-64).")
       validate
       return if errors.present?
+      return unless mac.present?
       ip = mac_to_ip(mac)
       logger.debug("Generated #{ip}")
       ip
@@ -16,7 +17,6 @@ module IPAM
     private
 
     def validate
-      errors.add(:mac, _("can't be blank")) unless mac.present?
       errors.add(:subnet, _("Network can't be blank")) unless subnet.network.present?
       errors.add(:subnet, _("Prefix length can't be blank")) unless subnet.cidr.present?
       errors.add(:subnet, _("Prefix length must be /64 or less to use EUI-64")) if subnet.cidr > 64

--- a/app/services/nic_ip_required/base.rb
+++ b/app/services/nic_ip_required/base.rb
@@ -1,0 +1,65 @@
+module NicIpRequired
+  class Base
+    attr_reader :nic, :from_compute, :subnet, :field, :other_field
+
+    delegate :logger, :to => :Rails
+    delegate :host, :domain, :to => :nic
+
+    def initialize(opts = {})
+      @nic = opts.fetch(:nic)
+
+      # the compute resource can provide an IP, so don't validate yet
+      @from_compute = opts.fetch(:from_compute, true)
+    end
+
+    def required?
+      # if it's not managed there's nowhere to specify an IP anyway
+      return false unless nic_managed?
+
+      # if the CR will provide an IP, then don't validate yet
+      return false if compute_provides_ip?
+
+      [require_ip_for_dns?, require_ip_for_dhcp?, require_ip_instead_of_token?].any?
+    end
+
+    def nic_managed?
+      nic.host_managed? && nic.managed? && nic.provision?
+    end
+
+    def require_ip_for_dns?
+      reverse_dns? || forward_dns?
+    end
+
+    def reverse_dns?
+      subnet.present? && subnet.dns_id.present?
+    end
+
+    def forward_dns?
+      domain.present? && domain.dns_id.present? && !other_ip_protocol_provides_ip?
+    end
+
+    def require_ip_for_dhcp?
+      subnet.present? && subnet.dhcp_id.present?
+    end
+
+    def require_ip_instead_of_token?
+      tokens_disabled? && unattended_controller_used? && !other_ip_protocol_provides_ip?
+    end
+
+    def tokens_disabled?
+      Setting[:token_duration] == 0
+    end
+
+    def unattended_controller_used?
+      host.pxe_build? || (host.image_build? && host.image.try(:user_data?))
+    end
+
+    def compute_provides_ip?
+      from_compute && nic.compute_provides_ip?(field)
+    end
+
+    def other_ip_protocol_provides_ip?
+      nic.send(other_field).present? || nic.compute_provides_ip?(other_field)
+    end
+  end
+end

--- a/app/services/nic_ip_required/ipv4.rb
+++ b/app/services/nic_ip_required/ipv4.rb
@@ -1,0 +1,10 @@
+module NicIpRequired
+  class Ipv4 < Base
+    def initialize(opts = {})
+      super
+      @subnet = nic.subnet
+      @field = :ip
+      @other_field = :ip6
+    end
+  end
+end

--- a/app/services/nic_ip_required/ipv6.rb
+++ b/app/services/nic_ip_required/ipv6.rb
@@ -1,0 +1,10 @@
+module NicIpRequired
+  class Ipv6 < Base
+    def initialize(opts = {})
+      super
+      @subnet = nic.subnet6
+      @field = :ip6
+      @other_field = :ip
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2108,6 +2108,22 @@ class HostTest < ActiveSupport::TestCase
       assert host.require_ip6_validation?
     end
 
+    test "hosts with a DNS-enabled IPv6 Subnet, the mac provided by a CR and a mac based IPAM require neither a IPv6 nor a IPv4 address" do
+      Setting[:token_duration] = 30 #enable tokens so that we only test the subnet
+      subnet6 = FactoryGirl.build(:subnet_ipv6, :dns, :ipam => IPAM::MODES[:eui64])
+      host = FactoryGirl.build(:host,
+                               :on_compute_resource,
+                               :with_compute_profile,
+                               :with_ipv6_dns_orchestration,
+                               :ip6 => nil,
+                               :subnet6 => subnet6)
+      host.compute_resource.stubs(:provided_attributes).returns({:mac => :mac})
+      assert_nil host.ip
+      assert_nil host.ip6
+      refute host.require_ip4_validation?, 'should not require ipv4 validation'
+      refute host.require_ip6_validation?, 'should not require ipv6 validation'
+    end
+
     test "with tokens enabled hosts don't require an IPv4 or IPv6 address" do
       Setting[:token_duration] = 30
       host = FactoryGirl.build(:host, :managed)


### PR DESCRIPTION
This makes EUI-64 IPAM usable (that needs the mac address to calculate an ip) with compute resources that provide the mac address.
