### PR TITLE
refs #18760 - exclude test routes from permission checks

### DIFF
--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -33,7 +33,7 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     # App controller stubs
     "testable/index", "api/testable/index", "api/testable/raise_error",
     "api/testable/required_nested_values", "api/testable/optional_nested_values", "api/testable/nested_values",
-    "api/v2/testable/index", "api/v2/testable/create",
+    "api/v2/testable/index", "api/v2/testable/create", "fake/index", "api/v2/fake/index",
 
     #test stubs
     "testable_resources/index",


### PR DESCRIPTION
Running test/controllers/concerns/csv_responder_test.rb and
access_permissions_test in sequence (e.g. in `rake test`) would cause
failures against the "fake" routes introduced by CsvResponderTest as no
permissions were defined.