### PR TITLE
Fixes #19265 - Change empty settings value color

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -598,6 +598,10 @@ code.transparent {
   background-color: transparent;
 }
 
+.editable-empty {
+  color: grey;
+}
+
 #parameters {
   .table {
     tr {


### PR DESCRIPTION
Red color may indicates an error, therefore grey color is more suitable:
![empty_setting](https://cloud.githubusercontent.com/assets/11807069/25003274/4426eb4e-2057-11e7-99bb-6f87fef30725.png)
