### PR TITLE
Fixes #19017 - prefer request id over session id in logging

### DIFF
--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -55,7 +55,7 @@
   :log_trace: false
   :level: info
   :type: file
-  :pattern: "%d %.8X{session} [%c] [%.1l] %m\n"
+  :pattern: "%d %.8X{request} [%c] [%.1l] %m\n"
 
 :production:
   :filename: "production.log"


### PR DESCRIPTION
suggested to use session id if available. Although it seemed as a good
idea at the beginning, it has several disadvanteges:

* it treats UI and API requests differently

* it makes it impossible to differentiate requests made from the session
  at the same time (notifications is one example, but in general, we
  should not assume the user is performing
  on request at a time)

* the usability of this as correlation id is questionable, especially
  with asynchronous actions in place