### PR TITLE
Fixes #20384 - seed resources before admin exists

### DIFF
--- a/db/seeds.d/03-auth_sources.rb
+++ b/db/seeds.d/03-auth_sources.rb
@@ -1,13 +1,15 @@
 AuthSource.without_auditing do
-  # Auth sources
-  src = AuthSourceInternal.find_by_type "AuthSourceInternal"
-  AuthSourceInternal.create :name => "Internal" unless src.present?
+  AuthSource.skip_permission_check do
+    # Auth sources
+    src = AuthSourceInternal.find_by_type "AuthSourceInternal"
+    AuthSourceInternal.create :name => "Internal" unless src.present?
 
-  src = AuthSourceHidden.find_by_type "AuthSourceHidden"
-  AuthSourceHidden.create :name => "Hidden" unless src.present?
+    src = AuthSourceHidden.find_by_type "AuthSourceHidden"
+    AuthSourceHidden.create :name => "Hidden" unless src.present?
 
-  external_name = Setting[:authorize_login_delegation_auth_source_user_autocreate]
-  if external_name.present? && AuthSourceExternal.find_by_name(external_name).nil?
-    AuthSourceExternal.create :name => external_name
+    external_name = Setting[:authorize_login_delegation_auth_source_user_autocreate]
+    if external_name.present? && AuthSourceExternal.find_by_name(external_name).nil?
+      AuthSourceExternal.create :name => external_name
+    end
   end
 end

--- a/db/seeds.d/03-roles.rb
+++ b/db/seeds.d/03-roles.rb
@@ -1,10 +1,12 @@
 require (Rails.root + 'db/seeds.d/02-roles_list.rb')
 
 Role.without_auditing do
-  RolesList.seeded_roles.each do |role_name, permission_names|
-    SeedHelper.create_role(role_name, permission_names, 0)
-  end
-  RolesList.default_role.each do |role_name, permission_names|
-    SeedHelper.create_role(role_name, permission_names, Role::BUILTIN_DEFAULT_ROLE)
+  Role.skip_permission_check do
+    RolesList.seeded_roles.each do |role_name, permission_names|
+      SeedHelper.create_role(role_name, permission_names, 0)
+    end
+    RolesList.default_role.each do |role_name, permission_names|
+      SeedHelper.create_role(role_name, permission_names, Role::BUILTIN_DEFAULT_ROLE)
+    end
   end
 end


### PR DESCRIPTION
For seed scripts that executes before internal admin exist we need to
ignore creation permission check on resources that includes Authorizable
concern.