### PR TITLE
Fixes #17599 - Smart vars allow you to select 'none' class

### DIFF
--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -24,7 +24,7 @@ module LookupKeysHelper
       text_f(f, :puppetclass_id, :label => _('Puppet Class'), :value => f.object.param_class, :disabled => true)
     else # new smart-var with no particular context
          # Give a select for choosing the parent puppetclass
-      select_f(f, :puppetclass_id, Puppetclass.all, :id, :to_label, { :include_blank => _('None') }, {:label => _("Puppet class")})
+      select_f(f, :puppetclass_id, Puppetclass.all, :id, :to_label, {}, {:label => _("Puppet class")})
     end unless @puppetclass # nested smart-vars form in a tab of puppetclass/_form: no edition allowed, and the puppetclass is already visible as a context
   end
 


### PR DESCRIPTION
When you edit a smart variable, it allows in the form to 'not' associate
it with any Puppet class. This doesn't show any error on the UI, however
it's not associated and you will see "Failed to save: Puppetclass can't
be blank" on the logs.

Additionally some strings were not translated at all so I took the
chance to add support for that.