### PR TITLE
Fixes #17666 - prevent migration failures on counter cache

### DIFF
--- a/db/migrate/20140314004243_add_counter_caches.rb
+++ b/db/migrate/20140314004243_add_counter_caches.rb
@@ -3,59 +3,27 @@ class AddCounterCaches < ActiveRecord::Migration
     # Architectures
     add_column :architectures, :hosts_count, :integer, :default => 0
     add_column :architectures, :hostgroups_count, :integer, :default => 0
-    Architecture.all.each do |a|
-      Architecture.reset_counters(a.id, :hosts)
-      Architecture.reset_counters(a.id, :hostgroups)
-    end
 
     # Domains
     add_column :domains, :hosts_count, :integer, :default => 0
     add_column :domains, :hostgroups_count, :integer, :default => 0
-    Domain.all.each do |d|
-      Domain.reset_counters(d.id, :hosts)
-      Domain.reset_counters(d.id, :hostgroups)
-    end
 
     # Environments
     add_column :environments, :hosts_count, :integer, :default => 0
     add_column :environments, :hostgroups_count, :integer, :default => 0
-    Environment.all.each do |e|
-      Environment.reset_counters(e.id, :hosts)
-      Environment.reset_counters(e.id, :hostgroups)
-    end
 
     # Hardware Models
     add_column :models, :hosts_count, :integer, :default => 0
-    Model.all.each do |m|
-      Model.reset_counters(m.id, :hosts)
-    end
 
     # Operating Systems
     add_column :operatingsystems, :hosts_count, :integer, :default => 0
     add_column :operatingsystems, :hostgroups_count, :integer, :default => 0
-    Operatingsystem.unscoped.all.each do |o|
-      Operatingsystem.unscoped.reset_counters(o.id, :hosts)
-      Operatingsystem.unscoped.reset_counters(o.id, :hostgroups)
-    end
 
     # Puppetclasses
     add_column :puppetclasses, :hosts_count, :integer, :default => 0
     add_column :puppetclasses, :hostgroups_count, :integer, :default => 0
-    # On Rails 3.2.8, reset_counters doesn't work correctly for has_many :through
-    # Seems to be something like https://github.com/rails/rails/issues/4293.
-    # So set the intial counters with increment_counter instead:
-    HostClass.all.each do |hc|
-      Puppetclass.increment_counter(:hosts_count, hc.puppetclass_id)
-    end
-
-    HostgroupClass.all.each do |hgc|
-      Puppetclass.increment_counter(:hostgroups_count, hgc.puppetclass_id)
-    end
 
     add_column :puppetclasses, :lookup_keys_count, :integer, :default => 0
-    EnvironmentClass.all.each do |e|
-      Puppetclass.increment_counter(:lookup_keys_count, e.puppetclass_id) unless EnvironmentClass.used_by_other_environment_classes(e.lookup_key_id, e.id).count > 0
-    end
   end
 
   def down

--- a/db/migrate/20140318153157_fix_puppetclass_counters.rb
+++ b/db/migrate/20140318153157_fix_puppetclass_counters.rb
@@ -6,9 +6,6 @@ class FixPuppetclassCounters < ActiveRecord::Migration
 
     # Smart Variables Counts
     add_column    :puppetclasses, :lookup_keys_count, :integer, :default => 0
-    LookupKey.where("puppetclass_id IS NOT NULL").each do |k|
-      Puppetclass.reset_counters(k.puppetclass_id, :lookup_keys)
-    end
   end
 
   def down

--- a/db/migrate/20151104100257_add_hosts_count_to_hostgroup.rb
+++ b/db/migrate/20151104100257_add_hosts_count_to_hostgroup.rb
@@ -1,9 +1,6 @@
 class AddHostsCountToHostgroup < ActiveRecord::Migration
   def up
     add_column :hostgroups, :hosts_count, :integer, :default => 0
-    Hostgroup.all.each do |hg|
-      Hostgroup.reset_counters(hg.id, :hosts)
-    end
   end
 
   def down


### PR DESCRIPTION
Removal of counter cache causes migrations relying on the
`reset_counters` method to fail. The migrations are changes to not
update the counters (which are now removed anyways).