### PR TITLE
fixes #19131 - upgrade minitest to latest 5.x

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,7 +1,7 @@
 group :test do
   gem 'mocha', '~> 1.1'
   gem 'single_test', '~> 0.6'
-  gem 'minitest', '~> 5.1.0'
+  gem 'minitest', '~> 5.1'
   gem 'minitest-optional_retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -234,4 +234,11 @@ class ActiveSupport::TestCase
       raise "unknown RestClient::Response.create version (#{RestClient.version}, arity #{RestClient::Response.method(:create).arity})"
     end
   end
+
+  # Minitest provides a "_" expects syntax which overrides the gettext "_" method
+  # Override the minitest method and call the original instead for compatibility
+  # with the app's runtime environment.
+  def _(*args)
+    Object.instance_method(:_).bind(self).call(*args)
+  end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -853,11 +853,13 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       assert_response :created
       body = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil body['id']
-      host = Host.find_by_id(body['id'])
-      assert_equal 'dhcp75-197.virt.bos.redhat.com', host.name
-      assert_equal @domain, host.domain
-      assert_equal '00:50:56:a9:00:28', host.mac
-      assert_equal true, host.build
+      as_admin do
+        host = Host.find_by_id(body['id'])
+        assert_equal 'dhcp75-197.virt.bos.redhat.com', host.name
+        assert_equal domain, host.domain
+        assert_equal '00:50:56:a9:00:28', host.mac
+        assert_equal true, host.build
+      end
     end
 
     test 'should not import if associated host exists' do

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -41,7 +41,7 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     show_response = ActiveSupport::JSON.decode(@response.body)
 
     assert_equal taxonomies(:location1).id, show_response['default_location']['id']
-    assert_equal nil, show_response['default_organization']
+    assert_nil show_response['default_organization']
   end
 
   test "effective_admin is true if group admin is enabled" do

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -253,7 +253,7 @@ class HostgroupsControllerTest < ActionController::TestCase
       child.reload
       as_admin do
         assert_equal "original", child.parameters["z"]
-        assert_equal nil, child.parameters["x"]
+        assert_nil child.parameters["x"]
       end
     end
   end

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -566,7 +566,7 @@ class HostsControllerTest < ActionController::TestCase
       assert_empty flash[:error]
 
       @hosts.each do |host|
-        assert_equal nil, host.reload.puppet_ca_proxy
+        assert_nil host.reload.puppet_ca_proxy
       end
     end
 
@@ -582,7 +582,7 @@ class HostsControllerTest < ActionController::TestCase
       assert_empty flash[:error]
 
       @hosts.each do |host|
-        assert_equal nil, host.reload.puppet_ca_proxy
+        assert_nil host.reload.puppet_ca_proxy
       end
     end
   end
@@ -627,7 +627,7 @@ class HostsControllerTest < ActionController::TestCase
       assert_empty flash[:error]
 
       @hosts.each do |host|
-        assert_equal nil, host.reload.puppet_ca_proxy
+        assert_nil host.reload.puppet_ca_proxy
       end
     end
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -60,8 +60,8 @@ class LocationsControllerTest < ActionController::TestCase
       delete :destroy, {:id => location.id}, set_session_user.merge(:location_id => location.id)
     end
 
-    assert_equal Location.current, nil
-    assert_equal session[:location_id], nil
+    assert_nil Location.current
+    assert_nil session[:location_id]
   end
 
   test "should save location on session expiry" do
@@ -178,8 +178,8 @@ class LocationsControllerTest < ActionController::TestCase
   test "should clear out Location.current" do
     @request.env['HTTP_REFERER'] = root_url
     get :clear, {}, set_session_user
-    assert_equal Location.current, nil
-    assert_equal session[:location_id], nil
+    assert_nil Location.current
+    assert_nil session[:location_id]
     assert_redirected_to root_url
   end
 

--- a/test/controllers/notification_recipients_controller_test.rb
+++ b/test/controllers/notification_recipients_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'notifications_test_helper'
 
 class NotificationRecipientsControllerTest < ActionController::TestCase
   setup do
@@ -66,38 +67,42 @@ class NotificationRecipientsControllerTest < ActionController::TestCase
     assert_empty response['notifications']
   end
 
-  test "notification when host is destroyed" do
-    host = FactoryGirl.create(:host)
-    assert host.destroy
-    get :index, { :format => 'json' }, set_session_user
-    assert_response :success
-    response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 1, response['notifications'].size
-    assert_equal "#{host} has been deleted successfully", response['notifications'][0]["text"]
-  end
+  context "with seeded notification types" do
+    include NotificationBlueprintSeeds
 
-  test "notification when host is built" do
-    host = FactoryGirl.create(:host, owner: User.current)
-    assert host.update_attribute(:build, true)
-    assert host.built
-    get :index, { :format => 'json' }, set_session_user
-    assert_response :success
-    response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 1, response['notifications'].size
-    assert_equal "#{host} has been provisioned successfully", response['notifications'][0]["text"]
-  end
+    test "notification when host is destroyed" do
+      host = FactoryGirl.create(:host)
+      assert host.destroy
+      get :index, { :format => 'json' }, set_session_user
+      assert_response :success
+      response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 1, response['notifications'].size
+      assert_equal "#{host} has been deleted successfully", response['notifications'][0]["text"]
+    end
 
-  test "notification when host has no owner" do
-    host = FactoryGirl.create(:host, :managed)
-    User.current = nil
-    assert host.update_attributes(owner_id: nil, owner_type: nil, build: true)
-    assert_nil host.owner
-    assert host.built
-    get :index, { :format => 'json' }, set_session_user
-    assert_response :success
-    response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 1, response['notifications'].size
-    assert_equal "#{host} has no owner set", response['notifications'][0]["text"]
+    test "notification when host is built" do
+      host = FactoryGirl.create(:host, owner: User.current)
+      assert host.update_attribute(:build, true)
+      assert host.built
+      get :index, { :format => 'json' }, set_session_user
+      assert_response :success
+      response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 1, response['notifications'].size
+      assert_equal "#{host} has been provisioned successfully", response['notifications'][0]["text"]
+    end
+
+    test "notification when host has no owner" do
+      host = FactoryGirl.create(:host, :managed)
+      User.current = nil
+      assert host.update_attributes(owner_id: nil, owner_type: nil, build: true)
+      assert_nil host.owner
+      assert host.built
+      get :index, { :format => 'json' }, set_session_user
+      assert_response :success
+      response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 1, response['notifications'].size
+      assert_equal "#{host} has no owner set", response['notifications'][0]["text"]
+    end
   end
 
   test 'group mark as read' do

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -72,8 +72,8 @@ class OrganizationsControllerTest < ActionController::TestCase
       delete :destroy, {:id => organization.id}, set_session_user.merge(:organization_id => organization.id)
     end
 
-    assert_equal Organization.current, nil
-    assert_equal session[:organization_id], nil
+    assert_nil Organization.current
+    assert_nil session[:organization_id]
   end
 
   test "should save organization on session expiry" do
@@ -190,8 +190,8 @@ class OrganizationsControllerTest < ActionController::TestCase
   test "should clear out Organization.current" do
     @request.env['HTTP_REFERER'] = root_url
     get :clear, {}, set_session_user
-    assert_equal Organization.current, nil
-    assert_equal session[:organization_id], nil
+    assert_nil Organization.current
+    assert_nil session[:organization_id]
     assert_redirected_to root_url
   end
 

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -82,7 +82,7 @@ FactoryGirl.define do
   factory :nic_bmc, :class => Nic::BMC, :parent => :nic_managed do
     type 'Nic::BMC'
     sequence(:mac) { |n| "00:43:56:cd:" + n.to_s(16).rjust(4, '0').insert(2, ':') }
-    sequence(:ip) { |n| IPAddr.new((subnet.present? ? subnet.ipaddr.to_i : 255) + n, Socket::AF_INET).to_s }
+    sequence(:ip) { |n| IPAddr.new((subnet.present? ? subnet.ipaddr.to_i : 256 * 256 * 256) + n, Socket::AF_INET).to_s }
     provider 'IPMI'
     username 'admin'
     password 'admin'

--- a/test/fixtures/hostgroups.yml
+++ b/test/fixtures/hostgroups.yml
@@ -36,6 +36,7 @@ parent:
   environment: global_puppetmaster
   operatingsystem: centos5_3
   medium: one
+  ptable: autopart
   puppet_proxy: puppetmaster
   puppet_ca_proxy: puppetmaster
   domain: mydomain

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -93,3 +93,10 @@ locked:
   operatingsystems: centos5_3
   locked: true
   type: ProvisioningTemplate
+
+autopart:
+  name: Example partition table
+  template: autopart
+  operatingsystems: centos5_3
+  locked: true
+  type: Ptable

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -9,10 +9,6 @@ require 'show_me_the_cookies'
 require 'database_cleaner'
 require 'active_support_test_case_helper'
 require 'minitest-optional_retry'
-# load notification blueprint seeds
-require File.join(Rails.root,'db','seeds.d','17-notification_blueprints.rb')
-
-DatabaseCleaner.strategy = :transaction
 
 Capybara.register_driver :poltergeist do |app|
   opts = {
@@ -100,7 +96,7 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  setup :login_admin
+  setup :start_database_cleaner, :login_admin
 
   teardown do
     DatabaseCleaner.clean       # Truncate the database
@@ -110,6 +106,15 @@ class ActionDispatch::IntegrationTest
   end
 
   private
+
+  def start_database_cleaner
+    DatabaseCleaner.strategy = database_cleaner_strategy
+    DatabaseCleaner.start
+  end
+
+  def database_cleaner_strategy
+    :transaction
+  end
 
   def login_admin
     SSO.register_method(TestSSO)
@@ -134,9 +139,11 @@ class ActionDispatch::IntegrationTest
 end
 
 class IntegrationTestWithJavascript < ActionDispatch::IntegrationTest
+  def database_cleaner_strategy
+    :truncation
+  end
+
   def login_admin
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.start
     Capybara.current_driver = Capybara.javascript_driver
     super
   end

--- a/test/models/compute_resources/libvirt_test.rb
+++ b/test/models/compute_resources/libvirt_test.rb
@@ -43,7 +43,7 @@ class LibvirtTest < ActiveSupport::TestCase
       cr.stubs(:find_vm_by_uuid).returns(vm)
 
       attrs = cr.vm_compute_attributes_for('abc')
-      assert_equal nil, attrs[:memory]
+      assert_nil attrs[:memory]
     end
   end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -124,7 +124,7 @@ class HostTest < ActiveSupport::TestCase
 
   test "fetches nil vm compute attributes for bare metal" do
     host = FactoryGirl.create(:host)
-    assert_equal host.vm_compute_attributes, nil
+    assert_nil host.vm_compute_attributes
   end
 
   test "can authorize Host::Managed as non-admin user" do
@@ -415,7 +415,7 @@ class HostTest < ActiveSupport::TestCase
       assert host.import_facts(raw['facts'])
       host = Host.find_by_name('sinn1636.fail')
       assert_equal '10.35.27.2', host.interfaces.find_by_identifier('br180').ip
-      assert_equal nil, host.primary_interface.ip # eth0 does not have ip address among facts
+      assert_nil host.primary_interface.ip # eth0 does not have ip address among facts
     end
 
     test 'should update certname when host is found by hostname and certname is provided' do
@@ -1717,7 +1717,7 @@ class HostTest < ActiveSupport::TestCase
       end
 
       test "hosts should be able to retrieve their token if one exists" do
-        h = FactoryGirl.create(:host, :managed)
+        h = FactoryGirl.create(:host, :managed, build: true)
         assert_equal Token.first, h.token
       end
 
@@ -1765,12 +1765,12 @@ class HostTest < ActiveSupport::TestCase
         assert_equal Token.all.size, 0
       end
 
-      test "token should return false when tokens are disabled or invalid" do
+      test "token should be nil when tokens are disabled or invalid" do
         h = FactoryGirl.create(:host, :managed)
-        assert_equal h.token, nil
+        assert_nil h.token
         Setting[:token_duration] = 30
         h.reload
-        assert_equal h.token, nil
+        assert_nil h.token
       end
     end
 

--- a/test/models/hostgroup_test.rb
+++ b/test/models/hostgroup_test.rb
@@ -150,9 +150,10 @@ class HostgroupTest < ActiveSupport::TestCase
   end
 
   test "inherited id value equals field id value if no ancestry" do
-    hostgroup = hostgroups(:common)
+    hostgroup = hostgroups(:parent)
     [:compute_profile_id, :environment_id, :domain_id, :puppet_proxy_id, :puppet_ca_proxy_id,
      :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id].each do |field|
+      refute_nil hostgroup.send(field), "missing #{field}"
       assert_equal hostgroup.send(field), hostgroup.send("inherited_#{field}")
     end
   end
@@ -163,6 +164,7 @@ class HostgroupTest < ActiveSupport::TestCase
     # environment_id is not included in the array below since child value is not null
     [:compute_profile_id, :domain_id, :puppet_proxy_id, :puppet_ca_proxy_id,
      :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id].each do |field|
+      refute_nil parent.send(field), "missing #{field}"
       assert_equal parent.send(field), child.send("inherited_#{field}")
     end
   end
@@ -182,6 +184,7 @@ class HostgroupTest < ActiveSupport::TestCase
     # environment is not included in the array below since child value is not null
     [:compute_profile, :domain, :puppet_proxy, :puppet_ca_proxy,
      :operatingsystem, :architecture, :medium, :ptable, :subnet, :subnet6].each do |field|
+      refute_nil parent.send(field), "missing #{field}"
       assert_equal parent.send(field), child.send(field)
     end
   end

--- a/test/models/medium_test.rb
+++ b/test/models/medium_test.rb
@@ -103,6 +103,6 @@ class MediumTest < ActiveSupport::TestCase
 
   test "blank os family is saved as nil" do
     medium = Medium.new :name => "dummy", :path => "http://hello", :os_family => ""
-    assert_equal nil, medium.os_family
+    assert_nil medium.os_family
   end
 end

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -390,7 +390,7 @@ class NicTest < ActiveSupport::TestCase
     end
 
     test "type_by_name returns nil for an unknown name" do
-      assert_equal nil, Nic::Base.type_by_name("UNKNOWN_NAME")
+      assert_nil Nic::Base.type_by_name("UNKNOWN_NAME")
     end
 
     test "type_by_name finds the class" do
@@ -398,7 +398,7 @@ class NicTest < ActiveSupport::TestCase
     end
 
     test "type_by_name returns nil for classes that aren't allowed" do
-      assert_equal nil, Nic::Base.type_by_name("DisallowedTestNic")
+      assert_nil Nic::Base.type_by_name("DisallowedTestNic")
     end
 
     test 'fqdn_changed? should be true if name changes' do

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -142,7 +142,7 @@ class OperatingsystemTest < ActiveSupport::TestCase
 
     test "blank os family is saved as nil" do
       os.family = ""
-      assert_equal nil, os.family
+      assert_nil os.family
     end
 
     test "deduce_family correctly returns the family when not set" do

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -219,15 +219,15 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
   end
 
   describe 'setting eui-64 ip address based on mac provided by compute resource' do
-    let(:organization) { FactoryGirl.create(:organization) }
-    let(:location) { FactoryGirl.create(:location) }
+    let(:tax_organization) { FactoryGirl.create(:organization) }
+    let(:tax_location) { FactoryGirl.create(:location) }
     let(:subnet6) do
       FactoryGirl.build(:subnet_ipv6,
                         :network => '2001:db8::',
                         :mask => 'ffff:ffff:ffff:ffff::',
                         :dns => FactoryGirl.create(:dns_smart_proxy),
-                        :organizations => [organization],
-                        :locations => [location],
+                        :organizations => [tax_organization],
+                        :locations => [tax_location],
                         :ipam => IPAM::MODES[:eui64])
     end
 
@@ -237,8 +237,8 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
                         :on_compute_resource,
                         :with_compute_profile,
                         :subnet6 => subnet6,
-                        :organization => organization,
-                        :location => location,
+                        :organization => tax_organization,
+                        :location => tax_location,
                         :mac => nil)
     end
 

--- a/test/models/orchestration/dns_test.rb
+++ b/test/models/orchestration/dns_test.rb
@@ -86,7 +86,7 @@ class DnsOrchestrationTest < ActiveSupport::TestCase
       assert_valid @host
       assert !@host.dns?
       assert @host.reverse_dns?
-      assert_equal nil, @host.dns_record(:a)
+      assert_nil @host.dns_record(:a)
       assert_not_nil @host.dns_record(:ptr4)
     end
 

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -12,8 +12,8 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
       skip_without_unattended
       assert_equal false, @host.tftp?
       assert_equal false, @host.tftp6?
-      assert_equal nil, @host.tftp
-      assert_equal nil, @host.tftp6
+      assert_nil @host.tftp
+      assert_nil @host.tftp6
     end
 
     test '#setTFTP should not call any tftp proxy' do
@@ -59,7 +59,7 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
       skip_without_unattended
       @host.expects(:pxe_loader).returns('').at_least(1)
       assert_equal false, @host.tftp?
-      assert_equal nil, @host.tftp
+      assert_nil @host.tftp
     end
   end
 

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -48,7 +48,7 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     as_admin do
       assert tmplt.save
     end
-    assert_equal nil,tmplt.template_kind
+    assert_nil tmplt.template_kind
     assert_equal [],tmplt.hostgroups
     assert_equal [],tmplt.environments
     assert_equal [],tmplt.template_combinations
@@ -75,7 +75,7 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     end
     clone = tmplt.clone
 
-    assert_equal clone.name, nil
+    assert_nil clone.name
     assert_equal clone.operatingsystems, tmplt.operatingsystems
     assert_equal clone.template_kind_id, tmplt.template_kind_id
     assert_equal clone.template, tmplt.template

--- a/test/models/ptable_test.rb
+++ b/test/models/ptable_test.rb
@@ -40,7 +40,7 @@ class PtableTest < ActiveSupport::TestCase
 
   test "blank os family is saved as nil" do
     partition_table = Ptable.new :name => "Archlinux default", :layout => "any layout", :os_family => ""
-    assert_equal nil, partition_table.os_family
+    assert_nil partition_table.os_family
   end
 
   # I'm commenting this one out for now, as I'm not sure that its actully needed

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class SettingTest < ActiveSupport::TestCase
-  def setup
-    Setting.cache.clear
-  end
-
   should validate_presence_of(:name)
   should validate_presence_of(:default)
   should validate_uniqueness_of(:name)
@@ -76,7 +72,7 @@ class SettingTest < ActiveSupport::TestCase
 
   def test_default_value_can_be_nil
     assert Setting.create(:name => "foo", :default => nil, :description => "test foo")
-    assert_equal nil, Setting["foo"]
+    assert_nil Setting["foo"]
   end
 
   def test_should_return_updated_value_only_after_it_is_saved

--- a/test/models/taxonomy_test.rb
+++ b/test/models/taxonomy_test.rb
@@ -44,7 +44,7 @@ class TaxonomyTest < ActiveSupport::TestCase
   test 'does not expand if no user set' do
     org1 = FactoryGirl.build(:organization)
     org2 = FactoryGirl.build(:organization)
-    assert_equal nil, Taxonomy.expand(nil)
+    assert_nil Taxonomy.expand(nil)
     assert_equal [], Taxonomy.expand([])
     assert_equal org1, Taxonomy.expand(org1)
     assert_equal [org1, org2], Taxonomy.expand([org1, org2])
@@ -57,8 +57,8 @@ class TaxonomyTest < ActiveSupport::TestCase
     FactoryGirl.create(:organization) # this one won't be expanded
     user = FactoryGirl.create(:user, :organizations => [org1, org2])
     as_user(user) do
-      assert_equal [org1, org2], Organization.expand(nil)
-      assert_equal [org1, org2], Organization.expand([])
+      assert_equal [org1, org2].sort, Organization.expand(nil).sort
+      assert_equal [org1, org2].sort, Organization.expand([]).sort
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -173,7 +173,7 @@ class UserTest < ActiveSupport::TestCase
         user = User.try_to_auto_create_user('foo', 'password')
         assert_equal 'foo#bar', user.mail
         assert user.errors[:mail].present?
-        assert_equal nil, user.reload.mail
+        assert_nil user.reload.mail
       end
 
       test "ldap user attribute should not be saved in DB on create when invalid format (firstname)" do
@@ -182,7 +182,7 @@ class UserTest < ActiveSupport::TestCase
         user = User.try_to_auto_create_user('foo', 'password')
         assert_equal '$%$%%%', user.firstname
         assert user.errors[:firstname].present?
-        assert_equal nil, user.reload.firstname
+        assert_nil user.reload.firstname
       end
 
       test "ldap user attribute should not be saved in DB on login when invalid format (mail)" do
@@ -200,7 +200,7 @@ class UserTest < ActiveSupport::TestCase
         user = User.try_to_login('foo', 'password')
         assert_equal '$%$%%%', user.firstname
         assert user.errors[:firstname].present?
-        assert_equal nil, user.reload.firstname
+        assert_nil user.reload.firstname
       end
     end
   end

--- a/test/notifications_test_helper.rb
+++ b/test/notifications_test_helper.rb
@@ -1,0 +1,12 @@
+# Create notification blueprints prior to tests
+module NotificationBlueprintSeeds
+  extend ActiveSupport::Concern
+
+  included do
+    setup :seed_notification_blueprints
+  end
+
+  def seed_notification_blueprints
+    load File.join(Rails.root, 'db', 'seeds.d', '17-notification_blueprints.rb')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,9 +9,6 @@ require 'controllers/shared/basic_rest_response_test'
 require 'facet_test_helper'
 require 'active_support_test_case_helper'
 
-# load notification blueprint seeds
-require File.join(Rails.root,'db','seeds.d','17-notification_blueprints.rb')
-
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :minitest_4

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -153,7 +153,7 @@ class FactParserTest < ActiveSupport::TestCase
       parser.expects(:get_facts_for_interface).with('em1').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eno1').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       result = parser.send(:find_virtual_interface, parser.interfaces)
-      assert_equal result, nil
+      assert_nil result
     end
   end
 
@@ -164,7 +164,7 @@ class FactParserTest < ActiveSupport::TestCase
       parser.expects(:get_facts_for_interface).with('virbr0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('bond7').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       result = parser.send(:find_physical_interface, parser.interfaces)
-      assert_equal result, nil
+      assert_nil result
     end
   end
 

--- a/test/unit/foreman/model/ovirt_test.rb
+++ b/test/unit/foreman/model/ovirt_test.rb
@@ -24,7 +24,7 @@ class OvirtTest < ActiveSupport::TestCase
   test "fingerprint error is ignored on update of operating systems" do
     record = new_ovirt_cr
     record.stubs(:client).raises(Foreman::FingerprintException.new('fingerprint error'))
-    original_oses = record.attrs[:available_operating_systems]
+    original_oses = record.attrs[:available_operating_systems] = { foo: :bar }
 
     assert_nothing_raised do
       assert record.send(:update_available_operating_systems), 'before validation filter does not return true which would cancel the callback chain'

--- a/test/unit/interface_merge_test.rb
+++ b/test/unit/interface_merge_test.rb
@@ -87,6 +87,6 @@ class InterfaceMergeTest < ActiveSupport::TestCase
     assert_equal 'eth0', interfaces[0].identifier
 
     assert_equal expected_attrs(2), interfaces[1].compute_attributes
-    assert_equal nil, interfaces[1].identifier
+    assert_nil interfaces[1].identifier
   end
 end

--- a/test/unit/menu_mapper_test.rb
+++ b/test/unit/menu_mapper_test.rb
@@ -152,7 +152,7 @@ class MenuMapperTest < ActiveSupport::TestCase
     menu_mapper.item :test_overview, :url_hash => { :controller => 'hosts', :action => 'show'}
 
     item = menu_mapper.find(:nothing)
-    assert_equal nil, item
+    assert_nil item
   end
 
   def test_delete

--- a/test/unit/name_synchronizer_test.rb
+++ b/test/unit/name_synchronizer_test.rb
@@ -17,7 +17,7 @@ class NameSynchronizerName < ActiveSupport::TestCase
     test '#sync_name synchronizes name based on interface' do
       refute_equal @host.name, @host.primary_interface.name
       @hsync.sync_name
-      assert_equal @host.name, @host.primary_interface.name
+      assert_nil @host.primary_interface.name
       assert_nil @host.name
     end
   end

--- a/test/unit/owner_classifier_test.rb
+++ b/test/unit/owner_classifier_test.rb
@@ -15,11 +15,11 @@ class OwnerClassifierTest < ActiveSupport::TestCase
 
   test "Should return nil if id_and_type does not exist" do
     id_and_type = "0-Users"
-    assert_equal nil, OwnerClassifier.new(id_and_type).user_or_usergroup
+    assert_nil OwnerClassifier.new(id_and_type).user_or_usergroup
   end
 
   test "Should return nil if id_and_type is ilegal" do
     id_and_type = "5-UsErS"
-    assert_equal nil, OwnerClassifier.new(id_and_type).user_or_usergroup
+    assert_nil OwnerClassifier.new(id_and_type).user_or_usergroup
   end
 end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -68,7 +68,7 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
     test "release_name should be nil when lsbdistcodename isn't set on Debian" do
       @importer = PuppetFactParser.new(debian_facts.delete_if { |k, v| k == "lsbdistcodename" })
-      assert_equal nil, os.release_name
+      assert_nil os.release_name
       assert_os_idempotent
     end
 

--- a/test/unit/tasks/trends_test.rb
+++ b/test/unit/tasks/trends_test.rb
@@ -45,7 +45,8 @@ class TrendsTest < ActiveSupport::TestCase
     trend_20 = trend_20.first
 
     assert_equal trend_10.interval_start, trend_20.interval_start
-    assert_equal trend_10.interval_end, trend_20.interval_end
+    assert_nil trend_10.interval_end
+    assert_nil trend_20.interval_end
   end
 
   test 'trends:reduce crossing graphs' do
@@ -67,9 +68,15 @@ class TrendsTest < ActiveSupport::TestCase
       assert_equal start, old_os_intervals[idx].interval_start
       assert_equal start, new_os_intervals[idx].interval_start
 
-      next_start = interval_starts[idx + 1] unless idx >= 2
-      assert_equal next_start, old_os_intervals[idx].interval_end
-      assert_equal next_start, new_os_intervals[idx].interval_end
+      if idx < 2
+        next_start = interval_starts[idx + 1]
+        refute_nil next_start
+        assert_equal next_start, old_os_intervals[idx].interval_end
+        assert_equal next_start, new_os_intervals[idx].interval_end
+      else
+        assert_nil old_os_intervals[idx].interval_end
+        assert_nil new_os_intervals[idx].interval_end
+      end
 
       assert_equal 4, old_os_intervals[idx].count + new_os_intervals[idx].count
     end
@@ -95,9 +102,15 @@ class TrendsTest < ActiveSupport::TestCase
       assert_equal start, old_os_intervals[idx].interval_start
       assert_equal start, new_os_intervals[idx].interval_start
 
-      next_start = interval_starts[idx + 1] unless idx >= 3
-      assert_equal next_start, old_os_intervals[idx].interval_end
-      assert_equal next_start, new_os_intervals[idx].interval_end
+      if idx < 3
+        next_start = interval_starts[idx + 1]
+        refute_nil next_start
+        assert_equal next_start, old_os_intervals[idx].interval_end
+        assert_equal next_start, new_os_intervals[idx].interval_end
+      else
+        assert_nil old_os_intervals[idx].interval_end
+        assert_nil new_os_intervals[idx].interval_end
+      end
 
       assert_equal 4, old_os_intervals[idx].count + new_os_intervals[idx].count
       assert_equal new_os_counts[idx], new_os_intervals[idx].count

--- a/test/unit/ui_notifications/hosts/build_completed_test.rb
+++ b/test/unit/ui_notifications/hosts/build_completed_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'notifications_test_helper'
 
 class UINotificationsHostsBuildCompletedTest < ActiveSupport::TestCase
+  include NotificationBlueprintSeeds
+
   test 'create new host build notification' do
     host.update_attribute(:build, true)
     assert_difference("blueprint.notifications.where(:subject => host).count", 1) do

--- a/test/unit/ui_notifications/hosts/destroy_test.rb
+++ b/test/unit/ui_notifications/hosts/destroy_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'notifications_test_helper'
 
 class UINotificationsHostsDestroyTest < ActiveSupport::TestCase
+  include NotificationBlueprintSeeds
+
   test 'destroying a host should create a notification' do
     assert_equal 0, Notification.where(:subject => host).count
     host.destroy

--- a/test/unit/ui_notifications/hosts/missing_owner_test.rb
+++ b/test/unit/ui_notifications/hosts/missing_owner_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'notifications_test_helper'
 
 class UINotificationsHostsMissingOwnerTest < ActiveSupport::TestCase
+  include NotificationBlueprintSeeds
+
   test 'add missing host owner notification' do
     assert_difference("Notification.where(:subject => host).count", 1) do
       UINotifications::Hosts::MissingOwner.deliver!(host)


### PR DESCRIPTION
- override minitest's `_` expectation method with the gettext method
- rename `location` let helper, conflicted with a minitest method name
- fix `assert_equal nil, [..]` deprecation warnings, prefer `assert nil`

Contains fixes for tests that leak data or behavioral changes between
tests, as the ordering of test cases is now randomised:

- remove Host/Nic class modifications in orchestration concern test
- move NotificationBlueprint seeding into test transaction, preventing
  DB truncation in integration tests from removing the records
- ensure DBCleaner.start is called when in transaction mode to prevent
  records leaking out of integration tests
