### PR TITLE
refs #17228 - modify, don't re-define existing constant

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -6,7 +6,7 @@ class Setting::Provisioning < Setting
     end
   end
 
-  Setting::BLANK_ATTRS += default_global_labels
+  Setting::BLANK_ATTRS.push(*default_global_labels)
   validates :value, :pxe_template_name => true, :if => Proc.new { |s| s.class.default_global_labels.include?(s.name) }
 
   def self.default_settings


### PR DESCRIPTION
Prevents warnings during startup:

    app/models/setting/provisioning.rb:9: warning: already initialized constant Setting::BLANK_ATTRS
    app/models/setting.rb:13: warning: previous definition of BLANK_ATTRS was here