### PR TITLE
Fixes #17998 - Only print LDAP bind status if available

### DIFF
--- a/config/initializers/ldap_instrumentation.rb
+++ b/config/initializers/ldap_instrumentation.rb
@@ -15,7 +15,13 @@ module Foreman
   end
 
   class NetLdapSubscriber < LdapSubscriber
-    define_log(:bind, 'op bind', YELLOW) { |payload| "result=#{payload[:bind].status}" }
+    define_log(:bind, 'op bind', YELLOW) do |payload|
+      if payload[:bind].try(:status)
+        "result=#{payload[:bind].status}"
+      else
+        "result=#{payload[:bind]}"
+      end
+    end
     define_log(:search, 'op search', YELLOW) { |payload| "filter=#{payload[:filter]}, base=#{payload[:base]}" }
   end
 


### PR DESCRIPTION
The ldap logger tries to call payload[:bind].status but it might not be
defined if the bind goes wrong in some LDAP sources.

This causes a 500 instead of logging the status of the bind. We should
only display payload[:bind].status if it's available.