### PR TITLE
Fixes #18587 and #18588 - fix 'multipart form data' IE bug for domains, subnets and lookup_keys

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -254,7 +254,7 @@ module FormHelper
         options.merge! :'data-id' => form_to_submit_id(f) unless options.has_key?(:'data-id')
         link_to(_("Cancel"), args[:cancel_path], :class => "btn btn-default") + " " + f.submit(text, options)
       end
-    end
+    end + ie_multipart_fix
   end
 
   def add_help_to_label(size_class, label, help_inline)
@@ -373,6 +373,14 @@ module FormHelper
           end
         end.html_safe
       end
+    end
+  end
+
+  def ie_multipart_fix
+    # This hidden input is a workaround to fix IE Multipart form data bug (https://connect.microsoft.com/IE/Feedback/Details/868498)
+    # Only add this fix for two-pane layouts, as these are the only ones that trigger the bug
+    if request.headers["X-Foreman-Layout"] == 'two-pane'
+      content_tag(:input, '', {:type => "hidden", :name => "_ie_support"})
     end
   end
 end

--- a/app/views/common_parameters/_form.html.erb
+++ b/app/views/common_parameters/_form.html.erb
@@ -17,9 +17,10 @@
       </div>
     </div>
     <%= checkbox_f f, :hidden_value, :class => 'hidden_value_textarea_switch', :onchange => 'turn_textarea_switch()', :checked => f.object.hidden_value? %>
-    <%= submit_or_cancel f %>
 
     <input type="hidden" id="old" value="<%= @common_parameter.value %>" />
     <input type="hidden" id="new" value="<%= @common_parameter.value %>" />
+
+    <%= submit_or_cancel f %>
 <% end %>
 

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -153,13 +153,11 @@
     <%= render "custom_tabs", :f => f unless type == 'ptable'%>
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @template %>
 
+    <%# These hidden inputs are used for the diff Preview. They intentionally do
+        not have a 'name' attribute so browsers will not send them in the form POST. %>
+    <input type="hidden" id="old" value="<%= @template.template %>" />
+    <input type="hidden" id="new" value="<%= @template.template %>" />
+
     <%= submit_or_cancel f, false, :cancel_path => template_path_for(@template.class) %>
   </div>
-  <%# These hidden inputs are used for the diff Preview. They intentionally do
-      not have a 'name' attribute so browsers will not send them in the form POST. %>
-  <input type="hidden" id="old" value="<%= @template.template %>" />
-  <input type="hidden" id="new" value="<%= @template.template %>" />
-
-  <%# This hidden input is a workaround to fix IE Multipart form data bug (https://connect.microsoft.com/IE/Feedback/Details/868498) %>
-  <input type="hidden" name="_ie_support" %>
 <% end %>


### PR DESCRIPTION
According to this bug (https://connect.microsoft.com/IE/Feedback/Details/868498),
multipart form data is malformed if there are fields without names.
It been solved within Edge browser, however no solution is expected for IE10/IE11

It cause a failure with Rack - EOFError: bad content body, therefore pages like
domains and subnet create/edit cannot be submitted (and all other forms which are
submitted via ajax with multipart form data, and an unnamed field within).

This is identical to https://github.com/theforeman/foreman/pull/4125
but on the domains and subnets pages.