### PR TITLE
Fixes #17794 - Update user groups on EXTERNAL user creation

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -247,6 +247,7 @@ class UsersControllerTest < ActionController::TestCase
     Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache_mod'
     @request.session.clear
     @request.env['REMOTE_USER'] = 'ares'
+    AuthSourceLdap.any_instance.expects(:update_usergroups).with('ares')
     get :extlogin, {}, {}
     assert_redirected_to edit_user_path(User.unscoped.find_by_login('ares'))
   end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -9,6 +9,8 @@ class ApacheTest < ActiveSupport::TestCase
   def test_user_is_set_when_authenticated
     Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache'
     apache = get_apache_method
+    AuthSourceLdap.any_instance.expects(:update_usergroups).
+      with('ares').times(AuthSourceLdap.count)
     assert apache.authenticated?
     assert_equal apache.user, 'ares'
     assert_equal apache.session[:sso_method], 'SSO::Apache'
@@ -41,6 +43,8 @@ class ApacheTest < ActiveSupport::TestCase
     assert !apache.authenticated?
 
     apache.controller.request.env[SSO::Apache::CAS_USERNAME] = 'ares'
+    AuthSourceLdap.any_instance.expects(:update_usergroups).
+      with('ares').times(AuthSourceLdap.count)
     assert apache.authenticated?
   end
 


### PR DESCRIPTION
Given an user who logs in via external delegation (REMOTE_USER). This user
is created automatically upon login. The user is not authenticated using
regular LDAP authentication sources, but through the 'authorized login
delegation' setting. Since REMOTE_USER_GROUP_* is not set, the user
groups are not set.

The user in reality comes from ActiveDirectory which is listed in
Foreman as an LDAP auth source - but using the krb5 ticket. Since the
login provided by REMOTE_USER and LDAP is the same, one would expect
that the LDAP user groups would be updated when you log in. However the
user groups are only updated through the cron or click on
'refresh user groups'.

This patch moves all logic of refreshing user groups to
post_successful_login, which is called from try_to_login, and
find_or_create_external_user (which is called from SSO::Apache).