### PR TITLE
fixes #18512 - support sprockets-rails 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'net-ldap', '>= 0.8.0'
 gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 0.1.1', '< 2'
 gem 'sprockets', '~> 3'
-gem 'sprockets-rails', '>= 2.3.3', '< 3'
+gem 'sprockets-rails', '>= 2.3.3', '< 4'
 gem 'responders', '~> 2.0'
 gem 'roadie-rails', '>= 1.1', (RUBY_VERSION < '2.2' ? '< 1.2' : '< 2')
 gem 'x-editable-rails', '~> 1.5.5'

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -93,6 +93,7 @@ module Foreman #:nodoc:
       end
     end
 
+    prepend Foreman::Plugin::Assets
     prepend Foreman::Plugin::SearchOverrides
 
     def_field :name, :description, :url, :author, :author_url, :version, :path

--- a/app/registries/foreman/plugin/assets.rb
+++ b/app/registries/foreman/plugin/assets.rb
@@ -1,0 +1,69 @@
+module Foreman
+  class Plugin
+    module Assets
+      attr_reader :assets
+
+      def initialize(id)
+        super
+        @assets = []
+        @automatic_assets = true
+      end
+
+      def after_initialize
+        super
+        precompile_assets(*find_assets(path)) if @automatic_assets
+        precompile_assets(*assets_from_settings(id))
+        precompile_assets(*assets_from_settings(id.to_s.gsub('-', '_').to_sym))
+        register_assets
+      end
+
+      def precompile_assets(*assets)
+        @assets.push(*assets)
+      end
+
+      # Controls automatic searching of plugin_root/app/assets/
+      # Disable when assets are combined and only some need to be precompiled
+      def automatic_assets(enabled)
+        @automatic_assets = !!enabled
+      end
+
+      private
+
+      def find_assets(root)
+        return [] unless root.present? && Dir.exist?(root)
+
+        assets = Dir.chdir(root) do
+          Dir["app/assets/**/*"].select { |f| File.file?(f) }.map { |f| f.split(File::SEPARATOR, 4).last }
+        end
+
+        # Assets outside of the namespace can't properly be packaged, so don't
+        # automatically detect and include them. Requires manual configuration
+        # to use this unsupported layout.
+        assets, outside_prefix = assets.partition { |p| p.start_with?("#{id}/") }
+        if outside_prefix.present?
+          Rails.logger.warn "Plugin #{id} has assets outside of its namespace, these will be ignored: #{outside_prefix.join(', ')}"
+        end
+
+        assets
+      end
+
+      # Call any initializers that configure SETTINGS for the plugin:assets:precompile
+      # rake task and migrate the data.
+      def assets_from_settings(id)
+        Rails.application.initializers.detect { |i| i.name.to_s == "#{id}.configure_assets" }.try!(:run)
+        assets = SETTINGS[id].try!(:[], :assets).try!(:[], :precompile)
+        if assets
+          Foreman::Deprecation.deprecation_warning('1.18', "Plugin #{id} must register assets via precompile_assets, not SETTINGS[:#{id}]")
+          SETTINGS[id].delete(:assets)
+        end
+        assets
+      end
+
+      def register_assets
+        return unless self.assets.present?
+        Rails.logger.debug { "Registering #{self.assets.count} assets for plugin #{id} precompilation" }
+        Rails.application.config.assets.precompile.push(*self.assets)
+      end
+    end
+  end
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -499,6 +499,64 @@ class PluginTest < ActiveSupport::TestCase
     end
   end
 
+  context "asset precompilation" do
+    teardown do
+      Rails.application.config.assets.precompile.delete_if { |f| f.is_a?(String) && f.start_with?('test_assets_') }
+    end
+
+    def test_assets_from_precompile_assets
+      plugin = Foreman::Plugin.register(:test_assets_from_precompile_assets) do
+        precompile_assets 'test_assets_example.js', 'test_assets_another.css'
+      end
+      assert_equal ['test_assets_example.js', 'test_assets_another.css'], plugin.assets
+      assert_include Rails.application.config.assets.precompile, 'test_assets_example.js'
+    end
+
+    def test_assets_from_settings
+      SETTINGS[:test_assets_from_settings] = { assets: { precompile: [ 'test_assets_example' ] } }
+      Foreman::Deprecation.expects(:deprecation_warning)
+      plugin = Foreman::Plugin.register(:test_assets_from_settings) {}
+      assert_equal ['test_assets_example'], plugin.assets
+      assert_include Rails.application.config.assets.precompile, 'test_assets_example'
+    end
+
+    def test_assets_from_settings_hyphen
+      SETTINGS[:test_assets_from_settings_hyphen] = { assets: { precompile: [ 'test_assets_example' ] } }
+      Foreman::Deprecation.expects(:deprecation_warning)
+      plugin = Foreman::Plugin.register(:'test-assets-from-settings-hyphen') {}
+      assert_equal ['test_assets_example'], plugin.assets
+      assert_include Rails.application.config.assets.precompile, 'test_assets_example'
+    end
+
+    def test_assets_from_root
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p File.join(root, 'app', 'assets', 'javascripts', 'test_assets_from_root')
+        FileUtils.touch File.join(root, 'app', 'assets', 'javascripts', 'test_outside.js')
+        FileUtils.touch File.join(root, 'app', 'assets', 'javascripts', 'test_assets_from_root', 'test_assets_example.js')
+
+        Rails.logger.expects(:warn).with(regexp_matches(/test_outside\.js/))
+        plugin = Foreman::Plugin.register(:test_assets_from_root) do
+          path root
+        end
+        assert_equal ['test_assets_from_root/test_assets_example.js'], plugin.assets
+        assert_include Rails.application.config.assets.precompile, 'test_assets_from_root/test_assets_example.js'
+      end
+    end
+
+    def test_assets_without_automatic
+      Dir.mktmpdir do |root|
+        FileUtils.mkdir_p File.join(root, 'app', 'assets', 'javascripts', 'test_assets_without_automatic')
+        FileUtils.touch File.join(root, 'app', 'assets', 'javascripts', 'test_assets_without_automatic', 'test_assets_example.js')
+
+        plugin = Foreman::Plugin.register(:test_assets_without_automatic) do
+          path root
+          automatic_assets false
+        end
+        assert_equal [], plugin.assets
+      end
+    end
+  end
+
   context 'with pagelets' do
     include PageletsIsolation
 


### PR DESCRIPTION
The app.assets environment is no longer always configured, and instead
is only configured when the regular Rails environment is loaded. Loading
only the 'assets' group initializers isn't sufficient.

Because the asset group initializers are no longer run, the plugin API
has been extended with `precompile_assets` and `automatic_assets` to
store and optionally generate a list of assets for that plugin. It
deprecates using an assets initializer, modifying SETTINGS and
`config.assets.precompile` to configure the plugin asset list.