### PR TITLE
Fixes #17153 - Consistent name for variable_type in the api

### DIFF
--- a/app/views/api/v2/smart_variables/main.json.rabl
+++ b/app/views/api/v2/smart_variables/main.json.rabl
@@ -2,7 +2,7 @@ object @smart_variable
 
 extends "api/v2/smart_variables/base"
 
-attributes :description, :parameter_type, :default_value, :hidden_value?, :hidden_value, :validator_type, :validator_rule,
+attributes :description, :parameter_type, :variable_type, :default_value, :hidden_value?, :hidden_value, :validator_type, :validator_rule,
            :override_value_order, :override_values_count, :merge_overrides, :merge_default, :avoid_duplicates,
            :puppetclass_id, :puppetclass_name, :created_at, :updated_at
 


### PR DESCRIPTION
Both `parameter_type` and `variable_type` are aliases for `key_type`.
Leaving `parameter_type` for backward compatibility.