### PR TITLE
Fixes #17851 - Set hostgroup taxonomies after saving host

### DIFF
--- a/app/models/concerns/hostext/taxonomies.rb
+++ b/app/models/concerns/hostext/taxonomies.rb
@@ -1,0 +1,28 @@
+module Hostext
+  module Taxonomies
+    extend ActiveSupport::Concern
+
+    included do
+      if SETTINGS[:organizations_enabled]
+        validates :organization_id, :presence => true, :if => ->(host) { host.managed? }
+      end
+      if SETTINGS[:locations_enabled]
+        validates :location_id, :presence => true, :if => ->(host) { host.managed? }
+      end
+
+      after_validation :fix_hostgroup_mismatches, :if => ->(host) { host.hostgroup_id.present? }
+    end
+
+    def fix_hostgroup_mismatches
+      Taxonomy.enabled_taxonomies.each do |taxonomy|
+        host_taxonomy = public_send(taxonomy.singularize.to_sym)
+        next if host_taxonomy.blank?
+        TaxableTaxonomy.where(
+          :taxonomy_id  => host_taxonomy.id,
+          :taxable_id   => hostgroup_id,
+          :taxable_type => 'Hostgroup'
+        ).first_or_create
+      end
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3672,6 +3672,16 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "validating host with loc/org propagates these to hostgroup" do
+    host = FactoryGirl.build(:host, :managed)
+    refute_includes hostgroups(:common).locations, host.location
+    refute_includes hostgroups(:common).organizations, host.organization
+    host.update_attribute(:hostgroup, hostgroups(:common))
+    host.valid?
+    assert_includes host.hostgroup.locations, host.location
+    assert_includes host.hostgroup.organizations, host.organization
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)


### PR DESCRIPTION
To reproduce:

1. Have a host with no hostgroup but some location set
2. Have a hostgroup with no location set
3. Assign the hostgroup to the host
4. Access the hostgroup's "Locations" tab

Now it seems the hostgroup already has a location active which is not
true. The hostgroup still has no location.
The location is assigned only after you click submit, even though it
looks like its already assigned.