### PR TITLE
Refs #19717 - Pin npm to < 6.0.0 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
   - '6' # current LTS
   - '8' # current stable
 before_install:
-  npm install -g npm@'>=3.0.0, <5.0.0'
+  npm install -g npm@'>=3.0.0, <6.0.0'
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
All dependencies are compatible with npm 5.x now