### PR TITLE
Fixes #18040 - URL escape PuppetCA CN on proxy view

### DIFF
--- a/app/views/puppetca/_list.html.erb
+++ b/app/views/puppetca/_list.html.erb
@@ -23,11 +23,11 @@
         <td>
           <%= action_buttons(
                     if cert.state == "pending"
-                      display_link_if_authorized(_("Sign"), hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param, :id => cert), :method => :put)
+                      display_link_if_authorized(_("Sign"), hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param, :id => url_encode(cert.name)), :method => :put)
                     end,
                     if cert.state != "revoked"
                       display_delete_if_authorized(hash_for_smart_proxy_puppetca_path(:smart_proxy_id => @proxy.to_param,
-                                                                                      :id => cert,
+                                                                                      :id => url_encode(cert.name),
                                                                                       :text =>  cert.state == "pending" ? _("Delete") : _("Revoke")))
                     end)
             %>

--- a/test/controllers/puppetca_controller_test.rb
+++ b/test/controllers/puppetca_controller_test.rb
@@ -1,13 +1,27 @@
 require 'test_helper'
 
 class PuppetcaControllerTest < ActionController::TestCase
+  setup do
+    @proxy = smart_proxies(:puppetmaster)
+  end
+
   test 'problems when signing certificate redirect to certificates page' do
-    proxy = smart_proxies(:puppetmaster)
     # Try set any random path in the referer to ensure it doesn't redirect_to :back
     @request.env['HTTP_REFERER'] = hosts_path
     # This will try to find the certificate to no avail and will raise a ProxyException
-    post :update, { :smart_proxy_id => proxy.id, :id => 1 }, set_session_user
-    assert_redirected_to smart_proxy_path(proxy, :anchor => 'certificates')
-    assert_match /ProxyAPI::ProxyException/, flash[:error]
+    post :update, { :smart_proxy_id => @proxy.id, :id => 1 }, set_session_user
+    assert_redirected_to smart_proxy_path(@proxy, :anchor => 'certificates')
+    assert_match(/ProxyAPI::ProxyException/, flash[:error])
+  end
+
+  test 'index encodes any CN to an url safe string' do
+    cert = SmartProxies::PuppetCACertificate.new(
+      ['mcollective/OL=mcollective', 'pending'])
+    ProxyStatus::PuppetCA.any_instance.expects(:certs).returns([cert])
+    assert_nothing_raised do
+      get :index, { :smart_proxy_id => @proxy.id }, set_session_user
+    end
+    assert_match(/mcollective%252FOL%253Dmcollective/, response.body)
+    assert_empty flash[:error]
   end
 end


### PR DESCRIPTION
If the CN contains characters that cannot be displayed in an URL, like
'mcollective/OL=mcollective', the puppetca list will not be able to
render.

The reason is that Rails cannot generate an URL for such CNs, so we need
to convert it into URL-friendly style.