### PR TITLE
Fixes #12652 - Remove VMware Volume name

### DIFF
--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -11,7 +11,7 @@
 <% else %>
   <%= text_f f, :datastore, :class => "span5", :label => _("Data store"), :label_size => "col-md-2", :disabled => true %>
 <% end %>
-<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2", :disabled => !new_host %>
+<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2", :disabled => !new_host, :readonly => true %>
 <%= text_f f, :size_gb,
            :class       => "col-md-2",
            :label => _("Size (GB)"), :label_size => "col-md-2" %>


### PR DESCRIPTION
Remove the Volume name label under Create Host since at this time its not possible to name VMware volumes.