### PR TITLE
fixes #18248 - dashboard auto refresh mounts duplicate components

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -11,7 +11,7 @@ function auto_refresh(){
   if (element[0]) {
     refresh_timeout = setTimeout(function(){
       if ($(".auto-refresh").hasClass("on")) {
-        Turbolinks.visit(location.toString());
+        history.go(0);
       }
     },60000);
   }

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -14,7 +14,6 @@
           </ul>
           <% if SETTINGS[:login] %>
             <div id='notification_drawer'> </div>
-            <%= mount_react_component('NotificationDrawer', '#notification_drawer', {}) %>
           <% end %>
         </div>
       <% end %>
@@ -48,3 +47,5 @@
     <% end %>
   </div>
 </div>
+
+<%= mount_react_component('NotificationDrawer', '#notification_drawer', {}) %>

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -1,5 +1,4 @@
 <li id='notification_icon' class="drawer-pf-trigger dropdown"> </li>
-<%= mount_react_component('NotificationDrawerToggle', '#notification_icon', {:url => notification_recipients_path}.to_json ) %>
 <li class="dropdown menu_tab_dropdown">
   <%= user_header %>
   <ul class="dropdown-menu pull-right">
@@ -13,3 +12,5 @@
     <% end %>
   </ul>
 </li>
+
+<%= mount_react_component('NotificationDrawerToggle', '#notification_icon', {:url => notification_recipients_path}.to_json ) %>


### PR DESCRIPTION
This is an unfortunate side-effect of turbolinks.

The alternatives are 

1. not to refresh the page
2. refresh the page without using Turbolinks.visit

This PR implements the second option.