### PR TITLE
Fixes #6952 - Set hostgroup after provisioning from pxe

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -120,6 +120,7 @@ module Host
 
       facts[:domain] = facts[:domain].downcase if facts[:domain].present?
 
+      hostgroup_title = facts.delete(:foreman_hostgroup)
       time = facts[:_timestamp]
       time = time.to_time if time.is_a?(String)
       self.last_compile = time if time
@@ -128,6 +129,7 @@ module Host
       importer = FactImporter.importer_for(type).new(self, facts)
       importer.import!
 
+      set_hostgroup(hostgroup_title) if hostgroup_title.present? && new_record?
       save(:validate => false)
       set_taxonomies(facts)
       populate_fields_from_facts(facts, type)
@@ -207,6 +209,11 @@ module Host
         comparison_object.is_a?(Host::Base) &&
         id.present? &&
         comparison_object.id == id
+    end
+
+    def set_hostgroup(title)
+      self.hostgroup = Hostgroup.find_by_title(title)
+      set_hostgroup_defaults
     end
 
     def set_taxonomies(facts)

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -480,6 +480,28 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test 'set hostgroup when foreman_hostgroup present in facts' do
+    Setting[:create_new_host_when_facts_are_uploaded] = true
+    hostgroup = FactoryGirl.create(:hostgroup)
+    hostname = fact_json['name']
+    facts    = fact_json['facts']
+    facts['foreman_hostgroup'] = hostgroup.title
+    post :facts, {:name => hostname, :facts => facts}
+    assert_response :success
+    assert_equal hostgroup, Host.find_by(:name => hostname).hostgroup
+  end
+
+  test 'assign hostgroup attributes when foreman_hostgroup present in facts' do
+    Setting[:create_new_host_when_facts_are_uploaded] = true
+    hostgroup = FactoryGirl.create(:hostgroup, :with_rootpass)
+    hostname = fact_json['name']
+    facts    = fact_json['facts']
+    facts['foreman_hostgroup'] = hostgroup.title
+    post :facts, {:name => hostname, :facts => facts}
+    assert_response :success
+    assert_equal hostgroup.root_pass, Host.find_by(:name => hostname).root_pass
+  end
+
   test 'when ":restrict_registered_smart_proxies" is false, HTTP requests should be able to import facts' do
     User.current = users(:one) #use an unprivileged user, not apiadmin
     Setting[:restrict_registered_smart_proxies] = false


### PR DESCRIPTION
After hostgroup provisioning, when the machine has registered
with foreman, it should be in the same hostgroup.
to achieve this behavier, the [referenced](https://github.com/theforeman/community-templates/pull/327) snippet should be added
to hostgroup provisioning template.