### PR TITLE
Fixes #18292 - Make notifications from an RSS feed

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/create_rss_notifications.rb
+++ b/app/jobs/create_rss_notifications.rb
@@ -1,0 +1,16 @@
+class CreateRssNotifications < ApplicationJob
+  after_perform do |job|
+    self.class.set(:wait => 12.hours).perform_later(job.arguments.first)
+  end
+
+  def perform(options = {})
+    # Defaults to theforeman.org blog RSS
+    UINotifications::RssNotificationsChecker.new(options).deliver!
+  end
+
+  rescue_from(StandardError) do |error|
+    Foreman::Logging.logger('background').error(
+      'RSS notification checker: '\
+      "Error while creating notifications #{error}: #{error.backtrace}")
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -66,7 +66,7 @@ class Notification < ApplicationRecord
 
   def set_custom_attributes
     return unless notification_blueprint # let validation catch this.
-    self.actions = UINotifications::URLResolver.new(
+    self.actions ||= UINotifications::URLResolver.new(
       subject,
       notification_blueprint.actions
     ).actions if notification_blueprint.actions.any?

--- a/app/models/setting/notification.rb
+++ b/app/models/setting/notification.rb
@@ -1,0 +1,23 @@
+class Setting::Notification < Setting
+  def self.default_settings
+    [
+      self.set('rss_enable', N_('Whether to get RSS notifications or not'), true, N_('RSS enable')),
+      self.set('rss_url', N_('URL to fetch RSS notifications from'), 'https://theforeman.org/feed.xml', N_('RSS URL')),
+    ]
+  end
+
+  def self.load_defaults
+    # Check the table exists
+    return unless super
+
+    self.transaction do
+      default_settings.each { |s| self.create! s.update(:category => "Setting::Notification")}
+    end
+
+    true
+  end
+
+  def self.humanized_category
+    N_('Notifications')
+  end
+end

--- a/app/services/ui_notifications/rss_notifications_checker.rb
+++ b/app/services/ui_notifications/rss_notifications_checker.rb
@@ -1,0 +1,74 @@
+require 'rss'
+require 'date'
+
+module UINotifications
+  class RssNotificationsChecker
+    class Item
+      def initialize(feed_item)
+        @item = feed_item
+      end
+
+      def link
+        @link ||= @item.link.respond_to?(:href) ? @item.link.href : @item.link
+      end
+
+      def summary
+        @summary ||= begin
+          summary = @item.summary if @item.respond_to?(:summary)
+          summary = @item.description if @item.respond_to?(:description)
+          summary.respond_to?(:content) ? summary.content : summary
+        end
+      end
+
+      def title
+        @title ||= @item.title.respond_to?(:content) ? @item.title.content : @item.title
+      end
+    end
+
+    def initialize(options = [])
+      @url = options[:url] || Setting[:rss_url]
+      @latest_posts = options[:latest_posts] || 3
+      @force_repost = options[:force_repost] || false
+      @audience = options[:audience] || Notification::AUDIENCE_GLOBAL
+    end
+
+    def deliver!
+      # This is a noop every time rss_enable=false, the moment it
+      # gets enabled, notifications for RSS feeds are created again
+      return true unless Setting[:rss_enable]
+      feed = RSS::Parser.parse(@url, false)
+      feed.items[0, @latest_posts].each do |feed_item|
+        item = Item.new(feed_item)
+        blueprint = rss_notification_blueprint
+        if notification_already_exists?(item)
+          next unless @force_repost
+        end
+        Notification.create(
+          :initiator => User.anonymous_admin,
+          :audience => @audience,
+          :message => item.title,
+          :notification_blueprint => blueprint,
+          :actions => {
+            :links => [
+              {
+                :href => item.link,
+                :title => _('Open'),
+                :external => true
+              }
+            ]
+          }
+        )
+      end
+    end
+
+    private
+
+    def rss_notification_blueprint
+      NotificationBlueprint.unscoped.find_by_name('rss_post')
+    end
+
+    def notification_already_exists?(item)
+      !!Notification.unscoped.find_by_message(item.summary)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -247,7 +247,7 @@ module Foreman
         if defined?(ForemanTasks)
           ForemanTasks.dynflow
         else
-          ::Dynflow::Rails.new(nil, Foreman::Dynflow::Configuration.new)
+          ::Dynflow::Rails.new(nil, ::Foreman::Dynflow::Configuration.new)
         end
       @dynflow.require!
       @dynflow

--- a/config/initializers/rss_notifications.rb
+++ b/config/initializers/rss_notifications.rb
@@ -1,0 +1,12 @@
+# First, we check if there's a job already enqueued for RSS notifications
+::Foreman::Application.dynflow.config.on_init do |world|
+  pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
+  scheduled_job = pending_jobs.select do |job|
+    delayed_plan = world.persistence.load_delayed_plan job.id
+    next unless delayed_plan.present?
+    delayed_plan.to_hash[:serialized_args].first["job_class"] == 'CreateRssNotifications'
+  end
+
+  # Only create notifications if there isn't a scheduled job
+  CreateRssNotifications.perform_later unless scheduled_job.present?
+end

--- a/db/seeds.d/170-notification_blueprints.rb
+++ b/db/seeds.d/170-notification_blueprints.rb
@@ -32,6 +32,20 @@ blueprints = [
         title: N_('Update host')
       ]
     }
+  },
+  {
+    group: _('Community'),
+    name: 'rss_post',
+    level: 'info',
+    message: _('RSS post message goes here'),
+    actions:
+    {
+      links:
+      [
+        title: _('URL'),
+        external: true,
+      ]
+    }
   }
 ]
 

--- a/lib/tasks/rss.rake
+++ b/lib/tasks/rss.rake
@@ -1,0 +1,42 @@
+namespace :rss do
+  desc <<-END_DESC
+Create notifications from an RSS feed.
+
+By default, the last 3 posts from the feed are sent to a global audience,
+and expire in one week since the announcement. Previous posts in the feed will not
+create a new notification unless "FOREMAN_RSS_FORCE_REPOST" is set to true.
+
+This will trigger a job that will check for notifications every 12 hours.
+
+It accepts the following environment variables:
+ - FOREMAN_RSS_URL
+   + An RSS URL and finds the latest posts, by default 'https://theforeman.org/feed.xml'
+ - FOREMAN_RSS_LATEST_POSTS
+   + The number of latest posts to retrieve, by default '3'
+ - FOREMAN_RSS_FORCE_REPOST
+   + If 'true', the task will send notifications again for posts in the RSS feed that already created
+     notifications.
+   + For example, on the first run of this task, it creates notifications for the latest 3 posts,
+     "Newsletter December", "Newsletter November", "Newsletter October". If you run it again without
+     FOREMAN_RSS_FORCE_REPOST, no new notifications will be created for these three posts. If you do,
+     the task will create notifications once again for "Newsletter December", November and October.
+ - FOREMAN_RSS_AUDIENCE
+   + The audience that will recieve the notification. By default, 'global'
+   + Possible values:
+     - 'global' - All users will receive the notification
+     - 'admin' - Only administrator users will receive the notification
+
+Examples:
+  # foreman-rake rss:create_notifications FOREMAN_RSS_AUDIENCE='admin'
+END_DESC
+
+  task :create_notifications => :environment do
+    rss_checker = UINotifications::RssNotificationsChecker.new(
+      :url => ENV['FOREMAN_RSS_URL'],
+      :latest_posts => ENV['FOREMAN_RSS_LATEST_POSTS'],
+      :audience => ENV['FOREMAN_RSS_AUDIENCE'],
+      :force_repost => ENV['FOREMAN_RSS_FORCE_REPOST'] == 'true',
+    )
+    rss_checker.deliver!
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -353,3 +353,13 @@ attribute73:
   category: Setting::Provisioning
   default: PXELinux default local boot
   description: 'Set up default local boot template for PXELinux'
+attribute74:
+  name: rss_enable
+  category: Setting::Notification
+  default: true
+  description: 'Whether to enable or not RSS feed notifications'
+attribute75:
+  name: rss_url
+  category: Setting::Notification
+  default: "http://theforeman.org/feed.xml"
+  description: 'Default URL for RSS feed notifications'

--- a/test/unit/ui_notifications/rss_notifications_checker_test.rb
+++ b/test/unit/ui_notifications/rss_notifications_checker_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'ostruct'
+
+module UINotifications
+  class RssNotificationsCheckerTest < ActiveSupport::TestCase
+    context 'when force_repost is disabled' do
+      setup do
+        @notifications_service = RssNotificationsChecker.new(:force_repost => false)
+      end
+
+      test 'already existing notifications are not created' do
+        feed = OpenStruct.new(:items => [1,2,3])
+        RSS::Parser.expects(:parse).returns(feed)
+        Notification.expects(:create).never
+        @notifications_service.expects(:notification_already_exists?).
+          returns(true).at_least_once
+        @notifications_service.deliver!
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a task to connect to an RSS feed, by default the one from our
community blog. The idea is to make this run every night with 'cron' on
every Foreman installation to keep people updated about changes, and
inform them about events, etc...

Also, people can setup the task for their internal company blogs or give
it any other uses they may think about. The task can be easily removed
from cron, and I'd suggest enabling it by default.

The links don't look like actual HREF tags, which would require making React render the HTML without escaping. I don't think that's a good idea, so this PR is probably a good place to introduce an endpoint in the component to add links like the one provided here http://www.patternfly.org/pattern-library/communication/notification-drawer/#/example-overview-2.

Some milestones for this feature:

- [x] - Add endpoint to notifications component for links (https://github.com/theforeman/foreman/pull/4265)
- [x] - Add service that allows tasks that generate notifications to run on a schedule.
- [ ] - Add option to puppet-foreman to choose whether to enable this or not. Make a noticeable warning if it's enabled so the operator knows this app will contact external sources (theforeman.org) by default

![screenshot from 2017-01-27 22-04-43](https://cloud.githubusercontent.com/assets/598891/22387769/89e7f476-e4dd-11e6-8f60-339f30b0c4b7.png)
![screenshot from 2017-01-27 22-04-58](https://cloud.githubusercontent.com/assets/598891/22387822/bfd4e35a-e4dd-11e6-851f-7de506501088.png)

cc @GregSutcliffe @shlomizadok I hope you make good use of this if it gets merged 
cc @bkearney I think this would be cool to use downstream to connect it to the blog or other sources