### PR TITLE
Fixes #20087 - Pin rails-observers on Ruby < 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'net-scp'
 gem 'net-ssh'
 gem 'net-ldap', '>= 0.8.0'
 gem 'activerecord-session_store', '>= 0.1.1', '< 2'
-gem 'rails-observers', '~> 0.1'
+gem 'rails-observers', '>= 0.1', (RUBY_VERSION < '2.2.2' ? '< 0.1.4' : '< 1')
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
 gem 'responders', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'rails-observers', '>= 0.1', (RUBY_VERSION < '2.2.2' ? '< 0.1.4' : '< 1')
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '>= 2.3.3', '< 3'
 gem 'responders', '~> 2.0'
-gem 'roadie-rails', '~> 1.1'
+gem 'roadie-rails', '>= 1.1', (RUBY_VERSION < '2.2' ? '< 1.2' : '< 2')
 gem 'x-editable-rails', '~> 1.5.5'
 gem 'deacon', '~> 1.0'
 gem 'webpack-rails', '~> 0.9.8'


### PR DESCRIPTION
Notice this PR is against 1.11-stable. test_update currently fails with the following message,  this PR fixes it by pinning the gem.

```
Gem::InstallError: rails-observers requires Ruby version >= 2.2.2.
An error occurred while installing rails-observers (0.1.4), and Bundler cannot
continue.
Make sure that `gem install rails-observers -v '0.1.4'` succeeds before
bundling.

In Gemfile:
  audited-activerecord was resolved to 4.2.2, which depends on
    audited was resolved to 4.2.2, which depends on
      rails-observers
```