### PR TITLE
Fixes #17770 - Preserve timestamps for files collected from the system

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -87,16 +87,20 @@ add_file() {
   case $MIME in
         application/x-gzip)
           zcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
+	  touch -c -r "$FILE" "$DIR$FILE.txt"
           ;;
         application/x-bzip2)
           bzcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
+	  touch -c -r "$FILE" "$DIR$FILE.txt"
           ;;
         application/x-xz)
           xzcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
+	  touch -c -r "$FILE" "$DIR$FILE.txt"
           ;;
         text/plain | application/xml)
           sed -r "$FILTER" "$FILE" > "$DIR$FILE"
           [ $PRINTPASS -eq 1 ] && grep -H "+FILTERED+" "$DIR$FILE"
+	  touch -c -r "$FILE" "$DIR$FILE"
           ;;
         *)
           echo "Skipping file $FILE: unknown MIME type $MIME" >> "$DIR/skipped_files"
@@ -125,6 +129,7 @@ add_files() {
       add_file $FILE
       SUMSIZE=$(($((SUMSIZE))+$((SIZE))))
     fi
+    touch -c -r "$SUBDIR" "$DIR$SUBDIR"
   done
 }
 


### PR DESCRIPTION
Uses `touch -r` to use the source file/dir as a reference and replicate timestamps over to the file collected inside foreman-debug archive. `touch -c` ensures that new empty files aren't created if they don't exist.

Ideally only two touch commands should have been necessary, one for collected files and the other for directories. However, it seems like compressed log files are copied over in their uncompressed form with `*.txt` extension, hence I added a third touch command. Let me know what you think.