### PR TITLE
Fixes #18381 - PXE loader attr load in host/hostgroup form

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -98,6 +98,7 @@ class HostgroupsController < ApplicationController
     define_hostgroup
     inherit_parent_attributes
     load_vars_for_ajax
+    reset_explicit_attributes
 
     render :partial => "form"
   end
@@ -154,5 +155,9 @@ class HostgroupsController < ApplicationController
     @hostgroup.subnet             ||= @parent.subnet
     @hostgroup.realm              ||= @parent.realm
     @hostgroup.environment        ||= @parent.environment
+  end
+
+  def reset_explicit_attributes
+    @hostgroup.pxe_loader = nil if @parent.present?
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -332,7 +332,8 @@ module FormHelper
 
   def blank_or_inherit_f(f, attr)
     return true unless f.object.respond_to?(:parent_id) && f.object.parent_id
-    inherited_value   = f.object.send(attr).try(:name_method)
+    inherited_value   = f.object.send(attr)
+    inherited_value   = inherited_value.name_method if inherited_value.present? && inherited_value.respond_to?(:name_method)
     inherited_value ||= _("no value")
     _("Inherit parent (%s)") % inherited_value
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -750,6 +750,14 @@ class Host::Managed < Host::Base
     read_attribute(:provision_method) || capabilities.first.to_s
   end
 
+  def explicit_pxe_loader
+    read_attribute(:pxe_loader).presence
+  end
+
+  def pxe_loader
+    explicit_pxe_loader || hostgroup.try(:pxe_loader)
+  end
+
   def image_build?
     self.provision_method == 'image'
   end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -181,6 +181,14 @@ class Hostgroup < ApplicationRecord
     Setting[:root_pass]
   end
 
+  def explicit_pxe_loader
+    read_attribute(:pxe_loader).presence
+  end
+
+  def pxe_loader
+    explicit_pxe_loader || nested(:pxe_loader).presence
+  end
+
   include_in_clone :lookup_values, :hostgroup_classes, :locations, :organizations, :group_parameters
   exclude_from_clone :name, :title, :lookup_value_matcher
 

--- a/app/views/common/os_selection/_pxe_loader.html.erb
+++ b/app/views/common/os_selection/_pxe_loader.html.erb
@@ -1,8 +1,13 @@
 <%= fields_for item do |f| -%>
   <% loaders = @operatingsystem.available_loaders; if loaders.any? -%>
+  <%
+    pxe_loader_selected = true
+    pxe_loader_selected = blank_or_inherit_f(f, :pxe_loader) unless f.object.explicit_pxe_loader
+  %>
     <%= selectable_f f, :pxe_loader,
       loaders.to_a, {
-        :include_blank => blank_or_inherit_f(f, :pxe_loader),
+        :include_blank => pxe_loader_selected,
+        :selected => pxe_loader_selected == true ? f.object.pxe_loader : pxe_loader_selected
       },
       :label => _('PXE loader'),
       :label_help =>  _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE)"),

--- a/test/fixtures/hostgroups.yml
+++ b/test/fixtures/hostgroups.yml
@@ -44,6 +44,7 @@ parent:
   compute_profile: one
   id: 1
   lookup_value_matcher: hostgroup=Parent
+  pxe_loader: 'PXELinux BIOS'
 
 inherited:
   name: inherited

--- a/test/helpers/form_helper_test.rb
+++ b/test/helpers/form_helper_test.rb
@@ -15,6 +15,37 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  context '#blank_or_inherit_f attr is :pxe_loader' do
+    context 'form object is hostgroup' do
+      test "returns 'Inherit parent(<parent-pxe-loader-value>)'" do
+        hostgroup = hostgroups(:inherited)
+        f = ActionView::Helpers::FormBuilder.new(:hostgroup, hostgroup, nil, {})
+        attr = :pxe_loader
+        assert_equal "Inherit parent (#{hostgroup.parent.pxe_loader})", blank_or_inherit_f(f, attr)
+      end
+
+      test "inherited but pxe_loader attr is overriden -> returns 'Inherit parent(<parent-pxe-loader-value>)'" do
+        new_pxe_loader = 'Grub UEFI'
+        hostgroup = hostgroups(:inherited)
+        hostgroup.pxe_loader = new_pxe_loader
+        hostgroup.save
+        f = ActionView::Helpers::FormBuilder.new(:hostgroup, hostgroup, nil, {})
+        attr = :pxe_loader
+        assert_equal "Inherit parent (#{new_pxe_loader})", blank_or_inherit_f(f, attr)
+      end
+    end
+
+    context 'form object is host' do
+      test "returns true" do
+        hostgroup = hostgroups(:inherited)
+        host = FactoryGirl.build(:host, :managed, hostgroup_id: hostgroup.id)
+        f = ActionView::Helpers::FormBuilder.new(:host, host, nil, {})
+        attr = :pxe_loader
+        assert blank_or_inherit_f(f, attr)
+      end
+    end
+  end
+
   test "is_required?(f, attr) method returns true if attribute is required and false if not required" do
     f = ActionView::Helpers::FormBuilder.new(:hostgroup, Hostgroup.new, @hostgroup, {})
     assert is_required?(f, :name)

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -60,6 +60,29 @@ class HostgroupJSTest < IntegrationTestWithJavascript
     end
   end
 
+  describe 'with parent hostgroup' do
+    setup do
+      @hostgroup = hostgroups(:inherited)
+    end
+
+    describe 'edit' do
+      test 'explicit pxe loader' do
+        explicit_pxe_loader = @hostgroup.operatingsystem.available_loaders.last
+        visit edit_hostgroup_path(@hostgroup)
+
+        click_link 'Operating System'
+        wait_for_ajax
+        select2 explicit_pxe_loader, :from => 'hostgroup_pxe_loader'
+        wait_for_ajax
+
+        click_button 'Submit'
+        wait_for_ajax
+
+        assert_equal explicit_pxe_loader, @hostgroup.reload.pxe_loader
+      end
+    end
+  end
+
   test 'submit updates taxonomy' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     new_location = FactoryGirl.create(:location)


### PR DESCRIPTION
Override pxe_loader attribute to fail safe find nested pxe_loader from parent hostgroup. Host#pxe_loader needed override as similar behavior was observed in new host form.