### PR TITLE
Fixes #19436 - Better controller selection on host dropdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -209,7 +209,8 @@ module ApplicationHelper
   end
 
   def method_path(method)
-    send("#{method}_#{controller_name}_path")
+    controller = controller_name.start_with?('compute') ? 'hosts' : controller_name
+    send("#{method}_#{controller}_path")
   end
 
   def edit_textfield(object, property, options = {})

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -482,9 +482,4 @@ module HostsHelper
   def power_status_visible?
     SETTINGS[:unattended] && Setting[:host_power_status]
   end
-
-  def host_or_hostgroup_path(method)
-    controller = controller_name == 'hostgroups' ? 'hostgroups' : 'hosts'
-    send("#{method}_#{controller}_path")
-  end
 end

--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -4,6 +4,6 @@
     { :label => _("Operating system"),
       :disabled => arch_oss.empty? ? true : false,
       :help_inline => :indicator,
-      :onchange => 'os_selected(this);', :'data-url' => host_or_hostgroup_path('os_selected'), :'data-type' => controller_name.singularize, :required => true}
+      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize, :required => true}
   %>
 <% end %>

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -2,7 +2,7 @@
   <%= select_f f, :medium_id, os_media, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
     {:label => _("Media"), :disabled => os_media.empty?,
-     :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' => host_or_hostgroup_path('medium_selected'),
+     :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' => method_path('medium_selected'),
      :'data-type' => controller_name.singularize, :required => true }
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -1,6 +1,6 @@
 
 <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => true},
-    {:onchange => 'architecture_selected(this);', :'data-url' => host_or_hostgroup_path('architecture_selected'), :'data-type' => controller_name.singularize,
+    {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' => controller_name.singularize,
     :help_inline => :indicator, :required => true} %>
 
 <span id="os_select">


### PR DESCRIPTION
Always setting to `host` unless the controller is `hostgroup` broke
discovery's usage of the form as it uses the `discoverd_host`
controller.