### PR TITLE
Fixes #17248 - Run js tests with node versions we use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-  - "node"
-  - "4" # Fedora
+  #- "0.10" # EL6, Trusty, Jessie - sadly, jest does not work with 0.10
+  - "4.2" # Xenial
+  - "4.6" # Fedora 24
+  - "6.9" # EL 7
 before_install:
   npm install -g npm@'>=3.0.0'
 script: ./script/travis_run_js_tests.sh

--- a/script/travis_run_js_tests.sh
+++ b/script/travis_run_js_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ev
-if [[ $( git diff --name-only HEAD~1..HEAD webpack/ | wc -l ) -ne 0 ]]; then
+if [[ $( git diff --name-only HEAD~1..HEAD webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
   npm run test;
 fi


### PR DESCRIPTION
Our package builders and test infrastracture use different versions of
nodejs. We should check that all js tests pass for all different
versions used, to prevent breakage in any of our supported OSes.