### PR TITLE
Fixes #17503 - Only trigger PXELoader suggestion when needed

### DIFF
--- a/app/controllers/api/v1/hostgroups_controller.rb
+++ b/app/controllers/api/v1/hostgroups_controller.rb
@@ -41,6 +41,8 @@ module Api
 
       def create
         @hostgroup = Hostgroup.new(hostgroup_params)
+        @hostgroup.suggest_default_pxe_loader if params[:hostgroup] && params[:hostgroup][:pxe_loader].nil?
+
         process_response @hostgroup.save
       end
 

--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -71,6 +71,7 @@ module Api
       def create
         @host = Host.new(host_params)
         @host.managed = true if (params[:host] && params[:host][:managed].nil?)
+        @host.suggest_default_pxe_loader if params[:host] && params[:host][:pxe_loader].nil?
         forward_request_url
         process_response @host.save
       end

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -53,6 +53,8 @@ module Api
 
       def create
         @hostgroup = Hostgroup.new(hostgroup_params)
+        @hostgroup.suggest_default_pxe_loader if params[:hostgroup] && params[:hostgroup][:pxe_loader].nil?
+
         process_response @hostgroup.save
       end
 

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -112,6 +112,7 @@ module Api
         @host = Host.new(host_attributes(host_params))
         @host.managed = true if (params[:host] && params[:host][:managed].nil?)
         apply_compute_profile(@host)
+        @host.suggest_default_pxe_loader if params[:host] && params[:host][:pxe_loader].nil?
 
         forward_request_url
         process_response @host.save

--- a/app/controllers/concerns/foreman/controller/host_details.rb
+++ b/app/controllers/concerns/foreman/controller/host_details.rb
@@ -9,7 +9,9 @@ module Foreman::Controller::HostDetails
   end
 
   def os_selected
-    assign_parameter "operatingsystem", "common/os_selection/"
+    assign_parameter "operatingsystem", "common/os_selection/" do |item|
+      item.suggest_default_pxe_loader
+    end
   end
 
   def medium_selected
@@ -47,6 +49,7 @@ module Foreman::Controller::HostDetails
     Taxonomy.as_taxonomy @organization, @location do
       item = instance_variable_get("@#{controller_name.singularize}") || controller_name.classify.constantize.new(item_params)
       instance_variable_set("@#{name}", item.send(name.to_sym))
+      yield item if block_given?
       render :partial => root + name, :locals => { :item => item }
     end
   end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -363,6 +363,7 @@ class HostsController < ApplicationController
   def toggle_manage
     if @host.toggle! :managed
       if @host.managed
+        @host.suggest_default_pxe_loader
         msg = _("Foreman now manages the build cycle for %s") % (@host.name)
       else
         msg = _("Foreman now no longer manages the build cycle for %s") % (@host.name)

--- a/app/models/concerns/pxe_loader_suggestion.rb
+++ b/app/models/concerns/pxe_loader_suggestion.rb
@@ -1,10 +1,5 @@
 module PxeLoaderSuggestion
   extend ActiveSupport::Concern
-
-  included do
-    after_initialize :suggest_default_pxe_loader
-  end
-
   def suggest_default_pxe_loader
     self.pxe_loader ||= self.try(:operatingsystem).try(:preferred_loader) if self.respond_to?(:pxe_loader)
   end

--- a/test/controllers/api/v1/hostgroups_controller_test.rb
+++ b/test/controllers/api/v1/hostgroups_controller_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
+require 'controllers/shared/pxe_loader_test'
 
 class Api::V1::HostgroupsControllerTest < ActionController::TestCase
-  valid_attrs = { :name => 'TestHostgroup' }
+  include ::PxeLoaderTest
+
+  def basic_attrs
+    {
+      :architecture_id     => Architecture.find_by_name('x86_64').id,
+      :operatingsystem_id  => Operatingsystem.find_by_name('Redhat').id
+    }
+  end
+
+  def valid_attrs
+    { :name => 'TestHostgroup' }
+  end
+
+  def valid_attrs_with_root(extra_attrs = {})
+    { :hostgroup => valid_attrs.merge(extra_attrs) }
+  end
 
   test "should get index" do
     get :index, { }
@@ -58,5 +74,11 @@ class Api::V1::HostgroupsControllerTest < ActionController::TestCase
     put :update, { :id => hostgroups(:db).to_param, :hostgroup => {:parent_id => hostgroups(:common).id} }
     assert_response :success
     assert_equal hostgroups(:common).id.to_s, Hostgroup.find_by_name("db").ancestry
+  end
+
+  private
+
+  def last_record
+    Hostgroup.unscoped.order(:id).last
   end
 end

--- a/test/controllers/api/v1/hosts_controller_test.rb
+++ b/test/controllers/api/v1/hosts_controller_test.rb
@@ -1,18 +1,19 @@
 require 'test_helper'
+require 'controllers/shared/pxe_loader_test'
 
 class Api::V1::HostsControllerTest < ActionController::TestCase
+  include ::PxeLoaderTest
+
   def setup
     @host = FactoryGirl.create(:host)
     @ptable = FactoryGirl.create(:ptable)
     @ptable.operatingsystems = [ Operatingsystem.find_by_name('Redhat') ]
   end
 
-  def valid_attrs
+  def basic_attrs
     { :name                => 'testhost11',
       :environment_id      => environments(:production).id,
       :domain_id           => domains(:mydomain).id,
-      :ip                  => '10.0.0.20',
-      :mac                 => '52:53:00:1e:85:93',
       :ptable_id           => @ptable.id,
       :medium_id           => media(:one).id,
       :architecture_id     => Architecture.find_by_name('x86_64').id,
@@ -23,6 +24,18 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
       :location_id         => taxonomies(:location1).id,
       :organization_id     => taxonomies(:organization1).id
     }
+  end
+
+  def valid_attrs
+    net_attrs = {
+      :ip  => '10.0.0.20',
+      :mac => '52:53:00:1e:85:93'
+    }
+    basic_attrs.merge(net_attrs)
+  end
+
+  def valid_attrs_with_root(extra_attrs = {})
+    { :host => valid_attrs.merge(extra_attrs) }
   end
 
   test "should get index" do
@@ -184,5 +197,11 @@ class Api::V1::HostsControllerTest < ActionController::TestCase
     assert_response :success
     get :show, {:id => host.to_param}
     assert_response :success
+  end
+
+  private
+
+  def last_record
+    Host.unscoped.order(:id).last
   end
 end

--- a/test/models/concerns/pxe_loader_suggestion_test.rb
+++ b/test/models/concerns/pxe_loader_suggestion_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PxeLoaderSuggestionTest < ActiveSupport::TestCase
+  context 'host' do
+    def setup
+      @host = FactoryGirl.create(:host)
+      @os = FactoryGirl.create(:operatingsystem)
+      Operatingsystem.any_instance.stubs(:preferred_loader).returns('PXELinux UEFI')
+    end
+
+    test 'host does not suggest PXEloader when OS is not set' do
+      @host.suggest_default_pxe_loader
+      assert_nil @host.pxe_loader
+    end
+
+    test 'host suggests default PXEloader for OS' do
+      @host.operatingsystem = @os
+      @host.suggest_default_pxe_loader
+      assert_equal 'PXELinux UEFI', @host.pxe_loader
+    end
+  end
+
+  context 'hostgroup' do
+    def setup
+      @hostgroup = FactoryGirl.create(:hostgroup)
+      @os = FactoryGirl.create(:operatingsystem)
+      Operatingsystem.any_instance.stubs(:preferred_loader).returns('PXELinux UEFI')
+    end
+
+    test 'hostgroup does not suggest PXEloader when OS is not set' do
+      @hostgroup.suggest_default_pxe_loader
+      assert_nil @hostgroup.pxe_loader
+    end
+
+    test 'hostgroup suggests default PXEloader for OS' do
+      @hostgroup.operatingsystem = @os
+      @hostgroup.suggest_default_pxe_loader
+      assert_equal 'PXELinux UEFI', @hostgroup.pxe_loader
+    end
+
+    test 'hostgroup suggests default PXEloader for Parent OS' do
+      parent = FactoryGirl.create(:hostgroup, :operatingsystem => @os)
+      @hostgroup.update_attribute(:parent_id, parent.id)
+      @hostgroup.suggest_default_pxe_loader
+      assert_equal 'PXELinux UEFI', @hostgroup.pxe_loader
+    end
+  end
+end


### PR DESCRIPTION
Previously every host instantiation triggered a PXELoader suggestion,
which led to up to 3 extra queries per host loaded. This changes so that
the suggestion is only applied when a host changes it's OS.