### PR TITLE
Fixes #16846 - Org create failure with specific msg

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -39,8 +39,8 @@ module Api
 
     rescue_from Foreman::MaintenanceException, :with => :service_unavailable
 
-    def get_resource
-      instance_variable_get(:"@#{resource_name}") || raise('no resource loaded')
+    def get_resource(message = "Couldn't find resource")
+      instance_variable_get(:"@#{resource_name}") || raise(message)
     end
 
     def controller_permission
@@ -121,7 +121,7 @@ module Api
     end
 
     def process_resource_error(options = { })
-      resource = options[:resource] || get_resource
+      resource = options[:resource] || get_resource(options[:message])
 
       raise 'resource have no errors' if resource.errors.empty?
 


### PR DESCRIPTION
While creating an Organization and passing non existing attributes as parameter values should give appropriate message.

[this commit has partial dependency on katello side as katello is making a call to foreman's base controller action, can be merged in any order, katello first or foreman first] 