### PR TITLE
Fixes #17641 - Use force when destroying VMs

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -385,6 +385,13 @@ module Foreman::Model
       client.servers.new opts
     end
 
+    def destroy_vm(uuid)
+      find_vm_by_uuid(uuid).destroy :force => true
+    rescue ActiveRecord::RecordNotFound
+      # if the VM does not exists, we don't really care.
+      true
+    end
+
     # === Power on
     #
     # Foreman will try and start this vm after clone in a seperate request.


### PR DESCRIPTION
There's no point in waiting several seconds for any guest utils to shut
down the VM when we want to get rid of it as quickly as possible.  This
also works around cases like

  2016-12-12T10:33:22 [app] [W] Failed to destroy a compute foo (VMware) instance bar.example.com: ToolsUnavailable: Der Vorgang kann nicht abgeschlossen werden, weil VMware Tools auf dieser virtuellen Maschine nicht ausgeführt wird.
   | RbVmomi::Fault: ToolsUnavailable: Der Vorgang kann nicht abgeschlossen werden, weil VMware Tools auf dieser virtuellen Maschine
  nicht ausgeführt wird.
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/rbvmomi-1.8.2/lib/rbvmomi/connection.rb:61:in `parse_response'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/rbvmomi-1.8.2/lib/rbvmomi/connection.rb:90:in `call'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/rbvmomi-1.8.2/lib/rbvmomi/basic_types.rb:205:in `_call'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/rbvmomi-1.8.2/lib/rbvmomi/basic_types.rb:74:in `block (2 levels) in init'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/fog-1.34.0/lib/fog/vsphere/requests/compute/vm_power_off.rb:17:in `vm_power_off'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/fog-1.34.0/lib/fog/vsphere/models/compute/server.rb:94:in `stop'
   | /usr/share/foreman/vendor/ruby/2.1.0/gems/fog-1.34.0/lib/fog/vsphere/models/compute/server.rb:107:in `destroy'
   | /usr/share/foreman/app/models/compute_resource.rb:155:in `destroy_vm'
   | /usr/share/foreman/app/models/concerns/orchestration/compute.rb:164:in `delCompute'
   | /usr/share/foreman/app/models/concerns/orchestration.rb:168:in `execute'

where VMWare misdetecs the Openvm tools status.