### PR TITLE
Fixes #19930: Skip adding permissions to default_roles during migrate

### DIFF
--- a/app/registries/foreman/plugin/rbac_support.rb
+++ b/app/registries/foreman/plugin/rbac_support.rb
@@ -2,6 +2,7 @@ module Foreman
   class Plugin
     class RbacSupport
       def add_all_permissions_to_default_roles(all_permissions)
+        return if Foreman.in_rake?('db:migrate')
         view_permissions = all_permissions.where("name LIKE :name", :name => "view_%")
         Role.transaction do
           add_all_permissions_to_role("Manager", all_permissions)


### PR DESCRIPTION
This breaks during upgrades from my testing with foreman-tasks available. There is the possibility this can be called when the Role or Filter model have not been fully migrated and a plugin that calls the function during initialization triggers an error.

I'd like to have this considered for 1.15.1 to unblock some user upgrade scenarios.