### PR TITLE
Fixes #17521 - Use short name for hosts

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -21,7 +21,8 @@ class Setting::General < Setting
       self.set('host_power_status', N_("Show power status on host index page. This feature calls to compute resource providers which may lead to decreased performance on host listing page."), true, N_('Show host power status')),
       self.set('http_proxy', N_('Sets a proxy for all outgoing HTTP connections.'), nil, N_('HTTP(S) proxy')),
       self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied'), [], N_('HTTP(S) proxy except hosts')),
-      self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs'))
+      self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
+      self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
     ]
   end
 

--- a/app/services/name_synchronizer.rb
+++ b/app/services/name_synchronizer.rb
@@ -15,10 +15,16 @@ class NameSynchronizer
   # we have to use write_attribute, since host#name= is delegated to primary interface
   # which triggers the sync
   def sync_name
-    @host.send :write_attribute, :name, @interface.name
+    @host.send :write_attribute, :name, interface_name
   end
 
   def sync_required?
-    @interface.primary? && @host.present? && (@host.name != @interface.name)
+    @interface.primary? && @host.present? && (@host.name != interface_name)
+  end
+
+  private
+
+  def interface_name
+    Setting[:append_domain_name_for_hosts] ? @interface.name : @interface.shortname
   end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -364,3 +364,8 @@ attributes76:
   category: Setting::Provisioning
   default: "['lo', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
+attribute77:
+  name: append_domain_name_for_hosts
+  category: Setting::General
+  default: "true"
+  description: "Should append domain names when new hosts are provisioned"


### PR DESCRIPTION
This commit enforces the policy of using short name for hosts
while preserving the fqdn for interface values provided the user has
enabled 'use_shortname_for_vms' Setting.