### PR TITLE
Fixes #19266 - fix_db_cache crashes Rails initialization

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -64,7 +64,7 @@ class UserRole < ApplicationRecord
   end
 
   def build_user_role_cache
-    [ self.cached_user_roles.build(:user_id => owner.id, :role_id => role.id) ]
+    [ self.cached_user_roles.build(:user_id => owner_id, :role_id => role_id) ]
   end
 
   def build_user_group_role_cache(owner)

--- a/app/services/cache_manager.rb
+++ b/app/services/cache_manager.rb
@@ -10,7 +10,9 @@ class CacheManager
   end
 
   def self.create_new_filter_cache
-    Filter.all.each(&:save!)
+    Role.ignore_locking do
+      Filter.all.map(&:save!)
+    end
   end
 
   def self.recache!

--- a/test/unit/cache_manager_test.rb
+++ b/test/unit/cache_manager_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class CacheManagerTest < ActiveSupport::TestCase
+  test 'new filter cache can be created regardless of locked roles' do
+    as_admin do
+      assert Role.any?(&:locked?)
+      CacheManager.create_new_filter_cache
+    end
+  end
+end


### PR DESCRIPTION
The Filters cache that CacheManager recreates when
fix_db_cache is true, fails when the roles associated with said
filters are locked. To generate the cache, we call `.save` on the filter
object, which is not allowed by Role.

Another issue is that some Filters may have many resource types, which
will also fail to save again to recreate the cache. This behavior is now
autofixed in the cache. [See an example here](https://github.com/theforeman/foreman_remote_execution/blob/master/lib/foreman_remote_execution/engine.rb#L70), the remote_execution plugin creates a role with one filter which mixes many resource types (proxy, hosts, remote execution..) 