### PR TITLE
Fixes #19558 - improved orchestration task logging

### DIFF
--- a/app/models/concerns/orchestration/realm.rb
+++ b/app/models/concerns/orchestration/realm.rb
@@ -45,7 +45,6 @@ module Orchestration::Realm
   private
 
   def queue_realm
-    logger.debug "Queueing Realm"
     return unless realm? && errors.empty?
     new_record? ? queue_realm_create : queue_realm_update
   end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -33,10 +33,8 @@ module Nic
     # e.g. outside to Host nested attributes
     def queue_with_host
       if host && host.respond_to?(:queue)
-        logger.debug 'Using host queue'
         host.queue
       else
-        logger.debug 'Using nic queue'
         queue_without_host
       end
     end

--- a/app/services/orchestration/queue.rb
+++ b/app/services/orchestration/queue.rb
@@ -3,18 +3,21 @@ require_dependency 'orchestration/task'
 module Orchestration
   # Represents tasks queue for orchestration
   class Queue
-    attr_reader :items
+    attr_reader :items, :name
     STATUS = %w[ pending running failed completed rollbacked conflict canceled]
 
     delegate :count, :empty?, :to => :items
     delegate :to_json, :to => :all
+    delegate :to_s, :to => :name
 
-    def initialize
+    def initialize(name = "Unnamed")
       @items = []
+      @name = name
     end
 
     def create(options)
       options[:status] ||= default_status
+      Rails.logger.debug "Enqueued task '#{options[:name]}' to '#{name}' queue"
       items << Task.new(options)
     end
 


### PR DESCRIPTION
We do not log anything when things are added to orchestration queue, some messages are present but these are not useful and sparse. Example transaction:

```
Using host queue
Using host queue
Using host queue
Queueing Realm
Using host queue
```

This patch will add support for naming queues, the two main queues will be named in the following way:

* Host::Managed Main
* Host::Managed Post
* Nic::Managed Main
* Nic::Managed Post

It will add more logs into DEBUG app logger, example transaction:

```
Enqueued task 'Remove DHCP Settings for mac5254000a4dd1' to 'Host::Managed Main' queue
Enqueued task 'Remove Reverse IPv4 DNS record for mac5254000a4dd1' to 'Host::Managed Main' queue
Enqueued task 'Delete TFTP PXEGrub2 config for mac5254000a4dd1' to 'Host::Managed Main' queue
Enqueued task 'Delete TFTP PXELinux config for mac5254000a4dd1' to 'Host::Managed Main' queue
Enqueued task 'Delete TFTP PXEGrub config for mac5254000a4dd1' to 'Host::Managed Main' queue
Processed queue 'Host::Managed Main', 5/5 completed tasks
```

It also fixed a problem when `Processed queue` was logged multiple times (when no tasks were actually processed).