### PR TITLE
Fixes #18618 - Use Dynflow as an ActiveJob backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'webpack-rails', '~> 0.9.8'
 gem 'mail', '~> 2.6'
 gem 'sshkey', '~> 1.9'
 gem 'ruby2ruby', '2.3.2'
+gem 'dynflow', '>= 0.8.25', '< 1.0.0'
+gem 'daemons'
+gem 'get_process_mem'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/bin/dynflow-executor
+++ b/bin/dynflow-executor
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+class ArgvParser
+  attr_reader :options, :command
+
+  def initialize(argv, file)
+    @options = { rails_root: Dir.pwd }
+
+    opts = OptionParser.new do |opts|
+      opts.banner = banner(file)
+
+      opts.on('-h', '--help', 'Show this message') do
+        puts opts
+        exit 1
+      end
+      opts.on('-f', '--foreman-root=PATH', "Path to Foreman Rails root path. By default '#{@options[:rails_root]}'") do |path|
+        @options[:rails_root] = path
+      end
+      opts.on('-c', '--executors-count=COUNT', 'Number of parallel executors to spawn. Overrides EXECUTORS_COUNT environment varaible.') do |count|
+        @options[:executors_count] = count.to_i
+      end
+      opts.on('-m', '--memory-limit=SIZE', 'Limits the amount of memory an executor can consume. Overrides EXECUTOR_MEMORY_LIMIT environment varaible. You can use kb, mb, gb') do |size|
+        @options[:memory_limit] = size
+      end
+      opts.on('--executor-memory-init-delay=SECONDS', 'Start memory polling after SECONDS. Overrides EXECUTOR_MEMORY_MONITOR_DELAY environment varaible.') do |seconds|
+        @options[:memory_init_delay] = seconds.to_i
+      end
+      opts.on('--executor-memory-polling-interval=SECONDS', 'Check for memory useage every SECONDS sec. Overrides EXECUTOR_MEMORY_MONITOR_INTERVAL environment varaible.') do |seconds|
+        @options[:memory_polling_interval] = seconds.to_i
+      end
+    end
+
+    args = opts.parse!(argv)
+    @command = args.first || 'run'
+  end
+
+  def banner(file)
+    banner = <<BANNER
+Run Dynflow executor for Foreman tasks.
+
+Usage: #{File.basename(file)} [options] ACTION"
+
+ACTION can be one of:
+
+* start   - start the executor on background. It creates these files
+          in tmp/pid directory:
+
+            * dynflow_executor_monitor.pid - pid of monitor ensuring
+                                             the executor keeps running
+            * dynflow_executor.pid         - pid of the executor itself
+            * dynflow_executor.output      - stdout of the executor
+* stop    - stops the running executor
+* restart - restarts the running executor
+* run     - run the executor in foreground
+
+BANNER
+    banner
+  end
+end
+
+# run the script if it's executed explicitly
+if $PROGRAM_NAME == __FILE__
+  parser = ArgvParser.new(ARGV, $PROGRAM_NAME)
+
+  app_file = File.expand_path('./config/application', parser.options[:rails_root])
+  require app_file
+
+  Dynflow::Rails::Daemon.new.run_background(parser.command, parser.options)
+end
+

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -59,4 +59,7 @@
 #  :templates:
 #    :enabled: true
 #  :notifications:
+#  :background:
+#    :enabled: true
+#  :dynflow:
 #    :enabled: true

--- a/lib/foreman/dynflow.rb
+++ b/lib/foreman/dynflow.rb
@@ -1,0 +1,7 @@
+require 'dynflow'
+
+module Foreman
+  module Dynflow
+    require_relative 'dynflow/configuration'
+  end
+end

--- a/lib/foreman/dynflow/configuration.rb
+++ b/lib/foreman/dynflow/configuration.rb
@@ -1,0 +1,15 @@
+module Foreman
+  module Dynflow
+    class Configuration < ::Dynflow::Rails::Configuration
+      # Action related info such as exceptions raised inside the actions' methods
+      def action_logger
+        Foreman::Logging.logger('background')
+      end
+
+      # Dynflow related info about the progress of the execution
+      def dynflow_logger
+        Foreman::Logging.logger('dynflow')
+      end
+    end
+  end
+end

--- a/lib/tasks/dynflow.rake
+++ b/lib/tasks/dynflow.rake
@@ -1,0 +1,13 @@
+namespace :dynflow do
+  desc <<-END_DESC
+In development mode, the Dynflow executor is part of the web server process. However, in production, it's more suitable to have the web server process separated from the async executor. Therefore, Dynflow is set to use external process in production mode by default (can be changed with Foreman.dynflow.config.remote = false). This task can be used to start the executor manually in development mode.
+
+The executor process needs to be executed before the web server. You can run it by:
+
+  foreman-rake foreman_tasks:dynflow:executor
+
+END_DESC
+  task :executor => :environment do
+    Dynflow::Rails::Daemon.new.run
+  end
+end


### PR DESCRIPTION
This commit initializes the Dynflow world in a very similar manner to
foreman-tasks (if a Dynflow world is available from foreman-tasks, we
use that one). 

This is ready now that https://github.com/Dynflow/dynflow/pull/218 is merged and released.

To test, create a job on `app/jobs/`, for example (app/jobs/sample_job.rb)

```ruby
class SampleJob < ActiveJob::Base
  def perform(msg)
    5.times { logger.info("#{msg}") }
  end
end
```

If you use foreman-tasks, and apply https://github.com/theforeman/foreman-tasks/pull/235 , you can also define the usual `def humanize_name` etc.. methods so that the jobs are shown in the list of tasks. 

Then on the console run any of the methods from ActiveJob, such as `SampleJob.perform_now`, `SampleJob.perform_later`, `SampleJob.set(:wait => 10.seconds).perform_later`, etcetera. The output should be similar to https://gist.github.com/anonymous/429e7171e867c94182839a4b0d1ddddc 

cc @iNecas as you're familiar with this initialization (mostly drawn from foreman-tasks)

If you want to run it as in production, run `rake dynflow:executor` on a different terminal, and run the job I posted above.

![screenshot from 2017-02-22 10-29-43](https://cloud.githubusercontent.com/assets/598891/23205368/e9c0ba02-f8e9-11e6-9662-14064a895148.png)
