### PR TITLE
Fixes #20258 - better unique permission types error

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -200,7 +200,8 @@ class Filter < ApplicationRecord
 
   # if we have 0 types, empty validation will set error, we can't have more than one type
   def same_resource_type_permissions
-    errors.add(:permissions, _('Permissions must be of same resource type')) if self.permissions.map(&:resource_type).uniq.size > 1
+    types = self.permissions.map(&:resource_type).uniq
+    errors.add(:permissions, _('must be of same resource type (%s)') % types.join(',')) if types.size > 1
   end
 
   def not_empty_permissions


### PR DESCRIPTION
We see regressions in rex, scap and discovery (and possibly more). Unit tests are randomly failing with:

ActiveRecord::RecordInvalid: Validation failed: Permissions Permissions must be of same resource type

This improves the error message a bit so we see more, also removes the double Permissions words in there.