### PR TITLE
Fixes #17807 - Handy script to mirror rails runner

### DIFF
--- a/lib/tasks/runner.rake
+++ b/lib/tasks/runner.rake
@@ -1,0 +1,19 @@
+task :runner=> :environment do
+  Rails.application.require_environment!
+  Rails.application.load_runner
+  file=ENV['SCRIPT']
+  code=ENV['EVAL']
+  if !code && !file
+    puts "Either specify EVAL='Hostgroup.find(100)' or specify a script to run with SCRIPT=PATH_TO_FILE"
+  end
+
+  User.current = User.anonymous_admin
+  puts eval(code, binding, __FILE__, __LINE__) if code
+  if file
+    if File.exist? file
+      Kernel.load file
+    else
+      puts "#{file} not found" unless File.exist? file
+    end
+  end
+end


### PR DESCRIPTION
In a production environment I ve had to use "foreman-rake console" quite a few times to get information about objects while debugging customer instances. I know rails provides a "rails runner" script that can be used to run and fetch/execute data.


This is a  handy script to say something like
"foreman-rake runner EVAL='Hostgroup.find(5).inspect'"
or
"foreman-rake runner SCRIPT='script-to-fix-data-issues'
and have it executed as  admin.
