### PR TITLE
Fixes #16884 - enforce granular filters even during save

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -67,6 +67,11 @@ module AuditExtensions
 
     include Authorizable
 
+    # audits can be created regardless of permissions
+    def check_permissions_after_save
+      true
+    end
+
     def self.humanize_class_name
       _("Audit")
     end

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -26,6 +26,12 @@ class LookupValue < ApplicationRecord
   scoped_search :on => :match, :complete_value => true
   scoped_search :relation => :lookup_key, :on => :key, :rename => :lookup_key, :complete_value => true
 
+  # Lookup values are currently not authorized granularly,
+  # they should use permissions from their keys (puppet or variable)
+  def check_permissions_after_save
+    true
+  end
+
   def value=(val)
     if val.is_a?(HashWithIndifferentAccess)
       super(val.deep_to_hash)

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -25,4 +25,21 @@ class Permission < ApplicationRecord
   def self.reset_resources
     @all_resources = nil
   end
+
+  # converts klass to name used as resource_type in permissions table
+  def self.resource_name(klass)
+    return 'Operatingsystem' if klass <= Operatingsystem
+    return 'ComputeResource' if klass <= ComputeResource
+    return 'Subnet' if klass <= Subnet
+    return 'Parameter' if klass <= Parameter
+
+    case (name = klass.to_s)
+    when 'Audited::Audit'
+      'Audit'
+    when /\AHost::.*\Z/
+      'Host'
+    else
+      name
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,6 +126,15 @@ class User < ApplicationRecord
     allow :login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail
   end
 
+  # we need to allow self-editing and self-updating
+  def check_permissions_after_save
+    if User.current.try(:id) == self.id
+      true
+    else
+      super
+    end
+  end
+
   def can?(permission, subject = nil)
     if self.admin?
       true

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -11,6 +11,7 @@ class Authorizer
   end
 
   def can?(permission, subject = nil, cache = true)
+    return false if user.nil?
     return true if user.admin?
 
     if subject.nil?
@@ -161,21 +162,8 @@ class Authorizer
     [organizations, locations, values]
   end
 
-  # sometimes we need exceptions however we don't want to just split namespaces
   def resource_name(klass)
-    return 'Operatingsystem' if klass <= Operatingsystem
-    return 'ComputeResource' if klass <= ComputeResource
-    return 'Subnet' if klass <= Subnet
-    return 'Parameter' if klass <= Parameter
-
-    case (name = klass.to_s)
-    when 'Audited::Audit'
-      'Audit'
-    when /\AHost::.*\Z/
-      'Host'
-    else
-      name
-    end
+    Permission.resource_name(klass)
   end
 
   def base_ids

--- a/db/seeds.d/04-admin.rb
+++ b/db/seeds.d/04-admin.rb
@@ -10,8 +10,9 @@ unless User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
     user = User.new(:login => User::ANONYMOUS_ADMIN, :firstname => "Anonymous", :lastname => "Admin")
     user.admin = true
     user.auth_source = src_hidden
-    User.current = user
+    original_user, User.current = User.current, user
     raise "Unable to create anonymous admin user: #{format_errors user}" unless user.save
+    User.current = original_user
   end
 end
 
@@ -21,8 +22,9 @@ unless User.unscoped.find_by_login(User::ANONYMOUS_CONSOLE_ADMIN).present?
     user = User.new(:login => User::ANONYMOUS_CONSOLE_ADMIN, :firstname => "Console", :lastname => "Admin")
     user.admin = true
     user.auth_source = src_hidden
-    User.current = user
+    original_user, User.current = User.current, user
     raise "Unable to create anonymous console admin user: #{format_errors user}" unless user.save
+    User.current = original_user
   end
 end
 
@@ -33,8 +35,9 @@ unless User.unscoped.find_by_login(User::ANONYMOUS_API_ADMIN).present?
     user = User.new(:login => User::ANONYMOUS_API_ADMIN, :firstname => "API", :lastname => "Admin")
     user.admin = true
     user.auth_source = src_hidden
-    User.current = user
+    original_user, User.current = User.current, user
     raise "Unable to create anonymous API user: #{format_errors user}" unless user.save
+    User.current = original_user
   end
 end
 

--- a/db/seeds.d/05-taxonomies.rb
+++ b/db/seeds.d/05-taxonomies.rb
@@ -1,17 +1,17 @@
 # Create an initial organization if specified
 if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION'] && !Organization.any?
   Organization.without_auditing do
-    User.current = User.anonymous_admin
+    original_user, User.current = User.current, User.anonymous_admin
     Organization.where(:name => ENV['SEED_ORGANIZATION']).first_or_create
-    User.current = nil
+    User.current = original_user
   end
 end
 
 # Create an initial location if specified
 if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION'] && !Location.any?
   Location.without_auditing do
-    User.current = User.anonymous_admin
+    original_user, User.current = User.current, User.anonymous_admin
     Location.where(:name => ENV['SEED_LOCATION']).first_or_create!
-    User.current = nil
+    User.current = original_user
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,15 @@ end
 
 foreman_seeds.each do |seed|
   puts "Seeding #{seed}" unless Rails.env.test?
-  load seed
+
+  admin = User.unscoped.find_by_login(User::ANONYMOUS_ADMIN)
+  # anonymous admin does not exist until some of seed step creates it, therefore we use it only when it exists
+  if admin.present?
+    User.as_anonymous_admin do
+      load seed
+    end
+  else
+    load seed
+  end
 end
 puts "All seed files executed" unless Rails.env.test?

--- a/test/controllers/api/v1/reports_controller_test.rb
+++ b/test/controllers/api/v1/reports_controller_test.rb
@@ -82,8 +82,8 @@ class Api::V1::ReportsControllerTest < ActionController::TestCase
   end
 
   test 'cannot view the last report without hosts view permission' do
-    setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
+    setup_user('view', 'config_reports')
     get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end

--- a/test/controllers/api/v2/common_parameters_controller_test.rb
+++ b/test/controllers/api/v2/common_parameters_controller_test.rb
@@ -46,17 +46,17 @@ class Api::V2::CommonParametersControllerTest < ActionController::TestCase
     end
 
     test "should show a common parameter unhidden when show_hidden is true" do
+      parameter = FactoryGirl.create(:common_parameter, :hidden_value => true, :value => 'test')
       setup_user 'view', 'params'
       setup_user 'edit', 'params'
-      parameter = FactoryGirl.create(:common_parameter, :hidden_value => true, :value => 'test')
       get :show, { :id => parameter.to_param, :show_hidden => 'true' }, set_session_user(:one)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.value, show_response['value']
     end
 
     test "should show a common parameter as hidden even when show_hidden is true if user is not authorized" do
-      setup_user 'view', 'params'
       parameter = FactoryGirl.create(:common_parameter, :hidden_value => true)
+      setup_user 'view', 'params'
       get :show, { :id => parameter.to_param, :show_hidden => 'true' }, set_session_user(:one)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.hidden_value, show_response['value']

--- a/test/controllers/api/v2/config_reports_controller_test.rb
+++ b/test/controllers/api/v2/config_reports_controller_test.rb
@@ -48,7 +48,7 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
       Setting[:require_ssl_smart_proxies] = false
 
       proxy = smart_proxies(:puppetmaster)
-      proxy.update_attribute(:url, 'http://configreports.foreman')
+      as_admin { proxy.update_attribute(:url, 'http://configreports.foreman') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])
       post :create, { :config_report => create_a_puppet_transaction_report }
@@ -194,8 +194,8 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
   end
 
   test 'cannot view the last report without hosts view permission' do
-    setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
+    setup_user('view', 'config_reports')
     get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end

--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -100,16 +100,16 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see domain parameters" do
-    setup_user "view", "domains"
     domain_with_parameter = FactoryGirl.create(:domain, :with_parameter)
+    setup_user "view", "domains"
     get :show, {:id => domain_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see domain parameters" do
+    domain_with_parameter = FactoryGirl.create(:domain, :with_parameter)
     setup_user "view", "domains"
     setup_user "view", "params"
-    domain_with_parameter = FactoryGirl.create(:domain, :with_parameter)
     get :show, {:id => domain_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -84,16 +84,16 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see hostgroup parameters" do
-    setup_user "view", "hostgroups"
     hostgroup_with_parameter = FactoryGirl.create(:hostgroup, :with_parameter)
+    setup_user "view", "hostgroups"
     get :show, {:id => hostgroup_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see hostgroup parameters" do
+    hostgroup_with_parameter = FactoryGirl.create(:hostgroup, :with_parameter)
     setup_user "view", "hostgroups"
     setup_user "view", "params"
-    hostgroup_with_parameter = FactoryGirl.create(:hostgroup, :with_parameter)
     get :show, {:id => hostgroup_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/locations_controller_test.rb
+++ b/test/controllers/api/v2/locations_controller_test.rb
@@ -284,16 +284,17 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see location parameters" do
-    setup_user "view", "locations"
     location_with_parameter = FactoryGirl.create(:location, :with_parameter)
+    setup_user "view", "locations"
     get :show, {:id => location_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see location parameters" do
+    location_with_parameter = FactoryGirl.create(:location, :with_parameter)
+    location_with_parameter.users << users(:one)
     setup_user "view", "locations"
     setup_user "view", "params"
-    location_with_parameter = FactoryGirl.create(:location, :with_parameter)
     get :show, {:id => location_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/operatingsystems_controller_test.rb
+++ b/test/controllers/api/v2/operatingsystems_controller_test.rb
@@ -108,16 +108,16 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see os parameters" do
-    setup_user "view", "operatingsystems"
     os_with_parameter = FactoryGirl.create(:operatingsystem, :with_parameter)
+    setup_user "view", "operatingsystems"
     get :show, {:id => os_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see os parameters" do
+    os_with_parameter = FactoryGirl.create(:operatingsystem, :with_parameter)
     setup_user "view", "operatingsystems"
     setup_user "view", "params"
-    os_with_parameter = FactoryGirl.create(:operatingsystem, :with_parameter)
     get :show, {:id => os_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -23,16 +23,17 @@ class Api::V2::OrganizationsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see organization parameters" do
-    setup_user "view", "organizations"
     org_with_parameter = FactoryGirl.create(:organization, :with_parameter)
+    setup_user "view", "organizations"
     get :show, {:id => org_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see organization parameters" do
+    org_with_parameter = FactoryGirl.create(:organization, :with_parameter)
+    org_with_parameter.users << users(:one)
     setup_user "view", "organizations"
     setup_user "view", "params"
-    org_with_parameter = FactoryGirl.create(:organization, :with_parameter)
     get :show, {:id => org_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/override_values_controller_test.rb
+++ b/test/controllers/api/v2/override_values_controller_test.rb
@@ -140,35 +140,35 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     end
 
     test "should show override value unhidden when show_hidden is true" do
-      setup_user "view", "puppetclasses"
-      setup_user "view", "external_parameters"
-      setup_user "edit", "external_parameters"
       lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
       FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => lookup_key)
       lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => lookup_key, :value => 'abc', :match => 'os=fake')
+      setup_user "view", "puppetclasses"
+      setup_user "view", "external_parameters"
+      setup_user "edit", "external_parameters"
       get :show, { :smart_class_parameter_id => lookup_key.to_param, :id => lookup_value.to_param, :show_hidden => 'true' }
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal lookup_value.value, show_response['value']
     end
 
     test "should show a override value parameter as hidden when user in unauthorized for smart class variable" do
-      setup_user "view", "puppetclasses"
-      setup_user "view", "external_parameters"
-      setup_user "edit", "external_variables"
       lookup_key = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
       FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => lookup_key)
       lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => lookup_key, :value => 'abc', :match => 'os=fake')
+      setup_user "view", "puppetclasses"
+      setup_user "view", "external_parameters"
+      setup_user "edit", "external_variables"
       get :show, { :smart_class_parameter_id => lookup_key.to_param, :id => lookup_value.to_param, :show_hidden => 'true' }
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal lookup_value.hidden_value, show_response['value']
     end
 
     test "should show a override value parameter as hidden when user in unauthorized for smart class parameter" do
+      lookup_key = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
+      lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => lookup_key, :value => 'abc', :match => 'os=fake')
       setup_user "view", "puppetclasses"
       setup_user "view", "external_variables"
       setup_user "view", "external_parameters"
-      lookup_key = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
-      lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => lookup_key, :value => 'abc', :match => 'os=fake')
       get :show, { :smart_variable_id => lookup_key.to_param, :id => lookup_value.to_param, :show_hidden => 'true' }
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal lookup_value.hidden_value, show_response['value']

--- a/test/controllers/api/v2/parameters_controller_test.rb
+++ b/test/controllers/api/v2/parameters_controller_test.rb
@@ -316,19 +316,19 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
     end
 
     test "should show a host parameter unhidden when show_hidden is true" do
+      parameter = FactoryGirl.create(:host_parameter, :host => @host, :hidden_value => true)
       setup_user 'view', 'params'
       setup_user 'edit', 'params'
       setup_user 'view', 'hosts', "name = #{@host.name}"
-      parameter = FactoryGirl.create(:host_parameter, :host => @host, :hidden_value => true)
       get :show, { :host_id => @host.to_param, :id => parameter.to_param, :show_hidden => 'true' }, set_session_user(:one)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.value, show_response['value']
     end
 
     test "should show a host parameter as hidden even when show_hidden is true if user is not authorized" do
+      parameter = FactoryGirl.create(:host_parameter, :host => @host, :hidden_value => true)
       setup_user 'view', 'params'
       setup_user 'view', 'hosts', "name = #{@host.name}"
-      parameter = FactoryGirl.create(:host_parameter, :host => @host, :hidden_value => true)
       get :show, { :host_id => @host.to_param, :id => parameter.to_param, :show_hidden => 'true' }, set_session_user(:one)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.hidden_value, show_response['value']

--- a/test/controllers/api/v2/reports_controller_test.rb
+++ b/test/controllers/api/v2/reports_controller_test.rb
@@ -53,7 +53,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       Setting[:require_ssl_smart_proxies] = false
 
       proxy = smart_proxies(:puppetmaster)
-      proxy.update_attribute(:url, 'http://foremanimporter.report')
+      as_admin { proxy.update_attribute(:url, 'http://foremanimporter.report') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])
       post :create, {:report => create_a_puppet_transaction_report }
@@ -199,8 +199,8 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
   end
 
   test 'cannot view the last report without hosts view permission' do
-    setup_user('view', 'config_reports')
     report = FactoryGirl.create(:report)
+    setup_user('view', 'config_reports')
     get :last, { :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end

--- a/test/controllers/api/v2/smart_class_parameters_controller_test.rb
+++ b/test/controllers/api/v2/smart_class_parameters_controller_test.rb
@@ -203,45 +203,45 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     end
 
     test "should show a smart class parameter unhidden when show_hidden is true" do
+      parameter = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
+      FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => parameter)
       setup_user "view", "puppetclasses"
       setup_user "view", "external_parameters"
       setup_user "edit", "external_parameters"
-      parameter = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
-      FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => parameter)
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'true' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.default_value, show_response['default_value']
     end
 
     test "should show a smart class parameter parameter as hidden when show_hidden is true if user is not authorized" do
-      setup_user "view", "puppetclasses"
-      setup_user "view", "external_parameters"
       parameter = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
       FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => parameter)
+      setup_user "view", "puppetclasses"
+      setup_user "view", "external_parameters"
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'true' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.hidden_value, show_response['default_value']
     end
 
     test "should show a smart class parameter's overrides unhidden when show_hidden is true" do
-      setup_user "view", "puppetclasses"
-      setup_user "view", "external_parameters"
-      setup_user "edit", "external_parameters"
       parameter = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
       FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => parameter)
       lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => parameter, :value => 'abc', :match => 'os=fake')
+      setup_user "view", "puppetclasses"
+      setup_user "view", "external_parameters"
+      setup_user "edit", "external_parameters"
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'true' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal lookup_value.value, show_response['override_values'][0]['value']
     end
 
     test "should show a smart class parameter's overrides hidden when show_hidden is false" do
-      setup_user "view", "puppetclasses"
-      setup_user "view", "external_parameters"
-      setup_user "edit", "external_parameters"
       parameter = FactoryGirl.create(:puppetclass_lookup_key, :hidden_value => true, :default_value => 'hidden')
       FactoryGirl.create(:environment_class, :environment => environments(:testing),:puppetclass => puppetclasses(:one), :puppetclass_lookup_key => parameter)
       lookup_value = FactoryGirl.create(:lookup_value, :lookup_key => parameter, :value => 'abc', :match => 'os=fake')
+      setup_user "view", "puppetclasses"
+      setup_user "view", "external_parameters"
+      setup_user "edit", "external_parameters"
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'false' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal lookup_value.hidden_value, show_response['override_values'][0]['value']

--- a/test/controllers/api/v2/smart_variables_controller_test.rb
+++ b/test/controllers/api/v2/smart_variables_controller_test.rb
@@ -86,19 +86,19 @@ class Api::V2::SmartVariablesControllerTest < ActionController::TestCase
     end
 
     test "should show a smart variable unhidden when show_hidden is true" do
+      parameter = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
       setup_user "view", "puppetclasses"
       setup_user "view", "external_variables"
       setup_user "edit", "external_variables"
-      parameter = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'true' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.default_value, show_response['default_value']
     end
 
     test "should show a smart variable parameter as hidden even when show_hidden is true if user is not authorized" do
+      parameter = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
       setup_user "view", "puppetclasses"
       setup_user "view", "external_variables"
-      parameter = FactoryGirl.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
       get :show, { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id, :show_hidden => 'true' }, set_session_user.merge(:user => users(:one).id)
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.hidden_value, show_response['default_value']

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -122,16 +122,16 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
   end
 
   test "user without view_params permission can't see subnet parameters" do
-    setup_user "view", "subnets"
     subnet_with_parameter = FactoryGirl.create(:subnet_ipv4, :with_parameter)
+    setup_user "view", "subnets"
     get :show, {:id => subnet_with_parameter.to_param, :format => 'json'}
     assert_empty JSON.parse(response.body)['parameters']
   end
 
   test "user with view_params permission can see subnet parameters" do
+    subnet_with_parameter = FactoryGirl.create(:subnet_ipv4, :with_parameter)
     setup_user "view", "subnets"
     setup_user "view", "params"
-    subnet_with_parameter = FactoryGirl.create(:subnet_ipv4, :with_parameter)
     get :show, {:id => subnet_with_parameter.to_param, :format => 'json'}
     assert_not_empty JSON.parse(response.body)['parameters']
   end

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -50,7 +50,7 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     response = ActiveSupport::JSON.decode(@response.body)
     refute response["effective_admin"]
 
-    FactoryGirl.create(:usergroup, :admin => true, :users => [user])
+    as_admin { FactoryGirl.create(:usergroup, :admin => true, :users => [user]) }
     get :show, { :id => user.id }
     response = ActiveSupport::JSON.decode(@response.body)
     assert response["effective_admin"]

--- a/test/controllers/compute_resources_controller_test.rb
+++ b/test/controllers/compute_resources_controller_test.rb
@@ -41,7 +41,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should create compute resource" do
-    setup_user "create"
+    setup_user "create", 'compute_resources', ''
     assert_difference('ComputeResource.unscoped.count', +1) do
       attrs = {:name => "test", :provider => "Libvirt", :url => "qemu://host/system"}
       post :create, {:compute_resource => attrs}, set_session_user
@@ -214,7 +214,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
     SETTINGS[:login] ? {:user => User.current.id, :expires_at => 5.minutes.from_now} : {}
   end
 
-  def setup_user(operation, type = 'compute_resources')
-    super(operation, type, "id = #{@compute_resource.id}")
+  def setup_user(operation, type = 'compute_resources', condition = nil)
+    super(operation, type, condition || "id = #{@compute_resource.id}")
   end
 end

--- a/test/controllers/compute_resources_vms_controller_test.rb
+++ b/test/controllers/compute_resources_vms_controller_test.rb
@@ -184,8 +184,12 @@ class ComputeResourcesVmsControllerTest < ActionController::TestCase
     teardown { Fog.unmock! }
 
     let(:compute_resource) do
-      FactoryGirl.create(:compute_resource, :vmware, :uuid => 'Solutions',
-                         :organizations => User.current.organizations, :locations => User.current.locations)
+      orgs = User.current.organizations
+      locs = User.current.locations
+      as_admin do
+        FactoryGirl.create(:compute_resource, :vmware, :uuid => 'Solutions',
+                           :organizations => orgs, :locations => locs)
+      end
     end
 
     test 'imports a host' do

--- a/test/controllers/config_reports_controller_test.rb
+++ b/test/controllers/config_reports_controller_test.rb
@@ -4,8 +4,12 @@ require 'controllers/shared/report_host_permissions_test'
 class ConfigReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
 
+  let :report do
+    as_admin { FactoryGirl.create(:config_report) }
+  end
+
   def test_index
-    FactoryGirl.create(:config_report)
+    report
     get :index, {}, set_session_user
     assert_response :success
     assert_not_nil assigns('config_reports')
@@ -13,14 +17,13 @@ class ConfigReportsControllerTest < ActionController::TestCase
   end
 
   test 'csv export works' do
-    FactoryGirl.create(:config_report)
+    report
     get :index, {format: :csv}, set_session_user
     assert_response :success
     assert_equal 2, response.body.lines.size
   end
 
   def test_show
-    report = FactoryGirl.create(:config_report)
     get :show, {:id => report.id}, set_session_user
     assert_template 'show'
   end
@@ -32,7 +35,7 @@ class ConfigReportsControllerTest < ActionController::TestCase
   end
 
   def test_show_last
-    FactoryGirl.create(:config_report)
+    report
     get :show, {:id => "last"}, set_session_user
     assert_template 'show'
   end
@@ -44,7 +47,6 @@ class ConfigReportsControllerTest < ActionController::TestCase
   end
 
   def test_show_last_report_for_host
-    report = FactoryGirl.create(:config_report)
     get :show, {:id => "last", :host_id => report.host.to_param}, set_session_user
     assert_template 'show'
   end
@@ -56,7 +58,6 @@ class ConfigReportsControllerTest < ActionController::TestCase
   end
 
   def test_destroy
-    report = FactoryGirl.create(:config_report)
     delete :destroy, {:id => report}, set_session_user
     assert_redirected_to config_reports_url
     assert !ConfigReport.exists?(report.id)
@@ -83,7 +84,6 @@ class ConfigReportsControllerTest < ActionController::TestCase
 
   test 'cannot view the last report without hosts view permission' do
     setup_user('view', 'config_reports')
-    report = FactoryGirl.create(:config_report)
     get :show, { :id => 'last', :host_id => report.host.id }, set_session_user.merge(:user => User.current.id)
     assert_response :not_found
   end

--- a/test/controllers/domains_controller_test.rb
+++ b/test/controllers/domains_controller_test.rb
@@ -56,16 +56,16 @@ class DomainsControllerTest < ActionController::TestCase
   end
 
   test 'user with view_params rights should see parameters in a domain' do
+    domain = FactoryGirl.create(:domain, :with_parameter)
     setup_user "edit", "domains"
     setup_user "view", "params"
-    domain = FactoryGirl.create(:domain, :with_parameter)
     get :edit, {:id => domain.id}, set_session_user.merge(:user => users(:one).id)
     assert_not_nil response.body['Parameter']
   end
 
   test 'user without view_params rights should not see parameters in a domain' do
-    setup_user "edit", "domains"
     domain = FactoryGirl.create(:domain, :with_parameter)
+    setup_user "edit", "domains"
     get :edit, {:id => domain.id}, set_session_user.merge(:user => users(:one).id)
     assert_nil response.body['Parameter']
   end

--- a/test/controllers/fact_values_controller_test.rb
+++ b/test/controllers/fact_values_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class FactValuesControllerTest < ActionController::TestCase
   def setup
+    FactoryGirl.create(:fact_value)
     User.current = nil
   end
 
@@ -13,7 +14,6 @@ class FactValuesControllerTest < ActionController::TestCase
   end
 
   test 'csv export works' do
-    FactoryGirl.create(:fact_value)
     get :index, {format: :csv}, set_session_user
     assert_response :success
     assert_equal 2, response.body.lines.size
@@ -28,7 +28,6 @@ class FactValuesControllerTest < ActionController::TestCase
   end
 
   def test_index_with_sort
-    FactoryGirl.create(:fact_value)
     @request.env['HTTP_REFERER'] = fact_values_path
     get :index, {order: 'origin ASC'}, set_session_user
     assert_response :success

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -176,16 +176,16 @@ class HostgroupsControllerTest < ActionController::TestCase
   end
 
   test 'user with view_params rights should see parameters in a hostgroup' do
+    hg = FactoryGirl.create(:hostgroup, :with_parameter)
     setup_user "edit"
     setup_user "view", "params"
-    hg = FactoryGirl.create(:hostgroup, :with_parameter)
     get :edit, {:id => hg.id}, set_session_user.merge(:user => users(:one).id)
     assert_not_nil response.body['Global parameters']
   end
 
   test 'user without view_params rights should not see parameters in a hostgroup' do
-    setup_user "edit"
     hg = FactoryGirl.create(:hostgroup, :with_parameter)
+    setup_user "edit"
     get :edit, {:id => hg.id}, set_session_user.merge(:user => users(:one).id)
     assert_nil response.body['Global parameters']
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -200,17 +200,18 @@ class LocationsControllerTest < ActionController::TestCase
     put :update, { :id => location.id, :location => {:name => "Topbar Loc" }}, set_session_user
   end
 
-  test 'user with view_params rights should see parameters in an os' do
+  test 'user with view_params rights should see parameters in a location' do
+    location = FactoryGirl.create(:location, :with_parameter, :organizations => [taxonomies(:organization1)])
+    as_admin { location.users << users(:one) }
     setup_user "edit", "locations"
     setup_user "view", "params"
-    location = FactoryGirl.create(:location, :with_parameter)
     get :edit, {:id => location.id}, set_session_user.merge(:user => users(:one).id)
     assert_not_nil response.body['Parameter']
   end
 
   test 'user without view_params rights should not see parameters in an os' do
-    setup_user "edit", "locations"
     location = FactoryGirl.create(:location, :with_parameter)
+    setup_user "edit", "locations"
     get :edit, {:id => location.id}, set_session_user.merge(:user => users(:one).id)
     assert_nil response.body['Parameter']
   end

--- a/test/controllers/operatingsystems_controller_test.rb
+++ b/test/controllers/operatingsystems_controller_test.rb
@@ -73,16 +73,16 @@ class OperatingsystemsControllerTest < ActionController::TestCase
     end
 
     test 'user with view_params rights should see parameters in an os' do
+      os = FactoryGirl.create(:operatingsystem, :with_parameter)
       setup_user "edit", "operatingsystems"
       setup_user "view", "params"
-      os = FactoryGirl.create(:operatingsystem, :with_parameter)
       get :edit, {:id => os.id}, set_session_user.merge(:user => users(:one).id)
       assert_not_nil response.body['Parameter']
     end
 
     test 'user without view_params rights should not see parameters in an os' do
-      setup_user "edit", "operatingsystems"
       os = FactoryGirl.create(:operatingsystem, :with_parameter)
+      setup_user "edit", "operatingsystems"
       get :edit, {:id => os.id}, set_session_user.merge(:user => users(:one).id)
       assert_nil response.body['Parameter']
     end

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -205,16 +205,17 @@ class OrganizationsControllerTest < ActionController::TestCase
   end
 
   test 'user with view_params rights should see parameters in an os' do
+    organization = FactoryGirl.create(:organization, :with_parameter)
+    as_admin { organization.users << users(:one) }
     setup_user "edit", "organizations"
     setup_user "view", "params"
-    organization = FactoryGirl.create(:organization, :with_parameter)
     get :edit, {:id => organization.id}, set_session_user.merge(:user => users(:one).id)
     assert_not_nil response.body['Parameter']
   end
 
   test 'user without view_params rights should not see parameters in an os' do
-    setup_user "edit", "organizations"
     organization = FactoryGirl.create(:organization, :with_parameter)
+    setup_user "edit", "organizations"
     get :edit, {:id => organization.id}, set_session_user.merge(:user => users(:one).id)
     assert_nil response.body['Parameter']
   end

--- a/test/controllers/puppetclasses_controller_test.rb
+++ b/test/controllers/puppetclasses_controller_test.rb
@@ -212,11 +212,11 @@ class PuppetclassesControllerTest < ActionController::TestCase
   end
 
   test 'user with edit_puppetclasses permission should succeed in overriding all parameters' do
-    setup_user "edit", "puppetclasses"
     env = FactoryGirl.create(:environment,
                              :organizations => [users(:one).organizations.first],
                              :locations => [users(:one).locations.first])
     pc = FactoryGirl.create(:puppetclass, :with_parameters, :environments => [env])
+    setup_user "edit", "puppetclasses"
     refute pc.class_params.first.override
     post :override, {:id => pc.to_param, :enable => 'true'}, set_session_user.merge(:user => users(:one).id)
     assert_match /overridden all parameters/, flash[:notice]
@@ -224,11 +224,11 @@ class PuppetclassesControllerTest < ActionController::TestCase
   end
 
   test 'user without edit_puppetclasses permission should fail in overriding all parameters' do
-    setup_user "view", "puppetclasses"
     env = FactoryGirl.create(:environment,
                              :organizations => [users(:one).organizations.first],
                              :locations => [users(:one).locations.first])
     pc = FactoryGirl.create(:puppetclass, :with_parameters, :environments => [env])
+    setup_user "view", "puppetclasses"
     refute pc.class_params.first.override
     post :override, {:id => pc.to_param, :enable => 'true'}, set_session_user.merge(:user => users(:one).id)
     assert_match /You are not authorized to perform this action/, response.body

--- a/test/controllers/shared/report_host_permissions_test.rb
+++ b/test/controllers/shared/report_host_permissions_test.rb
@@ -2,17 +2,19 @@ module ReportHostPermissionsTest
   extend ActiveSupport::Concern
   included do
     context 'when user does not have permission to view hosts' do
+      let :report do
+        as_admin { FactoryGirl.create(:config_report) }
+      end
+
       setup { setup_user('view', 'config_reports') }
 
       test 'cannot view any reports' do
-        report = FactoryGirl.create(:config_report)
         get :show, { :id => report.id }, set_session_user.merge(:user => User.current.id)
         assert_response :not_found
       end
 
       test 'cannot delete host reports' do
         setup_user 'destroy', 'config_reports'
-        report = FactoryGirl.create(:config_report)
         delete :destroy, { :id => report.id }, set_session_user.merge(:user => User.current.id)
         assert_response :not_found
       end

--- a/test/controllers/subnets_controller_test.rb
+++ b/test/controllers/subnets_controller_test.rb
@@ -106,16 +106,16 @@ class SubnetsControllerTest < ActionController::TestCase
 
   context 'parameters permissions' do
     test 'with view_params user should see parameters in a subnet' do
+      subnet = FactoryGirl.create(:subnet_ipv4, :with_parameter)
       setup_user "edit", "subnets"
       setup_user "view", "params"
-      subnet = FactoryGirl.create(:subnet_ipv4, :with_parameter)
       get :edit, {:id => subnet.id}, set_session_user.merge(:user => users(:one).id)
       assert_not_nil response.body['Parameter']
     end
 
     test 'without view_params user should not see parameters in a subnet' do
-      setup_user "edit", "subnets"
       subnet = FactoryGirl.create(:subnet_ipv4, :with_parameter)
+      setup_user "edit", "subnets"
       get :edit, {:id => subnet.id}, set_session_user.merge(:user => users(:one).id)
       assert_nil response.body['Parameter']
     end

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -296,11 +296,11 @@ class UnattendedControllerTest < ActionController::TestCase
     setup do
       @host_param = FactoryGirl.create(:host_parameter, :host => @rh_host, :name => 'my_param')
       @secret_param = FactoryGirl.create(:host_parameter, :host => @rh_host, :name => 'secret_param')
+      @rh_host.provisioning_template(:kind => :provision).update_attribute(:template, "params: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
       setup_user 'view', 'hosts'
       setup_user 'view', 'params', 'name = my_param'
       users(:one).organizations << @rh_host.organization
       users(:one).locations << @rh_host.location
-      @rh_host.provisioning_template(:kind => :provision).update_attribute(:template, "params: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
     end
 
     test "in preview should only show permitted parameters" do
@@ -316,8 +316,10 @@ class UnattendedControllerTest < ActionController::TestCase
 
     context "and ptable with host parameters" do
       setup do
-        @rh_host.ptable.update_attribute(:template, "params: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
-        @rh_host.provisioning_template(:kind => :provision).update_attribute(:template, "ptable: <%= @host.diskLayout %>\nparams: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
+        as_admin do
+          @rh_host.ptable.update_attribute(:template, "params: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
+          @rh_host.provisioning_template(:kind => :provision).update_attribute(:template, "ptable: <%= @host.diskLayout %>\nparams: <%= @host.params['my_param'] %>, <%= @host.params['secret_param'] %>")
+        end
       end
 
       test "in preview should only show permitted parameters" do

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -244,6 +244,18 @@ manager_23_2:
 manager_23_3:
   filter: manager_23
   permission: destroy_realms
+manager_24_0:
+  filter: manager_24
+  permission: view_subnets
+manager_24_1:
+  filter: manager_24
+  permission: create_subnets
+manager_24_2:
+  filter: manager_24
+  permission: edit_subnets
+manager_24_3:
+  filter: manager_24
+  permission: destroy_subnets
 edit_partition_tables_1_0:
   filter: edit_partition_tables_1
   permission: view_ptables

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -44,6 +44,8 @@ manager_22:
   role_id: 1
 manager_23:
   role_id: 1
+manager_24:
+  role_id: 1
 edit_partition_tables_1:
   role_id: 2
 view_hosts_1:

--- a/test/models/concerns/authorizable_test.rb
+++ b/test/models/concerns/authorizable_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class AuthorizableTest < ActiveSupport::TestCase
+  def setup
+    User.current = users :admin
+    user_role = FactoryGirl.create(:user_user_role)
+    @user = user_role.owner
+    role = user_role.role
+    permission = Permission.find_by_name('create_domains')
+    role.filters << FactoryGirl.create(:filter, :on_name_starting_with_a, :role => role, :permissions => [ permission ])
+  end
+
+  test "create permissions respects search conditions of filters" do
+    as_user @user do
+      valid = FactoryGirl.build(:domain, :name => 'a.domain.will.save')
+      assert valid.save
+
+      invalid = FactoryGirl.build(:domain, :name => 'b.domain.wont.save')
+      refute invalid.save
+      assert_equal 1, invalid.errors.messages.size
+      assert_include invalid.errors.messages.keys, :base
+    end
+  end
+
+  test "rollback orchestration" do
+    Domain.stub(:included_modules, [Orchestration]) do
+      as_user @user do
+        invalid = FactoryGirl.build(:domain, :name => 'b.domain.wont.save')
+        invalid.stubs(:queue).returns([])
+        invalid.expects(:fail_queue).once
+        refute invalid.save
+      end
+    end
+  end
+
+  test "#permission_name" do
+    domain = FactoryGirl.build(:domain)
+    assert_equal 'create_domains', domain.permission_name('create')
+    assert_nil domain.permission_name('does_not_exist')
+  end
+end

--- a/test/models/fact_value_test.rb
+++ b/test/models/fact_value_test.rb
@@ -2,12 +2,14 @@ require 'test_helper'
 
 class FactValueTest < ActiveSupport::TestCase
   def setup
-    @host = FactoryGirl.create(:host)
-    @fact_name   = FactName.create(:name => "my_facting_name")
-    @fact_value  = FactValue.create(:value => "some value", :host => @host, :fact_name => @fact_name)
-    @child_name  = FactName.create(:name => 'my_facting_name::child', :parent => @fact_name)
-    @child_value = FactValue.create(:value => 'child value', :host => @host, :fact_name => @child_name)
-    [@fact_name, @fact_value, @child_name, @child_value].map(&:save)
+    as_admin do
+      @host = FactoryGirl.create(:host)
+      @fact_name   = FactName.create(:name => "my_facting_name")
+      @fact_value  = FactValue.create(:value => "some value", :host => @host, :fact_name => @fact_name)
+      @child_name  = FactName.create(:name => 'my_facting_name::child', :parent => @fact_name)
+      @child_value = FactValue.create(:value => 'child value', :host => @host, :fact_name => @child_name)
+      [@fact_name, @fact_value, @child_name, @child_value].map(&:save)
+    end
   end
 
   test "should return the count of each fact" do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -173,6 +173,8 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "non-admin user should be able to create host with new lookup value" do
+    subnets(:two).organizations = users(:one).organizations
+    subnets(:two).locations = users(:one).locations
     User.current = users(:one)
     User.current.roles << [roles(:manager)]
     assert_difference('LookupValue.unscoped.count') do
@@ -180,7 +182,7 @@ class HostTest < ActiveSupport::TestCase
       :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat),
       :subnet => subnets(:two), :architecture => architectures(:x86_64),
       :puppet_proxy => smart_proxies(:puppetmaster), :medium => media(:one),
-      :organization => nil, :location => nil,
+      :organization => users(:one).organizations.first, :location => users(:one).locations.first,
       :environment => environments(:production), :disk => "empty partition",
       :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lookup_keys(:complex).id, "value"=>"some_value", "match" => "fqdn=abc.mydomain.net"}}
     end

--- a/test/models/orchestration/puppetca_test.rb
+++ b/test/models/orchestration/puppetca_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class PuppetCaOrchestrationTest < ActiveSupport::TestCase
   def setup
+    users(:one).roles << Role.find_by_name('Manager')
     User.current = users(:one)
     disable_orchestration
     SETTINGS[:locations_enabled] = false

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -30,4 +30,8 @@ class PermissionTest < ActiveSupport::TestCase
       assert_includes permissions, permission
     end
   end
+
+  test ".resource_name" do
+    assert_equal 'Domain', Permission.resource_name(Domain)
+  end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -177,8 +177,8 @@ class RoleTest < ActiveSupport::TestCase
       let(:first) { Role.create(:name => 'First') }
       let(:second) { Role.create(:name => 'Second') }
       before do
+        users(:one).roles<< first
         User.current = users(:one)
-        User.current.roles<< first
       end
 
       subject { Role.for_current_user.to_a }

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -193,6 +193,7 @@ module TaxonomiesBaseTest
 
     test "non-admin user is added to taxonomy after creating it" do
       user = users(:one)
+      setup_user 'create', taxonomy_class.to_s.underscore.pluralize
       as_user(:one) do
         refute user.admin?
         assert taxonomy = taxonomy_class.create(:name => 'new taxonomy')

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -247,8 +247,13 @@ class TaxonomixTest < ActiveSupport::TestCase
     role = FactoryGirl.create(:role)
     role.filters = [ filter ]
 
+    filter2 = FactoryGirl.create(:filter)
+    filter2.permissions = Permission.where(:name => [ 'edit_domains' ])
+    role2 = FactoryGirl.create(:role)
+    role2.filters = [ filter2 ]
+
     user = FactoryGirl.create(:user)
-    user.roles = [ role ]
+    user.roles = [ role, role2 ]
     org1 = FactoryGirl.create :organization, :name => 'visible1'
     org2 = FactoryGirl.create :organization, :name => 'visible2'
     org3 = FactoryGirl.create :organization, :name => 'hidden'

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -16,9 +16,9 @@ class SeedsTest < ActiveSupport::TestCase
 
   def seed
     # Authorisation is disabled usually when run from a rake db:* task
-    User.current = FactoryGirl.build(:user, :admin => true,
-                                     :organizations => [], :locations => [])
-    load File.expand_path('../../../../db/seeds.rb', __FILE__)
+    as_admin do
+      load File.expand_path('../../../../db/seeds.rb', __FILE__)
+    end
   end
 
   teardown do


### PR DESCRIPTION
Seems to work surprisingly well, if this gets :+1: to get in, we should probably cover it in release notes. Note that I'm unable to exactly tell which attribute caused the authorization to fail so I add error message to base.