### PR TITLE
Fixes #19700 - update rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,9 @@ Metrics/ClassLength:
 Performance/FixedSize:
   Exclude:
     - 'test/**/*'
+
+Performance/RedundantMatch:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -109,17 +109,6 @@ Performance/CompareWithBlock:
 Performance/RangeInclude:
   Enabled: false
 
-# Offense count: 7
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Enabled: false
-
-# Offense count: 42
-# Cop supports --auto-correct.
-# Configuration parameters: MaxKeyValuePairs.
-Performance/RedundantMerge:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect.

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -100,7 +100,7 @@ module Api
 
       case options
       when String
-        not_found_message.merge! :message => options
+        not_found_message[:message] = options
       when Hash
         not_found_message.merge! options
       else

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -48,7 +48,7 @@ module Api
       end
 
       def resource_scope(options = {})
-        options.merge!(:permission => :view_config_reports)
+        options[:permission] = :view_config_reports
         super(options).my_reports
       end
 

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -116,10 +116,10 @@ module Api
             association_name_ids = "#{k.singularize}_ids"
             association_name_names = "#{k.singularize}_names"
             if resource_class.instance_methods.map(&:to_s).include?(association_name_ids) && v.any? && v.all? { |a| a.keys.include?("id") }
-              params[model_name].merge!(association_name_ids => v.map { |a| a["id"] })
+              params[model_name][association_name_ids] = v.map { |a| a["id"] }
               params[model_name].except!(k)
             elsif resource_class.instance_methods.map(&:to_s).include?(association_name_names) && v.any? && v.all? { |a| a.keys.include?("name") }
-              params[model_name].merge!(association_name_names => v.map { |a| a["name"] })
+              params[model_name][association_name_names] = v.map { |a| a["name"] }
               params[model_name].except!(k)
             end
           end

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -65,7 +65,7 @@ module Api
       private
 
       def resource_scope(options = {})
-        options.merge!(:permission => :view_config_reports)
+        options[:permission] = :view_config_reports
         super(options).my_reports
       end
 

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -50,9 +50,9 @@ module Api::ImportPuppetclassesCommonController
     begin
       opts = { :url => @smart_proxy.url }
       if @environment.present?
-        opts.merge!(:env => @environment.name)
+        opts[:env] = @environment.name
       else
-        opts.merge!(:env => @env_id)
+        opts[:env] = @env_id
       end
       @importer = PuppetClassImporter.new(opts)
       @changed  = @importer.changes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
           Foreman::Logging.exception("Failed generating link using #{args.inspect}", e)
           id = 'not_parseable'
         end
-        html_options.merge!(:'data-id' => "aid_#{id}")
+        html_options[:'data-id'] = "aid_#{id}"
       end
       if html_options[:confirm]
         html_options[:data] ||= {}
@@ -195,7 +195,8 @@ module ApplicationHelper
   def auto_complete_search(name, val, options = {})
     path = options[:full_path]
     path ||= (options[:path] || send("#{auto_complete_controller_name}_path")) + "/auto_complete_#{name}"
-    options.merge!(:class => "autocomplete-input form-control", :'data-url' => path)
+    options[:class] = "autocomplete-input form-control"
+    options[:'data-url'] = path
     text_field_tag(name, val, options)
   end
 

--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -59,9 +59,7 @@ module ComputeResourcesVmsHelper
       :subject     => console[:subject],
       :title       => _("%s - Press Shift-F12 to release the cursor.") % console[:name]
     ) if supports_spice_xpi?
-    options.merge!(
-      :ca_cert     => URI.escape(console[:ca_cert])
-    ) if console[:ca_cert].present?
+    options[:ca_cert] = URI.escape(console[:ca_cert]) if console[:ca_cert].present?
     options
   end
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -54,7 +54,7 @@ module FormHelper
 
   # add hidden field for options[:disabled]
   def multiple_selects(f, attr, associations, selected_ids, options = {}, html_options = {})
-    options.merge!(:size => "col-md-10")
+    options[:size] = "col-md-10"
     case attr
       when :organizations
         klass = Organization
@@ -119,9 +119,9 @@ module FormHelper
     end
 
     select_options[:disabled] = '' if select_options[:disabled] == include_blank
-    html_options.merge!(:disabled => true) if disable_button_enabled
+    html_options[:disabled] = true if disable_button_enabled
 
-    html_options.merge!(:size => 'col-md-10') if html_options[:multiple]
+    html_options[:size] = 'col-md-10' if html_options[:multiple]
     field(f, attr, html_options) do
       addClass html_options, "form-control"
 
@@ -168,7 +168,7 @@ module FormHelper
   end
 
   def selectable_f(f, attr, array, select_options = {}, html_options = {})
-    html_options.merge!(:size => 'col-md-10') if html_options[:multiple]
+    html_options[:size] = 'col-md-10' if html_options[:multiple]
     field(f, attr, html_options) do
       addClass html_options, "form-control"
       f.select attr, array, select_options, html_options
@@ -260,7 +260,7 @@ module FormHelper
     options = {}
     options[:disabled] = true if args[:disabled]
     options[:class] = "btn btn-#{overwrite ? 'danger' : 'primary'} remove_form_templates"
-    options.merge! :'data-id' => form_to_submit_id(f) unless options.has_key?(:'data-id')
+    options[:'data-id'] = form_to_submit_id(f) unless options.has_key?(:'data-id')
     options
   end
 

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -86,10 +86,10 @@ module HostsHelper
   def last_report_tooltip(record)
     opts = { :rel => "twipsy" }
     if @last_report_ids[record.id]
-      opts.merge!("data-original-title" => _("View last report details"))
+      opts["data-original-title"] = _("View last report details")
     else
       opts.merge!(:disabled => true, :class => "disabled", :onclick => 'return false')
-      opts.merge!("data-original-title" => _("Report Already Deleted")) unless record.last_report.nil?
+      opts["data-original-title"] = _("Report Already Deleted") unless record.last_report.nil?
     end
     opts
   end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -54,7 +54,7 @@ module LayoutHelper
   end
 
   def will_paginate(collection = nil, options = {})
-    options.merge!(:class=>"col-md-7")
+    options[:class] = "col-md-7"
     options[:renderer] ||= "WillPaginate::ActionView::BootstrapLinkRenderer"
     options[:inner_window] ||= 2
     options[:outer_window] ||= 0

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -22,9 +22,7 @@ module RolesHelper
   end
 
   def new_link_unless_locked(name, path_hash, role)
-    if role && !role.locked?
-      new_link name, path_hash
-    end
+    new_link name, path_hash if role && !role.locked?
   end
 
   def delete_role_confirmation(role)

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -37,7 +37,7 @@ module Foreman::Model
     def create_vm(args = { })
       args = vm_instance_defaults.merge(args.to_hash.symbolize_keys).deep_symbolize_keys
       if (name = args[:name])
-        args.merge!(:tags => {:Name => name})
+        args[:tags] = {:Name => name}
       end
       if (image_id = args[:image_id])
         image = images.find_by_uuid(image_id.to_s)

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -207,7 +207,6 @@ module Foreman::Model
       @volume_client ||= ::Fog::Volume.new(fog_credentials)
     end
 
-
     def vm_instance_defaults
       super.merge(:key_name => key_pair.name)
     end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -211,7 +211,7 @@ module Foreman::Model
     def create_vm(args = {})
       args[:comment] = args[:user_data] if args[:user_data]
       if (image_id = args[:image_id])
-        args.merge!({:template => image_id})
+        args[:template] = image_id
       end
       vm = super({ :first_boot_dev => 'network', :quota => ovirt_quota }.merge(args))
       begin

--- a/app/models/concerns/configuration_status_scoped_search.rb
+++ b/app/models/concerns/configuration_status_scoped_search.rb
@@ -3,7 +3,8 @@ module ConfigurationStatusScopedSearch
 
   module ClassMethods
     def scoped_search_status(status, options)
-      options.merge!({ :offset => ConfigReport::METRIC.index(status.to_s), :word_size => ConfigReport::BIT_NUM })
+      options[:offset] = ConfigReport::METRIC.index(status.to_s)
+      options[:word_size] = ConfigReport::BIT_NUM
       scoped_search options
     end
   end

--- a/app/models/concerns/host_params.rb
+++ b/app/models/concerns/host_params.rb
@@ -9,7 +9,7 @@ module HostParams
     attr_reader :cached_host_params
 
     def params
-      Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_param') unless caller.first.match(/renderer\.rb.*host_param/)
+      Foreman::Deprecation.renderer_deprecation('1.17', __method__, 'host_param') unless caller.first =~ /renderer\.rb.*host_param/
       host_params.update(lookup_keys_params)
     end
 
@@ -25,9 +25,7 @@ module HostParams
         options = {:value => param.value,
                    :source => source,
                    :safe_value => param.safe_value }
-        if source != 'global'
-          options.merge!(:source_name => param.associated_label)
-        end
+        options[:source_name] = param.associated_label if source != 'global'
         hp.update(Hash[param.name => include_source ? options : param.value])
       end
       hp

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -117,9 +117,9 @@ module Orchestration::DHCP
     }
 
     if provision?
-      dhcp_attr.merge!(:nextServer => boot_server)
+      dhcp_attr[:nextServer] = boot_server
       filename = operatingsystem.boot_filename(self.host)
-      dhcp_attr.merge!(:filename => filename) if filename.present?
+      dhcp_attr[:filename] = filename if filename.present?
       if jumpstart?
         jumpstart_arguments = os.jumpstart_params self.host, model.vendor_class
         dhcp_attr.merge! jumpstart_arguments unless jumpstart_arguments.empty?

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -118,7 +118,7 @@ module Taxonomix
       conditions = { :taxable_type => self.base_class.name }
       if taxonomy.present?
         taxonomy_ids = get_taxonomy_ids(taxonomy, inner_method)
-        conditions.merge!(:taxonomy_id => taxonomy_ids)
+        conditions[:taxonomy_id] = taxonomy_ids
       end
 
       TaxableTaxonomy.where(conditions).uniq.pluck(:taxable_id).compact

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -66,7 +66,7 @@ class LookupValue < ApplicationRecord
   def validate_and_cast_value
     return if !self.value.is_a?(String) || value.contains_erb?
     Foreman::Parameters::Caster.new(self, :attribute_name => :value, :to => lookup_key.key_type).cast!
-    rescue StandardError, SyntaxError => e
+  rescue StandardError, SyntaxError => e
       Foreman::Logging.exception("Error while parsing #{lookup_key}", e)
       errors.add(:value, _("is invalid %s") % lookup_key.key_type)
   end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -175,8 +175,8 @@ class Operatingsystem < ApplicationRecord
     a = str.split(" ")
     b = a[1].split('.') if a[1]
     cond = {:name => a[0]}
-    cond.merge!(:major => b[0]) if b && b[0]
-    cond.merge!(:minor => b[1]) if b && b[1]
+    cond[:major] = b[0] if b && b[0]
+    cond[:minor] = b[1] if b && b[1]
     self.where(cond).first
   end
 
@@ -288,7 +288,7 @@ class Operatingsystem < ApplicationRecord
   def reject_empty_provisioning_template(attributes)
     template_exists = attributes[:id].present?
     provisioning_template_id_empty = attributes[:provisioning_template_id].blank?
-    attributes.merge!({:_destroy => 1}) if template_exists && provisioning_template_id_empty
+    attributes[:_destroy] = 1 if template_exists && provisioning_template_id_empty
     (!template_exists && provisioning_template_id_empty)
   end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -221,7 +221,7 @@ class Setting < ApplicationRecord
     bypass_readonly(s) do
       attrs = column_check([:default, :description, :full_name, :encrypted])
       to_update = Hash[opts.select { |k,v| attrs.include? k }]
-      to_update.merge!(:value => readonly_value(s.name.to_sym)) if s.has_readonly_value?
+      to_update[:value] = readonly_value(s.name.to_sym) if s.has_readonly_value?
       s.update_attributes(to_update)
       s.update_column :category, opts[:category] if s.category != opts[:category]
       s.update_column :full_name, opts[:full_name] if !column_check([:full_name]).empty?

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -45,7 +45,7 @@ class SmartProxy < ApplicationRecord
 
   def to_s
     return hostname unless Setting[:legacy_puppet_hostname]
-    hostname.match(/^puppet\./) ? 'puppet' : hostname
+    hostname =~ /^puppet\./ ? 'puppet' : hostname
   end
 
   def self.smart_proxy_ids_for(hosts)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -541,7 +541,7 @@ class User < ApplicationRecord
   def reject_empty_intervals(attributes)
     user_mail_notification_exists = attributes[:id].present?
     interval_empty = attributes[:interval].blank?
-    attributes.merge!({:_destroy => 1}) if user_mail_notification_exists && interval_empty
+    attributes[:_destroy] = 1 if user_mail_notification_exists && interval_empty
     (!user_mail_notification_exists && interval_empty)
   end
 

--- a/app/registries/foreman/access_control.rb
+++ b/app/registries/foreman/access_control.rb
@@ -89,7 +89,7 @@ module Foreman
 
       def permission(name, hash, options = {})
         @permissions ||= []
-        options.merge!(:security_block => @security_block) if @security_block
+        options[:security_block] = @security_block if @security_block
         @permissions << Permission.new(name, hash, options)
       end
 

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -167,14 +167,14 @@ module Foreman #:nodoc:
     # name parameter can be: :top_menu or :admin_menu
     #
     def menu(menu, name, options = {})
-      options.merge!(:parent => @parent) if @parent
+      options[:parent] = @parent if @parent
       Menu::Manager.map(menu).item(name, options)
     end
 
     alias_method :add_menu_item, :menu
 
     def sub_menu(menu, name, options = {}, &block)
-      options.merge!(:parent => @parent) if @parent
+      options[:parent] = @parent if @parent
       Menu::Manager.map(menu).sub_menu(name, options)
       current = @parent
       @parent = name
@@ -230,7 +230,7 @@ module Foreman #:nodoc:
     def permission(name, hash, options = {})
       rbac_registry.register name, options
       options[:engine] ||= self.id.to_s
-      options.merge!(:security_block => @security_block)
+      options[:security_block] = @security_block
       Foreman::AccessControl.map do |map|
         map.permission name, hash, options
       end

--- a/app/services/classification/base.rb
+++ b/app/services/classification/base.rb
@@ -173,7 +173,7 @@ module Classification
         computed_lookup_value = {:value => lookup_value.send(value_method), :element => element,
                                  :element_name => element_name}
 
-        computed_lookup_value.merge!({ :managed => lookup_value.omit }) if lookup_value.lookup_key.puppet?
+        computed_lookup_value[:managed] = lookup_value.omit if lookup_value.lookup_key.puppet?
         break
       end
       computed_lookup_value

--- a/app/services/foreman/deprecation.rb
+++ b/app/services/foreman/deprecation.rb
@@ -7,7 +7,7 @@ module Foreman
     end
 
     def self.check_version_format(foreman_version_deadline)
-      raise Foreman::Exception.new(N_("Invalid version format, please enter in x.y (only major version).")) unless foreman_version_deadline.to_s.match(/\A\d[.]\d+\z/)
+      raise Foreman::Exception.new(N_("Invalid version format, please enter in x.y (only major version).")) unless foreman_version_deadline.to_s =~ /\A\d[.]\d+\z/
     end
 
     def self.api_deprecation_warning(info)
@@ -18,9 +18,9 @@ module Foreman
       check_version_format foreman_version_deadline
       called_from_params = false
       caller.each_with_index do |item, index|
-        called_from_params = true if item.match(/host_params\.rb.*params/)
+        called_from_params = true if item =~ /host_params\.rb.*params/
         return if called_from_params && item.match(/managed\.rb.*info/)
-        next unless item.match(/renderer\.rb.*render_safe/)
+        next unless item =~ /renderer\.rb.*render_safe/
         Rails.logger.warn "DEPRECATION WARNING: you are using deprecated @host.#{method} in a template, it will be removed in #{foreman_version_deadline}. Use #{new_method} instead."
         return
       end

--- a/app/services/power_manager/base.rb
+++ b/app/services/power_manager/base.rb
@@ -48,8 +48,8 @@ module PowerManager
     def translate_status(result)
       result = result.to_s
       return N_("Unknown") if result.empty?
-      return 'on' if result.match(/on/i)
-      return 'off' if result.match(/off/i)
+      return 'on' if result =~ /on/i
+      return 'off' if result =~ /off/i
       result
     end
 

--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -24,8 +24,8 @@ module PowerManager
 
     def state_output(result)
       result = result.to_s
-      return 'on' if result.match(/started/i)
-      return 'off' if result.match(/paused/i)
+      return 'on' if result =~ /started/i
+      return 'off' if result =~ /paused/i
       translate_status(result) # unknown output
     end
 

--- a/app/services/ui_notifications/url_resolver.rb
+++ b/app/services/ui_notifications/url_resolver.rb
@@ -41,7 +41,7 @@ module UINotifications
 
     def validate_link link
       path_method = link[:path_method]
-      unless path_method.to_s.match(/_path$/)
+      unless path_method.to_s =~ /_path$/
         raise(Foreman::Exception, "Invalid path_method #{path_method}, must end with _path")
       end
     end

--- a/app/views/api/v2/auth_source_ldaps/index.json.rabl
+++ b/app/views/api/v2/auth_source_ldaps/index.json.rabl
@@ -5,4 +5,3 @@ extends "api/v2/auth_source_ldaps/main"
 node do |auth_source_ldap|
    partial("api/v2/taxonomies/children_nodes", :object => auth_source_ldap)
 end
-

--- a/db/seeds.d/07-data.rb
+++ b/db/seeds.d/07-data.rb
@@ -93,5 +93,5 @@ SEEDED_TEMPLATES = [
   { :name => 'redhat_register', :source => 'snippet/_redhat_register.erb', :snippet => true },
   { :name => 'remote_execution_ssh_keys', :source => 'snippet/_remote_execution_ssh_keys.erb', :snippet => true },
   { :name => 'saltstack_minion', :source => 'snippet/_saltstack_minion.erb', :snippet => true },
-  { :name => 'saltstack_setup', :source => 'snippet/_saltstack_setup.erb', :snippet => true },
+  { :name => 'saltstack_setup', :source => 'snippet/_saltstack_setup.erb', :snippet => true }
 ]

--- a/db/seeds.d/07-provisioning_templates.rb
+++ b/db/seeds.d/07-provisioning_templates.rb
@@ -17,7 +17,7 @@ ProvisioningTemplate.without_auditing do
       end
     else
       next if SeedHelper.audit_modified? ProvisioningTemplate, input[:name]
-      input.merge!(:default => true)
+      input[:default] = true
 
       t = ProvisioningTemplate.create({
         :snippet  => false,

--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -25,7 +25,8 @@ module Foreman
 
       url_options = foreman_url_options_from_url(url) if url.present?
 
-      url_options.merge!(:action => action, :path => config.path)
+      url_options[:action] = action
+      url_options[:path] = config.path
       render_foreman_url(host, url_options)
     end
 

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -22,9 +22,12 @@ module ProxyAPI
 
     def unused_ip(subnet, mac = nil)
       params = {}
-      params.merge!({:mac => mac}) if mac.present?
+      params[:mac] = mac if mac.present?
 
-      params.merge!({:from => subnet.from, :to => subnet.to}) if subnet.from.present? && subnet.to.present?
+      if subnet.from.present? && subnet.to.present?
+        params[:from] = subnet.from
+        params[:to] = subnet.to
+      end
       if params.any?
         params = "?" + params.map{|e| e.join("=")}.join("&")
       else

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -9,7 +9,7 @@ module ProxyAPI
                         :user => args[:user], :password => args[:password]}
 
       # We authenticate only if we are using SSL
-      if url.match(/^https/i)
+      if url =~ /^https/i
         cert         = Setting[:ssl_certificate]
         ca_cert      = Setting[:ssl_ca_file]
         hostprivkey  = Setting[:ssl_priv_key]

--- a/test/controllers/puppetclasses_controller_test.rb
+++ b/test/controllers/puppetclasses_controller_test.rb
@@ -104,7 +104,7 @@ class PuppetclassesControllerTest < ActionController::TestCase
     # below is the same test as above, except environment is changed from production to global_puppetmaster, so custom_class_param is NOT added
     host = FactoryGirl.create(:host, :environment => environments(:production))
     existing_host_attributes = host_attributes(host)
-    existing_host_attributes.merge!('environment_id' => environments(:global_puppetmaster).id)
+    existing_host_attributes['environment_id'] = environments(:global_puppetmaster).id
     puppetclass = puppetclasses(:two)
     post :parameters, {:id => puppetclass.id, :host_id => host.id,
                        :host => existing_host_attributes }, set_session_user

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -755,19 +755,20 @@ class UserTest < ActiveSupport::TestCase
 
     test "update self" do
       editing_self_helper
-      @options.merge!({ :action => "update" })
+      @options[:action] = "update"
       assert User.current.editing_self?(@options)
     end
 
     test "update other user" do
       editing_self_helper
-      @options.merge!({ :id => users(:two).id })
+      @options[:id] = users(:two).id
       refute User.current.editing_self?(@options)
     end
 
     test "update through other controller" do
       editing_self_helper
-      @options.merge!({ :controller => "hosts", :id => User.current.id })
+      @options[:controller] = "hosts"
+      @options[:id] = User.current.id
       refute User.current.editing_self?(@options)
     end
   end


### PR DESCRIPTION
The following changes have been made:

- Performance/RedundantMerge:
changes lines such as:
```ruby
not_found_message.merge! :message => options
```
to:
```ruby
not_found_message[:message] = options
```

- converts str.match() to str =~ ()
- remove extra whitespaces etc.