### PR TITLE
Fixes #12649 - Index search not retained on cancel click

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -376,6 +376,12 @@ module ApplicationHelper
     sub_model.map {|model| link_to(model.to_label, { :controller => model.class.model_name.plural.downcase, :action => :index, :search => "name = \"#{model.name}\"" })}.to_sentence
   end
 
+  def cancel_path_with_index_search
+    prev_controller_url = session["redirect_to_url_#{controller_name}"].to_s
+    return nil unless prev_controller_url.include?('search')
+    prev_controller_url
+  end
+
   private
 
   def edit_inline(object, property, options = {})

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -86,5 +86,5 @@
   </div>
 
   <%= f.hidden_field :id %>
-  <%= submit_or_cancel f %>
+  <%= submit_or_cancel(f, false, { :cancel_path => cancel_path_with_index_search }) %>
 <% end %>

--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -93,5 +93,5 @@
     <%= new_child_fields_template(f, :lookup_keys, {:partial => "lookup_keys/fields"})%>
   </div>
 
-  <%= submit_or_cancel f %>
+  <%= submit_or_cancel(f, false, { :cancel_path => cancel_path_with_index_search }) %>
 <% end %>


### PR DESCRIPTION
On pages puppet classes and host group, index search is not
retained on form's cancel click.
Added cancel_path_with_index_search method
in file application_helper.rb