### PR TITLE
Fixes #18175 - Optionaly disable preview for templates

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template.rb
@@ -8,6 +8,7 @@ module Foreman::Controller::Parameters::Template
         :locked,
         :name,
         :snippet,
+        :preview_enabled,
         :template,
         :template_kind, :template_kind_id, :template_kind_name,
         :vendor

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -27,6 +27,8 @@
         <%= checkbox_f f, :default, :label=>_('Default'), :help_block => default_template_description %>
       <% end -%>
 
+      <%= f.hidden_field(:preview_enabled, :value => @template.preview_enabled) %>
+
       <%= render "custom_tabs", :f => f if type == 'ptable' %>
       <%= render_if_exists "#{@type_name_plural}/_alerts" %>
 
@@ -42,7 +44,7 @@
 
         <div class="col-md-12">
           <div class="editor-container">
-            <%= render :partial => 'editor/toolbar', :locals => {:show_preview => true} %>
+            <%= render :partial => 'editor/toolbar', :locals => { :show_preview => @template.preview_enabled } %>
 
             <%= alert :class => 'alert-danger hide', :id => 'preview_error', :close => false %>
             <%= textarea_f f, :template, :class => "editor_source", :label =>:none, :disabled => @template.locked?, :size => "max",

--- a/db/migrate/20170120110725_add_preview_field_to_templates.rb
+++ b/db/migrate/20170120110725_add_preview_field_to_templates.rb
@@ -1,0 +1,9 @@
+class AddPreviewFieldToTemplates < ActiveRecord::Migration
+  def up
+    add_column :templates, :preview_enabled, :boolean, :default => true
+  end
+
+  def down
+    remove_column :templates, :preview_enabled
+  end
+end


### PR DESCRIPTION
If a template is not allowed for previewing, its clones will not be allowed as well.