### PR TITLE
Fixes #17771 - Test if rsync successfully uploaded tarball

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -377,10 +377,15 @@ fi
 # upload if -u was passed in
 if [ $UPLOAD_DISABLED -eq 0 -a $UPLOAD -eq 1 ]; then
   qprintf "Uploading...\n"
-  rsync $TARBALL rsync://theforeman.org/debug-incoming
-  qprintf "The tarball has been uploaded, please contact us on our mailing list or IRC\n"
-  qprintf "referencing the following URL:\n\n"
-  qprintf "    http://debugs.theforeman.org/$(basename $TARBALL)\n\n"
+  if rsync $TARBALL rsync://theforeman.org/debug-incoming ; then
+    qprintf "The tarball has been uploaded, please contact us on our mailing list or IRC\n"
+    qprintf "referencing the following URL:\n\n"
+    qprintf "    http://debugs.theforeman.org/$(basename $TARBALL)\n\n"
+  else
+    error "The tarball could not be uploaded, please upload it to an alternate location"
+    error "and contact us on our mailing list or IRC referencing that URL."
+    exit 3
+  fi
 else
   [[ $UPLOAD_DISABLED -eq 0 ]] && qprintf "To upload a tarball to our secure site, please use the -u option.\n"
 fi


### PR DESCRIPTION
This PR checks if rsync executed successfully and only then it prints a success message, along with http url for the uploaded foreman-debug archive.

Upon failure, I've also added a suggestion to upload to an alternate location. Let me know if this suggestion is reasonable, or else I'll remove it.