### PR TITLE
Fixes #18549 - Don't rebuild already correct DNS entries

### DIFF
--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -42,7 +42,7 @@ module Orchestration::DNS
     results = {}
 
     DnsInterface::RECORD_TYPES.each do |record_type|
-      del_dns_record_safe(record_type)
+      dns_record(record_type).nil? || dns_record(record_type).valid? || del_dns_record_safe(record_type)
 
       begin
         results[record_type] = dns_feasible?(record_type) ? recreate_dns_record(record_type) : true


### PR DESCRIPTION
If we do so and try to recreate them right away ecreate_dns_record might
still see a valid entry due to zone transfer slowness or other caching
issues. In this case we'd end up without a DNS entry after all. So
intead do nothing if the entry is already good.

This is a forward port from a fix I applied to a local 1.10.x instance.

Signed-off-by: Guido Günther <agx@sigxcpu.org>