### PR TITLE
fixes #18130 - add autoincrement for bigint id columns

### DIFF
--- a/db/migrate/20170118142654_add_auto_increment_to_bigint_ids.rb
+++ b/db/migrate/20170118142654_add_auto_increment_to_bigint_ids.rb
@@ -1,0 +1,16 @@
+class AddAutoIncrementToBigintIds < ActiveRecord::Migration
+  def self.up
+    if ['mysql', 'mysql2'].include? ActiveRecord::Base.connection.instance_values['config'][:adapter]
+      change_column :logs, :id, 'SERIAL'
+      change_column :reports, :id, 'SERIAL'
+      change_column :fact_values, :id, 'SERIAL'
+    end
+  end
+  def self.down
+    if ['mysql', 'mysql2'].include? ActiveRecord::Base.connection.instance_values['config'][:adapter]
+      change_column :logs, :id, :bigint
+      change_column :reports, :id, :bigint
+      change_column :fact_values, :id, :bigint
+    end
+  end
+end


### PR DESCRIPTION
MySQL lost the auto_increment flag when the id column was changed to bigint. Postgres uses a sequence so there was no issue. Sqlite was not changed at all.

@ohadlevy : Thanks again for reporting this. Could you try if this fixes the issue for you, please?