### PR TITLE
Fixes #18438 - control notifications polling

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -73,7 +73,10 @@ var config = {
         allChunks: true
     }),
     new webpack.DefinePlugin({
-      'process.env': { NODE_ENV: JSON.stringify(production ? 'production' : 'development') }
+      'process.env': {
+        NODE_ENV: JSON.stringify(production ? 'production' : 'development'),
+        NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING
+      }
     })
   ]
 };
@@ -85,7 +88,7 @@ if (production) {
       compressor: { warnings: false },
       sourceMap: false
     }),
-    
+
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new CompressionPlugin()


### PR DESCRIPTION
This will allow the developer to control the timing of the notifications polling, or disable it:
on build, it reads the value of NOTIFICATIONS_POLLING enviroment variable, and:\
if not defined, it will default to polling with 10 sec interval.
if defined, it will poll with the supplied value in ms.
if false, polling will be disabled (after first polling request).
