### PR TITLE
fixes #18664 - ignore missing callbacks in SmartProxyAuth concern

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -6,10 +6,10 @@ module Foreman::Controller::SmartProxyAuth
 
   module ClassMethods
     def add_smart_proxy_filters(actions, options = {})
-      skip_before_action :require_login, :only => actions
+      skip_before_action :require_login, :only => actions, :raise => false
       skip_before_action :authorize, :only => actions
       skip_before_action :verify_authenticity_token, :only => actions
-      skip_before_action :set_taxonomy, :only => actions
+      skip_before_action :set_taxonomy, :only => actions, :raise => false
       skip_before_action :session_expiry, :update_activity_time, :only => actions
       before_action(:only => actions) { require_smart_proxy_or_login(options[:features]) }
       attr_reader :detected_proxy


### PR DESCRIPTION
Filters that are only registered on the UI controllers cause errors
when using SmartProxyAuth on an API controller under Rails 5.0.