### PR TITLE
Refs #18804 - move spinner help icons

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -205,9 +205,10 @@ module FormHelper
 
   def byte_size_f(f, attr, options = {})
     options[:class] = options[:class].to_s + ' byte_spinner'
-    options[:help_inline] ||= popover('', _("When specifying custom value, add 'MB' or 'GB' at the end. Field is not case sensitive and MB is default if unspecified."))
+    options[:label_help] = _("When specifying custom value, add 'MB' or 'GB' at the end. Field is not case sensitive and MB is default if unspecified.")
     options[:help_block] ||= soft_limit_warning_block
     options[:help_block] += f.hidden_field(attr, :class => "real-hidden-value", :id => nil)
+    options[:label_help_options] = { :rel => 'popover-modal' }
 
     text_f(f, attr, options)
   end

--- a/webpack/assets/javascripts/jquery.ui.custom_spinners.js
+++ b/webpack/assets/javascripts/jquery.ui.custom_spinners.js
@@ -115,6 +115,8 @@ export function initCounter() {
     field.change(function () {
       field.limitedSpinner('validate');
     });
+
+    field.parents('div.form-group').find('label a').popover();
   });
 }
 
@@ -134,5 +136,7 @@ export function initByte() {
       field.byteSpinner('updateValueTarget');
       field.byteSpinner('validate');
     });
+
+    field.parents('div.form-group').find('label a').popover();
   });
 }


### PR DESCRIPTION
Also the popover needs to be initialized (not sure when it was broken)

to reproduce
1) go to new host form
2) choose compute resource that allows to customize RAM e.g. libvirt
3) go to Virtual Machine tab
4) see the (i) icon as part of Memory label
5) clicking on it displays the help popover

steps 4 and 5 are fixed by this PR