### PR TITLE
fixes #18691 - add as_deprecation_tracker to test environment

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -15,4 +15,5 @@ group :test do
   gem 'test_after_commit', '>= 0.4', '< 2.0'
   gem 'shoulda-matchers', '~> 3.0'
   gem 'shoulda-context', '~> 1.2'
+  gem 'as_deprecation_tracker', '~> 1.4'
 end

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -1,0 +1,4 @@
+---
+# http://projects.theforeman.org/issues/7570
+- message: You didn't set `secret_key_base`. Read the upgrade documentation to learn
+    more about this new config option.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,8 @@
+# Track deprecation warnings in test environment as early as possible, but pause processing of
+# deprecations until all plugins are registered (prior to the finisher_hook initializer) to ensure
+# the whitelist is fully configured. This is done in the after_initialize block below.
+ASDeprecationTracker.pause!
+
 Foreman::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -62,4 +67,15 @@ Foreman::Application.configure do
   config.active_support.test_order = :random
 
   config.webpack.dev_server.enabled = false
+
+  # Whitelist all plugin engines by default from raising errors on deprecation warnings for
+  # compatibility, allow them to override it by adding an ASDT configuration file.
+  config.after_initialize do
+    Foreman::Plugin.all.each do |plugin|
+      unless File.exist?(File.join(plugin.path, 'config', 'as_deprecation_whitelist.yaml'))
+        ASDeprecationTracker.whitelist.add(engine: plugin.id.to_s.gsub('-', '_'))
+      end
+    end
+    ASDeprecationTracker.resume!
+  end
 end

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,0 +1,1 @@
+ActiveSupport::Deprecation.behavior = :silence if Rails.env.production?


### PR DESCRIPTION
Causes test failures if any new deprecation warnings are triggered by
changes in Foreman. Plugin code is automatically whitelisted unless it
supplies its own ASDT whitelist configuration, so developers can opt-in.

Warnings are now hidden in production as they're only relevant in
development or test environments.

---

Try reverting 0804d85 to see the effect.