### PR TITLE
Fixes #20146 - domain-less server email errors fixed

### DIFF
--- a/app/models/setting/email.rb
+++ b/app/models/setting/email.rb
@@ -4,8 +4,8 @@ class Setting::Email < Setting
   NON_EMAIL_YAML_SETTINGS = %w(send_welcome_email email_reply_address email_subject_prefix)
 
   def self.default_settings
-    domain = Facter.value(:domain) || SETTINGS[:domain]
-    email_reply_address = "Foreman-noreply@#{domain}"
+    domain = SETTINGS[:domain]
+    email_reply_address = "foreman-noreply@#{domain}"
 
     [
       self.set('email_reply_address', N_("Email reply address for emails that Foreman is sending"), email_reply_address, N_('Email reply address')),

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -2,7 +2,7 @@ require 'facter'
 class Setting::General < Setting
   def self.default_settings
     protocol = SETTINGS[:require_ssl] ? 'https' : 'http'
-    domain = Facter.value(:domain) || SETTINGS[:domain]
+    domain = SETTINGS[:domain]
     administrator = "root@#{domain}"
     foreman_url = "#{protocol}://#{Facter.value(:fqdn) || SETTINGS[:fqdn]}"
 

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -1,5 +1,6 @@
 require_relative 'boot_settings'
 require_relative '../app/services/foreman/version'
+require 'facter'
 
 root = File.expand_path(File.dirname(__FILE__) + "/..")
 settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
@@ -12,6 +13,7 @@ SETTINGS[:puppetconfdir] ||= '/etc/puppet'
 SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
 SETTINGS[:puppetssldir]  ||= "#{SETTINGS[:puppetvardir]}/ssl"
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value
+SETTINGS[:domain] ||= Facter.value(:domain) || Facter.value(:hostname)
 
 # Load plugin config, if any
 Dir["#{root}/config/settings.plugins.d/*.yaml"].each do |f|

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -264,7 +264,7 @@ attributes55:
 attributes56:
   name: email_reply_address
   category: Setting::Email
-  default: "Foreman-noreply@#{SETTINGS[:domain]}"
+  default: "foreman-noreply@#{SETTINGS[:domain]}"
   description: 'Email reply address for emails that Foreman is sending'
 attributes57:
   name: clean_up_failed_deployment


### PR DESCRIPTION
On a server without domain (e.g. `hostname -f` returning just host name) there were email validation errors because domain part was `nil` via Facter. This fixes it - it falls back to hostname if domain is not set.

More than that, our design was weird - there is a config setting `domain` in `settings.yaml` which I believe should override what's set on system but it does not - Facter wins. I refactored the code so it really overrides when it is present.

Also lowered case for the default "Foreman-noreply" email which looks much saner to me.