### PR TITLE
Fixes #19151 - progress_report_id fix for host edit

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -337,6 +337,10 @@ module Host
       false
     end
 
+    def orchestrated?
+      self.class.included_modules.include?(Orchestration)
+    end
+
     private
 
     def build_values_for_primary_interface!(values_for_primary_interface, args)

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -92,7 +92,7 @@
       <%= f.hidden_field :uuid if @host.uuid.present? %>
       <% # Required for import action %>
       <%= f.hidden_field :compute_resource_id if @host.new_record? && @host.uuid.present? %>
-      <%= f.hidden_field :progress_report_id, :data=>{:url=>task_path(@host.progress_report_id)} %>
+      <%= f.hidden_field(:progress_report_id, :data=>{:url=>task_path(@host.progress_report_id)}) if @host.orchestrated? %>
       <%= f.hidden_field :type, :value => @host.type if @host.type_changed? %>
 
       <div class="tab-pane"  id="network">


### PR DESCRIPTION
The whole orchestration skipping when unattended setting is false is weird. This patch fixes this hot problem, we need to backport this into 1.14 and 1.15.