### PR TITLE
Fixes #19459 -  improve vm boot failure feedback

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -329,6 +329,10 @@ class ComputeResource < ApplicationRecord
     vm_attrs
   end
 
+  def vm_ready(vm)
+    vm.wait_for { self.ready? }
+  end
+
   def user_data_supported?
     false
   end

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -139,6 +139,11 @@ module Foreman::Model
       raise message
     end
 
+    def vm_ready(vm)
+      vm.wait_for { self.ready? || self.failed? }
+      raise Foreman::Exception.new(N_("Failed to deploy vm %{name}, fault: %{e}"), { :name => vm.name, :e => vm.fault['message'] }) if vm.failed?
+    end
+
     def destroy_vm(uuid)
       vm           = find_vm_by_uuid(uuid)
       floating_ips = vm.all_addresses

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -149,7 +149,7 @@ module Orchestration::Compute
     attrs = compute_resource.provided_attributes
     if attrs.keys.include?(:ip) || attrs.keys.include?(:ip6)
       logger.info "Waiting for #{name} to become ready"
-      vm.wait_for { self.ready? }
+      compute_resource.vm_ready vm
       logger.info "waiting for instance to acquire ip address"
       vm.wait_for do
         (attrs.keys.include?(:ip) && self.send(attrs[:ip]).present?) ||


### PR DESCRIPTION
To be able to override the wait for vm ready we need to move
it to compute resource definition. Also improve Openstack one