### PR TITLE
Fixes #6006 - Add options to disable updates from facts

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -463,7 +463,15 @@ class Host::Managed < Host::Base
   end
 
   def attributes_to_import_from_facts
-    super + [:domain, :architecture, :operatingsystem]
+    attrs = [:architecture]
+    if !Setting[:ignore_facts_for_operatingsystem] || (Setting[:ignore_facts_for_operatingsystem] && !operatingsystem.present?)
+      attrs << :operatingsystem
+    end
+    if !Setting[:ignore_facts_for_domain] || (Setting[:ignore_facts_for_domain] && !domain.present?)
+      attrs << :domain
+    end
+
+    super + attrs
   end
 
   def populate_fields_from_facts(facts = self.facts_hash, type = 'puppet')

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -16,6 +16,8 @@ class Setting::Provisioning < Setting
         self.set('manage_puppetca', N_("Foreman will automate certificate signing upon provision of new host"), true, N_('Manage PuppetCA')),
         self.set('ignore_puppet_facts_for_provisioning', N_("Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"), false, N_('Ignore Puppet facts for provisioning')),
         self.set('ignored_interface_identifiers', N_("Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*"), ['lo', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*'], N_('Ignore interfaces with matching identifier')),
+        self.set('ignore_facts_for_operatingsystem', N_("Stop updating Operating System from facts"), false, N_('Ignore facts for operating system')),
+        self.set('ignore_facts_for_domain', N_("Stop updating domain values from facts"), false, N_('Ignore facts for domain')),
         self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),
         self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1", N_('Remote address')),
         self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6, N_('Token duration')),

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -333,3 +333,13 @@ attributes69:
   category: Setting::Email
   default: 'args'
   description: 'Specify additional options to sendmail'
+attribute70:
+  name: ignore_facts_for_operatingsystem
+  category: Setting::Provisioning
+  default: "false"
+  description: 'Stop updating Operating System from facts'
+attribute71:
+  name: ignore_facts_for_domain
+  category: Setting::Provisioning
+  default: "false"
+  description: 'Stop updating domain from facts'

--- a/test/static_fixtures/facts/facts_with_certname.json
+++ b/test/static_fixtures/facts/facts_with_certname.json
@@ -86,6 +86,9 @@
     "vlans": "181,182,183",
     "lsbmajdistrelease": "6",
     "swapfree": "16.72 GB",
-    "netmask": "255.255.255.192"
+    "netmask": "255.255.255.192",
+    "fqdn": "sinn1636.lan.cert",
+    "hostname": "sinn1636",
+    "domain": "lan.cert"
   }
 }


### PR DESCRIPTION
Add option ignore_puppet_facts_for_operatingsystem - do not update system's operating system based on facts
Add option ignore_puppet_facts_for_domain - do not update system's domain based on facts