### PR TITLE
Fixes #5483,#11106 - pass the virtualswitch value to fog

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -79,6 +79,16 @@ module ComputeResourcesVmsHelper
     compute.datastores.map { |datastore| [datastore_stats(datastore), datastore.name] }
   end
 
+  def vsphere_networks(compute_resource)
+    networks = compute_resource.networks
+    networks.map do |net|
+      net_id = net.id
+      net_name = net.name
+      net_name += " (#{net.virtualswitch})" if net.virtualswitch
+      [net_id, net_name]
+    end
+  end
+
   def datastore_stats(datastore)
     return datastore.name unless datastore.freespace && datastore.capacity
     "#{datastore.name} (#{_('free')}: #{number_to_human_size(datastore.freespace)}, #{_('prov')}: #{number_to_human_size(datastore.capacity + (datastore.uncommitted || 0) - datastore.freespace)}, #{_('total')}: #{number_to_human_size(datastore.capacity)})"

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -343,9 +343,10 @@ module Foreman::Model
       dc_networks = networks
       args["interfaces_attributes"].each do |key, interface|
         # Convert network id into name
-        net = dc_networks.find { |n| [n.id, n.name].include?(interface["network"]) }
+        net = dc_networks.detect { |n| [n.id, n.name].include?(interface["network"]) }
         raise "Unknown Network ID: #{interface['network']}" if net.nil?
         interface["network"] = net.name
+        interface["virtualswitch"] = net.virtualswitch
       end if args["interfaces_attributes"]
       args
     end

--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -37,12 +37,16 @@ module FogExtensions
 
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
-        selected_nic = fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
-        unless selected_nic
-          vm_network = service.get_network(nic_attrs['network'], datacenter)
-          if vm_network && vm_network.key?(:id)
-            selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:id] } # try and match on portgroup
-          end
+        all_networks = service.raw_networks(datacenter)
+        vm_network = all_networks.find { |network| network._ref == nic_attrs['network'] }
+        vm_network ||= all_networks.find { |network| network.name == nic_attrs['network'] }
+        unless vm_network
+          Rails.logger.info "Could not find Vsphere network for #{nic_attrs.inspect}"
+          return
+        end
+        selected_nic = fog_nics.detect { |fn| fn.network == vm_network.name } # grab any nic on the same network
+        if selected_nic.nil? && vm_network.respond_to?(:key)
+          selected_nic = fog_nics.detect { |fn| fn.network == vm_network.key } # try to match on portgroup
         end
         selected_nic
       end

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -3,7 +3,7 @@
   :label => _('NIC type'), :label_size => "col-md-3"
 %>
 <% if new_host %>
-  <%= select_f f, :network, compute_resource.networks, :name, :name, { },
+  <%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
     :class => "col-md-3 vmware_network",
     :label => _('Network'), :label_size => "col-md-3"
   %>

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -157,6 +157,7 @@ class VmwareTest < ActiveSupport::TestCase
       @mock_network = mock('network')
       @mock_network.stubs('id').returns('network-17')
       @mock_network.stubs('name').returns('Test network')
+      @mock_network.stubs('virtualswitch').returns(nil)
       @cr = FactoryGirl.build(:vmware_cr)
       @cr.stubs(:networks).returns([@mock_network])
     end
@@ -167,12 +168,12 @@ class VmwareTest < ActiveSupport::TestCase
 
     test "converts form network ID to network name" do
       attrs_in = HashWithIndifferentAccess.new("interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"network-17", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"network-17", "_delete"=>""}})
-      attrs_out = HashWithIndifferentAccess.new("interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"Test network", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"Test network", "_delete"=>""}})
+      attrs_out = HashWithIndifferentAccess.new("interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"Test network", "virtualswitch" => nil, "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"Test network", "virtualswitch" => nil, "_delete"=>""}})
       assert_equal attrs_out, @cr.parse_networks(attrs_in)
     end
 
     test "ignores existing network names" do
-      attrs = HashWithIndifferentAccess.new("interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"Test network", "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"Test network", "_delete"=>""}})
+      attrs = HashWithIndifferentAccess.new("interfaces_attributes"=>{"new_interfaces"=>{"type"=>"VirtualE1000", "network"=>"Test network", "virtualswitch" => nil, "_delete"=>""}, "0"=>{"type"=>"VirtualVmxnet3", "network"=>"Test network", "virtualswitch" => nil, "_delete"=>""}})
       assert_equal attrs, @cr.parse_networks(attrs)
     end
 


### PR DESCRIPTION
We can't pass the network id directly to the fog, but it accepts the
virtualswitch parameter, that we can use to point to the right value.

Also, it fixes another issue, where we used the vsphere network id to
match against the interface network value, in case of portgroup, but a
`key` value should be used instead, as the key and id might differ in
some situations.