### PR TITLE
fixes #18735 - truncate encryption key to match preferred length

### DIFF
--- a/lib/foreman/util.rb
+++ b/lib/foreman/util.rb
@@ -22,9 +22,10 @@ module Foreman
       SecureRandom.base64(96).tr('+/=', '-_*')
     end
 
-    # recommended to make encryption_key at least 32 bytes. Ex. SecureRandom.hex(20)
+    # recommended to make encryption_key 32 bytes, matching the key length preferred by
+    # AS::MessageEncryptor's default algorithm
     def secure_encryption_key
-      SecureRandom.hex(20)
+      SecureRandom.hex(ActiveSupport::MessageEncryptor.key_len / 2)
     end
   end
 end

--- a/test/unit/encryptable_test.rb
+++ b/test/unit/encryptable_test.rb
@@ -7,11 +7,15 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   def cr_with_encryption_key
-    stub_encryption_key(FactoryGirl.build(:ec2_cr, password: 'encrypted-NEN1YVJtdWdaaTdlOHdiUXRHd29nWUZsOHc1UjdMb3p1MFZLenlLekFEbz0tLVA0MGVzUEorUDlJZHVUV2F6azUzUEE9PQ==--9f45d5c88ec582eeb48ebb906ae0a66345ded0fa'))
+    stub_encryption_key(FactoryGirl.build(:ec2_cr, password: 'encrypted-aXVpUzdTSTArRlFwR1RKTy90QWFKQVZDOERGQXhteUFaMG1xVnMxWmFuaz0tLTJHcnlIUDV3N0RrcjhkMWRzdWtJNkE9PQ==--e9227b0757885a231036fe9a7e4f959cfdf66f56'))
   end
 
-  def stub_encryption_key(model)
-    model.stubs(:encryption_key).returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+  def cr_with_long_encryption_key
+    stub_encryption_key(FactoryGirl.build(:ec2_cr, password: 'encrypted-NEN1YVJtdWdaaTdlOHdiUXRHd29nWUZsOHc1UjdMb3p1MFZLenlLekFEbz0tLVA0MGVzUEorUDlJZHVUV2F6azUzUEE9PQ==--9f45d5c88ec582eeb48ebb906ae0a66345ded0fa'), '25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+  end
+
+  def stub_encryption_key(model, key = '25d224dd383e92a7e0c82b8bf7c985e8')
+    model.stubs(:encryption_key).returns(key)
     model
   end
 
@@ -99,6 +103,15 @@ class EncryptableTest < ActiveSupport::TestCase
 
   test "decrypt successfully" do
     compute_resource = cr_with_encryption_key
+    plain_str = "secretpassword"
+    encrypted_str = compute_resource.encrypt_field(plain_str)
+    decrypted_str = compute_resource.decrypt_field(encrypted_str)
+    refute_equal encrypted_str, decrypted_str
+    assert_equal plain_str, decrypted_str
+  end
+
+  test "decrypt successfully with over-sized key" do
+    compute_resource = cr_with_long_encryption_key
     plain_str = "secretpassword"
     encrypted_str = compute_resource.encrypt_field(plain_str)
     decrypted_str = compute_resource.decrypt_field(encrypted_str)

--- a/test/unit/foreman/util_test.rb
+++ b/test/unit/foreman/util_test.rb
@@ -36,4 +36,8 @@ class UtilTest < ActiveSupport::TestCase
     FileTest.stubs(:executable?).with('/usr/bin/utiltest').returns(false)
     assert_equal false, which('utiltest')
   end
+
+  test 'secure_encryption_key should match AS default key length' do
+    assert_equal ActiveSupport::MessageEncryptor.key_len, secure_encryption_key.length
+  end
 end


### PR DESCRIPTION
Ruby 2.4's OpenSSL bindings raise an ArgumentError during encryption if
the key length exceeds the cipher's configured length (32 bytes with the
default cipher), but the verification hash algorithm still uses the full
length key.

The encryption key is now truncated to the cipher's preferred length
while passing the full key (if supplied) for signatures.

The default new key length has been changed from 40 to 32 bytes matching
the cipher default, but there's no reason to deprecate or force existing
installations to change.