### PR TITLE
fixes #18551 - skip table_exists? error when the DB doesn't exist

### DIFF
--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -34,4 +34,4 @@ Dashboard::Loader.load
 
 # clear our users topbar cache
 # The users table may not be exist during initial migration of the database
-TopbarSweeper.expire_cache_all_users if User.table_exists?
+TopbarSweeper.expire_cache_all_users if (User.table_exists? rescue false)


### PR DESCRIPTION
MySQL and PostgreSQL DB adapters now throw a connection error under
Rails 5 if the the DB doesn't already exist, as the schema cache is no
longer used to answer the method call.