### PR TITLE
Fixes #20209 - Remove ovirt image from compute profile

### DIFF
--- a/app/views/compute_attributes/_compute_form.html.erb
+++ b/app/views/compute_attributes/_compute_form.html.erb
@@ -1,6 +1,6 @@
 
 <%= render :partial => provider_partial(compute_resource, 'base'),
-            :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true }.merge(args_for_compute_resource_partial(@host)) %>
+            :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :hide_image => true }.merge(args_for_compute_resource_partial(@host)) %>
 
 <!--NICS-->
 <%= render :partial => 'compute_resources_vms/form/networks', :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :item_layout => 'deletable' } %>

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -25,18 +25,20 @@
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2" } if new_vm && controller_name != "compute_attributes" %>
 
-<%
-   arch ||= nil ; os ||= nil
-   images = possible_images(compute_resource, arch, os)
--%>
+<% unless local_assigns[:hide_image] %>
+  <%
+     arch ||= nil ; os ||= nil
+     images = possible_images(compute_resource, arch, os)
+  -%>
 
-<div id='image_selection'>
-  <%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')},
-             { :disabled    => true, :'data-url' => template_selected_compute_resource_path(compute_resource),
-               :onchange    => 'ovirt_templateSelected(this);',
-               :help_inline => :indicator,
-               :help_block  => _("Image to use"),
-               :label => _('Image'), :label_size => "col-md-2"} %>
-</div>
+  <div id='image_selection'>
+    <%= select_f f, :image_id, images, :uuid, :name,{:include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image')},
+               { :disabled    => true, :'data-url' => template_selected_compute_resource_path(compute_resource),
+                 :onchange    => 'ovirt_templateSelected(this);',
+                 :help_inline => :indicator,
+                 :help_block  => _("Image to use"),
+                 :label => _('Image'), :label_size => "col-md-2"} %>
+  </div>
+<% end %>
 
 <%= compute_specific_js(compute_resource, "nic_info") %>


### PR DESCRIPTION
The image was disabled in compute profile.
Compute profile does not include the operating system and the possible list of images for a host depends on the operating system so it might not belong in compute profile anyway.
As a result I removed the image from compute profile.