### PR TITLE
fixes #19340 - replace all new_host calls with new_vm

### DIFF
--- a/app/views/compute_resources_vms/form/vmware/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_volume.html.erb
@@ -11,7 +11,7 @@
 <% else %>
   <%= text_f f, :datastore, :class => "span5", :label => _("Data store"), :label_size => "col-md-2", :disabled => true %>
 <% end %>
-<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2", :disabled => !new_host, :readonly => true %>
+<%= text_f f, :name, :class => "col-md-2", :label => _("Name"), :label_size => "col-md-2", :readonly => true %>
 <%= text_f f, :size_gb,
            :class       => "col-md-2",
            :label => _("Size (GB)"), :label_size => "col-md-2" %>
@@ -23,4 +23,4 @@
            :label => _("Eager zero"), :label_size => "col-md-2", :disabled => !new_vm},
            "true",
            "false" %>
-<%= select_f f, :mode, compute_resource.disk_mode_types, :first, :last, { }, :class => "span5", :label => _("Disk mode"), :label_size => "col-md-2", :disabled => !new_host %>
+<%= select_f f, :mode, compute_resource.disk_mode_types, :first, :last, { }, :class => "span5", :label => _("Disk mode"), :label_size => "col-md-2", :disabled => !new_vm %>


### PR DESCRIPTION
new_host was replaced by new_vm in 637da2f28accc1378f0326d97adcbb2efc5d9808. This cleans up leftovers of new_host.