### PR TITLE
fixes #18658 - Add pxe_loader to host REST

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -10,8 +10,8 @@ extends "api/v2/smart_proxies/children_nodes"
 
 attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :realm_id, :realm_name,
            :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
-           :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :build,
-           :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_type,
+           :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :pxe_loader,
+           :build, :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_type,
            :enabled, :managed, :use_image, :image_file, :uuid,
            :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,


### PR DESCRIPTION
Add the field `pxe_loader` to the GET part of the hosts/
It is possible to set or update (POST, UPDATE), but not to read it