### PR TITLE
Fixes #17939 - Refactored classification to reduce complexity

### DIFF
--- a/app/models/concerns/classification.rb
+++ b/app/models/concerns/classification.rb
@@ -1,0 +1,8 @@
+module Classification
+  extend ActiveSupport::Concern
+
+  included do
+    scope :values_hash, ->(host) { Classification::ValuesHashQuery.values_hash(host, current_scope || default_scoped) }
+    scope :inherited_values, ->(host) { Classification::ValuesHashQuery.inherited_values(host, current_scope || default_scoped) }
+  end
+end

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -1,6 +1,7 @@
 class LookupKey < ActiveRecord::Base
   include Authorizable
   include HiddenValue
+  include Classification
 
   KEY_TYPES = [N_("string"), N_("boolean"), N_("integer"), N_("real"), N_("array"), N_("hash"), N_("yaml"), N_("json")]
   VALIDATOR_TYPES = [N_("regexp"), N_("list") ]
@@ -147,33 +148,6 @@ class LookupKey < ActiveRecord::Base
   end
 
   private
-
-  # Generate possible lookup values type matches to a given host
-  def path2matches(host)
-    raise ::Foreman::Exception.new(N_("Invalid Host")) unless host.class.model_name == "Host"
-    matches = []
-    path_elements.each do |rule|
-      match = []
-      rule.each do |element|
-        match << "#{element}#{EQ_DELM}#{attr_to_value(host,element)}"
-      end
-      matches << match.join(KEY_DELM)
-    end
-    matches
-  end
-
-  # translates an element such as domain to its real value per host
-  # tries to find the host attribute first, parameters and then fallback to a puppet fact.
-  def attr_to_value(host, element)
-    # direct host attribute
-    return host.send(element) if host.respond_to?(element)
-    # host parameter
-    return host.host_params[element] if host.host_params.include?(element)
-    # fact attribute
-    if (fn = host.fact_names.first(:conditions => { :name => element }))
-      return FactValue.where(:host_id => host.id, :fact_name_id => fn.id).first.value
-    end
-  end
 
   def sanitize_path
     self.path = path.tr("\s","").downcase unless path.blank?

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -14,7 +14,7 @@ module Classification
     end
 
     def inherited_values
-      values_hash :skip_fqdn => true
+      keys.inherited_values(@host).raw
     end
 
     protected
@@ -23,212 +23,15 @@ module Classification
 
     #override this method to return the relevant parameters for a given set of classes
     def class_parameters
+      keys
+    end
+
+    def keys
       raise NotImplementedError
     end
 
-    def possible_value_orders
-      # the inner join makes sure we take only keys with actual values
-      class_parameters.joins(:lookup_values).flat_map(&:path_elements).uniq
-    end
-
-    def values_hash(options = {})
-      values = Hash.new { |h,k| h[k] = {} }
-      all_lookup_values = LookupValue.where(:match => path2matches).where(:lookup_key_id => class_parameters).includes(:lookup_key).to_a
-      class_parameters.each do |key|
-        lookup_values_for_key = all_lookup_values.select{|i| i.lookup_key_id == key.id}
-        sorted_lookup_values = lookup_values_for_key.sort_by do |lv|
-          matcher_key = ''
-          matcher_value = ''
-          lv.match.split(LookupKey::KEY_DELM).each do |match_key|
-            element = match_key.split(LookupKey::EQ_DELM).first
-            matcher_key += element + ','
-            if element == 'hostgroup'
-              matcher_value = match_key.split(LookupKey::EQ_DELM).last
-            end
-          end
-          # prefer matchers in order of the path, then more specific matches (i.e. hostgroup children)
-          [key.path.index(matcher_key.chomp(',')), -1 * matcher_value.length]
-        end
-        value = nil
-        if key.merge_overrides
-          default = key.merge_default ? key.default_value : nil
-          case key.key_type
-            when "array"
-              value = update_array_matcher(default, key.avoid_duplicates, sorted_lookup_values, options)
-            when "hash"
-              value = update_hash_matcher(default, sorted_lookup_values, options)
-            else
-              raise "merging enabled for non mergeable key #{key.key}"
-          end
-        else
-          value = update_generic_matcher(sorted_lookup_values, options)
-        end
-
-        values[key.id][key.key] = value if value.present?
-      end
-      values
-    end
-
-    def value_of_key(key, values)
-      value = if values[key.id] && values[key.id][key.to_s]
-                {:value => values[key.id][key.to_s][:value], :managed => values[key.id][key.to_s][:managed] }
-              else
-                default_value_method = %w(yaml json).include?(key.key_type) ? :default_value_before_type_cast : :default_value
-                {:value => key.send(default_value_method), :managed => key.omit}
-              end
-
-      return nil if value[:managed]
-      needs_late_validation = value[:value].contains_erb?
-      value = @safe_render.parse(value[:value])
-      value = type_cast(key, value)
-      validate_lookup_value(key, value) if needs_late_validation
-      value
-    end
-
-    def hostgroup_matches
-      @hostgroup_matches ||= matches_for_hostgroup
-    end
-
-    def matches_for_hostgroup
-      matches = []
-      if hostgroup
-        path = hostgroup.to_label
-        while path.include?("/")
-          path = path[0..path.rindex("/")-1]
-          matches << "hostgroup#{LookupKey::EQ_DELM}#{path}"
-        end
-      end
-      matches
-    end
-
-    # Generate possible lookup values type matches to a given host
-    def path2matches
-      matches = []
-      possible_value_orders.each do |rule|
-        match = Array.wrap(rule).map do |element|
-          "#{element}#{LookupKey::EQ_DELM}#{attr_to_value(element)}"
-        end
-        matches << match.join(LookupKey::KEY_DELM)
-
-        hostgroup_matches.each do |hostgroup_match|
-          match[match.index { |m| m =~ /hostgroup\s*=/ }]=hostgroup_match
-          matches << match.join(LookupKey::KEY_DELM)
-        end if Array.wrap(rule).include?("hostgroup") && Setting["host_group_matchers_inheritance"]
-      end
-      matches
-    end
-
-    # translates an element such as domain to its real value per host
-    # tries to find the host attribute first, parameters and then fallback to a puppet fact.
-    def attr_to_value(element)
-      # direct host attribute
-      return host.send(element) if host.respond_to?(element)
-      # host parameter
-      return host.host_params[element] if host.host_params.include?(element)
-      # fact attribute
-      if (fn = host.fact_names.where(:name => element).first)
-        return FactValue.where(:host_id => host.id, :fact_name_id => fn.id).first.value
-      end
-    end
-
-    def path_elements(path = nil)
-      path.split.map do |paths|
-        paths.split(LookupKey::KEY_DELM).map do |element|
-          element
-        end
-      end
-    end
-
-    private
-
-    def validate_lookup_value(key, value)
-      lookup_value = key.lookup_values.build(:value => value)
-      return true if lookup_value.validate_value
-      raise "Invalid value '#{value}' of parameter #{key.id} '#{key.key}'"
-    end
-
-    def type_cast(key, value)
-      Foreman::Parameters::Caster.new(key, :attribute_name => :default_value, :to => key.key_type, :value => value).cast
-    rescue TypeError
-      Rails.logger.warn "Unable to type cast #{value} to #{key.key_type}"
-    end
-
-    def get_element_and_element_name(lookup_value)
-      element = ''
-      element_name = ''
-      lookup_value.match.split(LookupKey::KEY_DELM).each do |match_key|
-        lv_element, lv_element_name = match_key.split(LookupKey::EQ_DELM)
-        element += lv_element + ','
-        element_name += lv_element_name + ','
-      end
-      [element.chomp(','), element_name.chomp(',')]
-    end
-
-    def update_generic_matcher(lookup_values, options)
-      computed_lookup_value = nil
-      lookup_values.each do |lookup_value|
-        element, element_name = get_element_and_element_name(lookup_value)
-        next if (options[:skip_fqdn] && element=="fqdn")
-        value_method = %w(yaml json).include?(lookup_value.lookup_key.key_type) ? :value_before_type_cast : :value
-        computed_lookup_value = {:value => lookup_value.send(value_method), :element => element,
-                                 :element_name => element_name}
-
-        computed_lookup_value.merge!({ :managed => lookup_value.omit }) if lookup_value.lookup_key.puppet?
-        break
-      end
-      computed_lookup_value
-    end
-
-    def update_array_matcher(default, should_avoid_duplicates, lookup_values, options)
-      elements = []
-      values = []
-      element_names = []
-
-      unless default.nil?
-        values += default
-        elements << s_("LookupKey|Default value")
-        element_names << s_("LookupKey|Default value")
-      end
-
-      lookup_values.each do |lookup_value|
-        element, element_name = get_element_and_element_name(lookup_value)
-        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.omit)
-        elements << element
-        element_names << element_name
-        if should_avoid_duplicates
-          values |= lookup_value.value
-        else
-          values += lookup_value.value
-        end
-      end
-
-      return nil unless values.present?
-      {:value => values, :element => elements, :element_name => element_names}
-    end
-
-    def update_hash_matcher(default, lookup_values, options)
-      elements = []
-      values = {}
-      element_names = []
-
-      unless default.nil?
-        values = default
-        elements << s_("LookupKey|Default value")
-        element_names << s_("LookupKey|Default value")
-      end
-
-      # to make sure seep merge overrides by priority, putting in the values with the lower priority first
-      # and then merging with higher priority
-      lookup_values.reverse_each do |lookup_value|
-        element, element_name = get_element_and_element_name(lookup_value)
-        next if ((options[:skip_fqdn] && element=="fqdn") || lookup_value.omit)
-        elements << element
-        element_names << element_name
-        values.deep_merge!(lookup_value.value)
-      end
-
-      return nil unless values.present?
-      {:value => values, :element => elements, :element_name => element_names}
+    def values_hash
+      keys.values_hash(@host).raw
     end
   end
 end

--- a/app/services/classification/class_param.rb
+++ b/app/services/classification/class_param.rb
@@ -1,36 +1,40 @@
 module Classification
   class ClassParam < Base
     def enc
-      key_hash = hashed_class_parameters
-      values   = values_hash
+      key_hash = hashed_class_keys(keys)
+      values = keys.values_hash(host)
 
       klasses = {}
       classes.each do |klass|
-        klasses[klass.name] ||= {}
-        if key_hash[klass.id]
-          key_hash[klass.id].each do |key|
-            key_value = value_of_key(key, values)
-            klasses[klass.name][key.to_s] = key_value unless key_value.nil?
-          end
-          klasses[klass.name] = nil if klasses[klass.name] == {}
-        else
-          klasses[klass.name] = nil
-        end
+        klasses[klass.name] = smart_class_params_for(klass, key_hash, values)
       end
       klasses
     end
 
     protected
 
-    def class_parameters
+    def keys
       @keys ||= PuppetclassLookupKey.includes(:environment_classes).parameters_for_class(puppetclass_ids, environment_id)
     end
 
     private
 
-    def hashed_class_parameters
+    def smart_class_params_for(klass, key_hash, values)
+      return nil unless key_hash[klass.id]
+
+      class_values = {}
+      key_hash[klass.id].each do |key|
+        key_value = values[key]
+        class_values[key.to_s] = key_value unless key_value.nil?
+      end
+
+      return nil if class_values == {}
+      class_values
+    end
+
+    def hashed_class_keys(keys)
       h = {}
-      class_parameters.each do |key|
+      keys.each do |key|
         klass_id = key.environment_classes.first.puppetclass_id
         h[klass_id] ||= []
         h[klass_id] << key

--- a/app/services/classification/classification_result.rb
+++ b/app/services/classification/classification_result.rb
@@ -1,0 +1,58 @@
+module Classification
+  # Responsible for proper rendering of classification results.
+  # Caches all neccessary objects for proper render.
+  # Exposes [] index for rendering the actual result and #raw attribute
+  # to access the raw LookupKey => LookupValue hash.
+  class ClassificationResult
+    attr_reader :raw
+
+    def initialize(raw_hash, host)
+      @host = host
+      @raw = raw_hash
+      @safe_render = SafeRender.new(:variables => {:host => host})
+    end
+
+    # Returns an object stored inside the LookupValue object, including running all
+    # neccessary validations and rendering.
+    # Inputs:
+    # key: LookupKey to retreive
+    def [](key)
+      value = extract_value(key)
+
+      return nil if value[:managed]
+      needs_late_validation = value[:value].contains_erb?
+      value = @safe_render.parse(value[:value])
+      value = type_cast(key, value)
+      validate_lookup_value(key, value) if needs_late_validation
+      value
+    end
+
+    private
+
+    def extract_value(key)
+      key_hash = key_hash(key)
+      if key_hash
+        {:value => key_hash[:value], :managed => key_hash[:managed] }
+      else
+        default_value_method = %w(yaml json).include?(key.key_type) ? :default_value_before_type_cast : :default_value
+        {:value => key.send(default_value_method), :managed => key.omit}
+      end
+    end
+
+    def key_hash(key)
+      raw[key.id][key.to_s] if raw[key.id]
+    end
+
+    def validate_lookup_value(key, value)
+      lookup_value = key.lookup_values.build(:value => value)
+      return true if lookup_value.validate_value
+      raise "Invalid value '#{value}' of parameter #{key.id} '#{key.key}'"
+    end
+
+    def type_cast(key, value)
+      Foreman::Parameters::Caster.new(key, :attribute_name => :default_value, :to => key.key_type, :value => value).cast
+    rescue TypeError
+      Rails.logger.warn "Unable to type cast #{value} to #{key.key_type}"
+    end
+  end
+end

--- a/app/services/classification/global_param.rb
+++ b/app/services/classification/global_param.rb
@@ -1,18 +1,17 @@
 module Classification
   class GlobalParam < Base
     def enc
-      values = values_hash
-
+      values = keys.values_hash(host)
       parameters = {}
-      class_parameters.each do |key|
-        parameters[key.to_s] = value_of_key(key, values)
+      keys.each do |key|
+        parameters[key.to_s] = values[key]
       end
       parameters
     end
 
     protected
 
-    def class_parameters
+    def keys
       @keys ||= VariableLookupKey.global_parameters_for_class(puppetclass_ids)
     end
   end

--- a/app/services/classification/matches_generator.rb
+++ b/app/services/classification/matches_generator.rb
@@ -1,0 +1,94 @@
+module Classification
+  # Responsible for generation of matcher strings for a given host and set of keys
+  class MatchesGenerator
+    def self.matches(host, keys)
+      self.new(host, keys).matches
+    end
+
+    attr_reader :host, :keys
+    def initialize(host, keys)
+      @host = host
+      @keys = keys
+    end
+
+    def matches
+      matches = []
+      possible_value_orders.each do |rule|
+        match = generate_match(rule)
+        matches << match.join(LookupKey::KEY_DELM)
+
+        hostgroup_matches.each do |hostgroup_match|
+          match[match.index { |m| m =~ /hostgroup\s*=/ }]=hostgroup_match
+          matches << match.join(LookupKey::KEY_DELM)
+        end if add_hostgroup_matches?(rule)
+      end
+      matches
+    end
+
+    private
+
+    def possible_value_orders
+      # the inner join makes sure we take only keys with actual values
+      keys.joins(:lookup_values).flat_map(&:path_elements).uniq
+    end
+
+    def generate_match(rule)
+      Array.wrap(rule).map do |element|
+        "#{element}#{LookupKey::EQ_DELM}#{attr_to_value(element)}"
+      end
+    end
+
+    def add_hostgroup_matches?(rule)
+      Array.wrap(rule).include?("hostgroup") && Setting["host_group_matchers_inheritance"]
+    end
+
+    # translates an element such as domain to its real value per host
+    # tries to find the host attribute first, parameters and then fallback to a puppet fact.
+    def attr_to_value(element)
+      # direct host attribute
+      return host.send(element) if is_method?(element)
+      # host parameter
+      return host.host_params[element] if is_parameter?(element)
+      # fact attribute
+      if (fn = fact_name(element))
+        return fact_value(fn)
+      end
+    end
+
+    def is_method?(element)
+      host.respond_to?(element)
+    end
+
+    def is_parameter?(element)
+      host.host_params.include?(element)
+    end
+
+    def hostgroup_matches
+      matches = []
+      if host.hostgroup
+        path = host.hostgroup.to_label
+        while path.include?("/")
+          path = path[0..path.rindex("/")-1]
+          matches << "hostgroup#{LookupKey::EQ_DELM}#{path}"
+        end
+      end
+      matches
+    end
+
+    def fact_name(element)
+      host.fact_names.where(:name => element).first
+    end
+
+    def fact_value(fact_name)
+      FactValue.where(:host_id => host.id, :fact_name_id => fn.id).first.value
+    end
+
+    def path_elements(path = nil)
+      path.split.map do |paths|
+        paths.split(LookupKey::KEY_DELM).map do |element|
+          element
+        end
+      end
+    end
+  end
+end

--- a/app/services/classification/values_hash_query.rb
+++ b/app/services/classification/values_hash_query.rb
@@ -1,0 +1,167 @@
+module Classification
+  module ValuesHashQuery
+    class << self
+      # Calculates values for a given set of keys and host, but returns only values that were not set
+      # on the host itself (inherited from different properties like hostgroup, interface e.t.c.).
+      # See values_hash for more info.
+      def inherited_values(host, keys)
+        values_hash host, keys, :skip_fqdn => true
+      end
+
+      # Calculates values for a given set of keys and a host supplied in the constructor.
+      # Inputs:
+      # keys: an ActiveRecord::Scope with a set of LookupKey instances
+      # options:
+      #   :skip_fqdn => true, if there is no need to calculate values specified directly for the host.
+      # returns: ClassificationResult instance.
+      def values_hash(host, keys, options = {})
+        values = Hash.new { |h,k| h[k] = {} }
+        keys.each do |key|
+          value = calculate_value(key, lookup_values_cache(host, keys), options)
+          values[key.id][key.key] = value if value.present?
+        end
+        Classification::ClassificationResult.new(values, host)
+      end
+
+      private
+
+      def lookup_values_cache(host, keys)
+        LookupValue.where(:match => Classification::MatchesGenerator.matches(host, keys)).where(:lookup_key_id => keys).includes(:lookup_key).to_a
+      end
+
+      def calculate_value(key, lookup_values_cache, options)
+        lookup_values_for_key = lookup_values_cache.select{|i| i.lookup_key_id == key.id}
+        sorted_lookup_values = sort_lookup_values(key, lookup_values_for_key)
+        value = nil
+        if key.merge_overrides
+          value = merged_value(key, sorted_lookup_values, options)
+        else
+          value = update_generic_matcher(sorted_lookup_values, options)
+        end
+
+        value
+      end
+
+      def merged_value(key, sorted_lookup_values, options)
+        default = key.merge_default ? key.default_value : nil
+        case key.key_type
+          when "array"
+            value = update_array_matcher(default, key.avoid_duplicates, sorted_lookup_values, options)
+          when "hash"
+            value = update_hash_matcher(default, sorted_lookup_values, options)
+          else
+            raise "merging enabled for non mergeable key #{key.key}"
+        end
+
+        value
+      end
+
+      def sort_lookup_values(key, lookup_values)
+        lookup_values.sort_by do |lv|
+          matcher_key, matcher_value = split_matcher(lv)
+          # prefer matchers in order of the path, then more specific matches (i.e. hostgroup children)
+          [key.path.index(matcher_key.chomp(',')), -1 * matcher_value.length]
+        end
+      end
+
+      def split_matcher(lookup_value)
+        matcher_key = ''
+        matcher_value = ''
+
+        lookup_value.match.split(LookupKey::KEY_DELM).each do |match_key|
+          element = match_key.split(LookupKey::EQ_DELM).first
+          matcher_key += element + ','
+          if element == 'hostgroup'
+            matcher_value = match_key.split(LookupKey::EQ_DELM).last
+          end
+        end
+
+        [matcher_key, matcher_value]
+      end
+
+      def get_element_and_element_name(lookup_value)
+        element = ''
+        element_name = ''
+        lookup_value.match.split(LookupKey::KEY_DELM).each do |match_key|
+          lv_element, lv_element_name = match_key.split(LookupKey::EQ_DELM)
+          element += lv_element + ','
+          element_name += lv_element_name + ','
+        end
+        [element.chomp(','), element_name.chomp(',')]
+      end
+
+      def update_generic_matcher(lookup_values, options)
+        computed_lookup_value = nil
+        lookup_values.each do |lookup_value|
+          element, element_name = get_element_and_element_name(lookup_value)
+          next if (options[:skip_fqdn] && element=="fqdn")
+          computed_lookup_value = compute_lookup_value(lookup_value, element, element_name)
+          computed_lookup_value.merge!({ :managed => lookup_value.omit }) if lookup_value.lookup_key.puppet?
+          break
+        end
+        computed_lookup_value
+      end
+
+      def compute_lookup_value(lookup_value, element, element_name)
+        value_method = %w(yaml json).include?(lookup_value.lookup_key.key_type) ? :value_before_type_cast : :value
+        {
+          :value => lookup_value.send(value_method),
+          :element => element,
+          :element_name => element_name
+        }
+      end
+
+      def update_array_matcher(default, should_avoid_duplicates, lookup_values, options)
+        values, elements, element_names = set_defaults(default, [])
+
+        lookup_values.each do |lookup_value|
+          element, element_name = get_element_and_element_name(lookup_value)
+          next if skip_value?(element, lookup_value, options)
+          elements << element
+          element_names << element_name
+
+          values = accumulate_value(values, lookup_value, should_avoid_duplicates)
+        end
+
+        return nil unless values.present?
+        {:value => values, :element => elements, :element_name => element_names}
+      end
+
+      def skip_value?(element, lookup_value, options)
+        ((options[:skip_fqdn] && element=="fqdn") || lookup_value.omit)
+      end
+
+      def accumulate_value(values, lookup_value, should_avoid_duplicates)
+        if should_avoid_duplicates
+          values |= lookup_value.value
+        else
+          values += lookup_value.value
+        end
+        values
+      end
+
+      def set_defaults(default, empty_value)
+        return [empty_value, [], []] if default.nil?
+
+        [default, [s_("LookupKey|Default value")], [s_("LookupKey|Default value")]]
+      end
+
+      def update_hash_matcher(default, lookup_values, options)
+        values, elements, element_names = set_defaults(default, {})
+
+        # to make sure seep merge overrides by priority, putting in the values with the lower priority first
+        # and then merging with higher priority
+        lookup_values.reverse_each do |lookup_value|
+          element, element_name = get_element_and_element_name(lookup_value)
+          next if skip_value?(element, lookup_value, options)
+          elements << element
+          element_names << element_name
+          values.deep_merge!(lookup_value.value)
+        end
+
+        return nil unless values.present?
+        {:value => values, :element => elements, :element_name => element_names}
+      end
+    end
+  end
+end

--- a/test/models/lookup_key_test.rb
+++ b/test/models/lookup_key_test.rb
@@ -37,7 +37,8 @@ class LookupKeyTest < ActiveSupport::TestCase
     end
 
     @host1.domain = domains(:mydomain)
-    assert_equal [value.match], key.send(:path2matches,@host1)
+    actual = Classification::MatchesGenerator.matches(@host1, VariableLookupKey.where(:key => 'ntp'))
+    assert_equal [value.match], actual
   end
 
   def test_fetching_the_correct_value_to_a_given_key
@@ -67,7 +68,9 @@ class LookupKeyTest < ActiveSupport::TestCase
       value = LookupValue.create!(:value => "ntp.pool.org", :match => "hostgroup =  Common", :lookup_key => key)
     end
     @host1.hostgroup = hostgroups(:common)
-    assert_equal [value.match], key.send(:path2matches,@host1)
+
+    actual = Classification::MatchesGenerator.matches(@host1, VariableLookupKey.where(:key => 'ntp'))
+    assert_equal [value.match], actual
   end
 
   def test_multiple_paths


### PR DESCRIPTION

1. Created a query object class to encapsulate the complex query for finding values that are relevant for a key
2. Made this query accessible via scope on `LookupKey` class
3. Encapsulated results rendering into a results class that behaves a bit like hash
4. Encapsulated matches generation logic into `MatchesGenerator` class.

For transition purposes, I have left the old classification classes but stripped down the logic and made them only adapters to the new system.