### PR TITLE
fixes #19235 - vmware.rb : add Server 2016 support

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -224,6 +224,7 @@ module Foreman::Model
         "windows8Server64Guest" => "Microsoft Windows Server 2012 (64-bit)",
         "windows9Guest" => "Microsoft Windows 10 (32-bit)",
         "windows9_64Guest" => "Microsoft Windows 10 (64-bit)",
+        "windows9srv-64" => "Microsoft Windows Server 2016 (64-bit)",
         "windows9Server64Guest" => "Microsoft Windows Server Threshhold (64-bit)",
         "windowsHyperVGuest" => "Microsoft Windows Hyper-V",
         "freebsd64Guest" => "FreeBSD (64-bit)",


### PR DESCRIPTION
Add support for Windows 2016 server image based provisionning