### PR TITLE
fixes #19437 - remove duplicate Rails.cache.clear calls

### DIFF
--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -7,14 +7,14 @@ class ActiveSupport::TestCase
   set_fixture_class :nics => Nic::BMC
 
   setup :begin_gc_deferment
-  setup :reset_setting_cache
+  setup :reset_rails_cache
   setup :skip_if_plugin_asked_to
   setup :set_admin
 
   teardown :reconsider_gc_deferment
   teardown :clear_current_user
   teardown :clear_current_taxonomies
-  teardown :reset_setting_cache
+  teardown :reset_rails_cache
 
   DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 1.0).to_f
 
@@ -54,8 +54,8 @@ class ActiveSupport::TestCase
     Organization.current = nil
   end
 
-  def reset_setting_cache
-    Setting.cache.clear
+  def reset_rails_cache
+    Rails.cache.clear
   rescue Errno::ENOENT
     # Clear on a file cache fails on a clean checkout when the cache hasn't been written to.
     # This rescue may be removed on Rails 5 (16d7cfb fixes it).

--- a/test/unit/compute_resource_cache_test.rb
+++ b/test/unit/compute_resource_cache_test.rb
@@ -1,14 +1,6 @@
 require 'test_helper'
 
 class ComputeResourceCacheTest < ActiveSupport::TestCase
-  setup do
-    Rails.cache.clear
-  end
-
-  teardown do
-    Rails.cache.clear
-  end
-
   let(:compute_resource) { compute_resources(:vmware) }
   let(:cache) { ComputeResourceCache.new(compute_resource) }
 

--- a/test/unit/proxy_statuses/proxy_status_tftp_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_tftp_test.rb
@@ -19,7 +19,6 @@ class ProxyStatusTftpTest < ActiveSupport::TestCase
   end
 
   test 'it does not cache tftp_server if set to false' do
-    Rails.cache.clear
     ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns('127.13.0.1')
     tftp_server = ProxyStatus::TFTP.new(@proxy, {:cache => false}).server
     assert_equal('127.13.0.1', tftp_server)

--- a/test/unit/proxy_statuses/proxy_status_versions_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_versions_test.rb
@@ -19,7 +19,6 @@ class ProxyStatusVersionsTest < ActiveSupport::TestCase
   end
 
   test 'it does not cache versions when set not to' do
-    Rails.cache.clear
     versions = ProxyStatus::Version.new(@proxy, {:cache => false}).versions
     assert_equal(@expected_versions, versions)
     assert_nil(Rails.cache.fetch("proxy_#{@proxy.id}/Version"))


### PR DESCRIPTION
Rely on the default cache clear in the AS test helper, which catches
errors from Rails when the file cache doesn't exist yet.