### PR TITLE
Fixes #17457 - multiple_checkboxes doesn't work with orgs/locs

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -46,8 +46,9 @@ module FormHelper
   end
 
   def multiple_checkboxes(f, attr, klass, associations, options = {}, html_options = {})
-    associated_obj = klass.send(ActiveModel::Naming.plural(associations.new))
-    selected_ids = associated_obj.select("#{associations.new.class.table_name}.id").map(&:id)
+    association_name = attr || ActiveModel::Naming.plural(associations)
+    associated_obj = klass.send(association_name)
+    selected_ids = associated_obj.select("#{associations.table_name}.id").map(&:id)
     multiple_selects(f, attr, associations, selected_ids, options, html_options)
   end
 

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -62,16 +62,13 @@
 
     <% if show_location_tab? %>
       <div class="tab-pane" id="locations">
-        <% collection = User.current.locations.empty? ? Location : User.current.locations %>
-        <%= multiple_checkboxes f, :locations, f.object, collection, {}, :label => _("Locations") %>
+        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, :label => _("Locations") %>
       </div>
     <% end %>
 
     <% if show_organization_tab? %>
       <div class="tab-pane" id="organizations">
-        <% collection = User.current.organizations.empty? ? Organization : User.current.organizations %>
-        <%= multiple_checkboxes f, :organizations, f.object, collection, {},
-                                {:label => _("Organizations")} %>
+        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, :label => _("Organizations") %>
       </div>
     <% end %>
   </div>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -23,13 +23,11 @@
       <% end %>
 
       <% if show_location_tab? %>
-        <% collection = User.current.locations.empty? ? Location : Location.my_locations %>
-        <%= multiple_checkboxes f, :locations, f.object, collection, {}, { :label => _("Locations") } %>
+        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, { :label => _("Locations") } %>
       <% end %>
 
       <% if show_organization_tab? %>
-        <% collection = User.current.organizations.empty? ? Organization : Organization.my_organizations %>
-        <%= multiple_checkboxes f, :organizations, f.object, collection, {}, { :label => _("Organizations") } %>
+        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, { :label => _("Organizations") } %>
       <% end %>
     </div>
 

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -22,7 +22,7 @@
       <%= render 'fields', :f => f %>
     </div>
     <div class="tab-pane" id="domains">
-      <%= multiple_checkboxes f, :domain, f.object, Domain, {:help_inline => _("Domains in which this subnet is part"), :size => 'col-md-6', :prefix => f.object_name}, { :label => _("Domain")} %>
+      <%= multiple_checkboxes f, :domains, f.object, Domain, {:help_inline => _("Domains in which this subnet is part"), :size => 'col-md-6', :prefix => f.object_name}, { :label => _("Domain")} %>
     </div>
     <div class="tab-pane" id="proxies">
       <%= smart_proxy_fields f %>

--- a/test/helpers/form_helper_test.rb
+++ b/test/helpers/form_helper_test.rb
@@ -50,4 +50,13 @@ class FormHelperTest < ActionView::TestCase
       end
     end
   end
+
+  test 'multiple_checkboxes produces right output for taxonomy relations' do
+    user = FactoryGirl.build(:user,
+                             :organizations => [taxonomies(:organization1)])
+    form_for Filter.new do |f|
+      assert_match(/input name=\"filter\[organization_ids\]\[\].*/,
+        multiple_checkboxes(f, :organizations, f.object, user.organizations))
+    end
+  end
 end


### PR DESCRIPTION
multiple_checkboxes calls ActiveModel::Naming on associations that could
be simply "Taxonomy". This results on a 500 error 'undefined method
`taxonomies' for #<Filter:0x005593624bdd18>' (or whatever other class
has the problem). Simply trying to edit a filter will throw this 500
error.

We've always had this problem , but since #16971 removed the check for
only using that method for '> 5' associations, you'd only see the error
if you had at least 6 organizations or locations (unlikely). Now it
became more apparent and it shows up every time.

The fix I've used is just to take advantage of the options hash to send
the association name directly, and if it's not set, then use
ActiveModel::Naming to get it (as usual).