### PR TITLE
Refs #19512 - use nodejs 6.10 for EL7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ node_js:
   #- "0.10" # EL6, Trusty, Jessie - sadly, jest does not work with 0.10
   - "4.2" # Xenial
   - "4.6" # Fedora 24
-  - "6.9" # EL 7
+  - "4.8" # legacy LTS, Stretch
+  - "6.9" # initial EPEL 7
+  - "6.10" # current LTS, current EPEL 7
 before_install:
   npm install -g npm@'>=3.0.0'
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
also add 4.8, which is the current legacy LTS release and used in Debian/stretch