### PR TITLE
refs #20193 - update to storybook that support webpack3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Foreman isn't really a node module, these are just dependencies needed to build the webpack bundle. 'dependencies' are the asset libraries in use and 'devDependencies' are used for the build process.",
   "private": true,
   "devDependencies": {
-    "@storybook/addon-actions": "^3.1.2",
-    "@storybook/react": "^3.1.3",
+    "@storybook/addon-actions": "^3.1.8",
+    "@storybook/react": "^3.1.8",
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.10.1",
     "babel-core": "~6.7.2",


### PR DESCRIPTION
older version of storybook could conflict on the verison of
webpack, and when working in development environment,
the hot live reload might be using webpack 2.x vs 3.x
linked binary (node_modules/.bin/..)