### PR TITLE
fixes #18155 - add string to empty form-encoded arrays in test

### DIFF
--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -231,10 +231,10 @@ class LocationsControllerTest < ActionController::TestCase
     location = taxonomies(:location2)
     location.update_attributes(:organization_ids => [taxonomies(:organization2).id])
     saved_location = Location.find_by_id(location.id)
-    assert_equal saved_location.organization_ids.count, 1
-    put :update, { :id => location.id, :location => {:organization_ids => []}}, set_session_user
+    assert_equal 1, saved_location.organization_ids.count
+    put :update, { :id => location.id, :location => {:organization_ids => [""]}}, set_session_user
     updated_location = Location.find_by_id(location.id)
-    assert_equal updated_location.organization_ids.count, 0
+    assert_equal 0, updated_location.organization_ids.count
   end
 
   context 'wizard' do

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -235,10 +235,10 @@ class OrganizationsControllerTest < ActionController::TestCase
     organization = taxonomies(:organization2)
     organization.update_attributes(:smart_proxy_ids => [ smart_proxies(:one).id ])
     saved_organization = Organization.find_by_id(organization.id)
-    assert_equal saved_organization.smart_proxy_ids.count, 1
-    put :update, { :id => organization.id, :organization => {:smart_proxy_ids => []}}, set_session_user
+    assert_equal 1, saved_organization.smart_proxy_ids.count
+    put :update, { :id => organization.id, :organization => {:smart_proxy_ids => [""]}}, set_session_user
     updated_organization = Organization.find_by_id(organization.id)
-    assert_equal updated_organization.smart_proxy_ids.count, 0
+    assert_equal 0, updated_organization.smart_proxy_ids.count
   end
 
   context 'wizard' do


### PR DESCRIPTION
This test attempts to send an empty `:smart_proxy_ids => []` parameter
emulating the UI to unset smart_proxy_ids on a taxonomy, but Rails 5
filters this empty parameter out when converting it internally to a form
encoded parameter (since it's not possible to specify an empty array in
a form) for the purposes of the test.

Comparing the test to the real UI shows that it really submits
`:smart_proxy_ids => [""]` to pass an empty array, so update the test
data to match.