### PR TITLE
Fixes #4519, #9531 - Correctly handle invalid host name changes

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -5,7 +5,7 @@
 
 <% Taxonomy.as_taxonomy @organization , @location do %>
 
-  <%= form_for @host,  :html => {:data => {:id => @host.try(:id), :type_changed => !!@host.type_changed?, :submit => 'progress_bar'}} do |f| %>
+  <%= form_for @host, :url => (@host.new_record? ? hosts_path : host_path(:id => @host.id)), :html => {:data => {:id => @host.try(:id), :type_changed => !!@host.type_changed?, :submit => 'progress_bar'}} do |f| %>
     <%= base_errors_for @host %>
 
     <ul class="nav nav-tabs" data-tabs="tabs">

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -3,10 +3,10 @@
 <% if SETTINGS[:unattended] %>
   <% title_actions(
       display_link_if_authorized((@host.managed? ? _("Unmanage host") : _("Manage host")),
-                                  hash_for_toggle_manage_host_path(:id => @host).merge(:auth_object => @host, :permission => 'edit_hosts'),
+                                  hash_for_toggle_manage_host_path(:id => @host.id).merge(:auth_object => @host, :permission => 'edit_hosts'),
                                   {:class => 'btn btn-default', :method => :put}),
       (display_link_if_authorized(_("Disassociate host"),
-                                  hash_for_disassociate_host_path(:id => @host).merge(:auth_object => @host, :permission => 'edit_hosts'),
+                                  hash_for_disassociate_host_path(:id => @host.id).merge(:auth_object => @host, :permission => 'edit_hosts'),
                                  {:class => 'btn btn-default', :method => :put}) if @host.compute?)
      )
   %>


### PR DESCRIPTION
Removing a host name or otherwise changing it to an invalid name (such
as a name containing /) caused the form to fail loading. This makes sure
all paths are generated correctly and validation error is shown.