### PR TITLE
Fixes #17332 - Test email error renders propertly in user email preferences

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -44,7 +44,7 @@ function test_mail(item, id, url) {
     },
     error: function (xhr) {
       var error = $.parseJSON(xhr.responseText).message;
-      notify("<p>" + error + "</p>", 'error');
+      notify("<p>" + error + "</p>", 'danger');
     },
     complete: function (result) {
       $('#test_indicator').hide();


### PR DESCRIPTION
When test email didn't succeed in User -> Email Preferences, an error message was rendered not properly:
 
![error_mail](https://cloud.githubusercontent.com/assets/11807069/20287003/688009e4-aad2-11e6-993a-74664bba5596.png)