### PR TITLE
Fixes #18065 - make API v1 deprecation warning more apparent

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       resource_description do
         api_version "v1"
-        app_info N_("Foreman API v1 is deprecated. Please use v2. If you still need to use v1, you may do so by either passing 'version=1' in the Accept Header or using api/v1/ in the URL.")
+        app_info N_("<b>Foreman API v1 is deprecated. Please use v2.</b><br />If you still need to use v1, you may do so by either passing 'version=1' in the Accept Header or using api/v1/ in the URL.")
       end
     end
   end


### PR DESCRIPTION
Since the text is wrapped in `N_()` and the whole string is translated later in apipie I didn't find any better solution than placing html tags into the string. Ideas are welcome.