### PR TITLE
Fixes #16807 - remove permission edit_users for test_mail

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -124,7 +124,7 @@ class UsersController < ApplicationController
 
   def test_mail
     begin
-      user = find_resource(:edit_users)
+      user = find_resource
       if (params.has_key?(:user_email) && params[:user_email].blank?) || user.mail.blank?
         render :json => {:message => _("Email address is missing")}, :status => :unprocessable_entity
         return

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -710,10 +710,10 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :users do |map|
-    ajax_actions = [:auth_source_selected, :test_mail]
+    ajax_actions = [:auth_source_selected]
 
     map.permission :view_users,
-                   :users => [:index, :show, :auto_complete_search],
+                   :users => [:index, :show, :auto_complete_search, :test_mail],
                    :"api/v1/users" => [:index, :show],
                    :"api/v2/users" => [:index, :show]
     map.permission :create_users,

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -391,6 +391,15 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal user.mail, mail.to[0]
   end
 
+  test "test email should be delivered even when user is not admin" do
+    user = users(:one)
+    User.current = user
+    put :test_mail, { :id => user.id, :user => {:login => user.login} }
+    mail = ActionMailer::Base.deliveries.last
+    assert mail.subject.include? "Foreman test email"
+    assert_equal user.mail, mail.to[0]
+  end
+
   context "when user is logged in" do
     test "#login redirects to previous url" do
       @previous_url = "/bookmarks"


### PR DESCRIPTION
Test email action requires that the user has either `create` or `edit_users`, which is  unnecessary.