### PR TITLE
Fixes #20373 - Add ESXi 6.5 to VMWare

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -357,6 +357,7 @@ module Foreman::Model
     def vm_hw_versions
       {
         'Default' => _("Default"),
+        'vmx-13' => '13 (ESXi 6.5)',
         'vmx-11' => '11 (ESXi 6.0)',
         'vmx-10' => '10 (ESXi 5.5)',
         'vmx-09' => '9 (ESXi 5.1)',


### PR DESCRIPTION
As per https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746 - that's the latest version with ESXi

12 is omitted as it doesn't have ESXi.