### PR TITLE
Fixes #17195 - CVE-2016-8634 escape html in alert text

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -102,7 +102,7 @@ module LayoutHelper
       result = "".html_safe
       result += alert_close if opts[:close]
       result += alert_header(opts[:header], opts[:class])
-      result += content_tag(:span, opts[:text].html_safe, :class => 'text')
+      result += content_tag(:span, opts[:text], :class => 'text')
       result += alert_actions(opts[:actions]) if opts[:actions].present?
       result
     end

--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -66,7 +66,7 @@ module ProvisioningTemplatesHelper
 
   def how_templates_are_determined
     alert(:class => 'alert-info', :header => 'How templates are determined',
-          :text => '<p>' + _("When editing a template, you must assign a list \
+          :text => ('<p>' + _("When editing a template, you must assign a list \
 of operating systems which this template can be used with. Optionally, you can \
 restrict a template to a list of host groups and/or environments.") + '</p>' +
 '<p>'+ _("When a Host requests a template (e.g. during provisioning), Foreman \
@@ -78,7 +78,7 @@ following order:") + '</p>' + '<ul>' +
     '<li>' + _("Operating system default") + '</li>' +
     '</ul>' +
     (_("The final entry, Operating System default, can be set by editing the %s page.") %
-     (link_to _("Operating System"), operatingsystems_path)).html_safe)
+     (link_to _("Operating System"), operatingsystems_path))).html_safe)
   end
 
   private

--- a/app/views/common/403.html.erb
+++ b/app/views/common/403.html.erb
@@ -2,9 +2,9 @@
 
 <div class='col-md-offset-4 col-md-4'>
   <%= alert :header => _("Permission denied"),
-    :text => _("You are not authorized to perform this action.") + '</br>'.html_safe +
-             _("Please request one of the required permissions listed below from a Foreman administrator:") +
-             content_tag(:ul, permissions.join.html_safe),
+    :text => (_("You are not authorized to perform this action.") + '</br>'.html_safe +
+                 _("Please request one of the required permissions listed below from a Foreman administrator:") +
+                 content_tag(:ul, permissions.join.html_safe)).html_safe,
     :actions => link_to(_('Back'), main_app.root_path, :class => 'btn btn-default'),
     :class => 'alert-danger',
     :close => false %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -15,11 +15,11 @@
       <%= hidden_field_tag :original_role_id, @original_role_id if @cloned_role %>
 
       <% if show_location_tab? || show_organization_tab? %>
-        <%= alert(:close => false, :class => 'alert-info', :header => '', :text => _("Changes to following associations will propagate to all inheriting filters") + ' ' +
+        <%= alert(:close => false, :class => 'alert-info', :header => '', :text => (_("Changes to following associations will propagate to all inheriting filters") + ' ' +
             popover("", _("When the role's associated %{orgs_or_locs} are changed,<br> the change will propagate to all inheriting filters.
                                Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.
                                Note that not all filters support <br> %{orgs_and_locs}, so these always remain global.") % { :orgs_or_locs => org_loc_string('or'), :orgs_and_locs => org_loc_string('and') },
-                    :title => _("Role %s.") % org_loc_string('and')).html_safe) %>
+                    :title => _("Role %s.") % org_loc_string('and'))).html_safe) %>
       <% end %>
 
       <% if show_location_tab? %>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -4,11 +4,12 @@
                  help_button %>
 
 <% if @count_nil_hosts > 0 %>
-  <%= alert :class => 'alert-warning', :header => '', :text => n_('There is', 'There are', @count_nil_hosts) + ' ' +
-    link_to(n_("%{count} host with no %{taxonomy_single} assigned",
-               "%{count} hosts with no %{taxonomy_single} assigned", @count_nil_hosts) %
-                 {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single },
-            hosts_path(:search => "not has #{controller_name.singularize}")) %>
+  <%= alert :class => 'alert-warning', :header => '',
+            :text => (n_('There is', 'There are', @count_nil_hosts) + ' ' +
+                      link_to(n_("%{count} host with no %{taxonomy_single} assigned",
+                      "%{count} hosts with no %{taxonomy_single} assigned", @count_nil_hosts) %
+                      {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single },
+                      hosts_path(:search => "not has #{controller_name.singularize}"))).html_safe %>
 <% end %>
 <table class="<%= table_css_classes %>">
   <thead>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -5,12 +5,12 @@
 
 <% if @trends.empty? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter defined"),
-            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting[:puppet_interval]) %>
+            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting[:puppet_interval]).html_safe %>
 <% end %>
 
 <% if @trends.any? and TrendCounter.unconfigured? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter found"),
-            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting[:puppet_interval]) %>
+            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting[:puppet_interval]).html_safe %>
 <% end %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">


### PR DESCRIPTION
The alert helper used to mark the alert text as html_safe by default.
However, in some cases it may be possible for a user to enter custom
text into the alert message leading to a possible XSS vulnerability.
This patch changes this so that text is escaped unless expilicitly
marked as html_safe in the code.