### PR TITLE
Fixes #6502 - Add a list of ignored classes in the Puppet classes view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ jenkins/reports/*
 test/reports/*
 db/schema.rb
 config/settings.yaml
+config/ignored_environments.yml
 config/settings.plugins.d
 config/email.yaml
 config/database.yml

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -28,14 +28,14 @@ module Api::ImportPuppetclassesCommonController
     if params[:except].present?
       kinds = params[:except].split(',')
       kinds.each do |kind|
-        @changed[kind] = {} if ["new", "obsolete", "updated"].include?(kind)
+        @changed[kind] = {} if ["new", "obsolete", "updated", "ignored"].include?(kind)
       end
     end
 
     # DRYRUN - /import_puppetclasses?dryrun - do not run PuppetClassImporter
     rabl_template = @environment ? 'show' : 'index'
     if params.key?('dryrun') && !['false', false].include?(params['dryrun'])
-      render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
+      render("api/v#{api_version}/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
       return
     end
 
@@ -46,7 +46,7 @@ module Api::ImportPuppetclassesCommonController
       if background
         process_success task
       else
-        render("api/v1/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
+        render("api/v#{api_version}/import_puppetclasses/#{rabl_template}", :layout => "api/layouts/import_puppetclasses_layout")
       end
     rescue ForemanTasks::TaskError => e
       render :json => { :message => _("Failed to update the environments and Puppet classes from the on-disk puppet installation: %s") % e.to_s }, :status => :internal_server_error
@@ -67,7 +67,7 @@ module Api::ImportPuppetclassesCommonController
       # check if environemnt id passed in URL is name of NEW environment in puppetmaster that doesn't exist in db
       if @environment || (@changed['new'].keys.include?(@env_id) && (@environment ||= OpenStruct.new(:name => @env_id)))
         # only return :keys equal to @environment in @changed hash
-        ["new", "obsolete", "updated"].each do |kind|
+        ["new", "obsolete", "updated", "ignored"].each do |kind|
           @changed[kind].slice!(@environment.name) unless @changed[kind].empty?
         end
       end
@@ -84,7 +84,7 @@ module Api::ImportPuppetclassesCommonController
     end
 
     # PuppetClassImporter expects [kind][env] to be in json format
-    ["new", "obsolete", "updated"].each do |kind|
+    ["new", "obsolete", "updated", "ignored"].each do |kind|
       unless (envs = @changed[kind]).empty?
         envs.keys.sort.each do |env|
           @changed[kind][env] = @changed[kind][env].to_json
@@ -93,7 +93,9 @@ module Api::ImportPuppetclassesCommonController
     end
 
     # @environments is used in import_puppletclasses/index.json.rabl
-    environment_names = (@changed["new"].keys + @changed["obsolete"].keys + @changed["updated"].keys).uniq.sort
+    environment_names = (@changed["new"].keys + @changed["obsolete"].keys +
+                         @changed["updated"].keys + @changed["ignored"].keys).uniq.sort
+
     @environments = environment_names.map do |name|
       OpenStruct.new(:name => name)
     end

--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -9,6 +9,7 @@ module Foreman::Controller::Environments
       opts[:env] = params[:env] unless params[:env].blank?
       @importer = PuppetClassImporter.new(opts)
       @changed  = @importer.changes
+
     rescue => e
       if e.message =~ /puppet feature/i
         error _("No smart proxy was found to import environments from, ensure that at least one smart proxy is registered with the 'puppet' feature.")
@@ -18,10 +19,20 @@ module Foreman::Controller::Environments
       end
     end
 
+    if @importer.ignored_boolean_environment_names?
+      warning(_("Ignored environment names resulting in booleans found. Please quote strings like true/false and yes/no in config/ignored_environments.yml."))
+    end
+
     if @changed["new"].size > 0 || @changed["obsolete"].size > 0 || @changed["updated"].size > 0
       render "common/_puppetclasses_or_envs_changed"
     else
-      notice _("No changes to your environments detected")
+      notice_message = _("No changes to your environments detected")
+
+      if @changed['ignored'].present?
+        list_ignored(notice_message, @changed['ignored'])
+      end
+
+      notice(notice_message)
       redirect_to :controller => controller_path
     end
   end
@@ -43,5 +54,18 @@ module Foreman::Controller::Environments
     error _("Failed to add task to queue: %s") % e.to_s
   ensure
     redirect_to :controller => controller_path
+  end
+
+  private
+
+  def list_ignored(notice, ignored)
+    environments = ignored.select { |_, values| values.first == '_ignored_' }
+    if environments.any?
+      ignore_notice = _("Ignored environments: %s") % environments.keys.to_sentence
+    else
+      ignore_notice = _("Ignored classes in the environments: %s") % ignored.keys.to_sentence
+    end
+
+    notice << "\n" + ignore_notice
   end
 end

--- a/app/helpers/puppetclasses_and_environments_helper.rb
+++ b/app/helpers/puppetclasses_and_environments_helper.rb
@@ -6,6 +6,8 @@ module PuppetclassesAndEnvironmentsHelper
       _("Deleted environment")
     elsif pcs.delete "_destroy_"
       _("Deleted environment %{env} and %{pcs}") % { :env => env, :pcs => pcs.to_sentence }
+    elsif pcs == ["_ignored_"]
+      _("Ignored environment")
     else
       pretty_print(pcs.is_a?(Hash) ? pcs.keys : pcs)
     end

--- a/app/views/api/layouts/import_puppetclasses_layout.json.erb
+++ b/app/views/api/layouts/import_puppetclasses_layout.json.erb
@@ -4,6 +4,7 @@
   "environments_with_new_puppetclasses": <%= @changed["new"].size.to_json.html_safe %>,
   "environments_updated_puppetclasses": <%= @changed["updated"].size.to_json.html_safe %>,
   "environments_obsolete": <%= @changed["obsolete"].size.to_json.html_safe %>,
+  "environments_ignored": <%= @changed["ignored"].size.to_json.html_safe %>,
   <% end %>
   "results": <%= yield %>
 }

--- a/app/views/api/v2/import_puppetclasses/show.json.rabl
+++ b/app/views/api/v2/import_puppetclasses/show.json.rabl
@@ -7,6 +7,7 @@ node(:actions) do |environment|
   actions << 'new' if @changed['new'][environment.name].present?
   actions << 'updated' if @changed['updated'][environment.name].present?
   actions << 'obsolete' if @changed['obsolete'][environment.name].present?
+  actions << 'ignored' if @changed['ignored'][environment.name].present?
   actions.as_json
 end
 
@@ -22,6 +23,14 @@ node(:obsolete_puppetclasses, :if => ->(environment) { @changed['obsolete'][envi
   JSON.parse(@changed['obsolete'][environment.name])
 end
 
+node(:ignored_puppetclasses, :if => ->(environment) { @changed['ignored'][environment.name].present? && !@changed['ignored'][environment.name].match(/_ignored_/) }) do |environment|
+  JSON.parse(@changed['ignored'][environment.name])
+end
+
 node(:removed_environment, :if => ->(environment) { @changed['obsolete'][environment.name].present? && @changed['obsolete'][environment.name].match(/_destroy_/) }) do |environment|
+  environment.name
+end
+
+node(:ignored_environment, :if => ->(environment) { @changed['ignored'][environment.name].present? && @changed['ignored'][environment.name].match(/_ignored_/) }) do |environment|
   environment.name
 end

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -27,18 +27,23 @@
       </tr>
     </thead>
     <tbody>
-      <% for kind in ["new", "obsolete", "updated"] %>
+      <% for kind in ["new", "obsolete", "updated", "ignored"] %>
         <% unless (envs = @changed[kind]).empty? %>
           <% for env in envs.keys.sort %>
             <tr>
+              <% unless kind == 'ignored' %>
+                <td>
+                  <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind} env_select_boxes_env_#{env}" %>
+                </td>
+                <td>
+                  <%= link_to_function("#{env}", "toggleCheckboxesBySelector('.env_select_boxes_env_#{env}')", :title => _("Check/Uncheck all %s changes") % env) %>
+                </td>
+              <% else %>
+                <td>&nbsp;</td>
+                <td><%= env %></td>
+              <% end %>
               <td>
-                <%= check_box_tag "changed[#{kind}][#{env}]", @changed[kind][env].to_json, false, :class => "env_select_boxes env_select_boxes_#{kind} env_select_boxes_env_#{env}" %>
-              </td>
-              <td>
-                <%= link_to_function("#{env}", "toggleCheckboxesBySelector('.env_select_boxes_env_#{env}')", :title => _("Check/Uncheck all %s changes") % env) %>
-              </td>
-              <td>
-                <%= {"new" => _("Add:"), "obsolete" => _("Remove:"), "updated" => _("Update:")}[kind] %>
+                <%= {"new" => _("Add:"), "obsolete" => _("Remove:"), "updated" => _("Update:"), "ignored" => _("Ignored:")}[kind] %>
               </td>
               <td>
                 <% pcs = @changed[kind][env] %>


### PR DESCRIPTION
This PR addresses the issue reported in [#6502](http://projects.theforeman.org/issues/6502) by making ignored environments and classes visible when importing like so: 
![screen shot 2016-11-14 at 13 50 43](https://cloud.githubusercontent.com/assets/7757/20265689/cc00ff4c-aa72-11e6-8275-ddf8349a9d2f.png)

In case all available environments are ignored as full and no other changes are detected it will also mention these in the notice:
![screen shot 2016-11-14 at 14 02 51](https://cloud.githubusercontent.com/assets/7757/20265777/42721616-aa73-11e6-8288-0169a7b002a8.png)
