### PR TITLE
Fixes #19325 - Adding VMware SCSI Controller ID Selection to volumes

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -31,6 +31,8 @@ module FogExtensions
       end
 
       def scsi_controller_type
+        # if the scsi_controller is a array, we are using the first to get the type
+        return scsi_controller.first[:type] if scsi_controller.is_a?(Array)
         return scsi_controller[:type] if scsi_controller.is_a?(Hash)
         scsi_controller.type
       end

--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -24,3 +24,4 @@
            "true",
            "false" %>
 <%= select_f f, :mode, compute_resource.disk_mode_types, :first, :last, { }, :class => "span5", :label => _("Disk mode"), :label_size => "col-md-2", :disabled => !new_host %>
+<%= select_f f, :controller_key, compute_resource.controller_ids, :first, :last, { }, :class => "span5", :label => _("SCSI Controller ID"), :label_size => "col-md-2" , :disabled => !new_vm %>


### PR DESCRIPTION
Adding VMware vSphere SCSI Controller ID Selection to volumes

Replaces previous PR #4471 (cleaned up and rebased)