### PR TITLE
Fixes #18244: Include node_modules and webpack in source tarball

### DIFF
--- a/lib/tasks/pkg.rake
+++ b/lib/tasks/pkg.rake
@@ -24,5 +24,8 @@ namespace :pkg do
     version = `git show #{ref}:VERSION`.chomp.chomp('-develop')
     raise "can't find VERSION from #{ref}" if version.empty?
     `git archive --prefix=foreman-#{version}/ #{ref} | bzip2 -9 > pkg/foreman-#{version}.tar.bz2`
+
+    `npm install --no-optional --global-style true`
+    `tar -cvjf pkg/foreman-node-modules-#{version}.tar.bz2 node_modules/`
   end
 end


### PR DESCRIPTION
This is likely a bit controversial at first due to the prior work done and change it imposes. I was largely inspired by @tbrisker recent frustrations as well as my own in trying to test and get nightly RPM builds back on track. I do realize prior debates concluded we should do this "properly" and not include other sources in our source. However, I think the "proper" way to handle things has to be balanced against the benefits or lack thereof. I have written up a good chunk of information in the Redmine issue for discussion and consideration. 

I ask that this be thought about in good faith and not out right dismissed by weighing the pros and cons of our current approach and this proposed approach.

@mmoll I know this would affect Debian packaging, so I would appreciate your thoughts as well.

[1] http://projects.theforeman.org/issues/18244