### PR TITLE
Fixes #19315 - redirect to login  when session expired

### DIFF
--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Session
   def session_expiry
     return if ignore_api_request?
     if session[:expires_at].blank? || (Time.at(session[:expires_at]).utc - Time.now.utc).to_i < 0
-      session[:original_uri] = request.fullpath unless session[:api_authenticated_session]
+      session[:original_uri] = request.fullpath unless api_request?
       expire_session
     end
   rescue => e

--- a/app/controllers/notification_recipients_controller.rb
+++ b/app/controllers/notification_recipients_controller.rb
@@ -1,6 +1,6 @@
 class NotificationRecipientsController < Api::V2::BaseController
   include Foreman::Controller::Parameters::NotificationRecipient
-
+  skip_before_action :update_activity_time, :only => [:index]
   before_action :require_login
   before_action :find_resource, :only => [:update, :destroy]
 

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -13,7 +13,6 @@ import {
   serverResponse
 } from './notifications.fixtures';
 jest.unmock('jquery');
-
 const mockStore = configureMockStore([thunk]);
 
 describe('notifications', () => {
@@ -89,5 +88,20 @@ describe('notifications', () => {
     expect(wrapper.find(`${matcher}[disabled=true]`).length).toBe(0);
     wrapper.find(matcher).simulate('click');
     expect(wrapper.find(`${matcher}[disabled=true]`).length).toBe(1);
+  });
+
+  it('should redirect to login when 401', () => {
+    window.location.replace = jest.fn();
+    $.getJSON = jest.genMockFunction().mockImplementation(url => {
+      return {
+        then: function (callback, failCallback) {
+          failCallback({status: 401});
+        }
+      };
+    });
+    const data = {url: '/notification_recipients'};
+
+    mount(<Notifications data={data} store={getStore()} />);
+    expect(global.location.replace).toBeCalled();
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
@@ -21,34 +21,38 @@ export const getNotifications = url => dispatch => {
       document.visibilityState === 'visible' ||
       document.visibilityState === 'prerender'
     ) {
-      API.get(url).then(
-        response => {
-          dispatch({
-            type: NOTIFICATIONS_GET_NOTIFICATIONS,
-            payload: {
-              notifications: response.notifications
-            }
-          });
-          resolve();
-        },
-        () => reject()
-      );
+      API.get(url).then(onSuccess, onFailure);
     } else {
       resolve();
     }
-    return null;
-  }).then(
-    () => {
-      if (notificationsInterval) {
-        setTimeout(
+
+    function onSuccess(response) {
+      dispatch({
+        type: NOTIFICATIONS_GET_NOTIFICATIONS,
+        payload: {
+          notifications: response.notifications
+        }
+      });
+      resolve();
+    }
+
+    function onFailure(error) {
+      if (error.status === 401) {
+        window.location.replace('/users/login');
+      }
+      reject();
+    }
+
+  }).then(triggerPolling);
+
+  function triggerPolling() {
+    if (notificationsInterval) {
+      setTimeout(
           () => dispatch(getNotifications(url)),
           notificationsInterval
-        );
-      }
-    },
-    // error handling
-    () => {}
-  );
+      );
+    }
+  }
 };
 
 export const onMarkAsRead = (group, id) => dispatch => {


### PR DESCRIPTION
When a session expired, the page remains on browser, and sensitive data may be leaked.
To deal with it, we can use notifications pull mechanism. When a notification pulled, if session expired, it'll return with http respond with status 401. 