### PR TITLE
fixes #18239 - wait for AJAX spinners removal on about page test

### DIFF
--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -28,5 +28,13 @@ class AboutIntegrationTest < IntegrationTestWithJavascript
     visit about_index_path
     wait_for_ajax
     assert page.has_selector?('th', :text => "Version")
+    assert page.has_selector?('div.proxy-version', :text => '1.13.0')
+  end
+
+  private
+
+  def wait_for_ajax
+    super
+    assert page.has_no_selector?('div.spinner'), 'AJAX spinners still active'
   end
 end


### PR DESCRIPTION
`wait_for_ajax` alone may return after page load before AJAX requests
have even begun, so also wait for the spinners to be replaced.

---

Recreate (hopefully) the same assertion failure locally by disabling the proxy_status/about JS assets on the page, which shows the new assertion will wait.