### PR TITLE
fixes #17853 - resolve ips in interface scope

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -79,7 +79,7 @@ module Orchestration::DHCP
     # if that failed, trying to guess out tftp next server based on the smart proxy hostname
     bs ||= URI.parse(subnet.tftp.url).host
     # now convert it into an ip address (see http://theforeman.org/issues/show/1381)
-    ip = to_ip_address(bs) if bs.present?
+    ip = NicIpResolver.new(:nic => self).to_ip_address(bs) if bs.present?
     return ip unless ip.nil?
 
     failure _("Unable to determine the host's boot server. The DHCP smart proxy failed to provide this information and this subnet is not provided with TFTP services.")

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -912,20 +912,9 @@ class Host::Managed < Host::Base
     result
   end
 
-  # converts a name into ip address using DNS.
-  # if we are managing DNS, we can query the correct DNS server
-  # otherwise, use normal systems dns settings to resolv
   def to_ip_address(name_or_ip)
-    return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
-    if dns_record(:ptr4)
-      lookup = dns_record(:ptr4).dns_lookup(name_or_ip)
-      return lookup.ip unless lookup.nil?
-    end
-    # fall back to normal dns resolution
-    domain.resolver.getaddress(name_or_ip).to_s
-  rescue => e
-    logger.warn "Unable to find IP address for '#{name_or_ip}': #{e}"
-    raise ::Foreman::WrappedException.new(e, N_("Unable to find IP address for '%s'"), name_or_ip)
+    Foreman::Deprecation.deprecation_warning('1.17', 'Host::Managed#to_ip_address has been deprecated, you should use NicIpResolver class instead')
+    NicIpResolver.new(:nic => provision_interface).to_ip_address(name_or_ip)
   end
 
   def apply_compute_profile(modification)

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -20,7 +20,7 @@ module Nic
     # this ensures our orchestration works on both a host and a managed interface
     delegate :progress_report_id, :capabilities, :compute_resource,
              :operatingsystem, :provisioning_template, :jumpstart?, :build, :build?, :os, :arch,
-             :image_build?, :pxe_build?, :pxe_build?, :token, :to_ip_address, :model, :to => :host
+             :image_build?, :pxe_build?, :pxe_build?, :token, :model, :to => :host
     delegate :operatingsystem_id, :hostgroup_id, :environment_id,
              :overwrite?, :skip_orchestration?, :skip_orchestration!, :to => :host, :allow_nil => true
 

--- a/app/services/nic_ip_resolver.rb
+++ b/app/services/nic_ip_resolver.rb
@@ -1,0 +1,26 @@
+# converts a name into ip address using DNS in the interface scope
+# if we are managing DNS, we can query the correct DNS server
+# otherwise, use normal systems dns settings to resolv
+class NicIpResolver
+  attr_accessor :nic
+
+  delegate :logger, :to => :Rails
+  delegate :dns_record, :domain, :to => :nic
+
+  def initialize(opts)
+    @nic = opts.fetch(:nic)
+  end
+
+  def to_ip_address(name_or_ip)
+    return name_or_ip if name_or_ip =~ Net::Validations::IP_REGEXP
+    if dns_record(:ptr4)
+      lookup = dns_record(:ptr4).dns_lookup(name_or_ip)
+      return lookup.ip unless lookup.nil?
+    end
+    # fall back to normal dns resolution
+    domain.resolver.getaddress(name_or_ip).to_s
+  rescue => e
+    logger.warn "Unable to find IP address for '#{name_or_ip}': #{e}"
+    raise ::Foreman::WrappedException.new(e, N_("Unable to find IP address for '%s'"), name_or_ip)
+  end
+end

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -144,7 +144,6 @@ class ActiveSupport::TestCase
 
   def self.disable_orchestration
     #This disables the DNS/DHCP orchestration
-    Host.any_instance.stubs(:boot_server).returns("boot_server")
     Resolv::DNS.any_instance.stubs(:getname).returns("foo.fqdn")
     Resolv::DNS.any_instance.stubs(:getaddress).returns("127.0.0.1")
     Resolv::DNS.any_instance.stubs(:getresources).returns([OpenStruct.new(:mname => 'foo', :name => 'bar')])

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3563,38 +3563,6 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
-  describe '#to_ip_address' do
-    setup do
-      @host = FactoryGirl.build(:host)
-    end
-
-    test 'uses host PTR4 record to lookup the IP when present' do
-      stub_dns_record = stub()
-      @host.expects(:dns_record).with(:ptr4).returns(stub_dns_record).twice
-      stub_dns_record.expects(:dns_lookup).with('foo').
-        returns(OpenStruct.new(:ip => '127.0.0.1'))
-      assert '127.0.0.1', @host.to_ip_address('foo')
-    end
-
-    test 'when IP is passed as argument, return it' do
-      assert '127.0.0.1', @host.to_ip_address('127.0.0.1')
-    end
-
-    test 'call host domain resolver if there is no PTR4 record' do
-      @host.domain = FactoryGirl.build(:domain)
-      @host.domain.expects(:nameservers).returns('8.8.8.8')
-      Resolv::DNS.any_instance.expects(:getaddress).with('foo')
-        .returns('127.0.0.1')
-      assert '127.0.0.1', @host.to_ip_address('foo')
-    end
-
-    test 'raises exception when any error happens (no domain)' do
-      assert_raises(::Foreman::WrappedException) do
-        @host.to_ip_address('foo')
-      end
-    end
-  end
-
   describe '#smart_proxy_ids' do
     test 'returns IDs for proxies associated with host services' do
       # IDs are fake, just to prove host.smart_proxy_ids gathers them

--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -258,4 +258,20 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     host = FactoryGirl.build(:host, :with_dhcp_orchestration, :interfaces => [FactoryGirl.build(:nic_primary_and_provision, :mac => "aaaaaa")])
     assert_nil host.dhcp_record
   end
+
+  context '#boot_server' do
+    let(:host) { FactoryGirl.build(:host, :managed, :with_tftp_orchestration) }
+    let(:nic) { host.provision_interface }
+
+    test 'should use boot server provided by proxy' do
+      ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns('127.13.0.1')
+      assert_equal '127.13.0.1', nic.send(:boot_server)
+    end
+
+    test 'should use boot server based on proxy url' do
+      ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns(nil)
+      Resolv::DNS.any_instance.expects(:getaddress).once.returns("127.12.0.1")
+      assert_equal '127.12.0.1', nic.send(:boot_server)
+    end
+  end
 end

--- a/test/unit/nic_ip_resolver.rb
+++ b/test/unit/nic_ip_resolver.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class NicIpResolverTest < ActiveSupport::TestCase
+  describe '#to_ip_address' do
+    let(:host) { FactoryGirl.build(:host) }
+    let(:nic) { host.provision_interface }
+    let(:resolver) { NicIpResolver.new(:nic => nic) }
+
+    test 'uses host PTR4 record to lookup the IP when present' do
+      stub_dns_record = stub()
+      nic.expects(:dns_record).with(:ptr4).returns(stub_dns_record).twice
+      stub_dns_record.expects(:dns_lookup).with('foo').
+        returns(OpenStruct.new(:ip => '127.0.0.1'))
+      assert '127.0.0.1', resolver.to_ip_address('foo')
+    end
+
+    test 'when IP is passed as argument, return it' do
+      assert '127.0.0.1', resolver.to_ip_address('127.0.0.1')
+    end
+
+    test 'call host domain resolver if there is no PTR4 record' do
+      host.domain = FactoryGirl.build(:domain)
+      host.domain.expects(:nameservers).returns('8.8.8.8')
+      Resolv::DNS.any_instance.expects(:getaddress).with('foo')
+        .returns('127.0.0.1')
+      assert '127.0.0.1', resolver.to_ip_address('foo')
+    end
+
+    test 'raises exception when any error happens (no domain)' do
+      assert_raises(::Foreman::WrappedException) do
+        resolver.to_ip_address('foo')
+      end
+    end
+  end
+end


### PR DESCRIPTION
`to_ip_address` should be executed in nic's scope, not in host's scope. This refactors the resolving into a class and adds some tests.
I saw the issue using Discovery when changing the provision interface to a bond (e.g. provision a discovered host, create a new bond interface and set it as managed, primary and provisioning; save the host).