### PR TITLE
fixes #17630 - show tooltips after deselecting selected item

### DIFF
--- a/app/assets/javascripts/jquery.multi-select.js
+++ b/app/assets/javascripts/jquery.multi-select.js
@@ -11,6 +11,7 @@ function multiSelectOnLoad(){
         var current_select = $(item).closest('.tab-pane').find('select[multiple]');
         current_select.data('descendants', null);
         $(current_select).multiSelect('refresh');
+        multiSelectToolTips();
       }
     })
   });


### PR DESCRIPTION
For example, on Organization tab under edit user page
if user have already organization which is associated
with host then it will show tooltip - "This is used by host".
When you will select any other Organization and de-select it
again, on de-selection of item all existing tooltips
are disappeared.