### PR TITLE
Fixes #12163 - add a rake task to clean up orphaned facts

### DIFF
--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -9,6 +9,9 @@ class FactName < ActiveRecord::Base
 
   scope :no_timestamp_fact, -> { where("fact_names.name <> ?",:_timestamp) }
   scope :timestamp_facts, -> { where(:name => :_timestamp) }
+  scope :composes, -> { where(:compose => true) }
+  scope :leaves, -> { where(:compose => false) }
+
   scope :with_parent_id, lambda { |find_ids|
     conds, binds = [], []
     [find_ids].flatten.each do |find_id|

--- a/app/services/fact_cleaner.rb
+++ b/app/services/fact_cleaner.rb
@@ -1,0 +1,49 @@
+class FactCleaner
+  delegate :logger, :to => :Rails
+
+  def clean!
+    to_delete = find_leaf_orphaned_facts
+    # we also delete all composes that either don't have any descendant or all of them are to be deleted
+    to_delete += find_compose_orphaned_facts(to_delete)
+    delete!(to_delete)
+    @deleted_count = to_delete.count
+    self
+  end
+
+  def deleted_count
+    raise 'cleaner has not cleaned anything yet, run #clean! first' if @deleted_count.nil?
+    @deleted_count
+  end
+
+  private
+
+  def find_leaf_orphaned_facts
+    result = []
+    logger.info "Searching for leaf orphaned facts..."
+    FactName.leaves.includes(:fact_values).find_in_batches do |batch|
+      result += batch.select do |fact|
+        fact.fact_values.empty?
+      end
+    end
+    result
+  end
+
+  def find_compose_orphaned_facts(found)
+    logger.info "Searching for compose orphaned facts..."
+    FactName.composes.find_in_batches do |batch|
+      found += batch.select do |compose|
+        compose.descendants.all? { |fact| found.include?(fact) }
+      end
+    end
+    found
+  end
+
+  def delete!(to_delete)
+    logger.info "#{to_delete.size} facts will be removed"
+    to_delete.each do |fact|
+      logger.debug { "Removing fact #{fact}" }
+      fact.destroy
+    end
+    logger.info "Cleanup of facts finished!"
+  end
+end

--- a/lib/tasks/facts.rake
+++ b/lib/tasks/facts.rake
@@ -1,0 +1,17 @@
+namespace :facts do
+  desc <<-END_DESC
+Removes facts without any values
+
+This is useful when you used custom facts of different facts sourcers that you don't use anymore.
+After cleaning of such facts they should no longer appear in auto-completion suggestions.
+
+Examples:
+  # foreman-rake facts:clean
+END_DESC
+
+  task :clean => :environment do
+    puts 'Starting orphaned facts clean up...'
+    count = FactCleaner.new.clean!.deleted_count
+    puts "Finished, cleaned #{count} facts"
+  end
+end

--- a/test/unit/fact_cleaner_test.rb
+++ b/test/unit/fact_cleaner_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class FactCleanerTest < ActiveSupport::TestCase
+  let(:cleaner) do
+    FactCleaner.new
+  end
+
+  test "it cleans orhpaned root leaves" do
+    root_1_fact = FactoryGirl.create(:fact_name)
+    cleaner.clean!
+    assert_not_include remaining_of(root_1_fact), root_1_fact
+  end
+
+  test "it cleans root composes without any leaves" do
+    root_2_fact = FactoryGirl.create(:fact_name, :compose => true)
+    cleaner.clean!
+    assert_not_include remaining_of(root_2_fact), root_2_fact
+  end
+
+  test "it cleans composes and it's leaves composes if there are no values for them" do
+    root_3_fact = FactoryGirl.create(:fact_name, :compose => true)
+    root_3_child_fact = FactoryGirl.create(:fact_name, :parent_id => root_3_fact.id)
+    cleaner.clean!
+    remaining = remaining_of(root_3_fact, root_3_child_fact)
+    assert_not_include remaining, root_3_fact
+    assert_not_include remaining, root_3_child_fact
+  end
+
+  test "it keeps composes and their only children that have values" do
+    root_4_fact = FactoryGirl.create(:fact_name, :compose => true)
+    root_4_child_1_fact = FactoryGirl.create(:fact_name, :parent_id => root_4_fact.id)
+    # root_4_child_1_fact_value
+    FactoryGirl.create(:fact_value, :fact_name => root_4_child_1_fact)
+    root_4_child_2_fact = FactoryGirl.create(:fact_name, :parent_id => root_4_fact.id)
+
+    cleaner.clean!
+    remaining = remaining_of(root_4_fact, root_4_child_1_fact, root_4_child_2_fact)
+    assert_include remaining, root_4_fact
+    assert_include remaining, root_4_child_1_fact
+    assert_not_include remaining, root_4_child_2_fact
+  end
+
+  test "it keeps root leaves if the have value" do
+    root_6_fact = FactoryGirl.create(:fact_name)
+    # root_6_fact_value
+    FactoryGirl.create(:fact_value, :fact_name => root_6_fact)
+    cleaner.clean!
+    assert_include remaining_of(root_6_fact), root_6_fact
+  end
+
+  private
+
+  def remaining_of(*names)
+    FactName.where(:name => names.map(&:name))
+  end
+end


### PR DESCRIPTION
On my system with 11k fact names it took 44 seconds. It could be more optimized but I don't think it's necessary at this point.