### PR TITLE
Fixes #17866 - Remove PXE Properties from Gentoo Operatingsystem

### DIFF
--- a/app/models/operatingsystems/gentoo.rb
+++ b/app/models/operatingsystems/gentoo.rb
@@ -4,12 +4,6 @@ class Gentoo < Operatingsystem
   def mediumpath(host)
   end
 
-  def pxe_type
-  end
-
-  def pxedir
-  end
-
   def url_for_boot(file)
   end
 


### PR DESCRIPTION
The Gentoo Operatingsystem cannot be installed via PXE and can only be provisioned via Image.

Implementing the pxe method causes the exception as described in #[17866](http://projects.theforeman.org/issues/17866).

Removing the methods fixes the template rendering of Gentoo Templates.