### PR TITLE
fixes #18157 - use AS::Duration division to get days from expiry

### DIFF
--- a/app/services/actions/foreman/report/import.rb
+++ b/app/services/actions/foreman/report/import.rb
@@ -33,7 +33,7 @@ module Actions
         end
 
         def self.cleanup_after
-          "#{Hash[::Report::DEFAULT_EXPIRATION.parts][:days]}d"
+          "#{::Report::DEFAULT_EXPIRATION / 1.day}d"
         end
       end
     end


### PR DESCRIPTION
ActiveSupport::Duration#parts was an unreliable API as it contains data
used internally when constructing durations.