### PR TITLE
Fixes #18412 - Alert styling for adrift host time

### DIFF
--- a/app/views/config_reports/show.html.erb
+++ b/app/views/config_reports/show.html.erb
@@ -3,13 +3,11 @@
 
 <p class='ra'> <%= _("Reported at %s ") % @config_report.reported_at %> </p>
 <% if @offset > 10 %>
-  <div class="alert alert-block alert-danger alert-dismissable">
-    <%= alert_close %>
-    <h3><%= _("Host times seems to be adrift!") %></h3>
-    <%= (_("Host reported time is <em>%s</em>") % @config_report.reported_at).html_safe %> <br/>
-    <%= (_("Foreman report creation time is <em>%s</em>") % @config_report.created_at).html_safe %> <br/>
-    <%= (_("Which is an offset of <b>%s</b>") % distance_of_time_in_words(@config_report.reported_at, @config_report.created_at, :include_seconds => true)).html_safe %>
-  </div>
+  <%= alert :class => 'alert-danger',
+    :header => _('Host times seem to be adrift!'),
+    :text => "</br>".html_safe + (_("Host reported time is <em>%s</em>") % @config_report.reported_at).html_safe + "</br>".html_safe +
+             (_("Foreman report creation time is <em>%s</em>") % @config_report.created_at).html_safe + "</br>".html_safe +
+             (_("Which is an offset of <b>%s</b>") % distance_of_time_in_words(@config_report.reported_at, @config_report.created_at, :include_seconds => true)).html_safe %>
 <% end %>
 
 <% content_for(:search_bar) {logs_show} %>

--- a/test/integration/config_report_test.rb
+++ b/test/integration/config_report_test.rb
@@ -30,6 +30,6 @@ class ConfigReportIntegrationTest < ActionDispatch::IntegrationTest
   test "adrift report displays warning" do
     report = FactoryGirl.create(:report, :adrift)
     visit config_report_path(report)
-    assert has_content?('Host times seems to be adrift!')
+    assert has_content?('Host times seem to be adrift!')
   end
 end


### PR DESCRIPTION
The alert for hosts time adrift on reports has the styling we had prior
to Patternfly. It should use the new styling.

Before:
![screenshot from 2017-02-07 16-43-43](https://cloud.githubusercontent.com/assets/598891/22698689/8a93c8f2-ed55-11e6-88a1-e684a84a8c9b.png)

After:
![screenshot from 2017-02-07 16-47-03](https://cloud.githubusercontent.com/assets/598891/22698688/8a8f0024-ed55-11e6-8e3b-61514dfa46de.png)
