### PR TITLE
Fixes #17343 - set deep munge config off

### DIFF
--- a/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
+++ b/app/controllers/concerns/api/v2/lookup_keys_common_controller.rb
@@ -49,7 +49,7 @@ module Api::V2::LookupKeysCommonController
     id = params.keys.include?('smart_variable_id') ? params['smart_variable_id'] : params['id']
     @smart_variable   = VariableLookupKey.authorized(:view_external_variables).smart_variables.find_by_id(id.to_i) if id.to_i > 0
     @smart_variable ||= (puppet_cond = { :puppetclass_id => @puppetclass.id } if @puppetclass
-                         VariableLookupKey.authorized(:view_external_variables).smart_variables.where(puppet_cond).find_by_key(id)
+                         VariableLookupKey.authorized(:view_external_variables).smart_variables.where(puppet_cond).find_by_key(id.to_s)
                         )
     @smart_variable
   end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -195,7 +195,7 @@ class HostsController < ApplicationController
   #will return HTML error codes upon failure
 
   def externalNodes
-    certname = params[:name]
+    certname = params[:name].to_s
     @host ||= resource_base.find_by_certname certname
     @host ||= resource_base.friendly.find certname
     unless @host
@@ -808,7 +808,7 @@ class HostsController < ApplicationController
       return false
     end
     @host   = resource_base.friendly.find(id)
-    @host ||= resource_base.find_by_mac params[:host][:mac] if params[:host] && params[:host][:mac]
+    @host ||= resource_base.find_by_mac params[:host][:mac].to_s if params[:host] && params[:host][:mac]
 
     unless @host
       not_found

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -32,8 +32,8 @@ class UnattendedController < ApplicationController
   def hostgroup_template
     return head(:not_found) unless (params.has_key?("id") && params.has_key?(:hostgroup))
 
-    template = ProvisioningTemplate.find_by_name(params['id'])
-    @host = Hostgroup.find_by_title(params['hostgroup'])
+    template = ProvisioningTemplate.find_by_name(params['id'].to_s)
+    @host = Hostgroup.find_by_title(params['hostgroup'].to_s)
     return head(:not_found) unless template && @host
 
     load_template_vars if template.template_kind.name == 'provision'

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -44,7 +44,7 @@ module Foreman::Model
         args.merge!(:tags => {:Name => name})
       end
       if (image_id = args[:image_id])
-        image = images.find_by_uuid(image_id)
+        image = images.find_by_uuid(image_id.to_s)
         iam_hash = image.iam_role.present? ? {:iam_instance_profile_name => image.iam_role} : {}
         args.merge!(iam_hash)
       end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -296,6 +296,7 @@ module Orchestration::Compute
   end
 
   def validate_foreman_attr(value, object, attr)
+    value = value.to_s if object.type_for_attribute(attr.to_s).type == :string
     # we can't ensure uniqueness of #foreman_attr using normal rails
     # validations as that gets in a later step in the process
     # therefore we must validate its not used already in our db.

--- a/app/models/concerns/parameterizable.rb
+++ b/app/models/concerns/parameterizable.rb
@@ -45,7 +45,7 @@ module Parameterizable
       end
 
       def self.from_param(name)
-        self.find_by_name(name)
+        self.find_by_name(name.to_s)
       end
     end
   end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -216,7 +216,7 @@ module Host
         taxonomy_fact = Setting["#{taxonomy}_fact"]
 
         if taxonomy_fact.present? && facts.keys.include?(taxonomy_fact)
-          taxonomy_from_fact = taxonomy_class.find_by_title(facts[taxonomy_fact])
+          taxonomy_from_fact = taxonomy_class.find_by_title(facts[taxonomy_fact].to_s)
         else
           default_taxonomy = taxonomy_class.find_by_title(Setting["default_#{taxonomy}"])
         end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -496,7 +496,7 @@ class Host::Managed < Host::Base
     classes = nodeinfo["classes"]
     classes = classes.keys if classes.is_a?(Hash)
     classes.each do |klass|
-      if (pc = Puppetclass.find_by_name(klass))
+      if (pc = Puppetclass.find_by_name(klass.to_s))
         myklasses << pc
       else
         error = _("Failed to import %{klass} for %{name}: doesn't exists in our database - ignoring") % { :klass => klass, :name => name }

--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -31,7 +31,7 @@ class MailNotification < ActiveRecord::Base
   # Easy way to reference the notification to support something like:
   #   MailNotification[:some_error_notification].deliver(options)
   def self.[](name)
-    self.find_by_name(name)
+    self.find_by_name(name.to_s)
   end
 
   def subscription_options

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -170,7 +170,7 @@ class Operatingsystem < ActiveRecord::Base
   end
 
   def self.find_by_to_label(str)
-    os = self.find_by_description(str)
+    os = self.find_by_description(str.to_s)
     return os if os
     a = str.split(" ")
     b = a[1].split('.') if a[1]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,7 +233,7 @@ class User < ActiveRecord::Base
 
   def self.find_or_create_external_user(attrs, auth_source_name)
     external_groups = attrs.delete(:groups)
-    auth_source = AuthSource.find_by_name(auth_source_name)
+    auth_source = AuthSource.find_by_name(auth_source_name.to_s)
 
     # existing user, we'll update them
     if (user = unscoped.find_by_login(attrs[:login]))

--- a/app/services/sso/oauth.rb
+++ b/app/services/sso/oauth.rb
@@ -19,7 +19,7 @@ module SSO
 
       if OAuth::Signature.verify(request, :consumer_secret => Setting['oauth_consumer_secret'])
         if Setting['oauth_map_users']
-          user_name = request.headers['HTTP_FOREMAN_USER']
+          user_name = request.headers['HTTP_FOREMAN_USER'].to_s
           User.find_by_login(user_name).tap do |obj|
             Rails.logger.warn "Oauth: mapping to user '#{user_name}' failed" if obj.nil?
           end.try(:login)

--- a/config/application.rb
+++ b/config/application.rb
@@ -165,6 +165,9 @@ module Foreman
     # Add apidoc hash in headers for smarter caching
     config.middleware.use Apipie::Middleware::ChecksumInHeaders
 
+    # New config option to opt out of params "deep munging" that was used to address security vulnerability CVE-2013-0155.
+    config.action_dispatch.perform_deep_munge = false
+
     Foreman::Logging.configure(
       :log_directory => "#{Rails.root}/log",
       :environment => Rails.env,

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -227,6 +227,16 @@ class LocationsControllerTest < ActionController::TestCase
     assert_nil response.body['Parameter']
   end
 
+  test 'should allow empty array as param value of array field while updating location' do
+    location = taxonomies(:location2)
+    location.update_attributes(:organization_ids => [taxonomies(:organization2).id])
+    saved_location = Location.find_by_id(location.id)
+    assert_equal saved_location.organization_ids.count, 1
+    put :update, { :id => location.id, :location => {:organization_ids => []}}, set_session_user
+    updated_location = Location.find_by_id(location.id)
+    assert_equal updated_location.organization_ids.count, 0
+  end
+
   context 'wizard' do
     test 'redirects to step 2 if unassigned hosts exist' do
       host = FactoryGirl.create(:host)

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -231,6 +231,16 @@ class OrganizationsControllerTest < ActionController::TestCase
     assert_nil response.body['Parameter']
   end
 
+  test 'should allow empty array as param value of array field while updating organization' do
+    organization = taxonomies(:organization2)
+    organization.update_attributes(:smart_proxy_ids => [ smart_proxies(:one).id ])
+    saved_organization = Organization.find_by_id(organization.id)
+    assert_equal saved_organization.smart_proxy_ids.count, 1
+    put :update, { :id => organization.id, :organization => {:smart_proxy_ids => []}}, set_session_user
+    updated_organization = Organization.find_by_id(organization.id)
+    assert_equal updated_organization.smart_proxy_ids.count, 0
+  end
+
   context 'wizard' do
     test 'redirects to step 2 if unassigned hosts exist' do
       host = FactoryGirl.create(:host)


### PR DESCRIPTION
deep_munge was introduced as a solution to keep Rails secure by default which results in
'empty array becomes nil in params'. Thats why, set deep_munge config off in application.rb.
Also, added changes which will cast param argument to string while calling find_by_{string_type_attr} method on object.