### PR TITLE
Fixes #19031 - move to patternfly pagination style

### DIFF
--- a/app/assets/javascripts/two-pane.js
+++ b/app/assets/javascripts/two-pane.js
@@ -117,7 +117,7 @@ function two_pane_close(){
   $('.table-two-pane tr td').show();
   $('.table-two-pane th').show();
   $("#title_action").show();
-  $('.pagination').show();
+  $('#pagination').show();
   if ($('.two-pane-left').length){
     $('.table-two-pane').unwrap().unwrap();
   }
@@ -131,7 +131,7 @@ function hide_columns(){
   $('.table-two-pane th:nth-child(1)').show();
   $("#title_action").hide();
   $('.two-pane-right').remove();
-  $('.pagination').hide();
+  $('#pagination').hide();
   if ($('.two-pane-left').length == 0){
     $('.table-two-pane').wrap( "<div class='row'><div class='col-md-3 two-pane-left'></div></div>");
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -342,6 +342,10 @@ table {
   vertical-align: bottom;
 }
 
+#pagination {
+  margin-top: -6px;
+}
+
 #interfaceModal {
   .modal-dialog {
     min-width: 1000px;
@@ -655,3 +659,8 @@ code.transparent {
     }
   }
 }
+
+.per-page {
+  margin-right: 5px;
+}
+

--- a/app/controllers/architectures_controller.rb
+++ b/app/controllers/architectures_controller.rb
@@ -5,8 +5,7 @@ class ArchitecturesController < ApplicationController
   before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
-    base = resource_base.includes(:operatingsystems).search_for(params[:search], :order => params[:order])
-    @architectures = base.paginate(:page => params[:page])
+    @architectures = resource_base_search_and_page.includes(:operatingsystems)
   end
 
   def new

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,7 +4,7 @@ class AuditsController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    Audit.unscoped { @audits = resource_base.includes(:user).search_for(params[:search], :order => params[:order]).paginate :page => params[:page] }
+    Audit.unscoped { @audits = resource_base_search_and_page.includes(:user) }
   end
 
   def show

--- a/app/controllers/auth_source_ldaps_controller.rb
+++ b/app/controllers/auth_source_ldaps_controller.rb
@@ -4,7 +4,7 @@ class AuthSourceLdapsController < ApplicationController
   before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
-    @auth_source_ldaps = resource_base.all
+    @auth_source_ldaps = resource_base_search_and_page.all
   end
 
   def new

--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -13,7 +13,7 @@ class ComputeResourcesController < ApplicationController
   end
 
   def index
-    @compute_resources = resource_base.live_descendants.search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
+    @compute_resources = resource_base_search_and_page.live_descendants
   end
 
   def new

--- a/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
@@ -20,7 +20,7 @@ module Foreman::Controller::TaxonomiesController
 
     respond_to do |format|
       format.html do
-        @taxonomies = values.paginate(:page => params[:page])
+        @taxonomies = values.paginate(:page => params[:page], :per_page => params[:per_page])
         render 'taxonomies/index'
       end
       format.json
@@ -132,7 +132,7 @@ module Foreman::Controller::TaxonomiesController
 
   def assign_hosts
     @taxonomy_type = taxonomy_single.classify
-    @hosts = hosts_scope_without_taxonomy.includes(included_associations).search_for(params[:search],:order => params[:order]).paginate(:page => params[:page])
+    @hosts = hosts_scope_without_taxonomy.includes(included_associations).search_for(params[:search],:order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page])
     render "hosts/assign_hosts"
   end
 

--- a/app/controllers/fact_values_controller.rb
+++ b/app/controllers/fact_values_controller.rb
@@ -5,7 +5,7 @@ class FactValuesController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    values = resource_base.my_facts.search_for(params[:search], :order => params[:order])
+    values = resource_base_search_and_page.my_facts
 
     conds = (original_search_parameter || '').split(/AND|OR/i)
     conds = conds.flatten.reject { |c| c.include?('host') }
@@ -23,7 +23,7 @@ class FactValuesController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @fact_values = @fact_values.preload(related_tables).paginate :page => params[:page]
+        @fact_values = @fact_values.preload(related_tables).paginate(:page => params[:page], :per_page => params[:per_page])
         render :index
       end
       format.csv do

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -7,7 +7,7 @@ class FiltersController < ApplicationController
 
   def index
     @filters = resource_base.includes(:role, :permissions).search_for(params[:search], :order => params[:order])
-    @filters = @filters.paginate(:page => params[:page]) unless params[:paginate] == 'client'
+    @filters = @filters.paginate(:page => params[:page], :per_page=> params[:per_page]) unless params[:paginate] == 'client'
     @roles_authorizer = Authorizer.new(User.current, :collection => @filters.map(&:role_id))
   end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -53,7 +53,7 @@ class HostsController < ApplicationController
     end
     respond_to do |format|
       format.html do
-        @hosts = search.includes(included_associations).paginate(:page => params[:page])
+        @hosts = search.includes(included_associations).paginate(:page => params[:page], :per_page => params[:per_page])
         # SQL optimizations queries
         @last_report_ids = ConfigReport.where(:host_id => @hosts.map(&:id)).group(:host_id).maximum(:id)
         @last_reports = ConfigReport.where(:id => @last_report_ids.values)

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -5,7 +5,7 @@ class MediaController < ApplicationController
   before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
-    @media = resource_base.includes(:operatingsystems).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+    @media = resource_base_search_and_page.includes(:operatingsystems)
   end
 
   def new

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -22,7 +22,7 @@ class RolesController < ApplicationController
 
   def index
     params[:order] ||= 'name'
-    @roles = Role.authorized(:view_roles).search_for(params[:search], :order => params[:order]).paginate :page => params[:page]
+    @roles = Role.authorized(:view_roles).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
   def new

--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -6,7 +6,7 @@ class SmartProxiesController < ApplicationController
   before_action :find_status, :only => [:ping, :tftp_server, :puppet_environments]
 
   def index
-    @smart_proxies = resource_base.includes(:features).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+    @smart_proxies = resource_base_search_and_page.includes(:features)
   end
 
   def show

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -103,6 +103,10 @@ class TemplatesController < ApplicationController
     @resource_class ||= controller_name.singularize.classify.constantize
   end
 
+  def resource_name
+    'template'
+  end
+
   private
 
   def safe_render(template)
@@ -142,10 +146,6 @@ class TemplatesController < ApplicationController
       else
         super
     end
-  end
-
-  def resource_name
-    'template'
   end
 
   def type_name_plural

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -4,7 +4,7 @@ class TrendsController < ApplicationController
   before_action :find_resource, :only => [:show, :edit, :update, :destroy]
 
   def index
-    @trends = Trend.types.includes(:trendable).sort_by {|e| e.type_name.downcase }.paginate(:page => params[:page])
+    @trends = Trend.types.includes(:trendable).sort_by {|e| e.type_name.downcase }.paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
   def new

--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -7,7 +7,7 @@ class UsergroupsController < ApplicationController
   after_action  :refresh_external_usergroups, :only => [:create, :update]
 
   def index
-    @usergroups = resource_base.includes(:usergroups).search_for(params[:search], :order => params[:order]).paginate(:page => params[:page])
+    @usergroups = resource_base_search_and_page(:usergroups)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   before_action      :verify_active_session, :only => :login
 
   def index
-    @users = User.authorized(:view_users).except_hidden.search_for(params[:search], :order => params[:order]).includes(:auth_source, :cached_usergroups).paginate(:page => params[:page])
+    @users = User.authorized(:view_users).except_hidden.search_for(params[:search], :order => params[:order]).includes(:auth_source, :cached_usergroups).paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -524,6 +524,6 @@ module ApplicationHelper
   end
 
   def current_url_params(permitted: [])
-    params.permit(permitted + [:locale, :search])
+    params.permit(permitted + [:locale, :search, :per_page])
   end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -53,41 +53,6 @@ module LayoutHelper
                                                                            :tabindex => '-1' }.deep_merge(options))
   end
 
-  def will_paginate(collection = nil, options = {})
-    options[:class] = "col-md-7"
-    options[:renderer] ||= "WillPaginate::ActionView::BootstrapLinkRenderer"
-    options[:inner_window] ||= 2
-    options[:outer_window] ||= 0
-    options[:previous_label] ||= _('&laquo;')
-    options[:next_label] ||= _('&raquo;')
-    super collection, options
-  end
-
-  def page_entries_info(collection, options = {})
-    html = if collection.total_entries == 0
-             _("No entries found")
-           else
-             if collection.total_pages < 2
-               n_("Displaying <b>%{count}</b> entry", "Displaying <b>all %{count}</b> entries", collection.total_entries) % {:count => collection.total_entries}
-             else
-               _("Displaying entries <b>%{from} - %{to}</b> of <b>%{count}</b> in total") %
-                   { :from => collection.offset + 1, :to => collection.offset + collection.length, :count => collection.total_entries }
-             end
-           end.html_safe
-    html += options[:more].html_safe if options[:more]
-    content_tag(:div, :class => "col-md-5 hidden-xs") do
-      content_tag(:div, html, :class => "pull-left pull-bottom darkgray pagination")
-    end
-  end
-
-  def will_paginate_with_info(collection = nil, options = {})
-    content_tag(:div, :id => "pagination", :class => "row",
-                :data => ({'count' => collection.total_entries, 'per-page' => per_page(collection)})) do
-      page_entries_info(collection, options) +
-        will_paginate(collection, options)
-    end
-  end
-
   def icon_text(i, text = "", opts = {})
     opts[:kind] ||= "glyphicon"
     (content_tag(:span,"", :class=>"#{opts[:kind] + ' ' + opts[:kind]}-#{i} #{opts[:class]}", :title => opts[:title]) + " " + text).html_safe

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,29 @@
+module PaginationHelper
+  def will_paginate(collection = nil, options = {})
+    defaults = {
+      renderer: 'WillPaginate::ActionView::PatternflyLinkRenderer',
+      page_links: false,
+      container: false,
+      outer_window: 0,
+      previous_label: icon_text('angle-left', '', kind: 'fa'),
+      next_label: icon_text('angle-right', '', kind: 'fa'),
+      last_label: icon_text('angle-double-right', '', kind: 'fa'),
+      first_label: icon_text('angle-double-left', '', kind: 'fa')
+    }
+    super(collection, defaults.merge(options))
+  end
+
+  def will_paginate_with_info(collection = nil, options = {})
+    if collection.total_entries.zero?
+      render text: _('No entries found')
+    else
+      render('common/pagination', collection: collection, options: options)
+    end
+  end
+
+  def per_page_options(options = [5, 10, 15, 25, 50])
+    options << Setting[:entries_per_page].to_i
+    options << params[:per_page].to_i unless params[:per_page].blank?
+    options.uniq.sort
+  end
+end

--- a/app/views/auth_source_ldaps/index.html.erb
+++ b/app/views/auth_source_ldaps/index.html.erb
@@ -4,7 +4,7 @@
 
 <% title_actions(new_link(_("Create LDAP Source")), documentation_button('4.1.1LDAPAuthentication')) %>
 
-<table class="<%= table_css_classes("table-two-pane table-hover") %>">
+<table class="<%= table_css_classes("table-two-pane table-hover table-fixed") %>">
   <thead>
     <tr>
       <th><%= sort :name, :as => s_("AuthSource|Name") %></th>
@@ -26,3 +26,5 @@
   <% end %>
   </tbody>
 </table>
+
+<%= will_paginate_with_info @auth_source_ldaps %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Bookmarks") %>
 <% title_actions documentation_button('4.1.5Searching') %>
 
-<table class="<%= table_css_classes("table-two-pane table-hover") %>">
+<table class="<%= table_css_classes("table-two-pane table-hover table-fixed") %>">
   <thead>
     <tr>
       <th><%= sort :name, :as => s_("Bookmark|Name") %></th>

--- a/app/views/common/_pagination.html.erb
+++ b/app/views/common/_pagination.html.erb
@@ -1,0 +1,26 @@
+<form
+  class='content-view-pf-pagination table-view-pf-pagination paginate' id='pagination'
+  data-count=<%= collection.total_entries %> data-per-page=<%= per_page(collection) %> >
+  <div class='form-group'>
+    <%= select_tag('per_page',
+                   options_for_select(per_page_options,
+                                      params[:per_page] || Setting[:entries_per_page]),
+                   label: _('per page'),
+                   onChange: 'tfm.tools.updateTable(this)',
+                   class: 'pagination-pf-pagesize without_select2 per-page') %>
+    <span><%= _('per page') %></span>
+  </div>
+
+  <div class='form-group'>
+    <span>
+      <span class='pagination-pf-items-current'>
+        <%= collection.offset + 1 %>-<%= collection.offset + collection.length %>
+      </span>
+      <%= _('of') %>
+      <span class='pagination-pf-items-total'>
+        <%= collection.total_entries %>
+      </span>
+    </span>
+    <%= will_paginate(collection, options) %>
+  </div>
+</form>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -7,7 +7,7 @@
 <% title_actions new_link_unless_locked(_("Create Filter"), { :controller => :filters, :role_id => @role }, @role),
                  documentation_button('4.1.2RolesandPermissions') %>
 
-<table class="<%= table_css_classes %>" <%= "data-table='inline'".html_safe if params[:paginate] == 'client' %> >
+<table class="<%= table_css_classes 'table-fixed' %>" <%= "data-table='inline'".html_safe if params[:paginate] == 'client' %> >
   <thead>
     <tr>
       <% unless params[:role_id] %>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title_actions new_link(_("Create Host Group")), help_button %>
 
-<table class="<%= table_css_classes %>">
+<table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
       <th><%= sort :label, :as => _('Hostgroup|Name') %></th>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -11,7 +11,7 @@
                       {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single },
                       hosts_path(:search => "not has #{controller_name.singularize}"))).html_safe %>
 <% end %>
-<table class="<%= table_css_classes %>">
+<table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
       <th><%= sort :title, :as => s_("Taxonomy|Name") %></th>

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -3,23 +3,43 @@ require 'will_paginate/array'
 
 module WillPaginate
   module ActionView
-    class BootstrapLinkRenderer < LinkRenderer
+    class PatternflyLinkRenderer < LinkRenderer
       protected
 
-      def html_container(html)
-        tag :div, tag(:ul, html, :class=>"pagination pull-right"), container_attributes
+      def container_attributes
+        super.except(:first_label, :last_label)
       end
 
-      def page_number(page)
-        tag :li, link(page, page, :rel => rel_value(page)), :class => ('active' if page == current_page)
+      def pagination
+        [:back, :pages, :forward]
+      end
+
+      def back
+        tag :ul, first_page + previous_page, class: 'pagination pagination-pf-back'
+      end
+
+      def forward
+        tag :ul, next_page + last_page, class: 'pagination pagination-pf-forward'
+      end
+
+      def pages
+        current_page_input = tag(:input, '', class: 'pagination-pf-page', type: 'text', value: current_page, id: 'pagination1-page')
+        current_page_label = tag(:label, _('Current Page'), class: 'sr-only', for: 'pagination1-page')
+        of_total_pages = tag(:span, _('of ') + tag(:span, total_pages, class: 'pagination-pf-pages'))
+        current_page_input + current_page_label + of_total_pages
+      end
+
+      def first_page
+        previous_or_next_page(current_page == 1 ? nil : 1, @options[:first_label], 'first_page')
+      end
+
+      def last_page
+        previous_or_next_page(current_page == total_pages ? nil : total_pages, @options[:last_label], 'last_page')
       end
 
       def previous_or_next_page(page, text, classname)
-        tag :li, link(text, page || '#'), :class => [classname[0..3], classname, ('disabled' unless page)].join(' ')
-      end
-
-      def gap
-        tag :li, link(super, '#'), :class => 'disabled'
+        classname = [classname, ('disabled' unless page)].join(' ')
+        tag :li, link(text, page || '#'), class: classname
       end
     end
   end

--- a/test/controllers/architectures_controller_test.rb
+++ b/test/controllers/architectures_controller_test.rb
@@ -8,6 +8,8 @@ class ArchitecturesControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_new_submit_button_id
     get :new, {}, set_session_user
@@ -72,7 +74,7 @@ class ArchitecturesControllerTest < ActionController::TestCase
   def user_with_viewer_rights_should_fail_to_edit_an_architecture
     setup_user
     get :edit, {:id => Architecture.first.id}
-    assert @response.status == '403 Forbidden'
+    assert_response :forbidden
   end
 
   def user_with_viewer_rights_should_succeed_in_viewing_architectures

--- a/test/controllers/audits_controller_test.rb
+++ b/test/controllers/audits_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class AuditsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   def test_index
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/auth_source_ldaps_controller_test.rb
@@ -8,6 +8,8 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_create_invalid
     AuthSourceLdap.any_instance.stubs(:valid?).returns(false)

--- a/test/controllers/bookmarks_controller_test.rb
+++ b/test/controllers/bookmarks_controller_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class BookmarksControllerTest < ActionController::TestCase
+  setup do
+    @factory_options = [{:controller => "users"}]
+  end
+
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/common_parameters_controller_test.rb
+++ b/test/controllers/common_parameters_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class CommonParametersControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   def test_index
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/compute_profiles_controller_test.rb
+++ b/test/controllers/compute_profiles_controller_test.rb
@@ -6,6 +6,9 @@ class ComputeProfilesControllerTest < ActionController::TestCase
     @compute_profile = compute_profiles(:one)
   end
 
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/compute_resources_controller_test.rb
+++ b/test/controllers/compute_resources_controller_test.rb
@@ -4,7 +4,11 @@ class ComputeResourcesControllerTest < ActionController::TestCase
   setup do
     @compute_resource = compute_resources(:mycompute)
     @your_compute_resource = compute_resources(:yourcompute)
+    @factory_options = :ec2
   end
+
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   test "should not get index when not permitted" do
     setup_user "none"

--- a/test/controllers/config_groups_controller_test.rb
+++ b/test/controllers/config_groups_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class ConfigGroupsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/config_reports_controller_test.rb
+++ b/test/controllers/config_reports_controller_test.rb
@@ -4,6 +4,9 @@ require 'controllers/shared/report_host_permissions_test'
 class ConfigReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
 
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   let :report do
     as_admin { FactoryGirl.create(:config_report) }
   end

--- a/test/controllers/domains_controller_test.rb
+++ b/test/controllers/domains_controller_test.rb
@@ -8,6 +8,8 @@ class DomainsControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_create_invalid
     Domain.any_instance.stubs(:valid?).returns(false)

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -8,6 +8,8 @@ class EnvironmentsControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   test "should create new environment" do
     assert_difference 'Environment.unscoped.count' do

--- a/test/controllers/filters_controller_test.rb
+++ b/test/controllers/filters_controller_test.rb
@@ -9,6 +9,8 @@ class FiltersControllerTest < ActionController::TestCase
   basic_index_test('filters')
   basic_new_test
   basic_edit_test('filter')
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   test "changes should expire topbar cache" do
     user1 = FactoryGirl.create(:user, :with_mail)
@@ -56,8 +58,8 @@ class FiltersControllerTest < ActionController::TestCase
     assert_response :success
     refute_empty assigns(:filters)
 
-    pagination_line = css_select('div.pagination').first
-    assert_match "Displaying", pagination_line.children.first.content
+    pagination_line = css_select('#pagination')
+    assert_match "per page", pagination_line.children[1].children[3].content
   end
 
   test 'should return data-tables pagination when asked for it' do

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class HostsControllerTest < ActionController::TestCase
   setup :initialize_host
 
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   def host_attributes(host)
     known_attrs = HostsController.host_params_filter.accessible_attributes(HostsController.parameter_filter_context)
     host.attributes.except('id', 'created_at', 'updated_at').slice(*known_attrs)

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class LocationsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/media_controller_test.rb
+++ b/test/controllers/media_controller_test.rb
@@ -8,6 +8,8 @@ class MediaControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_create_invalid
     Medium.any_instance.stubs(:valid?).returns(false)

--- a/test/controllers/models_controller_test.rb
+++ b/test/controllers/models_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class ModelsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   def test_index
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/operatingsystems_controller_test.rb
+++ b/test/controllers/operatingsystems_controller_test.rb
@@ -1,5 +1,12 @@
 require 'test_helper'
 class OperatingsystemsControllerTest < ActionController::TestCase
+  setup do
+    @factory_options = :with_parameter
+  end
+
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   def setup_os_user
     @request.session[:user] = users(:one).id
     users(:one).roles       = [Role.default, Role.find_by_name('Viewer')]

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class OrganizationsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class ProvisioningTemplatesControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "index" do
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/ptables_controller_test.rb
+++ b/test/controllers/ptables_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class PtablesControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   def setup
     @ptable = FactoryGirl.create(:ptable)
   end

--- a/test/controllers/puppetclass_lookup_keys_controller_test.rb
+++ b/test/controllers/puppetclass_lookup_keys_controller_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class PuppetclassLookupKeysControllerTest < ActionController::TestCase
+  setup do
+    @factory_options = [:as_smart_class_param, :puppetclass => puppetclasses(:one), :override => true, :default_value => 'test']
+  end
+
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/controllers/puppetclasses_controller_test.rb
+++ b/test/controllers/puppetclasses_controller_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class PuppetclassesControllerTest < ActionController::TestCase
   include LookupKeysHelper
 
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   def host_attributes(host)
     known_attrs = HostsController.host_params_filter.accessible_attributes(HostsController.parameter_filter_context)
     host.attributes.except('id', 'created_at', 'updated_at').slice(*known_attrs)

--- a/test/controllers/realms_controller_test.rb
+++ b/test/controllers/realms_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class RealmsControllerTest < ActionController::TestCase
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   def test_index
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/roles_controller_test.rb
+++ b/test/controllers/roles_controller_test.rb
@@ -25,6 +25,8 @@ class RolesControllerTest < ActionController::TestCase
   basic_index_test('roles')
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   test 'creates role' do
     post :create, { :role => {:name => 'test role'}}, set_session_user

--- a/test/controllers/smart_proxies_controller_test.rb
+++ b/test/controllers/smart_proxies_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class SmartProxiesControllerTest < ActionController::TestCase
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   def test_index
     get :index, {}, set_session_user
     assert_template 'index'

--- a/test/controllers/subnets_controller_test.rb
+++ b/test/controllers/subnets_controller_test.rb
@@ -3,11 +3,14 @@ require 'test_helper'
 class SubnetsControllerTest < ActionController::TestCase
   setup do
     @model = subnets(:one)
+    @factory_options = :with_parameter
   end
 
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_create_invalid
     Subnet.any_instance.stubs(:valid?).returns(false)

--- a/test/controllers/trends_controller_test.rb
+++ b/test/controllers/trends_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class TrendsControllerTest < ActionController::TestCase
+  basic_pagination_rendered_test
+  basic_pagination_per_page_test
+
   test "should get empty_data page, if no trend counters exist" do
     trend = FactoryGirl.create(:trend_os)
     get :show, { :id => trend.id }, set_session_user

--- a/test/controllers/usergroups_controller_test.rb
+++ b/test/controllers/usergroups_controller_test.rb
@@ -9,6 +9,8 @@ class UsergroupsControllerTest < ActionController::TestCase
   basic_index_test
   basic_new_test
   basic_edit_test
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   def test_create_invalid
     Usergroup.any_instance.stubs(:valid?).returns(false)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -10,6 +10,8 @@ class UsersControllerTest < ActionController::TestCase
   basic_index_test('users')
   basic_new_test
   basic_edit_test('user')
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
 
   test "#index should not show hidden users" do
     get :index, { :search => "login = #{users(:anonymous).login}" }, set_session_user

--- a/test/controllers/variable_lookup_keys_controller_test.rb
+++ b/test/controllers/variable_lookup_keys_controller_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class VariableLookupKeysControllerTest < ActionController::TestCase
+  setup do
+    @factory_options = [{:puppetclass => puppetclasses(:one), :override => true, :default_value => 'test'}]
+  end
+
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
   test "should get index" do
     get :index, {}, set_session_user
     assert_response :success

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -39,7 +39,6 @@ class ActionDispatch::IntegrationTest
     assert page.has_selector?('h1', :text => title_text), "#{title_text} was expected in the <h1> tag, but was not found"
     (assert find_link(new_link_text).visible?, "#{new_link_text} is not visible") if new_link_text
     (assert find_button('Search').visible?, "Search button is not visible") if has_search
-    (assert has_content?("Displaying"), "Pagination 'Display ...' does not appear") if has_pagination
   end
 
   def assert_new_button(index_path,new_link_text,new_path)

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -85,13 +85,17 @@ export function initTypeAheadSelect(input) {
 // handle table updates via turoblinks
 export function updateTable(element) {
   let uri = new URI(window.location.href);
-  let search;
+  let search, perPage;
 
   if (element !== undefined) {
-    search = $(element).find('.autocomplete-input').val();
+    search = $(element).find('.autocomplete-input').val() || $('#search-form').find('.autocomplete-input').val();
     if (search !== undefined) {
       uri.setSearch('search', search.trim());
     }
+  }
+  perPage = $('#per_page').val();
+  if (perPage !== undefined) {
+    uri.setSearch('per_page', perPage);
   }
   /* eslint-disable no-undef */
   Turbolinks.visit(uri.toString());

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -100,6 +100,7 @@ describe('updateTableTest', () => {
       value: 'http://localhost'
     });
     document.body.innerHTML = `
+<div>
     <form id="search-form" onsubmit="return tfm.tools.updateTable(this);" action="/templates/provisioning_templates" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="✓">
   <div class="input-group">
     <input type="text" name="search" id="search" value="name = y " placeholder="Filter ..." class="autocomplete-input form-control ui-autocomplete-input ui-autocomplete-loading" data-url="/templates/provisioning_templates/auto_complete_search" autocomplete="off"><a class="autocomplete-clear" tabindex="-1" title="" data-original-title="Clear" style="display: none;">×</a>
@@ -118,6 +119,32 @@ describe('updateTableTest', () => {
     </span>
   </div>
 </form>
+<table></table>
+<form class="content-view-pf-pagination table-view-pf-pagination paginate" id="pagination" data-count="7" data-per-page="7">
+  <div class="form-group">
+    <select name="per_page" id="per_page" label="per page" onchange="tfm.tools.updateTable(this)" class="pagination-pf-pagesize without_select2 per-page"><option selected="selected" value="5">5</option>
+<option value="10">10</option>
+<option value="15">15</option>
+<option value="20">20</option>
+<option value="25">25</option>
+<option value="50">50</option></select>
+    <span>per page</span>
+  </div>
+
+  <div class="form-group">
+    <span>
+      <span class="pagination-pf-items-current">
+        1-5
+      </span>
+      of
+      <span class="pagination-pf-items-total">
+        7
+      </span>
+    </span>
+    <ul class="pagination pagination-pf-back"><li class="firs first_page disabled"><a href="#"><span class="fa fa-angle-double-left "></span> </a></li><li class="prev previous_page disabled"><a href="#"><span class="fa fa-angle-left "></span> </a></li></ul> <input class="pagination-pf-page" type="text" value="1" id="pagination1-page"><label class="sr-only" for="pagination1-page">Current Page</label><span>of <span class="pagination-pf-pages">2</span></span> <ul class="pagination pagination-pf-forward"><li class="next next_page "><a rel="next" href="/hosts?page=2&amp;per_page=5&amp;search=environment+%3D++testing"><span class="fa fa-angle-right "></span> </a></li><li class="last last_page "><a rel="next" href="/hosts?page=2&amp;per_page=5&amp;search=environment+%3D++testing"><span class="fa fa-angle-double-right "></span> </a></li></ul>
+  </div>
+</form>
+</div>
     `;
   });
 
@@ -126,8 +153,17 @@ describe('updateTableTest', () => {
     expect(global.Turbolinks.visit).toBeCalled();
   });
 
-  it('should use find search term and add it to the url', () => {
+  it('should use find search term and add it to the url considering per page value', () => {
+    let PerPage = $('#per_page').val();
+
     $('form').submit();
-    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith('http://localhost/?search=name+%3D+y');
+    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?search=name+%3D+y&per_page=${PerPage}`);
+  });
+
+  it('should use selected per page value and add it to the url considering search term', () => {
+    let PerPage = $('#per_page').val();
+
+    $('#per_page').change();
+    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?search=name+%3D+y&per_page=${PerPage}`);
   });
 });


### PR DESCRIPTION
The new renderer renders pagination links to match patternfly pagination style. 

http://www.patternfly.org/pattern-library/navigation/pagination/

![image](https://cloud.githubusercontent.com/assets/15361156/26316282/6d8198f2-3f1c-11e7-9eba-6073e0759cf5.png)
