### PR TITLE
[WIP] Fixes 6502 - Add a list of ignored classes in the Puppet classes view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ jenkins/reports/*
 test/reports/*
 db/schema.rb
 config/settings.yaml
+config/ignored_environments.yml
 config/settings.plugins.d
 config/email.yaml
 config/database.yml

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -17,7 +17,7 @@ class PuppetClassImporter
 
   # return changes hash, currently exists to keep compatibility with importer html
   def changes
-    changes = { 'new' => { }, 'obsolete' => { }, 'updated' => { } }
+    changes = { 'new' => { }, 'obsolete' => { }, 'updated' => { }, 'ignored' => { } }
 
     if @environment.nil?
       actual_environments.each do |env|
@@ -32,6 +32,11 @@ class PuppetClassImporter
       old_environments.each do |env|
         changes['obsolete'][env] ||= []
         changes['obsolete'][env] << "_destroy_" unless actual_environments.include?(env)
+      end
+
+      ignored_environments.each do |env|
+        changes['ignored'][env] ||= []
+        changes['ignored'][env] << '_ignored_'
       end
     else
       env = @environment

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -21,12 +21,7 @@ class PuppetClassImporter
 
     if @environment.nil?
       actual_environments.each do |env|
-        new     = new_classes_for(env)
-        old     = removed_classes_for(env)
-        updated = updated_classes_for(env)
-        changes['new'][env] = new if new.any?
-        changes['obsolete'][env] = old if old.any?
-        changes['updated'][env] = updated if updated.any?
+        changes_for_environment(env, changes)
       end
 
       old_environments.each do |env|
@@ -39,15 +34,26 @@ class PuppetClassImporter
         changes['ignored'][env] << '_ignored_'
       end
     else
-      env = @environment
-      new     = new_classes_for(env)
-      old     = removed_classes_for(env)
-      updated = updated_classes_for(env)
-      changes['new'][env] = new if new.any?
-      changes['obsolete'][env] = old if old.any?
-      changes['updated'][env] = updated if updated.any?
+      changes_for_environment(@environment, changes)
     end
+
     changes
+  end
+
+  # Adds class changes of an environment to a changes hash in new, obsolete and updated
+  #
+  # Params:
+  #  * ++environment++:: {String} of environments name
+  #  * ++changes++:: {Hash} to add changes to
+  #
+  def changes_for_environment(environment, changes)
+    new_classes     = new_classes_for(environment)
+    old_classes     = removed_classes_for(environment)
+    updated_classes = updated_classes_for(environment)
+
+    changes['new'][environment] = new_classes if new_classes.any?
+    changes['obsolete'][environment] = old_classes if old_classes.any?
+    changes['updated'][environment] = updated_classes if updated_classes.any?
   end
 
   # Update the environments and puppetclasses based upon the user's selection

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -43,6 +43,24 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
     end
   end
 
+  describe "#changes_for_environment" do
+    setup do
+      @proxy = smart_proxies(:puppetmaster)
+    end
+
+    test 'it calls for new, updated and obsolete classes' do
+      importer = PuppetClassImporter.new(url: @proxy.url)
+      environment_name = 'foreman-testing'
+      changes = { 'new' => { }, 'obsolete' => { }, 'updated' => { }, 'ignored' => { } }
+
+      importer.expects(:updated_classes_for).with(environment_name).once.returns({})
+      importer.expects(:new_classes_for).with(environment_name).once.returns({})
+      importer.expects(:removed_classes_for).with(environment_name).once.returns({})
+
+      importer.changes_for_environment(environment_name, changes)
+    end
+  end
+
   test "should return list of envs" do
     assert_kind_of Array, get_an_instance.db_environments
   end

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -31,6 +31,13 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
         assert !importer.changes['new'].include?('foreman-testing-1')
       end
     end
+
+    context 'has ignored environments' do
+      test 'it returns them' do
+        importer = PuppetClassImporter.new(url: @proxy.url)
+        assert_not_nil importer.changes['ignored']
+      end
+    end
   end
 
   test "should return list of envs" do

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -38,6 +38,7 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
         importer.stubs(:ignored_environments).returns(['ignored-env'])
 
         assert_not_nil importer.changes['ignored']
+        assert_not_nil importer.changes['ignored']['ignored-env']
       end
     end
   end

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -18,11 +18,19 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
     assert_kind_of ProxyAPI::Puppet, klass.send(:proxy)
   end
 
-  test "should contain only the specified environment in changes" do
-    proxy = smart_proxies(:puppetmaster)
-    importer = PuppetClassImporter.new(:url => proxy.url, :env => 'foreman-testing')
-    assert importer.changes['new'].include?('foreman-testing')
-    assert !importer.changes['new'].include?('foreman-testing-1')
+  describe '#changes' do
+    setup do
+      @proxy = smart_proxies(:puppetmaster)
+    end
+
+    context 'a spcefific environment is set' do
+      test "should contain only the specified environment in changes" do
+        importer = PuppetClassImporter.new(url: @proxy.url, env: 'foreman-testing')
+
+        assert importer.changes['new'].include?('foreman-testing')
+        assert !importer.changes['new'].include?('foreman-testing-1')
+      end
+    end
   end
 
   test "should return list of envs" do

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -35,6 +35,8 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
     context 'has ignored environments' do
       test 'it returns them' do
         importer = PuppetClassImporter.new(url: @proxy.url)
+        importer.stubs(:ignored_environments).returns(['ignored-env'])
+
         assert_not_nil importer.changes['ignored']
       end
     end


### PR DESCRIPTION
This will add importing ignored `PuppetClass`es as "hidden".

The hidden `PuppetClass`es have no functionality, but will be added to the "Puppet Classes" overview and can be shown on demand. Mockup will follow, when the backend part is done.

In the process I'm adding tests for the methods that need to be touched in `PuppetClassImporter` and add basic documentation.

Any feedback or concerns welcome.

_Will be squashed when finalised_