### PR TITLE
Fixes #19357 - update the edit icon in hostgroup os edit page

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -28,7 +28,7 @@ module FormHelper
              title="'.html_safe + _('Caps lock ON') +
               '" style="display:none"></span>'.html_safe
           if unset_button
-            button = link_to_function(icon_text('pencil'), 'toggle_input_group(this)', {:id => 'disable-pass-btn', :class => 'btn btn-default', :title => _("Change the password")})
+            button = link_to_function(icon_text("edit", "", :kind => "pficon"), 'toggle_input_group(this)', {:id => 'disable-pass-btn', :class => 'btn btn-default', :title => _("Change the password")})
             input_group(pass, input_group_btn(button))
           else
             pass


### PR DESCRIPTION
Updating the edit icon in HostGroup Operation System Edit Page.
Updating the edit icon from Bootstrap icon to PatternFly icon.

Please check the before vs after attachment.
![edit-root-password](https://cloud.githubusercontent.com/assets/701009/25331057/4a688196-2914-11e7-87be-fdff9af4fdc1.png)
