### PR TITLE
Update vmware.rb to set boot_retry

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -578,7 +578,8 @@ module Foreman::Model
         :scsi_controller => { :type => scsi_controller_default_type },
         :datacenter => datacenter,
         :firmware => 'automatic',
-        :boot_order => ['network', 'disk']
+        :boot_order => ['network', 'disk'],
+        :boot_retry => 10
       )
     end
 


### PR DESCRIPTION
refs #19013  - When provisioning a VMware host and using an ISO, the ISO is sometimes not mounted quick enough to boot.  Setting the Boot Retry option will allow the host to automatically reboot if it is unable to find a bootable medium.  This also partially addresses feature http://projects.theforeman.org/issues/4533. 