### PR TITLE
Fixes #18410 - log permission denials

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -273,8 +273,10 @@ module Api
     def set_error_details(error, options)
       case error
       when 'access_denied'
+        fail_message = _('Missing one of the required permissions: %s') % missing_permissions.map(&:name).join(', ')
+        Foreman::Logging.logger('permissions').info fail_message
         if options.fetch(:locals, {}).fetch(:details, nil).blank?
-          options = options.deep_merge({:locals => {:details => _('Missing one of the required permissions: %s') % missing_permissions.map(&:name).join(', ') }})
+          options = options.deep_merge({:locals => {:details => fail_message }})
         end
       end
       options

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -242,10 +242,10 @@ class ApplicationController < ActionController::Base
   def render_403(msg = nil)
     if msg.nil?
       @missing_permissions = Foreman::AccessControl.permissions_for_controller_action(path_to_authenticate)
-      Foreman::Logging.logger('permissions').debug "rendering 403 because of missing permission #{@missing_permissions.map(&:name).join(', ')}"
+      Foreman::Logging.logger('permissions').info "rendering 403 because of missing permission #{@missing_permissions.map(&:name).join(', ')}"
     else
       @missing_permissions = []
-      Foreman::Logging.logger('permissions').debug msg
+      Foreman::Logging.logger('permissions').info msg
     end
 
     respond_to do |format|


### PR DESCRIPTION
I've added logging of reason for permissions denials + changed the level
in UI logging from debug to info, as I believe this information is on
different level than other debug info from permissions.