### PR TITLE
fixes #14699 - Enable host edit to accept new params

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -347,7 +347,7 @@ function architecture_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
   var attrs = {};
-  attrs[type] = attribute_hash(['architecture_id', 'organization_id', 'location_id']);
+  attrs[type] = attribute_hash(tfm.hosts.getAttributesToPost("architecture"));
   tfm.tools.showSpinner();
   $.ajax({
     data: attrs,
@@ -366,7 +366,7 @@ function os_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
   var attrs = {};
-  attrs[type] = attribute_hash(['operatingsystem_id', 'organization_id', 'location_id']);
+  attrs[type] = attribute_hash(tfm.hosts.getAttributesToPost("os"));
   tfm.tools.showSpinner();
   $.ajax({
     data: attrs,
@@ -419,7 +419,7 @@ function medium_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
   var attrs = {};
-  attrs[type] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id']);
+  attrs[type] = attribute_hash(tfm.hosts.getAttributesToPost("medium"));
   attrs[type]["use_image"] = $('*[id*=use_image]').attr('checked') == "checked";
   $.ajax({
     data: attrs,
@@ -435,7 +435,7 @@ function use_image_selected(element){
   var url = $(element).attr('data-url');
   var type = $(element).attr('data-type');
   var attrs = {};
-  attrs[type] = attribute_hash(['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']);
+  attrs[type] = attribute_hash(tfm.hosts.getAttributesToPost("image"));
   attrs[type]['use_image'] = ($(element).attr('checked') == "checked");
   $.ajax({
     data: attrs,

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -18,6 +18,7 @@ window.tfm = Object.assign(
     sshKeys: require('./foreman_ssh_keys'),
     trends: require('./foreman_trends'),
     hostgroups: require('./foreman_hostgroups'),
+    hosts: require('./foreman_hosts'),
     toastNotifications: require('./foreman_toast_notifications'),
     numFields: require('./jquery.ui.custom_spinners'),
     reactMounter: require('./react_app/common/MountingService'),

--- a/webpack/assets/javascripts/foreman_hosts.js
+++ b/webpack/assets/javascripts/foreman_hosts.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+
+let pluginEditAttributes = {
+  architecture: [],
+  os: [],
+  medium: [],
+  image: []
+};
+
+export function registerPluginAttributes(componentType, attributes) {
+  if (pluginEditAttributes[componentType] !== undefined) {
+    pluginEditAttributes[componentType] = _.uniq(
+      pluginEditAttributes[componentType].concat(attributes));
+  }
+}
+
+export function getAttributesToPost(componentType) {
+  const defaultAttributes = {
+    'architecture': ['architecture_id', 'organization_id', 'location_id'],
+    'os': ['operatingsystem_id', 'organization_id', 'location_id'],
+    'medium': ['medium_id', 'operatingsystem_id', 'architecture_id'],
+    'image': ['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']
+  };
+  let attrsToPost = defaultAttributes[componentType];
+
+  if (attrsToPost === undefined) {
+    return [];
+  }
+  if (pluginEditAttributes[componentType] !== undefined) {
+      attrsToPost = attrsToPost.concat(pluginEditAttributes[componentType]);
+  }
+  return _.uniq(attrsToPost);
+}

--- a/webpack/assets/javascripts/foreman_hosts.test.js
+++ b/webpack/assets/javascripts/foreman_hosts.test.js
@@ -1,0 +1,21 @@
+jest.unmock('./foreman_hosts');
+const hosts = require('./foreman_hosts');
+
+describe('getAttributesToPost', () => {
+    beforeEach(() => {
+      window.tfm = {hosts: {pluginEditAttributes: {}}};
+  });
+
+  it('attribute hash holds the default attributes', () => {
+    let ret = hosts.getAttributesToPost('os');
+
+    expect(ret).toEqual(['operatingsystem_id', 'organization_id', 'location_id']);
+  });
+
+  it('adds the plugin_edit_attributes', () => {
+    hosts.registerPluginAttributes('os', ['foo']);
+    expect(hosts.getAttributesToPost('os')).toEqual(
+                 ['operatingsystem_id', 'organization_id', 'location_id', 'foo']);
+  });
+
+});


### PR DESCRIPTION
Prior to this commit:
Foreman plugins like Katello/Discovery extended the Host edit page
and added fields of their own.
For example
Katello adds things like Content Views, enviroments etc.

However they were unable to get their attibutes passed to the backend
because the os_selected and other "*_selected"  methods do something
like
attrs = attribute_hash(['operatingsystem_id', 'organization_id',
                        'location_id']);
sending a hard coded list. This makes it impossible for plugins to send
more data when things like OS or Medium or image get selected.

This commit does the following:

Updates the Host edit js's os_select and other functions
to use a globally available map to figure out which attributes to
send to the server when one calls "medium_selected" "os_selected" etc.

This will help plugins like Katello and foreman-discovery extend the
global map and add their parameters.

For example all katello would have to do now is to say something like
window.tfm.hosts.pluginEditAttributes.os.push("content_view_id")
window.tfm.hosts.pluginEditAttributes.os.
push("kickstart_repository_id")

and when os gets selected these attributes will be automatically
get sent to server.
