### PR TITLE
Fixes #19828 - Fix Rails/Blank cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,6 @@ Performance/RedundantMatch:
 
 Performance/RedundantMerge:
   Enabled: true
+
+Rails/Blank:
+  UnlessPresent: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -347,12 +347,6 @@ Rails/ActiveSupportAliases:
 Rails/ApplicationRecord:
   Enabled: false
 
-# Offense count: 64
-# Cop supports --auto-correct.
-# Configuration parameters: NilOrEmpty, NotPresent, UnlessPresent.
-Rails/Blank:
-  Enabled: false
-
 # Offense count: 5
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: strict, flexible

--- a/app/helpers/shared_smart_proxies_helper.rb
+++ b/app/helpers/shared_smart_proxies_helper.rb
@@ -17,7 +17,7 @@ module SharedSmartProxiesHelper
     blank = options.fetch(:blank, blank_or_inherit_f(f, resource))
 
     proxies = accessible_smart_proxies(f.object, resource, options[:feature])
-    return if !required && !proxies.present?
+    return if !required && proxies.blank?
 
     select_options = {
       :disable_button => can_override ? _(INHERIT_TEXT) : nil,

--- a/app/models/concerns/encrypt_value.rb
+++ b/app/models/concerns/encrypt_value.rb
@@ -11,7 +11,7 @@ module EncryptValue
   end
 
   def is_encryptable?(str)
-    if !encryption_key.present? || str.blank? || matches_prefix?(str)
+    if encryption_key.blank? || str.blank? || matches_prefix?(str)
       false
     else
       true
@@ -19,7 +19,7 @@ module EncryptValue
   end
 
   def is_decryptable?(str)
-    if !matches_prefix?(str) || !encryption_key.present?
+    if !matches_prefix?(str) || encryption_key.blank?
       false
     else
       true

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -817,7 +817,7 @@ class Host::Managed < Host::Base
   end
 
   def compute_attributes_empty?
-    compute_attributes.nil? || compute_attributes.empty?
+    compute_attributes.blank?
   end
 
   # validate uniqueness can't prevent saving two interfaces that has same DNS name
@@ -841,7 +841,7 @@ class Host::Managed < Host::Base
   end
 
   def assign_hostgroup_attribute(attr, value, force)
-    self.send("#{attr}=", value) if force || !send(attr).present?
+    self.send("#{attr}=", value) if force || send(attr).blank?
   end
 
   # checks if the host association is a valid association for this host

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -25,7 +25,7 @@ module Nic
     validates :host, :presence => true, :if => Proc.new { |nic| nic.require_host? }
 
     validates :identifier, :uniqueness => { :scope => :host_id },
-      :if => ->(nic) { nic.identifier.present? && nic.host && !nic.identifier_was.present? }
+      :if => ->(nic) { nic.identifier.present? && nic.host && nic.identifier_was.blank? }
 
     validate :exclusive_primary_interface
     validate :exclusive_provision_interface
@@ -129,7 +129,7 @@ module Nic
     # if this interface does not have MAC and is attached to other interface,
     # we can fetch mac from this other interface
     def inheriting_mac
-      if self.mac.nil? || self.mac.empty?
+      if self.mac.blank?
         self.host.interfaces.detect { |i| i.identifier == self.attached_to }.try(:mac)
       else
         self.mac

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -105,7 +105,7 @@ module Nic
       # no hostname was given or a domain was selected, since this is before validation we need to ignore
       # it and let the validations to produce an error
       return if name.empty?
-      if domain.nil? && name.include?('.') && !changed_attributes['domain_id'].present?
+      if domain.nil? && name.include?('.') && changed_attributes['domain_id'].blank?
         # try to assign the domain automatically based on our existing domains from the host FQDN
         self.domain = Domain.find_by(:name => name.partition('.')[2])
       elsif persisted? && changed_attributes['domain_id'].present?

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -12,7 +12,7 @@ module SSO
     def available?
       return false unless Setting['authorize_login_delegation']
       return false if controller.api_request? && !(Setting['authorize_login_delegation_api'])
-      return false if controller.api_request? && !request.env[CAS_USERNAME].present?
+      return false if controller.api_request? && request.env[CAS_USERNAME].blank?
       true
     end
 


### PR DESCRIPTION
I disabled the default UnlessPresent value since sometimes it's clearer
to use `unless attribute.present?` instead of `if attribute.blank?`.