### PR TITLE
Fixes #19632 - changed shim and grub1 PXE names

### DIFF
--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -19,10 +19,9 @@ module PxeLoaderSupport
         "None" => "",
         "PXELinux BIOS" => "pxelinux.0",
         "PXELinux UEFI" => "pxelinux.efi",
-        "Grub UEFI" => "grub/boot#{precision}.efi",
-        "Grub UEFI SecureBoot" => "grub/shim.efi",
+        "Grub UEFI" => "grub/grub#{precision}.efi",
         "Grub2 UEFI" => "grub2/grub#{precision}.efi",
-        "Grub2 UEFI SecureBoot" => "grub2/shim.efi"
+        "Grub2 UEFI SecureBoot" => "grub2/shim#{precision}.efi"
       }.freeze
     end
 

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -28,12 +28,22 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
     end
 
     test "PXEGrub is found for given filename" do
-      @host.pxe_loader = "grub/bootx64.efi"
+      @host.pxe_loader = "grub/grubx64.efi"
       assert_equal :PXEGrub, @subject.pxe_loader_kind(@host)
     end
 
     test "PXEGrub2 is found for given filename" do
       @host.pxe_loader = "grub2/grubx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for shimx64.efi filename" do
+      @host.pxe_loader = "grub2/shimx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for shimia32.efi filename" do
+      @host.pxe_loader = "grub2/shimia32.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 


### PR DESCRIPTION
Foreman PXE loader naming conventions expects SecureBoot option to be loading
`grub2/shim.efi` but recent versions of RHEL introduced `shimaa64.efi` and also
`shimia32.efi` therefore we should change names to follow this.

Additionally, Foreman lists "Grub UEFI SecureBoot" which was resolving to
`grub/shim.efi` but Grub1 does not support SecureBoot via shim. It can be
signed manually if user wants to, but that does not need an extra option,
therefore the "Grub UEFI SecureBoot" will be removed completely.

Finally, items `grub/bootx64.efi` and `grub/bootia32.efi` should be named
`grub/grubx64.efi` and `grub/grubia32.efi` respectively to follow naming
convention with grub2.

This patch will require foreman ticket 19556 (ship foreman-bootloaders
package) to be present, it will respect the new naming conventions.