### PR TITLE
Fixes #17297 - added PXE loader flags for Debian family

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -17,6 +17,10 @@ class Debian < Operatingsystem
     super(medium, architecture, host).each{ |img_uri| img_uri.path = img_uri.path.gsub('x86_64','amd64') }
   end
 
+  def available_loaders
+    self.class.all_loaders
+  end
+
   def pxe_type
     "preseed"
   end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -20,7 +20,6 @@ class Redhat < Operatingsystem
     end
   end
 
-  # Redhat supports all PXE loaders
   def available_loaders
     self.class.all_loaders
   end


### PR DESCRIPTION
Enables users to use Grub/Grub2 with Debian family systems.