### PR TITLE
Fixes #18760 - Allow export to CSV

### DIFF
--- a/app/controllers/concerns/foreman/controller/csv_responder.rb
+++ b/app/controllers/concerns/foreman/controller/csv_responder.rb
@@ -1,0 +1,15 @@
+module Foreman::Controller::CsvResponder
+  extend ActiveSupport::Concern
+
+  def csv_response(resources, columns = csv_columns)
+    headers["Cache-Control"] = "no-cache"
+    headers["Content-Type"] = "text/csv; charset=utf-8"
+    headers["Content-Disposition"] = %(attachment; filename="#{controller_name}-#{Date.today}.csv")
+    self.response_body = CsvExporter.export(resources, columns)
+  end
+
+  private
+  def csv_columns
+    resource_class.column_names - ['created_at', 'updated_at']
+  end
+end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -99,6 +99,10 @@ class TemplatesController < ApplicationController
     send_data @template.to_erb, :type => 'text/plain', :disposition => 'attachment', :filename => @template.filename
   end
 
+  def resource_class
+    @resource_class ||= controller_name.singularize.classify.constantize
+  end
+
   private
 
   def safe_render(template)
@@ -142,10 +146,6 @@ class TemplatesController < ApplicationController
 
   def resource_name
     'template'
-  end
-
-  def resource_class
-    @resource_class ||= controller_name.singularize.classify.constantize
   end
 
   def type_name_plural

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -152,6 +152,11 @@ module ApplicationHelper
     display_link_if_authorized(name, options, html_options)
   end
 
+  def csv_link
+    link_to(_('Export'), params.merge(:format => :csv),
+      {:title => _('Export to CSV'), :class => 'btn btn-default', 'data-no-turbolink' => true})
+  end
+
   # renders a style=display based on an attribute properties
   def display?(attribute = true)
     "style=#{display(attribute)}"

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -1,0 +1,17 @@
+require 'csv'
+
+module CsvExporter
+  def self.export(resources, columns)
+    Enumerator.new do |csv|
+      csv << csv_header(columns)
+
+      resources.reorder(nil).limit(nil).find_each do |obj|
+        csv << CSV.generate_line(columns.map{|c| obj.send(c)})
+      end
+    end
+  end
+
+  def self.csv_header(columns)
+    CSV.generate_line(columns.map{|c| c.to_s.titleize})
+  end
+end

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,2 +1,2 @@
-<% title_actions multiple_actions_select, button_group(new_link(_("Create Host"))) %>
+<% title_actions multiple_actions_select, csv_link, button_group(new_link(_("Create Host"))) %>
 <%= render 'list', :hosts => @hosts, :header => @title || _("Hosts")  %>

--- a/test/controllers/concerns/csv_responder_test.rb
+++ b/test/controllers/concerns/csv_responder_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class FakeController < ApplicationController
+  include Foreman::Controller::CsvResponder
+
+  def index
+    csv_response(Domain.unscoped, [:name])
+  end
+end
+
+class Api::V2::FakeController < Api::V2::BaseController
+  include Foreman::Controller::CsvResponder
+
+  def index
+    csv_response(Domain.unscoped, [:name])
+  end
+end
+
+#add the fake controllers to the routes table
+Rails.application.routes.disable_clear_and_finalize = true
+Rails.application.routes.draw do
+  get '/fake' => 'fake#index'
+  get '/fake_api' => 'api/v2/fake#index'
+end
+
+class CsvResponderTest < ActionController::TestCase
+  tests FakeController
+
+  test "response is streamed correctly with right headers" do
+    get :index, {}, set_session_user
+    assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "no-cache", response.headers["Cache-Control"]
+    assert_equal "attachment; filename=\"fake-#{Date.today}.csv\"", response.headers["Content-Disposition"]
+    assert response.stream.instance_variable_get(:@buf).is_a? Enumerator
+    assert_equal "Name\n", response.stream.instance_variable_get(:@buf).next
+  end
+end
+
+class CsvApiResponderTest < ActionController::TestCase
+  tests Api::V2::FakeController
+
+  test "response is streamed correctly with right headers" do
+    get :index
+    assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "no-cache", response.headers["Cache-Control"]
+    assert_equal "attachment; filename=\"fake-#{Date.today}.csv\"", response.headers["Content-Disposition"]
+    assert response.stream.instance_variable_get(:@buf).is_a? Enumerator
+    assert_equal "Name\n", response.stream.instance_variable_get(:@buf).next
+  end
+end

--- a/test/unit/csv_exporter_test.rb
+++ b/test/unit/csv_exporter_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class CsvExporterTest < ActiveSupport::TestCase
+  test 'return correct amount of lines' do
+    result = CsvExporter.export(Host::Managed, [:id])
+    assert_equal "Id\n", result.next
+    assert_equal result.count, Host::Managed.count+1
+  end
+
+  test 'handles empty results correctly' do
+    result = CsvExporter.export(Host::Managed.where(:name => 'no-such-host'), [:id, :name])
+    assert_equal "Id,Name\n", result.next
+    assert_equal 1, result.count
+    assert_raises StopIteration do
+      result.next
+    end
+  end
+
+  test 'calls methods on records' do
+    id = Domain.first.id
+    Domain.any_instance.expects(:test_method).once.returns('success!')
+    result = CsvExporter.export(Domain.where(:id => id), [:id, :test_method])
+    assert_equal "Id,Test Method\n", result.next
+    assert_equal "#{id},success!\n", result.next
+    assert_raises StopIteration do
+      result.next
+    end
+  end
+end


### PR DESCRIPTION
This introduces a way of exporting tables from the UI to CSV.
There are 3 steps to adding a CSV export to a table:

1. Add the CsvResponder concern to the relevant controller.
2. Add a `format.csv` block to the index controller action. This block
should include a call to `csv_response` with the wanted resources.
3. Add `csv_link` to the title actions. (Or wherever you want the export
button to appear)

By default, the csv will include all columns that exist for that model
in the database, except for the `created_at` and `updated_at` ones. To
override the default, add a method `csv_columns` to the controllers that
returns an array of columns. Columns can be actual column names in the
database, reflections, or any method that can be called on an instance
of the model.

This commit also includes an example of the feature implemented on the
Hosts index page.