### PR TITLE
Fixes #18468 - Include JS in libvirt compute profile form

### DIFF
--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag 'compute_resource' %>
+
 <%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-2", :disabled => !new_host if show_vm_name? %>


### PR DESCRIPTION
When the form is loaded via XHR the needed JavaScript is not loaded and selecting of certain attributes fail.

The oVirt templates include their JS via the `javascript` helper to included it as `content_for` in the head, but that won't be loaded there and here when requesting via XHR.

I will look into the oVirt form as well and open an issue in case, but #18468 would be fixed by this PR.

Including the JavaScript other than in the head is not the most elegant solution, having the `javascript` helper either include directly or set as content_for might be a better approach, but might cause issues in other places.