### PR TITLE
Fixes #19585 - Allow csv export of nested attributes

### DIFF
--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -2,12 +2,14 @@ require 'csv'
 
 module CsvExporter
   def self.export(resources, columns)
+    header = csv_header(columns)
     Enumerator.new do |csv|
-      csv << csv_header(columns)
+      csv << header
+      columns.map!{|c| c.to_s.split('.').map(&:to_sym)}
 
       resources.uncached do
         resources.reorder(nil).limit(nil).find_each do |obj|
-          csv << CSV.generate_line(columns.map{|c| obj.send(c)})
+          csv << CSV.generate_line(columns.map{|c| c.inject(obj, :try)})
         end
       end
     end

--- a/test/controllers/concerns/csv_responder_test.rb
+++ b/test/controllers/concerns/csv_responder_test.rb
@@ -31,8 +31,9 @@ class CsvResponderTest < ActionController::TestCase
     assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
     assert_equal "no-cache", response.headers["Cache-Control"]
     assert_equal "attachment; filename=\"fake-#{Date.today}.csv\"", response.headers["Content-Disposition"]
-    assert response.stream.instance_variable_get(:@buf).is_a? Enumerator
-    assert_equal "Name\n", response.stream.instance_variable_get(:@buf).next
+    buf = response.stream.instance_variable_get(:@buf)
+    assert buf.is_a? Enumerator
+    assert_equal "Name\n", buf.next
   end
 end
 
@@ -40,11 +41,12 @@ class CsvApiResponderTest < ActionController::TestCase
   tests Api::V2::FakeController
 
   test "response is streamed correctly with right headers" do
-    get :index
+    get :index, {}, set_session_user
     assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
     assert_equal "no-cache", response.headers["Cache-Control"]
     assert_equal "attachment; filename=\"fake-#{Date.today}.csv\"", response.headers["Content-Disposition"]
-    assert response.stream.instance_variable_get(:@buf).is_a? Enumerator
-    assert_equal "Name\n", response.stream.instance_variable_get(:@buf).next
+    buf = response.stream.instance_variable_get(:@buf)
+    assert buf.is_a? Enumerator
+    assert_equal "Name\n", buf.next
   end
 end


### PR DESCRIPTION
This is required for example to export host facet attributes.