### PR TITLE
Fixes #19541 - properly mark user <-> mail_notification relation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
   has_many :widgets, :dependent => :destroy
   has_many :ssh_keys, :dependent => :destroy
 
-  has_many :user_mail_notifications, :dependent => :destroy
+  has_many :user_mail_notifications, :dependent => :destroy, :inverse_of => :user
   has_many :mail_notifications, :through => :user_mail_notifications
 
   accepts_nested_attributes_for :user_mail_notifications, :allow_destroy => true, :reject_if => :reject_empty_intervals

--- a/app/models/user_mail_notification.rb
+++ b/app/models/user_mail_notification.rb
@@ -1,6 +1,6 @@
 class UserMailNotification < ApplicationRecord
-  belongs_to :user
-  belongs_to :mail_notification
+  belongs_to :user, :inverse_of => :user_mail_notifications
+  belongs_to :mail_notification, :inverse_of => :user_mail_notifications
 
   scope :daily, -> { where(:interval => 'Daily') }
   scope :weekly, -> { where(:interval => 'Weekly') }


### PR DESCRIPTION
Mark `:inverse_of` on `User` and `UserMailNotifiaction` objects so the relation properties would be set automatically, even for new in-memory instances.

Example:
```
[6] pry(main)> User.new(:login => 'zzz', :mail_notifications => [MailNotification.new]).user_mail_notifications.first.user
=> #<User:0x0000000c16a330
 id: nil,
 login: "zzz",
 firstname: nil,
...
```