### PR TITLE
Fixes #19544 - fix test warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jsdom": "^9.5.0",
     "node-sass": "^4.5.0",
     "react-addons-test-utils": "^15.3.1",
+    "react-test-renderer": "^15.5.4",
     "redux-mock-store": "^1.2.2",
     "sass-loader": "~4.1.1",
     "stats-webpack-plugin": "^0.2.1",


### PR DESCRIPTION
Enzyme start giving warnings after react version update, installing react-test-renderer fixes this issue as shown in the article:
https://github.com/airbnb/enzyme/issues/905