### PR TITLE
refs #17526 - reset taxonomy.current after each test

### DIFF
--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -12,6 +12,7 @@ class ActiveSupport::TestCase
 
   teardown :reconsider_gc_deferment
   teardown :clear_current_user
+  teardown :clear_current_taxonomies
   teardown :reset_setting_cache
 
   DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 1.0).to_f
@@ -41,6 +42,11 @@ class ActiveSupport::TestCase
 
   def clear_current_user
     User.current = nil
+  end
+
+  def clear_current_taxonomies
+    Location.current = nil
+    Organization.current = nil
   end
 
   def reset_setting_cache

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -10,7 +10,6 @@ module TaxonomiesBaseTest
 
     setup do
       User.current = users :admin
-      taxonomy_class.current = nil # Any context
     end
 
     test 'name can be the same if parent is different' do
@@ -403,8 +402,9 @@ module TaxonomiesBaseTest
       taxonomy = taxonomies(:"#{taxonomy_name}1")
       assert_empty taxonomy.ignore_types
       taxonomy.ignore_types << 'Environment'
-      taxonomy_class.current = taxonomy
-      assert taxonomy_class.ignore?('Environment')
+      in_taxonomy(taxonomy) do
+        assert taxonomy_class.ignore?('Environment')
+      end
     end
 
     test "'no current Taxonomy' is understood as 'any taxonomy'" do


### PR DESCRIPTION
The shared "ignores the taxable_type if current taxonomy ignores it"
test failed to reset the taxonomy in teardown, instead using the setup
routine. This causes failures in different test cases when the test was
last to run.