### PR TITLE
Fixes #15861 - increase size of audited_changes column

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -71,6 +71,8 @@ module AuditExtensions
     def self.humanize_class_name
       _("Audit")
     end
+
+    serialize :audited_changes
   end
 
   private

--- a/db/migrate/20170525112713_change_audited_changes_in_audits.rb
+++ b/db/migrate/20170525112713_change_audited_changes_in_audits.rb
@@ -1,0 +1,14 @@
+class ChangeAuditedChangesInAudits < ActiveRecord::Migration
+  # Sets the audited_changes to MEDIUMTEXT type in mysql
+  def up
+    if ['mysql', 'mysql2'].include? ActiveRecord::Base.connection.instance_values['config'][:adapter]
+      change_column :audits, :audited_changes, :mediumtext
+    end
+  end
+
+  def down
+    if ['mysql', 'mysql2'].include? ActiveRecord::Base.connection.instance_values['config'][:adapter]
+      change_column :audits, :audited_changes, :text
+    end
+  end
+end

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -46,4 +46,15 @@ class AuditExtensionsTest < ActiveSupport::TestCase
     FactoryGirl.create(:ec2_cr, :with_auditing)
     refute_empty Audit.search_for("type = compute_resource")
   end
+
+  test "audited changes field can be greater then 65K bytes" do
+    prov_template = templates(:mystring)
+    prov_template.template = "0000000000" * 3500
+    as_admin do
+      assert prov_template.save!
+      prov_template.template = "1111111111" * 3500
+      assert prov_template.save!
+    end
+    assert Audit.last.audited_changes.to_s.bytesize > 66000
+  end
 end


### PR DESCRIPTION
In mysql text type is limited to 64K, while in psql there's no limit.
Changing column's type to MEDIUMTEXT, which limited to 16MB,
should solve this issue in mysql