### PR TITLE
fixes #20142 - adds storybook deployer

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "phantomjs-prebuilt": "^2.1.0"
   },
   "dependencies": {
+    "@storybook/storybook-deployer": "^2.0.0",
     "brace": "^0.10.0",
     "c3": "^0.4.11",
     "datatables.net": "~1.10.12",
@@ -76,7 +77,8 @@
     "test": "node node_modules/.bin/jest",
     "test:watch": "node node_modules/.bin/jest --watchAll",
     "storybook": "start-storybook --dont-track -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "deploy-storybook": "storybook-to-ghpages"
   },
   "jest": {
     "automock": true,


### PR DESCRIPTION
this adds supports to create a storybook
per branch and deploy it either to github pages
or to rawgit.

the benefit of using this is to allow multiple
storybooks(per branch) instead of overwritting your
github pages each time you share a storybook.

to use:

using github pages:
./node_modules/.bin/storybook-to-ghpages --remote=(my branch)

using rawgit:
./node_modules/.bin/storybook-to-ghpages --remote=ohadlevy --branch=storybook-my-feature