### PR TITLE
Fixes #18783 - refactor role form help

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -307,13 +307,13 @@ module FormHelper
     label = options[:label] == :none ? '' : options.delete(:label)
     label ||= ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
         s_(clazz.gettext_translation_for_attribute_name attr)) if f
-    label = label.present? ? label_tag(attr, "#{label}#{required_mark}", :class => label_size + " control-label") : ''
+    label = label.present? ? label_tag(attr, label.to_s + required_mark.to_s, :class => label_size + " control-label") : ''
     label
   end
 
   def check_required options, f, attr
     required = options.delete(:required) # we don't want to use html5 required attr so we delete the option
-    return ' *' if required.nil? ? is_required?(f, attr) : required
+    return ' *'.html_safe if required.nil? ? is_required?(f, attr) : required
   end
 
   def blank_or_inherit_f(f, attr)

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -10,24 +10,26 @@
 
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
+      <% if @role.persisted? && (show_location_tab? || show_organization_tab?) %>
+          <h5><%= _("Changes to %s will propagate to all inheriting filters").html_safe % org_loc_string(_('and')) %></h5>
+          <hr>
+      <% end %>
+
       <%= text_f f, :name, :class => @role.builtin? ? "disabled" : ""  %>
       <%= textarea_f f, :description, :rows=> 5, :size => "col-md-4" %>
       <%= hidden_field_tag :original_role_id, @original_role_id if @cloned_role %>
 
-      <% if show_location_tab? || show_organization_tab? %>
-        <%= alert(:close => false, :class => 'alert-info', :header => '', :text => (_("Changes to following associations will propagate to all inheriting filters") + ' ' +
-            popover("", _("When the role's associated %{orgs_or_locs} are changed,<br> the change will propagate to all inheriting filters.
-                               Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.
-                               Note that not all filters support <br> %{orgs_and_locs}, so these always remain global.") % { :orgs_or_locs => org_loc_string('or'), :orgs_and_locs => org_loc_string('and') },
-                    :title => _("Role %s.") % org_loc_string('and'))).html_safe) %>
-      <% end %>
-
+      <% tax_help = N_("When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.
+                         Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.
+                         Note that not all filters support <br>%{taxonomies}, so these always remain global.") %>
       <% if show_location_tab? %>
-        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, { :label => _("Locations") } %>
+        <% loc_help = _(tax_help) % { :taxonomies => _('locations') }%>
+        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, { :label => (_("Locations") + ' ' + popover("", loc_help, :title => _("Role locations"))).html_safe } %>
       <% end %>
 
       <% if show_organization_tab? %>
-        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, { :label => _("Organizations") } %>
+        <% org_help = _(tax_help) % { :taxonomies => _('organizations') }%>
+        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, { :label => (_("Organizations") + ' ' + popover("", org_help, :title => _("Role organizations"))).html_safe } %>
       <% end %>
     </div>
 


### PR DESCRIPTION
While working on this area I took the liberty to improve the form help after consulting with @rohoover 
This PR allows us to start moving popover icons to labels (safe mode fix) and actually uses it for multiple select in this form. Since we couldn't add it to label before, the inline notification has it's own popover. Also it turned out that the positioning of it was confusing, when it's on top it makes more sense since you start from there when you're editing.

after:
![roles1](https://cloud.githubusercontent.com/assets/109773/23544134/f37f5f40-fff5-11e6-810c-643494e19489.png)

before:
![roles2](https://cloud.githubusercontent.com/assets/109773/23544194/3db47a78-fff6-11e6-99c1-372b746e6c91.png)
