### PR TITLE
Fixes #18099 - Update the close button style in two-pane pages

### DIFF
--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -146,7 +146,7 @@ function right_pane_content(response){
 
   if (!$("#content", response).length){
     $('.two-pane-right').html(response);
-    $('.two-pane-right form').prepend("<div class='fr close-button'><a class='two-pane-close' href='#'>&times;</a></div>");
+    $('.two-pane-right form').prepend("<div class='fr close-button'><span class='pficon pficon-close two-pane-close'></span></div>");
     $('.form-actions a').addClass('two-pane-close');
     fix_multi_checkbox();
   } else {
@@ -186,4 +186,3 @@ function handle_redirect(response){
   }
   return redirect
 }
-

--- a/app/assets/stylesheets/two_pane.scss
+++ b/app/assets/stylesheets/two_pane.scss
@@ -49,4 +49,7 @@
       text-decoration: none;
     }
   }
+  .two-pane-close{
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
In the two-pane pages, the color of close button in the right pane is a bit light, not easy to see.
So based my proposal on the close button in this link https://groups.google.com/forum/#!msg/foreman-dev/jy2Ytas4SRw/s8yos26AEAAJ.
I updated the close button to PatternFly style.

To check the screenshots:
![close-button](https://cloud.githubusercontent.com/assets/701009/22011437/fd85b024-dcc9-11e6-8b7d-ab00525bad56.png)
