### PR TITLE
fixes #17895 - do not import link-local ipv6 addr fact

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -392,6 +392,7 @@ module Host
       iface.mac = attributes.delete(:macaddress)
       iface.ip = attributes.delete(:ipaddress)
       iface.ip6 = attributes.delete(:ipaddress6)
+      iface.ip6 = nil if (IPAddr.new('fe80::/10').include?(iface.ip6) rescue false)
 
       if Setting[:update_subnets_from_facts]
         iface.subnet = Subnet.subnet_for(iface.ip) if iface.ip_changed? && !iface.matches_subnet?(:ip, :subnet)


### PR DESCRIPTION
If facter reports a link-local ipv6 address as an interfaces primary ipv6 address, drop the address from the interface and either remove an existing address or simply don't set the address.