### PR TITLE
fixes #19463 - disable auditing of factory_girl fixtures

### DIFF
--- a/test/factories/disable_auditing.rb
+++ b/test/factories/disable_auditing.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  # Default to disabling auditing when saving new models to reduce database
+  # work and speed up tests. Add the :with_auditing global trait to enable it.
+  trait :with_auditing do
+    before(:create) do |instance, evaluator|
+      instance.instance_variable_set(:@_factory_girl_with_auditing, true)
+    end
+  end
+
+  to_create do |instance|
+    with_auditing = !!instance.instance_variable_get(:@_factory_girl_with_auditing) # default to no auditing
+    if instance.respond_to?(:without_auditing) && !with_auditing
+      instance.without_auditing { instance.save! }
+    else
+      instance.save!
+    end
+  end
+end

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -15,7 +15,7 @@ class AuditExtensionsTest < ActiveSupport::TestCase
   end
 
   test "host scoped search for audit works" do
-    resource = FactoryGirl.create(:host, :managed)
+    resource = FactoryGirl.create(:host, :managed, :with_auditing)
     assert Audit.search_for("host = #{resource.name}").count > 0
   end
 
@@ -38,12 +38,12 @@ class AuditExtensionsTest < ActiveSupport::TestCase
 
   test "search for type=lookupvalue in audit" do
     key = lookup_keys(:three)
-    FactoryGirl.create :lookup_value, :lookup_key_id => key.id, :value => false, :match => "hostgroup=Common"
+    FactoryGirl.create :lookup_value, :with_auditing, :lookup_key_id => key.id, :value => false, :match => "hostgroup=Common"
     refute_empty Audit.search_for("type = override_value")
   end
 
   test "search for type=compute_resource in audit" do
-    FactoryGirl.create(:ec2_cr)
+    FactoryGirl.create(:ec2_cr, :with_auditing)
     refute_empty Audit.search_for("type = compute_resource")
   end
 end

--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -123,7 +123,7 @@ class LookupValueTest < ActiveSupport::TestCase
     key = pc.class_params.first
     lvalue = nil
     assert_difference('Audit.count') do
-      lvalue = FactoryGirl.create :lookup_value, :lookup_key_id => key.id, :value => 'test', :match => 'os=bar'
+      lvalue = FactoryGirl.create :lookup_value, :with_auditing, :lookup_key_id => key.id, :value => 'test', :match => 'os=bar'
     end
     assert_equal "#{pc.name}::#{key.key}", lvalue.audits.last.associated_name
   end


### PR DESCRIPTION
Audit entries are mostly superfluous in the test environment, but can
be enabled by adding the :with_auditing trait. Disabling audits
improves the test:models runtime from 160 to 128 seconds for me.