### PR TITLE
Fixes #19123 - fix labels on multiple action pages

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -314,8 +314,9 @@ module FormHelper
     label_size = options.delete(:label_size) || "col-md-2"
     required_mark = check_required(options, f, attr)
     label = ''.html_safe + options.delete(:label)
-    label += ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name) &&
-      s_(clazz.gettext_translation_for_attribute_name attr).html_safe) if f && label.empty?
+    if label.empty? && f.try(:object) && ((clazz = f.object.class).respond_to?(:gettext_translation_for_attribute_name))
+      label = s_(clazz.gettext_translation_for_attribute_name attr).html_safe
+    end
 
     if options[:label_help].present?
       label += ' '.html_safe + popover("", options[:label_help], options[:label_help_options] || {})

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -471,7 +471,7 @@ module HostsHelper
       [[_("*Clear %s proxy*") % _(proxy_feature), "" ]] +
       SmartProxy.with_features(proxy_feature).map {|p| [p.name, p.id]},
       {},
-      { :onchange => "toggle_multiple_ok_button(this)" }
+      {:label => _(proxy_feature), :onchange => "toggle_multiple_ok_button(this)" }
   end
 
   def randomize_mac_link

--- a/app/views/hosts/select_multiple_environment.html.erb
+++ b/app/views/hosts/select_multiple_environment.html.erb
@@ -4,5 +4,5 @@
     <%= selectable_f f, :id, [[_("Select environment"), "disabled"],
                         [_("*Clear environment*"), "" ],
                         [_("*Inherit from host group*"), "inherit"]] + Environment.all.map{|e| [e.name, e.id]},{},
-                 :onchange => "toggle_multiple_ok_button(this)" %>
+                     :label => _("Environment"), :onchange => "toggle_multiple_ok_button(this)" %>
 <% end %>

--- a/app/views/hosts/select_multiple_hostgroup.html.erb
+++ b/app/views/hosts/select_multiple_hostgroup.html.erb
@@ -2,5 +2,5 @@
 
 <%= form_for :hostgroup, :url => update_multiple_hostgroup_hosts_path(:host_ids => params[:host_ids]) do |f| %>
   <%= selectable_f f, :id, [[_("Select host group"),"disabled"],[_("*Clear host group*"), "" ]] + Hostgroup.all.map{|h| [h.to_label, h.id]}.sort,{},
-        :onchange => "toggle_multiple_ok_button(this)" %>
+        :label => _("Hostgroup"), :onchange => "toggle_multiple_ok_button(this)" %>
 <% end %>

--- a/app/views/hosts/select_multiple_location.html.erb
+++ b/app/views/hosts/select_multiple_location.html.erb
@@ -2,6 +2,6 @@
 
 <%= form_for :location, :url => update_multiple_location_hosts_path(:host_ids => params[:host_ids]) do |f| %>
   <%= selectable_f f, :id, [[_("Select Location"), "disabled"]] + Location.all.map{|e| [e.title, e.id]},{},
-        :onchange => "toggle_multiple_ok_button(this)" %>
+        :label => _("Location"), :onchange => "toggle_multiple_ok_button(this)" %>
   <%= render 'taxonomy_import_option', :f => f, :taxonomy_type => 'Location' %>
 <% end %>

--- a/app/views/hosts/select_multiple_organization.html.erb
+++ b/app/views/hosts/select_multiple_organization.html.erb
@@ -2,6 +2,6 @@
 
 <%= form_for :organization, :url => update_multiple_organization_hosts_path(:host_ids => params[:host_ids]) do |f| %>
   <%= selectable_f f, :id, [[_("Select Organization"), "disabled"]] + Organization.all.map{|e| [e.title, e.id]},{},
-        :onchange => "toggle_multiple_ok_button(this)" %>
+        :label => _("Organization"), :onchange => "toggle_multiple_ok_button(this)" %>
   <%= render 'taxonomy_import_option', :f => f, :taxonomy_type => 'Organization' %>
 <% end %>

--- a/app/views/hosts/select_multiple_owner.html.erb
+++ b/app/views/hosts/select_multiple_owner.html.erb
@@ -3,6 +3,6 @@
 <%= form_for :owner, :url => update_multiple_owner_hosts_path(:host_ids => params[:host_ids]) do |f| %>
   <%= selectable_f f, :id, options_for_select({_('select an owner') => 'disabled'}) + option_groups_from_collection_for_select(
     [User, Usergroup], :visible, :table_name, :id_and_type, :select_title,
-    'disabled'), {}, { :onchange => "toggle_multiple_ok_button(this)" }
+    'disabled'), {}, { :label => _("Owner"), :onchange => "toggle_multiple_ok_button(this)" }
   %>
 <% end %>

--- a/app/views/hosts/select_multiple_power_state.html.erb
+++ b/app/views/hosts/select_multiple_power_state.html.erb
@@ -6,6 +6,6 @@
     [[_("Select desired state"), "disabled"]] +
     PowerManager::REAL_ACTIONS.map { |a| [_(a.to_s.capitalize), a] },
     {},
-    { :onchange => "toggle_multiple_ok_button(this)" }
+    { :label => _("Power"), :onchange => "toggle_multiple_ok_button(this)" }
   %>
 <% end %>


### PR DESCRIPTION
Labels in select multiple hosts actions pages are presented incorrectly:
![uncorrect_label](https://cloud.githubusercontent.com/assets/11807069/24583490/52e22ba0-1754-11e7-957d-f4b5e068d3e5.png)
