### PR TITLE
fixes #17354 - test and improve idempotency of OS fact parser

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -74,6 +74,20 @@ class Operatingsystem < ActiveRecord::Base
     allow :name, :media_url, :major, :minor, :family, :to_s, :repos, :==, :release_name, :kernel, :initrd, :pxe_type, :medium_uri, :boot_files_uri, :password_hash
   end
 
+  def self.inherited(child)
+    child.instance_eval do
+      # Ensure all subclasses behave in the same way as the parent, and remain
+      # identified as Operatingsystems instead of subclasses in UI paths etc.
+      #
+      # rubocop:disable Rails/Delegate
+      def model_name
+        superclass.model_name
+      end
+      # rubocop:enable Rails/Delegate
+    end
+    super
+  end
+
   # As Rails loads an object it casts it to the class in the 'type' field. If we ensure that the type and
   # family are the same thing then rails converts the record to a Debian or a solaris object as required.
   # Manually managing the 'type' field allows us to control the inheritance chain and the available methods

--- a/app/models/operatingsystems/aix.rb
+++ b/app/models/operatingsystems/aix.rb
@@ -1,11 +1,6 @@
 class AIX < Operatingsystem
   PXEFILES = {:kernel => "powerpc", :initrd => "initrd"}
 
-  # Override the class representation, as this breaks many rails helpers
-  def class
-    Operatingsystem
-  end
-
   def pxe_type
     "nim"
   end

--- a/app/models/operatingsystems/altlinux.rb
+++ b/app/models/operatingsystems/altlinux.rb
@@ -1,10 +1,6 @@
 class Altlinux < Operatingsystem
   PXEFILES = {:kernel => "vmlinuz", :initrd => "full.cz" }
 
-  def class
-    Operatingsystem
-  end
-
   def boot_files_uri(medium, architecture)
     raise ::Foreman::Exception.new(N_("invalid medium for %s"), to_s) unless media.include?(medium)
     raise ::Foreman::Exception.new(N_("invalid architecture for %s"), to_s) unless architectures.include?(architecture)

--- a/app/models/operatingsystems/archlinux.rb
+++ b/app/models/operatingsystems/archlinux.rb
@@ -1,10 +1,6 @@
 class Archlinux < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   # Simple output of the media url
   def mediumpath(host)
     medium_uri(host).to_s

--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -1,10 +1,6 @@
 class Coreos < Operatingsystem
   PXEFILES = {:kernel => 'coreos_production_pxe.vmlinuz', :initrd => 'coreos_production_pxe_image.cpio.gz'}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   def pxe_type
     'coreos'
   end

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -44,10 +44,6 @@ class Debian < Operatingsystem
     s.blank? ? description : s
   end
 
-  def self.model_name
-    superclass.model_name
-  end
-
   private
 
   # tries to guess if this an ubuntu or a debian os

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -6,10 +6,6 @@ class Freebsd < Operatingsystem
   # -as initrd we will use your custom FreeBSD-<arch>-<version>-mfs.img in boot
   PXEFILES = {}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   # Simple output of the media url
   def mediumpath(host)
     medium_uri(host).to_s.gsub("x86_64","amd64")

--- a/app/models/operatingsystems/gentoo.rb
+++ b/app/models/operatingsystems/gentoo.rb
@@ -1,10 +1,6 @@
 class Gentoo < Operatingsystem
   PXEFILES = {}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   def mediumpath(host)
   end
 

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -7,10 +7,6 @@ class Junos < Operatingsystem
     medium_uri(host).to_s
   end
 
-  def class
-    Operatingsystem
-  end
-
   # The PXE type to use when generating actions and evaluating attributes. jumpstart, kickstart and preseed are currently supported.
   def pxe_type
     "ZTP"

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -7,10 +7,6 @@ class NXOS < Operatingsystem
     medium_uri(host).to_s
   end
 
-  def class
-    Operatingsystem
-  end
-
   def template_kinds
     ["POAP"]
   end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -1,10 +1,6 @@
 class Redhat < Operatingsystem
   PXEFILES = {:kernel => "vmlinuz", :initrd => "initrd.img"}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   # outputs kickstart installation medium based on the medium type (NFS or URL)
   # it also convert the $arch string to the current host architecture
   def mediumpath(host)

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -1,10 +1,6 @@
 class Solaris < Operatingsystem
   PXEFILES = {:initrd => "x86.miniroot", :kernel => "multiboot"}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   def file_prefix
     (self).to_s.gsub(/[\s\(\)]/,"-").gsub("--", "-").gsub(/-\Z/, "")
   end

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -1,10 +1,6 @@
 class Suse < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   # Simple output of the media url
   def mediumpath(host)
     medium_uri(host).to_s

--- a/app/models/operatingsystems/windows.rb
+++ b/app/models/operatingsystems/windows.rb
@@ -1,10 +1,6 @@
 class Windows < Operatingsystem
   PXEFILES = {:kernel => "wimboot", :initrd => "bootmgr", :bcd => "bcd", :bootsdi => "boot.sdi", :bootwim => "boot.wim"}
 
-  class << self
-    delegate :model_name, :to => :superclass
-  end
-
   def pxe_type
     "waik"
   end

--- a/app/models/operatingsystems/xenserver.rb
+++ b/app/models/operatingsystems/xenserver.rb
@@ -26,10 +26,6 @@ class Xenserver < Operatingsystem
     "XenServer"
   end
 
-  def self.model_name
-    superclass.model_name
-  end
-
   def bootfile(arch, type)
     pxe_prefix(arch) + "-" + eval("#{self.family}::PXEFILES[:#{type}]").split("/")[-1]
   end


### PR DESCRIPTION
Contains the commit from #4025 which fixes an issue when parsing OSes with only a major version.