### PR TITLE
Fixes #18039 - Change documentation buttons to secondary button style

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -367,8 +367,8 @@ module ApplicationHelper
 
   def documentation_button(section = "", options = {})
     url = documentation_url section, options
-    link_to(icon_text('help', _('Documentation'), :class => 'icon-white', :kind => 'pficon'),
-      url, :rel => 'external', :class => 'btn btn-info btn-docs', :target => '_blank')
+    link_to(icon_text('help', _('Documentation'), :kind => 'pficon'),
+      url, :rel => 'external', :class => 'btn btn-default btn-docs', :target => '_blank')
   end
 
   def generate_links_for(sub_model)


### PR DESCRIPTION
[1]Primary Button: The primary button is blue. It should be used for the primary call to action on page/modal. Each page should have one clear call to action, so there should never be more than one primary button used on a single page. There is an accessibility reason being that on enter the primary button should be enacted. It's possible that there could be no primary action button on a page.
[2]Secondary Button: The secondary button is gray. This will be the majority of the buttons used in an application. Any button that exists on a page that isn't a primary call to action should use this color.

So update the documentation button to secondary button style. Please checking the screenshot after updating:
![documentation-button](https://cloud.githubusercontent.com/assets/701009/21882741/d9326dc0-d8e6-11e6-9709-945a64b07dac.png)

Reference the page1 in this pdf:https://groups.google.com/forum/#!msg/foreman-dev/jy2Ytas4SRw/s8yos26AEAAJ  