### PR TITLE
Require fog subprojects instead of fog

### DIFF
--- a/bundler.d/fog.rb
+++ b/bundler.d/fog.rb
@@ -1,3 +1,4 @@
 group :fog do
-  gem 'fog', '1.38.0', :require => false
+  gem 'fog-aws', '1.3.0', :require => false
+  gem 'fog-google', '0.5.2', :require => false
 end


### PR DESCRIPTION
In response to https://github.com/fog/fog-google/issues/158, update your fog dependency to include modern versions of fog.