### PR TITLE
fixes #18665 - call #to_h before comparing AC::Parameters to hash

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/keep_param.rb
@@ -8,7 +8,11 @@ module Foreman::Controller::Parameters::KeepParam
   def keep_param(params, top_level_hash, *keys)
     # Delete keys being kept from the `params` hash, so the block yielded to filters the others
     old_params = keys.inject({}) do |op,(key,val)|
-      params[top_level_hash].has_key?(key) ? op.update(key => params[top_level_hash].delete(key)) : op
+      if params[top_level_hash].has_key?(key)
+        op[key] = params[top_level_hash].delete(key)
+        op[key].permit! if op[key].is_a?(ActionController::Parameters)
+      end
+      op
     end
 
     filtered = yield

--- a/test/controllers/concerns/parameters/host_test.rb
+++ b/test/controllers/concerns/parameters/host_test.rb
@@ -14,7 +14,7 @@ class HostParametersTest < ActiveSupport::TestCase
     filtered = host_params
 
     assert_equal 'test.example.com', filtered['name']
-    assert_equal({'foo' => 'bar', 'memory' => 2}, filtered['compute_attributes'])
+    assert_equal({'foo' => 'bar', 'memory' => 2}, filtered['compute_attributes'].to_h)
     assert filtered.permitted?
   end
 
@@ -26,7 +26,7 @@ class HostParametersTest < ActiveSupport::TestCase
 
     assert_equal 'test.example.com', filtered['name']
     assert_equal 'abc', filtered['interfaces_attributes'][0][:name]
-    assert_equal({'type' => 'awesome', 'network' => 'superawesome'}, filtered['interfaces_attributes'][0]['compute_attributes'])
+    assert_equal({'type' => 'awesome', 'network' => 'superawesome'}, filtered['interfaces_attributes'][0]['compute_attributes'].to_h)
     assert filtered.permitted?
   end
 end

--- a/test/controllers/concerns/parameters/nic_interface_test.rb
+++ b/test/controllers/concerns/parameters/nic_interface_test.rb
@@ -13,7 +13,7 @@ class NicInterfaceParametersTest < ActiveSupport::TestCase
     filtered = nic_interface_params
 
     assert_equal 'test.example.com', filtered['name']
-    assert_equal({'foo' => 'bar', 'memory' => 2}, filtered['compute_attributes'])
+    assert_equal({'foo' => 'bar', 'memory' => 2}, filtered['compute_attributes'].to_h)
     assert filtered.permitted?
   end
 

--- a/test/unit/parameter_filter_test.rb
+++ b/test/unit/parameter_filter_test.rb
@@ -11,12 +11,12 @@ class ParameterFilterTest < ActiveSupport::TestCase
 
   test "permitting second-level attributes via permit(Symbol)" do
     filter.permit(:test)
-    assert_equal({'test' => 'a'}, filter.filter_params(params(:example => {:test => 'a', :denied => 'b'}), ui_context))
+    assert_equal({'test' => 'a'}, filter.filter_params(params(:example => {:test => 'a', :denied => 'b'}), ui_context).to_h)
   end
 
   test "permitting second-level attributes via block" do
     filter.permit { |ctx| ctx.permit(:test) }
-    assert_equal({'test' => 'a'}, filter.filter_params(params(:example => {:test => 'a', :denied => 'b'}), ui_context))
+    assert_equal({'test' => 'a'}, filter.filter_params(params(:example => {:test => 'a', :denied => 'b'}), ui_context).to_h)
   end
 
   test "block contains controller/action names" do
@@ -29,13 +29,13 @@ class ParameterFilterTest < ActiveSupport::TestCase
 
   test "permitting second-level arrays via permit(Symbol => Array)" do
     filter.permit(:test => [])
-    assert_equal({}, filter.filter_params(params(:example => {:test => 'a'}), ui_context))
-    assert_equal({'test' => ['a']}, filter.filter_params(params(:example => {:test => ['a']}), ui_context))
+    assert_equal({}, filter.filter_params(params(:example => {:test => 'a'}), ui_context).to_h)
+    assert_equal({'test' => ['a']}, filter.filter_params(params(:example => {:test => ['a']}), ui_context).to_h)
   end
 
   test "permitting third-level attributes via permit(Symbol => Array[Symbol])" do
     filter.permit(:test => [:inner])
-    assert_equal({'test' => {'inner' => 'a'}}, filter.filter_params(params(:example => {:test => {:inner => 'a', :denied => 'b'}}), ui_context))
+    assert_equal({'test' => {'inner' => 'a'}}, filter.filter_params(params(:example => {:test => {:inner => 'a', :denied => 'b'}}), ui_context).to_h)
   end
 
   test "constructs permit() args for second-level attribute" do
@@ -45,7 +45,7 @@ class ParameterFilterTest < ActiveSupport::TestCase
 
   test "blocks second-level attributes for UI when :ui => false" do
     filter.permit_by_context(:test, :ui => false)
-    assert_equal({}, filter.filter_params(params(:example => {:test => 'a'}), ui_context))
+    assert_equal({}, filter.filter_params(params(:example => {:test => 'a'}), ui_context).to_h)
   end
 
   test "#permit_by_context raises error for unknown context types" do
@@ -76,8 +76,8 @@ class ParameterFilterTest < ActiveSupport::TestCase
       filter2.permit_by_context(:inner, :nested => true)
       filter2.permit(:ui_only)
       filter.permit(:test, :nested => [filter2])
-      assert_equal({'test' => 'a', 'nested' => [{'inner' => 'b'}]}, filter.filter_params(params(:example => {:test => 'a', :nested => [{:inner => 'b', :ui_only => 'b'}]}), ui_context))
-      assert_equal({'test' => 'a', 'nested' => {'123' => {'inner' => 'b'}}}, filter.filter_params(params(:example => {:test => 'a', :nested => {'123' => {:inner => 'b', :ui_only => 'b'}}}), ui_context))
+      assert_equal({'test' => 'a', 'nested' => [{'inner' => 'b'}]}, filter.filter_params(params(:example => {:test => 'a', :nested => [{:inner => 'b', :ui_only => 'b'}]}), ui_context).to_h)
+      assert_equal({'test' => 'a', 'nested' => {'123' => {'inner' => 'b'}}}, filter.filter_params(params(:example => {:test => 'a', :nested => {'123' => {:inner => 'b', :ui_only => 'b'}}}), ui_context).to_h)
     end
 
     test "second filter block has access to original controller/action" do
@@ -95,28 +95,28 @@ class ParameterFilterTest < ActiveSupport::TestCase
       plugin = mock('plugin')
       plugin.expects(:parameter_filters).with(klass).returns([[:plugin_ext, :another]])
       Foreman::Plugin.expects(:all).returns([plugin])
-      assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context))
+      assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context).to_h)
     end
 
     test "permits plugin-added attributes from blocks" do
       plugin = mock('plugin')
       plugin.expects(:parameter_filters).with(klass).returns([[Proc.new { |ctx| ctx.permit(:plugin_ext) }]])
       Foreman::Plugin.expects(:all).returns([plugin])
-      assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context))
+      assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context).to_h)
     end
   end
 
   context "with top_level_hash" do
     test "applies filters without top-level hash" do
       filter.permit(:test)
-      assert_equal({'test' => 'a'}, filter.filter_params(params(:changed => {:test => 'a', :denied => 'b'}), ui_context, :changed))
+      assert_equal({'test' => 'a'}, filter.filter_params(params(:changed => {:test => 'a', :denied => 'b'}), ui_context, :changed).to_h)
     end
   end
 
   context "with top_level_hash => :none" do
     test "applies filters without top-level hash" do
       filter.permit(:test)
-      assert_equal({'test' => 'a'}, filter.filter_params(params(:test => 'a', :denied => 'b'), ui_context, :none))
+      assert_equal({'test' => 'a'}, filter.filter_params(params(:test => 'a', :denied => 'b'), ui_context, :none).to_h)
     end
   end
 


### PR DESCRIPTION
Allows comparisons when ActionController::Parameters is separated from
Hash in Rails 5.0. #permit! is now called on inner hashes sent through
KeepParam (similar to rails/rails@e86524c in 5.1) so they are included
in the #to_h permitted output.