### PR TITLE
Fixes #18901 - fix bottom notification dropdown

### DIFF
--- a/webpack/assets/javascripts/react_app/components/notifications/Notifications.scss
+++ b/webpack/assets/javascripts/react_app/components/notifications/Notifications.scss
@@ -10,6 +10,7 @@
       
       .panel-body {
         overflow-y: auto;
+        flex: 1;
       }
     }
   }


### PR DESCRIPTION
before:
![recording](https://cloud.githubusercontent.com/assets/2626198/23941586/b27bc67a-093f-11e7-9261-0fe0235e9438.gif)

after:
![recording 1](https://cloud.githubusercontent.com/assets/2626198/23941588/b4f008e4-093f-11e7-8e02-d698c8b613ee.gif)
