### PR TITLE
Fixes #19236 - handle situation when host is destroyed oVirt

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -253,12 +253,8 @@ module Foreman::Model
     end
 
     def destroy_vm(uuid)
-      begin
-        find_vm_by_uuid(uuid).destroy
-      rescue OVIRT::OvirtException => e
-        #404 error are ignored on delete.
-        raise e unless e.message =~ /404/
-      end
+      find_vm_by_uuid(uuid).destroy
+    rescue ActiveRecord::RecordNotFound
       true
     end
 

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -13,6 +13,14 @@ class OvirtTest < ActiveSupport::TestCase
     assert_equal host, as_admin { cr.associated_host(vm) }
   end
 
+  describe "destroy_vm" do
+    it "handles situation when vm is not present" do
+      cr = mock_cr_servers(Foreman::Model::Ovirt.new, empty_servers)
+      cr.expects(:find_vm_by_uuid).raises(ActiveRecord::RecordNotFound)
+      assert cr.destroy_vm('abc')
+    end
+  end
+
   describe "find_vm_by_uuid" do
     it "raises RecordNotFound when the vm does not exist" do
       cr = mock_cr_servers(Foreman::Model::Ovirt.new, empty_servers)


### PR DESCRIPTION
The issue was introduced in 4269abbd, where we replaced the
`OVIRT::OvirtException` error by `ActiveRecord::RecordNotFound` in
`find_vm_by_uuid method`, but we haven't updated the corresponding
`rescue` block in `destroy_vm`.