### PR TITLE
Refs #17525 - verify domain dns id also on update

### DIFF
--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -49,6 +49,15 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test "should not create invalid dns_id" do
+    skip if ActiveRecord::Base.connection_config[:adapter].eql?("sqlite3")
+    invalid_proxy_id = -1
+    post :update, { :id => Domain.first.to_param, :domain => { :name => "domain.new", :dns_id => invalid_proxy_id } }
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_includes(show_response["error"]["full_messages"], "Dns Invalid smart-proxy id")
+    assert_response :unprocessable_entity
+  end
+
   test "should destroy domain" do
     domain = Domain.first
     domain.hosts.clear


### PR DESCRIPTION
While still not systematic solution to all possible relations in Foreman, this tries to close the gap from https://github.com/theforeman/foreman/pull/4120, except for relying on `dns_id` being the only foreign key, we proactively check for the value. The patch is still small so I think could be cherry-picked to 1.15.3 since the original fix was introduced in 1.15 branch.