### PR TITLE
Fixes #19717 - Pin npm to < 5.0.0 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ node_js:
   - "6.9" # initial EPEL 7
   - "6.10" # current LTS, current EPEL 7
 before_install:
-  npm install -g npm@'>=3.0.0'
+  npm install -g npm@'>=3.0.0, <5.0.0'
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
5.0.0 fails to install some of our dependencies like node-sass and
phantomjs-compiled.