### PR TITLE
Fixes #19475 - Rename test variables to more specific term

### DIFF
--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -17,40 +17,40 @@ class ImageTest < ActiveSupport::TestCase
   end
 
   context "audits for password change" do
-    let(:image) { FactoryGirl.build(:image, :compute_resource => FactoryGirl.create(:compute_resource, :libvirt)) }
+    let(:protected_image) { FactoryGirl.build(:image, :compute_resource => FactoryGirl.create(:compute_resource, :libvirt)) }
 
     test "audit of password change should be saved only once, second time audited changes should not contain password_changed" do
       as_admin do
-        image.password = "newpassword"
-        assert_valid image
-        assert image.password_changed_changed?
-        assert image.password_changed
-        assert_includes image.changed, "password_changed"
-        assert image.save
+        protected_image.password = "newpassword"
+        assert_valid protected_image
+        assert protected_image.password_changed_changed?
+        assert protected_image.password_changed
+        assert_includes protected_image.changed, "password_changed"
+        assert protected_image.save
         #testing after_save
-        refute image.password_changed_changed?
-        refute image.password_changed
-        refute_includes image.changed, "password_changed"
+        refute protected_image.password_changed_changed?
+        refute protected_image.password_changed
+        refute_includes protected_image.changed, "password_changed"
       end
     end
 
     test "audit of password change should be saved" do
       as_admin do
-        assert image.save
-        image.password = "newpassword"
-        assert image.save
-        assert_includes image.audits.last.audited_changes, "password_changed"
+        assert protected_image.save
+        protected_image.password = "newpassword"
+        assert protected_image.save
+        assert_includes protected_image.audits.last.audited_changes, "password_changed"
       end
     end
 
     test "audit of password change should not be saved - due to no password change" do
       as_admin do
-        image.name = image.name + '_changed'
-        refute image.password_changed_changed?
-        refute image.password_changed
-        refute_includes image.changed, "password_changed"
-        assert image.save
-        refute_includes image.audits.last.audited_changes, "password_changed"
+        protected_image.name = protected_image.name + '_changed'
+        refute protected_image.password_changed_changed?
+        refute protected_image.password_changed
+        refute_includes protected_image.changed, "password_changed"
+        assert protected_image.save
+        refute_includes protected_image.audits.last.audited_changes, "password_changed"
       end
     end
   end

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -102,7 +102,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
     let(:compute_resource) { FactoryGirl.create(:openstack_cr) }
     let(:compute) { compute_resource.send(:client) }
     let(:flavor) { compute.flavors.first.id }
-    let(:image) { compute.images.first.id }
+    let(:os_image) { compute.images.first.id }
     let(:floating_ip) do
       compute.allocate_address('f0000000-0000-0000-0000-000000000000').body["floating_ip"]["ip"].to_s
     end
@@ -110,7 +110,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
       compute.servers.new(
         :name       => 'test.example.com',
         :flavor_ref => flavor,
-        :image_ref  => image
+        :image_ref  => os_image
       )
     end
     setup do
@@ -147,12 +147,12 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
     let(:uuid) { '52b9406e-cf66-4867-8655-719a094e324c' }
     let(:compute) { compute_resource.send(:client) }
     let(:flavor) { compute.flavors.first.id }
-    let(:image) { compute.images.first.id }
+    let(:os_image) { compute.images.first.id }
     let(:vm) do
       compute.servers.new(
         :name         => 'test.example.com',
         :flavor_id    => flavor,
-        :image_id     => image,
+        :image_id     => os_image,
         :ipv4_address => '192.168.100.1',
         :ipv6_address => '2001:db8::1'
       )


### PR DESCRIPTION
An issue occurring with a recent minitest upgrade broke tests.
Renaming variables set with let to a less ambiguous wording is
to work around the issue.

**Note:** CI might be green, but test might not have been run in a way that they are failing. For the tests to fail the foreman-docker plugin needs to be installed to cause a failure (see http://ci.theforeman.org/job/test_plugin_matrix/database=postgresql,ruby=2.0.0,slave=fast/3027/console). To verify the patch best is to run tests locally in develop with the plugin included, which should fail, if the minitest is at the latest. The same tests should pass in this branch with the plugin included as well.