### PR TITLE
Fixes #19064 - seed the external auth source

### DIFF
--- a/db/seeds.d/03-auth_sources.rb
+++ b/db/seeds.d/03-auth_sources.rb
@@ -5,4 +5,9 @@ AuthSource.without_auditing do
 
   src = AuthSourceHidden.find_by_type "AuthSourceHidden"
   AuthSourceHidden.create :name => "Hidden" unless src.present?
+
+  external_name = Setting[:authorize_login_delegation_auth_source_user_autocreate]
+  if external_name.present? && AuthSourceExternal.find_by_name(external_name).nil?
+    AuthSourceExternal.create :name => external_name
+  end
 end

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -10,6 +10,7 @@ class SeedsTest < ActiveSupport::TestCase
     DatabaseCleaner.clean_with :truncation
     Setting.stubs(:[]).with(:administrator).returns("root@localhost")
     Setting.stubs(:[]).with(:send_welcome_email).returns(false)
+    Setting.stubs(:[]).with(:authorize_login_delegation_auth_source_user_autocreate).returns('EXTERNAL')
     Foreman.stubs(:in_rake?).returns(true)
   end
 
@@ -107,6 +108,12 @@ class SeedsTest < ActiveSupport::TestCase
     count = Bookmark.unscoped.where(:public => true).count
     seed
     assert_not_equal count, Bookmark.unscoped.where(:public => true).count
+  end
+
+  test 'populates external auth source if the authorize_login_delegation_auth_source_user_autocreate setting is set' do
+    assert_difference 'AuthSourceExternal.count', 1 do
+      seed
+    end
   end
 
   test 'is idempotent' do


### PR DESCRIPTION
To test, configure `authorize_login_delegation_auth_source_user_autocreate` setting to some value (e.g. External) which is normally set by the installer. Run rake db:seed. Then go to user group edit form, you should see external usergroups tab. After you click on "+ Add external user group" you should see "EXTERNAL" in auth source selection.