### PR TITLE
Fixes #17482 - make strings translatable

### DIFF
--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -28,7 +28,7 @@ module Foreman::Controller::Environments
 
   def obsolete_and_new
     import_params = { :changed => params[:changed] }
-    if params[:commit] == _("Update on background")
+    if params[:commit] == _("Update in the background")
       ForemanTasks.async_task(::Actions::Foreman::PuppetClass::Import, import_params)
       notice _("Added import task to the queue, it will be run shortly")
     else

--- a/app/services/actions/foreman/puppet_class/import.rb
+++ b/app/services/actions/foreman/puppet_class/import.rb
@@ -15,9 +15,9 @@ module Actions
           return nil if input[:changed].nil?
 
           humanized_output = []
-          humanized_output << _('Add') + ' ' + format_env_and_classes_input(input[:changed][:new]) if input[:changed][:new].present?
-          humanized_output << _('Remove') + ' ' + format_env_and_classes_input(input[:changed][:obsolete]) if input[:changed][:obsolete].present?
-          humanized_output << _('Update') + ' ' + format_env_and_classes_input(input[:changed][:updated]) if input[:changed][:updated].present?
+          humanized_output << _('Add %s') % format_env_and_classes_input(input[:changed][:new]) if input[:changed][:new].present?
+          humanized_output << _('Remove %s') % format_env_and_classes_input(input[:changed][:obsolete]) if input[:changed][:obsolete].present?
+          humanized_output << _('Update %s') % format_env_and_classes_input(input[:changed][:updated]) if input[:changed][:updated].present?
           humanized_output.join("\n")
         end
 
@@ -38,11 +38,12 @@ module Actions
 
         def format_env_and_classes_input(selection)
           selection.map do |environment, classes|
-            result = _('environment') + " #{environment}"
             classes = JSON.parse(classes)
-            no_classes_info = classes.include?('_destroy_')
-            result += " (#{classes.size} " + _('classes') + ")" unless no_classes_info
-            result
+            if classes.include?('_destroy_')
+              _('environment %s') % environment
+            else
+              n_('environment %{environment} (%{count} class)', 'environment %{environment} (%{count} classes)', classes.size) % { :environment => environment, :count => classes.size }
+            end
           end.join(', ')
         end
       end

--- a/app/views/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/common/_puppetclasses_or_envs_changed.html.erb
@@ -53,6 +53,6 @@
   <div>
     <%= link_to _("Cancel"), send("#{controller_name}_path"), :class => "btn btn-default" %>
     <%= submit_tag _("Update"), :class => "btn btn-primary" %>
-    <%= submit_tag _("Update on background"), :class => "btn btn-primary" %>
+    <%= submit_tag _("Update in the background"), :class => "btn btn-primary" %>
   </div>
 <% end %>


### PR DESCRIPTION
I can't combine the string into one as asked in the issue because the environments part is generated dynamically, the result can be following

```
Update environment one (5 classes), environment two (3 classes)
```

I added it as translation parameter at least in case order needs to be changed, hopefully that helps. I also updated button labels and plural form.