### PR TITLE
fixes #18136 - add index for reports type column

### DIFF
--- a/db/migrate/20170118154134_add_type_index_to_reports.rb
+++ b/db/migrate/20170118154134_add_type_index_to_reports.rb
@@ -1,0 +1,6 @@
+class AddTypeIndexToReports < ActiveRecord::Migration
+  def change
+    add_index :reports, :type
+    add_index :reports, [:type, :host_id]
+  end
+end


### PR DESCRIPTION
This increases performance when using plugins like openscap or omaha that do add an reports STI class.