### PR TITLE
Fixes #19383 - document enabled host attribute

### DIFF
--- a/app/controllers/api/v1/hosts_controller.rb
+++ b/app/controllers/api/v1/hosts_controller.rb
@@ -57,7 +57,7 @@ module Api
           param :value, String, :desc => "Parameter value", :required => true
         end
         param :build, :bool
-        param :enabled, :bool
+        param :enabled, :bool, :desc => "Include this host within Foreman reporting"
         param :provision_method, String
         param :managed, :bool, :desc => "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
         param :progress_report_id, String, :desc => "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -88,7 +88,7 @@ module Api
             param :value, String, :desc => N_("Parameter value"), :required => true
           end
           param :build, :bool
-          param :enabled, :bool
+          param :enabled, :bool, :desc => N_("Include this host within Foreman reporting")
           param :provision_method, String, :desc => N_("The method used to provision the host. Possible provision_methods may be %{provision_methods}") # values are defined in apipie initializer
           param :managed, :bool, :desc => N_("True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not")
           param :progress_report_id, String, :desc => N_("UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks")


### PR DESCRIPTION
For some reason, my hammer does not display this even though I see it in /apidoc and at public/apidoc/v2.json and I'm running `hammer -r host create --help`. Anyway I believe it needs documentation like this. The string is copied from UI but if $reviewer thinks it's worth of rephrasing, I'm happy to change it both for API and UI.