### PR TITLE
fixes #18214 - accept `params` as AC::Parameters or Hash

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -304,7 +304,7 @@ Return the host's compute attributes that can be used to create a clone of this 
         params = params.deep_clone
         if params[:interfaces_attributes]
           # handle both hash and array styles of nested attributes
-          if params[:interfaces_attributes].is_a? Hash
+          if params[:interfaces_attributes].is_a?(Hash) || params[:interfaces_attributes].is_a?(ActionController::Parameters)
             params[:interfaces_attributes] = params[:interfaces_attributes].values
           end
           # map interface types

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -92,7 +92,7 @@ class Role < ActiveRecord::Base
   # * a parameter-like Hash (eg. :controller => 'projects', :action => 'edit')
   # * a permission Symbol (eg. :edit_project)
   def allowed_to?(action)
-    if action.is_a? Hash
+    if action.is_a?(Hash) || action.is_a?(ActionController::Parameters)
       allowed_actions.include? Foreman::AccessControl.path_hash_to_string(action)
     else
       allowed_permissions.include? action

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -324,7 +324,7 @@ class User < ActiveRecord::Base
   # * a permission Symbol (eg. :edit_project)
   def allowed_to?(action)
     return true if admin?
-    if action.is_a? Hash
+    if action.is_a?(Hash) || action.is_a?(ActionController::Parameters)
       action = Foreman::AccessControl.normalize_path_hash(action)
       return true if editing_self?(action)
     end

--- a/app/services/foreman/access_control.rb
+++ b/app/services/foreman/access_control.rb
@@ -30,7 +30,7 @@ module Foreman
       end
 
       def permissions_for_controller_action(controller_action)
-        controller_action = path_hash_to_string(controller_action) if controller_action.is_a?(Hash)
+        controller_action = path_hash_to_string(controller_action) if controller_action.is_a?(Hash) || controller_action.is_a?(ActionController::Parameters)
         @permissions.select { |p| p.actions.include?(controller_action) }
       end
 

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -27,7 +27,7 @@ class ReportImporter
   end
 
   def initialize(raw, proxy_id = nil)
-    raise ::Foreman::Exception.new(_('Invalid report')) unless raw.is_a?(Hash)
+    raise ::Foreman::Exception.new(_('Invalid report')) unless raw.is_a?(Hash) || raw.is_a?(ActionController::Parameters)
     @raw      = raw
     @proxy_id = proxy_id
   end


### PR DESCRIPTION
In Rails 5, ActionController::Parameters no longer inherits from Hash
and so type checks for params.is_a?(Hash) now return false and should
accept either. (Rails commit 14a3bd5.)