### PR TITLE
Fixes #18763 - Change delete button to the secondary button style

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,7 +130,7 @@ module ApplicationHelper
     text = options.delete(:text) || _("Delete")
     method = options.delete(:method) || :delete
     options = {:auth_action => :destroy}.merge(options)
-    html_options = { :data => { :confirm => _('Are you sure?') }, :method => method, :class => 'delete' }.merge(html_options)
+    html_options = { :data => { :confirm => _('Are you sure?') }, :method => method }.merge(html_options)
     display_link_if_authorized(text, options, html_options)
   end
 


### PR DESCRIPTION
From the demo meeting[1], we suggested the delete button to follow the secondary button style, also the default style, please check the attachment as following:
![delete-button-2 1](https://cloud.githubusercontent.com/assets/701009/23500861/70605ee0-ff6c-11e6-8c2d-3f3da3e7c76a.png)

As when user choose to click the delete button, in the system, it has a confirmation with user, so it's not necessary to be different with others.
This patch is aim to fix this issue. 



[1] https://groups.google.com/forum/?fromgroups#!topic/foreman-dev/Gx69q6ZRB3s
