### PR TITLE
fixes #18982 - replace AC::Params#each using one-arg block

### DIFF
--- a/app/controllers/concerns/api/compatibility_checker.rb
+++ b/app/controllers/concerns/api/compatibility_checker.rb
@@ -4,9 +4,11 @@ module Api
 
     # removes unsupported "nested" flag from "host_parameters_attributes" (both Array and Hash formats supported)
     def check_create_host_nested
-      params[:host] && params[:host][:host_parameters_attributes] && params[:host][:host_parameters_attributes].each do |attribute|
-        attribute = attribute[1] if attribute.is_a? Array
-        Foreman::Deprecation.api_deprecation_warning("Field host_parameters_attributes.nested ignored") unless attribute.delete(:nested).nil?
+      if params[:host] && (attrs = params[:host][:host_parameters_attributes])
+        attrs = attrs.values unless attrs.is_a?(Array)
+        attrs.each do |attribute|
+          Foreman::Deprecation.api_deprecation_warning("Field host_parameters_attributes.nested ignored") unless attribute.delete(:nested).nil?
+        end
       end
     end
   end


### PR DESCRIPTION
ActionController::Parameters#each works differently in Rails 5.0: it no
longer yields an array of [key, value] entries for hashes, only the
key when given a block with arity of one. This method now iterates over
only the values when passed a hash or AC::Parameters instance.