### PR TITLE
Fixes #17468 - build pxe returns error when no tftp in proxy

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -106,7 +106,7 @@ class ProvisioningTemplate < Template
   end
 
   def self.build_pxe_default(renderer)
-    return [200, _("No TFTP proxies defined, can't continue")] if (proxies = SmartProxy.with_features("TFTP")).empty?
+    return [422, _("No TFTP proxies defined, can't continue")] if (proxies = SmartProxy.with_features("TFTP")).empty?
 
     error_msgs = []
     TemplateKind::PXE.each do |kind|

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -132,6 +132,12 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
       assert_redirected_to provisioning_templates_path
     end
 
+    test "build menu should return with error code if no TFTP defined" do
+      SmartProxy.stubs(:with_features).with('TFTP').returns([])
+      get :build_pxe_default, {}, set_session_user
+      assert flash[:error].present?
+    end
+
     test "pxe menu's labels should be sorted" do
       t1 = TemplateCombination.new :hostgroup => hostgroups(:db), :environment => environments(:production)
       t1.provisioning_template = templates(:mystring2)


### PR DESCRIPTION
`build_pxe_default` in `ProvisioningTemplate`  returns status code 200 when no TFTP
has found in proxy, should return  422, and therefore an error message should render in UI.