### PR TITLE
fixes #4166 - vmware: update cpus, memory for vms

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -159,9 +159,9 @@ module ComputeResourcesVmsHelper
     host.try(:new_record?)
   end
 
-  def vsphere_resource_pools(form, compute_resource)
+  def vsphere_resource_pools(form, compute_resource, new_host = false)
     resource_pools = compute_resource.available_resource_pools(:cluster_id => form.object.cluster) rescue []
-    selectable_f form, :resource_pool, resource_pools, { }, :class => "col-md-2", :label => _('Resource pool')
+    selectable_f form, :resource_pool, resource_pools, { }, :class => "col-md-2", :label => _('Resource pool'), :disabled => !new_host
   end
 
   def vms_table

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -20,6 +20,10 @@ module Foreman::Model
       true
     end
 
+    def supports_update?
+      true
+    end
+
     def capabilities
       [:build, :image]
     end
@@ -391,6 +395,10 @@ module Foreman::Model
     rescue ActiveRecord::RecordNotFound
       # if the VM does not exists, we don't really care.
       true
+    end
+
+    def update_required?(old_attrs, new_attrs)
+      super(old_attrs.deep_merge(old_attrs) {|_,_,v| v.to_s}, new_attrs)
     end
 
     # === Power on

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -1,10 +1,10 @@
 <%= javascript 'compute_resource' %>
 <%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initCounter)"); %>
 <%= text_f f, :name, :label => _('Name'), :disabled => !new_host if show_vm_name? %>
-<%= counter_f f, :cpus, :disabled => !new_host, :label => _('CPUs'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
+<%= counter_f f, :cpus, :label => _('CPUs'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
 
-<%= counter_f f, :corespersocket, :disabled => !new_host, :label => _('Cores per socket'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count, :value => f.object.corespersocket || 1 %>
-<%= text_f f, :memory_mb, :class => "col-md-2", :disabled => !new_host, :label => _("Memory (MB)") %>
+<%= counter_f f, :corespersocket, :label => _('Cores per socket'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count, :value => f.object.corespersocket || 1 %>
+<%= text_f f, :memory_mb, :class => "col-md-2", :label => _("Memory (MB)") %>
 <%= field(f, :firmware, :label => _('Firmware'), :label_size => "col-md-2") do
   compute_resource.firmware_types.collect do |type, name|
     radio_button_f f, :firmware, {:disabled => !new_host, :value => type, :text => _(name)}
@@ -15,7 +15,7 @@ end %>
                     :label => _('Cluster'), :onchange => 'vsphereGetResourcePools(this)',
                     :help_inline => :indicator,
                     :data => {:url => resource_pools_compute_resource_path(compute_resource)} %>
-<%= vsphere_resource_pools(f, compute_resource)%>
+<%= vsphere_resource_pools(f, compute_resource, new_host) %>
 <%= select_f f, :path, compute_resource.folders, :path, :to_label , {}, { :label => _("Folder"), :class => "col-md-2", :disabled => !new_host } %>
 <%= select_f f, :guest_id, compute_resource.guest_types, :first, :last, {}, { :label => _("Guest OS"), :class => "col-md-2", :disabled => !new_host } %>
 <%= select_f f, :scsi_controller_type, compute_resource.scsi_controller_types, :first, :last, {}, { :label => _("SCSI controller"), :class => "col-md-2", :disabled => !new_host } %>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,6 +1,6 @@
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
   :class => "col-md-3 vmware_type",
-  :label => _('NIC type'), :label_size => "col-md-3"
+  :label => _('NIC type'), :label_size => "col-md-3", :disabled => !new_host
 %>
 <% if new_host %>
   <%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
@@ -8,5 +8,5 @@
     :label => _('Network'), :label_size => "col-md-3"
   %>
 <% else %>
-  <%= text_f f, :network, :class => 'col-md-3 vmware_network', :label => _("Network"), :label_size => "col-md-3" %>
+  <%= text_f f, :network, :class => 'col-md-3 vmware_network', :label => _("Network"), :label_size => "col-md-3", :disabled => true %>
 <% end %>

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -9,17 +9,17 @@
 <% if new_host %>
   <%= selectable_f f, :datastore, vsphere_datastores(compute_resource), { }, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
 <% else %>
-  <%= text_f f, :datastore, :class => "span5", :label => _("Data store"), :label_size => "col-md-2" %>
+  <%= text_f f, :datastore, :class => "span5", :label => _("Data store"), :label_size => "col-md-2", :disabled => true %>
 <% end %>
-<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2" %>
+<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2", :disabled => !new_host %>
 <%= text_f f, :size_gb,
            :class       => "col-md-2",
-           :label => _("Size (GB)"), :label_size => "col-md-2" %>
+           :label => _("Size (GB)"), :label_size => "col-md-2", :disabled => !new_host %>
 <%= checkbox_f f, :thin, {
-           :label => _("Thin provision"), :label_size => "col-md-2"},
+           :label => _("Thin provision"), :label_size => "col-md-2", :disabled => !new_host},
            "true",
            "false" %>
 <%= checkbox_f f, :eager_zero, {
-           :label => _("Eager zero"), :label_size => "col-md-2"},
+           :label => _("Eager zero"), :label_size => "col-md-2", :disabled => !new_host},
            "true",
            "false" %>

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 0.6.2'
+  gem 'fog-vsphere', '>= 1.6.0'
 end


### PR DESCRIPTION
This commit adds support for editing cpus, corespersocket and memory of an existing vm. All other form fields are disabled when editing a vm.

![image](https://cloud.githubusercontent.com/assets/4107560/21540294/a7fdbca2-cdae-11e6-8352-aed9244fddd5.png)

 🔥 Video demonstrating the change: http://recordit.co/KwTP31J5vc 🔥 

Corresponding PR against fog-vsphere: https://github.com/fog/fog-vsphere/pull/63