### PR TITLE
Fixes #17570 - Only execute `onContentLoad` once per page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,8 +21,6 @@
 //= require editable/bootstrap-editable
 //= require editable/rails
 
-$(document).on('ContentLoad', onContentLoad);
-
 $(document).on("page:fetch", tfm.tools.showSpinner)
 
 $(document).on("page:change", tfm.tools.hideSpinner)

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -142,5 +142,5 @@ function show_widget(id){
 
 function widgetLoaded(widget){
     refreshCharts();
-    tfm.tools.activateTooltips($(widget));
+    tfm.tools.activateTooltips(widget);
 }

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -56,7 +56,7 @@
         <%= spinner(_('Loading VM information ...')) %>
         </div>
       <% end %>
-      <div id="nics" class="tab-pane" data-ajax-url='<%= nics_host_path(@host)%>' data-on-complete='onContentLoad'>
+      <div id="nics" class="tab-pane" data-ajax-url='<%= nics_host_path(@host)%>' data-on-complete='tfm.tools.activateTooltips'>
         <%= spinner(_('Loading NICs information ...')) %>
       </div>
       <% if @host.bmc_available? %>

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -44,7 +44,7 @@ describe('activateTooltips', () => {
       <div title='test' rel='popover'></div>`;
 
     $.fn.tooltip = jest.fn();
-    tools.activateTooltips($(elements));
+    tools.activateTooltips(elements);
     expect($.fn.tooltip).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
When an event is triggered, jQuery attempts to execute the on<name>
method if it exists for event <name>. We were also manually triggering
the `onContentLoad` every time the `ContentLoad` event was triggered,
leading to the function executing twice on every page.
This commit removes the explicit event listener so that the function
will only execute once.