### PR TITLE
Fixes #18143 - enable variables for snippets

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -97,7 +97,7 @@ module Foreman
     def snippet(name, options = {})
       if (template = Template.where(:name => name, :snippet => true).first)
         begin
-          return unattended_render(template)
+          return unattended_render(template, nil, options[:variables] || {})
         rescue => exc
           raise "The snippet '#{name}' threw an error: #{exc}"
         end
@@ -135,13 +135,13 @@ module Foreman
     end
 
     # accepts either template object or plain string
-    def unattended_render(template, overridden_name = nil)
+    def unattended_render(template, overridden_name = nil, variables = {})
       @template_name = template.respond_to?(:name) ? template.name : (overridden_name || 'Unnamed')
       template_logger.info "Rendering template '#{@template_name}'"
       raise ::Foreman::Exception.new(N_("Template '%s' is either missing or has an invalid organization or location"), @template_name) if template.nil?
       content = template.respond_to?(:template) ? template.template : template
       allowed_variables = allowed_variables_mapping(ALLOWED_VARIABLES)
-      render_safe content, ALLOWED_HELPERS, allowed_variables
+      render_safe content, ALLOWED_HELPERS, allowed_variables.merge(variables)
     end
 
     def unattended_render_to_temp_file(content, prefix = id.to_s, options = {})

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -159,6 +159,13 @@ class RendererTest < ActiveSupport::TestCase
       assert_equal 'content', tmpl
     end
 
+    test "#{renderer_name} should render a snippet with variables" do
+      send "setup_#{renderer_name}"
+      snippet = FactoryGirl.create(:provisioning_template, :snippet, :template => "A <%= @b + ' ' + @c -%> D")
+      tmpl = @renderer.snippet(snippet.name, :variables => { :b => 'B', :c => 'C' })
+      assert_equal 'A B C D', tmpl
+    end
+
     test "#{renderer_name} should render a templates_used" do
       send "setup_#{renderer_name}"
       @renderer.host = FactoryGirl.build(


### PR DESCRIPTION
snippet "ahoy" definition 
![a](https://cloud.githubusercontent.com/assets/109773/22082019/492fae56-ddc6-11e6-939f-d83d64580c3c.png)
template definition
![b](https://cloud.githubusercontent.com/assets/109773/22082017/492d1d3a-ddc6-11e6-84e0-2f3950bb4f27.png)
template output
![c](https://cloud.githubusercontent.com/assets/109773/22082018/492f6ed2-ddc6-11e6-813d-428bbcd0b7ce.png)
