### PR TITLE
Fixes #17749 - Remove confusing .gz.txt extension from logs

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -86,21 +86,25 @@ add_file() {
   MIME=$(file -bi "$FILE" | cut -d\; -f1)
   case $MIME in
         application/x-gzip)
-          zcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
-	  touch -c -r "$FILE" "$DIR$FILE.txt"
+          OUTFILE="$DIR${FILE/%.gz/}"
+          zcat "$FILE" | sed -r "$FILTER" > "$OUTFILE"
+          touch -c -r "$FILE" "$OUTFILE"
           ;;
         application/x-bzip2)
-          bzcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
-	  touch -c -r "$FILE" "$DIR$FILE.txt"
+          OUTFILE="$DIR${FILE/%.bz2/}"
+          bzcat "$FILE" | sed -r "$FILTER" > "$OUTFILE"
+          touch -c -r "$FILE" "$OUTFILE"
           ;;
         application/x-xz)
-          xzcat "$FILE" | sed -r "$FILTER" > "$DIR$FILE.txt"
-	  touch -c -r "$FILE" "$DIR$FILE.txt"
+          OUTFILE="$DIR${FILE/%.xz/}"
+          xzcat "$FILE" | sed -r "$FILTER" > "$OUTFILE"
+          touch -c -r "$FILE" "$OUTFILE"
           ;;
         text/plain | application/xml)
-          sed -r "$FILTER" "$FILE" > "$DIR$FILE"
-          [ $PRINTPASS -eq 1 ] && grep -H "+FILTERED+" "$DIR$FILE"
-	  touch -c -r "$FILE" "$DIR$FILE"
+          OUTFILE="$DIR$FILE"
+          sed -r "$FILTER" "$FILE" > "$OUTFILE"
+          [ $PRINTPASS -eq 1 ] && grep -H "+FILTERED+" "$OUTFILE"
+          touch -c -r "$FILE" "$OUTFILE"
           ;;
         *)
           echo "Skipping file $FILE: unknown MIME type $MIME" >> "$DIR/skipped_files"


### PR DESCRIPTION
Currently .txt extension is appended to log files that are processed
by foreman-debug and added to the debug archive. This is confusing to
the user.

This PR gets rid of the .txt extension, and also removes .gz/.bz2/xz
extension from log files that have been uncompressed.