### PR TITLE
Fixes #19372 - replace children fact values icon

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -17,7 +17,7 @@ module FactValuesHelper
 
     if value.compose
       url = host_parent_fact_facts_path(:parent_fact => value_name, :host_id => params[:host_id] || value.host.name)
-      link_to(icon_text('plus-sign','', :title => _('Expand nested items')), url) + ' ' + name
+      link_to(icon_text('angle-down', '', :kind => 'fa', :title => _('Expand nested items')), url) + ' ' + content_tag(:span, name)
     else
       name
     end


### PR DESCRIPTION
before: 
![plus_icon](https://cloud.githubusercontent.com/assets/15361156/25562273/cab26398-2d89-11e7-9b31-1cdf4f5c7aaa.png)

after:
![zoom_in](https://cloud.githubusercontent.com/assets/15361156/25562276/d86269f2-2d89-11e7-9523-b7c5c1607b8e.png)

@rohoover what do you think?
