### PR TITLE
Add rdoc to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'webpack-rails', '~> 0.9.8'
 gem 'mail', '~> 2.6'
 gem 'nokogiri', '< 1.7' if RUBY_VERSION.start_with? '2.0.'
 gem 'sshkey', '~> 1.9'
+gem 'rdoc'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))


### PR DESCRIPTION
CentOS7 minimal installer fails without it