### PR TITLE
Fixes #18952 - fix destroy of host without owner

### DIFF
--- a/app/models/concerns/hostext/ui_notifications.rb
+++ b/app/models/concerns/hostext/ui_notifications.rb
@@ -8,10 +8,12 @@ module Hostext
 
     def provision_notification
       ::UINotifications::Hosts::BuildCompleted.deliver!(self) if just_provisioned?
+      true
     end
 
     def remove_ui_notifications
       ::UINotifications::Hosts::Destroy.deliver!(self)
+      true
     end
 
     def just_provisioned?

--- a/test/unit/ui_notifications/hosts/destroy_test.rb
+++ b/test/unit/ui_notifications/hosts/destroy_test.rb
@@ -21,6 +21,11 @@ class UINotificationsHostsDestroyTest < ActiveSupport::TestCase
     assert_equal 1, blueprint.notifications.count
   end
 
+  test 'the result of deliver! method should not prevent the deletion of the host' do
+    ::UINotifications::Hosts::Destroy.stubs(:deliver!).returns(false)
+    assert host.destroy
+  end
+
   private
 
   def host


### PR DESCRIPTION
The notifications failure caused the host not being deleted.
I don't think the notifications should interfere with the core
functionality of the objects.