### PR TITLE
Fixes #18045 - Puppet classes show up choosing only env.

### DIFF
--- a/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
@@ -8,6 +8,7 @@ module Foreman::Controller::Puppet::HostsControllerExtensions
                              select_multiple_puppet_proxy update_multiple_puppet_proxy
                              select_multiple_puppet_ca_proxy update_multiple_puppet_ca_proxy)
   PUPPET_MULTIPLE_ACTIONS = %w(multiple_puppetrun update_multiple_puppetrun) + MULTIPLE_EDIT_ACTIONS
+
   included do
     add_smart_proxy_filters PUPPETMASTER_ACTIONS, :features => ['Puppet']
     alias_method :find_resource_for_puppet_host_extensions, :find_resource
@@ -27,9 +28,11 @@ module Foreman::Controller::Puppet::HostsControllerExtensions
   end
 
   def hostgroup_or_environment_selected
+    refresh_host
+    set_class_variables(@host)
     Taxonomy.as_taxonomy @organization, @location do
-      if params['host']['environment_id'].present? || params['host']['hostgroup_id'].present?
-        render :partial => 'puppetclasses/class_selection', :locals => {:obj => (refresh_host)}
+      if @environment || @hostgroup
+        render :partial => 'puppetclasses/class_selection', :locals => {:obj => (@host)}
       else
         logger.info "environment_id or hostgroup_id is required to render puppetclasses"
       end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -38,6 +38,7 @@ class HostsController < ApplicationController
   before_action :set_host_type, :only => [:update]
   before_action :find_multiple, :only => MULTIPLE_ACTIONS
   before_action :validate_power_action, :only => :update_multiple_power_state
+
   helper :hosts, :reports, :interfaces
 
   def index(title = nil)
@@ -162,19 +163,6 @@ class HostsController < ApplicationController
     @host.apply_compute_profile(InterfaceMerge.new)
 
     render :partial => "interfaces_tab"
-  end
-
-  def hostgroup_or_environment_selected
-    @environment = Environment.find(params['host']['environment_id'])
-    @hostgroup = Hostgroup.find(params['host']['hostgroup_id'])
-
-    Taxonomy.as_taxonomy @organization, @location do
-      if @environment || @hostgroup
-        render :partial => 'puppetclasses/class_selection', :locals => {:obj => (refresh_host)}
-      else
-        logger.info "environment_id or hostgroup_id is required to render puppetclasses"
-      end
-    end
   end
 
   def current_parameters
@@ -898,6 +886,7 @@ class HostsController < ApplicationController
       @subnet          = host.subnet
       @compute_profile = host.compute_profile
       @realm           = host.realm
+      @hostgroup       = host.hostgroup
     end
   end
 

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1439,6 +1439,31 @@ class HostsControllerTest < ActionController::TestCase
     assert_response :method_not_allowed
   end
 
+  describe '#hostgroup_or_environment_selected' do
+    test 'choosing only one of hostgroup or environment renders classes' do
+      xhr :post, :hostgroup_or_environment_selected, {
+        :host_id => nil,
+        :host => {
+          :environment_id => Environment.unscoped.first.id
+        }
+      }, set_session_user
+      assert_response :success
+      assert_template :partial => 'puppetclasses/_class_selection'
+    end
+
+    test 'choosing both hostgroup and environment renders classes' do
+      xhr :post, :hostgroup_or_environment_selected, {
+        :host_id => @host.id,
+        :host => {
+          :environment_id => Environment.unscoped.first.id,
+          :hostgroup_id => Hostgroup.unscoped.first.id
+        }
+      }, set_session_user
+      assert_response :success
+      assert_template :partial => 'puppetclasses/_class_selection'
+    end
+  end
+
   private
 
   def initialize_host


### PR DESCRIPTION
After #3551 was merged, the hosts controller requires both environment
and hostgroup to be set in order to display puppetclasses.

It shouldn't be required to have both, so we should check what's
available and use it. If it's only the hostgroup or the environment, it
should work.

To reproduce, simply go to Hosts > New host, and select environment (without selecting hostgroup), notice how puppet classes do not load anymore.

cc @bastilian 