### PR TITLE
Fixes #17439 - Moved facet base to a concern

### DIFF
--- a/app/models/concerns/facets/base.rb
+++ b/app/models/concerns/facets/base.rb
@@ -1,0 +1,51 @@
+require 'facets'
+
+module Facets
+  module Base
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to_host
+    end
+
+    # Add facet's details to host's ENC by returning it from this method
+    # Basic ENC hash structure:
+    # ---
+    # classes:
+    #   ...
+    # parameters:
+    #   ...
+    # environment:
+    #   ...
+    def info
+      {}
+    end
+
+    # Specify any smart proxy id's used by this facet.
+    def smart_proxy_ids
+      []
+    end
+
+    # Add any filters to template selection returned from host
+    def template_filter_options(kind)
+      {}
+    end
+
+    # Add search criteria for finding a configuration template.
+    def provisioning_template_options
+      {}
+    end
+
+    module ClassMethods
+      # Change attributes that will be sent to an facet based on inherited values from the hostgroup.
+      def self.inherited_attributes(hostgroup, facet_attributes)
+        facet_attributes
+      end
+
+      # Use this method to populate host's fields based on fact values exposed by the importer.
+      # You can populate fields in the associated host's facets too.
+      def self.populate_fields_from_facts(host, importer, type, proxy_id)
+      end
+    end
+  end
+end

--- a/app/models/host_facets/base.rb
+++ b/app/models/host_facets/base.rb
@@ -2,44 +2,6 @@ module HostFacets
   class Base < ActiveRecord::Base
     self.abstract_class = true
 
-    belongs_to_host
-
-    # Add facet's details to host's ENC by returning it from this method
-    # Basic ENC hash structure:
-    # ---
-    # classes:
-    #   ...
-    # parameters:
-    #   ...
-    # environment:
-    #   ...
-    def info
-      {}
-    end
-
-    # Specify any smart proxy id's used by this facet.
-    def smart_proxy_ids
-      []
-    end
-
-    # Add any filters to template selection returned from host
-    def template_filter_options(kind)
-      {}
-    end
-
-    # Add search criteria for finding a configuration template.
-    def provisioning_template_options
-      {}
-    end
-
-    # Change attributes that will be sent to an facet based on inherited values from the hostgroup.
-    def self.inherited_attributes(hostgroup, facet_attributes)
-      facet_attributes
-    end
-
-    # Use this method to populate host's fields based on fact values exposed by the importer.
-    # You can populate fields in the associated host's facets too.
-    def self.populate_fields_from_facts(host, importer, type, proxy_id)
-    end
+    include Facets::Base
   end
 end


### PR DESCRIPTION
If the plugin that wants to create a new facet doesn't want to take the inheritance slot (for example if it already has some base class), it can `include` the new concern.