### PR TITLE
Fixes #20248, #20327 - Respect context in CSV export

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -62,7 +62,7 @@ class HostsController < ApplicationController
         render :index if title && (@title = title)
       end
       format.csv do
-        @hosts = search.includes(included_associations - [:host_statuses, :token, :compute_resource])
+        @hosts = search.preload(included_associations - [:host_statuses, :token])
         csv_response(@hosts)
       end
     end
@@ -941,7 +941,7 @@ class HostsController < ApplicationController
   end
 
   def csv_columns
-    [:name, :operatingsystem, :environment, :model, :hostgroup, :last_report]
+    [:name, :operatingsystem, :environment, :compute_resource_or_model, :hostgroup, :last_report]
   end
 
   def normalize_vm_attributes

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -1,12 +1,6 @@
 module HostsAndHostgroupsHelper
   include AncestryHelper
 
-  def model_name(host)
-    name = host.try(:model)
-    name = host.compute_resource.name if host.compute_resource
-    name
-  end
-
   def domain_subnets(type)
     accessible_related_resource(@domain, :subnets, :where => {:type => type})
   end

--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -37,6 +37,24 @@ module Foreman
       end
     end
 
+    # This allows getting and setting all current values in case it's needed,
+    # for example to pass to an enumerator that is executed by a separate thread
+    module Context
+      def self.get
+        {
+          :user => User.current,
+          :organization => Organization.current,
+          :location => Location.current
+        }
+      end
+
+      def self.set(user: nil, organization: nil, location: nil)
+        User.current = user
+        Organization.current = organization
+        Location.current = location
+      end
+    end
+
     # include this in the User model
     module UserModel
       extend ActiveSupport::Concern

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -810,6 +810,11 @@ class Host::Managed < Host::Base
     Operatingsystem.firmware_type(pxe_loader)
   end
 
+  def compute_resource_or_model
+    return self.compute_resource.name if self.compute_resource
+    self.hardware_model_name
+  end
+
   private
 
   def compute_profile_present?

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -4,9 +4,11 @@ module CsvExporter
   def self.export(resources, columns, header = nil)
     header ||= default_header(columns)
     raise ArgumentError, "Columns and header row aren't the same length" unless columns.length == header.length
+    # need to save the current context as the enumerator is executed by a separate thread
+    context = Foreman::ThreadSession::Context.get
     Enumerator.new do |csv|
+      Foreman::ThreadSession::Context.set(context)
       csv << CSV.generate_line(header)
-
       columns.map!{|c| c.to_s.split('.').map(&:to_sym)}
       resources.uncached do
         resources.reorder(nil).limit(nil).find_each do |obj|

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -26,7 +26,7 @@
               </td>
               <td class="hidden-xs"><%= (icon(host.operatingsystem, :size => "18x18") + trunc_with_tooltip(" #{host.operatingsystem.to_label}",14)).html_safe if host.operatingsystem %></td>
               <td class="hidden-xs"><%= trunc_with_tooltip(host.try(:environment), 14) %></td>
-              <td class="hidden-tablet hidden-xs"><%= model_name host %></td>
+              <td class="hidden-tablet hidden-xs"><%= host.compute_resource_or_model %></td>
               <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 26 %></td>
             </tr>
           <% end %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -33,7 +33,7 @@
         </td>
         <td class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
         <td class="hidden-xs ellipsis"><%= host.environment %></td>
-        <td class="hidden-tablet hidden-xs ellipsis"><%= model_name host %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= host.compute_resource_or_model %></td>
         <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 23, @hostgroup_authorizer %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
         <td>

--- a/test/controllers/config_reports_controller_test.rb
+++ b/test/controllers/config_reports_controller_test.rb
@@ -23,6 +23,24 @@ class ConfigReportsControllerTest < ActionController::TestCase
     assert_equal 2, response.body.lines.size
   end
 
+  test 'csv export respects taxonomy scope' do
+    host = FactoryGirl.create(:host)
+    FactoryGirl.create(:config_report, :host => host)
+
+    # "any context"
+    get :index, {format: :csv}, set_session_user
+    assert_response :success
+    assert_equal 2, response.body.lines.size
+
+    get :index, {format: :csv}, set_session_user.merge(location_id: host.location_id)
+    assert_response :success
+    assert_equal 2, response.body.lines.size
+
+    get :index, {format: :csv}, set_session_user.merge(location_id: FactoryGirl.create(:location).id)
+    assert_response :success
+    assert_equal 1, response.body.lines.size
+  end
+
   def test_show
     get :show, {:id => report.id}, set_session_user
     assert_template 'show'

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -31,6 +31,18 @@ class HostsControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
+  test "should get csv index with data" do
+    host = FactoryGirl.create(:host, :with_hostgroup, :with_environment, :on_compute_resource, :with_reports)
+    get :index, { :format => 'csv', :search => "name = #{host.name}" }, set_session_user
+    assert_response :success
+    buf = response.stream.instance_variable_get(:@buf)
+    assert_equal "Name,Operatingsystem,Environment,Compute Resource Or Model,Hostgroup,Last Report\n", buf.next
+    assert_equal "#{host.name},#{host.operatingsystem},#{host.environment},#{host.compute_resource.name},#{host.hostgroup},#{host.last_report}\n", buf.next
+    assert_raises StopIteration do
+      buf.next
+    end
+  end
+
   test "should include registered scope on index" do
     # remember the previous state
     old_scopes = HostsController.scopes_for(:index).dup

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -174,8 +174,8 @@ FactoryGirl.define do
       after(:create) do |host,evaluator|
         evaluator.report_count.times do |i|
           report = FactoryGirl.create(:report, :host => host, :reported_at => (evaluator.report_count - i).minutes.ago)
-          host.last_report = report.reported_at
         end
+        host.update_attribute(:last_report, host.reports.last.reported_at)
       end
     end
 


### PR DESCRIPTION
Since CSV export is done using an enumerator which is executed by a
different thread to the one that creates it, we need to manually pass in
the context (user, location, organization) to the enumerator.