### PR TITLE
Fixes #17516 - Update jquery to 2.2.4 to fix XSS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -63,7 +63,7 @@ function onContentLoad(){
   // highlight tabs with errors
   var errorFields = $(".tab-content .has-error");
   errorFields.parents(".tab-pane").each(function() {
-      $("a[href=#"+this.id+"]").addClass("tab-error");
+    $('a[href="#'+this.id+'"]').addClass("tab-error");
   })
   $(".tab-error").first().click();
   $('.nav-pills .tab-error').first().click();

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "events": "^1.1.1",
     "flux": "^2.1.1",
     "ipaddr.js": "~1.2.0",
-    "jquery": "~1.11.0",
+    "jquery": "~2.2.4",
     "jquery-flot": "~0.8.3",
     "jquery-ujs": "~1.2.0",
     "jquery.cookie": "~1.4.1",

--- a/webpack/assets/javascripts/foreman_users.test.js
+++ b/webpack/assets/javascripts/foreman_users.test.js
@@ -39,6 +39,6 @@ describe('initInheritedRoles', () => {
     $('.dropdown-menu li a').last().click();
     expect($('.btn').text()).toContain('First');
     expect($('.list-group li[data-id="1"]').is(':visible')).toBeTruthy();
-    expect($('.list-group li[data-id="2"]').is(':visible')).toBeFalsy();
+    expect($('.list-group li[data-id="2"]').css('display')).toEqual('none');
   });
 });


### PR DESCRIPTION
Affected versions of the package (< 1.12) are vulnerable to Cross-site Scripting (XSS) attacks when a cross-domain ajax request is performed without the dataType option causing text/javascript responses to be executed.

https://github.com/jquery/jquery/issues/2432 for more information