### PR TITLE
Fixes #17686 - wider focus area of action buttons

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -77,6 +77,9 @@ span.input-group-btn .hidden-xs {display:inline !important;}
 span.btn a {
   text-decoration: none;
   color: #333333;
+  // make sure the link inside span covers the whole area of the button
+  padding: 8px;
+  margin: -8px
 }
 
 a {


### PR DESCRIPTION
The buttons in tables were not capturing the click, if it was outside of the
text. Let's avoid the frustration this might cause.

![table-button-click](https://cloud.githubusercontent.com/assets/190443/21232785/290c975e-c2ed-11e6-9e8e-920dbbc18a4b.gif)
