### PR TITLE
fixes #13618 - cache expensive vmware api calls

### DIFF
--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -4,7 +4,7 @@ class ComputeResourcesController < ApplicationController
 
   AJAX_REQUESTS = [:template_selected, :cluster_selected, :resource_pools]
   before_action :ajax_request, :only => AJAX_REQUESTS
-  before_action :find_resource, :only => [:show, :edit, :associate, :update, :destroy, :ping] + AJAX_REQUESTS
+  before_action :find_resource, :only => [:show, :edit, :associate, :update, :destroy, :ping, :refresh_cache] + AJAX_REQUESTS
 
   #This can happen in development when removing a plugin
   rescue_from ActiveRecord::SubclassNotFound do |e|
@@ -73,6 +73,20 @@ class ComputeResourcesController < ApplicationController
     end
   end
 
+  def refresh_cache
+    if @compute_resource.respond_to?(:refresh_cache) && @compute_resource.refresh_cache
+      process_success(
+        :success_msg => _('Successfully refreshed the cache.'),
+        :success_redirect => @compute_resource
+      )
+    else
+      process_error(
+        :error_msg => _('Failed to refresh the cache.'),
+        :redirect => @compute_resource
+      )
+    end
+  end
+
   #ajax methods
   def provider_selected
     @compute_resource = ComputeResource.new_provider :provider => params[:provider]
@@ -125,7 +139,7 @@ class ComputeResourcesController < ApplicationController
     case params[:action]
       when 'associate'
         'edit'
-      when 'ping', 'template_selected', 'cluster_selected', 'resource_pools'
+      when 'ping', 'template_selected', 'cluster_selected', 'resource_pools', 'refresh_cache'
         'view'
       else
         super

--- a/app/controllers/concerns/foreman/controller/parameters/compute_resource.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/compute_resource.rb
@@ -47,7 +47,8 @@ module Foreman::Controller::Parameters::ComputeResource
         filter.permit :datacenter,
           :pubkey_hash,
           :server,
-          :uuid
+          :uuid,
+          :caching_enabled
 
         add_taxonomix_params_filter(filter)
       end

--- a/app/models/concerns/compute_resource_caching.rb
+++ b/app/models/concerns/compute_resource_caching.rb
@@ -1,0 +1,13 @@
+module ComputeResourceCaching
+  extend ActiveSupport::Concern
+
+  def refresh_cache
+    cache.refresh
+  end
+
+  private
+
+  def cache
+    @cache ||= ComputeResourceCache.new(self)
+  end
+end

--- a/app/services/compute_resource_cache.rb
+++ b/app/services/compute_resource_cache.rb
@@ -1,0 +1,89 @@
+# This class caches attributes for a compute resource in
+# rails cache to speed up slow or expensive API calls
+class ComputeResourceCache
+  attr_accessor :compute_resource, :cache_duration
+
+  delegate :logger, :to => ::Rails
+
+  def initialize(compute_resource, cache_duration: 180.minutes)
+    self.compute_resource = compute_resource
+    self.cache_duration = cache_duration
+  end
+
+  # Tries to retrieve the value for a given key from the cache
+  # and returns the retrieved value. If the cache is empty,
+  # the given block is executed and the block's return stored
+  # in the cache. This value is then returned by this method.
+  def cache(key, &block)
+    return get_uncached_value(key, &block) unless cache_enabled?
+    cached_value = read(key)
+    return cached_value if cached_value
+    return unless block_given?
+    uncached_value = get_uncached_value(key, &block)
+    write(key, uncached_value)
+    uncached_value
+  end
+
+  def delete(key)
+    logger.debug "Deleting from compute resource cache: #{key}"
+    Rails.cache.delete(cache_key + key.to_s)
+  end
+
+  def read(key)
+    logger.debug "Reading from compute resource cache: #{key}"
+    Rails.cache.read(cache_key + key.to_s, cache_options)
+  end
+
+  def write(key, value)
+    logger.debug "Storing in compute resource cache: #{key}"
+    Rails.cache.write(cache_key + key.to_s, value, cache_options)
+  end
+
+  def refresh
+    # Rolls the cache_scope to refresh the cache as not all
+    # cache implementations (eg. memcached) support deleting
+    # keys by a regex
+    Rails.cache.delete(cache_scope_key)
+    true
+  rescue StandardError => e
+    Foreman::Logging.exception('Failed to refresh a compute resource cache', e)
+    false
+  end
+
+  def cache_scope
+    Rails.cache.fetch(cache_scope_key, cache_options) do
+      Foreman.uuid
+    end
+  end
+
+  def cache_enabled?
+    compute_resource.persisted? && compute_resource.caching_enabled
+  end
+
+  private
+
+  def get_uncached_value(key, &block)
+    return unless block_given?
+    start_time = Time.now.utc
+    result = compute_resource.instance_eval(&block)
+    end_time = Time.now.utc
+    duration = end_time - (start_time).round(4)
+    logger.info("Loaded compute resource data for #{key} in #{duration} seconds")
+    result
+  end
+
+  def cache_key
+    "compute_resource_#{compute_resource.id}-#{cache_scope}/"
+  end
+
+  def cache_scope_key
+    "compute_resource_#{compute_resource.id}-cache_scope_key"
+  end
+
+  def cache_options
+    {
+      :expires_in => cache_duration,
+      :race_condition_ttl => 1.minute
+    }
+  end
+end

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -81,12 +81,12 @@ Foreman::AccessControl.map do |permission_set|
 
   permission_set.security_block :compute_resources do |map|
     ajax_actions = [:test_connection]
-    map.permission :view_compute_resources, {:compute_resources => [:index, :show, :auto_complete_search, :ping, :available_images],
+    map.permission :view_compute_resources, {:compute_resources => [:index, :show, :auto_complete_search, :ping, :available_images, :refresh_cache],
                                                 :"api/v1/compute_resources" => [:index, :show],
                                                 :"api/v2/compute_resources" => [:index, :show, :available_images, :available_clusters, :available_folders,
                                                                                 :available_flavors, :available_networks, :available_resource_pools,
                                                                                 :available_security_groups, :available_storage_domains, :available_zones,
-                                                                                :available_storage_pods]
+                                                                                :available_storage_pods, :refresh_cache]
     }
     map.permission :create_compute_resources, {:compute_resources => [:new, :create].push(*ajax_actions),
                                                 :"api/v1/compute_resources" => [:create],

--- a/app/views/api/v2/compute_resources/vmware.json.rabl
+++ b/app/views/api/v2/compute_resources/vmware.json.rabl
@@ -1,1 +1,1 @@
-attributes :user, :datacenter, :server, :set_console_password
+attributes :user, :datacenter, :server, :set_console_password, :caching_enabled

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -7,4 +7,6 @@
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console passwords"),
                   :help_inline => _("Set a randomly generated password on the display connection") %>
+<%= checkbox_f f, :caching_enabled, :label => _("Enable caching"),
+                  :help_inline => _("Cache slow calls to VMWare to speed up page rendering") %>
 <%= f.hidden_field(:pubkey_hash) if f.object.uuid.present? %>

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -4,6 +4,7 @@
 <% title_actions display_link_if_authorized(_("Associate VMs"),
                                             hash_for_associate_compute_resource_path(:compute_resource_id => @compute_resource).merge(:auth_object => @compute_resource, :permission => 'edit_compute_resources'),
                                             :title => _("Associate VMs to Foreman hosts"), :method => :put, :class=>"btn btn-default"),
+(display_link_if_authorized(_('Refresh Cache'), hash_for_refresh_cache_compute_resource_path(@compute_resource).merge(:auth_object => @compute_resource), :method => :put, :class => "btn btn-default") if @compute_resource.respond_to?(:refresh_cache) && @compute_resource.caching_enabled),
    link_to_if_authorized(_('Edit'), hash_for_edit_compute_resource_path(@compute_resource).merge(:auth_object => @compute_resource), :class => "btn btn-default")  %>
 
 <ul class="nav nav-tabs" data-tabs="tabs">

--- a/app/views/compute_resources/show/_vmware.html.erb
+++ b/app/views/compute_resources/show/_vmware.html.erb
@@ -6,3 +6,7 @@
   <td><%= _("Console passwords") %></td>
   <td><%= @compute_resource.set_console_password? ? _("Enabled") : _("Disabled") %></td>
 </tr>
+<tr>
+  <td><%= _("Caching") %></td>
+  <td><%= @compute_resource.caching_enabled ? _("Enabled") : _("Disabled") %></td>
+</tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -399,6 +399,7 @@ Foreman::Application.routes.draw do
           get 'resource_pools'
           post 'ping'
           put 'associate'
+          put 'refresh_cache'
         end
         constraints(:id => /[^\/]+/) do
           resources :vms, :controller => "compute_resources_vms" do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -270,6 +270,7 @@ Foreman::Application.routes.draw do
           get 'available_clusters/(:cluster_id)/available_resource_pools', :to => 'compute_resources#available_resource_pools', :on => :member
           get :available_zones, :on => :member
           put :associate, :on => :member
+          put :refresh_cache, :on => :member
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
           resources :compute_attributes, :only => [:create, :update]

--- a/db/migrate/20170127094357_add_caching_enabled_to_compute_resource.rb
+++ b/db/migrate/20170127094357_add_caching_enabled_to_compute_resource.rb
@@ -1,0 +1,5 @@
+class AddCachingEnabledToComputeResource < ActiveRecord::Migration
+  def change
+    add_column :compute_resources, :caching_enabled, :boolean, default: true
+  end
+end

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -148,6 +148,18 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     assert !available_storage_domains.empty?
   end
 
+  context 'cache refreshing' do
+    test 'should refresh cache if supported' do
+      put :refresh_cache, { :id => compute_resources(:vmware).to_param }
+      assert_response :success
+    end
+
+    test 'should fail if unsupported' do
+      put :refresh_cache, { :id => compute_resources(:ovirt).to_param }
+      assert_response :unprocessable_entity
+    end
+  end
+
   context 'ec2' do
     setup do
       @ec2_object = Object.new

--- a/test/controllers/compute_resources_controller_test.rb
+++ b/test/controllers/compute_resources_controller_test.rb
@@ -194,6 +194,21 @@ class ComputeResourcesControllerTest < ActionController::TestCase
     end
   end
 
+  context 'compute resource cache' do
+    test 'should refresh the cache' do
+      @compute_resource = compute_resources(:vmware)
+      put :refresh_cache, {:id => @compute_resource.to_param}, set_session_user
+      assert_redirected_to compute_resource_url(@compute_resource)
+      assert_match /Successfully refreshed the cache/, flash[:notice]
+    end
+
+    test 'should not refresh the cache if unsupported' do
+      put :refresh_cache, {:id => @compute_resource.to_param}, set_session_user
+      assert_redirected_to compute_resource_url(@compute_resource)
+      assert_match /Failed to refresh the cache/, flash[:error]
+    end
+  end
+
   def set_session_user
     User.current = users(:admin) unless User.current
     SETTINGS[:login] ? {:user => User.current.id, :expires_at => 5.minutes.from_now} : {}

--- a/test/unit/compute_resource_cache_test.rb
+++ b/test/unit/compute_resource_cache_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class ComputeResourceCacheTest < ActiveSupport::TestCase
+  setup do
+    Rails.cache.clear
+  end
+
+  teardown do
+    Rails.cache.clear
+  end
+
+  let(:compute_resource) { compute_resources(:vmware) }
+  let(:cache) { ComputeResourceCache.new(compute_resource) }
+
+  context 'with caching enabled' do
+    setup do
+      compute_resource.caching_enabled = true
+    end
+
+    test 'it caches data' do
+      mock_networks = {'net' => 'work'}
+      compute_resource.expects(:networks).once.returns(mock_networks)
+      values = 10.times.map do
+        cache.cache(:networks) do
+          networks
+        end
+      end
+      assert_equal mock_networks, values.first
+      assert_equal 1, values.uniq.size
+    end
+
+    test 'refresh the cache' do
+      initial_scope = cache.cache_scope
+      initial_value = 'testvalue'
+      cache.write(:test, initial_value)
+      cache.refresh
+      new_scope = cache.cache_scope
+      assert_not_equal initial_scope, new_scope
+      assert_nil cache.read(:test)
+    end
+
+    test '#delete deletes keys from the cache' do
+      cache.write(:delete_test, 'Foreman is great.')
+      cache.delete(:delete_test)
+      assert_nil cache.read(:delete_test)
+    end
+
+    test '#write and #read store and read data in the cache' do
+      message = "Foreman is super."
+      cache.write(:write_test, message)
+      assert_equal message, cache.read(:write_test)
+    end
+  end
+
+  context 'with caching disabled' do
+    setup do
+      compute_resource.caching_enabled = false
+    end
+
+    test 'does not cache data' do
+      mock_networks = {'net' => 'work'}
+      Rails.cache.expects(:write).never
+      Rails.cache.expects(:read).never
+      Rails.cache.expects(:fetch).never
+      compute_resource.expects(:networks).times(10).returns(mock_networks)
+      values = 10.times.map do
+        cache.cache(:networks) do
+          networks
+        end
+      end
+      assert_equal mock_networks, values.first
+      assert_equal 1, values.uniq.size
+    end
+  end
+end


### PR DESCRIPTION
In my dev environment the `compute_resource_selected` call got approx. 10 times faster. I'm really thrilled!

The caching can be enabled for every compute resource. The code is reusable to plugins or other compute resources can reuse the caching mechanism.
Cache invalidation was not straight forward to implement because I wanted to support memcached so I had to use a "scope" when creating the cache keys. The scope is changed when the cache is invalidated.

Some "benchmarks":

Before:
Completed 200 OK in 16121ms (Views: 15963.0ms | ActiveRecord: 6.4ms)

After:
Completed 200 OK in 1710ms (Views: 1583.8ms | ActiveRecord: 5.1ms)