### PR TITLE
fixes #17407 - add a new hosts dashboard widget

### DIFF
--- a/app/services/dashboard/loader.rb
+++ b/app/services/dashboard/loader.rb
@@ -4,7 +4,8 @@ module Dashboard
     DEFAULT_WIDGETS = [ {:template=>'status_widget',       :sizex=>8,:sizey=>1,:name=> N_('Host Configuration Status')},
                         {:template=>'status_chart_widget', :sizex=>4,:sizey=>1,:name=> N_('Host Configuration Chart')},
                         {:template=>'reports_widget',      :sizex=>6,:sizey=>1,:name=> N_('Latest Events')},
-                        {:template=>'distribution_widget', :sizex=>6,:sizey=>1,:name=> N_('Run Distribution Chart')}]
+                        {:template=>'distribution_widget', :sizex=>6,:sizey=>1,:name=> N_('Run Distribution Chart')},
+                        {:template=>'new_hosts_widget',    :sizex=>8,:sizey=>1,:name=> N_('New Hosts')}]
     # Widget templates that are allowed on dashboard. Default widgets automatically allow their templates.
     ALLOWED_TEMPLATES = []
 

--- a/app/views/dashboard/_new_hosts_widget.html.erb
+++ b/app/views/dashboard/_new_hosts_widget.html.erb
@@ -1,0 +1,11 @@
+<% hosts = @data.hosts.includes(:operatingsystem).preload(:owner).order(:created_at => :desc).limit(9) %>
+
+<h4 class="header">
+  <%= N_('New Hosts') %>
+</h4>
+
+<% if hosts.empty? %>
+  <p class="ca"><%= _("No hosts available.") %></p>
+<% else %>
+  <%= render :partial => 'new_hosts_widget_host_list', :locals => { :hosts => hosts } %>
+<% end %>

--- a/app/views/dashboard/_new_hosts_widget_host_list.html.erb
+++ b/app/views/dashboard/_new_hosts_widget_host_list.html.erb
@@ -1,0 +1,20 @@
+<table class="table table-striped table-fixed">
+  <thead>
+    <th width="30%"><%= _('Host') %></th>
+    <th><%= _('Operating system') %></th>
+    <th><%= _('Owner') %></th>
+    <th><%= _('Created') %></th>
+    <th><%= _('Installed') %></th>
+  </thead>
+  <tbody>
+    <% hosts.each do |host| %>
+      <tr>
+        <td class="ellipsis"><%= link_to host.name, host_path(host) %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= safe_join([icon(host.operatingsystem, :size => '16x16'), host.operatingsystem.to_label]) if host.operatingsystem.present? %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= host.owner %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= _('%s ago') % time_ago_in_words(host.created_at) %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= host.installed_at.present? ? _('%s ago') % time_ago_in_words(host.installed_at) : '-' %></td>
+      </tr>
+  <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
This commit adds a small dashboard that shows a list of the latest eight hosts that were created. Nothing too fancy.