### PR TITLE
Fixes #17910 - Quote strings for JQuery href attribute selector

### DIFF
--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -117,8 +117,8 @@ function setTab(){
   if (anchor.length) {
     var parent_tab = $(anchor).parents('.tab-pane');
     if (parent_tab.exists()){
-      $('.nav-tabs a[href=#'+parent_tab[0].id+']').tab('show');
+      $('.nav-tabs a[href="#'+parent_tab[0].id+'"]').tab('show');
     }
-    $('.nav-tabs a[href='+anchor+']').tab('show');
+    $('.nav-tabs a[href="'+anchor+'"]').tab('show');
   }
 }


### PR DESCRIPTION
When the attribute starts with an hash (#) the query can not be
parsed by JQquery, quoting them prevents that from happening.