### PR TITLE
fixes #18662 - stop default scope being overridden by association

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -134,7 +134,7 @@ module Taxonomix
         scope
       when []
         # If *no* taxable ids were found, then don't show any resources
-        scope.where(:id => [])
+        scope.where('1=0')
       else
         # We need to generate the WHERE part of the SQL query as a string,
         # otherwise the default scope would set id on each new instance

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -110,9 +110,13 @@ class HostsControllerTest < ActionController::TestCase
         }
       }, set_session_user
     end
-    new_host = Host.search_for('myotherfullhost').first
-    assert_equal new_host.environment, hostgroup.environment
-    assert_equal new_host.puppet_proxy, hostgroup.puppet_proxy
+    as_admin do
+      new_host = Host.search_for('myotherfullhost').first
+      assert new_host.environment.present?
+      assert_equal hostgroup.environment, new_host.environment
+      assert new_host.puppet_proxy.present?
+      assert_equal hostgroup.puppet_proxy, new_host.puppet_proxy
+    end
     assert_redirected_to host_url(assigns['host'])
   end
 


### PR DESCRIPTION
Ensure the Taxonomix empty default scope isn't overridden by association
scopes which (effectively) calls `.where(:id => ...)` and overrides the
value of :id set in this default scope. This occurs on Rails 5.0 which
merges the scopes more correctly/effectively than 4.2, and so invisible
resources became visible through the association getter.

Like the case where there is at least one visible resource, a string SQL
fragment is used instead to prevent it being overridden by ActiveRecord.

The host test now uses an admin user as it was testing that the host's
environment was nil (since hostgroup#environment now returns nil due to
the default scope), rather than a present value. This failed on 5.0 when
hostgroup#environment returned the invisible record.