### PR TITLE
Fixes #18554 - skip collection_cache_lookup on authorized_for

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,7 +97,7 @@ module ApplicationHelper
       user.allowed_to?({ :controller => controller_name, :action => action, :id => id }) rescue false
     else
       authorizer = options.delete(:authorizer) || Authorizer.new(user)
-      authorizer.can?(permission, object) rescue false
+      authorizer.can?(permission, object, false) rescue false
     end
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -87,4 +87,18 @@ class ApplicationHelperTest < ActionView::TestCase
       end
     end
   end
+  describe 'authorized_for' do
+    setup do
+      @permission = Permission.find_by_name('view_domains')
+      @user = FactoryGirl.create(:user)
+      @domain1 = FactoryGirl.create(:domain, :name => 'fake-domain.arpa')
+    end
+
+    test "disable cache when calling can?" do
+      as_user @user do
+        Authorizer.any_instance.expects(:can?).with(@permission, @domain1, false)
+        authorized_for({:permission => @permission, :auth_object => @domain1})
+      end
+    end
+  end
 end


### PR DESCRIPTION
The call to `authorized_for` can take multiple seconds in some cases, leading
to performance issues.

This patch will bypass the cache lookup, resulting in similar times for admins
and non-admins when viewing pages with lots of hosts.