### PR TITLE
Fixes #17228 - Select templates as global defaults

### DIFF
--- a/app/validators/pxe_template_name_validator.rb
+++ b/app/validators/pxe_template_name_validator.rb
@@ -1,0 +1,13 @@
+class PxeTemplateNameValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value.empty?
+      template_kind = record.name.split('_').last
+      tmpl = ProvisioningTemplate.find_global_default_template value, template_kind
+      unless tmpl
+        msg = _('is invalid. No provisioning template with name "%{name}" and kind "%{kind}" found. ') % { :name => value, :kind => template_kind }
+        msg << _('Consult "Provisioning Templates" page to see what templates are available.')
+        record.errors[attribute] << msg
+      end
+    end
+  end
+end

--- a/db/seeds.d/07-provisioning_templates.rb
+++ b/db/seeds.d/07-provisioning_templates.rb
@@ -95,6 +95,8 @@ ProvisioningTemplate.without_auditing do
     contents = File.read(File.join("#{Rails.root}/app/views/unattended", input.delete(:source)))
 
     if (t = ProvisioningTemplate.unscoped.find_by_name(input[:name])) && !audit_modified?(ProvisioningTemplate, input[:name])
+      next if t.global_default?
+
       if t.template != contents
         t.template = contents
         raise "Unable to update template #{t.name}: #{format_errors t}" unless t.save

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -119,7 +119,8 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
           ProvisioningTemplate.create!(:name => "#{kind.downcase}_#{snippet_type}", :template => snippet, :snippet => true)
         end
         template = File.read(File.expand_path(File.dirname(__FILE__) + "/../../app/views/unattended/pxe/#{kind}_default.erb"))
-        ProvisioningTemplate.find_or_create_by(:name => "#{kind} global default").update_attribute(:template, template)
+        template_kind = TemplateKind.find_by :name => kind
+        ProvisioningTemplate.find_or_create_by(:name => "#{kind} global default").update_attributes(:template => template, :template_kind => template_kind)
       end
       ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
       Setting[:unattended_url] = "http://foreman.unattended.url"

--- a/test/unit/validators/pxe_template_name_validator_test.rb
+++ b/test/unit/validators/pxe_template_name_validator_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class PxeTemplateNameValidatorTest < ActiveSupport::TestCase
+  setup do
+    class Validatable
+      include ActiveModel::Validations
+      validates :value, :pxe_template_name => true
+      attr_accessor :value, :name
+    end
+    @item = Validatable.new
+    @item.name = "global_PXELinux"
+  end
+
+  test "should be valid when empty" do
+    assert @item.valid?
+  end
+
+  test "should not be valid when template does not exist" do
+    @item.value = "nonexisting template"
+    refute @item.valid?
+  end
+
+  test "should be valid when template exists" do
+    template = TemplateKind.find_by(:name => "PXELinux").provisioning_templates.first
+    @item.value = template.name
+    assert @item.valid?
+  end
+end


### PR DESCRIPTION
This should allow user to select templates that will be used
for building PXE Default on TFTP proxy. These templates will
not be updated from seeds during updates.