### PR TITLE
Fixes #17680 - templates_used host helper

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -72,7 +72,7 @@ class Host::Managed < Host::Base
       :image_build?, :pxe_build?, :otp, :realm, :param_true?, :param_false?, :nil?, :indent, :primary_interface,
       :provision_interface, :interfaces, :bond_interfaces, :bridge_interfaces, :interfaces_with_identifier,
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
-      :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic
+      :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used
   end
 
   scope :recent,      ->(*args) { where(["last_report > ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago)]) }
@@ -821,6 +821,14 @@ class Host::Managed < Host::Base
                                            :environment_id     => environment_id
                                          })
     end.compact
+  end
+
+  def templates_used
+    result = {}
+    available_template_kinds.map do |template|
+      result[template.template_kind_name] = template.name
+    end
+    result
   end
 
   def render_template(template)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3640,6 +3640,17 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#templates_used' do
+    test 'returns all templates used on a given host' do
+      os = operatingsystems(:redhat)
+      host = FactoryGirl.build(:host, :managed, :operatingsystem => os)
+      host.templates_used.each do |template_kind, template_name|
+        template = os.provisioning_templates.find_by_name(template_name).name
+        assert_equal template, host.templates_used[template_kind]
+      end
+    end
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)


### PR DESCRIPTION
templates_used contains the names of all of the provisioning templates
kickstart used during a host build. This allows users to be able to show the
name of a provisioning template during PXEBoot, for example.

Submitted in behalf of Peter Vreman.