### PR TITLE
Fixes #18260 - Display proper organizations count on table

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -433,7 +433,13 @@ module ApplicationHelper
   end
 
   def hosts_count(resource_name = controller.resource_name)
-    @hosts_count ||= Host::Managed.reorder('').authorized.group("#{resource_name}_id").count
+    # If we are on /organizations or /locations, this allows to display the
+    # count for hosts not in the current organization & location.
+    hosts_scope = Host::Managed.reorder('')
+    if ['organization', 'location'].include? resource_name
+      hosts_scope = hosts_scope.unscoped
+    end
+    @hosts_count ||= hosts_scope.authorized.group("#{resource_name}_id").count
   end
 
   def webpack_dev_server


### PR DESCRIPTION
If the user is scoped to taxonomy "A", "Host.count" will only return
hosts in that taxonomy. That is correct. However there is a usecase
where we want to display the hosts count regardless of the current
taxonomy.

The table for locations and organizations was showing the "Host.count"
scoped to the current taxonomy, so it would show 0 everywhere but in the
current taxonomy.

The fix is to make the helper aware of this issue, and show the unscoped
Host.count when displaying the organizations/locations table

"Spot the difference"

![screenshot from 2017-01-26 16-23-36](https://cloud.githubusercontent.com/assets/598891/22337413/2d8ad444-e3e5-11e6-8443-fe03a6894e08.png)
![screenshot from 2017-01-26 16-24-04](https://cloud.githubusercontent.com/assets/598891/22337415/2dbf0908-e3e5-11e6-9163-f32d0ee6a771.png)
