### PR TITLE
Fixes #20174 - handle no storage pool gracefully

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -95,6 +95,10 @@ class ComputeResource < ApplicationRecord
     []
   end
 
+  def capable?(feature)
+    capabilities.include?(feature)
+  end
+
   # attributes that this provider can provide back to the host object
   def provided_attributes
     {:uuid => :identity}
@@ -277,6 +281,17 @@ class ComputeResource < ApplicationRecord
 
   def available_storage_pods(storage_pod = nil)
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
+  # if this method is overridden in a provider, new_volume_errors should be also overridden
+  # method should return nil in case it can't build new volume because of some misconfiguration or runtime issue
+  def new_volume(attr = {})
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
+  # returs an array of translated errors that prevents to build a volume on this provider
+  def new_volume_errors
+    []
   end
 
   # this method is overwritten for Libvirt and OVirt

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -16,7 +16,7 @@ module Foreman::Model
     end
 
     def capabilities
-      [:image]
+      [:image, :new_volume]
     end
 
     def project

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -31,7 +31,7 @@ module Foreman::Model
     end
 
     def capabilities
-      [:build, :image]
+      [:build, :image, :new_volume]
     end
 
     def find_vm_by_uuid(uuid)

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -29,7 +29,7 @@ module Foreman::Model
     end
 
     def capabilities
-      [:build, :image]
+      [:build, :image, :new_volume]
     end
 
     def vms(opts = {})

--- a/app/views/compute_resources_vms/form/_volumes.html.erb
+++ b/app/views/compute_resources_vms/form/_volumes.html.erb
@@ -1,20 +1,24 @@
-<% if provider_partial_exist?(compute_resource, 'volume') %>
-  <div class="children_fields">
-    <%= new_child_fields_template(f, :volumes, {
-        :object  => compute_resource.new_volume,
-        :partial => provider_partial(compute_resource, 'volume'),
-        :form_builder_attrs => { :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm, :remove_title => _('remove storage volume') },
-        :layout => "compute_resources_vms/form/#{item_layout}_layout" }) %>
-
+<% if compute_resource.capable?(:new_volume) || provider_partial_exist?(compute_resource, 'volume') %>
+  <% volume = compute_resource.new_volume %>
     <%= field_set_tag _("Storage"), :id => "storage_volumes" do %>
+      <% if volume.present? %>
+        <div class="children_fields">
+          <%= new_child_fields_template(f, :volumes, {
+              :object  => volume,
+              :partial => provider_partial(compute_resource, 'volume'),
+              :form_builder_attrs => { :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm, :remove_title => _('remove storage volume') },
+              :layout => "compute_resources_vms/form/#{item_layout}_layout" }) %>
 
-      <%= f.fields_for :volumes do |i| %>
-        <%= render :partial => provider_partial(compute_resource, 'volume'), :locals => { :f => i, :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm, :remove_title => _('remove storage volume') }, :layout => "compute_resources_vms/form/#{item_layout}_layout" %>
-      <% end %>
+          <%= f.fields_for :volumes do |i| %>
+            <%= render :partial => provider_partial(compute_resource, 'volume'), :locals => { :f => i, :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm, :remove_title => _('remove storage volume') }, :layout => "compute_resources_vms/form/#{item_layout}_layout" %>
+          <% end %>
 
-      <% if new_vm %>
-        <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+          <% if new_vm %>
+            <%= add_child_link '+ ' + _("Add Volume"), :volumes, { :class => "info", :title => _('add new storage volume') } %>
+          <% end %>
+        </div>
+      <% else %>
+        <%= alert :text => _('Unable to define volumes:') + ' ' + compute_resource.new_volume_errors.join(', '), :close => false, :class => 'alert-warning', :header => '' %>
       <% end %>
-    <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -369,4 +369,18 @@ class ComputeResourceTest < ActiveSupport::TestCase
       assert_equal true, compute_resource.update_required?(old_attrs, new_attrs)
     end
   end
+
+  test 'capable? returns true if capabilities include the feature' do
+    cr = compute_resources(:mycompute)
+    cr.stubs(:capabilities).returns([:new_volume]) do
+      assert cr.capable?(:new_volume)
+    end
+  end
+
+  test 'capable? returns false if capabilities do not include the feature' do
+    cr = compute_resources(:mycompute)
+    cr.stubs(:capabilities).returns([:new_volume]) do
+      refute cr.capable?(:build)
+    end
+  end
 end

--- a/test/models/compute_resources/libvirt_test.rb
+++ b/test/models/compute_resources/libvirt_test.rb
@@ -88,4 +88,20 @@ class LibvirtTest < ActiveSupport::TestCase
       assert_equal 'create_error', err.message
     end
   end
+
+  describe '#new_volume' do
+    let(:cr) { FactoryGirl.build(:libvirt_cr) }
+
+    test 'new_volume_errors reports error for empty storage pool' do
+      cr.stubs(:storage_pools).returns([]) do
+        assert_equal 1, cr.new_volume_errors.size
+      end
+    end
+
+    test 'new_volume returns nil if there is an error' do
+      cr.stubs(:new_volume_errors).returns(['something']) do
+        assert_nil cr.new_volume({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the ugly error and as a side effect it:
* refactors how we detect that compute resource supports adding volumes
* allows provisioning vms on libvirt without storage (probably not too useful)
* introduces a way to detect storage errors before we run the provisioning orchestration, could be reused by other CRs that support it

Mainly it fixes 500 on compute profile edit, after applying this patch you can see:
![20175_after_profile](https://user-images.githubusercontent.com/109773/27733143-d0348626-5d94-11e7-923f-73114b208792.png)

Note that it also affects host form, before if the storage pool was missing, you could see following error on VM tab
![20174_after_host](https://user-images.githubusercontent.com/109773/27733142-d030bdac-5d94-11e7-91c6-a40079eb4312.png)

Now it only displays warning and it allows you to continue with provisioning
![20176_before_host](https://user-images.githubusercontent.com/109773/27733144-d038abf2-5d94-11e7-829c-9061646ed82d.png)

To reproduce the issue you can simply deactivate your libvirt storage pools e.g. using virt-manager, you don't have to delete them.