### PR TITLE
Refs #15779 - move the foreman-tasks to own bundle group

### DIFF
--- a/bundler.d/foreman_tasks.rb
+++ b/bundler.d/foreman_tasks.rb
@@ -1,1 +1,3 @@
-gem 'foreman-tasks', '>= 0.8.5'
+group :foreman_tasks do
+  gem 'foreman-tasks', '>= 0.8.5'
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,11 @@ else
         end
       end
     end
+    begin
+      Bundler.require(:foreman_tasks)
+    rescue LoadError => e
+      warn "Could not load foreman tasks, async processing will not be available: #{e.message}"
+    end
   end
 end
 


### PR DESCRIPTION
This makes it easier to achieve a minimal setup, that might be needed for
things like plugins building etc.

See discussion in https://github.com/theforeman/foreman-packaging/pull/1436