### PR TITLE
help block from libvirt updated

### DIFF
--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,4 +1,4 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
+<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu+ssh://root@host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
 
 <%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display type") %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,


### PR DESCRIPTION
help block from libvirt updated from 
*e.g. qemu://host.example.com/system* 
  to 
*e.g. qemu+ssh://root@host.example.com/system*

According the official documentation