### PR TITLE
Fixes #17403 - enable exporting of templates

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -8,7 +8,7 @@ module Api
       include Foreman::Controller::Parameters::ProvisioningTemplate
 
       before_action :find_optional_nested_object
-      before_action :find_resource, :only => %w{show update destroy clone}
+      before_action :find_resource, :only => %w{show update destroy clone export}
 
       before_action :handle_template_upload, :only => [:create, :update]
       before_action :process_template_kind, :only => [:create, :update]
@@ -110,6 +110,12 @@ module Api
         end
       end
 
+      api :GET, '/provisioning_templates/:id/export', N_('Export a provisioning template to ERB')
+      param :id, :identifier, :required => true
+      def export
+        send_data @provisioning_template.to_erb, :type => 'text/plain', :disposition => 'attachment', :filename => @provisioning_template.filename
+      end
+
       private
 
       def resource_class
@@ -129,6 +135,8 @@ module Api
         case params[:action]
           when 'clone'
             'create'
+          when 'export'
+            'view'
           else
             super
         end

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -6,7 +6,7 @@ module Api
       wrap_parameters :ptable, :include => ptable_params_filter.accessible_attributes(parameter_filter_context)
 
       before_action :find_optional_nested_object
-      before_action :find_resource, :only => %w{show update destroy clone}
+      before_action :find_resource, :only => %w{show update destroy clone export}
 
       api :GET, "/ptables/", N_("List all partition tables")
       api :GET, "/operatingsystems/:operatingsystem_id/ptables", N_("List all partition tables for an operating system")
@@ -89,6 +89,12 @@ module Api
         process_response @ptable.save
       end
 
+      api :GET, '/ptables/:id/export', N_('Export a partition template to ERB')
+      param :id, :identifier, :required => true
+      def export
+        send_data @ptable.to_erb, :type => 'text/plain', :disposition => 'attachment', :filename => @ptable.filename
+      end
+
       private
 
       def load_vars_from_ptable
@@ -107,6 +113,8 @@ module Api
         case params[:action]
           when 'clone'
             'create'
+          when 'export'
+            'view'
           else
             super
         end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -4,7 +4,7 @@ class TemplatesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
   before_action :handle_template_upload, :only => [:create, :update]
-  before_action :find_resource, :only => [:edit, :update, :destroy, :clone_template, :lock, :unlock]
+  before_action :find_resource, :only => [:edit, :update, :destroy, :clone_template, :lock, :unlock, :export]
   before_action :load_history, :only => :edit
   before_action :type_name_plural, :type_name_singular, :resource_class
 
@@ -95,6 +95,10 @@ class TemplatesController < ApplicationController
     safe_render(@template)
   end
 
+  def export
+    send_data @template.to_erb, :type => 'text/plain', :disposition => 'attachment', :filename => @template.filename
+  end
+
   private
 
   def safe_render(template)
@@ -124,7 +128,7 @@ class TemplatesController < ApplicationController
     case params[:action]
       when 'lock', 'unlock'
         :lock
-      when 'clone_template', 'preview'
+      when 'clone_template', 'preview', 'export'
         :view
       else
         super

--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -13,7 +13,10 @@ module ProvisioningTemplatesHelper
   end
 
   def permitted_actions(template)
-    actions = [display_link_if_authorized(_('Clone'), template_hash_for_member(template, 'clone_template'))]
+    actions = [
+      display_link_if_authorized(_('Clone'), template_hash_for_member(template, 'clone_template')),
+      display_link_if_authorized(_('Export'), template_hash_for_member(template, 'export'), { :data => { :no_turbolink => true } })
+    ]
 
     if template.locked?
       confirm = [

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -33,6 +33,9 @@ class ProvisioningTemplate < Template
   scoped_search :in => :hostgroups,       :on => :name, :rename => :hostgroup,       :complete_value => true
   scoped_search :in => :template_kind,    :on => :name, :rename => :kind,            :complete_value => true
 
+  attr_exportable :kind => Proc.new { |template| template.template_kind.try(:name) },
+                  :oses => Proc.new { |template| template.operatingsystems.map(&:name).uniq }
+
   # Override method in Taxonomix as Template is not used attached to a Host,
   # and matching a Host does not prevent removing a template from its taxonomy.
   def used_taxonomy_ids(type)

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -33,6 +33,8 @@ class Ptable < Template
 
   alias_attribute :layout, :template
 
+  attr_exportable :os_family
+
   # with proc support, default_scope can no longer be chained
   # include all default scoping here
   default_scope lambda {

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -113,10 +113,10 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :provisioning_templates do |map|
-    map.permission :view_provisioning_templates,    {:provisioning_templates => [:index, :show, :revision, :auto_complete_search, :preview],
+    map.permission :view_provisioning_templates,    {:provisioning_templates => [:index, :show, :revision, :auto_complete_search, :preview, :export],
                                         :"api/v1/config_templates" => [:index, :show, :revision],
                                         :"api/v2/config_templates" => [:index, :show, :revision],
-                                        :"api/v2/provisioning_templates" => [:index, :show, :revision],
+                                        :"api/v2/provisioning_templates" => [:index, :show, :revision, :export],
                                         :"api/v2/template_combinations" => [:index, :show],
                                         :"api/v1/template_kinds" => [:index],
                                         :"api/v2/template_kinds" => [:index]
@@ -534,9 +534,9 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :partition_tables do |map|
-    map.permission :view_ptables, {:ptables => [:index, :show, :auto_complete_search, :revision, :preview, :welcome],
+    map.permission :view_ptables, {:ptables => [:index, :show, :auto_complete_search, :revision, :preview, :welcome, :export],
                                       :"api/v1/ptables" => [:index, :show],
-                                      :"api/v2/ptables" => [:index, :show, :revision]
+                                      :"api/v2/ptables" => [:index, :show, :revision, :export]
     }
     map.permission :create_ptables, {:ptables => [:new, :create, :clone_template],
                                       :"api/v1/ptables" => [:create],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,6 +318,7 @@ Foreman::Application.routes.draw do
           get 'clone_template'
           get 'lock'
           get 'unlock'
+          get 'export'
           post 'preview'
         end
         collection do
@@ -332,6 +333,7 @@ Foreman::Application.routes.draw do
           get 'clone_template'
           get 'lock'
           get 'unlock'
+          get 'export'
           post 'preview'
         end
         collection do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -39,7 +39,10 @@ Foreman::Application.routes.draw do
       resources :provisioning_templates, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
-        post :clone, :on => :member
+        member do
+          post :clone
+          get :export
+        end
         collection do
           post 'build_pxe_default'
           get 'revision'
@@ -146,7 +149,10 @@ Foreman::Application.routes.draw do
       resources :ptables, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
-        post :clone, :on => :member
+        member do
+          post :clone
+          get :export
+        end
         collection do
           get 'revision'
         end

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -96,6 +96,14 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test 'export should export the erb of the template' do
+    get :export, { :id => templates(:pxekickstart).to_param }
+    assert_response :success
+    assert_equal 'text/plain', response.content_type
+    assert_equal templates(:pxekickstart).to_erb, response.body
+    assert_equal 'attachment; filename="centos5_3_pxelinux.erb"', response.headers['Content-Disposition']
+  end
+
   test "should show templates from os" do
     get :index, { :operatingsystem_id => operatingsystems(:centos5_3).fullname }
     assert_response :success

--- a/test/controllers/api/v2/ptables_controller_test.rb
+++ b/test/controllers/api/v2/ptables_controller_test.rb
@@ -85,6 +85,14 @@ class Api::V2::PtablesControllerTest < ActionController::TestCase
     assert_equal(template['template'], original_ptable.template)
   end
 
+  test 'export should export the erb of the template' do
+    ptable = FactoryGirl.create(:ptable)
+    get :export, { :id => ptable.to_param }
+    assert_response :success
+    assert_equal 'text/plain', response.content_type
+    assert_equal ptable.to_erb, response.body
+  end
+
   test 'clone name should not be blank' do
     post :clone, { :id => FactoryGirl.create(:ptable).to_param,
                    :ptable => {:name => ''} }

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -55,6 +55,14 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
     assert_template 'new'
   end
 
+  test "export" do
+    get :export, { :id => templates(:pxekickstart).to_param }, set_session_user
+    assert_response :success
+    assert_equal 'text/plain', response.content_type
+    assert_equal templates(:pxekickstart).to_erb, response.body
+    assert_equal 'attachment; filename="centos5_3_pxelinux.erb"', response.headers['Content-Disposition']
+  end
+
   test "update invalid" do
     ProvisioningTemplate.any_instance.stubs(:valid?).returns(false)
     put :update, {:id => templates(:pxekickstart).to_param, :provisioning_template => {:name => "123"} }, set_session_user

--- a/test/controllers/ptables_controller_test.rb
+++ b/test/controllers/ptables_controller_test.rb
@@ -53,6 +53,13 @@ class PtablesControllerTest < ActionController::TestCase
     assert !Ptable.exists?(ptable.id)
   end
 
+  test "export" do
+    get :export, { :id => @ptable.to_param }, set_session_user
+    assert_response :success
+    assert_equal 'text/plain', response.content_type
+    assert_equal @ptable.to_erb, response.body
+  end
+
   def setup_view_user
     @request.session[:user] = users(:one).id
     users(:one).roles       = [Role.default, Role.find_by_name('Viewer')]

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -214,5 +214,19 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
       TemplatesController.any_instance.expects(:render_safe).with(anything, includes(*Foreman::Renderer::ALLOWED_GENERIC_HELPERS), anything).returns(true)
       ProvisioningTemplate.build_pxe_default(TemplatesController.new)
     end
+
+    test "#metadata should include OSes and kind" do
+      template = FactoryGirl.build(:provisioning_template, :operatingsystems => [
+        FactoryGirl.create(:operatingsystem, :name => 'CentOS'),
+        FactoryGirl.create(:operatingsystem, :name => 'CentOS'),
+        FactoryGirl.create(:operatingsystem, :name => 'Fedora')])
+
+      lines = template.metadata.split("\n")
+      assert_includes lines, '- CentOS'
+      assert_includes lines, '- Fedora'
+      assert_equal 1, lines.select { |l| l == '- CentOS' }.size
+      assert_includes lines, "kind: #{template.template_kind.name}"
+      assert_includes lines, "name: #{template.name}"
+    end
   end
 end

--- a/test/models/ptable_test.rb
+++ b/test/models/ptable_test.rb
@@ -78,4 +78,12 @@ class PtableTest < ActiveSupport::TestCase
     Host.expects(:authorized).with(:view_hosts).returns(Host.where(nil))
     ptable.preview_host_collection
   end
+
+  test "#metadata should include OS family" do
+    ptable = FactoryGirl.build(:ptable)
+
+    lines = ptable.metadata.split("\n")
+    assert_includes lines, "os_family: #{ptable.os_family}"
+    assert_includes lines, "name: #{ptable.name}"
+  end
 end

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+
+class TemplateTest < ActiveSupport::TestCase
+  describe "generating metadata" do
+    setup do
+      @template = Template.new :name => 'Name of template'
+    end
+
+    test "metadata are placed in erb comment" do
+      assert_match /\A<%#(\n|.)*%>/, @template.metadata
+    end
+
+    test "metadata contains name unchanged" do
+      assert_match /^name: Name of template$/, @template.metadata
+    end
+
+    test "metadata skips blank attributes" do
+      @template.name = ''
+      refute_match /^name:&/, @template.metadata
+    end
+
+    test "metadata does not contain dashes prefix" do
+      refute_includes @template.metadata, '---'
+    end
+  end
+
+  describe "stripping metadata" do
+    setup do
+      content = "<%#
+name: basic
+%>
+few
+lines
+below"
+      @template = Template.new :name => 'basic', :template => content
+    end
+
+    test "metadata are stripped from the beginning" do
+      without = @template.template_without_metadata
+      refute_includes without, '<%#'
+    end
+
+    test "silent metadata are stripped too" do
+      @template.template.gsub('%>', '-%>')
+      without = @template.template_without_metadata
+      refute_includes without, '<%#'
+    end
+
+    test "metadata are stripped from the middle" do
+      @template.template = "<%#\another comment\n%>\nsome\ndata\n" + @template.template
+      without = @template.template_without_metadata
+      refute_includes without, 'name: basic'
+    end
+
+    test "other erb comments not containing name: are preserved" do
+      @template.template = "prefix\n<% another erb tag %>\nsome\ndata\n" + @template.template
+      without = @template.template_without_metadata
+      assert_includes without, "prefix"
+      assert_includes without, "<% another erb tag %>"
+      assert_includes without, "\nsome\ndata\n"
+      assert_includes without, "\nfew\nlines\nbelow"
+    end
+
+    test "metadata are detected by name attribute on any comment line" do
+      lines = @template.template.lines
+      @template.template = [ lines[0], 'another: comment', lines[1..-1] ].flatten.join("\n")
+      without = @template.template_without_metadata
+      refute_includes without, 'name: basic'
+    end
+  end
+
+  describe "#filename" do
+    setup do
+      @template = Template.new
+    end
+
+    test "filename adds erb suffix" do
+      @template.name = 'a'
+      assert_equal 'a.erb', @template.filename
+    end
+
+    test "filename replaces spaces to underscores" do
+      @template.name = 'a bc d'
+      assert_equal 'a_bc_d.erb', @template.filename
+    end
+
+    test "filename removes dashes" do
+      @template.name = 'a-bc-d'
+      assert_equal 'abcd.erb', @template.filename
+    end
+  end
+
+  describe "#to_erb" do
+    setup do
+      content = "<%#
+name: basic
+%>
+data"
+      @template = Template.new :name => 'basic', :template => content
+    end
+
+    test "it generates fresh fresh metadata and replaces original ones" do
+      @template.stub(:metadata, "METADATA\n") do
+        assert_equal "METADATA\ndata", @template.to_erb
+      end
+    end
+
+    test "it keeps data that present before original metadata" do
+      @template.template = "<?xml ...>\n" + @template.template
+      @template.stub(:metadata, "METADATA") do
+        assert_equal "<?xml ...>\nMETADATA\ndata", @template.to_erb
+      end
+    end
+  end
+end


### PR DESCRIPTION
this adds new action for all kinds of templates
![export](https://cloud.githubusercontent.com/assets/109773/20457904/7424d154-ae96-11e6-9a0b-c0bef22eee27.png)

the same can be achieved through V2 API.