### PR TITLE
Fixes #19377 - available_flavors for OpenStack

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -9,6 +9,8 @@ module Foreman::Model
     validates :user, :password, :presence => true
     validates :allow_external_network, inclusion: { in: [true, false] }
 
+    alias_method :available_flavors, :flavors
+
     SEARCHABLE_ACTIONS = [:server_group_anti_affinity, :server_group_affinity, :raw]
 
     def provided_attributes


### PR DESCRIPTION
fixes GET /api/v2/compute_resources/:id/available_flavors resulting in
"Not implemented for OpenStack".