### PR TITLE
Fixes #14716 - Added option to transform thin template to thick disk

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -423,6 +423,8 @@ module Foreman::Model
         "resource_pool" => [args[:cluster], args[:resource_pool]]
       }
 
+      opts['transform'] = args[:volumes].first[:thin] == 'true' ? 'sparse' : 'flat' unless args[:volumes].empty?
+
       vm_model = new_vm(raw_args)
       opts['interfaces'] = vm_model.interfaces
       opts['volumes'] = vm_model.volumes


### PR DESCRIPTION
Unfortunately, it's a single setting for all disks - you can't choose which disks (inherited from template) will be thin and which not.

For new disks, the logic remains the same - "thin" flag would be used.