### PR TITLE
Fixes #20048 - Wait before checking CR password

### DIFF
--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -43,7 +43,7 @@ class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
     find("#disable-pass-btn").click
     fill_in "compute_resource_password", :with => "123456"
     click_link "Test Connection"
-    assert_equal "123456", find_field("compute_resource_password").value
+    assert find_field("compute_resource_password").has_content?('123456')
     wait_for_ajax
   end
 end


### PR DESCRIPTION
The test is trying to check the value for the password field.
However it's failing to get it, possibly because jQuery is still
setting the password.

I see find_field is supposed to wait for Capybara.default_max_wait_time, but there is no apparent reason why the password would not show up. Is there a way to check in Jenkins, saving Rails logs somewhere..?