### PR TITLE
Fixes #16043 - add 'select all hosts' option into hosts page

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -42,4 +42,11 @@ module HostsAndHostgroupsHelper
                 { :help_inline   => :indicator }
             ).html_safe
   end
+
+  def multiple_filter(hosts)
+    return unless multiple_with_filter?
+    no_filter   = _("Reminder: <strong> All #{hosts.size} hosts are selected </strong>").html_safe
+    with_filter = _("Reminder: <strong> All #{hosts.size} hosts are selected </strong> for query filter #{h(params[:search])}").html_safe
+    params[:search].blank? ? no_filter : with_filter
+  end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -81,7 +81,8 @@ module LayoutHelper
   end
 
   def will_paginate_with_info(collection = nil, options = {})
-    content_tag(:div, :id => "pagination", :class => "row") do
+    content_tag(:div, :id => "pagination", :class => "row",
+                :data => ({'count' => collection.total_entries, 'per-page' => per_page(collection)})) do
       page_entries_info(collection, options) +
         will_paginate(collection, options)
     end
@@ -186,6 +187,10 @@ module LayoutHelper
 
   def render_if_partial_exists(path, f)
     render path, :f => f if lookup_context.exists?(path, [], true)
+  end
+
+  def per_page(collection)
+    [Setting[:entries_per_page], collection.total_entries].min
   end
 
   private

--- a/app/views/hosts/_selected_hosts.html.erb
+++ b/app/views/hosts/_selected_hosts.html.erb
@@ -1,6 +1,9 @@
 <div class="row">
-  <table class="<%= table_css_classes %>">
-    <thead>
+  <%= alert(:class => 'alert-info hide', :id => 'multiple-modal-alert', :close => true, :header => '',
+            :text => multiple_filter(hosts)) %>
+  <% unless multiple_with_filter? %>
+    <table class="<%= table_css_classes %>">
+      <thead>
       <tr>
         <th>
           <%= _("Name") %>
@@ -14,8 +17,8 @@
         <%= raw("<th>" + _("Location") + "</th>") if SETTINGS[:locations_enabled]%>
         <%= raw("<th>" + _("Organization") + "</th>") if SETTINGS[:organizations_enabled]%>
       </tr>
-    </thead>
-    <tbody>
+      </thead>
+      <tbody>
       <% associations = [:hostgroup, :environment] %>
       <% associations << :organization if SETTINGS[:organizations_enabled]  %>
       <% associations << :location     if SETTINGS[:locations_enabled]  %>
@@ -33,8 +36,9 @@
           <% end %>
         </tr>
       <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
   <%= check_box_tag "keep_selected", "", false, :title => _("Keep selected hosts for a future action") %>
   <%= _('Keep selected hosts for a future action') %><br/><br/>
+  <% end %>
 </div>

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,2 +1,5 @@
 <% title_actions multiple_actions_select, csv_link, button_group(new_link(_("Create Host"))) %>
+<%= alert(:class => 'alert-info hide', :id => 'multiple-alert', :close => false, :header => '',
+          :text => _("All #{per_page(@hosts)} hosts on this page are selected. ").html_safe +
+                   link_to_function((_("Select all <b> #{@hosts.total_entries.to_s} </b> hosts")).html_safe, "multiple_selection()")) %>
 <%= render 'list', :hosts => @hosts, :header => @title || _("Hosts")  %>


### PR DESCRIPTION
`Select all items` checkbox in hosts page selects only the hosts within the page.  when the user wish to select all hosts for a bulk action, he has to select all hosts page after page.

![multiple_selection1](https://cloud.githubusercontent.com/assets/11807069/23341140/b0703818-fc4a-11e6-88d1-6e0266493bd5.png)

![multiple_selection](https://cloud.githubusercontent.com/assets/11807069/23341141/b07082a0-fc4a-11e6-8bc3-7749326729a9.png)



![ezgif com-resize](https://cloud.githubusercontent.com/assets/11807069/23341085/01ee8600-fc4a-11e6-8074-4b9c3ff52582.gif)
