### PR TITLE
Fixes #19213 - use provision interface in foreman_url

### DIFF
--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -16,7 +16,7 @@ module Foreman
 
       host = @host
       host = self if @host.nil? && self.class < Host::Base
-      proxy = host.try(:subnet).try(:tftp)
+      proxy = host.try(:provision_interface).try(:subnet).try(:tftp)
 
       # use template_url from the request if set, but otherwise look for a Template
       # feature proxy, as PXE templates are written without an incoming request.

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -368,6 +368,20 @@ FactoryGirl.define do
       subnet { FactoryGirl.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]) }
     end
 
+    trait :with_separate_provision_interface do
+      interfaces do
+        [FactoryGirl.build(:nic_managed,
+                           :primary => true,
+                           :provision => false,
+                           :domain => FactoryGirl.build(:domain)),
+         FactoryGirl.build(:nic_managed,
+                           :primary => false,
+                           :provision => true,
+                           :domain => FactoryGirl.build(:domain),
+                           :subnet => FactoryGirl.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]))]
+      end
+    end
+
     trait :with_tftp_v6_subnet do
       subnet6 { FactoryGirl.build(:subnet_ipv6, :tftp, locations: [location], organizations: [organization]) }
     end

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -79,6 +79,12 @@ class RendererTest < ActiveSupport::TestCase
     Setting[:safemode_render] = true
   end
 
+  test "foreman_url should respect proxy with Templates feature" do
+    host = FactoryGirl.build(:host, :with_separate_provision_interface)
+    @renderer.host = host
+    assert_match(host.provision_interface.subnet.tftp.url, @renderer.foreman_url)
+  end
+
   test "foreman_url should run with @host as nil" do
     assert_nothing_raised(NoMethodError) { @renderer.foreman_url }
   end


### PR DESCRIPTION
Before this patch, we were using primary interface for checking on ftfp
proxy and its template feature. Provision interface is more appropriate
for this purposes.