### PR TITLE
fixes #17157 - inconsistent mapping of host owner

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
   has_many :auditable_changes, :class_name => '::Audit', :as => :user
   has_many :direct_hosts,      :class_name => 'Host',    :as => :owner
   has_many :usergroup_member,  :dependent => :destroy,   :as => :member
-  has_many :user_roles,        -> { where(:owner_type => 'User') }, :dependent => :destroy, :foreign_key => 'owner_id'
+  has_many :user_roles,        :dependent => :destroy, :as => :owner
   has_many :cached_user_roles, :dependent => :destroy
   has_many :cached_usergroups, :through => :cached_usergroup_members, :source => :usergroup
   has_many :cached_roles,      -> { uniq }, :through => :cached_user_roles, :source => :role
@@ -352,7 +352,7 @@ class User < ActiveRecord::Base
   end
 
   def taxonomy_foreign_conditions
-    { :owner_id => id }
+    { :owner_id => id, :owner_type => 'User' }
   end
 
   def set_current_taxonomies

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -8,7 +8,7 @@ class Usergroup < ActiveRecord::Base
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts), :ensure_last_admin_group_is_not_deleted
 
-  has_many :user_roles, -> { where(:owner_type => 'Usergroup') }, :dependent => :destroy, :foreign_key => 'owner_id'
+  has_many :user_roles, :dependent => :destroy, :as => :owner
   has_many :roles, :through => :user_roles, :dependent => :destroy
 
   has_many :usergroup_members, :dependent => :destroy

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -273,4 +273,14 @@ class TaxonomixTest < ActiveSupport::TestCase
     assert_includes found_admins, direct_admin.id
     assert_includes found_admins, group_admin.id
   end
+
+  test "#used_organization_ids should not return organization for user with same id as of user_group which is assigned to host as owner." do
+    org = FactoryGirl.create(:organization)
+    user = FactoryGirl.create(:user, :id => 25, :organizations => [org])
+    ugroup = FactoryGirl.create(:usergroup, :id=> 25)
+    FactoryGirl.create(:host, :owner => ugroup, :organization => org)
+    used_organizations = user.used_organization_ids
+    assert_empty used_organizations
+    assert_equal used_organizations.count, 0
+  end
 end


### PR DESCRIPTION
There is user_group which is assigned to one host as owner
with id=x. For organization assigned to user with same id=x,
on edit page showing a grey color with message
"this is used by a host".
With this commit, it should not show message to organization
assigned to user with same id as of user_groups.

Also, refactored the association code for
(User, Usergroup) -> UserRoles.