### PR TITLE
fixes #20228 - fix jest testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,13 @@
     },
     "globals": {
       "__testing__": true
-    }
+    },
+    "transform": {
+      "^.+\\.js$": "babel-jest"
+    },
+    "moduleDirectories": [
+      "node_modules",
+      "webpack"
+    ]
   }
 }


### PR DESCRIPTION
jest is failing since removing .babelrc.
this PR adds jest configurationt to handle es6 syntax + babelrc to handle spread operator (until babel-jest supports it).