### PR TITLE
fixes #18366 - vmware: delete vm only if created with errors

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -402,7 +402,7 @@ module Foreman::Model
       end
     rescue Fog::Errors::Error => e
       Foreman::Logging.exception("Unhandled VMware error", e)
-      destroy_vm vm.id if vm
+      destroy_vm vm.id if vm && vm.id
       raise e
     end
 


### PR DESCRIPTION
If there were errors when deploying the vm, the `vm` object exists but `vm.id` is `nil`. Trying to delete a VM with name `nil` causes an exception.