### PR TITLE
fixes #17484 - remove reported_at sequence from report factory

### DIFF
--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -168,8 +168,8 @@ FactoryGirl.define do
         report_count 5
       end
       after(:create) do |host,evaluator|
-        evaluator.report_count.times do
-          report = FactoryGirl.create(:report, :host => host)
+        evaluator.report_count.times do |i|
+          report = FactoryGirl.create(:report, :host => host, :reported_at => (evaluator.report_count - i).minutes.ago)
           host.last_report = report.reported_at
         end
       end

--- a/test/factories/reports_related.rb
+++ b/test/factories/reports_related.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :report do
     host
-    sequence(:reported_at) { |n| n.minutes.ago }
+    reported_at { Time.now.utc }
     status 0
     metrics YAML.load("--- \n  time: \n    schedule: 0.00083\n    service: 0.149739\n    mailalias: 0.000283\n    cron: 0.000419\n    config_retrieval: 16.3637869358063\n    package: 0.003989\n    filebucket: 0.000171\n    file: 0.007025\n    exec: 0.000299\n  resources: \n    total: 33\n  changes: {}\n  events: \n    total: 0")
     type 'ConfigReport'

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -21,10 +21,10 @@ class ReportTest < ActiveSupport::TestCase
 
   describe '.my_reports' do
     setup do
-      @target_host = FactoryGirl.create(:host, :with_hostgroup)
-      @target_reports = FactoryGirl.create_pair(:config_report, host: @target_host)
-      @other_host = FactoryGirl.create(:host, :with_hostgroup)
-      @other_reports = FactoryGirl.create_pair(:report, host: @other_host)
+      @target_host = FactoryGirl.create(:host, :with_hostgroup, :with_reports, :report_count => 2)
+      @target_reports = @target_host.reports
+      @other_host = FactoryGirl.create(:host, :with_hostgroup, :with_reports, :report_count => 2)
+      @other_reports = @other_host.reports
     end
 
     test 'returns all reports for admin' do


### PR DESCRIPTION
Prevents reports getting ever more out of sync from Time.now.