### PR TITLE
Fixes #17627 - remove tooltips after clicking back

### DIFF
--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -44,4 +44,5 @@ export function activateTooltips(el = 'body') {
                                    }
                               });
   el.find('*[title]').not('*[rel]').tooltip({ container: 'body' });
+  $(document).on('page:restore', () => {$('.tooltip.in').remove();});
 }


### PR DESCRIPTION
Turbolinks will keep the page cached as it is when a link with a tooltip
is clicked, so that clicking back will show the page with the tooltip
still active. This will make sure any tooltips are hidden when a page is
loaded from turbolinks' cache.