### PR TITLE
fixes #3158 - Remove rescues from try calls in helper file

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -30,9 +30,7 @@ module ComputeResourcesVmsHelper
         value = @vm.send(method) rescue nil
         case value
         when Array
-          #TODO in 4.0 #try will return nil if the method doesn't exist (instead of raising NoMethodError)
-          # we can drop rescues then.
-          value.map{|v| (v.try(:name) rescue nil) || (v.try(:to_s) rescue nil) || v}.to_sentence
+          value.map{|v| v.try(:name) || v.try(:to_s) || v}.to_sentence
         when Fog::Time, Time
           _("%s ago") % time_ago_in_words(value)
         when nil


### PR DESCRIPTION
In app/helpers/compute_resources_vms_helper.rb, we added rescues to
try calls as the method may not exist with older version of rails.
Now, we have updated rails to 4.x.
In this commit removed rescue block as Rails 4.0's try method
will return nil instead of throwing an error,