### PR TITLE
Fixes #20274 - Filter fixtures have many resource_types

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -201,7 +201,14 @@ class Filter < ApplicationRecord
   # if we have 0 types, empty validation will set error, we can't have more than one type
   def same_resource_type_permissions
     types = self.permissions.map(&:resource_type).uniq
-    errors.add(:permissions, _('must be of same resource type (%s)') % types.join(',')) if types.size > 1
+    errors.add(
+      :permissions,
+      _('must be of same resource type (%s) - Role (%s)') %
+      [
+        types.join(','),
+        self.role.name
+      ]
+    ) if types.size > 1
   end
 
   def not_empty_permissions

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -376,8 +376,9 @@ crud_hosts_1_3:
 <% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).each do |role,permissions| %>
 <% role_id = role.tr(' ', '_').scan(/[a-z_]/i).join %>
 <% permissions.each do |permission| %>
+<% resource = permission.to_s.split('_')[1..-1].join('_') %>
 <%= role_id %>_<%= permission %>:
-  filter: <%= role_id %>
+  filter: <%= "#{role_id}_#{resource}" %>
   permission: <%= permission %>
 <% end %>
 <% end %>

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -108,8 +108,12 @@ view_compute_resources_1:
   role_id: 11
 crud_hosts_1:
   role_id: 12
-<% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).keys.each do |role| %>
+<% Foreman::Plugin.all.map(&:default_roles).inject({}, :merge).each do |role, permissions| %>
 <% role_id = role.tr(' ', '_').scan(/[a-z_]/i).join %>
-<%= role_id %>:
+# This line assumes permissions come in the form of a symbol 'action_resource'
+<% resources = permissions.map { |p| p.to_s.split('_')[1..-1].join('_') } %>
+<% resources.each do |resource| %>
+<%= "#{role_id}_#{resource}" %>:
   role: <%= role_id %>
+<% end %>
 <% end %>


### PR DESCRIPTION
Filters cannot have many resource_types - each filter needs to have its
own resource type, e.g: one filter does not accommodate permissions for
"Host" and "DiscoveredHost".

This is enforced by a validator in the model, but our fixtures are able
to completely skip it. The result is that plugins have Filters with
multiple resource types.

This has not been a problem until recently, as we added a test that
checks that the db filter cache can be recreated (CacheManagerTest).
On plugins, this test fails to pass as fixtures are
wrongly created.

To reproduce, make sure your test DB is either Postgres or MySQL, add a
plugin (like foreman_discovery), and try to run the CacheManagerTest

This should unblock plugin tests - REX, Ansible, Discovery.. make the CacheManagerTest because of this issue with fixtures.