### PR TITLE
fixes #19479, #10587 notifications now works with two-pane again

### DIFF
--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -136,6 +136,7 @@ function hide_columns(){
     $('.table-two-pane').wrap( "<div class='row'><div class='col-md-3 two-pane-left'></div></div>");
   }
   tfm.tools.showSpinner();
+  tfm.toastNotifications.clear()
   $('.two-pane-left').after("<div class='col-md-9 two-pane-right'></div>");
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -160,16 +160,25 @@ class ApplicationController < ActionController::Base
                        end
   end
 
-  def notice(notice)
-    flash[:notice] = CGI.escapeHTML(notice)
+  def notice(message, now = false)
+    flash_message(:notice, message, now)
   end
 
-  def error(error)
-    flash[:error] = CGI.escapeHTML(error)
+  def error(message, now = false)
+    flash_message(:error, message, now)
   end
 
-  def warning(warning)
-    flash[:warning] = CGI.escapeHTML(warning)
+  def warning(message, now = false)
+    flash_message(:warning, message, now)
+  end
+
+  def flash_message(type, message, now = false)
+    message = CGI.escapeHTML(message)
+    if now
+      flash.now[type] = message
+    else
+      flash[type] = message
+    end
   end
 
   # this method is used with nested resources, where obj_id is passed into the parameters hash.
@@ -294,7 +303,7 @@ class ApplicationController < ActionController::Base
     hash[:error_msg] ||= [hash[:object].errors[:base] + hash[:object].errors[:conflict].map{|e| _("Conflict - %s") % e}].flatten
     hash[:error_msg] = [hash[:error_msg]].flatten.to_sentence
     if hash[:render]
-      flash.now[:error] = CGI.escapeHTML(hash[:error_msg]) unless hash[:error_msg].empty?
+      error(hash[:error_msg], true) unless hash[:error_msg].empty?
       render hash[:render]
     elsif hash[:redirect]
       error(hash[:error_msg]) unless hash[:error_msg].empty?
@@ -335,7 +344,7 @@ class ApplicationController < ActionController::Base
                              elsif session[:organization_id]
                                orgs.find_by_id(session[:organization_id])
                              end
-      warning _("Organization you had selected as your context has been deleted.") if (session[:organization_id] && Organization.current.nil?)
+      warning _("Organization you had selected as your context has been deleted") if (session[:organization_id] && Organization.current.nil?)
     end
 
     if SETTINGS[:locations_enabled]
@@ -345,7 +354,7 @@ class ApplicationController < ActionController::Base
                          elsif session[:location_id]
                            locations.find_by_id(session[:location_id])
                          end
-      warning _("Location you had selected as your context has been deleted.") if (session[:location_id] && Location.current.nil?)
+      warning _("Location you had selected as your context has been deleted") if (session[:location_id] && Location.current.nil?)
     end
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -23,7 +23,7 @@ class BookmarksController < ApplicationController
   def create
     @bookmark = Bookmark.new(bookmark_params)
     if @bookmark.save
-      redirect_to send("#{@bookmark.controller}_path"), :notice => _('Bookmark was successfully created.')
+      redirect_to send("#{@bookmark.controller}_path"), :notice => _('Bookmark was successfully created')
     else
       render :action => "new"
     end
@@ -31,7 +31,7 @@ class BookmarksController < ApplicationController
 
   def update
     if @bookmark.update_attributes(bookmark_params)
-      redirect_to(bookmarks_path, :notice => _('Bookmark was successfully updated.'))
+      redirect_to(bookmarks_path, :notice => _('Bookmark was successfully updated'))
     else
       render :action => "edit"
     end

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -23,7 +23,7 @@ module Foreman::Controller::Authentication
         @available_sso ||= SSO::Base.new(self)
         if session[:user] && !User.current
           backup_session_content { reset_session }
-          flash[:warning] = _('Your session has expired, please login again')
+          warning _('Your session has expired, please login again')
         end
         return if @available_sso.has_rendered
         redirect_to @available_sso.login_url

--- a/app/controllers/concerns/foreman/controller/environments.rb
+++ b/app/controllers/concerns/foreman/controller/environments.rb
@@ -12,7 +12,7 @@ module Foreman::Controller::Environments
 
     rescue => e
       if e.message =~ /puppet feature/i
-        error _("No smart proxy was found to import environments from, ensure that at least one smart proxy is registered with the 'puppet' feature.")
+        error _("No smart proxy was found to import environments from, ensure that at least one smart proxy is registered with the 'puppet' feature")
         redirect_to :controller => controller_path
       else
         raise e
@@ -20,7 +20,7 @@ module Foreman::Controller::Environments
     end
 
     if @importer.ignored_boolean_environment_names?
-      warning(_("Ignored environment names resulting in booleans found. Please quote strings like true/false and yes/no in config/ignored_environments.yml."))
+      warning(_("Ignored environment names resulting in booleans found. Please quote strings like true/false and yes/no in config/ignored_environments.yml"))
     end
 
     if @changed["new"].size > 0 || @changed["obsolete"].size > 0 || @changed["updated"].size > 0

--- a/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
@@ -150,13 +150,13 @@ module Foreman::Controller::Puppet::HostsControllerExtensions
 
     if failed_hosts.empty?
       if proxy
-        notice _('The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}.') % {:proxy_name => proxy.name, :proxy_type => proxy_type}
+        notice _('The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}') % {:proxy_name => proxy.name, :proxy_type => proxy_type}
       else
         notice _('The %{proxy_type} proxy of the selected hosts was cleared.') % {:proxy_type => proxy_type}
       end
     else
       error n_("The %{proxy_type} proxy could not be set for host: %{host_names}.",
-               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}.",
+               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}",
                failed_hosts.count) % {:proxy_type => proxy_type, :host_names => failed_hosts.map {|h, err| "#{h} (#{err})"}.to_sentence}
     end
     redirect_back_or_to hosts_path
@@ -171,7 +171,7 @@ module Foreman::Controller::Puppet::HostsControllerExtensions
       end
     else
       error n_("The %{proxy_type} proxy could not be set for host: %{host_names}.",
-               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}.",
+               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}",
                errors.count) % {:proxy_type => proxy_type, :host_names => errors.map {|h, err| "#{h} (#{err})"}.to_sentence}
     end
   end

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -37,7 +37,7 @@ module Foreman::Controller::Session
     else
       sso = get_sso_method
       if sso.nil? || !sso.support_expiration?
-        flash[:warning] = _("Your session has expired, please login again")
+        warning _("Your session has expired, please login again")
         redirect_to main_app.login_users_path
       else
         redirect_to sso.expiration_url

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -93,7 +93,7 @@ class HostsController < ApplicationController
     @clone_host = @host
     @host = @clone_host.clone
     load_vars_for_ajax
-    flash[:warning] = _("The marked fields will need reviewing")
+    warning(_("The marked fields will need reviewing"), true)
     @host.valid?
   end
 
@@ -393,7 +393,7 @@ class HostsController < ApplicationController
 
   def update_multiple_parameters
     if params[:name].empty?
-      notice _("No parameters were allocated to the selected hosts, can't mass assign.")
+      notice _("No parameters were allocated to the selected hosts, can't mass assign")
       redirect_to hosts_path
       return
     end
@@ -511,7 +511,7 @@ class HostsController < ApplicationController
     end
 
     if message.blank?
-      notice _('Configuration successfully rebuilt.')
+      notice _('Configuration successfully rebuilt')
     else
       error message
     end
@@ -878,13 +878,13 @@ class HostsController < ApplicationController
 
     if failed_hosts.empty?
       if proxy
-        notice _('The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}.') % {:proxy_name => proxy.name, :proxy_type => proxy_type}
+        notice _('The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}') % {:proxy_name => proxy.name, :proxy_type => proxy_type}
       else
-        notice _('The %{proxy_type} proxy of the selected hosts was cleared.') % {:proxy_type => proxy_type}
+        notice _('The %{proxy_type} proxy of the selected hosts was cleared') % {:proxy_type => proxy_type}
       end
     else
       error n_("The %{proxy_type} proxy could not be set for host: %{host_names}.",
-               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}.",
+               "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}",
                failed_hosts.count) % {:proxy_type => proxy_type, :host_names => failed_hosts.map {|h, err| "#{h} (#{err})"}.to_sentence}
     end
     redirect_back_or_to hosts_path

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -69,7 +69,7 @@ class SubnetsController < ApplicationController
     proxy = SmartProxy.find(params[:smart_proxy_id])
     @subnets = Subnet::Ipv4.import(proxy)
     if @subnets.empty?
-      flash[:warning] = _("No new IPv4 subnets found")
+      warning _("No new IPv4 subnets found")
       redirect_to :subnets
     end
   end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -26,7 +26,7 @@ class TemplatesController < ApplicationController
     @template = @template.dup
     @template.locked = false
     load_vars_from_template
-    flash[:warning] = _("The marked fields will need reviewing")
+    warning(_("The marked fields will need reviewing"), true)
     @template.valid?
     render :action => :new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,7 +49,7 @@ class UsersController < ApplicationController
   def destroy
     @user = find_resource(:destroy_users)
     if @user == User.current
-      notice _("You cannot delete this user while logged in as this user.")
+      warning _("You cannot delete this user while logged in as this user")
       redirect_to :back
       return
     end

--- a/app/views/layouts/_application_content.html.erb
+++ b/app/views/layouts/_application_content.html.erb
@@ -1,6 +1,6 @@
 <div id="main">
-  <%= notifications %>
   <div id="content" class="container">
+    <%= notifications %>
     <% unless @page_header.blank? %>
       <div class="row form-group">
         <h1 class="col-md-8"><%=h @page_header %></h1>

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -185,7 +185,7 @@ class EnvironmentsControllerTest < ActionController::TestCase
    PuppetClassImporter.any_instance.stubs(:ignored_environments).returns([true])
 
    get :import_environments, {:proxy => smart_proxies(:puppetmaster)}, set_session_user
-   assert_equal "Ignored environment names resulting in booleans found. Please quote strings like true/false and yes/no in config/ignored_environments.yml.", flash[:warning]
+   assert_equal "Ignored environment names resulting in booleans found. Please quote strings like true/false and yes/no in config/ignored_environments.yml", flash[:warning]
   end
 
   def setup_user

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -81,7 +81,7 @@ class LocationsControllerTest < ActionController::TestCase
 
   test "should display a warning if current location has been deleted" do
     get :index, {}, set_session_user.merge(:location_id => 1234)
-    assert_equal "Location you had selected as your context has been deleted.", flash[:warning]
+    assert_equal "Location you had selected as your context has been deleted", flash[:warning]
   end
 
   # Assign All Hosts

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -93,7 +93,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
   test "should display a warning if current organization has been deleted" do
     get :index, {}, set_session_user.merge(:organization_id => 1234)
-    assert_equal "Organization you had selected as your context has been deleted.", flash[:warning]
+    assert_equal "Organization you had selected as your context has been deleted", flash[:warning]
   end
 
   # Assign All Hosts

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -177,7 +177,7 @@ class UsersControllerTest < ActionController::TestCase
     delete :destroy, {:id => user.id}, set_session_user.merge(:user => user.id)
     assert_redirected_to users_url
     assert User.unscoped.exists?(user.id)
-    assert @request.flash[:notice] == "You cannot delete this user while logged in as this user."
+    assert_equal @request.flash[:warning], 'You cannot delete this user while logged in as this user'
   end
 
   test 'user with viewer rights should fail to edit a user' do

--- a/webpack/assets/javascripts/foreman_toast_notifications.js
+++ b/webpack/assets/javascripts/foreman_toast_notifications.js
@@ -13,15 +13,27 @@ export function notify({message, type, link, sticky = isSticky(type)}) {
       }));
 }
 
+export function clear() {
+  store.dispatch(ToastActions.clearToasts());
+}
+
 function importFlashMessagesFromRails() {
-  $('#notifications').data().flash.forEach(([type, message]) => {
+  const notifications = $('#notifications');
+
+  if (notifications.length === 0 ||
+    !notifications.data('flash')) {return;}
+
+  notifications.data('flash').forEach(([type, message]) => {
     notify({message, type});
   });
+  // remove both jquery cache and dom entry to avoid ajax ContentLoad events
+  // reloading our notifications
+  notifications.attr('data-flash', '').removeData();
 }
 
 // load notifications from Rails on ContentLoad
 // to accommodate rails flash syntax
 $(document).on('ContentLoad', () => {
-  store.dispatch(ToastActions.clearToasts());
+  clear();
   importFlashMessagesFromRails();
 });


### PR DESCRIPTION
- notification is now inside the content div, allowing two-pane server
responses to include it.
- refactored all notifications to use notification helpers (notice,
warning and error) instead of direct flash manipulation
- also added the usage of flash now via the helpers, and fixed
it in a couple of places it was used incorrectly (mostly clone rendering
which does not redirect at all).
- fixed consisteny to remove trailing dots from toast messages (as it
seems most strings are without dot suffix).