### PR TITLE
Fixes #20325 - Pin ruby2ruby to 2.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'deacon', '~> 1.0'
 gem 'webpack-rails', '~> 0.9.8'
 gem 'mail', '~> 2.6'
 gem 'sshkey', '~> 1.9'
+gem 'ruby2ruby', '2.3.2'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))


### PR DESCRIPTION
Version 2.4.0 seems to break safe render, pinning for now to last known
good version.