### PR TITLE
Fixes #14951 - Allow matcher for host turning into managed host

### DIFF
--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -75,7 +75,8 @@ class LookupValue < ActiveRecord::Base
     md = ensure_matcher(/fqdn=(.*)/)
     return md if md == true || md == false
     fqdn = md[1].split(LookupKey::KEY_DELM)[0]
-    return true if Host.unscoped.find_by_name(fqdn) || host_or_hostgroup.try(:new_record?)
+    return true if Host.unscoped.find_by_name(fqdn) || host_or_hostgroup.try(:new_record?) ||
+        (host_or_hostgroup.present? && host_or_hostgroup.type_changed? && host_or_hostgroup.type == "Host::Managed")
     errors.add(:match, _("%{match} does not match an existing host") % { :match => "fqdn=#{fqdn}" })
 
     false

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1320,6 +1320,17 @@ class HostsControllerTest < ActionController::TestCase
     assert_match(/host must have/, flash[:error])
   end
 
+  test "should create matcher for host turning into managed" do
+    original_host = Host::Base.create(:name => 'test', :domain => FactoryGirl.create(:domain))
+    lookup_key = FactoryGirl.create(:lookup_key)
+    host = original_host.becomes(::Host::Managed)
+    host.type = 'Host::Managed'
+    host.managed = true
+    host.primary_interface.managed = true
+    host.lookup_values.build({"match"=>"fqdn=#{host.fqdn}", "value"=>'4', "lookup_key_id" => lookup_key.id, "host_or_hostgroup" => host})
+    assert_valid host.lookup_values.first
+  end
+
   describe '#ipmi_boot' do
     setup do
       @request.env['HTTP_REFERER'] = host_path(@host.id)


### PR DESCRIPTION
I've only been able to test this with discovery, I can add a corresponding discovery pr with tests unless someone has an idea how to test this in core.