### PR TITLE
Fixes #17992, #18103 - Improve external usergroup errors

### DIFF
--- a/app/controllers/concerns/foreman/controller/external_usergroups_errors.rb
+++ b/app/controllers/concerns/foreman/controller/external_usergroups_errors.rb
@@ -1,0 +1,31 @@
+module Foreman::Controller::ExternalUsergroupsErrors
+  extend ActiveSupport::Concern
+
+  def suggestion_external_group(exception)
+    case exception
+    when LdapFluff::Generic::UnauthenticatedException
+      _('The authentication source of your external user groups could not '\
+        'connect to LDAP with the provided credentials. Please verify the '\
+        'credentials are still valid.')
+    when Net::LDAP::Error
+      _('An error happened trying to connect to LDAP, please verify the '\
+        'authentication source host is reachable from your Foreman host and '\
+        'is online.')
+    when LdapFluff::ActiveDirectory::MemberService::UIDNotFoundException
+      _('The groups you added as external user groups were found. '\
+        'However, no users inside of them that match with your '\
+        'authentication source base DN and filter were found. Please verify '\
+        'the external user groups belong in the authentication source filter')
+    end
+  end
+
+  def external_usergroups_error(group, exception)
+    group.errors.add(
+      :base,
+      _("Could not refresh external usergroups: %{e} - %{message} - %{suggestion}") %
+      { :e => exception.class,
+        :message => exception.to_s,
+        :suggestion => suggestion_external_group(exception) }
+    )
+  end
+end

--- a/app/controllers/external_usergroups_controller.rb
+++ b/app/controllers/external_usergroups_controller.rb
@@ -1,4 +1,6 @@
 class ExternalUsergroupsController < ApplicationController
+  include Foreman::Controller::ExternalUsergroupsErrors
+
   before_action :find_resource, :only => [:refresh]
 
   def refresh
@@ -7,7 +9,9 @@ class ExternalUsergroupsController < ApplicationController
     else
       warning _("External user group %{name} could not be refreshed") % { :name => @external_usergroup.name }
     end
-    redirect_to :usergroups
+  rescue => e
+    external_usergroups_error(@external_usergroup, e)
+    process_error :redirect => edit_usergroup_url(@external_usergroup.usergroup)
   end
 
   private

--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -1,10 +1,10 @@
 class UsergroupsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::Parameters::Usergroup
+  include Foreman::Controller::ExternalUsergroupsErrors
 
   before_action :find_resource, :only => [:edit, :update, :destroy]
   before_action :get_external_usergroups_to_refresh, :only => [:update]
-  after_action  :refresh_external_usergroups, :only => [:create, :update]
 
   def index
     @usergroups = resource_base_search_and_page(:usergroups)
@@ -16,24 +16,31 @@ class UsergroupsController < ApplicationController
 
   def create
     @usergroup = Usergroup.new(usergroup_params)
-    if @usergroup.save
+    if @usergroup.save && refresh_external_usergroups
       process_success
     else
       process_error
     end
+  rescue => e
+    external_usergroups_error(e)
+    process_error
   end
 
   def edit
   end
 
   def update
-    if @usergroup.update_attributes(usergroup_params)
+    if @usergroup.update_attributes(usergroup_params) &&
+        refresh_external_usergroups
       process_success
     else
       process_error
     end
   rescue Foreman::CyclicGraphException => e
     @usergroup.errors[:usergroups] = e.record.errors[:base].join(' ')
+    process_error
+  rescue => e
+    external_usergroups_error(@usergroup, e)
     process_error
   end
 

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -53,7 +53,7 @@ class AuthSourceLdap < AuthSource
   # Loads the LDAP info for a user and authenticates the user with their password
   # Returns : Array of Strings.
   #           Either the users's DN or the user's full details OR nil
-  def authenticate(login, password)
+  def authenticate(login = account, password = account_password)
     return if login.blank? || password.blank?
 
     logger.debug "LDAP auth with user #{login} against #{self}"
@@ -106,6 +106,11 @@ class AuthSourceLdap < AuthSource
     else
       @ldap_con ||= LdapFluff.new(self.to_config)
     end
+
+  rescue Net::LDAP::Error => e
+    message = _("Error during LDAP connection #{name} using login #{login}: #{e}")
+    Foreman::Logging.exception(message, e, :level => :warn)
+    errors.add(:base, message)
   end
 
   def update_usergroups(login)
@@ -152,7 +157,7 @@ class AuthSourceLdap < AuthSource
       end
       result[:success] = true
       result[:message] = _("Test connection to LDAP server was successful.")
-    rescue StandardError => exception
+    rescue => exception
       raise ::Foreman::WrappedException.new exception, N_("Unable to connect to LDAP server")
     end
     result

--- a/test/controllers/usergroups_controller_test.rb
+++ b/test/controllers/usergroups_controller_test.rb
@@ -68,15 +68,36 @@ class UsergroupsControllerTest < ActionController::TestCase
     put :update, { :id => usergroup.id, :usergroup => {:admin => true }}, set_session_user
   end
 
-  test 'external user group is refreshed even when destroyed' do
-    AuthSourceLdap.any_instance.stubs(:valid_group? => true)
-    external = FactoryGirl.create(:external_usergroup)
-    ExternalUsergroup.any_instance.expects(:refresh).returns(true)
+  context "external user groups" do
+    test 'a suggestion is shown if the LDAP source is not reachable' do
+      AuthSourceLdap.any_instance.stubs(:valid_group? => true)
+      external = FactoryGirl.create(:external_usergroup)
+      ExternalUsergroup.any_instance.expects(:refresh).
+        raises(Net::LDAP::Error.new('foo'))
+      put :update, { :id => external.usergroup_id, :usergroup => {
+        :external_usergroups_attributes => {
+          '0' => {
+            'name' => external.name,
+            'auth_source_id' => external.auth_source_id,
+            'id' => external.id
+          }
+        }
+      }}, set_session_user
 
-    put :update, { :id => external.usergroup_id, :usergroup => { :external_usergroups_attributes => {
-      '0' => {'_destroy' => '1', 'name' => external.name, 'auth_source_id' => external.auth_source_id, 'id' => external.id}
-    }}}, set_session_user
-    assert_response :redirect
+      assert_match(/.*refresh.*external.*verify.*reachable.*/, response.body)
+      assert_template 'edit'
+    end
+
+    test 'are refreshed even when destroyed' do
+      AuthSourceLdap.any_instance.stubs(:valid_group? => true)
+      external = FactoryGirl.create(:external_usergroup)
+      ExternalUsergroup.any_instance.expects(:refresh).returns(true)
+
+      put :update, { :id => external.usergroup_id, :usergroup => { :external_usergroups_attributes => {
+        '0' => {'_destroy' => '1', 'name' => external.name, 'auth_source_id' => external.auth_source_id, 'id' => external.id}
+      }}}, set_session_user
+      assert_response :redirect
+    end
   end
 
   test 'index supports search' do


### PR DESCRIPTION
When one submit an user group with external user groups, and this
doesn't work for whatever reason, like:

Net::LDAP::Error - No route to host - connect(2)
LdapFluff::Generic::UnauthenticatedException
LdapFluff::ActiveDirectory::MemberService::UIDNotFoundException,

it should show these errors in the UI and ideally some text explaining
how to solve the issue.

Currently the errors are merely logged to production.log, which leaves
users unable to understand what happened.

This commit makes those errors show up in the UI with a suggestion on
how to fix those we know.

To test you don't need an AuthSourceLDAP, actually just testing with broken IPs and so forth should show the error in the usergroups page.