### PR TITLE
Fixes #18855 - Add better error message on invalid taxonomies

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -60,9 +60,9 @@ class Role < ApplicationRecord
   taxonomy_join_table = :taxable_taxonomies
   has_many taxonomy_join_table.to_sym, :dependent => :destroy, :as => :taxable
   has_many :locations, -> { where(:type => 'Location') },
-           :through => taxonomy_join_table, :source => :taxonomy
+           :through => taxonomy_join_table, :source => :taxonomy, :validate => false
   has_many :organizations, -> { where(:type => 'Organization') },
-           :through => taxonomy_join_table, :source => :taxonomy
+           :through => taxonomy_join_table, :source => :taxonomy, :validate => false
 
   validates :name, :presence => true, :uniqueness => true
   validates :builtin, :inclusion => { :in => 0..2 }


### PR DESCRIPTION
We can't really fix this right now, so I just aim to add better error message. The validation errors appear when a taxonomy is invalid. It is really easy to make a taxonomy invalid, all it takes is to update os from facts.