### PR TITLE
Fixes #18804 - replace inline helps with label helps

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -20,9 +20,15 @@ module CommonParametersHelper
   end
 
   def omit_help
-    title = _("Omit parameter from classification")
-    body = _("Foreman will not send this parameter in classification output.")
-    popover(nil, body, :title => title)
+    popover(nil, omit_help_body, :title => omit_help_title)
+  end
+
+  def omit_help_title
+    _("Omit parameter from classification")
+  end
+
+  def omit_help_body
+    _("Foreman will not send this parameter in classification output.")
   end
 
   def hidden_value_field(f, field, disabled, options = {})

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -302,18 +302,24 @@ module FormHelper
   end
 
   def add_label options, f, attr
+    return ''.html_safe if options[:label] == :none
+
     label_size = options.delete(:label_size) || "col-md-2"
     required_mark = check_required(options, f, attr)
-    label = options[:label] == :none ? '' : options.delete(:label)
-    label ||= ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
-        s_(clazz.gettext_translation_for_attribute_name attr)) if f
-    label = label.present? ? label_tag(attr, "#{label}#{required_mark}", :class => label_size + " control-label") : ''
+    label = ''.html_safe + options.delete(:label)
+    label += ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
+      s_(clazz.gettext_translation_for_attribute_name attr).html_safe) if f && label.empty?
+
+    if options[:label_help].present?
+      label += ' '.html_safe + popover("", options[:label_help], options[:label_help_options] || {})
+    end
+    label = label.present? ? label_tag(attr, label.to_s + required_mark.to_s, :class => label_size + " control-label") : ''
     label
   end
 
   def check_required options, f, attr
     required = options.delete(:required) # we don't want to use html5 required attr so we delete the option
-    return ' *' if required.nil? ? is_required?(f, attr) : required
+    return ' *'.html_safe if required.nil? ? is_required?(f, attr) : required
   end
 
   def blank_or_inherit_f(f, attr)

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -31,26 +31,28 @@ module LookupKeysHelper
   def param_type_selector(f, options = {})
     selectable_f f, :key_type, options_for_select(LookupKey::KEY_TYPES.map { |e| [_(e),e] }, f.object.key_type),{},
                  options.merge({ :disabled => (f.object.puppet? && !f.object.override), :size => "col-md-8", :class=> "without_select2",
-                 :help_inline => popover("",_("<dl>" +
-               "<dt>String</dt> <dd>Everything is taken as a string.</dd>" +
-               "<dt>Boolean</dt> <dd>Common representation of boolean values are accepted.</dd>" +
-               "<dt>Integer</dt> <dd>Integer numbers only, can be negative.</dd>" +
-               "<dt>Real</dt> <dd>Accept any numerical input.</dd>" +
-               "<dt>Array</dt> <dd>A valid JSON or YAML input, that must evaluate to an array.</dd>" +
-               "<dt>Hash</dt> <dd>A valid JSON or YAML input, that must evaluate to an object/map/dict/hash.</dd>" +
-               "<dt>YAML</dt> <dd>Any valid YAML input.</dd>" +
-               "<dt>JSON</dt> <dd>Any valid JSON input.</dd>" +
-               "</dl>"), :title => _("How values are validated")).html_safe})
+                 :label_help => _("<dl>" +
+                   "<dt>String</dt> <dd>Everything is taken as a string.</dd>" +
+                   "<dt>Boolean</dt> <dd>Common representation of boolean values are accepted.</dd>" +
+                   "<dt>Integer</dt> <dd>Integer numbers only, can be negative.</dd>" +
+                   "<dt>Real</dt> <dd>Accept any numerical input.</dd>" +
+                   "<dt>Array</dt> <dd>A valid JSON or YAML input, that must evaluate to an array.</dd>" +
+                   "<dt>Hash</dt> <dd>A valid JSON or YAML input, that must evaluate to an object/map/dict/hash.</dd>" +
+                   "<dt>YAML</dt> <dd>Any valid YAML input.</dd>" +
+                   "<dt>JSON</dt> <dd>Any valid JSON input.</dd>" +
+               "</dl>").html_safe,
+                 :label_help_options => { :title => _("How values are validated") }})
   end
 
   def validator_type_selector(f)
     selectable_f f, :validator_type, options_for_select(LookupKey::VALIDATOR_TYPES.map { |e| [_(e),e] }, f.object.validator_type),{:include_blank => _("None")},
                { :disabled => (f.object.puppet? && !f.object.override), :size => "col-md-8", :class=> "without_select2",
                  :onchange => 'validatorTypeSelected(this)',
-                 :help_inline => popover("",_("<dl>" +
-               "<dt>List</dt> <dd>A list of the allowed values, specified in the Validator rule field.</dd>" +
-               "<dt>Regexp</dt> <dd>Validates the input with the regular expression in the Validator rule field.</dd>" +
-               "</dl>"), :title => _("Validation types")).html_safe}
+                 :label_help => _("<dl>" +
+                   "<dt>List</dt> <dd>A list of the allowed values, specified in the Validator rule field.</dd>" +
+                   "<dt>Regexp</dt> <dd>Validates the input with the regular expression in the Validator rule field.</dd>" +
+                   "</dl>").html_safe,
+                 :label_help_options => { :title => _("Validation types") } }
   end
 
   def overridable_lookup_keys(klass, obj)

--- a/app/views/common/os_selection/_pxe_loader.html.erb
+++ b/app/views/common/os_selection/_pxe_loader.html.erb
@@ -5,6 +5,7 @@
         :include_blank => blank_or_inherit_f(f, :pxe_loader),
       },
       :label => _('PXE loader'),
-      :help_inline => popover("", _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE)"), :data => { :placement => 'top' }) %>
+      :label_help =>  _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE)"),
+      :label_help_options => { :data => { :placement => 'top' } } %>
   <% end -%>
 <% end -%>

--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -25,11 +25,8 @@
     <%= text_f f, :bridge,
       :class => "libvirt_bridge",
       :label => _("Network"),
-      :help_inline => popover(
-        '',
-        _('There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)'),
-        :rel => 'popover-modal'
-      ),
+      :label_help => _('There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)'),
+      :label_help_options => { :rel => 'popover-modal' },
       :disabled => !new_host,
       :label_size => "col-md-3" %>
   <% end %>

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -44,13 +44,13 @@
 
       <div id="override_taxonomy_form" class="<%= f.object.allows_taxonomies_filtering? && Taxonomy.enabled_taxonomies.any? ? '' : 'hidden' %>">
         <%= checkbox_f f, :override?,
-                       :help_inline => popover('', _("Filters inherit %{orgs_and_locs} from their role by default. If override field is enabled, <br> filter can override the set of its %{orgs_and_locs}. Later role changes will not affect <br> such filter. After disabling override field, role %{orgs_and_locs} apply again.") % { :orgs_and_locs => org_loc_string('and') }),
+                       :label_help => (_("Filters inherit %{orgs_and_locs} from their role by default. If override field is enabled, <br> filter can override the set of its %{orgs_and_locs}. Later role changes will not affect <br> such filter. After disabling override field, role %{orgs_and_locs} apply again.") % { :orgs_and_locs => org_loc_string('and') }).html_safe,
                        :id => 'override_taxonomy_checkbox' %>
       </div>
 
       <div id="granular_form" style="<%= f.object.granular? ? '' : 'display:none' %>">
         <%= checkbox_f f, :unlimited?,
-                       :help_inline => popover('', _("By unchecking this you can specify filter using Foreman search syntax in search field. If filter remains <br> unlimited (this field is checked) it applies on all resources of the selected type. When a role is associated <br> with some %s filter is not considered unlimited as it's scoped accordingly.") % org_loc_string('or') ) %>
+                       :label_help => (_("By unchecking this you can specify filter using Foreman search syntax in search field. If filter remains <br> unlimited (this field is checked) it applies on all resources of the selected type. When a role is associated <br> with some %s filter is not considered unlimited as it's scoped accordingly.") % org_loc_string('or')).html_safe %>
 
 
         <%= autocomplete_f f, :search,

--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -14,25 +14,26 @@
     <h2><%= _("Default behavior") %></h2>
     <h6><%= _("Override the default value of the Puppet class parameter.") if is_param%></h6>
     <%= checkbox_f(f, :override, :onchange => 'toggleOverrideValue(this)', :size => "col-md-8",
-                   :help_inline => popover('', _('Whether the class parameter value is managed by Foreman.'))
+                   :label_help => _('Whether the class parameter value is managed by Foreman.')
         ) if is_param %>
     <%= param_type_selector(f, :onchange => 'keyTypeChange(this)') %>
     <%= textarea_f f, :default_value, :value => f.object.default_value_before_type_cast, :size => "col-md-8",
                    :disabled => (is_param && (!f.object.override || f.object.omit)),
                    :input_group_btn => fullscreen_input,
                    :rows => 1,
-                   :help_inline => popover('', _("Value to use when there is no match.")),
+                   :label_help => _("Value to use when there is no match."),
                    :class => "no-stretch #{'masked-input' if f.object.hidden_value?}" %>
     <div class="form-group">
       <%= checkbox_f(f, :omit, :label => _('Omit'),
-                     :help_inline => omit_help,
+                     :label_help => omit_help_body,
+                     :label_help_options => { :title => omit_help_title },
                      :size => "col-md-1", :label_size => "col-md-2", :table_field => true,
                      :onchange => 'toggleOmitValue(this, "default_value")',
                      :disabled => (is_param && !f.object.override)) if is_param %>
       <%= checkbox_f(f, :hidden_value, :label => _('Hidden value'),
                      :class => 'hidden_value_textarea_switch', :onchange => 'toggle_lookupkey_hidden(this)',
                      :checked => f.object.hidden_value?,
-                     :help_inline => popover("", _("Hide all values for this parameter.")),
+                     :label_help => _("Hide all values for this parameter."),
                      :size => "col-md-1", :label_size => "col-md-2", :table_field => true,
                      :disabled => (is_param && !f.object.override)) %>
     </div>
@@ -40,10 +41,10 @@
   <fieldset>
     <%= collapsing_header _("Optional input validator"), "#optional_input_validators_#{f.object.id}", "collapsed" %>
     <div id="optional_input_validators_<%= f.object.id %>" class="collapse out">
-      <%= alert :class => 'alert-info', :header => _('Note'), :text => _('If ERB is used in a parameter value, the validation of the value will happen during the ENC request. If the value is invalid, the ENC request will fail.') %>
+      <h6><%= _('If ERB is used in a parameter value, the validation of the value will happen during the ENC request. If the value is invalid, the ENC request will fail.') %></h6>
 
       <%= checkbox_f(f, :required, :size => "col-md-8", :disabled => !f.object.override,
-                     :help_inline => popover('', _("If checked, will raise an error if there is no default value and no matcher provide a value."))
+                     :label_help => _("If checked, will raise an error if there is no default value and no matcher provide a value.")
           ) if is_param %>
       <%= validator_type_selector f %>
       <%= text_f f, :validator_rule, :size => "col-md-8", :disabled => f.object.validator_type.blank?, :class => "no-stretch" %>
@@ -53,17 +54,17 @@
   <div class="matcher-parent" <%= "id=#{(f.object.key || 'new_lookup_keys').to_s.gsub(' ', '_')}_lookup_key_override_value" %> style=<%= "display:none;" if (is_param && !f.object.override) %>>
     <fieldset>
       <h2><%= _("Prioritize attribute order") %></h2>
-      <h6><%= popover("", _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>"),
-                      :title => _("The order in which values are resolved.")).html_safe %> <%= _("Set the order in which values are resolved.") %></h6>
-      <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :id => 'order', :size => "col-md-8", :onchange => 'fill_in_matchers()', :value => f.object.path, :class => "no-stretch" %>
+      <h6><%= _("Set the order in which values are resolved.") %></h6>
+      <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :id => 'order', :size => "col-md-8", :onchange => 'fill_in_matchers()', :value => f.object.path, :class => "no-stretch",
+                        :label_help => _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>").html_safe %>
       <%= checkbox_f(f, :merge_overrides, :onchange => 'mergeOverridesChanged(this)', :table_field => true,
                         :disabled => !f.object.supports_merge?, :size => "col-md-1", :label_size => "col-md-2",
-                        :help_inline => popover("", _("Continue to look for matches after first find (only array/hash type)? Note: merging overrides ignores all matchers that are omitted."))) %>
+                        :label_help => _("Continue to look for matches after first find (only array/hash type)? Note: merging overrides ignores all matchers that are omitted.")) %>
       <%= checkbox_f(f, :merge_default, :disabled =>  !f.object.merge_overrides, :size => "col-md-1", :table_field => true,
-                        :label_size => "col-md-2", :help_inline => popover('',_("Include default value when merging all matching values."))) %>
+                        :label_size => "col-md-2", :label_help => _("Include default value when merging all matching values.")) %>
       <%= checkbox_f(f, :avoid_duplicates, :disabled => (!f.object.supports_uniq? || !f.object.merge_overrides),
                         :size => "col-md-1", :label_size => "col-md-2", :table_field => true,
-                        :help_inline => popover("", _("Avoid duplicate values when merging them (only array type)?"))) %>
+                        :label_help => _("Avoid duplicate values when merging them (only array type)?")) %>
     </fieldset>
     </br>
     <fieldset>

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -4,24 +4,21 @@
                     :size => "col-md-8", :label_size => "col-md-3" %>
 
 <%= text_f f, :mac,
-              :help_inline => popover('', _("Media access control address for this interface. Format must be six groups of two hexadecimal digits separated by colons (:), e.g. 00:11:22:33:44:55. Most virtualization compute resources (e.g. VMware, oVirt, libvirt) will overwrite the provided value with new random MAC address."),
-                      :rel => 'popover-modal'),
+              :label_help => _("Media access control address for this interface. Format must be six groups of two hexadecimal digits <br/> separated by colons (:), e.g. 00:11:22:33:44:55. Most virtualization compute resources (e.g. VMware, oVirt, libvirt) <br/> will overwrite the provided value with new random MAC address.").html_safe,
+              :label_help_options => { :rel => 'popover-modal' },
               :class => :interface_mac, :'data-url' => random_name_interfaces_path, :size => "col-md-8", :label_size => "col-md-3" %>
 <%= text_f f, :identifier,
               :label => _("Device identifier"),
-              :help_inline => popover('',
-                      _("Device identifier for this interface. This may be different on various platforms and environments, here are some common examples.<br/><ul>" +
+              :label_help => _("Device identifier for this interface. This may be different on various platforms and environments, here are some common examples.<br/><ul>" +
                                 "<li>Use the basic name for physical interface identifiers, e.g. <strong>eth0</strong> or <strong>em0</strong> with biosdevname.</li>" +
                                 "<li>For virtual interfaces, use either alias notation (<strong>eth0:1</strong>, name:index) or VLAN notation (<strong>eth0.15</strong>, name.tag).</li>" +
-                                "<li>For bonds it's common to use <strong>bond0</strong> on Linux, <strong>lagg0</strong> on FreeBSD systems.</li></ul>"),
-                      :title => _("Device identifier"),
-                      :rel => 'popover-modal',
-                      :'data-placement' => "top"
-              ),
+                                "<li>For bonds it's common to use <strong>bond0</strong> on Linux, <strong>lagg0</strong> on FreeBSD systems.</li></ul>").html_safe,
+              :label_help_options => { :rel => 'popover-modal', :'data-placement' => "top" },
               :class => :interface_identifier,
               :size => "col-md-8", :label_size => "col-md-3" %>
 <%= text_f f, :name, :label => _("DNS name"), :value => f.object.shortname,
-              :help_inline => popover('', _("Primary interface's DNS name and domain define host's FQDN"), :rel => 'popover-modal'),
+              :label_help => _("Primary interface's DNS name and domain define host's FQDN"),
+              :label_help_options => { :rel => 'popover-modal' },
               :class => :interface_name,
               :size => "col-md-8", :label_size => "col-md-3" %>
 <% if SETTINGS[:unattended] %>
@@ -43,37 +40,40 @@
               :label => _("IPv4 address"),
               :autocomplete => 'off',
               :help_block => suggest_new_link(f, :subnet , 'suggest_new_ip'),
-              :help_inline => popover('',
-                  _("An IP address will be auto-suggested if you have enabled IPAM on the IPv4 subnet selected above.<br/><br/>The IP address can be left blank when:<br/><ul><li>provisioning tokens are enabled</li><li>the domain does not manage DNS</li><li>the subnet does not manage reverse DNS</li><li>and the subnet does not manage DHCP reservations</li></ul>"),
-                  :title => _("IP address auto-suggest"),
-                  :rel => 'popover-modal',
-                  :'data-placement' => "top"
-                ).html_safe,
-                :size => "col-md-8", :label_size => "col-md-3" %>
+              :label_help => _("An IP address will be auto-suggested if you have enabled IPAM on the IPv4 subnet selected above.<br/><br/>The IP address can be left blank when:<br/><ul><li>provisioning tokens are enabled</li><li>the domain does not manage DNS</li><li>the subnet does not manage reverse DNS</li><li>and the subnet does not manage DHCP reservations</li></ul>").html_safe,
+              :label_help_options => {
+                :title => _("IP address auto-suggest"),
+                :rel => 'popover-modal',
+                :'data-placement' => "top"
+              },
+              :size => "col-md-8", :label_size => "col-md-3" %>
 
 <%= text_f f, :ip6,
               :label => _("IPv6 address"),
               :class => :interface_ip6,
               :autocomplete => 'off',
               :help_block => suggest_new_link(f, :subnet6, 'suggest_new_ip6'),
-              :help_inline => popover('',
-                  _("An IP address will be auto-suggested if you have enabled IPAM on the IPv6 subnet selected above."),
-                  :title => _("IP address auto-suggest"),
-                  :rel => 'popover-modal',
-                  :'data-placement' => "top"
-                ).html_safe,
+              :label_help => _("An IP address will be auto-suggested if you have enabled IPAM on the IPv6 subnet selected above."),
+              :label_help_options => {
+                :title => _("IP address auto-suggest"),
+                :rel => 'popover-modal',
+                :'data-placement' => "top"
+              },
               :size => "col-md-8", :label_size => "col-md-3" %>
 
 <% if SETTINGS[:unattended] %>
   <%= checkbox_f f, :managed,
-                 :help_inline => popover('',_("Should this interface be managed via DHCP and DNS smart proxy and should it be configured during provisioning?"), :rel => 'popover-modal'),
+                 :label_help => _("Should this interface be managed via DHCP and DNS smart proxy and should it be configured during provisioning?"),
+                 :label_help_options => { :rel => 'popover-modal' },
                  :size => "col-md-8", :label_size => "col-md-3" %>
 <% end %>
 <%= checkbox_f f, :primary,
-               :help_inline => popover('',_("The Primary interface is used for constructing the FQDN of the host"), :rel => 'popover-modal'),
+               :label_help => _("The Primary interface is used for constructing the FQDN of the host"),
+               :label_help_options => { :rel => 'popover-modal' },
                :class => :interface_primary,
                :size => "col-md-8", :label_size => "col-md-3" %>
 <%= checkbox_f f, :provision,
-               :help_inline => popover('',_("The Provisioning interface is used for TFTP of PXELinux (or SSH for image-based hosts)"), :rel => 'popover-modal'),
+               :label_help => _("The Provisioning interface is used for TFTP of PXELinux (or SSH for image-based hosts)"),
+               :label_help_options => { :rel => 'popover-modal' },
                :class => :interface_provision,
                :size => "col-md-8", :label_size => "col-md-3" %>

--- a/app/views/nic/_virtual_form.html.erb
+++ b/app/views/nic/_virtual_form.html.erb
@@ -1,3 +1,5 @@
-<%= text_f f, :tag, :help_inline => popover('',_("Inherits from subnet VLAN ID if not set"), :rel => 'popover-modal'), :size => "col-md-8", :label_size => "col-md-3" %>
-<%= text_f f, :attached_to, :help_inline => popover('',_("Identifier of the interface to which this interface belongs, e.g. eth1"), :rel => 'popover-modal'),
+<%= text_f f, :tag, :label_help => _("Inherits from subnet VLAN ID if not set"),
+           :label_help_options => { :rel => 'popover-modal' }, :size => "col-md-8", :label_size => "col-md-3" %>
+<%= text_f f, :attached_to, :label_help => _("Identifier of the interface to which this interface belongs, e.g. eth1"),
+           :label_help_options => { :rel => 'popover-modal' },
            :required => local_assigns[:attached_to_required], :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>

--- a/app/views/nic/bmcs/_bmc.html.erb
+++ b/app/views/nic/bmcs/_bmc.html.erb
@@ -3,15 +3,15 @@
 <%= content_tag :span, :id => 'bmc_fields' do %>
   <%= text_f f, :username, :size => "col-md-8", :label_size => "col-md-3" %>
   <%= password_f f, :password, :unset => action_name == "edit", :size => "col-md-8", :label_size => "col-md-3",
-                    :help_inline => popover('',
-                        _("The BMC password will be used by Foreman to access the host's BMC controller via a BMC-enabled smart proxy, if available.") + ' ' +
+                    :label_help => _("The BMC password will be used by Foreman to access the host's BMC controller via a BMC-enabled smart proxy, if available.<br/>").html_safe +
                           (Setting[:bmc_credentials_accessible] ?
                             _("The password will also be accessible to other users via templates and in the ENC YAML output; disable the bmc_credentials_accessible setting to prevent access.") :
                             _("The password will not be accessible to other users; enable the bmc_credentials_accessible setting to permit access via templates and in the ENC YAML output.")),
+                     :label_help_options => {
                         :title => _("BMC password usage"),
                         :rel => 'popover-modal',
                         :'data-placement' => "top"
-                      ).html_safe
+                     }
  %>
   <%= selectable_f f, :provider, Nic::BMC::PROVIDERS, {}, :size => "col-md-8", :label_size => "col-md-3" %>
 <% end %>

--- a/app/views/nic/bonds/_bond.html.erb
+++ b/app/views/nic/bonds/_bond.html.erb
@@ -2,8 +2,10 @@
 
 <%= content_tag :span, :class => 'bond_fields' do %>
   <%= selectable_f f, :mode, Nic::Bond::MODES, {}, :size => "col-md-8", :label_size => "col-md-3" %>
-  <%= text_f f, :attached_devices, :help_inline => popover('', _('comma separated interface identifiers'), :rel => 'popover-modal'), :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
-  <%= text_f f, :bond_options, :help_inline => popover('', _('space separated options, e.g. miimon=100'), :rel => 'popover-modal'), :size => "col-md-8", :label_size => "col-md-3" %>
+  <%= text_f f, :attached_devices, :label_help => _('comma separated interface identifiers'),
+             :label_help_options => { :rel => 'popover-modal' }, :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
+  <%= text_f f, :bond_options, :label_help => _('space separated options, e.g. miimon=100'),
+             :label_help_options => { :rel => 'popover-modal' }, :size => "col-md-8", :label_size => "col-md-3" %>
 <% end %>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/nic/bridges/_bridge.html.erb
+++ b/app/views/nic/bridges/_bridge.html.erb
@@ -1,7 +1,8 @@
 <%= render 'nic/base_form', :f => f %>
 
 <%= content_tag :span, :class => 'bridge_fields' do %>
-  <%= text_f f, :attached_devices, :help_inline => popover('', _('comma separated interface identifiers'), :rel => 'popover-modal'), :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
+  <%= text_f f, :attached_devices, :label_help => _('comma separated interface identifiers'),
+             :label_help_options => { :rel => 'popover-modal' }, :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
 <% end %>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/nic/manageds/_managed.html.erb
+++ b/app/views/nic/manageds/_managed.html.erb
@@ -3,7 +3,8 @@
 <%= checkbox_f f, :virtual,
                :disabled => !f.object.new_record?,
                :label => _("Virtual NIC"),
-               :help_inline => popover('',_("Enable if this is an alias or VLAN interface, note that alias can be used only with static boot mode subnet"), :rel => 'popover-modal'),
+               :label_help => _("Enable if this is an alias or VLAN interface, note that alias can be used only with static boot mode subnet"),
+               :label_help_options => { :rel => 'popover-modal'},
                :class => 'virtual',
                :size => "col-md-8", :label_size => "col-md-3" %>
 

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -10,24 +10,26 @@
 
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
+      <% if @role.persisted? && (show_location_tab? || show_organization_tab?) %>
+          <h5><%= _("Changes to %s will propagate to all inheriting filters") % org_loc_string(_('and')) %></h5>
+          <hr>
+      <% end %>
+
       <%= text_f f, :name, :class => @role.builtin? ? "disabled" : ""  %>
       <%= textarea_f f, :description, :rows=> 5, :size => "col-md-4" %>
       <%= hidden_field_tag :original_role_id, @original_role_id if @cloned_role %>
 
-      <% if show_location_tab? || show_organization_tab? %>
-        <%= alert(:close => false, :class => 'alert-info', :header => '', :text => (_("Changes to following associations will propagate to all inheriting filters") + ' ' +
-            popover("", _("When the role's associated %{orgs_or_locs} are changed,<br> the change will propagate to all inheriting filters.
-                               Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.
-                               Note that not all filters support <br> %{orgs_and_locs}, so these always remain global.") % { :orgs_or_locs => org_loc_string('or'), :orgs_and_locs => org_loc_string('and') },
-                    :title => _("Role %s.") % org_loc_string('and'))).html_safe) %>
-      <% end %>
-
+      <% tax_help = N_("When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.
+                         Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.
+                         Note that not all filters support <br>%{taxonomies}, so these always remain global.") %>
       <% if show_location_tab? %>
-        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, { :label => _("Locations") } %>
+        <% loc_help = _(tax_help) % { :taxonomies => _('locations') }%>
+        <%= multiple_checkboxes f, :locations, f.object, User.current.my_locations, { :label => _("Locations"), :label_help => loc_help, :label_help_options => { :title => _("Role locations") } } %>
       <% end %>
 
       <% if show_organization_tab? %>
-        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, { :label => _("Organizations") } %>
+        <% org_help = _(tax_help) % { :taxonomies => _('organizations') }%>
+        <%= multiple_checkboxes f, :organizations, f.object, User.current.my_organizations, { :label => _("Organizations"), :label_help => org_help, :label_help_options => { :title => _("Role organizations") } } %>
       <% end %>
     </div>
 

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -9,15 +9,12 @@
 <%= text_f f, :dns_secondary, :help_inline => _("Optional: Secondary DNS for this subnet") %>
 <%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64]]},
                  :label => _('IPAM'),
-                 :help_inline => popover(
-                         _("IP Address Management"),
-                         _("You can select one of the IPAM modes supported by the selected IP protocol:<br/>" +
+                 :label_help => _("You can select one of the IPAM modes supported by the selected IP protocol:<br/>" +
                                    "<ul><li><strong>DHCP</strong> - will manage the IP on DHCP through assigned DHCP proxy, auto-suggested IPs come from DHCP <em>(IPv4)</em></li>" +
                                    "<li><strong>Internal DB</strong> - use internal DB to auto-suggest free IP based on other interfaces on same subnet respecting range if specified, useful mainly with static boot mode <em>(IPv4, IPv6)</em></li>" +
                                    "<li><strong>EUI-64</strong> - will assign the IPv6 address based on the MAC address of the interface <em>(IPv6)</em></li>" +
-                                   "<li><strong>None</strong> - leave IP management solely on user, no auto-suggestion <em>(IPv4, IPv6)</em></li></ul>"),
-                         :'data-placement' => "top"
-                 ).html_safe %>
+                                   "<li><strong>None</strong> - leave IP management solely on user, no auto-suggestion <em>(IPv4, IPv6)</em></li></ul>").html_safe,
+                 :label_help_options => { :title => _("IP Address Management"), :'data-placement' => 'top' }%>
 <div id='ipam_options' class ='<%= f.object.ipam_needs_range? ? "" : "hide" %>'>
   <%= text_f f, :from, :help_inline => _("Optional: Starting IP Address for IP auto suggestion") %>
   <%= text_f f, :to,   :help_inline => _("Optional: Ending IP Address for IP auto suggestion") %>


### PR DESCRIPTION
Depends on changes from #4354 
Also for the reviewer, I think we should give enough time to plugin devs to align their code bases. While I can work on some, it's out of my capacity to fix everything. Releasing this with 1.15 introduces a risk that we'd have mixed icons in single form (e.g. rex adding flag to interface, see example below). Therefore I'd suggest to keep this for 1.16

![nics](https://cloud.githubusercontent.com/assets/109773/23611108/eb2a3bb2-0275-11e7-901f-047b861fa885.png)
