### PR TITLE
Fixes #20097 - Allow plugins JS to be added to webpack

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -11,11 +11,13 @@ var devServerPort = 3808;
 
 // set TARGETNODE_ENV=production on the environment to add asset fingerprints
 var production = process.env.RAILS_ENV === 'production' || process.env.NODE_ENV === 'production';
+const execSync = require('child_process').execSync;
 
 var config = {
   entry: {
     // Sources are expected to live in $app_root/webpack
     'bundle': './webpack/assets/javascripts/bundle.js'
+    'plugin': execSync('./script/plugin_webpack_directories.rb').toString().split('\n');
   },
 
   output: {
@@ -98,6 +100,7 @@ if (production) {
 
   config.devServer = {
     host: process.env.BIND || '127.0.0.1',
+    disableHostCheck: true,
     port: devServerPort,
     headers: { 'Access-Control-Allow-Origin': '*' },
     hot: true

--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require 'bundler'
+
+# Only works for local dependencies
+Bundler.load.specs.select { |dep| dep.name =~ /foreman*/ }.each do |dependency|
+  webpack_path = "#{dependency.to_spec.full_gem_path}/webpack"
+  puts webpack_path if Dir.exists? webpack_path
+end


### PR DESCRIPTION
At the moment, the only entrypoint for webpack seems to be /webpack.
webpack.config.js should also support code coming from plugins.
Using bundler, we can fetch this directory trivially - a dumb heuristic
could be to add as an entry point the '/webpack' directory of all gem
dependencies that look like "foreman*".