### PR TITLE
Fixes 19298 - Use chevron instead of colons for breadcrumbs

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -10,20 +10,22 @@ module FactValuesHelper
     memo       = ''
     name       = name.split(FactName::SEPARATOR).map do |current_name|
       memo = memo.empty? ? current_name : memo + FactName::SEPARATOR + current_name
-      if parent.present? && h(parent.name) == memo
-        current_name
-      else
-        if value_name != memo || value.compose
-          parameters = { :parent_fact => memo }
-          url = host_parent_fact_facts_path(parameters.merge({ :host_id => params[:host_id] || value.host.name }))
-          link_to(current_name, url,
-                  :title => _("Show all %s children fact values") % memo)
+      content_tag(:li) do
+        if parent.present? && h(parent.name) == memo
+          current_name
         else
-          link_to(current_name, fact_values_path(:search => "name = #{value_name}"),
-                  :title => _("Show %s fact values for all hosts") % value_name)
+          if value_name != memo || value.compose
+            parameters = { :parent_fact => memo }
+            url = host_parent_fact_facts_path(parameters.merge({ :host_id => params[:host_id] || value.host.name }))
+            link_to(current_name, url,
+                    :title => _("Show all %s children fact values") % memo)
+          else
+            link_to(current_name, fact_values_path(:search => "name = #{value_name}"),
+                    :title => _("Show %s fact values for all hosts") % value_name)
+          end
         end
       end
-    end.join(FactName::SEPARATOR).html_safe
+    end.join.html_safe
 
     if value.compose
       url = host_parent_fact_facts_path(:parent_fact => value_name, :host_id => params[:host_id] || value.host.name)
@@ -36,11 +38,11 @@ module FactValuesHelper
   def show_full_fact_value(fact_value)
     content_tag(:div, :class => 'replace-hidden-value') do
       link_to_function(icon_text('plus', '', :class => 'small'), 'replace_value_control(this)',
-               :title => _('Show full value'),
-               :class => 'replace-hidden-value pull-right') +
-      content_tag(:span, :class => 'full-value') do
-        fact_value
-      end
+                       :title => _('Show full value'),
+                       :class => 'replace-hidden-value pull-right') +
+          content_tag(:span, :class => 'full-value') do
+            fact_value
+          end
     end.html_safe
   end
 

--- a/app/views/fact_values/_fact.html.erb
+++ b/app/views/fact_values/_fact.html.erb
@@ -9,7 +9,8 @@
       </td>
   <% end %>
   <td>
-    <%= fact_name(fact, parent) %>
+    <%= content_tag(:ol, fact_name(fact, parent), :class => "breadcrumb") %>
+
   </td>
   <td class="fact-col">
     <% unless fact.compose %>


### PR DESCRIPTION
before: 
![colons](https://cloud.githubusercontent.com/assets/15361156/25134828/4efa41b4-2459-11e7-9266-293bd627ec05.png)

after:
![chevron](https://cloud.githubusercontent.com/assets/15361156/25134878/6d115444-2459-11e7-9c8c-9f6a3a2f040c.png)
