### PR TITLE
Refs #18001 - Avoid role extending from rake tasks permission

### DIFF
--- a/app/services/foreman/plugin.rb
+++ b/app/services/foreman/plugin.rb
@@ -225,7 +225,7 @@ module Foreman #:nodoc:
     #   class to which this permissions is related, rest of options is passed
     #   to AccessControl
     def permission(name, hash, options = {})
-      rbac_registry.permission_names << name
+      rbac_registry.register name, options
       options[:engine] ||= self.id.to_s
       options.merge!(:security_block => @security_block)
       Foreman::AccessControl.map do |map|
@@ -269,7 +269,7 @@ module Foreman #:nodoc:
     # Add plugin permissions to Manager and Viewer roles. Use this method if there are no special cases that need to be taken care of.
     # Otherwise add_permissions_to_default_roles or add_resource_permissions_to_default_roles might be the methods you are looking for.
     def add_all_permissions_to_default_roles
-      Plugin::RbacSupport.new.add_all_permissions_to_default_roles(registered_permissions)
+      Plugin::RbacSupport.new.add_all_permissions_to_default_roles(Permission.where(:name => @rbac_registry.permission_names))
     end
 
     def pending_migrations

--- a/app/services/foreman/plugin/rbac_registry.rb
+++ b/app/services/foreman/plugin/rbac_registry.rb
@@ -1,11 +1,11 @@
 module Foreman
   class Plugin
     class RbacRegistry
-      attr_accessor :role_ids, :permission_names, :default_roles
+      attr_accessor :role_ids, :default_roles, :registered_permissions
 
       def initialize
         @role_ids = []
-        @permission_names = []
+        @registered_permissions = []
         @default_roles = {}
       end
 
@@ -13,16 +13,18 @@ module Foreman
         Role.where(:id => @role_ids)
       end
 
-      def registered_permissions
-        Permission.where(:name => @permission_names.map(&:to_s))
+      def register(name, options)
+        @registered_permissions << [name, options]
       end
 
       # needed for fixtures permissions.yml,
       # because we do not write plugin permissions and roles to db when registering in test
       def permissions
-        registered_permissions.inject({}.with_indifferent_access) do |memo, perm|
-          memo.tap { |mem| mem[perm.name] = { :resource_type => perm.resource_type } }
-        end
+        Hash[registered_permissions.map { |name, options| [name, :resource_type => options[:resource_type]] }].with_indifferent_access
+      end
+
+      def permission_names
+        registered_permissions.map(&:first)
       end
     end
   end

--- a/app/services/foreman/plugin/rbac_support.rb
+++ b/app/services/foreman/plugin/rbac_support.rb
@@ -7,6 +7,8 @@ module Foreman
           add_all_permissions_to_role("Manager", all_permissions)
           add_all_permissions_to_role("Viewer", view_permissions)
         end
+      rescue ActiveRecord::StatementInvalid => e
+        Foreman::Logging.exception _("Could not add permissions to Manager and Viewer roles: %s") % e.message, e, :level => :debug
       end
 
       def add_resource_permissions_to_default_roles(resources, opts = {})
@@ -38,6 +40,8 @@ module Foreman
         manager = Role.find_by :name => "Manager"
         return if !manager || resources.empty?
         include_permissions manager, resources, opts
+      rescue ActiveRecord::StatementInvalid => e
+        Foreman::Logging.exception _("Could not add permissions to Manager role: %s") % e.message, e, :level => :debug
       end
 
       def add_resource_permissions_to_viewer(resources, opts)
@@ -46,6 +50,8 @@ module Foreman
         opts[:condition_hash] = { :name => "view_%" }
         return if !viewer || resources.empty?
         include_permissions viewer, resources, opts
+      rescue ActiveRecord::StatementInvalid => e
+        Foreman::Logging.exception _("Could not add permissions to Viewer role: %s") % e.message, e, :level => :debug
       end
 
       def include_permissions(role, resources, opts)
@@ -85,6 +91,8 @@ module Foreman
         role = Role.find_by :name => role_name
         return unless role
         include_permissions_for_role role, permissions.map(&:name)
+      rescue ActiveRecord::StatementInvalid => e
+        Foreman::Logging.exception _("Could not extend role '%{name}': %{message}") % {:name => role_name, :message => e.message}, e, :level => :debug
       end
     end
   end

--- a/test/unit/plugin/rbac_registry_test.rb
+++ b/test/unit/plugin/rbac_registry_test.rb
@@ -16,16 +16,19 @@ class RbacRegistryTest < ActiveSupport::TestCase
 
   def test_registered_permissions
     registry = Foreman::Plugin::RbacRegistry.new
-    registry.permission_names = [:view_hosts, :create_hosts]
+    registry.register :view_hosts, :resource_type => 'Host'
+    registry.register :create_hosts, :resource_type => 'Host'
     result = registry.registered_permissions
     assert_equal 2, result.count
-    assert result.map(&:name).include? "view_hosts"
-    assert result.map(&:name).include? "create_hosts"
+    assert_equal 'view_hosts', result.first.first.to_s
+    assert_equal 'create_hosts', result.last.first.to_s
+    assert result.first.last.has_key?(:resource_type)
+    assert_equal 'Host', result.first.last[:resource_type]
   end
 
   def test_permissions
     registry = Foreman::Plugin::RbacRegistry.new
-    registry.permission_names = [:view_hosts]
+    registry.register :view_hosts, :resource_type => 'Host'
     result = registry.permissions
     assert_equal "Host", result[:view_hosts][:resource_type]
   end


### PR DESCRIPTION
Loading roles too early causes problems when there's no db yet. Even running rake db:create for production database fails. For development it works but fails later when environment is being loaded for migrations etc.

http://ci.theforeman.org/job/test_plugin_pull_request/3536/database=sqlite3,label=fast,ruby=2.3/consoleFull