### PR TITLE
Fixes #20097 - Foreman plugin support for webpack/react

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["react", "es2015"],
-  "plugins": ["transform-object-rest-spread", "transform-object-assign"]
-}

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,6 +15,7 @@
     <%= yield(:stylesheets) %>
 
     <%= csrf_meta_tags %>
+    <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag "locale/#{FastGettext.locale}/app", "data-turbolinks-track" => true %>
     <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var*/
 'use strict';
 
 var path = require('path');
@@ -5,6 +6,7 @@ var webpack = require('webpack');
 var StatsPlugin = require('stats-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CompressionPlugin = require('compression-webpack-plugin');
+var execSync = require('child_process').execSync;
 
 // must match config.webpack.dev_server.port
 var devServerPort = 3808;
@@ -14,12 +16,15 @@ var production =
   process.env.RAILS_ENV === 'production' ||
   process.env.NODE_ENV === 'production';
 
-var config = {
-  entry: {
-    // Sources are expected to live in $app_root/webpack
-    bundle: './webpack/assets/javascripts/bundle.js'
-  },
+var plugins = JSON.parse(execSync('./script/plugin_webpack_directories.rb'));
 
+var config = {
+  entry: Object.assign(
+    {
+      bundle: './webpack/assets/javascripts/bundle.js'
+    },
+    plugins.entries
+  ),
   output: {
     // Build assets directly in to public/webpack/, let webpack know
     // that all webpacked assets start with webpack/
@@ -34,31 +39,46 @@ var config = {
   resolve: {
     modules: [
       path.join(__dirname, '..', 'webpack'),
-      path.join(__dirname, '..', 'node_modules')
-    ]
+      path.join(__dirname, '..', 'node_modules'),
+    ],
+    alias: {
+      foremanReact:
+        path.join(__dirname,
+           '../webpack/assets/javascripts/react_app/components')
+    }
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          'presets': [
+            path.join(__dirname, '..', 'node_modules/babel-preset-react'),
+            path.join(__dirname, '..', 'node_modules/babel-preset-es2015')
+          ],
+          'plugins': [
+            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),
+            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-assign')
+          ]
+        }
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract({
+        use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
           use: 'css-loader'
         })
       },
       {
         test: /(\.png|\.gif)$/,
-        loader: 'url-loader?limit=32767'
+        use: 'url-loader?limit=32767'
       },
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract({
+        use: ExtractTextPlugin.extract({
           fallback: 'style-loader', // The backup style loader
           use: 'css-loader?sourceMap!sass-loader?sourceMap'
         })
@@ -85,7 +105,11 @@ var config = {
         NODE_ENV: JSON.stringify(production ? 'production' : 'development'),
         NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING
       }
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
     })
+
   ]
 };
 

--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -1,0 +1,25 @@
+#! /usr/bin/env ruby
+
+require 'bundler'
+require 'json'
+
+PLUGIN_NAME_REGEXP = /foreman*|katello*/
+
+config = { entries: {}, paths: [] }
+Bundler.load.specs.each do |dep|
+  # skip other rails engines that are not plugins
+  # TOOD: Consider using the plugin registeration api?
+  next unless dep.name =~ PLUGIN_NAME_REGEXP
+  path = "#{dep.to_spec.full_gem_path}/webpack"
+  entry = "#{path}/index.js"
+  # some plugings share the same base directory (tasks-core and tasks, REX etc)
+  # skip the plugin if its path is already included
+  next if config[:paths].include?(path)
+  if File.exist?(entry)
+    bundle_name = dep.name.gsub(/-|_|#{PLUGIN_NAME_REGEXP}/,'')
+    config[:entries][bundle_name] = entry
+    config[:paths] << path
+  end
+end
+
+puts config.to_json


### PR DESCRIPTION
How to use:

in a plugin, create a directory called webpack
then inside a file called index.js put something like:

```js
import React from 'react';
import ReactDOM from 'react-dom';
import Icon from 'foremanReact/common/Icon';

const reactNode = document.querySelector('#content');

if (reactNode) {
  ReactDOM.render(
    <Icon type='ok' />,
    reactNode);
};

```
TODOS:
- [ ] support JEST / eslint
- [ ] extend the react mounter, so plugins can add more mounting points and use
them.
- [ ] update storybook to support plugins too
- [ ] make equivalent of rake test