### PR TITLE
Fixes #19583 - reworded blank label for subnet

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -593,7 +593,7 @@ $(document).on('change', '.interface_type', function () {
 
 function interface_subnet_activate_if_not_empty(element) {
   if (element.find('option').length > 0) {
-    element.prepend($("<option />").val(null).text(__('Please select')));
+    element.prepend($("<option />").val(null).text(null).prop('selected', true));
     element.attr('disabled', false);
     element.change();
   }

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -494,7 +494,7 @@ class HostJSTest < IntegrationTestWithJavascript
         subnet_label = modal.find('#s2id_host_interfaces_attributes_0_subnet_id span.select2-chosen').text
 
         assert_equal '', subnet_id
-        assert_equal 'Please select', subnet_label
+        assert_equal '', subnet_label
       end
 
       test "selecting domain updates puppetclass parameters" do


### PR DESCRIPTION
It is possible to create hosts without subnets, therefore "Please select" label
is misleading, let's change it to "Not set" or similar.