### PR TITLE
Fixes #18321 - added migration for builtin roles

### DIFF
--- a/db/migrate/20170131142526_fix_builtin_roles.rb
+++ b/db/migrate/20170131142526_fix_builtin_roles.rb
@@ -1,0 +1,5 @@
+class FixBuiltinRoles < ActiveRecord::Migration
+  def up
+    Role.where(:builtin => nil).update_all(:builtin => 0)
+  end
+end


### PR DESCRIPTION
We fixed this in code but existing incorrectly cloned roles stays undeletable.