### PR TITLE
Fixes #17683 - Wrong resource type in hostgroup AJAX permission check

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -671,7 +671,7 @@ class HostsController < ApplicationController
     return head(:not_found) unless @hostgroup
 
     @host = if params[:host][:id]
-              host = Host::Base.authorized(:view_hosts, Host).find(params[:host][:id])
+              host = Host::Base.authorized(:view_hosts).find(params[:host][:id])
               host = host.becomes Host::Managed
               host.attributes = host.apply_inherited_attributes(host_params)
               host


### PR DESCRIPTION
Specifying `Host` causes this not to work on `Host::Discovered` and I guess others. 