### PR TITLE
Fixes #18085 - Update 'Build PXE Default' to secondary button style

### DIFF
--- a/app/views/provisioning_templates/index.html.erb
+++ b/app/views/provisioning_templates/index.html.erb
@@ -3,7 +3,7 @@
 <% title_actions new_link(_("New Template")),
                  display_link_if_authorized(_("Build PXE Default"), { :controller => 'provisioning_templates', :action => :build_pxe_default },{
                    :confirm => _("You are about to change the default PXE menu on all configured TFTP servers - continue?"),
-                   :class => "btn btn-info"}),
+                   :class => "btn btn-default"}),
                 documentation_button('4.4.3ProvisioningTemplates')
 %>
 


### PR DESCRIPTION
[1]Primary Button: The primary button is blue. It should be used for the primary call to action on page/modal. Each page should have one clear call to action, so there should never be more than one primary button used on a single page. There is an accessibility reason being that on enter the primary button should be enacted. It's possible that there could be no primary action button on a page.
[2]Secondary Button: The secondary button is gray. This will be the majority of the buttons used in an application. Any button that exists on a page that isn't a primary call to action should use this color.

So update the Build-PXE-Default button to secondary button style. Please checking the screenshot after updating:
![build-pxe-default](https://cloud.githubusercontent.com/assets/701009/21973771/fc758d34-dbfd-11e6-94d3-4bfbd3e79e26.png)

Reference the page1 in this pdf:https://groups.google.com/forum/#!msg/foreman-dev/jy2Ytas4SRw/s8yos26AEAAJ