### PR TITLE
Fixes #13775 - merge only on same class collections

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -61,7 +61,7 @@ module Api
       association = resource_class.reflect_on_all_associations.find {|assoc| assoc.plural_name == parent_name.pluralize}
       #if couldn't find an association by name, try to find one by class
       association ||= resource_class.reflect_on_all_associations.find {|assoc| assoc.class_name == parent_name.camelize}
-      result_scope = resource_class.joins(association.name).merge(scope)
+      result_scope = resource_class_join(association, scope)
       # Check that the scope resolves before return
       result_scope if result_scope.to_a
     rescue ActiveRecord::ConfigurationError
@@ -77,6 +77,10 @@ module Api
       # on the results
       resource_class.joins(association.name).
         where(association.name => scope.map(&:id))
+    end
+
+    def resource_class_join(association, scope)
+      resource_class.joins(association.name).merge(scope)
     end
 
     def resource_scope_for_index(options = {})

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -368,6 +368,11 @@ Return the host's compute attributes that can be used to create a clone of this 
       def allowed_nested_id
         %w(hostgroup_id location_id organization_id environment_id)
       end
+
+      def resource_class_join(association, scope)
+        resource_class_join = resource_class.joins(association.name)
+        resource_class_join.merge(scope).present? ? resource_class_join.merge(scope) : resource_class_join
+      end
     end
   end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -45,6 +45,13 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     )
   end
 
+  def basic_attrs_with_hg
+    hostgroup_attr = {
+      :hostgroup_id => Hostgroup.first.id
+    }
+    basic_attrs.merge(hostgroup_attr)
+  end
+
   def nics_attrs
     [{
       :primary => true,
@@ -256,6 +263,12 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should update host" do
     put :update, { :id => @host.to_param, :host => valid_attrs }
+    assert_response :success
+  end
+
+  test "should update hostgroup_id of host" do
+    @host = FactoryGirl.create(:host, basic_attrs_with_hg)
+    put :update, { :id => @host.to_param, :hostgroup_id => Hostgroup.last.id }
     assert_response :success
   end
 


### PR DESCRIPTION
`merging` is an intersection between two collection objects, it makes valid sense if the both collections are of same class otherwise it will always return an empty array set.