### PR TITLE
Fixes #17808 - fix 'multipart form data' IE bug

### DIFF
--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -159,4 +159,7 @@
       not have a 'name' attribute so browsers will not send them in the form POST. %>
   <input type="hidden" id="old" value="<%= @template.template %>" />
   <input type="hidden" id="new" value="<%= @template.template %>" />
+
+  <%# This hidden input is a workaround to fix IE Multipart form data bug (https://connect.microsoft.com/IE/Feedback/Details/868498) %>
+  <input type="hidden" name="_ie_support" %>
 <% end %>


### PR DESCRIPTION
According to this bug (https://connect.microsoft.com/IE/Feedback/Details/868498),
multipart form data is malformed if there are fields without names.
It been solved within Edge browser, however no solution is expected for IE10/IE11

It cause a failure with Rack -  `EOFError: bad content body`,  therefore pages like provisioning template cannot be submitted (and all other forms which are submitted via ajax with `multipart form data`, and an unnamed field within).
  
Two suggested and tested workaround are:
1. Add an hidden input with no meaning name
2. Disable ajax submission form (via `two-pane.js`) . This bug occurs only when the form is submitted via ajax.

