### PR TITLE
Fixes #3551 - Show unavailable Puppet Classes in Host Group edit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -359,6 +359,7 @@ function update_puppetclasses(element) {
       $('#puppet_klasses').html(request);
       reload_puppetclass_params();
       tfm.tools.activateTooltips();
+      tfm.hostgroups.checkForUnavailablePuppetclasses();
     },
     complete: function() {
       reloadOnAjaxComplete(element);

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -496,6 +496,8 @@ function load_with_placeholder(target, url, data){
 
 function onHostEditLoad(){
   update_interface_table();
+  tfm.hostgroups.checkForUnavailablePuppetclasses();
+
   $("#host-conflicts-modal").modal({show: "true", backdrop: "static"});
    $('#host-conflicts-modal').click(function(){
      $('#host-conflicts-modal').modal('hide');

--- a/app/assets/stylesheets/puppetclasses.scss
+++ b/app/assets/stylesheets/puppetclasses.scss
@@ -32,8 +32,12 @@
   .matcher .matcher-group {
     display: block;
   }
-  
+
   .matcher_value {
     width: 60%;
   }
+}
+
+.selected_puppetclass.unavailable a {
+  color: $color-pf-black-400;
 }

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -82,7 +82,8 @@ class HostgroupsController < ApplicationController
   end
 
   def environment_selected
-    return not_found unless (@environment = Environment.find(params[:environment_id])) if params[:environment_id].to_i > 0
+    env_id = params[:environment_id] || params[:hostgroup][:environment_id]
+    return not_found unless (@environment = Environment.find(env_id)) if env_id.to_i > 0
 
     @hostgroup ||= Hostgroup.new
     @hostgroup.environment = @environment if @environment

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -165,8 +165,11 @@ class HostsController < ApplicationController
   end
 
   def hostgroup_or_environment_selected
+    @environment = Environment.find(params['host']['environment_id'])
+    @hostgroup = Hostgroup.find(params['host']['hostgroup_id'])
+
     Taxonomy.as_taxonomy @organization, @location do
-      if params['host']['environment_id'].present? || params['host']['hostgroup_id'].present?
+      if @environment || @hostgroup
         render :partial => 'puppetclasses/class_selection', :locals => {:obj => (refresh_host)}
       else
         logger.info "environment_id or hostgroup_id is required to render puppetclasses"

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -203,16 +203,14 @@ module HostCommon
     end
   end
 
+  # Returns Puppetclasses of a Host or Hostgroup
+  #
+  # It does not include Puppetclasses of it's ConfigGroupClasses
+  #
   def individual_puppetclasses
     ids = host_class_ids - cg_class_ids
     return puppetclasses if ids.blank? && new_record?
-
-    conditions = {:id => ids}
-    if environment
-      environment.puppetclasses.where(conditions)
-    else
-      Puppetclass.where(conditions)
-    end
+    Puppetclass.includes(:environments).where(id: ids)
   end
 
   def available_puppetclasses

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -14,7 +14,7 @@
     <ul id="selected_classes">
       <% if authorized_for(:controller => :host_editing, :action => :edit_classes) %>
         <%= render :partial => "puppetclasses/selectedClasses",
-          :collection => obj.individual_puppetclasses ,:as => :klass, :locals => { :type => obj_type(obj), :host => obj } %>
+          :collection => obj.individual_puppetclasses,:as => :klass, :locals => { :type => obj_type(obj), :host => obj } %>
         <% unless controller_name == 'config_groups' %>
             <%= render :partial => "puppetclasses/classes_in_groups",
           :collection => obj.classes_in_groups ,:as => :klass, :locals => { :type => obj_type(obj), :obj => obj } %>

--- a/app/views/puppetclasses/_selectedClasses.html.erb
+++ b/app/views/puppetclasses/_selectedClasses.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for :li, klass, :selected, :class => cycle('even', 'odd') do %>
+<%= content_tag_for :li, klass, :selected, :class => [cycle('even', 'odd'), ('unavailable' unless klass.environments.include?(@environment))] do %>
   <%= link_to_remove_puppetclass(klass, host) %>
   <%= hidden_field_tag "#{type}[puppetclass_ids][]", klass.id %>
 <% end %>

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -30,6 +30,36 @@ class HostgroupJSTest < IntegrationTestWithJavascript
     assert_equal env.name, host.environment.name
   end
 
+  describe 'edit form' do
+    setup do
+      @hostgroup = FactoryGirl.create(:hostgroup, :with_puppetclass)
+      @another_puppetclass = FactoryGirl.create(:puppetclass)
+    end
+
+    context 'puppet classes are not available in the environment' do
+      setup do
+        @hostgroup.puppetclasses << @another_puppetclass
+        visit edit_hostgroup_path(@hostgroup)
+      end
+
+      describe 'Puppet classes tab' do
+        test 'it shows a warning' do
+          click_link 'Puppet Classes'
+          wait_for_ajax
+
+          assert page.has_selector?('#puppetclasses_unavailable_warning')
+        end
+
+        test 'it marks selected classes as unavailable' do
+          click_link 'Puppet Classes'
+          wait_for_ajax
+
+          assert page.has_selector?('.selected_puppetclass.unavailable')
+        end
+      end
+    end
+  end
+
   test 'submit updates taxonomy' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     new_location = FactoryGirl.create(:location)

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -13,12 +13,32 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_link? 'staging'
   end
 
-  test "edit page" do
-    visit hostgroups_path
-    click_link "db"
-    fill_in "hostgroup_name", :with => "db Old"
-    assert_submit_button(hostgroups_path)
-    assert page.has_link? 'db Old'
+  describe 'edit page' do
+    setup do
+      @another_environment = FactoryGirl.create(:environment)
+      @hostgroup = FactoryGirl.create(:hostgroup, :with_puppetclass)
+      visit hostgroups_path
+      click_link @hostgroup.name
+    end
+
+    test 'changing hostgroup_name' do
+      new_hostgroup_name = "#{@hostgroup.name} Old"
+      fill_in 'hostgroup_name', with: new_hostgroup_name
+      assert_submit_button(hostgroups_path)
+
+      assert page.has_link? new_hostgroup_name
+    end
+
+    describe 'changing the environment' do
+      test 'preserves the puppetclasses' do
+        puppetclasses = @hostgroup.puppetclasses.all
+
+        select @another_environment.name, from: 'hostgroup_environment_id'
+        assert_submit_button(hostgroups_path)
+
+        assert_equal puppetclasses, @hostgroup.puppetclasses.all
+      end
+    end
   end
 
   test 'edit shows errors on invalid lookup values' do

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -16,6 +16,7 @@ window.tfm = Object.assign(
     tools: require('./foreman_tools'),
     users: require('./foreman_users'),
     trends: require('./foreman_trends'),
+    hostgroups: require('./foreman_hostgroups'),
     numFields: require('./jquery.ui.custom_spinners'),
     reactMounter: require('./react_app/common/MountingService')
   }

--- a/webpack/assets/javascripts/foreman_hostgroups.js
+++ b/webpack/assets/javascripts/foreman_hostgroups.js
@@ -1,0 +1,21 @@
+import $ from 'jquery';
+
+export function checkForUnavailablePuppetclasses() {
+  let unavailableClasses = $('#puppet_klasses #selected_classes .unavailable');
+  let puppetKlassesTab = $('#puppet_klasses');
+  let tab = puppetKlassesTab.closest('form').find('.nav-tabs a[href="#puppet_klasses"]');
+  let warningMessage = __('Some Puppet Classes are unavailable in the selected environment');
+  let warning = `<div class="alert alert-warning" id="puppetclasses_unavailable_warning">
+      <span class="pficon pficon-warning-triangle-o"></span>
+      ${warningMessage}
+    </span>`;
+
+  if (unavailableClasses.size() > 0) {
+    tab.prepend('<span class="pficon pficon-warning-triangle-o"></span> ');
+    puppetKlassesTab.prepend(warning);
+  } else {
+    puppetKlassesTab.find('#puppetclasses_unavailable_warning').remove();
+    tab.find('.pficon-warning-triangle-o').remove();
+  }
+}
+

--- a/webpack/assets/javascripts/foreman_hostgroups.test.js
+++ b/webpack/assets/javascripts/foreman_hostgroups.test.js
@@ -1,0 +1,54 @@
+jest.unmock('./foreman_hostgroups');
+const hostgroups = require('./foreman_hostgroups');
+const $ = require('jquery');
+
+describe('checkForUnavailablePuppetclasses', () => {
+  beforeEach(() => {
+    window.Jed = { sprintf: function (input) { return input; } };
+    window.__ = function (input) { return input; };
+
+    document.body.innerHTML = `<div>
+        <ul class="nav-tabs">
+          <li><a href="#puppet_klasses" data-toggle="tab">Puppet Classes</a></li>
+        </ul>
+        <div class="tab-content">
+          <form>
+            <div class="tab-pane active" id="hostgroup">
+                <div class="form-group">
+                  <div>
+                    <input id="hostgroup_environment_id"/>
+                  </div>
+                  <span class="help-block"></span>
+                </div>
+            </div>
+            <div class="tab-pane" id="puppet_klasses">
+              <div id="selected_classes"></div>
+            </div>
+          </form>
+        </div>
+      </div>`;
+  });
+
+  it('adds a warning if an unavailable class is found', () => {
+    $('#selected_classes').append('<li class="unavailable">Unavailable Class</li>');
+
+    hostgroups.checkForUnavailablePuppetclasses();
+    expect($('#puppetclasses_unavailable_warning').size()).toBe(1);
+  });
+
+  it('does not add a warning if no unavailable classes are found', () => {
+    $('#hostgroup .help-block').empty();
+    $('#selected_classes').empty();
+
+    hostgroups.checkForUnavailablePuppetclasses();
+    expect($('#hostgroup .help-block').first().children().size()).toBe(0);
+  });
+
+  it('adds a warning sign to the tab if unavailable classes are found', () => {
+    $('#selected_classes').append('<li class="unavailable">Unavailable Class</li>');
+    hostgroups.checkForUnavailablePuppetclasses();
+    setTimeout(() => {
+      expect($('a .pficon').size()).toBe(1);
+    }, 100);
+  });
+});


### PR DESCRIPTION
Puppet Classes can be assigned to a Host Group even if they are
not in the set environment. They will persist through out changes
of the environment, but were previously hidden from the UI.

Unavailable Puppet Classes are now shown in the UI as unavailable
and a warning is triggered to inform the user about them.

**Host Group edit form / Puppet Classes with changed environment:**
![screen shot 2016-11-24 at 16 08 21](https://cloud.githubusercontent.com/assets/7757/20603126/66e1e54a-b260-11e6-9618-122f1d9f6c45.png)

**Warning:**
![screen shot 2016-11-24 at 16 08 10](https://cloud.githubusercontent.com/assets/7757/20603125/66e18280-b260-11e6-8c15-d1239eb8e0d5.png)

