### PR TITLE
fixes #19969 - Find a vlanid for a subnet6 if no subnet4 is present

### DIFF
--- a/test/fixtures/subnets.yml
+++ b/test/fixtures/subnets.yml
@@ -51,3 +51,11 @@ six:
   network: '2001:db10::'
   mask: 'ffff:ffff:ffff:ffff::'
   dns: three
+
+seven:
+  name: seven
+  type: Subnet::Ipv6
+  network: '2001:db10:7::'
+  mask: 'ffff:ffff:ffff:ffff::'
+  dns: three
+  vlanid: 44

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -72,16 +72,37 @@ class NicTest < ActiveSupport::TestCase
 
   test "should delegate subnet attributes" do
     subnet = subnets(:two)
+    subnet6 = subnets(:seven)
     domain = (subnet.domains.any? ? subnet.domains : subnet.domains << Domain.first).first
     interface = FactoryGirl.build(:nic_managed,
                                   :ip => "3.3.4.127",
                                   :mac => "cabbccddeeff",
                                   :host => FactoryGirl.create(:host),
                                   :subnet => subnet,
+                                  :subnet6 => subnet6,
                                   :name => "a" + FactoryGirl.create(:host).name,
                                   :domain => domain)
     assert_equal subnet.network, interface.network
+    assert_equal subnet6.network, interface.network6
     assert_equal subnet.vlanid, interface.vlanid
+    assert_equal '42', interface.vlanid
+  end
+
+  test "should delegate subnet6 attributes if subnet is nil" do
+    subnet = nil
+    subnet6 = subnets(:seven)
+    domain = (subnet6.domains.any? ? subnet6.domains : subnet6.domains << Domain.first).first
+    interface = FactoryGirl.build(:nic_managed,
+                                  :ip => "3.3.4.127",
+                                  :mac => "cabbccddeeff",
+                                  :host => FactoryGirl.create(:host),
+                                  :subnet => subnet,
+                                  :subnet6 => subnet6,
+                                  :name => "a" + FactoryGirl.create(:host).name,
+                                  :domain => domain)
+    assert_equal subnet6.vlanid, interface.vlanid
+    assert_equal subnet6.network, interface.network6
+    assert_equal '44', interface.vlanid
   end
 
   test "should reject subnet with mismatched taxonomy in host" do


### PR DESCRIPTION
You can have a network interface with an ipv6 subnet configured but
without an ipv4 subnet; in this case, the function `vlanid` for
`interface` will throw an error.

This fix will test for `nil` and fall back to `subnet6`. If both subnets
are `nil`, we return `nil` too.