### PR TITLE
Fixes #20049 - Retry various integration tests before failing

### DIFF
--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class AboutIntegrationTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   AboutIntegrationTest.test_0002_about page proxies should have version
+  extend Minitest::OptionalRetry
+
   setup do
     ComputeResource.any_instance.expects(:ping).at_least_once.returns([])
     proxy_status = mock('ProxyStatus::Version')

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class ComputeProfileJSTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   ComputeProfileJSTest.test_0001_edit compute attribute page
+  extend MiniTest::OptionalRetry
+
   setup do
     Fog.mock!
   end

--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   ComputeResourceJSIntegrationTest.test_0002_add new compute attributes two pane
+  extend Minitest::OptionalRetry
+
   setup do
     Fog.mock!
   end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class DashboardIntegrationTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   DashboardIntegrationTest.test_0005_dashboard link hosts that had pending changes
+  extend MiniTest::OptionalRetry
+
   def setup
     Dashboard::Manager.reset_user_to_default(users(:admin))
   end

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class PuppetclassIntegrationTest < IntegrationTestWithJavascript
+  # intermittent failures:
+  #   PuppetclassIntegrationTest.test_0001_edit page
+  extend Minitest::OptionalRetry
+
   test "edit page" do
     visit puppetclasses_path
     click_link "vim"

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -1,6 +1,10 @@
 require 'integration_test_helper'
 
 class UserIntegrationTest < ActionDispatch::IntegrationTest
+  # intermittent failures:
+  #   UserIntegrationTest.test_0002_edit page
+  extend Minitest::OptionalRetry
+
   test "index page" do
     assert_index_page(users_path,"Users","Create User")
   end


### PR DESCRIPTION
Thanks to #15894 we can retry some tests. Some of the failures I'm
seeing I'm having a hard time to reproduce, like
"Capybara::Poltergeist::StatusFailError: Request to
'http://127.0.0.1:41550/compute_profiles/980190962-1-Small' failed to
reach server, check DNS and/or server status - Timed out with no open
resource requests...". I think it's not a bad idea to let these test run
3 times and only count them as failed if they fail 3 times.