### PR TITLE
Fixes #18726 - Set :null => true on migrations for Rails 5

### DIFF
--- a/db/migrate/20090715143858_create_architectures.rb
+++ b/db/migrate/20090715143858_create_architectures.rb
@@ -2,7 +2,7 @@ class CreateArchitectures < ActiveRecord::Migration
   def up
     create_table :architectures do |t|
       t.string   "name", :limit => 10, :default => "x86_64", :null => false
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :architectures_operatingsystems, :id => false do |t|

--- a/db/migrate/20090717025820_create_media.rb
+++ b/db/migrate/20090717025820_create_media.rb
@@ -4,7 +4,7 @@ class CreateMedia < ActiveRecord::Migration
       t.string :name, :limit => 50, :default => "", :null => false
       t.string :path, :limit => 100, :default => "", :null => false
       t.references :operatingsystem
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090718060746_create_domains.rb
+++ b/db/migrate/20090718060746_create_domains.rb
@@ -5,7 +5,7 @@ class CreateDomains < ActiveRecord::Migration
       t.string  :dnsserver,  :limit => 255
       t.string  :gateway,    :limit => 40
       t.string  :fullname,   :limit => 32
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090718064254_create_subnets.rb
+++ b/db/migrate/20090718064254_create_subnets.rb
@@ -8,7 +8,7 @@ class CreateSubnets < ActiveRecord::Migration
       t.string   :ranges, :limit => 512
       t.text     :name
       t.string   :vlanid, :limit => 10
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090720134126_create_operatingsystems.rb
+++ b/db/migrate/20090720134126_create_operatingsystems.rb
@@ -6,7 +6,7 @@ class CreateOperatingsystems < ActiveRecord::Migration
       t.string   :minor, :limit => 16
       t.string   :nameindicator, :limit => 3
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090722140138_create_models.rb
+++ b/db/migrate/20090722140138_create_models.rb
@@ -3,7 +3,7 @@ class CreateModels < ActiveRecord::Migration
     create_table :models do |t|
       t.string :name, :limit => 64, :null => false
       t.text :info
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_column :hosts, :model_id, :integer

--- a/db/migrate/20090722141107_create_environments.rb
+++ b/db/migrate/20090722141107_create_environments.rb
@@ -2,7 +2,7 @@ class CreateEnvironments < ActiveRecord::Migration
   def up
     create_table :environments do |t|
       t.string :name, :null => false, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
     create_table :environments_puppetclasses, :id => false do |t|
       t.references :puppetclass, :null => false

--- a/db/migrate/20090729132209_create_reports.rb
+++ b/db/migrate/20090729132209_create_reports.rb
@@ -4,7 +4,7 @@ class CreateReports < ActiveRecord::Migration
       t.references :host, :null => false
       t.text       :log
       t.datetime   :reported_at
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090730152224_create_ptables.rb
+++ b/db/migrate/20090730152224_create_ptables.rb
@@ -5,7 +5,7 @@ class CreatePtables < ActiveRecord::Migration
       t.string :name,   :limit => 64, :null => false
       t.string :layout, :limit => 4096, :null => false
       t.references :operatingsystem
-      t.timestamps
+      t.timestamps null: true
     end
     create_table :operatingsystems_ptables, :id => false do |t|
       t.references :ptable, :null => false

--- a/db/migrate/20090802062223_create_puppetclasses.rb
+++ b/db/migrate/20090802062223_create_puppetclasses.rb
@@ -5,7 +5,7 @@ class CreatePuppetclasses < ActiveRecord::Migration
       t.string :nameindicator, :limit => 255
       t.integer :operatingsystem_id
 
-      t.timestamps
+      t.timestamps null: true
     end
     create_table :hosts_puppetclasses, :id => false do |t|
       t.references :puppetclass, :null => false

--- a/db/migrate/20090804130144_create_parameters.rb
+++ b/db/migrate/20090804130144_create_parameters.rb
@@ -3,7 +3,7 @@ class CreateParameters < ActiveRecord::Migration
     create_table :parameters do |t|
       t.string :name, :value, :limit => 255
       t.references :host
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090820130541_create_auth_sources.rb
+++ b/db/migrate/20090820130541_create_auth_sources.rb
@@ -15,7 +15,7 @@ class CreateAuthSources < ActiveRecord::Migration
       t.boolean "onthefly_register",               :default => false, :null => false
       t.boolean "tls",                             :default => false, :null => false
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20090905150131_create_hostgroups.rb
+++ b/db/migrate/20090905150131_create_hostgroups.rb
@@ -3,7 +3,7 @@ class CreateHostgroups < ActiveRecord::Migration
     create_table :hostgroups do |t|
       t.string :name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :hostgroups_puppetclasses, :id => false do |t|

--- a/db/migrate/20091012135004_create_users.rb
+++ b/db/migrate/20091012135004_create_users.rb
@@ -9,7 +9,7 @@ class CreateUsers < ActiveRecord::Migration
       t.datetime :last_login_on
       t.integer :auth_source_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20091016031017_create_sessions.rb
+++ b/db/migrate/20091016031017_create_sessions.rb
@@ -3,7 +3,7 @@ class CreateSessions < ActiveRecord::Migration
     create_table :sessions do |t|
       t.string :session_id, :null => false, :limit => 255
       t.text :data
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :sessions, :session_id

--- a/db/migrate/20091219132338_create_lookup_keys.rb
+++ b/db/migrate/20091219132338_create_lookup_keys.rb
@@ -2,7 +2,7 @@ class CreateLookupKeys < ActiveRecord::Migration
   def up
     create_table :lookup_keys do |t|
       t.string :key, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :lookup_keys, :key
   end

--- a/db/migrate/20091219132839_create_lookup_values.rb
+++ b/db/migrate/20091219132839_create_lookup_values.rb
@@ -5,7 +5,7 @@ class CreateLookupValues < ActiveRecord::Migration
       t.string :value, :limit => 255
       t.references :lookup_key
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :lookup_values, :priority
   end

--- a/db/migrate/20100416124600_create_usergroups.rb
+++ b/db/migrate/20100416124600_create_usergroups.rb
@@ -2,7 +2,7 @@ class CreateUsergroups < ActiveRecord::Migration
   def up
     create_table :usergroups do |t|
       t.string :name, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
     create_table :usergroup_members do |t|
       t.references :member, :polymorphic => true

--- a/db/migrate/20100625155400_create_notices.rb
+++ b/db/migrate/20100625155400_create_notices.rb
@@ -5,7 +5,7 @@ class CreateNotices < ActiveRecord::Migration
       t.string  :content, :null => false, :limit => 1024
       t.boolean :global,  :null => false, :default => true
       t.string  :level,   :null => false, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
     # Global messages have to be acknowledged by every user individually
     create_table :user_notices, :id => false do |t|

--- a/db/migrate/20100822072954_create_user_facts.rb
+++ b/db/migrate/20100822072954_create_user_facts.rb
@@ -8,7 +8,7 @@ class CreateUserFacts < ActiveRecord::Migration
       t.string     :criteria, :limit => 255
       t.string     :operator, :limit => 3, :default => "="
       t.string     :andor,    :limit => 3, :default => "or"
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20101018120621_create_logs.rb
+++ b/db/migrate/20101018120621_create_logs.rb
@@ -6,7 +6,7 @@ class CreateLogs < ActiveRecord::Migration
       t.integer :report_id
       t.integer :level_id
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :logs, :report_id
     add_index :logs, :message_id

--- a/db/migrate/20101121080425_create_config_templates.rb
+++ b/db/migrate/20101121080425_create_config_templates.rb
@@ -5,7 +5,7 @@ class CreateConfigTemplates < ActiveRecord::Migration
       t.text :template
       t.boolean :snippet
       t.references :template_kind
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20101121135521_create_template_combinations.rb
+++ b/db/migrate/20101121135521_create_template_combinations.rb
@@ -5,7 +5,7 @@ class CreateTemplateCombinations < ActiveRecord::Migration
       t.references :hostgroup
       t.references :environment
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20101123152150_create_template_kinds.rb
+++ b/db/migrate/20101123152150_create_template_kinds.rb
@@ -2,7 +2,7 @@ class CreateTemplateKinds < ActiveRecord::Migration
   def up
     create_table :template_kinds do |t|
       t.string :name, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20101123153303_create_os_default_templates.rb
+++ b/db/migrate/20101123153303_create_os_default_templates.rb
@@ -5,7 +5,7 @@ class CreateOsDefaultTemplates < ActiveRecord::Migration
       t.references :template_kind
       t.references :operatingsystem
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20101130100315_create_proxies.rb
+++ b/db/migrate/20101130100315_create_proxies.rb
@@ -3,7 +3,7 @@ class CreateProxies < ActiveRecord::Migration
     create_table :smart_proxies do |t|
       t.string :name, :limit => 255
       t.string :url, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20110213104226_create_proxy_features.rb
+++ b/db/migrate/20110213104226_create_proxy_features.rb
@@ -5,7 +5,7 @@ class CreateProxyFeatures < ActiveRecord::Migration
     # Create the tables
     create_table :features do |t|
       t.string :name, :limit => 16
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :features_smart_proxies, :id => false do |t|

--- a/db/migrate/20110628115422_create_settings.rb
+++ b/db/migrate/20110628115422_create_settings.rb
@@ -7,7 +7,7 @@ class CreateSettings < ActiveRecord::Migration
       t.string :category, :limit => 255
       t.string :settings_type, :limit => 255
       t.text :default, :null => false
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :settings, :name, :unique => true
   end

--- a/db/migrate/20120110113051_create_subnet_domain.rb
+++ b/db/migrate/20120110113051_create_subnet_domain.rb
@@ -4,7 +4,7 @@ class CreateSubnetDomain < ActiveRecord::Migration
       t.references :domain
       t.references :subnet
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     Subnet.unscoped.find_each do |s|

--- a/db/migrate/20120122131037_create_compute_resources.rb
+++ b/db/migrate/20120122131037_create_compute_resources.rb
@@ -9,7 +9,7 @@ class CreateComputeResources < ActiveRecord::Migration
       t.string :uuid, :limit => 255
       t.string :type, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20120311081257_create_nics.rb
+++ b/db/migrate/20120311081257_create_nics.rb
@@ -10,7 +10,7 @@ class CreateNics < ActiveRecord::Migration
       t.references :domain
       t.text :attrs
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :nics, [:type], :name => 'index_by_type'

--- a/db/migrate/20120506143325_create_images.rb
+++ b/db/migrate/20120506143325_create_images.rb
@@ -8,7 +8,7 @@ class CreateImages < ActiveRecord::Migration
       t.string :username, :limit => 255
       t.string :name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20120510113417_create_key_pairs.rb
+++ b/db/migrate/20120510113417_create_key_pairs.rb
@@ -5,7 +5,7 @@ class CreateKeyPairs < ActiveRecord::Migration
       t.integer :compute_resource_id
       t.string :name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20120621135042_create_taxonomies.rb
+++ b/db/migrate/20120621135042_create_taxonomies.rb
@@ -4,7 +4,7 @@ class CreateTaxonomies < ActiveRecord::Migration
       t.string :name, :limit => 255
       t.string :type, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 

--- a/db/migrate/20121012170851_create_trends.rb
+++ b/db/migrate/20121012170851_create_trends.rb
@@ -8,7 +8,7 @@ class CreateTrends < ActiveRecord::Migration
       t.string :fact_value, :limit => 255
       t.string :fact_name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :trends, :type
     add_index :trends, [:trendable_type, :trendable_id]

--- a/db/migrate/20121012170936_create_trend_counters.rb
+++ b/db/migrate/20121012170936_create_trend_counters.rb
@@ -4,7 +4,7 @@ class CreateTrendCounters < ActiveRecord::Migration
       t.integer :trend_id
       t.integer :count
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :trend_counters, :trend_id
   end

--- a/db/migrate/20121118125341_create_taxable_taxonomies.rb
+++ b/db/migrate/20121118125341_create_taxable_taxonomies.rb
@@ -5,7 +5,7 @@ class CreateTaxableTaxonomies < ActiveRecord::Migration
       t.integer :taxable_id
       t.string :taxable_type, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :taxable_taxonomies, [:taxable_id, :taxable_type]

--- a/db/migrate/20131114094841_create_cached_user_roles.rb
+++ b/db/migrate/20131114094841_create_cached_user_roles.rb
@@ -5,7 +5,7 @@ class CreateCachedUserRoles < ActiveRecord::Migration
       t.integer :role_id, :null => false
       t.integer :user_role_id, :null => false
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :cached_user_roles, :user_id

--- a/db/migrate/20131122170726_create_cached_usergroup_members.rb
+++ b/db/migrate/20131122170726_create_cached_usergroup_members.rb
@@ -4,7 +4,7 @@ class CreateCachedUsergroupMembers < ActiveRecord::Migration
       t.integer :user_id
       t.integer :usergroup_id
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :cached_usergroup_members, :user_id

--- a/db/migrate/20131125230654_create_realms.rb
+++ b/db/migrate/20131125230654_create_realms.rb
@@ -6,7 +6,7 @@ class CreateRealms < ActiveRecord::Migration
       t.integer     :realm_proxy_id
       t.integer     :hosts_count, :default => 0
       t.integer     :hostgroups_count, :default => 0
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :realms, :name, :unique => true

--- a/db/migrate/20131202120621_create_permissions.rb
+++ b/db/migrate/20131202120621_create_permissions.rb
@@ -4,7 +4,7 @@ class CreatePermissions < ActiveRecord::Migration
       t.string :name, :null => false, :limit => 255
       t.string :resource_type, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :permissions, [:name, :resource_type]

--- a/db/migrate/20131202131847_create_filters.rb
+++ b/db/migrate/20131202131847_create_filters.rb
@@ -4,7 +4,7 @@ class CreateFilters < ActiveRecord::Migration
       t.text :search
       t.integer :role_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20131202144415_create_filterings.rb
+++ b/db/migrate/20131202144415_create_filterings.rb
@@ -4,7 +4,7 @@ class CreateFilterings < ActiveRecord::Migration
       t.integer :filter_id
       t.integer :permission_id
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :filterings, :filter_id

--- a/db/migrate/20131224153518_create_compute_profiles.rb
+++ b/db/migrate/20131224153518_create_compute_profiles.rb
@@ -3,7 +3,7 @@ class CreateComputeProfiles < ActiveRecord::Migration
     create_table :compute_profiles do |t|
       t.string :name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20131224153743_create_compute_attributes.rb
+++ b/db/migrate/20131224153743_create_compute_attributes.rb
@@ -6,7 +6,7 @@ class CreateComputeAttributes < ActiveRecord::Migration
       t.string :name, :limit => 255
       t.text :vm_attrs
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :compute_attributes, :compute_profile_id

--- a/db/migrate/20140407161817_create_config_groups.rb
+++ b/db/migrate/20140407161817_create_config_groups.rb
@@ -3,7 +3,7 @@ class CreateConfigGroups < ActiveRecord::Migration
     create_table :config_groups do |t|
       t.string :name, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20140407162007_create_config_group_classes.rb
+++ b/db/migrate/20140407162007_create_config_group_classes.rb
@@ -4,7 +4,7 @@ class CreateConfigGroupClasses < ActiveRecord::Migration
       t.integer :puppetclass_id
       t.integer :config_group_id
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20140407162059_create_host_config_groups.rb
+++ b/db/migrate/20140407162059_create_host_config_groups.rb
@@ -5,7 +5,7 @@ class CreateHostConfigGroups < ActiveRecord::Migration
       t.integer :host_id
       t.string  :host_type, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20140928140206_create_widgets.rb
+++ b/db/migrate/20140928140206_create_widgets.rb
@@ -12,7 +12,7 @@ class CreateWidgets < ActiveRecord::Migration
       t.integer :row, :default => 1
       t.boolean :hide, :default => false
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20140929073150_create_mail_notifications.rb
+++ b/db/migrate/20140929073150_create_mail_notifications.rb
@@ -8,7 +8,7 @@ class CreateMailNotifications < ActiveRecord::Migration
       t.boolean :subscriptable, :default => true
       t.string :default_interval, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20140929073343_create_user_mail_notifications.rb
+++ b/db/migrate/20140929073343_create_user_mail_notifications.rb
@@ -6,7 +6,7 @@ class CreateUserMailNotifications < ActiveRecord::Migration
       t.datetime :last_sent
       t.string :interval, :limit => 255
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_foreign_key :user_mail_notifications, :users, :name => "user_mail_notifications_user_id_fk"

--- a/db/migrate/20151009084350_drop_ptables.rb
+++ b/db/migrate/20151009084350_drop_ptables.rb
@@ -8,7 +8,7 @@ class DropPtables < ActiveRecord::Migration
       t.string :name, :limit => 64, :null => false
       t.text :layout, :null => false
       t.string :os_family, :limit => 255
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end


### PR DESCRIPTION
Currently I'm seeing

`#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing.