### PR TITLE
Fixes #20241 - Fix test for mail notifications

### DIFF
--- a/test/unit/tasks/reports_test.rb
+++ b/test/unit/tasks/reports_test.rb
@@ -28,7 +28,7 @@ class ReportsTest < ActiveSupport::TestCase
     @owner.locations = []
     User.current, saved_user = nil, User.current
     Rake.application.invoke_task 'reports:daily'
-    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Configuration Management Summary/ }
+    mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Puppet Summary/ }
     User.current = saved_user
     assert mail
     assert_match /Summary from/, mail.body.encoded


### PR DESCRIPTION
One of the tests in test/unit/tasks/reports_test is testing for
delivery.subject =~ /Configuration Management Summary/
This made sense in develop because since #16159 mail alerts have that
subject. However on the 1.15-stable branch, it still has the old
subject, "Puppet Summary".

Notice this is going ONLY to 1.15-stable.