### PR TITLE
Fixes #16082 - Associate FactValues with Host::Base

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -2,7 +2,7 @@ class FactValue < ActiveRecord::Base
   include Authorizable
   include ScopedSearchExtensions
 
-  belongs_to_host
+  belongs_to :host, {:class_name => "Host::Base", :foreign_key => :host_id}
   belongs_to :fact_name
   delegate :name, :short_name, :compose, :origin, :to => :fact_name
   has_many :hostgroup, :through => :host

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -27,6 +27,7 @@ module Host
 
     belongs_to :location
     belongs_to :organization
+    belongs_to :hostgroup
 
     alias_attribute :hostname, :name
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -10,7 +10,6 @@ class Host::Managed < Host::Base
 
   has_many :host_classes, :foreign_key => :host_id
   has_many :puppetclasses, :through => :host_classes, :dependent => :destroy
-  belongs_to :hostgroup
   has_many :reports, :foreign_key => :host_id, :class_name => 'ConfigReport'
   has_one :last_report_object, -> { order("#{Report.table_name}.id DESC") }, :foreign_key => :host_id, :class_name => 'ConfigReport'
 


### PR DESCRIPTION
To prevent regression in existing search functionality, this also
requires that the hostgroup relation will be moved to the base class as
well. Since Host::Managed inherits from Host::Base, this should not
break anything.