### PR TITLE
refs #17485 - use IP within host's primary subnet

### DIFF
--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -33,6 +33,11 @@ FactoryGirl.define do
       ipam "Internal DB"
     end
 
+    trait :with_taxonomies do
+      locations { [FactoryGirl.create(:location)] }
+      organizations { [FactoryGirl.create(:organization)] }
+    end
+
     factory :subnet_ipv4, :class => Subnet::Ipv4 do
       network { 3.times.map { rand(256) }.join('.') + '.0' }
       mask { '255.255.255.0' }

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -128,7 +128,7 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
 
   context 'host with bond interface' do
     let(:subnet) do
-      FactoryGirl.build(:subnet_ipv4, :tftp)
+      FactoryGirl.build(:subnet_ipv4, :tftp, :with_taxonomies)
     end
     let(:interfaces) do
       [
@@ -153,8 +153,11 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     let(:host) do
       FactoryGirl.create(:host,
                          :with_tftp_orchestration,
+                         :subnet => subnet,
                          :interfaces => interfaces,
-                         :build => true)
+                         :build => true,
+                         :location => subnet.locations.first,
+                         :organization => subnet.organizations.first)
     end
 
     test '#setTFTP should provision tftp for all bond child macs' do


### PR DESCRIPTION
The host factory with the given trait overrides the primary interface's
subnet, so pass in the subnet being used to prevent the override.

---

Fixes test failure from edadebee981e41bbcd75bda75e32e122cb3f8b3e on develop (http://ci.theforeman.org/job/test_develop/2555/):

<pre>
TFTPOrchestrationTest::host with bond interface.test_0001_#setTFTP should provision tftp for all bond child macs (from TFTPOrchestrationTest__host with bond interface) 
ActiveRecord::RecordInvalid: Validation failed: Ip does not match selected subnet
    test_after_commit (1.1.0) lib/test_after_commit/database_statements.rb:11:in `block in transaction'
    test_after_commit (1.1.0) lib/test_after_commit/database_statements.rb:5:in `transaction'
    test/models/orchestration/tftp_test.rb:154:in `block (2 levels) in &lt;class:TFTPOrchestrationTest>'
    test/models/orchestration/tftp_test.rb:171:in `block (2 levels) in &lt;class:TFTPOrchestrationTest>' (ActiveRecord::RecordInvalid)
/usr/local/rvm/gems/ruby-2.2.5@test_develop-1/gems/activerecord-4.2.7.1/lib/active_record/validations.rb:43    
</pre>