### PR TITLE
Fixes #17864 - Show smart proxy errors on unattended fail

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -114,8 +114,13 @@ class ApplicationController < ActionController::Base
   end
 
   def smart_proxy_exception(exception = nil)
-    process_error(:redirect => :back, :error_msg => exception.message)
     Foreman::Logging.exception("ProxyAPI operation FAILED", exception)
+    if request.headers.include? 'HTTP_REFERER'
+      process_error(:redirect => :back, :error_msg => exception.message)
+    else
+      process_error(:render => { :text => exception.message },
+                    :error_msg => exception.message)
+    end
   end
 
   # this method sets the Current user to be the Admin

--- a/test/controllers/application_controller_subclass_test.rb
+++ b/test/controllers/application_controller_subclass_test.rb
@@ -6,6 +6,10 @@ class ::TestableResourcesController < ::ApplicationController
   end
 
   def index
+    if params[:exception].present?
+      raise ProxyAPI::ProxyException.new('url', StandardError.new('noo'),
+                                         params[:exception])
+    end
     render :text => Time.zone.name, :status => 200
   end
 end
@@ -288,6 +292,14 @@ class TestableResourcesControllerTest < ActionController::TestCase
       assert_response :redirect
       assert_redirected_to login_users_url
       assert_equal('Your session has expired, please login again', flash[:warning])
+    end
+  end
+
+  context 'smart proxy errors are displayed when no referer is set' do
+    test 'proxy exception' do
+      get :index, { :exception => 'some error' }, set_session_user
+      assert_response :success
+      assert_match(/.*ProxyAPI::ProxyException.*some error.*/, response.body)
     end
   end
 end


### PR DESCRIPTION
If your proxy is has some error (like misconfigured sudoers, puppet not
available, etc...) and you try to boot a host through unattended
mode [1], the exception will not show up when you try to fetch the
kickstart template. Instead, it will show something like No HTTP_REFERER
was set in the request to this action, so redirect_to :back could not be
called successfully.

The application controller should be aware of this situation and don't
try to redirect to back in it, instead just render the error.

[1] an example of such error - ProxyAPI::ProxyException: ERF12-0104
[ProxyAPI::ProxyException]: Unable to set PuppetCA autosign for
tonia-rippeon.lobatolan.home ([RestClient::NotAcceptable]: 406 Not
    Acceptable) for proxy
https://centos7-devel.lobatolan.home:9090/puppet/ca