### PR TITLE
Refs #17491 - Revert "polyfill Map for ARMv8 node"

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,9 +1,6 @@
 'use strict';
 
 require( 'es6-promise' ).polyfill(); //needed for compatibility with older node versions
-if (process.arch === 'arm64'){
-  require('es6-map/implement'); // ARMv8 nodejs 4.2.6 implementation is broken somehow
-}
 
 var path = require('path');
 var webpack = require('webpack');

--- a/package.json
+++ b/package.json
@@ -6,20 +6,19 @@
   "private": true,
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-core": "^6.7.2",
+    "babel-core": "~6.7.2",
     "babel-eslint": "^6.1.2",
     "babel-jest": "^15.0.0",
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015": "~6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.9.0",
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",
     "enzyme": "^2.4.1",
-    "es6-map": "^0.1.4",
     "es6-promise": "^3.2.1",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
@@ -64,13 +63,8 @@
     "automock": true,
     "verbose": true,
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "webpack/**/*.js",
-      "!webpack/**/bundle*"
-    ],
-    "coverageReporters": [
-      "lcov"
-    ],
+    "collectCoverageFrom": ["webpack/**/*.js", "!webpack/**/bundle*"],
+    "coverageReporters": ["lcov"],
     "unmockedModulePathPatterns": [
       "react",
       "node_modules/"


### PR DESCRIPTION
This reverts commit f101368449b450b1ede5c822af0852166c45bc4c.

We do use a patched nodejs package on ARMv8 now, as using the polyfill didn't fix it reliably.