### PR TITLE
[Performance] Menu item url_hash optimized

### DIFF
--- a/app/services/menu/item.rb
+++ b/app/services/menu/item.rb
@@ -27,7 +27,8 @@ module Menu
     end
 
     def url_hash
-      @url_hash ||= @context.routes.url_helpers.send("hash_for_#{name}_path")
+      return @url_hash if @url_hash
+      @url_hash = @context.routes.url_helpers.send("hash_for_#{name}_path")
       @url_hash.inject({}) do |h,(key,value)|
         h[key] = (value.respond_to?(:call) ? value.call : value)
         h


### PR DESCRIPTION
My foreman-tracer utility revealed that we allocate hundreds of arrays each request here. I think we can optimize this, not creating ticket until confirmed by someone else.

For the record, output of foreman-tracer for two requests - login and dashboard:

```
                                           FILENAME   LINE                         METHOD  CALLS
                                    /usr/share/foreman/app/services/menu/item.rb     32                    respond_to?    650
                                    /usr/share/foreman/app/services/menu/item.rb     32            respond_to_missing?    646
                                    /usr/share/foreman/app/services/menu/item.rb     31                           each    230
                                    /usr/share/foreman/app/services/menu/item.rb     31                         inject    230
                                    /usr/share/foreman/app/services/menu/item.rb     29                       url_hash    230
                /usr/share/foreman/app/models/concerns/foreman/thread_session.rb     46                             []    227
                /usr/share/foreman/app/models/concerns/foreman/thread_session.rb     45                        current    227
                /usr/share/foreman/app/models/concerns/foreman/thread_session.rb     46                        current    227
                                        /usr/share/foreman/app/models/setting.rb    218                          cache    14
```