### PR TITLE
Fixes #17487 - support sessions for api calls

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -371,7 +371,7 @@ module Api
     end
 
     def protect_api_from_forgery?
-      session[:user].present?
+      session[:user].present? && !session[:api_authenticated_session]
     end
 
     def parameter_filter_context

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Session
   def session_expiry
     return if ignore_api_request?
     if session[:expires_at].blank? || (Time.at(session[:expires_at]).utc - Time.now.utc).to_i < 0
-      session[:original_uri] = request.fullpath
+      session[:original_uri] = request.fullpath unless session[:api_authenticated_session]
       expire_session
     end
   rescue => e
@@ -22,6 +22,10 @@ module Foreman::Controller::Session
 
   def update_activity_time
     return if ignore_api_request?
+    set_activity_time
+  end
+
+  def set_activity_time
     session[:expires_at] = Setting[:idle_timeout].minutes.from_now.to_i
   end
 

--- a/test/controllers/api/v2/base_controller_subclass_test.rb
+++ b/test/controllers/api/v2/base_controller_subclass_test.rb
@@ -28,4 +28,26 @@ class Api::V2::TestableControllerTest < ActionController::TestCase
       assert_response 200
     end
   end
+
+  context "when authentication is enabled" do
+    setup do
+      User.current = nil
+      SETTINGS[:login] = true
+
+      @sso = mock('dummy_sso')
+      @sso.stubs(:authenticated?).returns(true)
+      @sso.stubs(:current_user).returns(users(:admin))
+      @sso.stubs(:support_expiration?).returns(true)
+      @sso.stubs(:expiration_url).returns("/users/extlogin")
+      @sso.stubs(:controller).returns(@controller)
+      @controller.instance_variable_set(:@available_sso, @sso)
+      @controller.stubs(:get_sso_method).returns(@sso)
+    end
+
+    it "sets the session user" do
+      get :index
+      assert_response :success
+      assert_equal users(:admin).id, session[:user]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,6 +59,10 @@ class ActionController::TestCase
     set_basic_auth(users(:apiadmin), "secret")
   end
 
+  def reset_api_credentials
+    @request.env.delete('HTTP_AUTHORIZATION')
+  end
+
   def set_basic_auth(user, password)
     login = user.is_a?(User) ? user.login : user
     @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(login, password)


### PR DESCRIPTION
- authenticated api calls save user to session and set flag api_authenticated_session
- sessions with such flag allow posting requests without CSRF token
- api sessions exipre the same way as UI sessions
- api sessions don't store any additional data to keep the requests stateless

This way the standard UI requests as well as API requests authenticated with session created from UI remain protected against CSRF. At the same time applications using API (such as hammer) can benefit from using session authentication and avoid the need of storing two tokens (CSRF and _session_id).