### PR TITLE
Fixes #18800 - strong params no longer breaks inherited attrs

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -561,8 +561,9 @@ class Host::Managed < Host::Base
 
   def apply_inherited_attributes(attributes, initialized = true)
     return nil unless attributes
-    #don't change the source to minimize side effects.
-    attributes = hash_clone(attributes).with_indifferent_access
+    #convert possible strong parameters to unsafe hash (filtering out unsafe items) and
+    #clone to minimize side effects
+    attributes = hash_clone(attributes.to_h).with_indifferent_access
 
     new_hostgroup_id = attributes['hostgroup_id'] || attributes['hostgroup_name'] || attributes['hostgroup'].try(:id)
     #hostgroup didn't change, no inheritance needs update.

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3040,6 +3040,20 @@ class HostTest < ActiveSupport::TestCase
       host = Host.new(:name => "test-host", :hostgroup => hg)
       assert host.environment
     end
+
+    test 'should filter out unpermitted strong parameters' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      attributes = ActionController::Parameters.new({ 'unpermitted_attribute' => 1 })
+      actual_attr = host.apply_inherited_attributes(attributes)
+      assert_nil actual_attr['unpermitted_attribute']
+    end
+
+    test 'must not return strong parameters' do
+      host = FactoryGirl.build(:host, :managed, :with_hostgroup)
+      attributes = ActionController::Parameters.new
+      actual_attr = host.apply_inherited_attributes(attributes)
+      refute actual_attr.is_a? ActionController::Parameters
+    end
   end
 
   describe 'rendering interface' do


### PR DESCRIPTION
We have two bugs already, this is important issue that prevents from host
creations when Katello is installed. The other one was reported on discovery
and we already have a PR to fix this in discovery, but it's preferred to fix
this in core.

https://github.com/theforeman/foreman_discovery/pull/331