### PR TITLE
Fixes #17681 - Switch to newly created taxonomy

### DIFF
--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -273,4 +273,11 @@ class OrganizationsControllerTest < ActionController::TestCase
       Host.unstub(:authorized)
     end
   end
+
+  test 'should switch to newly created org' do
+    name = 'test-org'
+    put :create, { :commit => "Submit", :organization => { :name => name } }, set_session_user
+    new_org = Organization.find_by :name => name
+    assert_equal new_org.id, session[:organization_id]
+  end
 end


### PR DESCRIPTION
The context switches to newly created taxonomy as soon as user leaves the wizard.