### PR TITLE
Fixes #18949 - user information in logger

### DIFF
--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -27,11 +27,12 @@ module Foreman
       def clear_thread
         if Thread.current[:user] && !Rails.env.test?
           Rails.logger.warn("Current user is set, but not expected. Clearing")
-          Thread.current[:user] = nil
+          User.current = nil
         end
         yield
       ensure
-        [:user, :organization, :location].each do |key|
+        User.current = nil
+        [:organization, :location].each do |key|
           Thread.current[key] = nil
         end
       end

--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -52,6 +52,11 @@ module Foreman
           end
 
           Rails.logger.debug "Setting current user thread-local variable to " + (o.is_a?(User) ? o.login : 'nil')
+          if o.is_a? User
+            ::Logging.mdc['user'] = o.login
+          else
+            ::Logging.mdc.delete('user')
+          end
           Thread.current[:user] = o
         end
 

--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -53,7 +53,7 @@ module Foreman
 
           Rails.logger.debug "Setting current user thread-local variable to " + (o.is_a?(User) ? o.login : 'nil')
           if o.is_a? User
-            ::Logging.mdc['user'] = o.login
+            ::Logging.mdc['user'] = "[user:#{o.login}]"
           else
             ::Logging.mdc.delete('user')
           end

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -47,6 +47,7 @@
 #     [%M] method name where the logging request was issued
 #     [%X{request}] request-ID set in HTTP headers, or random UUID
 #     [%X{session}] session ID from cookies, else the request-ID
+#     [%X{user}] information about current user
 #     [%X{string}] variable set using ::Logging.mdc['string'] =
 
 :default:
@@ -55,7 +56,7 @@
   :log_trace: false
   :level: info
   :type: file
-  :pattern: "%d %.8X{session} [user:%X{user}] [%c] [%.1l] %m\n"
+  :pattern: "%d %.8X{session} %X{user} [%c] [%.1l] %m\n"
 
 :production:
   :filename: "production.log"

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -55,7 +55,7 @@
   :log_trace: false
   :level: info
   :type: file
-  :pattern: "%d %.8X{session} [%c] [%.1l] %m\n"
+  :pattern: "%d %.8X{session} [user:%X{user}] [%c] [%.1l] %m\n"
 
 :production:
   :filename: "production.log"


### PR DESCRIPTION
After the change, the log messages look like this:

```
2017-03-17T14:36:06 23eeb21c [user:] [app] [D] Setting current user thread-local variable to skoroadmin
2017-03-17T14:36:06 23eeb21c [user:skoroadmin] [sql] [D]   Usergroup Load (0.2ms)  SELECT "usergroups".* FROM "usergroups" INNER JOIN "cached_usergroup_members" ON "usergroups"."id" = "cached_usergroup_members"."usergroup_id" WHERE "cached_usergroup_members"."user_id" = $1  ORDER BY usergroups.name  [["user_id", 4]]
2017-03-17T14:36:06 23eeb21c [user:skoroadmin] [sql] [D]   Role Load (0.2ms)  SELECT DISTINCT "roles".* FROM "roles" INNER JOIN "cached_user_roles" ON "roles"."id" = "cached_user_roles"."role_id" WHERE "cached_user_roles"."user_id" = $1  [["user_id", 4]]
2017-03-17T14:36:06 23eeb21c [user:skoroadmin] [sql] [D]    (0.2ms)  SELECT permissions.name FROM "permissions" INNER JOIN "filterings" ON "permissions"."id" = "filterings"."permission_id" INNER JOIN "filters" ON "filterings"."filter_id" = "filters"."id" WHERE "filters"."role_id" = $1  ORDER BY filters.role_id, filters.id  [["role_id", 3]]
```