### PR TITLE
Fixes #19047 - change the last report date format

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 module ReportsHelper
   def reported_at_column(record)
-    link_to(_("%s ago") % time_ago_in_words(record.reported_at), config_report_path(record))
+    link_to(l(record.reported_at, :format => :short), config_report_path(record))
   end
 
   def report_event_column(event, style = "")


### PR DESCRIPTION
Current situation - the problem is user can't tell exact time of a report arrival
![reports0](https://cloud.githubusercontent.com/assets/109773/24402533/4fa8b6b4-13b9-11e7-9f76-f350dbb4a53f.png)

Possible solution 1 - very detailed information (actually asked by user)
![reports1](https://cloud.githubusercontent.com/assets/109773/24402535/4faa0cee-13b9-11e7-859b-0b9dc665bea5.png)
Possible solution 2 - short information, contains enough data IMHO, implemented in this PR
![reports2](https://cloud.githubusercontent.com/assets/109773/24402536/4faddcc0-13b9-11e7-83d8-80eb2a1034e3.png)
Possible solution 3 - full information after you hover on "1 month ago"
![reports3](https://cloud.githubusercontent.com/assets/109773/24402534/4fa96ee2-13b9-11e7-837c-693e4d91ecca.png)
Possible solution 4 - combination of full / ago in the same column
![reports4](https://cloud.githubusercontent.com/assets/109773/24402537/4fb0b3f0-13b9-11e7-88fa-d4050a8cecf6.png)

@rohoover your input would be appreciated as well as opinions of others of course