### PR TITLE
fixes #6150 - users need taxonomy added on "all Users"

### DIFF
--- a/app/assets/javascripts/jquery.multi-select.js
+++ b/app/assets/javascripts/jquery.multi-select.js
@@ -20,42 +20,46 @@ function multiSelectOnLoad(){
 
 function multiSelectToolTips(){
   $('select[multiple]').each(function(i,item){
-    var mismatches = $(item).attr('data-mismatches');
-    var inheriteds = $(item).attr('data-inheriteds');
-    var descendants = $(item).attr('data-descendants');
-    var useds = $(item).attr('data-useds');
-    var msid = '#ms-'+item.id;
+    var mismatches = $(item).attr('data-mismatches'),
+    inheriteds = $(item).attr('data-inheriteds'),
+    descendants = $(item).attr('data-descendants'),
+    useds = $(item).attr('data-useds'),
+    used_all = $(item).attr('data-used-all'),
+    msid = '#ms-'+item.id;
     // it an <li> items match multiple tooltips, then only the first tooltip will show
+    if (!(used_all == null || used_all == 'undefined')) {
+      addTooltipForElements(msid, used_all,
+                            [{class_to_find_li: 'selection', clname: 'selected_taxonomy', label: "Select all option enabled for this taxonomy", position: 'right'}]);
+    }
     if (!(mismatches == null || mismatches == 'undefined')) {
-      var missing_ids = $.parseJSON(mismatches);
-      $.each(missing_ids, function(index,missing_id){
-        opt_id = sanitize(missing_id+'');
-        $(msid).find('li#'+opt_id+'-selectable').addClass('delete').tooltip({container: 'body', title: __("Select this since it belongs to a host"), placement: "left"});
-      })
+      addTooltipForElements(msid, mismatches,
+                            [{class_to_find_li: 'selectable', clname: 'delete', label: "Select this since it belongs to a host", position: 'left'}]);
     }
     if (!(useds == null || descendants == 'useds')) {
-      var used_ids = $.parseJSON(useds);
-      $.each(used_ids, function(index,used_id){
-        opt_id = sanitize(used_id+'');
-        $(msid).find('li#'+opt_id+'-selection').addClass('used_by_hosts').tooltip({container: 'body', title: __("This is used by a host"), placement: "right"});
-      })
+      addTooltipForElements(msid, useds,
+                            [{class_to_find_li: 'selection', clname: 'used_by_hosts', label: "This is used by a host", position: 'right'}]);
     }
     if (!(inheriteds == null || inheriteds == 'undefined')) {
-      var inherited_ids = $.parseJSON(inheriteds);
-      $.each(inherited_ids, function(index,inherited_id){
-        opt_id = sanitize(inherited_id+'');
-        $(msid).find('li#'+opt_id+'-selection').addClass('inherited').tooltip({container: 'body', title: __("This is inherited from parent"), placement: "right"});
-      })
+      addTooltipForElements(msid, inheriteds,
+                            [{class_to_find_li: 'selection', clname: 'inherited', label: "This is inherited from parent", position: 'right'}]);
     }
     if (!(descendants == null || descendants == 'undefined')) {
-      var descendant_ids = $.parseJSON(descendants);
-      $.each(descendant_ids, function(index,descendant_id){
-        opt_id = sanitize(descendant_id+'');
-        $(msid).find('li#'+opt_id+'-selection').addClass('descendants').tooltip({container: 'body', title: __("Parent is already selected"), placement: "right"});
-        $(msid).find('li#'+opt_id+'-selectable').addClass('descendants').tooltip({container: 'body', title: __("Parent is already selected"), placement: "left"});
-      })
+      addTooltipForElements(msid, descendants,
+                            [{class_to_find_li: 'selection', clname: 'descendants', label: 'Parent is already selected', position: 'right'},
+			     {class_to_find_li: 'selectable', clname: 'descendants', label: 'Parent is already selected', position: 'left'}]);
     }
   })
+}
+
+function addTooltipForElements(msid, json_ids, tooltips_with_options) {
+  var ids = $.parseJSON(json_ids);
+  $.each(ids, function(index, id){
+    opt_id = sanitize(id+'');
+    $.each(tooltips_with_options, function(tooltip_index, tooltip_opts) {
+      $(msid).find('li#'+opt_id+'-' + tooltip_opts.class_to_find_li).addClass(tooltip_opts.clname).tooltip(
+      {container: 'body', title: __(tooltip_opts.label), placement: tooltip_opts.position});
+    });
+  });
 }
 
 // function below is copy/paste from source of multi-select-rails gem

--- a/app/assets/javascripts/taxonomy_edit.js
+++ b/app/assets/javascripts/taxonomy_edit.js
@@ -2,6 +2,11 @@ $(function() {
   $(':checkbox').each(function(i, item) {
     ignore_checked(item);
   });
+
+  $('form').on('submit', function() {
+    $('select.without_select2').prop('disabled', false);
+    $('.ms-selection li.ms-elem-selection').removeClass('disabled');
+  });
 });
 
 function ignore_checked(item) {
@@ -11,6 +16,7 @@ function ignore_checked(item) {
 
   if ($(item).is(':checked')) {
     current_select.attr('disabled', 'disabled');
+    current_select.find("option").prop('selected', true);
   } else {
     current_select.removeAttr('disabled');
   }

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -222,11 +222,11 @@ module Taxonomix
 
   def assign_taxonomy_ids(taxonomy_class_name, taxonomy_ids_by_ignore_type)
     taxonomy_ids_meth = taxonomy_class_name.underscore + '_ids'
-    existing_obj_ids = self.send(taxonomy_ids_meth)
+    existing_obj_ids = send(taxonomy_ids_meth)
     return if (taxonomy_ids_by_ignore_type - existing_obj_ids).blank?
 
     taxonomy_ids_by_ignore_type.concat(existing_obj_ids).uniq!
-    self.send("#{taxonomy_ids_meth}=", taxonomy_ids_by_ignore_type)
+    send("#{taxonomy_ids_meth}=", taxonomy_ids_by_ignore_type)
   end
 
   protected

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -212,10 +212,11 @@ module Taxonomix
   end
 
   def add_taxonomies_with_ignore_type_enabled
-    Taxonomy.enabled_taxonomies.each do |taxonomy_pluralize_str|
-      taxonomy_class_name = taxonomy_pluralize_str.classify
+    ['location', 'organization'].map(&:classify).each do |taxonomy_class_name|
       obj_ids = taxonomy_class_name.constantize.taxonomy_ids_by_ignore_type(self.class.to_s)
-      assign_taxonomy_ids(taxonomy_class_name, obj_ids) if obj_ids.present?
+      if obj_ids.present?
+        assign_taxonomy_ids(taxonomy_class_name, obj_ids)
+      end
     end
   end
 
@@ -223,6 +224,7 @@ module Taxonomix
     taxonomy_ids_meth = taxonomy_class_name.underscore + '_ids'
     existing_obj_ids = self.send(taxonomy_ids_meth)
     return if (taxonomy_ids_by_ignore_type - existing_obj_ids).blank?
+
     taxonomy_ids_by_ignore_type.concat(existing_obj_ids).uniq!
     self.send("#{taxonomy_ids_meth}=", taxonomy_ids_by_ignore_type)
   end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -206,8 +206,8 @@ class Taxonomy < ApplicationRecord
   def assign_default_templates
     Template.where(:default => true).select(&:valid?).each do |template|
       template_class_string = template.class.to_s
-      unless self.ignore_types.include?(template_class_string)
-        self.send(template_class_string.underscore.pluralize.to_s) << template
+      unless ignore_types.include?(template_class_string)
+        send(template_class_string.underscore.pluralize.to_s) << template
       end
     end
   end
@@ -242,9 +242,9 @@ class Taxonomy < ApplicationRecord
     ignore_types.each do |klass|
       klass_obj_ids = klass.constantize.unscoped.pluck(:id)
       klass_ids_meth = klass.underscore + '_ids'
-      existing_ids = self.send(klass_ids_meth)
+      existing_ids = send(klass_ids_meth)
       next if (klass_obj_ids - existing_ids).blank?
-      self.send("#{klass_ids_meth}=", klass_obj_ids)
+      send("#{klass_ids_meth}=", klass_obj_ids)
     end
   end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -204,12 +204,10 @@ class Taxonomy < ApplicationRecord
     :to => :tax_host
 
   def assign_default_templates
-    # Template.where(:default => true).group_by { |t| t.class.to_s.underscore.pluralize }.each do |association, templates|
-    #  self.send("#{association}=", self.send(association) + templates.select(&:valid?))
-    Template.where(:default => true).select(&:valid?).find_each do |template|
-      classify_template_str = template.class.to_s
-      unless self.ignore_types.include?(classify_template_str)
-        self.send(classify_template_str.underscore.pluralize.to_s) << template
+    Template.where(:default => true).select(&:valid?).each do |template|
+      template_class_string = template.class.to_s
+      unless self.ignore_types.include?(template_class_string)
+        self.send(template_class_string.underscore.pluralize.to_s) << template
       end
     end
   end

--- a/app/views/taxonomies/_loc_org_tabs.html.erb
+++ b/app/views/taxonomies/_loc_org_tabs.html.erb
@@ -5,12 +5,14 @@
 
 <% if show_location_tab? %>
   <div class="tab-pane" id="locations">
+    <% location_ids_with_select_all_for_ignore_type = Location.taxonomy_ids_by_ignore_type(obj.class.to_s) %>
     <%= location_selects f, obj.used_or_selected_location_ids,
-            {:disabled => obj.used_location_ids }.merge!(select_options),
+            {:disabled => obj.used_location_ids.concat(location_ids_with_select_all_for_ignore_type)}.merge!(select_options),
             {'data-descendants' => obj.children_of_selected_location_ids.to_json,
-             'data-useds' => obj.used_location_ids.to_json }.merge!(html_options[:location]) %>
+             'data-useds' => obj.used_location_ids.to_json,
+             'data-used-all' => location_ids_with_select_all_for_ignore_type.to_json }.merge!(html_options[:location]) %>
     <% if obj.kind_of? User %>
-      <%= select_f f, :default_location_id, (obj.admin? ? Location.all : obj.my_locations), :id, :title,
+       <%= select_f f, :default_location_id, (obj.admin? ? Location.all : obj.my_locations), :id, :title,
                     { :include_blank => true }, { :label => _('Default on login') } %>
     <% end %>
   </div>
@@ -18,14 +20,15 @@
 
 <% if show_organization_tab? %>
   <div class="tab-pane" id="organizations">
+    <% organization_ids_with_select_all_for_ignore_type = Organization.taxonomy_ids_by_ignore_type(obj.class.to_s) %>
     <%= organization_selects f, obj.used_or_selected_organization_ids,
-            {:disabled => obj.used_organization_ids }.merge!(select_options),
+            {:disabled => obj.used_organization_ids.concat(organization_ids_with_select_all_for_ignore_type)}.merge!(select_options),
             {'data-descendants' => obj.children_of_selected_organization_ids.to_json,
-             'data-useds' => obj.used_organization_ids.to_json }.merge!(html_options[:organization]) %>
+             'data-useds' => obj.used_organization_ids.to_json,
+             'data-used-all' => organization_ids_with_select_all_for_ignore_type.to_json }.merge!(html_options[:organization]) %>
     <% if obj.kind_of? User %>
       <%= select_f f, :default_organization_id,(obj.admin? ? Organization.all : obj.my_organizations), :id, :title,
-                    { :include_blank => true }, { :label => _('Default on login') } %>
+                   { :include_blank => true }, { :label => _('Default on login') } %>
     <% end %>
   </div>
 <% end %>
-

--- a/db/migrate/20170922082617_update_taxonomies_with_selected_ignore_types_objects.rb
+++ b/db/migrate/20170922082617_update_taxonomies_with_selected_ignore_types_objects.rb
@@ -1,0 +1,9 @@
+class UpdateTaxonomiesWithSelectedIgnoreTypesObjects < ActiveRecord::Migration[4.2]
+  def up
+    say "This Migration will take time for updating organization & location records with all objects of selected ignore_types."
+    Rake::Task['taxonomy:update_taxonomy'].invoke
+  end
+
+  def down
+  end
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -1,0 +1,18 @@
+namespace :taxonomy do
+  desc <<-END_DESC
+    This task will update organization & location records with ignore_types.
+  END_DESC
+  task :update_taxonomy => :environment do
+    User.as_anonymous_admin do
+      Organization.unscoped.each do |org|
+        success = org.save
+        puts "Failed to save Organization #{org.id}- #{org.errors.full_messages.inspect}" unless success
+      end
+
+      Location.unscoped.each do |loc|
+        success = loc.save
+        puts "Failed to save Location #{loc.id}- #{loc.errors.full_messages.inspect}" unless success
+      end
+    end
+  end
+end

--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -3,15 +3,17 @@ namespace :taxonomy do
     This task will update organization & location records with ignore_types.
   END_DESC
   task :update_taxonomy => :environment do
-    User.as_anonymous_admin do
-      Organization.unscoped.each do |org|
-        success = org.save
-        puts "Failed to save Organization #{org.id}- #{org.errors.full_messages.inspect}" unless success
-      end
+    if User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
+      User.as_anonymous_admin do
+        Organization.unscoped.each do |org|
+          success = org.save
+          puts "Failed to save Organization #{org.id}- #{org.errors.full_messages.inspect}" unless success
+        end
 
-      Location.unscoped.each do |loc|
-        success = loc.save
-        puts "Failed to save Location #{loc.id}- #{loc.errors.full_messages.inspect}" unless success
+        Location.unscoped.each do |loc|
+          success = loc.save
+          puts "Failed to save Location #{loc.id}- #{loc.errors.full_messages.inspect}" unless success
+        end
       end
     end
   end

--- a/test/models/taxonomy_test.rb
+++ b/test/models/taxonomy_test.rb
@@ -73,4 +73,24 @@ class TaxonomyTest < ActiveSupport::TestCase
     location.save
     assert_match /expecting organizations/, location.errors.messages[:organizations].first
   end
+
+  test "#taxonomy_ids_by_ignore_type should return ids of taxonomy_type for which 'Select All' option is checked for a resource." do
+    FactoryBot.create(:organization, :ignore_types => [ 'User' ])
+    user = FactoryBot.create(:user, :id => 20)
+    organization_ids_with_select_all = Organization.taxonomy_ids_by_ignore_type(user.class.to_s)
+    assert_not organization_ids_with_select_all.empty?
+    assert_equal organization_ids_with_select_all.count, 1
+  end
+
+  test "#add_references_for_selected_ignore_types assigns all objects of selected ignore_types to taxonomy" do
+    user = FactoryBot.create(:user, :login => 'foo_test_u1')
+    org1 = FactoryBot.create(:organization, :ignore_types => ['User'])
+    assert_includes org1.user_ids, user.id
+  end
+
+  test "taxonomy created with ignore_type Domain, this taxonomy will get assign to all new domains created after it" do
+    org1 = FactoryBot.create(:organization, :ignore_types => ['Domain'], :name => "Test_OrgA")
+    domain1 = FactoryBot.create(:domain, :name => 'test-domain.com')
+    assert_includes domain1.organization_ids, org1.id
+  end
 end

--- a/test/models/taxonomy_test.rb
+++ b/test/models/taxonomy_test.rb
@@ -75,7 +75,7 @@ class TaxonomyTest < ActiveSupport::TestCase
   end
 
   test "#taxonomy_ids_by_ignore_type should return ids of taxonomy_type for which 'Select All' option is checked for a resource." do
-    FactoryBot.create(:organization, :ignore_types => [ 'User' ])
+    FactoryBot.create(:organization, :ignore_types => ['User'])
     user = FactoryBot.create(:user, :id => 20)
     organization_ids_with_select_all = Organization.taxonomy_ids_by_ignore_type(user.class.to_s)
     assert_not organization_ids_with_select_all.empty?


### PR DESCRIPTION
With this commit, if "All users" is ticked then
locations and organizations are added to users. On edit user page,
you can not edit this taxonomy as they are disabled with tooltip
"Select all option enabled for this taxonomy".

Likewise, it will fix 'select all' option functionality for other ignore_types as well.