### PR TITLE
Fixes #17904 - Show tooltips for long proxy log messages

### DIFF
--- a/app/assets/javascripts/proxy_status/logs.js
+++ b/app/assets/javascripts/proxy_status/logs.js
@@ -52,6 +52,8 @@ function activateLogsDataTable() {
     if (link.data('message')) modal.find('#modal-bt-message').text(link.data('message'));
     if (link.data('backtrace')) modal.find('#modal-bt-backtrace').text(link.data('backtrace'));
   })
+  // Activate tooltips for fields with ellipsis
+  tfm.tools.activateTooltips('#table-proxy-status-logs');
 }
 
 function expireLogs(item, from) {


### PR DESCRIPTION
To reproduce, get a proxy with long messages in the logs, and try to do this:

![](http://i.imgur.com/ToKzkZj.gif)

One can click on the "ERROR" part of the table but it's not obvious, the ellipsis fields are supposed to show a tooltip with the full content.
