### PR TITLE
fixes #18373 - vmware: do not pass automatic firmware to vm

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -398,6 +398,7 @@ module Foreman::Model
         clone_vm(args)
       else
         vm = new_vm(args)
+        vm.firmware = 'bios' if vm.firmware == 'automatic'
         vm.save
       end
     rescue Fog::Errors::Error => e

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -19,6 +19,7 @@ class VmwareTest < ActiveSupport::TestCase
 
     mock_vm = mock('vm')
     mock_vm.expects(:save).returns(mock_vm)
+    mock_vm.expects(:firmware).returns('biod')
 
     cr = FactoryGirl.build(:vmware_cr)
     cr.expects(:parse_networks).with(attrs_in).returns(attrs_parsed)
@@ -68,8 +69,20 @@ class VmwareTest < ActiveSupport::TestCase
       args = {"image_id" =>"2", "provision_method" => "build" }
       mock_vm = mock('vm')
       mock_vm.expects(:save).returns(mock_vm)
+      mock_vm.stubs(:firmware).returns('bios')
       @cr.stubs(:parse_networks).returns(args)
       @cr.expects(:clone_vm).times(0)
+      @cr.expects(:new_vm).returns(mock_vm)
+      @cr.create_vm(args)
+    end
+
+    test 'converts automatic firmware to bios default' do
+      args = {"provision_method" => "build"}
+      mock_vm = mock('vm')
+      mock_vm.expects(:save).returns(mock_vm)
+      mock_vm.stubs(:firmware).returns('automatic')
+      mock_vm.expects(:firmware=).with('bios')
+      @cr.stubs(:parse_networks).returns(args)
       @cr.expects(:new_vm).returns(mock_vm)
       @cr.create_vm(args)
     end


### PR DESCRIPTION
`vm_instance_defaults` sets `firmware` to `automatic` as this should be the default value shown in the UI. The default value may be overwritten by a user. It it's unset, the default (and invalid) value of `automatic` may be passed to fog for vm creation. This commit prohibits this by defaulting to `bios`.