### PR TITLE
fixes #18445 - always define eager_load_paths, use require_dep

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -1,5 +1,5 @@
-require "proxy_api"
-require 'orchestration/queue'
+require_dependency "proxy_api"
+require_dependency 'orchestration/queue'
 
 module Orchestration
   extend ActiveSupport::Concern

--- a/app/services/orchestration/queue.rb
+++ b/app/services/orchestration/queue.rb
@@ -1,4 +1,5 @@
-require 'orchestration/task'
+require_dependency 'orchestration/task'
+
 module Orchestration
   # Represents tasks queue for orchestration
   class Queue

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,13 +50,13 @@ end
 # load the corresponding bit of fog
 require 'fog/ovirt' if defined?(::OVIRT)
 
-require File.expand_path('../../lib/foreman.rb', __FILE__)
-require File.expand_path('../../lib/timed_cached_store.rb', __FILE__)
-require File.expand_path('../../lib/foreman/exception', __FILE__)
-require File.expand_path('../../lib/core_extensions', __FILE__)
-require File.expand_path('../../lib/foreman/logging', __FILE__)
-require File.expand_path('../../lib/middleware/catch_json_parse_errors', __FILE__)
-require File.expand_path('../../lib/middleware/tagged_logging', __FILE__)
+require_dependency File.expand_path('../../lib/foreman.rb', __FILE__)
+require_dependency File.expand_path('../../lib/timed_cached_store.rb', __FILE__)
+require_dependency File.expand_path('../../lib/foreman/exception', __FILE__)
+require_dependency File.expand_path('../../lib/core_extensions', __FILE__)
+require_dependency File.expand_path('../../lib/foreman/logging', __FILE__)
+require_dependency File.expand_path('../../lib/middleware/catch_json_parse_errors', __FILE__)
+require_dependency File.expand_path('../../lib/middleware/tagged_logging', __FILE__)
 
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
@@ -96,6 +96,9 @@ module Foreman
     config.autoload_paths += %W(#{config.root}/app/models/trends)
     config.autoload_paths += %W(#{config.root}/app/models/taxonomies)
     config.autoload_paths += %W(#{config.root}/app/models/mail_notifications)
+
+    # Eager load all classes under lib directory
+    config.eager_load_paths += ["#{config.root}/lib"]
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,8 +13,7 @@ Foreman::Application.configure do |app|
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Eager load all classes under lib directory
-  config.eager_load_paths += ["#{config.root}/lib"]
+  # Eager load all classes pre-fork for performance
   config.eager_load = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -1,7 +1,6 @@
 # The audit class is part of audited plugin
 # we reopen here to add search functionality
 require 'audited'
-require 'audit_extensions'
 
 Audit = Audited::Audit
 Audit.send(:include, AuditExtensions)

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -1,16 +1,17 @@
-require 'foreman/access_permissions'
-require 'menu/loader'
-require 'dashboard/loader'
-require 'foreman/plugin'
-require 'foreman/renderer'
-require 'foreman/foreman_url_renderer'
-require 'foreman/controller'
-require 'net'
-require 'foreman/provision' if SETTINGS[:unattended]
-require 'foreman'
-require 'filters_helper_overrides'
 require 'English'
-require 'fog_extensions'
+
+require_dependency 'foreman/access_permissions'
+require_dependency 'menu/loader'
+require_dependency 'dashboard/loader'
+require_dependency 'foreman/plugin'
+require_dependency 'foreman/renderer'
+require_dependency 'foreman/foreman_url_renderer'
+require_dependency 'foreman/controller'
+require_dependency 'net'
+require_dependency 'foreman/provision' if SETTINGS[:unattended]
+require_dependency 'foreman'
+require_dependency 'filters_helper_overrides'
+require_dependency 'fog_extensions'
 
 # We may be executing something like rake db:migrate:reset, which destroys this table
 # only continue if the table exists

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,4 +1,4 @@
-require 'foreman/util'
+require_dependency 'foreman/util'
 include Foreman::Util
 
 unless Foreman::Application.config.secret_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-require 'api_constraints'
-
 Foreman::Application.routes.draw do
   resources :mail_notifications, :only => [] do
     collection do

--- a/lib/net.rb
+++ b/lib/net.rb
@@ -1,4 +1,4 @@
-require "net/validations"
+require_dependency "net/validations"
 
 module Net
   class Record

--- a/lib/tasks/encrypt.rake
+++ b/lib/tasks/encrypt.rake
@@ -1,4 +1,4 @@
-require 'foreman/util'
+require_dependency 'foreman/util'
 
 namespace :security do
   desc 'Generate new encryption key'

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -1,4 +1,4 @@
-require 'foreman/util'
+require_dependency 'foreman/util'
 
 namespace :security do
   desc 'Generate new security token'


### PR DESCRIPTION
Allows `eager_load!` to be called or enabled in any environment without
loading files under lib/ twice. Switches many `require` calls to Rails'
`require_dependency` to always use its dependency loader, so when eager
loading it will track whether the file is loaded or not.
