### PR TITLE
Do not ignore updated classes

### DIFF
--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -94,7 +94,7 @@ namespace :puppet do
         exit 1
       end
 
-      if changes["new"].empty? and changes["obsolete"].empty?
+      if changes["new"].empty? and changes["obsolete"].empty? and changes["updated"].empty?
         puts "No changes detected" unless args.batch
       else
         unless args.batch


### PR DESCRIPTION
When running foreman-rake puppet:import:puppet_classes classes that changed their parameters are ignored.
Do not ignore classes that changed parameters in
 puppet:import:puppet_classes task

Was this ignored for a reason or just forgot?