### PR TITLE
fixes #18233, #18235 - isolate pagelets state between tests

### DIFF
--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -195,7 +195,7 @@ module Foreman #:nodoc:
     #                       :onlyif => Proc.new { |subject| subject.should_show_pagelet? }
     # end
     def extend_page(virtual_path, &block)
-      yield Pagelets::Manager.new(virtual_path) if block_given?
+      Pagelets::Manager.with_key(virtual_path, &block) if block_given?
     end
 
     def tests_to_skip(hash)

--- a/app/services/pagelets/manager.rb
+++ b/app/services/pagelets/manager.rb
@@ -1,44 +1,72 @@
 module Pagelets
   class Manager
-    def initialize(key)
-      @key = key
-    end
-
-    def add_pagelet(mountpoint, opts)
-      self.class.add_pagelet(@key, mountpoint, opts)
-    end
-
     class << self
-      def add_pagelet(key, mountpoint, opts)
-        handle_empty_keys_for key, mountpoint
-        raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without partial"), key) unless opts[:partial]
-        raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without mountpoint"), key) if mountpoint.nil?
-        priority = opts[:priority] || default_pagelet_priority(key, mountpoint)
-        pagelet = Pagelets::Pagelet.new(opts.delete(:name), opts.delete(:partial), priority, opts)
-        @pagelets[key][mountpoint] << pagelet
+      delegate :add_pagelet, :pagelets_at, :with_key, to: :instance
+
+      def instance
+        @instance ||= self.new
+      end
+      attr_writer :instance
+    end
+
+    def initialize
+      @pagelets = {}.with_indifferent_access
+    end
+
+    def initialize_copy(orig)
+      super
+      @pagelets = @pagelets.deep_dup
+    end
+
+    def add_pagelet(key, mountpoint, opts)
+      handle_empty_keys_for key, mountpoint
+      raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without partial"), key) unless opts[:partial]
+      raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without mountpoint"), key) if mountpoint.nil?
+      priority = opts[:priority] || default_pagelet_priority(key, mountpoint)
+      pagelet = Pagelets::Pagelet.new(opts.delete(:name), opts.delete(:partial), priority, opts)
+      @pagelets[key][mountpoint] << pagelet
+      pagelet
+    end
+
+    def clear
+      @pagelets.clear
+    end
+
+    def pagelets_at(key, mountpoint)
+      handle_empty_keys_for key, mountpoint
+      @pagelets[key][mountpoint]
+    end
+
+    # Yields a simpler interface for add_pagelet to avoid re-stating the key
+    def with_key(key, &block)
+      yield KeyContext.new(self, key)
+    end
+
+    class KeyContext
+      def initialize(manager, key)
+        @manager = manager
+        @key = key
       end
 
-      def default_pagelet_priority(key, mountpoint)
-        # We need a default priority value for the first pagelet if it is not specified
-        @pagelets[key][mountpoint].map(&:priority).push(0).max + 100
+      def add_pagelet(*args)
+        @manager.add_pagelet(*args.unshift(@key))
       end
 
-      def pagelets_at(key, mountpoint)
-        handle_empty_keys_for key, mountpoint
-        @pagelets[key][mountpoint]
+      def pagelets_at(*args)
+        @manager.pagelets_at(*args.unshift(@key))
       end
+    end
 
-      def clear
-        @pagelets.clear
-      end
+    private
 
-      private
+    def handle_empty_keys_for(key, mountpoint)
+      @pagelets[key] ||= {}
+      @pagelets[key][mountpoint] ||= []
+    end
 
-      def handle_empty_keys_for(key, mountpoint)
-        @pagelets ||= {}.with_indifferent_access
-        @pagelets[key] ||= {}
-        @pagelets[key][mountpoint] ||= []
-      end
+    def default_pagelet_priority(key, mountpoint)
+      # We need a default priority value for the first pagelet if it is not specified
+      @pagelets[key][mountpoint].map(&:priority).push(0).max + 100
     end
   end
 end

--- a/config/initializers/puppet.rb
+++ b/config/initializers/puppet.rb
@@ -1,12 +1,13 @@
 # initialize puppet related pagelets
-mgr = Pagelets::Manager.new "hosts/_form"
-mgr.add_pagelet :main_tabs,
-  :id => :puppet_klasses,
-  :name => _("Puppet Classes"),
-  :partial => "hosts/puppet/puppet_classes_tab",
-  :priority => 100,
-  :onlyif => proc { |host, context| context.instance_eval { accessible_resource(host, :smart_proxy, :name, association: :puppet_proxy).present? } }
+Pagelets::Manager.with_key "hosts/_form" do |mgr|
+  mgr.add_pagelet :main_tabs,
+    :id => :puppet_klasses,
+    :name => _("Puppet Classes"),
+    :partial => "hosts/puppet/puppet_classes_tab",
+    :priority => 100,
+    :onlyif => proc { |host, context| context.instance_eval { accessible_resource(host, :smart_proxy, :name, association: :puppet_proxy).present? } }
 
-mgr.add_pagelet :main_tab_fields,
-  :partial => "hosts/puppet/main_tab_fields",
-  :priority => 100
+  mgr.add_pagelet :main_tab_fields,
+    :partial => "hosts/puppet/main_tab_fields",
+    :priority => 100
+end

--- a/test/helpers/pagelets_helper_test.rb
+++ b/test/helpers/pagelets_helper_test.rb
@@ -1,16 +1,13 @@
 require 'test_helper'
+require 'pagelets_test_helper'
 
 class PageletsHelperTest < ActionView::TestCase
   include PageletsHelper
+  include PageletsIsolation
 
   setup do
-    @prev_state = Pagelets::Manager.instance_variable_get(:@pagelets).clone
     controller.prepend_view_path File.expand_path('../../static_fixtures/views', __FILE__)
     self.stubs(:virtual_path).returns("nonexisting/path")
-  end
-
-  teardown do
-    Pagelets::Manager.instance_variable_set :@pagelets, @prev_state
   end
 
   def action_name

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -1,4 +1,5 @@
 require 'integration_test_helper'
+require 'pagelets_test_helper'
 
 class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   test "index page" do
@@ -47,13 +48,14 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   describe 'pagelets on show page' do
+    include PageletsIsolation
+
     setup do
       @view_paths = SmartProxiesController.view_paths
       SmartProxiesController.prepend_view_path File.expand_path('../../static_fixtures/views', __FILE__)
     end
 
     def teardown
-      Pagelets::Manager.clear
       SmartProxiesController.view_paths = @view_paths
     end
 

--- a/test/pagelets_test_helper.rb
+++ b/test/pagelets_test_helper.rb
@@ -1,0 +1,19 @@
+# Backup and restore the main pagelets manager instance so any global
+# modifications made in tests are lost, but also any plugin or Foreman pagelets
+# remain registered after the test.
+module PageletsIsolation
+  extend ActiveSupport::Concern
+
+  included do
+    setup :pagelets_backup
+    teardown :pagelets_restore
+  end
+
+  def pagelets_backup
+    @pagelets_backup = Pagelets::Manager.instance.dup
+  end
+
+  def pagelets_restore
+    Pagelets::Manager.instance = @pagelets_backup
+  end
+end

--- a/test/unit/pagelet_manager_test.rb
+++ b/test/unit/pagelet_manager_test.rb
@@ -1,28 +1,71 @@
 require 'test_helper'
 
 class PageletManagerTest < ActiveSupport::TestCase
-  test 'should assign default priority' do
-    ::Pagelets::Manager.add_pagelet("test", :test_point, :partial => "tests")
-    assert_equal 100, ::Pagelets::Manager.pagelets_at("test", :test_point).first.priority
+  let(:manager) { ::Pagelets::Manager.new }
+
+  test '.add_pagelet uses instance' do
+    Pagelets::Manager.instance.expects(:add_pagelet).with('key', 'mount', {})
+    Pagelets::Manager.add_pagelet('key', 'mount', {})
   end
 
-  test 'should add default priority' do
-    ::Pagelets::Manager.add_pagelet("test", :point, :partial => "tests")
-    ::Pagelets::Manager.add_pagelet("test", :point, :partial => "tests")
-
-    assert_equal 100, ::Pagelets::Manager.pagelets_at("test", :point).sort.first.priority
-    assert_equal 200, ::Pagelets::Manager.pagelets_at("test", :point).sort.last.priority
+  test '.pagelets_at uses instance' do
+    Pagelets::Manager.instance.expects(:pagelets_at).with('key', 'mount').returns([:test])
+    assert_equal [:test], Pagelets::Manager.pagelets_at('key', 'mount')
   end
 
-  test '.add_pagelet should raise error when partial is missing' do
+  test '#add_pagelet assigns default priority' do
+    manager.add_pagelet("test", :test_point, :partial => "tests")
+    assert_equal 100, manager.pagelets_at("test", :test_point).first.priority
+  end
+
+  test '#add_pagelet increments default priority' do
+    manager.add_pagelet("test", :point, :partial => "tests")
+    manager.add_pagelet("test", :point, :partial => "tests")
+
+    assert_equal 100, manager.pagelets_at("test", :point).sort.first.priority
+    assert_equal 200, manager.pagelets_at("test", :point).sort.last.priority
+  end
+
+  test '#add_pagelet should raise error when partial is missing' do
     assert_raise Foreman::Exception do
-      Pagelets::Manager.add_pagelet('test', :mountpoint, {})
+      manager.add_pagelet('test', :mountpoint, {})
     end
   end
 
-  test '.add_pagelet should raise error when mountpoint is nil' do
+  test '#add_pagelet should raise error when mountpoint is nil' do
     assert_raise Foreman::Exception do
-      Pagelets::Manager.add_pagelet('test', nil, {:partial => 'test'})
+      manager.add_pagelet('test', nil, {:partial => 'test'})
+    end
+  end
+
+  test '#clear removes all pagelets' do
+    manager.add_pagelet("test", :point, :partial => "original")
+    manager.clear
+    assert_equal [], manager.pagelets_at("test", :point)
+  end
+
+  test '#dup fully isolates pagelet state' do
+    pagelet = manager.add_pagelet("test", :point, :partial => "original")
+    assert_equal [pagelet], manager.pagelets_at("test", :point)
+
+    new_manager = manager.dup
+    new_pagelet1 = new_manager.pagelets_at("test", :point).first
+    assert_equal pagelet.partial, new_pagelet1.partial
+
+    new_pagelet2 = new_manager.add_pagelet("test", :point, :partial => "another")
+    assert_equal [new_pagelet1, new_pagelet2], new_manager.pagelets_at("test", :point)
+    assert_equal [pagelet], manager.pagelets_at("test", :point)
+  end
+
+  context '#with_key' do
+    test '#add_pagelet registers without key' do
+      pagelet = manager.with_key('test') { |mgr| mgr.add_pagelet(:point, partial: 'original') }
+      assert_equal [pagelet], manager.pagelets_at('test', :point)
+    end
+
+    test '#pagelets_at retrieves without key' do
+      pagelet = manager.add_pagelet('test', :point, partial: 'original')
+      assert_equal [pagelet], manager.with_key('test') { |mgr| mgr.pagelets_at(:point) }
     end
   end
 end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'test_helper'
+require 'pagelets_test_helper'
 
 module Awesome
   module Provider; class MyAwesome < ::ComputeResource; end; end
@@ -321,17 +322,6 @@ class PluginTest < ActiveSupport::TestCase
     assert_equal 'Awesomeness Based', Host::Managed.provision_methods['awesome']
   end
 
-  def test_extend_page
-    Foreman::Plugin.register(:foo) do
-      extend_page("tests/show") do |context|
-        context.add_pagelet :main_tabs, :name => "My Tab", :partial => "partial"
-      end
-    end
-
-    assert_equal 1, ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).count
-    assert_equal "My Tab", ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).first.name
-  end
-
   def test_register_facet
     Facets.stubs(:configuration).returns({})
 
@@ -452,6 +442,21 @@ class PluginTest < ActiveSupport::TestCase
         role 'Test role', [:test_permission]
       end
       assert_equal({'Test role' => [:test_permission]}, Foreman::Plugin.find(:test_role).default_roles)
+    end
+  end
+
+  context 'with pagelets' do
+    include PageletsIsolation
+
+    def test_extend_page
+      Foreman::Plugin.register(:foo) do
+        extend_page("tests/show") do |context|
+          context.add_pagelet :main_tabs, :name => "My Tab", :partial => "partial"
+        end
+      end
+
+      assert_equal 1, ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).count
+      assert_equal "My Tab", ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).first.name
     end
   end
 end


### PR DESCRIPTION
Moves pagelets state into instances of Pagelets::Manager with clearer
dup semantics, and allows the instance to be backed up and restored
around tests using the PageletsIsolation test case mixin.