### PR TITLE
Fixes #17303 - correct position of validation msg for parameters

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -154,7 +154,9 @@ function check_caps_lock(key, e) {
 
 function remove_fields(link) {
   $(link).prev("input[type=hidden]").val("1");
-  $(link).closest(".fields").hide();
+  var $field_row = $(link).closest(".fields");
+  $field_row.next("tr.error-msg-block").hide();
+  $field_row.hide();
   mark_params_override();
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -590,3 +590,21 @@ code.transparent {
   color: black;
   background-color: transparent;
 }
+
+#parameters {
+  .table {
+    tr {
+      td {
+        border-top: none;
+      }
+      &.error-msg-block td {
+        .help-block {
+          margin-top: 0px;
+        }
+      }
+      &.fields td {
+        padding-top: 10px;
+      }
+    }
+  }
+}

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -9,7 +9,13 @@
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if can_edit_params? %>
     <%= link_to_remove_fields(_('remove'), f) if authorized_via_my_scope("host_editing", "destroy_params") %>
   </td>
-  <span class="help-block">
-    <%= f.object.errors.full_messages.to_sentence %>
-  </span>
 </tr>
+<% if f.object.errors.any? %>
+  <tr class="error-msg-block has-error">
+    <td colspan="3">
+      <span class="help-block">
+        <%= f.object.errors.full_messages.to_sentence %>
+      </span>
+    </td>
+  </tr>
+<% end %>


### PR DESCRIPTION
Instead of showing all validation error messages on top, this commit will show each validation error message on the top of respective parameter.