### PR TITLE
fixes #17533 - provision dhcp for bond child macs

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -19,58 +19,58 @@ module Orchestration::DHCP
         !subnet.nil? && subnet.dhcp? && SETTINGS[:unattended] && (!provision? || operatingsystem.present?)
   end
 
-  def dhcp_record
-    return unless dhcp? || @dhcp_record
-    handle_validation_errors do
-      @dhcp_record ||= (provision? && jumpstart?) ? Net::DHCP::SparcRecord.new(dhcp_attrs) : Net::DHCP::Record.new(dhcp_attrs)
+  def dhcp_records
+    return [] unless dhcp?
+    @dhcp_records ||= mac_addresses_for_provisioning.map do |record_mac|
+      build_dhcp_record(record_mac)
     end
   end
 
   def reset_dhcp_record_cache
-    @dhcp_record = nil
+    @dhcp_records = nil
   end
 
   def rebuild_dhcp
-    if dhcp?
-      del_dhcp_safe
-      begin
-        set_dhcp
-      rescue => e
-        Foreman::Logging.exception "Failed to rebuild DHCP record for #{name}, #{ip}", e, :level => :error
-        false
-      end
-    else
+    unless dhcp?
       logger.info "DHCP not supported for #{name}, #{ip}, skipping orchestration rebuild"
-      true
+      return true
+    end
+
+    del_dhcp_safe
+    begin
+      set_dhcp
+    rescue => e
+      Foreman::Logging.exception "Failed to rebuild DHCP record for #{name}, #{ip}", e, :level => :error
+      false
     end
   end
 
   protected
 
   def del_dhcp_safe
-    if dhcp_record
-      begin
-        del_dhcp
-      rescue => e
-        Foreman::Logging.exception "Proxy failed to delete DHCP record for #{name}, #{ip}", e, :level => :error
-      end
-    end
+    del_dhcp
+  rescue => e
+    Foreman::Logging.exception "Proxy failed to delete DHCP record for #{name}, #{ip}", e, :level => :error
   end
 
   def set_dhcp
-    dhcp_record.create
+    dhcp_records.all? { |record| record.create }
   end
 
   def set_dhcp_conflicts
-    dhcp_record.conflicts.each{|conflict| conflict.create}
+    dhcp_records.all? do |record|
+      record.conflicts.each { |conflict| conflict.create }
+    end
   end
 
   def del_dhcp
-    dhcp_record.destroy
+    dhcp_records.all? { |record| record.destroy }
   end
 
   def del_dhcp_conflicts
-    dhcp_record.conflicts.each{|conflict| conflict.destroy}
+    dhcp_records.all? do |record|
+      record.conflicts.all? { |conflict| conflict.destroy }
+    end
   end
 
   # where are we booting from
@@ -93,16 +93,27 @@ module Orchestration::DHCP
 
   private
 
-  # returns a hash of dhcp record settings
-  def dhcp_attrs
+  def build_dhcp_record(record_mac)
     raise ::Foreman::Exception.new(N_("DHCP not supported for this NIC")) unless dhcp?
+    record_attrs = dhcp_attrs(record_mac)
+    record_type = (provision? && jumpstart?) ? Net::DHCP::SparcRecord : Net::DHCP::Record
+    handle_validation_errors do
+      record_type.new(record_attrs)
+    end
+  end
+
+  # returns a hash of dhcp record settings
+  def dhcp_attrs(record_mac)
+    raise ::Foreman::Exception.new(N_("DHCP not supported for this NIC")) unless dhcp?
+
     dhcp_attr = {
-      :name => name,
+      :name => dhcp_record_name(record_mac),
       :hostname => hostname,
       :ip => ip,
-      :mac => mac,
+      :mac => record_mac,
       :proxy => subnet.dhcp_proxy,
-      :network => subnet.network
+      :network => subnet.network,
+      :related_macs => mac_addresses_for_provisioning - [record_mac]
     }
 
     if provision?
@@ -118,6 +129,11 @@ module Orchestration::DHCP
     dhcp_attr
   end
 
+  def dhcp_record_name(record_mac)
+    return name if mac_addresses_for_provisioning.size <= 1
+    "#{name}-#{'%02d' % (mac_addresses_for_provisioning.index(record_mac) + 1)}"
+  end
+
   def queue_dhcp
     return unless (dhcp? || (old && old.dhcp?)) && orchestration_errors?
     queue_remove_dhcp_conflicts
@@ -131,20 +147,19 @@ module Orchestration::DHCP
   end
 
   def queue_dhcp_update
-    if dhcp_update_required?
-      logger.debug("Detected a changed required for DHCP record")
-      queue.create(:name => _("Remove DHCP Settings for %s") % old, :priority => 5,
-                   :action => [old, :del_dhcp]) if old.dhcp?
-      queue.create(:name   => _("Create DHCP Settings for %s") % self, :priority => 9,
-                   :action => [self, :set_dhcp]) if dhcp?
-    end
+    return unless dhcp_update_required?
+    logger.debug("Detected a changed required for DHCP record")
+    queue.create(:name => _("Remove DHCP Settings for %s") % old, :priority => 5,
+                 :action => [old, :del_dhcp]) if old.dhcp?
+    queue.create(:name   => _("Create DHCP Settings for %s") % self, :priority => 9,
+                 :action => [self, :set_dhcp]) if dhcp?
   end
 
   # do we need to update our dhcp reservations
   def dhcp_update_required?
     # IP Address / name changed, or 'rebuild' action is triggered and DHCP record on the smart proxy is not present/identical.
-    return true if ((old.ip != ip) || (old.hostname != hostname) || (old.mac != mac) || (old.subnet != subnet) || (operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(self.host)) ||
-                    (!old.build? && build? && !dhcp_record.valid?))
+    return true if ((old.ip != ip) || (old.hostname != hostname) || (provision_mac_addresses_changed?) || (old.subnet != subnet) || (operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(self.host)) ||
+                    (!old.build? && build? && !all_dhcp_records_valid?))
     # Handle jumpstart
     #TODO, abstract this way once interfaces are fully used
     if self.is_a?(Host::Base) && jumpstart?
@@ -154,6 +169,10 @@ module Orchestration::DHCP
       end
     end
     false
+  end
+
+  def all_dhcp_records_valid?
+    dhcp_records.all? { |record| record.valid? }
   end
 
   def queue_dhcp_destroy
@@ -176,10 +195,14 @@ module Orchestration::DHCP
     return false if mac.blank? || hostname.blank?
     return false unless dhcp?
 
-    if dhcp_record && dhcp_record.conflicting? && (!overwrite?)
-      failure(_("DHCP records %s already exists") % dhcp_record.conflicts.to_sentence, nil, :conflict)
+    if dhcp_records.any? && dhcp_records.any? { |record| record.conflicting? } && !overwrite?
+      failure(_("DHCP records %s already exists") % dhcp_records.map {|record| record.conflicts}.flatten.to_sentence, nil, :conflict) # compact?
       return true
     end
     false
+  end
+
+  def provision_mac_addresses_changed?
+    old.mac_addresses_for_provisioning != mac_addresses_for_provisioning
   end
 end

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -99,7 +99,7 @@ module Orchestration::TFTP
     if content
       logger.info "Deploying TFTP #{kind} configuration for #{host.name}"
       each_unique_feasible_tftp_proxy do |proxy|
-        mac_addresses_for_tftp.each do |mac_addr|
+        mac_addresses_for_provisioning.each do |mac_addr|
           proxy.set(kind, mac_addr, :pxeconfig => content)
         end
       end
@@ -114,7 +114,7 @@ module Orchestration::TFTP
   def delTFTP(kind)
     logger.info "Delete the TFTP configuration for #{host.name}"
     each_unique_feasible_tftp_proxy do |proxy|
-      mac_addresses_for_tftp.each do |mac_addr|
+      mac_addresses_for_provisioning.each do |mac_addr|
         proxy.delete(kind, mac_addr)
       end
     end
@@ -208,9 +208,5 @@ module Orchestration::TFTP
       yield(proxy)
     end
     results.all?
-  end
-
-  def mac_addresses_for_tftp
-    [mac, children_mac_addresses].flatten.compact.uniq
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -167,7 +167,7 @@ class Host::Managed < Host::Base
     include UnattendedHelper # which also includes Foreman::Renderer
     include Orchestration
     # DHCP orchestration delegation
-    delegate :dhcp?, :dhcp_record, :to => :primary_interface
+    delegate :dhcp?, :dhcp_records, :to => :primary_interface
     # DNS orchestration delegation
     delegate :dns?, :dns6?, :reverse_dns?, :reverse_dns6?, :dns_record, :to => :primary_interface
     # IP delegation

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -259,6 +259,10 @@ module Nic
       errors.add(:mac, _('must be a unicast MAC address')) if Net::Validations.multicast_mac?(mac) || Net::Validations.broadcast_mac?(mac)
     end
 
+    def mac_addresses_for_provisioning
+      [mac, children_mac_addresses].flatten.compact.uniq
+    end
+
     private
 
     def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil))

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -64,7 +64,7 @@ module Nic
     end
 
     def mac_available?
-      mac.present? || (host.present? && host.compute_provides?(:mac))
+      mac_addresses_for_provisioning.any? || (host.present? && host.compute_provides?(:mac))
     end
 
     protected

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -78,10 +78,10 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
     host.primary_interface.subnet = FactoryGirl.build(:subnet, :dhcp, :network => '255.255.255.0')
     host.operatingsystem = FactoryGirl.build(:operatingsystem)
 
-    refute_nil host.primary_interface.dhcp_record
-    original = host.primary_interface.dhcp_record.object_id
+    refute_nil host.primary_interface.dhcp_records
+    original = host.primary_interface.dhcp_records.map(&:object_id)
     host.send :match_macs_to_nics, :mac
-    new = host.primary_interface.dhcp_record.object_id
+    new = host.primary_interface.dhcp_records.map(&:object_id)
     refute_equal original, new
     assert_equal '00:00:00:00:01', host.primary_interface.mac
   end

--- a/test/unit/proxy_api/dhcp_test.rb
+++ b/test/unit/proxy_api/dhcp_test.rb
@@ -1,18 +1,69 @@
 require 'test_helper'
 
 class ProxyApiDhcpTest < ActiveSupport::TestCase
-  def setup
-    @url = "http://localhost:8443"
-    @dhcp = ProxyAPI::DHCP.new({:url => @url})
-  end
+  let(:url) { 'http://localhost:8443' }
+  let(:proxy_dhcp) { ProxyAPI::DHCP.new(:url => url) }
 
   test "constructor should complete" do
-    assert_not_nil(@dhcp)
+    assert_not_nil(proxy_dhcp)
   end
 
   test "base url should equal /dhcp" do
-    expected = "#{@url}/dhcp"
-    assert_equal(expected, @dhcp.url)
+    expected = "#{url}/dhcp"
+    assert_equal(expected, proxy_dhcp.url)
+  end
+
+  context 'record retrieval' do
+    let(:fake_response) do
+      {
+        'name' => 'www.example.com',
+        'mac' => '00:11:22:33:44:55',
+        'ip' => '192.168.0.10',
+        'filename' => 'pxelinux.0',
+        'nextServer' => '1.2.3.4',
+        'hostname' => 'www.example.com',
+        'subnet' => '192.168.0.0/255.255.255.0'
+      }
+    end
+
+    describe '#record' do
+      setup do
+        proxy_dhcp.expects(:get).with('192.168.0.0/mac/192.168.0.10').returns(fake_rest_client_response(fake_response))
+      end
+
+      test 'retrieves an array with a single dhcp record' do
+        result = proxy_dhcp.record('192.168.0.0', '192.168.0.10')
+        assert_kind_of Net::DHCP::Record, result
+        assert_equal({:hostname=>"www.example.com",
+                      :mac=>"00:11:22:33:44:55",
+                      :ip=>"192.168.0.10",
+                      :network=>"192.168.0.0",
+                      :nextServer=>"1.2.3.4",
+                      :filename=>"pxelinux.0",
+                      :name=>"www.example.com",
+                      :related_macs=>[]}, result.attrs)
+      end
+    end
+
+    describe '#records_by_ip' do
+      setup do
+        proxy_dhcp.expects(:get).with('192.168.0.0/ip/192.168.0.10').returns(fake_rest_client_response([fake_response]))
+      end
+
+      test 'retrieves an array with a single dhcp record' do
+        result = proxy_dhcp.records_by_ip('192.168.0.0', '192.168.0.10')
+        assert_kind_of Array, result
+        assert_kind_of Net::DHCP::Record, result.first
+        assert_equal({:hostname=>"www.example.com",
+                      :mac=>"00:11:22:33:44:55",
+                      :ip=>"192.168.0.10",
+                      :network=>"192.168.0.0",
+                      :nextServer=>"1.2.3.4",
+                      :filename=>"pxelinux.0",
+                      :name=>"www.example.com",
+                      :related_macs=>[]}, result.first.attrs)
+      end
+    end
   end
 
   test "unused_ip should get an IP using only the network address" do
@@ -20,8 +71,8 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    @dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
+    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
+    assert_equal({'ip'=>'192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock))
   end
 
   test "unused_ip should get an IP using the network, from and to addresses" do
@@ -36,13 +87,13 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:from).at_least_once.returns(from_mock)
     subnet_mock.expects(:to).at_least_once.returns(to_mock)
 
-    @dhcp.expects(:get).with() do |path|
+    proxy_dhcp.expects(:get).with() do |path|
       # Params built with a hash, so order can change
       path.include?('192.168.0.0/unused_ip?') &&
         path.include?('from=192.168.0.50') &&
         path.include?('to=192.168.0.150')
     end.returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock))
+    assert_equal({'ip'=>'192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock))
   end
 
   test "unused_ip should get an IP using the network and MAC address" do
@@ -50,7 +101,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    @dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
-    assert_equal({'ip'=>'192.168.0.50'}, @dhcp.unused_ip(subnet_mock, '00:11:22:33:44:55'))
+    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_rest_client_response({:ip=>'192.168.0.50'}))
+    assert_equal({'ip'=>'192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock, '00:11:22:33:44:55'))
   end
 end


### PR DESCRIPTION
This commit adds the ability to provision a host which has a bond interface as its provisioning interface. The bond interface doesn't have a mac address set, but is linked to usually two physical interfaces that are connected to the same VLAN for additional redundancy or speed.
While the host is PXE-booting it just sees two independent interfaces, which it tries to boot from. We therefore need to set TFTP (bcb107cf8d5039486f07b136e4b41c337fda2921) and DHCP records for both physical interfaces. This commit adds the latter functionality.

The idea is, that two static leases would be written with the same IP-address but different mac. For a bond interface, the records are not named like the hostname, but the hostname suffixed with a consecutive numbering (e.g. "example.com-01", "example.com-02"). 

Cobbler already supports this functionality and handles the dhcp records in a similar matter.

Feedback is much appreciated.

This needs changes to Smart Proxy to work, see https://github.com/theforeman/smart-proxy/pull/485