### PR TITLE
Fixes #18843 - Changed from eager_load to includes in #index

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -20,7 +20,7 @@ module Api
 
       add_smart_proxy_filters :facts, :features => Proc.new { FactImporter.fact_features }
 
-      add_scope_for(:index) { |base_scope| base_scope.eager_load([:host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token]) }
+      add_scope_for(:index) { |base_scope| base_scope.preload([:host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token]) }
 
       api :GET, "/hosts/", N_("List all hosts")
       api :GET, "/hostgroups/:hostgroup_id/hosts", N_("List all hosts for a host group")


### PR DESCRIPTION
Avoiding multiple joins that result in very wide result rows. It leads to big memory footprint in the DB especially on big datasets. This big footprint translates then into DB high CPU usage while processing the query.