### PR TITLE
Fixes #19288 - word button instead of icon button

### DIFF
--- a/app/views/fact_values/_fact.html.erb
+++ b/app/views/fact_values/_fact.html.erb
@@ -24,7 +24,7 @@
   <td class='fact-origin'><%= fact_origin_icon(fact.origin) %></td>
   <td><%= fact_from fact %></td>
   <td><% unless fact.compose %>
-          <%= link_to_function(content_tag(:button, icon_text("adjust", "")),
+          <%= link_to_function(content_tag(:span, "View Chart", :class => "btn btn-sm btn-default"),
                                "get_pie_chart('fact_chart-#{fact.fact_name_id}', '#{fact_path(fact.fact_name_id)}')",
                                :title => _("Show distribution chart")) %>
       <% end %>


### PR DESCRIPTION
before: 
![image](https://cloud.githubusercontent.com/assets/15361156/25098545/a7c815b2-23b1-11e7-9a23-d71c21ec2f11.png)

after: 
![image](https://cloud.githubusercontent.com/assets/15361156/25098568/c1f773f6-23b1-11e7-83fd-3b36eb07e944.png)

