### PR TITLE
Fixes #18280 - Adds compute resource provider name

### DIFF
--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -10,6 +10,8 @@ class ComputeAttribute < ActiveRecord::Base
   serialize :vm_attrs, Hash
   before_save :update_name
 
+  delegate :provider_friendly_name, :to => :compute_resource
+
   def method_missing(method, *args, &block)
     method = method.to_s
     return super if method[-1]=="="

--- a/app/views/api/v2/compute_attributes/base.json.rabl
+++ b/app/views/api/v2/compute_attributes/base.json.rabl
@@ -1,4 +1,4 @@
 object @compute_attribute
 
-attributes :id, :name, :compute_resource_id, :compute_resource_name,
+attributes :id, :name, :compute_resource_id, :compute_resource_name, :provider_friendly_name,
            :compute_profile_id, :compute_profile_name, :vm_attrs

--- a/test/models/compute_attribute_test.rb
+++ b/test/models/compute_attribute_test.rb
@@ -29,6 +29,11 @@ class ComputeAttributeTest < ActiveSupport::TestCase
     end
   end
 
+  test "#provider_friendly_name" do
+    refute_nil @set.provider_friendly_name
+    assert_equal(@compute_resource.provider_friendly_name, @set.provider_friendly_name)
+  end
+
   describe "vm_interfaces" do
     test "returns array of interface attributes" do
       set = compute_attributes(:with_interfaces)


### PR DESCRIPTION
In order to normalize `vm_attrs` in Hammer (and not only), we'd need to know the provider name of the compute resource

(related to: https://github.com/theforeman/hammer-cli-foreman/pull/279)