### PR TITLE
Fixes #17632 - Reports widget will not fail on ambiguous filter

### DIFF
--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -20,11 +20,12 @@ class Dashboard::Data
   end
 
   def latest_events
+    con = ActiveRecord::Base.connection
     #workaround to get the inner query working
-    ids = hosts.to_sql.sub(/SELECT.*FROM/, "SELECT #{Host.connection.quote_table_name('hosts')}.#{Host.connection.quote_column_name('id')} FROM")
+    ids = hosts.to_sql.sub(/SELECT.*FROM/, "SELECT #{Host.quoted_table_name}.#{con.quote_column_name('id')} FROM")
     # 9 reports + header fits the events box nicely...
     @latest_events ||= ConfigReport.authorized(:view_config_reports).my_reports.interesting
-                                   .where("host_id in (#{ids})")
+                                   .where("#{ConfigReport.quoted_table_name}.#{con.quote_column_name('host_id')} IN (#{ids})")
                                    .search_for('reported > "7 days ago"')
                                    .limit(9).includes(:host)
   end

--- a/test/unit/dashboard_test.rb
+++ b/test/unit/dashboard_test.rb
@@ -82,5 +82,14 @@ class DashboardTest < ActiveSupport::TestCase
         assert_equal 0, data.latest_events.length
       end
     end
+
+    test 'latest_events does not fail on ambiguous column name host_id' do
+      data = Dashboard::Data.new
+      #instead of going through the authorizer, force a join that will cause ambiguity.
+      ConfigReport.expects(:authorized).with(:view_config_reports).returns(ConfigReport.joins(:host => :interfaces))
+      as_admin do
+        assert_equal 1, data.latest_events.length
+      end
+    end
   end
 end


### PR DESCRIPTION
A user with a filter on a joined table that has a host_id column (such
as nics for example) will cause the report widget to break due to an
ambiguous column name. This fix makes sure the columns use the table
name and are correctly quoted.