### PR TITLE
Fixes #16740 - Access host params through macro

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -146,10 +146,12 @@ module HostCommon
   end
 
   def param_true?(name)
+    Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_param_true?')
     params.has_key?(name) && Foreman::Cast.to_bool(params[name])
   end
 
   def param_false?(name)
+    Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_param_false?')
     params.has_key?(name) && Foreman::Cast.to_bool(params[name]) == false
   end
 

--- a/app/models/concerns/host_params.rb
+++ b/app/models/concerns/host_params.rb
@@ -9,6 +9,7 @@ module HostParams
     attr_reader :cached_host_params
 
     def params
+      Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_param') unless caller.first.match(/renderer\.rb.*host_param/)
       host_params.update(lookup_keys_params)
     end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -383,6 +383,10 @@ class Host::Managed < Host::Base
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/CyclomaticComplexity
   def info
+    renderer_regex = /renderer\.rb.*host_enc/
+    unless caller.first.match(renderer_regex) || caller[1].match(renderer_regex)
+      Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_enc')
+    end
     # Static parameters
     param = {}
     # maybe these should be moved to the common parameters, leaving them in for now
@@ -422,16 +426,8 @@ class Host::Managed < Host::Base
     # Parse ERB values contained in the parameters
     param = SafeRender.new(:variables => { :host => self }).parse(param)
 
-    classes = if self.environment.nil?
-                []
-              elsif Setting[:Parametrized_Classes_in_ENC] && Setting[:Enable_Smart_Variables_in_ENC]
-                lookup_keys_class_params
-              else
-                self.puppetclasses_names
-              end
-
     info_hash = {}
-    info_hash['classes'] = classes
+    info_hash['classes'] = self.enc_puppetclasses
     info_hash['parameters'] = param
     info_hash['environment'] = param["foreman_env"] if Setting["enc_environment"] && param["foreman_env"]
 
@@ -928,6 +924,16 @@ class Host::Managed < Host::Base
   def firmware_type
     return unless pxe_loader.present?
     Operatingsystem.firmware_type(pxe_loader)
+  end
+
+  def enc_puppetclasses
+    if self.environment.nil?
+      []
+    elsif Setting[:Parametrized_Classes_in_ENC] && Setting[:Enable_Smart_Variables_in_ENC]
+      lookup_keys_class_params
+    else
+      self.puppetclasses_names
+    end
   end
 
   private

--- a/app/services/foreman/deprecation.rb
+++ b/app/services/foreman/deprecation.rb
@@ -2,12 +2,28 @@ module Foreman
   class Deprecation
     #deadline_version - is the version the deprecation is going to be deleted, the format must be a major release e.g "1.8"
     def self.deprecation_warning(foreman_version_deadline, info)
-      raise Foreman::Exception.new(N_("Invalid version format, please enter in x.y (only major version).")) unless foreman_version_deadline.to_s.match(/\A\d[.]\d+\z/)
+      check_version_format foreman_version_deadline
       ActiveSupport::Deprecation.warn("You are using a deprecated behavior, it will be removed in version #{foreman_version_deadline}, #{info}", caller(2))
+    end
+
+    def self.check_version_format(foreman_version_deadline)
+      raise Foreman::Exception.new(N_("Invalid version format, please enter in x.y (only major version).")) unless foreman_version_deadline.to_s.match(/\A\d[.]\d+\z/)
     end
 
     def self.api_deprecation_warning(info)
       ActiveSupport::Deprecation.warn("Your API call uses deprecated behavior, #{info}", caller)
+    end
+
+    def self.renderer_deprecation(foreman_version_deadline, method, new_method)
+      check_version_format foreman_version_deadline
+      called_from_params = false
+      caller.each_with_index do |item, index|
+        called_from_params = true if item.match(/host_params\.rb.*params/)
+        return if called_from_params && item.match(/managed\.rb.*info/)
+        next unless item.match(/renderer\.rb.*render_safe/)
+        Rails.logger.warn "DEPRECATION WARNING: you are using deprecated @host.#{method} in a template, it will be removed in #{foreman_version_deadline}. Use #{new_method} instead."
+        return
+      end
     end
   end
 end

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -14,7 +14,9 @@ module Foreman
                                   :foreman_server_url, :log_debug, :log_info, :log_warn, :log_error, :log_fatal, :template_name, :dns_lookup,
                                   :pxe_kernel_options ]
     ALLOWED_HOST_HELPERS ||= [ :grub_pass, :ks_console, :root_pass,
-                               :media_path, :param_true?, :param_false?, :match ]
+                               :media_path, :param_true?, :param_false?, :match,
+                               :host_param_true?, :host_param_false?,
+                               :host_param, :host_puppet_classes, :host_enc ]
 
     ALLOWED_HELPERS ||= ALLOWED_GENERIC_HELPERS + ALLOWED_HOST_HELPERS
 
@@ -24,6 +26,30 @@ module Foreman
 
     def template_logger
       @template_logger ||= Foreman::Logging.logger('templates')
+    end
+
+    def host_enc(*path)
+      @enc ||= @host.info.deep_dup
+      return @enc if path.compact.empty?
+      enc = @enc
+      path.each { |step| enc = enc.fetch step }
+      enc
+    end
+
+    def host_param(param_name)
+      @host.params[param_name]
+    end
+
+    def host_puppet_classes
+      @host.puppetclasses
+    end
+
+    def host_param_true?(name)
+      @host.params.has_key?(name) && Foreman::Cast.to_bool(@host.params[name])
+    end
+
+    def host_param_false?(name)
+      @host.params.has_key?(name) && Foreman::Cast.to_bool(@host.params[name]) == false
     end
 
     def render_safe(template, allowed_methods = [], allowed_vars = {})

--- a/test/unit/foreman/renderer_deprecation_test.rb
+++ b/test/unit/foreman/renderer_deprecation_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class RendererTest < ActiveSupport::TestCase
+  class DummyRenderer
+    attr_accessor :host
+
+    include Foreman::Renderer
+  end
+
+  test 'should show the deprecation for @host.info' do
+    renderer = DummyRenderer.new
+    renderer.host = FactoryGirl.create(:host, :with_puppet)
+    template = FactoryGirl.create(:provisioning_template, :template => '<%= @host.info %>')
+    Rails.logger.expects(:warn).with("DEPRECATION WARNING: you are using deprecated @host.info in a template, it will be removed in 1.17. Use host_enc instead.").once
+    renderer.unattended_render template
+  end
+
+  test 'should show the deprecation for @host.params' do
+    renderer = DummyRenderer.new
+    renderer.host = FactoryGirl.create(:host, :with_puppet)
+    template = FactoryGirl.create(:provisioning_template, :template => '<%= @host.params %>')
+    Rails.logger.expects(:warn).with("DEPRECATION WARNING: you are using deprecated @host.params in a template, it will be removed in 1.17. Use host_param instead.").once
+    renderer.unattended_render template
+  end
+
+  test 'should render host param using "host_param" helper without deprecation' do
+    renderer = DummyRenderer.new
+    renderer.host = FactoryGirl.create(:host, :with_puppet)
+    Rails.logger.expects(:warn).never
+    assert renderer.render_safe("<%= host_param('test') %>", DummyRenderer::ALLOWED_HELPERS).present?
+  end
+
+  test 'should render host info using "host_enc" helper without deprecation' do
+    renderer = DummyRenderer.new
+    renderer.host = FactoryGirl.create(:host, :with_puppet)
+    Rails.logger.expects(:warn).never
+    assert renderer.render_safe("<%= host_enc %>", DummyRenderer::ALLOWED_HELPERS).present?
+  end
+end

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -221,4 +221,37 @@ class RendererTest < ActiveSupport::TestCase
     @renderer.instance_variable_set '@whatever_random_name', 'has_value'
     assert_equal({ :whatever_random_name => 'has_value' }, @renderer.send(:allowed_variables_mapping, [ :whatever_random_name ]))
   end
+
+  test 'should render puppetclasses using host_puppetclasses helper' do
+    @renderer.host = FactoryGirl.create(:host, :with_puppetclass)
+    assert @renderer.host_puppet_classes
+  end
+
+  test 'should render host param using "host_param" helper' do
+    @renderer.host = FactoryGirl.create(:host, :with_puppet)
+    assert @renderer.host_param('test').present?
+  end
+
+  test 'should have host_param_true? helper' do
+    @renderer.host = FactoryGirl.create(:host, :with_puppet)
+    FactoryGirl.create(:parameter, :name => 'true_param', :value => "true")
+    assert @renderer.host_param_true?('true_param')
+  end
+
+  test 'should have host_param_false? helper' do
+    @renderer.host = FactoryGirl.create(:host, :with_puppet)
+    FactoryGirl.create(:parameter, :name => 'false_param', :value => "false")
+    assert @renderer.host_param_false?('false_param')
+  end
+
+  test 'should have host_enc helper' do
+    @renderer.host = FactoryGirl.create(:host, :with_puppet)
+    assert @renderer.host_enc
+  end
+
+  test "should find path in host_enc" do
+    host = FactoryGirl.create(:host, :with_puppet)
+    @renderer.host = host
+    assert_equal host.puppetmaster, @renderer.host_enc('parameters', 'puppetmaster')
+  end
 end


### PR DESCRIPTION
The host params can now be accessed using host_param macro in templates.
There is also host_info, that gives access to host.info.
It seems only parameters are needed most of the time, so I decided
to go for 2 methods. Both methods call host.info on first use and subsequently
use cached result of the first call.

Usage: ~~host_param 'puppetmaster'
is equivalent to: host_info 'parameters', 'puppetmaster'~~

`host_enc` instead of `@host.info`
`host_param_true?` instead of `@host.param_true?`
`host_param_false?` instead of `@host.param_false?`
`host_param('param_name')` instead of `@host.params['param_name']`