### PR TITLE
fixes #17187 - IPv6 address not required when CR provides IPv4

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -152,9 +152,9 @@ module Nic
       # if the CR will provide an IP, then don't validate yet
       return false if host.compute_provides?(ip_field)
 
-      ip_for_dns   = (subnet_object.present? && subnet_object.dns_id.present?) || (domain.present? && domain.dns_id.present? && !self.send(other_ip_field).present?)
+      ip_for_dns   = (subnet_object.present? && subnet_object.dns_id.present?) || (domain.present? && domain.dns_id.present? && !ip_protocol_provides_ip?(other_ip_field))
       ip_for_dhcp  = subnet_object.present? && subnet_object.dhcp_id.present?
-      ip_for_token = Setting[:token_duration] == 0 && (host.pxe_build? || (host.image_build? && host.image.try(:user_data?))) && !self.send(other_ip_field).present?
+      ip_for_token = Setting[:token_duration] == 0 && (host.pxe_build? || (host.image_build? && host.image.try(:user_data?))) && !ip_protocol_provides_ip?(other_ip_field)
 
       # Any of these conditions will require an IP, so chain with OR
       ip_for_dns || ip_for_dhcp || ip_for_token
@@ -249,6 +249,10 @@ module Nic
     end
 
     private
+
+    def ip_protocol_provides_ip?(field)
+      send(field).present? || (host_managed? && host.compute_provides?(field))
+    end
 
     def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil))
       in_memory_candidates = self.host.present? ? self.host.interfaces.select { |i| i.persisted? && !i.marked_for_destruction? } : [self]

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2068,6 +2068,23 @@ class HostTest < ActiveSupport::TestCase
       refute host.require_ip6_validation?
     end
 
+    test "hosts with a DNS-enabled Domain on CR providing a IPv4 address do not require any kind of address" do
+      Setting[:token_duration] = 30 #enable tokens so that we only test the subnet
+      proxy = FactoryGirl.create(:smart_proxy,
+                                 :features => [FactoryGirl.create(:feature, :dns)])
+      domain = FactoryGirl.create(:domain,
+                                  :dns => proxy)
+      host = FactoryGirl.build(:host,
+                               :managed,
+                               :on_compute_resource,
+                               :with_compute_profile,
+                               :ip => nil,
+                               :domain => domain)
+      host.compute_resource.stubs(:provided_attributes).returns({:ip => :ip})
+      refute host.require_ip4_validation?
+      refute host.require_ip6_validation?
+    end
+
     test "hosts with a DHCP-enabled Subnet do require an IP" do
       Setting[:token_duration] = 30 #enable tokens so that we only test the subnet
       host = FactoryGirl.build(:host, :managed, :subnet => FactoryGirl.build(:subnet_ipv4, :dhcp))


### PR DESCRIPTION
This is a small fix for a reported bug, that we should 🚢 for 1.13.2. This basically breaks AWS.
#3977 contains refactorings to improve the `require_ip_validation` madness.