### PR TITLE
Fixes #19496 - added passenger recycler

### DIFF
--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -14,6 +14,7 @@ MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
 
 def is_redhat; File.exist?("/etc/redhat-release"); end
 def is_debian; File.exist?("/etc/debian-release"); end
+def cp_p(*a); cp(*a, {:verbose => true, :preserve => true}); end
 
 file BUILDDIR do
   mkdir BUILDDIR
@@ -43,18 +44,18 @@ task :build => [
 
 task :install => :build do |t|
   mkdir_p "#{MANDIR}/man8"
-  cp "#{BUILDDIR}/foreman-rake.8.gz", "#{MANDIR}/man8/"
-  cp "#{BUILDDIR}/foreman-debug.8.gz", "#{MANDIR}/man8/"
-  cp "#{BUILDDIR}/foreman-tail.8.gz", "#{MANDIR}/man8/"
+  cp_p "#{BUILDDIR}/foreman-rake.8.gz", "#{MANDIR}/man8/"
+  cp_p "#{BUILDDIR}/foreman-debug.8.gz", "#{MANDIR}/man8/"
+  cp_p "#{BUILDDIR}/foreman-tail.8.gz", "#{MANDIR}/man8/"
 
   # foreman-tail
   TAILDIR = ENV['TAILDIR'] || "script/foreman-tail.d"
   mkdir_p "#{DATAROOTDIR}/foreman/#{TAILDIR}"
-  cp Dir.glob("#{TAILDIR}/common/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+  cp_p Dir.glob("#{TAILDIR}/common/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/"
   if is_redhat
-    cp Dir.glob("#{TAILDIR}/redhat/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+    cp_p Dir.glob("#{TAILDIR}/redhat/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/"
   elsif is_debian
-    cp Dir.glob("#{TAILDIR}/debian/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/", :verbose => true
+    cp_p Dir.glob("#{TAILDIR}/debian/*"), "#{DATAROOTDIR}/foreman/#{TAILDIR}/"
   else
     raise "Unsupported system"
   end
@@ -65,6 +66,14 @@ task :install => :build do |t|
 
   # ssh
   mkdir_p "#{DATAROOTDIR}/foreman/.ssh"
+
+  # cron scripts
+  mkdir_p "#{SYSCONFDIR}/cron.hourly"
+  cp_p "script/passenger-recycler.rb", "#{SYSCONFDIR}/cron.hourly/passenger-recycler"
+
+  # configuration files
+  mkdir_p "#{SYSCONFDIR}/foreman"
+  cp_p "script/passenger-recycler.rb.conf.example", "#{SYSCONFDIR}/foreman/passenger-recycler.rb.conf"
 end
 
 task :default => :build

--- a/script/passenger-recycler.rb
+++ b/script/passenger-recycler.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+#
+# Trivial Passenger memory monitor installed via /etc/cron.hourly/. To modify
+# configuration create /etc/foreman/passenger-recycler.rb.conf file.
+#
+
+CONFIG = '/etc/foreman/passenger-recycler.rb.conf'
+load CONFIG if File.readable?(CONFIG)
+ENABLED ||= true
+MAX_PRIV_RSS_MEMORY ||= 2_000_000
+GRACEFUL_SHUTDOWN_SLEEP ||= 120
+KILL_BUSY ||= true
+SEND_STATUS ||= true
+exit 0 unless ENABLED
+
+def running?(pid)
+  return Process.getpgid(pid) != -1
+rescue Errno::ESRCH
+  return false
+end
+
+require 'phusion_passenger'
+require 'phusion_passenger/platform_info'
+require 'phusion_passenger/platform_info/ruby'
+require 'phusion_passenger/admin_tools/memory_stats'
+stats = PhusionPassenger::AdminTools::MemoryStats.new
+unless stats.platform_provides_private_dirty_rss_information?
+  puts "Please run as root or platform unsupported"
+  exit 1
+end
+stats.passenger_processes.each do |p|
+  if p.private_dirty_rss > MAX_PRIV_RSS_MEMORY
+    pid = p.pid.to_i
+    started = `ps -p#{pid} -o start=`.strip rescue '?'
+    status_ps = `ps -p#{pid} -u`
+    status_all = `passenger-status`
+    status_backtraces = `passenger-status --show=backtraces`
+    puts "Terminating #{pid} (started #{started}) with private dirty RSS size of #{p.private_dirty_rss} MB"
+    Process.kill "SIGUSR1", pid
+    sleep GRACEFUL_SHUTDOWN_SLEEP
+    if running?(pid) && KILL_BUSY
+      puts "Process #{pid} is still running, sending SIGKILL"
+      Process.kill "KILL", pid
+      sleep 5
+    end
+    if running?(pid)
+      puts "Process #{pid} still terminating, moving on..."
+    else
+      puts "Process successfully #{pid} terminated"
+    end
+    if SEND_STATUS
+      puts status_ps
+      puts status_all
+      puts status_backtraces
+    end
+    exit 1
+  end
+end
+exit 0

--- a/script/passenger-recycler.rb.conf.example
+++ b/script/passenger-recycler.rb.conf.example
@@ -1,0 +1,19 @@
+#
+# Trivial Passenger memory monitor. This configuration file is Ruby syntax.
+#
+
+# set to 'false' to disable script (use configuration file)
+#ENABLED = true
+
+# RSS memory threashold to recycle processes (in kB)
+#MAX_PRIV_RSS_MEMORY = 2_000_000
+
+# seconds to wait for graceful shutdown
+#GRACEFUL_SHUTDOWN_SLEEP = 120
+
+# kill processes which do not terminate gracefully
+#KILL_BUSY = true
+
+# print 'passenger-status' output before termination
+#SEND_STATUS = true
+


### PR DESCRIPTION
Passenger open-source version does support process restarting on memory threshold. It looks like passenger have reserved SIGUSR1 for graceful restart. A cron job could do the job easily.

I wrote initial version of a script that gracefully terminates Passenger processes consuming more than 2 GB of private RSS memory. Typical consumption of Foreman with Katello and other basic plugins is around 1.2 GB and since only Passenger Enterprise allows to limit maximum amount of RSS memory for processes, this simple script does exactly that.

Motivation is simple - we often introduce bugs in our Rails codebase which performs some eager loading or there are memory leaks in our code or dependencies and Passenger processes can grow up to dozens gigabytes. Unfortunately, there is no other way of getting out other than restarting httpd with passenger. This script could help to avoid situations when production instance starts to swap hard thank to some small regression we introduced. Also administrator will be noticed early via email when this happens so we will keep track of these regressions in production.

Once merged I will follow up with a cron job in foreman package so by default we run it once every hour.