### PR TITLE
Fixes #10539 - Add compute resources to subnets

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -669,6 +669,7 @@ function interface_subnet_selected(element, ip_field) {
   if (subnet_id == '') return;
   var interface_ip = $(element).closest('fieldset').find('input[id$=_' + ip_field + ']');
 
+  update_compute_resource_subnet(element);
   toggle_suggest_new_link(element, ip_field);
 
   interface_ip.attr('disabled', true);
@@ -731,6 +732,50 @@ function interface_subnet_selected(element, ip_field) {
     complete: function () {
       tfm.tools.hideSpinner();
       interface_ip.attr('disabled', false);
+    }
+  });
+}
+
+function update_compute_resource_subnet(element) {
+  var compute_resource = $('#host_compute_resource_id :selected').val();
+  var select = $(element).closest('fieldset#interface').find('select[id$=_compute_attributes_network]');
+  var subnet = $(element).val();
+  var url = $(select).attr('data-url');
+  if (subnet == '' || compute_resource == '' || !url) return;
+  tfm.tools.showSpinner();
+  select.attr('disabled', true);
+  var cluster = $('#host_compute_attributes_cluster :selected').val();
+
+  // mark the selected value to preserve it for form hiding
+  preserve_selected_options($(select));
+
+  var org = $('#host_organization_id :selected').val();
+  var loc = $('#host_location_id :selected').val();
+
+  var data = {
+    subnet_id: subnet,
+    organization_id: org,
+    location_id: loc,
+    compute_resource_id: compute_resource,
+    cluster_id: cluster
+  }
+  $.ajax({
+    data: data,
+    type: 'post',
+    url: url,
+    dataType: 'json',
+    success: function (result) {
+      select.empty();
+      $.each(result, function () {
+        opt = select.append($("<option />").val(this.id).text(this.name));
+        if (this.vlanid) {
+          opt.prop('selected', true);
+        }
+      });
+    },
+    complete: function () {
+      reloadOnAjaxComplete(select);
+      select.attr('disabled', false);
     }
   });
 }

--- a/app/controllers/concerns/foreman/controller/parameters/subnet.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/subnet.rb
@@ -22,6 +22,7 @@ module Foreman::Controller::Parameters::Subnet
           :type,
           :vlanid,
           :domain_ids => [], :domain_names => [],
+          :compute_resource_ids => [],
           :subnet_parameters_attributes => [parameter_params_filter(::SubnetParameter)]
         add_taxonomix_params_filter(filter)
         add_smart_proxies_common_params_filter(filter)

--- a/app/helpers/hosts_nic_helper.rb
+++ b/app/helpers/hosts_nic_helper.rb
@@ -7,16 +7,20 @@ module HostsNicHelper
   end
 
   def nic_subnet_field(f, attr, klass, html_options = {})
+    subnets = accessible_resource(f.object, klass)
+    if @host.compute_resource
+      subnets.select!{|subnet| @host.compute_resource.subnets.include?(subnet)}
+    end
     html_options.merge!(
-      { :disabled => accessible_resource(f.object, klass).empty? ? true : false,
+      { :disabled => subnets.empty? ? true : false,
         :help_inline => :indicator,
         :'data-url' => freeip_subnets_path,
         :size => "col-md-8", :label_size => "col-md-3" }
     )
-    if accessible_resource(f.object, klass).any?
+    if subnets.any?
       array = options_for_select(
         [[]] +
-        accessible_resource(f.object, klass).map{ |subnet| [subnet.to_label, subnet.id, {'data-suggest_new' => subnet.unused_ip.suggest_new?}]}, f.object.public_send(attr)
+        subnets.map{ |subnet| [subnet.to_label, subnet.id, {'data-suggest_new' => subnet.unused_ip.suggest_new?}]}, f.object.public_send(attr)
       )
     else
       array = [[_("No subnets"), '']]

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -25,6 +25,8 @@ class ComputeResource < ActiveRecord::Base
   before_validation :set_attributes_hash
   has_many :compute_attributes, :dependent => :destroy
   has_many :compute_profiles, :through => :compute_attributes
+  has_many :subnet_compute_resources, :dependent => :destroy
+  has_many :subnets, :through => :subnet_compute_resources
 
   # The DB may contain compute resource from disabled plugins - filter them out here
   scope :live_descendants, -> { where(:type => self.descendants.map(&:to_s)) unless Rails.env.development? }
@@ -273,6 +275,11 @@ class ComputeResource < ActiveRecord::Base
 
   def available_storage_pods(storage_pod = nil)
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
+  # this method is overwritten for OVirt
+  def networks_from_subnet(subnet, opts = {})
+    networks
   end
 
   # this method is overwritten for Libvirt and OVirt

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -60,11 +60,14 @@ class Subnet < ActiveRecord::Base
   has_many :hostgroups
   has_many :subnet_domains, :dependent => :destroy, :inverse_of => :subnet
   has_many :domains, :through => :subnet_domains
+  has_many :subnet_compute_resources, :dependent => :destroy, :inverse_of => :subnet
+  has_many :compute_resources, :through => :subnet_compute_resources
   has_many :subnet_parameters, :dependent => :destroy, :foreign_key => :reference_id, :inverse_of => :subnet
   has_many :parameters, :dependent => :destroy, :foreign_key => :reference_id, :class_name => "SubnetParameter"
   accepts_nested_attributes_for :subnet_parameters, :allow_destroy => true
   validates :network, :mask, :name, :cidr, :presence => true
   validates_associated :subnet_domains
+  validates_associated :subnet_compute_resources
   validates :boot_mode, :inclusion => BOOT_MODES.values
   validates :ipam, :inclusion => {:in => Proc.new { |subnet| subnet.supported_ipam_modes.map {|m| IPAM::MODES[m]} }, :message => N_('not supported by this protocol')}
   validates :type, :inclusion => {:in => Proc.new { Subnet::SUBNET_TYPES.keys.map(&:to_s) }, :message => N_("must be one of [ %s ]" % Subnet::SUBNET_TYPES.keys.map(&:to_s).join(', ')) }

--- a/app/models/subnet_compute_resource.rb
+++ b/app/models/subnet_compute_resource.rb
@@ -1,0 +1,11 @@
+class SubnetComputeResource < ActiveRecord::Base
+  belongs_to :subnet
+  belongs_to :compute_resource
+
+  validates :subnet, :presence => true
+  validates :compute_resource, :presence => true
+
+  def to_s
+    "#{compute_resource} : #{subnet}"
+  end
+end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -318,7 +318,7 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :hosts do |map|
-    ajax_actions = [:architecture_selected, :compute_resource_selected, :domain_selected, :environment_selected,
+    ajax_actions = [:architecture_selected, :compute_resource_selected, :domain_selected, :subnet_selected, :environment_selected,
                     :hostgroup_or_environment_selected, :medium_selected, :os_selected, :use_image_selected, :process_hostgroup,
                     :process_taxonomy, :current_parameters, :puppetclass_parameters, :template_used, :interfaces, :scheduler_hint_selected,
                     :random_name]

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -2,4 +2,5 @@
 <% selected_cluster ||= compute_resource.clusters.first.id %>
 <%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
              { }, :disabled => !new_host, :class => "ovirt_network",
-             :label         => _('Network'), :label_size => "col-md-3" %>
+             :label         => _('Network'), :label_size => "col-md-3",
+             :'data-url'    => subnet_selected_hosts_path %>

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -4,6 +4,7 @@
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("Subnet") %></a></li>
     <li><a href="#domains" data-toggle="tab"><%= _("Domains") %></a></li>
+    <li><a href="#compute_resources" data-toggle="tab"><%= _("Compute resources") %></a></li>
     <li><a href="#proxies" data-toggle="tab"><%= _("Proxies") %></a></li>
     <% if authorized_for(:controller => "host_editing", :action => "view_params") %>
       <li><a href="#params" data-toggle="tab"><%= _("Parameters") %></a></li>
@@ -23,6 +24,9 @@
     </div>
     <div class="tab-pane" id="domains">
       <%= multiple_checkboxes f, :domains, f.object, Domain, {:help_inline => _("Domains in which this subnet is part"), :size => 'col-md-6', :prefix => f.object_name}, { :label => _("Domain")} %>
+    </div>
+    <div class="tab-pane" id="compute_resources">
+      <%= multiple_checkboxes f, :compute_resources, f.object, ComputeResource, {:help_inline => _("Compute resources in which this subnet is available"), :size => 'col-md-6', :prefix => f.object_name}, { :label => _("Compute resource")} %>
     </div>
     <div class="tab-pane" id="proxies">
       <%= smart_proxy_fields f %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Foreman::Application.routes.draw do
         post 'architecture_selected'
         post 'os_selected'
         post 'domain_selected'
+        post 'subnet_selected'
         post 'use_image_selected'
         post 'compute_resource_selected'
         post 'scheduler_hint_selected'

--- a/db/migrate/20161124170211_create_subnet_compute_ressources.rb
+++ b/db/migrate/20161124170211_create_subnet_compute_ressources.rb
@@ -1,0 +1,14 @@
+class CreateSubnetComputeRessources < ActiveRecord::Migration
+  def up
+    create_table :subnet_compute_resources do |t|
+      t.references :compute_resource
+      t.references :subnet
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :subnet_compute_resources
+  end
+end

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -54,6 +54,16 @@ FactoryGirl.define do
       after(:build) { |cr| cr.stubs(:update_public_key) }
     end
 
+    trait :with_subnets do
+      transient do
+        subnets_count 2
+      end
+
+      after(:create) do |compute_resource, evaluator|
+        FactoryGirl.create_list(:subnet, evaluator.subnets_count, :compute_resources => [compute_resource])
+      end
+    end
+
     factory :ec2_cr, :class => Foreman::Model::EC2, :traits => [:ec2]
     factory :gce_cr, :class => Foreman::Model::GCE, :traits => [:gce]
     factory :libvirt_cr, :class => Foreman::Model::Libvirt, :traits => [:libvirt]

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -19,6 +19,16 @@ FactoryGirl.define do
       association :dns, :factory => :dns_smart_proxy
     end
 
+    trait :with_compute_resources do
+      transient do
+        cr_count 2
+      end
+
+      after(:create) do |subnet, evaluator|
+        FactoryGirl.create_list(:compute_resource, evaluator.cr_count, :subnets => [subnet])
+      end
+    end
+
     trait :with_domains do
       transient do
         domains_count 2


### PR DESCRIPTION
 Depends on [1]. No change needed on fog.

* Add association between foreman subnets and compute resource
  * Add migration for SubnetComputeResource
  * Now in the subnet form, a new tab to select compute resources was added (like it was for DNS domains)
* On host nic's form, select only subnets associated to the selected compute resource
* On host nic's form, when you select a subnet for the current nic:
  * For oVirt CR, the 'network' select have only untagged networks or tagged networks with the same VLAN ID of the selected subnet. Preselect the last CR network with the same VLAN ID as selected subnet if any.
  * For other CR types, 'network' select didn't change and return all CR networks without automatic pre-selection.

Tested with oVirt 4.0.5 with APIv3 and [1] applied to rbovirt. Any advises to add automated test for this PR are welcome.

[1] https://github.com/abenari/rbovirt/pull/116