### PR TITLE
refs #18468 - move compute_resources JS to compute profile index

### DIFF
--- a/app/views/compute_profiles/index.html.erb
+++ b/app/views/compute_profiles/index.html.erb
@@ -1,3 +1,5 @@
+<%= javascript 'compute_resource' %>
+
 <% title _('Compute profiles') %>
 
 <% title_actions new_link(_('Create Compute Profile')),

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_include_tag 'compute_resource' %>
-
 <%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-2", :disabled => !new_host if show_vm_name? %>


### PR DESCRIPTION
The CR JS should always be ready and loaded on the compute profile
index, as the new attributes form is rendered into the existing page
after the profile is created.

Because the new attributes form is loaded via the two-pane #content
replacement, the additional JavaScript tag specified in
compute_profiles/show is not automatically loaded into the page.

This fixes the issue for all compute resources, not only Libvirt. It
also uses the `javascript` header to properly track the asset with
Turbolinks so it's unloaded later.