### PR TITLE
refs #19589 - foreman can now start in production

### DIFF
--- a/lib/generators/plugin/migration_generator.rb
+++ b/lib/generators/plugin/migration_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators'
+
 module Plugin
   class MigrationGenerator < Rails::Generators::Base
     class_option :plugin_name, :required => true


### PR DESCRIPTION
this avoids the following error in production (under passenger):

 Message from application: uninitialized constant Generators::Base (NameError)
 lib/generators/plugin/migration_generator.rb:2:in `<module:Plugin>'
 lib/generators/plugin/migration_generator.rb:1:in `<top (required)>