### PR TITLE
Fixes #4238 - Prevent login brute forcing

### DIFF
--- a/app/controllers/concerns/foreman/controller/bruteforce_protection.rb
+++ b/app/controllers/concerns/foreman/controller/bruteforce_protection.rb
@@ -1,0 +1,19 @@
+module Foreman::Controller::BruteforceProtection
+  extend ActiveSupport::Concern
+
+  def count_login_failure
+    Rails.cache.write("failed_login_#{request.ip}", get_login_failures+1, :expires_in => 5.minutes)
+  end
+
+  def get_login_failures
+    Rails.cache.fetch("failed_login_#{request.ip}") {0} if request.ip.present?
+  end
+
+  def bruteforce_attempt?
+    get_login_failures >= 30
+  end
+
+  def log_bruteforce
+    logger.warn("Brute-force attempt blocked from IP: #{request.ip}")
+  end
+end

--- a/test/controllers/api/base_controller_subclass_test.rb
+++ b/test/controllers/api/base_controller_subclass_test.rb
@@ -130,6 +130,14 @@ class Api::TestableControllerTest < ActionController::TestCase
       assert_response :unauthorized
     end
 
+    it "prevents brute-force attempts" do
+      @controller.expects(:authenticate).times(30).returns(false)
+      @controller.expects(:log_bruteforce).once
+      31.times do
+        get :index, {:user => 'admin', :password => 'brute-force'}
+      end
+    end
+
     context "and SSO (plain) authenticates" do
       setup do
         @sso = mock('dummy_sso')

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -335,6 +335,15 @@ class UsersControllerTest < ActionController::TestCase
     assert flash[:inline][:error].present?
   end
 
+  test "#login prevents brute-force login attempts" do
+    User.expects(:try_to_login).times(30).returns(nil)
+    @controller.expects(:log_bruteforce)
+    31.times do
+      post :login, {:login => {'login' => 'admin', 'password' => 'password'}}
+    end
+    assert_equal "Too many tries, please try again in a few minutes.", flash[:inline][:error]
+  end
+
   test "#login retains taxonomy session attributes in new session" do
     post :login, {:login => {'login' => users(:admin).login, 'password' => 'secret'}},
                  {:location_id => taxonomies(:location1).id,


### PR DESCRIPTION
After 5 failed attempts from the same ip, login will be blocked for 5
minutes.