### PR TITLE
fixes #18950 - enable password field in CR form test

### DIFF
--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -35,4 +35,14 @@ class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
   test "add new compute attributes two pane" do
     check_two_pane(compute_resources(:ec2), compute_profiles(:three))
   end
+
+  test "compute resource password isn't deleted when testing connection" do
+    visit compute_resources_path
+    click_link "Vmware"
+    click_link "Edit"
+    find("#disable-pass-btn").click
+    fill_in "compute_resource_password", :with => "123456"
+    click_link "Test Connection"
+    assert_equal "123456", find_field("compute_resource_password").value
+  end
 end

--- a/test/integration/compute_resource_test.rb
+++ b/test/integration/compute_resource_test.rb
@@ -13,13 +13,4 @@ class ComputeResourceIntegrationTest < ActionDispatch::IntegrationTest
     assert_submit_button(compute_resources_path)
     assert page.has_link? 'mycompute_old'
   end
-
-  test "compute resource password doesn't deleted while test connection" do
-    visit compute_resources_path
-    click_link "Vmware"
-    click_link "Edit"
-    fill_in "compute_resource_password", :disabled => true, :with => "123456"
-    click_link "Load Datacenters"
-    assert_equal "123456", find_field("compute_resource_password",:disabled => true).value
-  end
 end


### PR DESCRIPTION
Prior to capybara 2.13.0, the test passed despite filling in a disabled
password field, but a change now prevents this odd assumption. The test
now enables the field via the provided button, also requiring JS.