### PR TITLE
fixes #19087 - create host built notification from Host#built

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -34,7 +34,7 @@ class Host::Managed < Host::Base
   # Define custom hook that can be called in model by magic methods (before, after, around)
   define_model_callbacks :build, :only => :after
   define_model_callbacks :provision, :only => :before
-  include Hostext::UINotifications
+  prepend Hostext::UINotifications
 
   before_validation :refresh_build_status, :if => :build_changed?
 


### PR DESCRIPTION
Comparing the host's installed_at timestamp is unreliable on MySQL
databases, as the timestamp field has a limited granularity. Under Rails
5 in a sub-second test, this field will not be changed.

Instead, extend Host#built to create notifications as the original
method is also used to send e-mail notifications and update the
installed_at field.