### PR TITLE
Fixes #17571 - Refactor tfm.tools to use ES6 syntax

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -76,7 +76,7 @@
                               { :label => _('Roles')}, {:disabled => @editing_self ? Role.givable.for_current_user.pluck(:id) : false } %>
       <% usergroups = @user.cached_usergroups.includes(:roles).uniq %>
       <% if usergroups.any? %>
-        <div class="form-group">
+        <div class="form-group" id="inherited-roles">
           <label class="col-md-2 control-label" for="roles"><%= _("Roles from user groups") %></label>
           <div class="col-md-5">
             <div class="dropdown">
@@ -86,7 +86,7 @@
               </button>
               <ul class="dropdown-menu" role="menu" aria-labelledby="usergroupsDropdownMenuBtn">
                 <% usergroups.each do |usergroup| %>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" onclick=tfm.tools.userInheritedRolesUpdater(<%=usergroup.id %>)><%= usergroup %></a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" data-id="<%=usergroup.id %>"><%= usergroup %></a></li>
                 <% end %>
               </ul>
             </div>
@@ -115,7 +115,7 @@
 <% if @user.cached_usergroups.any? %>
   <script>
       $(function() {
-        tfm.tools.userInheritedRolesUpdater(<%= @user.cached_usergroups.uniq.first.id %>)
+        tfm.users.initInheritedRoles();
       });
   </script>
 <% end  %>

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -14,6 +14,7 @@ window.tfm = Object.assign(
   window.tfm || {},
   {
     tools: require('./foreman_tools'),
+    users: require('./foreman_users'),
     numFields: require('./jquery.ui.custom_spinners'),
     reactMounter: require('./react_app/common/MountingService')
   }

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -9,10 +9,10 @@ export function hideSpinner() {
 }
 
 export function iconText(name, innerText, iconClass) {
-  let icon = '<span class="' + iconClass + ' ' + iconClass + '-' + name + '"/>';
+  let icon = `<span class="${iconClass} ${iconClass}-${name}"/>`;
 
   if (innerText !== '') {
-    icon += '<strong>' + innerText + '</strong>';
+    icon += `<strong>${innerText}</strong>`;
   }
   return icon;
 }
@@ -22,11 +22,10 @@ export function activateDatatables() {
       dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>>"
   });
 
-  $('[data-table=server]').not('.dataTable').each(function () {
-    const $this = $(this);
-    const url = $this.data('source');
+  $('[data-table=server]').not('.dataTable').each((i, el) => {
+    const url = el.getAttribute('data-source');
 
-    $this.DataTable({
+    $(el).DataTable({
       processing: true,
       serverSide: true,
       ordering: false,
@@ -36,17 +35,10 @@ export function activateDatatables() {
   });
 }
 
-export function userInheritedRolesUpdater(id) {
-  $('#roles_tab li').hide();
-  $("#roles_tab li[data-id = '" + id + "']").show();
-  $('.dropdown-menu li a').click(function () {
-    $(this).parents('.dropdown').find('.btn').html($(this).text() + ' <span class="caret"></span>');
-  });
-}
-
-export function activateTooltips(el = $('body')) {
+export function activateTooltips(el = 'body') {
+  el = $(el);
   el.find('[rel="twipsy"]').tooltip({ container: 'body' });
-  el.find('.ellipsis').tooltip({ container: 'body', title: () => {
+  el.find('.ellipsis').tooltip({ container: 'body', title: function () {
                                    return (this.scrollWidth > this.clientWidth ?
                                            this.textContent : null);
                                    }

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -19,9 +19,9 @@ describe('activateDatatables', () => {
 
     // Used for rendering lists of VMs under compute resources
     document.body.innerHTML =
-      '<div data-table=server data-source=http://example.foo>' +
-      'To be filled by a table' +
-        '</div>';
+      `<div data-table=server data-source=http://example.foo>
+      To be filled by a table
+      </div>`;
     $.fn.DataTable = jest.fn();
     tools.activateDatatables();
     expect($.fn.DataTable).toBeCalledWith({
@@ -37,12 +37,11 @@ describe('activateDatatables', () => {
 describe('activateTooltips', () => {
   it('calls $.fn.tooltip on all matching elements', () => {
     const $ = require('jquery');
-    const elements = `
-    <div rel='twipsy'></div>
-    <div class='ellipsis'></div>
-    <div title='test'></div>
-    <div title='test' rel='popover'></div>
-    `;
+    const elements =
+      `<div rel='twipsy'></div>
+      <div class='ellipsis'></div>
+      <div title='test'></div>
+      <div title='test' rel='popover'></div>`;
 
     $.fn.tooltip = jest.fn();
     tools.activateTooltips($(elements));

--- a/webpack/assets/javascripts/foreman_users.js
+++ b/webpack/assets/javascripts/foreman_users.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+
+export function initInheritedRoles() {
+  $('#inherited-roles .dropdown-menu a').click(({target}) => {
+    $('#roles_tab li').hide();
+    $(`#roles_tab li[data-id = '${target.getAttribute('data-id')}']`).show();
+    $(target).closest('.dropdown')
+             .children('.btn')
+             .html(`${_.escape(target.text)} <span class="caret"></span>`);
+  }).first().click();
+}

--- a/webpack/assets/javascripts/foreman_users.test.js
+++ b/webpack/assets/javascripts/foreman_users.test.js
@@ -1,0 +1,44 @@
+jest.unmock('./foreman_users');
+const users = require('./foreman_users');
+
+describe('initInheritedRoles', () => {
+  it('updates the button text and role list on click', () => {
+    const $ = require('jquery');
+
+    window._ = require('lodash');
+    document.body.innerHTML =
+      `<div id="inherited-roles">
+        <div class="dropdown">
+          <button class="btn btn-default dropdown-toggle" type="button"
+                  id="usergroupsDropdownMenuBtn" data-toggle="dropdown">
+            Second <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu"
+              aria-labelledby="usergroupsDropdownMenuBtn">
+            <li role="presentation">
+              <a role="menuitem" tabindex="-1"
+                 data-id='2'">Second</a>
+            </li>
+            <li role="presentation">
+              <a role="menuitem" tabindex="-1"
+                 data-id='1'">First</a>
+            </li>
+          </ul>
+        </div>
+        <ul class="list-group" id="roles_tab">
+          <li data-id="2" class="list-group-item">
+            Manager
+          </li>
+          <li data-id="1" class="list-group-item hidden" style="display: none;">
+            Viewer
+          </li>
+        </ul>
+      </div>`;
+
+    users.initInheritedRoles();
+    $('.dropdown-menu li a').last().click();
+    expect($('.btn').text()).toContain('First');
+    expect($('.list-group li[data-id="1"]').is(':visible')).toBeTruthy();
+    expect($('.list-group li[data-id="2"]').is(':visible')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This also extracts the inherited user roles function to a sepereate
module, adds tests and refactors it. These changes also fix two other
issues:
1. a possible stored XSS in usergroup names
2. tooltips on tables were broken (due to => syntax not changing `this`)