### PR TITLE
fixes #17076 - Duplicate "Smart Class Parameter" entries.

### DIFF
--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -40,6 +40,7 @@ module Api
         param :override, :bool, :desc => N_("Whether the smart class parameter value is managed by Foreman")
         param :description, String, :desc => N_("Description of smart class")
         param :default_value, String, :desc => N_("Value to use when there is no match")
+        param :puppetclass_id, :number, :desc => N_("Puppet class ID")
         param :hidden_value, :bool, :desc => N_("When enabled the parameter is hidden in the UI")
         param :use_puppet_default, :bool, :desc => N_("Deprecated, please use omit")
         param :omit, :bool, :desc => N_("Foreman will not send this parameter in classification output. Puppet will use the value defined in the Puppet manifest for this parameter")

--- a/app/controllers/concerns/foreman/controller/parameters/puppetclass_lookup_key.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/puppetclass_lookup_key.rb
@@ -5,7 +5,7 @@ module Foreman::Controller::Parameters::PuppetclassLookupKey
   class_methods do
     def puppetclass_lookup_key_params_filter
       Foreman::ParameterFilter.new(::PuppetclassLookupKey).tap do |filter|
-        filter.permit :environments => [], :environment_ids => [], :environment_names => [],
+        filter.permit :puppetclass, :environments => [], :environment_ids => [], :environment_names => [],
           :environment_classes => [], :environment_classes_ids => [], :environment_classes_names => [],
           :param_classes => [], :param_classes_ids => [], :param_classes_names => []
         filter.permit_by_context :required, :nested => true

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -2,7 +2,8 @@ class PuppetclassLookupKey < LookupKey
   has_many :environment_classes, :dependent => :destroy
   has_many :environments, -> { uniq }, :through => :environment_classes
   has_many :param_classes, :through => :environment_classes, :source => :puppetclass
-
+  belongs_to :puppetclass, :inverse_of => :puppetclass_lookup_keys
+  validates :puppetclass, :presence => true
   before_validation :cast_default_value, :if => :override?
   before_validation :check_override_selected, :if => -> { persisted? && @validation_context != :importer }
   validate :validate_default_value, :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default, :if => :override?

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -17,6 +17,8 @@ class Puppetclass < ActiveRecord::Base
   has_many :config_group_classes
   has_many :config_groups, :through => :config_group_classes, :dependent => :destroy
   has_many :lookup_keys, :inverse_of => :puppetclass, :dependent => :destroy, :class_name => 'VariableLookupKey'
+  has_many :puppetclass_lookup_keys, :inverse_of => :puppetclass, :dependent => :destroy
+
   accepts_nested_attributes_for :lookup_keys, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
   # param classes
   has_many :class_params, -> { where('environment_classes.puppetclass_lookup_key_id is NOT NULL').uniq },

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -273,6 +273,7 @@ class PuppetClassImporter
     klass.class_params.where(:key => param_name).first ||
       PuppetclassLookupKey.create!(:key => param_name, :required => value.nil?,
                                    :override => value.nil?, :default_value => value,
+                                   :puppetclass_id => klass.id,
                                    :key_type => Foreman::ImporterPuppetclass.suggest_key_type(value))
   end
 end

--- a/db/migrate/20161105191512_update_puppetclass_lookup_keys_with_puppetclass.rb
+++ b/db/migrate/20161105191512_update_puppetclass_lookup_keys_with_puppetclass.rb
@@ -1,0 +1,19 @@
+class UpdatePuppetclassLookupKeysWithPuppetclass < ActiveRecord::Migration
+  def up
+    say_with_time "updating puppetclass_lookup_keys records - this may take a long time to process" do
+      Puppetclass.all.each do |pc|
+        pc_lookup_key_ids = pc.class_params.map(&:id)
+        if pc_lookup_key_ids.length > 0
+          begin
+            PuppetclassLookupKey.where(id: pc_lookup_key_ids).update_all(:puppetclass_id => pc.id)
+          rescue => e
+            puts "Puppetclass #{pc.id} with #{pc_lookup_key_ids.inspect}: #{e} - ignoring these records"
+          end
+        end
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20161106134534_destroy_puppetclass_lookup_keys_with_empty_puppetclass.rb
+++ b/db/migrate/20161106134534_destroy_puppetclass_lookup_keys_with_empty_puppetclass.rb
@@ -1,0 +1,12 @@
+class DestroyPuppetclassLookupKeysWithEmptyPuppetclass < ActiveRecord::Migration
+  def up
+    say_with_time "destroying puppetclass_lookup_keys records with empty puppetclass - this may take a long time to process" do
+      pc_lookup_keys_with_empty_puppetclass = PuppetclassLookupKey.where(puppetclass_id: nil)
+      puts "there are #{pc_lookup_keys_with_empty_puppetclass.length} records to delete"
+      pc_lookup_keys_with_empty_puppetclass.destroy_all
+    end
+  end
+
+  def down
+  end
+end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -29,9 +29,6 @@ FactoryGirl.define do
       end
 
       trait :as_smart_class_param do
-        transient do
-          puppetclass nil
-        end
         after(:create) do |lkey, evaluator|
           evaluator.puppetclass.environments.each do |env|
             FactoryGirl.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
@@ -90,7 +87,7 @@ FactoryGirl.define do
       after(:create) do |pc,evaluator|
         evaluator.parameter_count.times do
           evaluator.environments.each do |env|
-            lkey = FactoryGirl.create :puppetclass_lookup_key
+            lkey = FactoryGirl.create :puppetclass_lookup_key, :puppetclass_id => pc.id
             FactoryGirl.create :environment_class, :puppetclass_id => pc.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
           end
         end

--- a/test/fixtures/lookup_keys.yml
+++ b/test/fixtures/lookup_keys.yml
@@ -5,6 +5,7 @@ one:
   key_type: integer
   validator_type:
   default_value: 80
+  puppetclass: one
   type: PuppetclassLookupKey
 
 three:
@@ -31,6 +32,7 @@ five:
   default_value: 'abcdef'
   path: 'organization,location'
   override: true
+  puppetclass: one
   type: PuppetclassLookupKey
 
 five_same_name:
@@ -40,6 +42,7 @@ five_same_name:
   default_value: 'abcdef'
   path: 'organization,location'
   override: true
+  puppetclass: one
   type: PuppetclassLookupKey
 
 six:
@@ -78,3 +81,11 @@ four:
   puppetclass: two
   path: 'organization,location'
   type: VariableLookupKey
+
+eight:
+  key: dependant_class_param
+  key_type: integer
+  validator_type:
+  default_value: 80
+  puppetclass: nine
+  type: PuppetclassLookupKey

--- a/test/fixtures/puppetclasses.yml
+++ b/test/fixtures/puppetclasses.yml
@@ -23,3 +23,6 @@ seven:
 
 eight:
   name: auth
+
+nine:
+  name: checkeditor

--- a/test/models/puppetclass_test.rb
+++ b/test/models/puppetclass_test.rb
@@ -198,4 +198,11 @@ class PuppetclassTest < ActiveSupport::TestCase
       assert_includes(Puppetclass.search_for("config_group = #{@config_group.to_label}"), @class)
     end
   end
+
+  it "destroys dependent puppetclass_lookup_keys" do
+    puppetclass, puppetclass_lkey = puppetclasses(:nine), lookup_keys(:eight)
+    assert puppetclass.destroy
+    assert !PuppetclassLookupKey.exists?(puppetclass_lkey.id)
+    assert_raise(ActiveRecord::RecordNotFound) { puppetclass_lkey.reload }
+  end
 end


### PR DESCRIPTION
Previously, there is no association between puppet class with smart class parameters i.e puppet class lookup keys directly, it is through environment class.
When someone tries to delete puppet class then dependent environment class objects also get deleted, but the smart class parameters remains in database.

Likewise association between puppet class and smart variables i.e variable lookup keys, there should be the association required between the puppet class and smart class parameters.
