### PR TITLE
Fixes #18675 - added telemetry stack with PCP integration

### DIFF
--- a/config/initializers/telemetry.rb
+++ b/config/initializers/telemetry.rb
@@ -1,0 +1,30 @@
+require 'pcptrace'
+
+ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  controller = event.payload[:controller]
+  action = event.payload[:action]
+  format = event.payload[:format] || "all"
+  format = "all" if format == "*/*"
+  status = event.payload[:status]
+  key = "#{controller}.#{action}.#{format}"
+  r = PCPTrace::obs "#{key}.total_duration", event.duration
+  Rails.logger.warn("Telemetry error: " + PCPTrace::errstr(r)) if r != 0
+  PCPTrace::obs "#{key}.db_time", event.payload[:db_runtime]
+  PCPTrace::obs "#{key}.view_time", (event.payload[:view_runtime] || 0)
+  PCPTrace::counter "#{controller}.hit_#{status}", 1
+  PCPTrace::counter "total.hit_#{status}", 1
+end
+
+ActiveSupport::Notifications.subscribe /instantiation.active_record/ do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  class_name = event.payload[:class_name]
+  record_count = event.payload[:record_count]
+  PCPTrace::counter "instantiation.#{class_name}", record_count
+end
+
+ActiveSupport::Notifications.subscribe /deliver.action_mailer/ do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  to = event.payload[:to].gsub(/[^0-9a-z ]/i, '_')
+  PCPTrace::counter "mail_delivery.#{to}", 1
+end


### PR DESCRIPTION
Rails provides many instrumentation points which can be very easily hooked and exported to some monitoring framework. This is completely rewrriten from scratch integration with PCP (Performance Co-Pilot) framework.

This patch aims to be as simple as possible to allow some integration for existing stable versions. It is the first version which we can extend afterwards. It requires just one dependency (pcptrace) I wrote which does not have a RPM package. It uses simple API called "trace" for application instrumentation. For production deployments do:

~~~
yum -y install rh-ruby22-ruby-devel
scl enable tfm -- gem install pcptrace
~~~

For the record, I am leaving my initial description about initial version which was using statsd protocol instead:

Protocol statsd is very simple, UDP based and provides decent integration options. This change will be unintrusive, telemetry will be opt-in and it will be always disabled for test environment. It will also work without any external service sending the telemetry data into Rails logger if needed.

This initial implementation provides Rails controller processing times for individual controllers and actions (view, db, total times in ms). In addition, it provides number of success/failed login attempts, ActiveRecord instantianed classes, Foreman templates rendering time and ActionMailer sent mail counts.

The only dependency introduced is pure-Ruby library "statsd-instrument" that provides client library for statsd daemon. The idea is to run this daemon on localhost aggregating the data and/or sending to RRD or other monitoring solutions.

My goal is to spend as little cpu cycles on telemetry as possible, for this reason Rails will export the data via the UDP standard protocol to statsd and the daemon itself will do aggregation and further integration. More details in the articles below.

I will provide more details next week about how to set statsd with Foreman, you can test with "logger" output setting that will put the telemetry data to Rails log meanwhile. My favourite server implementation is collectd (plugin collectd-statsd), because I already wrote a Foreman plugin that integrates with collectd. Further reading

https://codeascraft.com/2011/02/15/measure-anything-measure-everything/
https://signalvnoise.com/posts/3091-pssst-your-rails-application-has-a-secret-to-tell-you
https://anomaly.io/statsd-in-collectd/
https://github.com/Shopify/statsd-instrument