### PR TITLE
Fixes #17636 - token no longer needed for proxied preview

### DIFF
--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -35,9 +35,9 @@ module HostTemplateHelpers
 
     # use template_url from the request if set, but otherwise look for a Template
     # feature proxy, as PXE templates are written without an incoming request.
-    url = if @template_url && @host.try(:token).present?
+    url = if @template_url
             @template_url
-          elsif proxy.present? && proxy.has_feature?('Templates') && @host.try(:token).present?
+          elsif proxy.present? && proxy.has_feature?('Templates')
             temp_url = ProxyAPI::Template.new(:url => proxy.url).template_url
             if temp_url.nil?
               logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")


### PR DESCRIPTION
I removed this in renderer method, but we do have this twice in our codebase.

https://github.com/theforeman/foreman/pull/3404

I am aware this needs to be refactored, we are tracking this as a separate
ticket:

http://projects.theforeman.org/issues/8290