### PR TITLE
fixes #18676 - don't ignore notification expiry

### DIFF
--- a/app/controllers/notification_recipients_controller.rb
+++ b/app/controllers/notification_recipients_controller.rb
@@ -6,7 +6,7 @@ class NotificationRecipientsController < Api::V2::BaseController
 
   def index
     @notifications = NotificationRecipient.
-      where(:user_id => User.current.id).
+      where(:user_id => User.current.id, :notification_id => Notification.active).
       order(:created_at).
       eager_load(:notification, :notification_blueprint)
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,11 +21,11 @@ class Notification < ActiveRecord::Base
     :in => [AUDIENCE_USER, AUDIENCE_GROUP, AUDIENCE_TAXONOMY,
             AUDIENCE_GLOBAL, AUDIENCE_ADMIN]
   }, :presence => true
-  before_create :calculate_expiry, :set_notification_recipients,
+  before_create :set_expiry, :set_notification_recipients,
     :set_default_initiator
 
-  scope :active, -> { where('expired_at >= :now', {:now => Time.now.utc}) }
-  scope :expired, -> { where('expired_at < :now', {:now => Time.now.utc}) }
+  scope :active, -> { where('notifications.expired_at >= :now', {:now => Time.now.utc}) }
+  scope :expired, -> { where('notifications.expired_at < :now', {:now => Time.now.utc}) }
 
   def expired?
     Time.now.utc > expired_at
@@ -48,8 +48,9 @@ class Notification < ActiveRecord::Base
 
   private
 
-  def calculate_expiry
-    self.expired_at = Time.now.utc + notification_blueprint.expires_in
+  # use timestamp definitions from blueprint and store the value in our model.
+  def set_expiry
+    self.expired_at = notification_blueprint.expired_at
   end
 
   def set_default_initiator

--- a/app/models/notification_blueprint.rb
+++ b/app/models/notification_blueprint.rb
@@ -18,6 +18,14 @@ class NotificationBlueprint < ActiveRecord::Base
   validates :expires_in, :numericality => {:greater_than => 0}
   before_validation :set_default_expiry
 
+  def mass_update_expiry
+    notifications.update_all(expired_at: expired_at)
+  end
+
+  def expired_at
+    Time.now.utc + expires_in
+  end
+
   private
 
   def set_default_expiry

--- a/test/controllers/notification_recipients_controller_test.rb
+++ b/test/controllers/notification_recipients_controller_test.rb
@@ -57,6 +57,16 @@ class NotificationRecipientsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "should not respond with expired notifications" do
+    notification = add_notification
+    notification.update_attribute(:expired_at, Time.now.utc - 48.hours)
+    get :index, { :format => 'json' }, set_session_user
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_empty response['notifications']
+    assert_equal 0, response['total']
+  end
+
   private
 
   def add_notification


### PR DESCRIPTION
This also adds the ability to mass refresh expiry dates.