### PR TITLE
Fixes #18788 - log protected attributes in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,7 @@ Foreman::Application.configure do |app|
   config.active_record.dump_schema_after_migration = false
 
   config.webpack.dev_server.enabled = false
+
+  # Log denied attributes into logger
+  config.action_controller.action_on_unpermitted_parameters = :log
 end


### PR DESCRIPTION
I see no reason not to do this. More info in the ticket.