### PR TITLE
Fixes #20104 - fix_db_cache needs to run as admin

### DIFF
--- a/lib/tasks/fix_cache.rake
+++ b/lib/tasks/fix_cache.rake
@@ -1,22 +1,36 @@
 desc 'Fix user groups and authorization cache by removing all cached records and recreating them'
 task :fix_db_cache => :environment do
   puts 'Recreating cache'
-  CacheManager.recache!
+  if User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
+    User.as_anonymous_admin do
+      CacheManager.recache!
+    end
+  else
+    User.without_auditing do
+      CacheManager.recache!
+    end
+  end
 end
 
 namespace :fix_db_cache do
   task :delete_old_cache do
-    CacheManager.delete_old_permission_cache
+    User.as_anonymous_admin do
+      CacheManager.delete_old_permission_cache
+    end
     puts "Old cached records were deleted"
   end
 
   task :create_new_cache do
-    CacheManager.create_new_permission_cache
+    User.as_anonymous_admin do
+      CacheManager.create_new_permission_cache
+    end
     puts "New cached records were saved"
   end
 
   task :cache_filter_searches do
-    CacheManager.create_new_filter_cache
+    User.as_anonymous_admin do
+      CacheManager.create_new_filter_cache
+    end
     puts "Filters cache saved"
   end
 end


### PR DESCRIPTION
The rake task 'fix_db_cache' triggers CacheManager, and CacheManager
tries to find roles, user groups, etc.. without any permissions. This
will cause it to fail with an error similar to
https://gist.github.com/52da11cb368ec530bcf0247d3ee38855 .

Many of the actions called by CacheManager, like UsergroupMember.save
will have to find objects that needs permissions to be viewed, hence
CacheManager has to be called "as_admin".

Similarly an user may destroy or save a new UsergroupMember. The cache
needs to be updated with information about *all* user groups in the
system, not only the ones visible to the user making the change.