### PR TITLE
fixes #19303 - adds jest watch mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ || exit 0",
     "test": "node --harmony_proxies node_modules/.bin/jest",
+    "test:watch": "node --harmony_proxies node_modules/.bin/jest --watchAll",
     "storybook": "start-storybook --dont-track -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
This patch allows javascript tests to continusly run when
developing webpack features, to run execute
```npm run test:watch```