### PR TITLE
Fixes #19991 - Add network6 to nic model

### DIFF
--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -20,7 +20,11 @@ module Nic
 
     validate :alias_subnet
 
-    delegate :network, :to => :subnet
+    delegate :network, :to => :subnet, :prefix => true
+    delegate :network, :to => :subnet6, :prefix => true
+
+    alias_method :network, :subnet_network
+    alias_method :network6, :subnet6_network
 
     def vlanid
       self.tag.blank? ? self.subnet.vlanid : self.tag


### PR DESCRIPTION
Fixes #19991 - Add network6 to nic model

This adds the method `network6`, delegated to the `subnet6` relation.
Because the `delegate` methods does not support completely renaming a
method, I use a combination of delegate and alias. I updated the
definition for `network` (the v4 equivalent) to be consistent.

Attention: builds further upon #4577, because I extend those tests...