### PR TITLE
refs #17463 - require test helper for smart proxy mixin

### DIFF
--- a/test/controllers/api/v1/smart_proxies_controller_test.rb
+++ b/test/controllers/api/v1/smart_proxies_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'controllers/shared/smart_proxies_controller_shared_test'
 
 class Api::V1::SmartProxiesControllerTest < ActionController::TestCase
   valid_attrs = { :name => 'master02', :url => 'http://server:8443' }

--- a/test/controllers/api/v2/smart_proxies_controller_test.rb
+++ b/test/controllers/api/v2/smart_proxies_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'controllers/shared/smart_proxies_controller_shared_test'
 
 class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   valid_attrs = { :name => 'master02', :url => 'http://server:8443' }


### PR DESCRIPTION
Tests currently fail as the module is undefined:

    test/controllers/api/v1/smart_proxies_controller_test.rb:5:in `<class:SmartProxiesControllerTest>': uninitialized constant Api::V1::SmartProxiesControllerTest::SmartProxiesControllerSharedTest (NameError)
            from test/controllers/api/v1/smart_proxies_controller_test.rb:3:in `<top (required)>'
