### PR TITLE
Fixes #17883 - enforce newer fog-vsphere

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 1.7.0'
+  gem 'fog-vsphere', '>= 1.9.2'
 end


### PR DESCRIPTION
this version escapes the datacenter name properly and therefore fixes the issue