### PR TITLE
Fixes #10273 - Clone disk from template when preallocate marked

### DIFF
--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem 'fog-ovirt', '~> 0.1.2'
+  gem 'fog-ovirt', '~> 0.1.3'
 end


### PR DESCRIPTION
This won't work without a fix in fog.
The `attributes` here: https://github.com/fog/fog-core/blob/master/lib/fog/core/attributes.rb#L69 is not a `HashWithIndifferentAccess`.
As a result the options to use when building the vm: https://github.com/abenari/rbovirt/blob/master/lib/client/vm_api.rb#L58 will contain the keys `clone` and `disks` as strings which will prevent them from being part of the xml that is sent to ovirt: https://github.com/abenari/rbovirt/blob/master/lib/ovirt/vm.rb#L111-L117