### PR TITLE
Fixes #19952 - Allow view_audit_logs to work

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -169,7 +169,7 @@ class Authorizer
     return 'Parameter' if klass <= Parameter
 
     case (name = klass.to_s)
-    when 'Audited::Adapters::ActiveRecord::Audit'
+    when 'Audited::Audit'
       'Audit'
     when /\AHost::.*\Z/
       'Host'


### PR DESCRIPTION
Every time the /audits page is visited by a non-admin user, it checks
whether the permission 'view_audit_logs' is for the Audit class. In
previous versions of 'audited', this was
Audited::Adapters::ActiveRecord::Audit, but right now it's simply
Audited::Audit.

To test the change, visit the page with an user that just has the
'view_audit_logs' permission. Check how without updating the
authorizer.rb file, /audits will be empty.