### PR TITLE
Fixes #19217 - update the close icon to remove icon

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -338,7 +338,7 @@ module FormHelper
   end
 
   def link_to_remove_fields(name, f, options = {})
-    f.hidden_field(:_destroy) + link_to_function(icon_text('close', name, :kind => 'pficon'), "remove_fields(this)", options.merge(:title => _("Remove Parameter")))
+    f.hidden_field(:_destroy) + link_to_function(icon_text('remove', name, :kind => 'pficon'), "remove_fields(this)", options.merge(:title => _("Remove Parameter")))
   end
 
   # Creates a link to a javascript function that creates field entries for the association on the web page

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -16,7 +16,7 @@
           </td>
           <td><%= parameter_value_field inherited_parameters[name] %></td>
           <td>
-            <%= link_to_function(_("override"), "override_param(this)", :title => _("Override this value"),
+            <%= link_to_function(_("Override"), "override_param(this)", :title => _("Override this value"),
                                  :'data-tag' => 'override', :class => "btn btn-default", :id => "override-param-#{name}") if authorized_via_my_scope("host_editing", "create_params") %>
           </td>
         </tr>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -8,7 +8,7 @@
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if authorized %>
-    <%= link_to_remove_fields(_('remove'), f) if f.object.new_record? || authorizer.can?(:destroy_params, f.object) %>
+    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || authorizer.can?(:destroy_params, f.object) %>
   </td>
 </tr>
 <% if f.object.errors.any? %>

--- a/app/views/provisioning_templates/_combination.html.erb
+++ b/app/views/provisioning_templates/_combination.html.erb
@@ -1,5 +1,5 @@
 <div class="fields">
   <%= select_f f, :hostgroup_id, Hostgroup.all, :id, :to_label, {:include_blank => true}, :label => _("Hostgroup") %>
   <%= select_f f, :environment_id, Environment.all, :id, :name, {:include_blank => true},
-    :label => _("Environment"), :help_inline => link_to_remove_fields('', f) %>
+    :label => _("Environment"), :help_inline => link_to_remove_fields('Remove', f) %>
 </div>

--- a/app/views/provisioning_templates/_combinations.html.erb
+++ b/app/views/provisioning_templates/_combinations.html.erb
@@ -1,6 +1,6 @@
-<%= field_set_tag _("Valid host group and environment combinations"), :id => "template_combination" do %>
+<%= field_set_tag _("Valid Host Group and Environment Combinations"), :id => "template_combination" do %>
   <%= f.fields_for :template_combinations do |builder| %>
     <%= render 'provisioning_templates/combination', :f => builder %>
   <% end %>
 <% end %>
-<p><%= link_to_add_fields('+ ' + _("Add combination"), f, :template_combinations, "provisioning_templates/combination", :target => '#template_combination') %></p>
+<p><%= link_to_add_fields('+ ' + _("Add Combination"), f, :template_combinations, "provisioning_templates/combination", :target => '#template_combination') %></p>

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -262,14 +262,14 @@ class HostJSTest < IntegrationTestWithJavascript
       assert page.has_link? '+ Add Parameter'
       click_link '+ Add Parameter'
       assert page.has_no_css? '#new_host_parameter_value[disabled=disabled]'
-      assert page.has_link? 'remove'
-      click_link 'remove'
+      assert page.has_link? 'Remove'
+      click_link 'Remove'
 
       assert page.has_css? 'a#override-param-a_parameter'
       find(:css, 'a#override-param-a_parameter').click
 
       assert page.has_no_css? '#new_host_parameter_value[disabled=disabled]'
-      assert page.has_link? 'remove'
+      assert page.has_link? 'Remove'
     end
   end
 

--- a/test/integration/parameters_permissions_test.rb
+++ b/test/integration/parameters_permissions_test.rb
@@ -122,7 +122,7 @@ class ParametersPermissionsIntegrationTest < ActionDispatch::IntegrationTest
   def assert_domain_parameter_can_be_deleted(domain, parameter)
     visit edit_domain_path(domain)
     within("tr#domain_parameter_#{parameter.id}_row") do
-      assert page.has_link?('remove')
+      assert page.has_link?('Remove')
       # click_link 'remove' (we don't want to use JS here)
       hidden = find(:css, "#domain_domain_parameters_attributes_0__destroy", :visible => false)
       hidden.set '1'


### PR DESCRIPTION
In "Add Parameters[1]" and "Add Combinations[2]" pages, we noticed there are "Remove" icons, but currently using the Close icon, based on the icon guideline, we suggest to use the right icon for correct meaning.
Please check the Before&After attachment as below:
![close-remove](https://cloud.githubusercontent.com/assets/701009/25033135/4f603874-210d-11e7-96cc-d6783033604c.png)




[1]Create Host -> Parameters -> Add Parameters
[2]Provisioning Template -> Association -> Add Combinations

P.S. When doing the icon updating, I also modified the capitalization matters.
