### PR TITLE
Fixes #19044 - filter out :login field from logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -193,6 +193,9 @@ module Foreman
     config.log_level = Foreman::Logging.logger_level('app').to_sym
     config.active_record.logger = Foreman::Logging.logger('sql')
 
+    # Rails info log message filtering (password is filtered by default)
+    config.filter_parameters << :login
+
     if config.serve_static_files
       ::Rails::Engine.subclasses.map(&:instance).each do |engine|
         if File.exist?("#{engine.root}/public/assets")


### PR DESCRIPTION
This removes login field from INFO logs, password is filtered by default by Rails.

```
Parameters: {"utf8"=>"✓", "login"=>{"login"=>"admin", "password"=>"[FILTERED]"}, "commit"=>"Log In"}
```

In addition, I don't much like what was introduced in

https://github.com/theforeman/foreman/pull/4393

this is unnecessary exposal of username which can be abused for password brute-forcing. In addition to that, we already include this information, but in DEBUG level, meaning we duplicate this.

```
Rails.logger.debug "Setting current user thread-local variable to " + (o.is_a?(User) ? o.login : 'nil')
```

This patch changes this to database ID instead of username. To be honest, I liked the initial proposal of sending this to each individual log file which enables us to easily grep for all logs of particular user, it's essentially another correlation ID:

https://github.com/theforeman/foreman/pull/4385

So I am rewriting this back to this approach. Also I am adding some prefixes to the IDs so it's easily "grepable". My proposal:

* RXXXXXXX - request id
* SXXXXXXX - session id (or RXXXXX if there is no session)
* U12345 - regular user
* A12345 - admin user

In journald this does not make much difference, but in syslog where the only tool we have is grep this can be quite a difference. Example output:

```
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa  [app] [I] Started GET "/widgets/20" for ::1 at 2017-03-28 11:34:19 +0200
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa  [app] [I] Processing by DashboardController#show as HTML
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa  [app] [I]   Parameters: {"id"=>"20"}
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa A3 [app] [D] Setting current user thread-local variable to admin
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa A3 [app] [D] Setting current organization thread-local variable to none
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa A3 [app] [D] Setting current location thread-local variable to none
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa A3 [app] [I]   Rendered dashboard/_distribution_widget.html.erb (11.7ms)
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa  [app] [D] Setting current user thread-local variable to nil
11:34:19 rails.1   | 2017-03-28T11:34:19 R556aa  [app] [I] Completed 200 OK in 28ms (Views: 12.1ms | ActiveRecord: 3.1ms)
```