### PR TITLE
Fixes #20306 - allow the same key for two users

### DIFF
--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -27,7 +27,7 @@ class SshKey < ApplicationRecord
     :format => { :without => /\n|\r/, :message => N_('should be a single line') }
 
   validates :fingerprint,
-    :uniqueness => true,
+    :uniqueness => { :scope => :user_id },
     :presence => { :message => N_('could not be generated') }
 
   validates :length,


### PR DESCRIPTION
If that's accepted, I suppose this should go into 1.15 where we introduced ssh keys.