### PR TITLE
fixes #18568 - replace deprecated AC::Parameters#update

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
@@ -11,10 +11,13 @@ module Foreman::Controller::Parameters::KeepParam
       params[top_level_hash].has_key?(key) ? op.update(key => params[top_level_hash].delete(key)) : op
     end
 
-    # Restore the deleted (kept) keys to the filtered hash of params from the block
-    filtered = yield.update(old_params)
-    # Restore the deleted (kept) keys to the original params hash so it remains unchanged
-    params[top_level_hash].update old_params
+    filtered = yield
+    old_params.each do |key,val|
+      # Restore the deleted (kept) keys to the filtered hash of params from the block
+      filtered[key] = val
+      # Restore the deleted (kept) keys to the original params hash so it remains unchanged
+      params[top_level_hash][key] = val
+    end
     filtered
   end
 end

--- a/test/unit/concerns/parameters/keep_param_test.rb
+++ b/test/unit/concerns/parameters/keep_param_test.rb
@@ -5,27 +5,28 @@ class KeepParamParametersTest < ActiveSupport::TestCase
 
   test "retains parameter within top-level hash" do
     params = ActionController::Parameters.new(:user => {:login => 'foo'})
-    returned = keep_param(params, 'user', :login) { {} }
+    returned = keep_param(params, 'user', :login) { params.permit(:another) }
+    assert_kind_of ActionController::Parameters, returned
     assert_equal 'foo', returned[:login]
   end
 
   test "retains multiple parameters" do
     params = ActionController::Parameters.new(:user => {:login => 'foo', :other => 'bar'})
-    returned = keep_param(params, 'user', :login, :other) { {} }
+    returned = keep_param(params, 'user', :login, :other) { params.permit(:another) }
     assert_equal 'foo', returned[:login]
     assert_equal 'bar', returned[:other]
   end
 
   test "ignores unknown parameters" do
     params = ActionController::Parameters.new(:user => {:login => 'foo'})
-    returned = keep_param(params, 'user', :login, :other) { {} }
+    returned = keep_param(params, 'user', :login, :other) { params.permit(:another) }
     assert_equal 'foo', returned[:login]
     refute returned.has_key?(:other)
   end
 
   test "doesn't modify input hash" do
     params = ActionController::Parameters.new(:user => {:login => 'foo'})
-    returned = keep_param(params, 'user', :login) { {:login => 'foo'} }
+    returned = keep_param(params, 'user', :login) { params.permit(:another) }
     assert_equal 'foo', returned[:login]
     assert_equal 'foo', params[:user][:login]
   end


### PR DESCRIPTION
The #update method in Rails 5 is returning a HWIA rather than the
ActionController::Parameters instance, causing keep_param to return the
wrong object type. It is also deprecated in 5.0, so replace it with a
simpler and supported assignment through #[]=.