### PR TITLE
fixes #19085 - remove test for Token#expires

### DIFF
--- a/test/models/token_test.rb
+++ b/test/models/token_test.rb
@@ -5,12 +5,6 @@ class TokenTest < ActiveSupport::TestCase
   should validate_presence_of(:expires)
   should validate_presence_of(:host_id)
 
-  test "a token expires when set to expire" do
-    expiry = Time.now.utc
-    t      = Token.new :value => "aaaaaa", :expires => expiry
-    assert_equal t.expires, expiry
-  end
-
   test "a host can create a token" do
     h = FactoryGirl.create(:host)
     h.create_token(:value => "aaaaaa", :expires => Time.now.utc)


### PR DESCRIPTION
Token expiry is fully tested in HostTest, as the expiry is actually a
concern on the Host::Managed model. This test fails due to datetime
field precision on MySQL databases with Rails 5, and doesn't appear to
have any value - it only tests a default constructor.