### PR TITLE
Fixes #17309 - Made facets resilient to class reloading.

### DIFF
--- a/app/services/facets.rb
+++ b/app/services/facets.rb
@@ -26,6 +26,7 @@ module Facets
     configuration[entry.name] = entry
 
     Facets::ManagedHostExtensions.register_facet_relation(Host::Managed, entry)
+    entry
   end
 
   #declare private module methods.
@@ -33,7 +34,11 @@ module Facets
     private
 
     def configuration
-      @configuration ||= {}
+      @configuration ||= Hash[entries_from_plugins.map { |entry| [entry.name, entry]}]
+    end
+
+    def entries_from_plugins
+      Foreman::Plugin.all.map {|plugin| plugin.facets}.compact.flatten
     end
   end
 end

--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -92,7 +92,8 @@ module Foreman #:nodoc:
     end
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
-    attr_reader :id, :logging, :default_roles, :provision_methods, :compute_resources, :to_prepare_callbacks, :permissions
+    attr_reader :id, :logging, :default_roles, :provision_methods, :compute_resources, :to_prepare_callbacks,
+                :permissions, :facets
 
     def initialize(id)
       @id = id.to_sym
@@ -336,7 +337,9 @@ module Foreman #:nodoc:
     end
 
     def register_facet(klass, name, &block)
-      Facets.register(klass, name, &block)
+      # Save the entry in case of reloading
+      @facets ||= []
+      @facets << Facets.register(klass, name, &block)
     end
 
     def in_to_prepare(&block)

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -347,6 +347,26 @@ class PluginTest < ActiveSupport::TestCase
     Host::Managed.cloned_parameters[:include].delete(:fake_facet)
   end
 
+  def test_register_facet_resilience
+    old_config = Facets.instance_variable_get('@configuration')
+    Facets.instance_variable_set('@configuration', nil)
+
+    Foreman::Plugin.register :awesome_facet do
+      name 'Awesome facet'
+      register_facet(Awesome::FakeFacet, :fake_facet) do
+        api_view :list => 'api/v2/awesome/index', :single => 'api/v2/awesome/show'
+      end
+    end
+
+    # reset the configuration
+    Facets.instance_variable_set('@configuration', nil)
+
+    assert Facets.registered_facets[:fake_facet]
+
+    Host::Managed.cloned_parameters[:include].delete(:fake_facet)
+    Facets.instance_variable_set('@configuration', old_config)
+  end
+
   def test_add_template_label
     kind = FactoryGirl.build(:template_kind)
     Foreman::Plugin.register :test_template_kind do


### PR DESCRIPTION
Now the configuration is stored in plugin declaration.
If you are using `Facets.register` directly, please make sure
you are re-registering it after reload occurs.