### PR TITLE
refs #16982 - remove User.current deassignment (no such user)

### DIFF
--- a/test/models/subnet/ipv6_test.rb
+++ b/test/models/subnet/ipv6_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class Subnet::Ipv6Test < ActiveSupport::TestCase
-  def setup
-    User.current = User.find_by_login "admin"
-  end
-
   should_not allow_value(9.times.map { 'abcd' }.join(':')).for(:mask) # 45 characters
   should_not allow_value('2001:db8::1:').for(:network)
   should_not allow_value('2001:db8:abcde::1').for(:network)
@@ -26,7 +22,7 @@ class Subnet::Ipv6Test < ActiveSupport::TestCase
 
   test "should find the subnet by ip" do
     subnet = FactoryGirl.create(:subnet_ipv6)
-    assert_equal subnet, Subnet::Ipv6.unscoped.subnet_for(get_ip(subnet, 10))
+    assert_equal subnet, Subnet::Ipv6.subnet_for(get_ip(subnet, 10))
   end
 
   test "from cant be bigger than to range" do


### PR DESCRIPTION
Allows the scope change to be reverted, as User.current is no longer set
to `nil` (there is no 'admin' user).

This was relying on a bug in Ruby on Rails 4.2 where the `unscoped` call
filtered through thread variables into Subnet.subnet_for which calls
Subnet.all. This is fixed in 5.0, so the user must be set correctly.