### PR TITLE
Fixes #14714 - Make inherited Puppet Classes more apparent

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -319,3 +319,30 @@ a.btn-info span{
 .pficon-ok.warn:before {
   color: #ec7a08;
 }
+
+.paneless {
+  .panel {
+    box-shadow: none;
+  }
+
+  .panel-title {
+    font-size: inherit;
+  }
+
+  .panel-heading + .panel-collapse .panel-body {
+    border: none;
+    padding: 0;
+  }
+
+  .panel-heading {
+    background: none;
+    border: none;
+    padding-left: inherit;
+    padding-right: inherit;
+
+    a {
+      font-weight: inherit;
+      font-size: inherit;
+    }
+  }
+}

--- a/app/assets/stylesheets/puppetclasses.scss
+++ b/app/assets/stylesheets/puppetclasses.scss
@@ -41,3 +41,11 @@
 .selected_puppetclass.unavailable a {
   color: $color-pf-black-400;
 }
+
+#inherited_ids {
+  padding-left: 0;
+}
+
+#inherited-classes .panel-title {
+  font-size: 1.6rem;
+}

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -62,6 +62,14 @@ module HostCommon
     end
   end
 
+  def parent_name
+    if is_a?(Host::Base) && hostgroup
+      hostgroup.name
+    elsif is_a?(Hostgroup) && parent
+      parent.name
+    end
+  end
+
   # Returns a url pointing to boot file
   def url_for_boot(file)
     "#{os.medium_uri(self)}/#{os.url_for_boot(file)}"

--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -20,18 +20,36 @@
           :collection => obj.classes_in_groups ,:as => :klass, :locals => { :type => obj_type(obj), :obj => obj } %>
         <% end %>
       <% else %>
+
         <% obj.puppetclasses.each do |klass| %>
           <li data-original-title="<%= _('Not authorized to edit classes') %>" rel="twipsy" ><%= h klass.name %></li>
         <% end %>
       <% end %>
     </ul>
 
-    <% if (obj.kind_of?(Host::Base) && obj.hostgroup) || (obj.kind_of?(Hostgroup) && obj.parent) %>
-      <%= content_tag(:ul, :id => 'inherited_ids', :'data-inherited-puppetclass-ids' => obj.parent_classes.map(&:id).to_json) do %>
-        <% obj.parent_classes.each do |klass| %>
-          <li data-original-title="<%= _('included already from parent') %>" rel="twipsy" style='color:black;'><%= h klass.name %></li>
-        <% end %>
-      <% end %>
+    <% if obj.respond_to?(:parent_classes) && obj.parent_classes.size > 0 %>
+      <div class="panel-group paneless" id="inherited-classes">
+	<div class="panel">
+	  <div class="panel-heading">
+	    <h3 class="panel-title">
+	      <a data-toggle="collapse" data-parent="#inherited-classes" href="#inherited-classes-list" class="collapsed">
+      		<%= _('Inherited Classes from %s') % obj.parent_name %>
+	      </a>
+	    </h3>
+	  </div>
+	  <div id="inherited-classes-list" class="panel-collapse collapse">
+	    <div class="panel-body">
+
+	      <%= content_tag(:ul, :id => 'inherited_ids', :'data-inherited-puppetclass-ids' => obj.parent_classes.map(&:id).to_json) do %>
+		<% obj.parent_classes.each do |klass| %>
+		  <li style='color:black;'><%= h klass.name %></li>
+		<% end %>
+	      <% end %>
+
+	    </div>
+	  </div>
+	</div>
+      </div>
     <% end %>
   </div>
 

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -539,6 +539,31 @@ class HostJSTest < IntegrationTestWithJavascript
     end
   end
 
+  describe 'Puppet Classes tab' do
+    context 'has inherited Puppetclasses' do
+      setup do
+        @hostgroup = FactoryGirl.create(:hostgroup, :with_puppetclass)
+        @host = FactoryGirl.create(:host, hostgroup: @hostgroup, environment: @hostgroup.environment)
+
+        visit edit_host_path(@host)
+        page.find(:link, 'Puppet Classes', href: '#puppet_klasses').click
+      end
+
+      test 'it mentions the hostgroup by name in the tooltip' do
+        page.find('#puppet_klasses .panel h3 a').click
+        class_element = page.find('#inherited_ids>li')
+
+        assert_equal @hostgroup.puppetclasses.first.name, class_element.text
+      end
+
+      test 'it shows a header mentioning the hostgroup inherited from' do
+        header_element = page.find('#puppet_klasses .panel h3 a')
+
+        assert header_element.text =~ /#{@hostgroup.name}$/
+      end
+    end
+  end
+
   private
 
   def subnet_and_domain_are_selected(modal, domain)

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -95,6 +95,30 @@ class HostgroupJSTest < IntegrationTestWithJavascript
     assert page.has_selector?("#inherited_parameters #name_x")
   end
 
+  describe 'Puppet Classes tab' do
+    context 'has inherited Puppetclasses' do
+      setup do
+        @hostgroup = FactoryGirl.create(:hostgroup, :with_puppetclass)
+        @child_hostgroup = FactoryGirl.create(:hostgroup, parent: @hostgroup)
+
+        visit edit_hostgroup_path(@child_hostgroup)
+        page.find(:link, 'Puppet Classes', href: '#puppet_klasses').click
+      end
+
+      test 'it mentions the parent hostgroup by name in the tooltip' do
+        page.find('#puppet_klasses .panel h3 a').click
+        class_element = page.find('#inherited_ids>li')
+
+        assert_equal @hostgroup.puppetclasses.first.name, class_element.text
+      end
+
+      test 'it shows a header mentioning the hostgroup inherited from' do
+        header_element = page.find('#puppet_klasses .panel h3 a')
+        assert header_element.text =~ /#{@hostgroup.name}$/
+      end
+    end
+  end
+
   private
 
   def select_from_list(list_id, item)


### PR DESCRIPTION
To better recognise which Puppet Classes are inherited for Host
or Hostgroup they are under a sub-heading as a separated list and mentions the Hostgroup inherited from by name in the tooltip.

![new host group - puppet classes](https://cloud.githubusercontent.com/assets/7757/21608671/4e0a5e4e-d1be-11e6-8187-e1b7c600012c.png)

The issue suggests to have the Hostgroup the class is inherited from as part of the module name, should this be as following the pattern of `Parent-Hostgroup/module-name` or is the approach with with the header and the mention in the tooltip already a good approach to address #14714?

