### PR TITLE
Fixes #19400 - deffer loading of tables list cache

### DIFF
--- a/app/validators/bookmark_controller_validator.rb
+++ b/app/validators/bookmark_controller_validator.rb
@@ -1,7 +1,17 @@
 class BookmarkControllerValidator < ActiveModel::EachValidator
-  @@active_record_tables = ActiveRecord::Base.connection.tables.map(&:to_s)
   def validate_each(record, attribute, value)
-    controllers = ["dashboard"] + (@@active_record_tables + Permission.resources.map {|x| x.tableize }).uniq
-    record.errors[attribute] << _("%{value} is not a valid controller") % {:value => value } unless controllers.include?(value)
+    unless self.class.valid_controllers_list.include?(value)
+      record.errors[attribute] << _("%{value} is not a valid controller") % {:value => value }
+    end
+  end
+
+  def self.valid_controllers_list
+    @valid_controllers_list ||= (["dashboard"] +
+      ActiveRecord::Base.connection.tables.map(&:to_s) +
+      Permission.resources.map(&:tableize)).uniq
+  end
+
+  def self.reset_controllers_list
+    @valid_controllers_list = nil
   end
 end

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -37,6 +37,7 @@ class BookmarkTest < ActiveSupport::TestCase
     FactoryGirl.create(:permission, :resource_type => 'ProvisioningTemplate', :name => 'manage_provisioning_templates')
     FactoryGirl.create(:permission, :resource_type => 'MyPlugin', :name => 'view_my_plugins')
     Permission.reset_resources
+    BookmarkControllerValidator.reset_controllers_list
     b = FactoryGirl.build(:bookmark, :name => 'STI controller', :controller => 'provisioning_templates', :query => 'foo=bar', :public => true)
     assert(b.valid?, 'STI controller bookmark should be valid')
     b = FactoryGirl.build(:bookmark, :name => 'My plugin controller', :controller => 'my_plugins', :query => 'foo=bar', :public => true)


### PR DESCRIPTION
The BookmarkControllerValidator can get loaded sooner than the tables are
loaded (especially in tests).