### PR TITLE
Fixes #19121 - clear selected hosts in new search

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -63,6 +63,7 @@ $(function() {
   }
   toggle_actions();
   update_counter();
+  $("#search-form").submit(resetSelection());
   return false;
 });
 


### PR DESCRIPTION
When a user search for a new query in hosts page, the previous selected hosts list remain and affects the bottom counter.
![selected_counter](https://cloud.githubusercontent.com/assets/11807069/24582322/c4228ad6-1735-11e7-8fbe-bfe291ff0621.png)
a new search should clear the previews selected hosts (as mention [here](https://github.com/theforeman/foreman/pull/4338#issuecomment-289596855))
