### PR TITLE
refs #18950 - wait for CR test connection to complete

### DIFF
--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -44,5 +44,6 @@ class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
     fill_in "compute_resource_password", :with => "123456"
     click_link "Test Connection"
     assert_equal "123456", find_field("compute_resource_password").value
+    wait_for_ajax
   end
 end


### PR DESCRIPTION
Should fix intermittent errors such as:

<pre>
ActionController::RoutingError: No route matches [PUT] "/locations"
    lib/middleware/tagged_logging.rb:18:in `call' (ActionController::RoutingError)
/usr/local/rvm/gems/ruby-2.0.0-p481@test_develop_pr_core-1/gems/actionpack-4.2.8/lib/action_dispatch/middleware/debug_exceptions.rb:21
</pre>

Can be reproduced by adding a short (2s) sleep to the end of the test, and a longer sleep prior to the `render` in `ComputeResourcesController#test_connection`, so the DB is cleared while the response is being rendered.