### PR TITLE
fixes #18489 - test AuthSourceLdap missing and blank passwords

### DIFF
--- a/test/controllers/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/auth_source_ldaps_controller_test.rb
@@ -73,14 +73,23 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     end
   end
 
-  test "blank account_password submitted does not erase existing account_password" do
-    auth_source_ldap = AuthSourceLdap.first
+  test "#update without account_password does not erase existing account_password" do
+    auth_source_ldap = FactoryGirl.create(:auth_source_ldap, :service_account)
     old_pass = auth_source_ldap.account_password
     as_admin do
-      put :update, {:commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:account_password => nil, :name => auth_source_ldap.name} }, set_session_user
+      put :update, {:commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:name => auth_source_ldap.name} }, set_session_user
     end
     auth_source_ldap = AuthSourceLdap.find(auth_source_ldap.id)
     assert_equal old_pass, auth_source_ldap.account_password
+  end
+
+  test "#update with blank account_password erases password" do
+    auth_source_ldap = FactoryGirl.create(:auth_source_ldap, :service_account)
+    as_admin do
+      put :update, {:commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:account_password => '', :name => auth_source_ldap.name} }, set_session_user
+    end
+    auth_source_ldap = AuthSourceLdap.find(auth_source_ldap.id)
+    assert_empty auth_source_ldap.account_password
   end
 
   test "LDAP test succeeded" do


### PR DESCRIPTION
After 2348fc8e, providing an empty password during update would erase
the existing password. Other resource type tests were updated, but not
AuthSourceLdap, so these now reflect the current behaviour.

These started failing on Rails 5 as the test params passed converted a
value of nil (not really possible) to an empty string, causing the
password to be blanked. On develop, the original password was nil
and the update to another nil value was a no-op.