### PR TITLE
Fixes #17850 - Prevent 414 on architecture/usergroup

### DIFF
--- a/db/migrate/20161227082709_change_architecture_name_limit.rb
+++ b/db/migrate/20161227082709_change_architecture_name_limit.rb
@@ -1,0 +1,5 @@
+class ChangeArchitectureNameLimit < ActiveRecord::Migration
+  def change
+    change_column :architectures, :name, :string, :default => nil, :limit => 255
+  end
+end

--- a/db/migrate/20161227082721_change_usergroup_name_limit.rb
+++ b/db/migrate/20161227082721_change_usergroup_name_limit.rb
@@ -1,0 +1,5 @@
+class ChangeUsergroupNameLimit < ActiveRecord::Migration
+  def change
+    change_column :usergroups, :name, :string, :null => false, :limit => 255
+  end
+end


### PR DESCRIPTION
These two fields had been modified using change_column in other
migrations which removed the limit on 'name'. This causes a 414 if
you create a very long name and try to edit the field.

After the change, the limit is restored so very long names are
forbidden by validates_length_in_database and 414s are prevented