### PR TITLE
fixes #18540 - update domain on primary in hosts_count tests

### DIFF
--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -287,8 +287,8 @@ class HostsControllerTest < ActionController::TestCase
     setup_user_and_host "view", "domain_id = #{domains(:mydomain).id}"
 
     as_admin do
-      @host1.update_attribute(:domain, domains(:mydomain))
-      @host2.update_attribute(:domain, domains(:yourdomain))
+      @host1.primary_interface.update_attribute(:domain, domains(:mydomain))
+      @host2.primary_interface.update_attribute(:domain, domains(:yourdomain))
     end
     get :index, {}, set_session_user.merge(:user => @one.id)
 

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -60,7 +60,9 @@ class DomainTest < ActiveSupport::TestCase
 
   test "should update hosts_count" do
     assert_difference "@domain.hosts_count" do
-      FactoryGirl.create(:host).update_attribute(:domain, @domain)
+      h = FactoryGirl.create(:host)
+      h.domain = @domain
+      h.save!
       @domain.reload
     end
   end
@@ -116,7 +118,7 @@ class DomainTest < ActiveSupport::TestCase
   test "should update hosts_count on domain_id change" do
     host = FactoryGirl.create(:host, :managed, :domain => @domain)
     assert_difference "@domain.hosts_count", -1 do
-      host.update_attribute(:domain_id, FactoryGirl.create(:domain).id)
+      host.primary_interface.update_attribute(:domain_id, FactoryGirl.create(:domain).id)
       @domain.reload
     end
   end


### PR DESCRIPTION
domain/domain_id are not attributes of the host itself, they're
delegated to the primary interface. When using update_attribute on the
host, the model doesn't appear `changed?` so Rails 5 skips the save.

The test "should update hosts_count" is left with delegation as the
direct interface modification is tested in the next test.