### PR TITLE
Refs #13772 - ensure ApplicationRecord is loaded soon enough

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,7 @@ end
 # load the corresponding bit of fog
 require 'fog/ovirt' if defined?(::OVIRT)
 
+require_dependency File.expand_path('../../app/models/application_record.rb', __FILE__)
 require_dependency File.expand_path('../../lib/foreman.rb', __FILE__)
 require_dependency File.expand_path('../../lib/timed_cached_store.rb', __FILE__)
 require_dependency File.expand_path('../../lib/foreman/exception', __FILE__)


### PR DESCRIPTION
In `lib/core_extensions.rb` we define as `per_page` method, that gets
called by `will_paginate` at load time of the models. The issue is
we are using `Setting` model there, that inherits from the
`ApplicationRecord` but the `ApplicationRecord` is not loaded yet at
that time, which leads to Rails not knowings it's abstract class
and therefore expecting it to be a base for STI.

After this patch, we require the `ApplicationRecord` soon enough to make
sure it's present before using any other model.