### PR TITLE
Fixes #17679 - Fixing the style issues in Login Page

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -58,6 +58,7 @@
 }
 .login-page .container .form-horizontal .control-label {
   font-weight: 400;
+  padding-left: 20px;
   text-align: left;
 }
 .login-page .container .form-horizontal .form-group:last-child,
@@ -75,4 +76,3 @@
 .login-page .container .submit {
   text-align: right;
 }
-

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -24,7 +24,7 @@
           </div>
           <div class="form-group">
             <div class="col-xs-offset-8 col-xs-4 submit">
-              <%= submit_tag(_("Login").html_safe, :class => "btn btn-primary", :data => { :disable_with => _("Please wait...") }) %>
+              <%= submit_tag(_("Log In").html_safe, :class => "btn btn-primary", :data => { :disable_with => _("Please wait...") }) %>
             </div>
           </div>
       <% end %>

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -20,7 +20,7 @@ class UserIntegrationTest < ActionDispatch::IntegrationTest
       visit "/"
       fill_in "login_login", :with => users(:admin).login
       fill_in "login_password", :with => "secret"
-      click_button "Login"
+      click_button "Log In"
       assert_current_path root_path
     end
   end


### PR DESCRIPTION
1, Based on [Terminology and Wording Style Guide](http://www.patternfly.org/styles/terminology-and-wording/#terms-and-words), Suggested to use a verb, we should say "Log In" as the button label for the login page.
2, The username should align the text box when the screen is smaller than 768px.
Please check the attachment picture.
![screenshot from 2016-11-05 03-06-49](https://cloud.githubusercontent.com/assets/701009/21215460/58aeac88-c2dc-11e6-8e5a-b6f5719d65b4.png)
