### PR TITLE
Fixes #19534 - removed excessive encryptor logging

### DIFF
--- a/test/unit/encryptable_test.rb
+++ b/test/unit/encryptable_test.rb
@@ -30,14 +30,12 @@ class EncryptableTest < ActiveSupport::TestCase
   test "is_encryptable? is false when key is empty" do
     cr = FactoryGirl.build(:ec2_cr)
     cr.stubs(:encryption_key).returns(nil)
-    cr.expects(:puts_and_logs)
     refute cr.is_encryptable?('foo')
   end
 
   test "is_decryptable? is false when key is empty" do
     cr = FactoryGirl.build(:ec2_cr)
     cr.stubs(:encryption_key).returns(nil)
-    cr.expects(:puts_and_logs)
     refute cr.is_decryptable?('encrypted-WkQyR0xMVXZCT2hRTmVGaTNIWlY3RkoxM1M4')
   end
 


### PR DESCRIPTION
I am still keeping the two most important one, when en/decryption fails, but we only log this once.