### PR TITLE
Fixes #20386 - Allow to identify smart proxy by ip only

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -92,6 +92,7 @@ module Foreman::Controller::SmartProxyAuth
       logger.warn "SSL is required - request from #{request.ip}"
     else
       request_hosts = Resolv.new.getnames(request.ip)
+      request_hosts = [request.ip] if request_hosts == []
     end
     return false unless request_hosts
 

--- a/test/controllers/smart_proxy_auth_test.rb
+++ b/test/controllers/smart_proxy_auth_test.rb
@@ -139,6 +139,17 @@ class SmartProxyAuthApiTest < ActionController::TestCase
     assert @controller.send(:auth_smart_proxy)
     assert_equal proxy, @controller.detected_proxy
   end
+
+  def test_trusted_puppet_master_hosts_by_ip_match
+    @request.env['REMOTE_ADDR'] = '127.0.0.2'
+    Setting[:trusted_puppetmaster_hosts] = ['127.0.0.2']
+    assert @controller.send(:auth_smart_proxy)
+  end
+
+  def test_trusted_puppet_master_hosts_by_ip_no_match
+    @request.env['REMOTE_ADDR'] = '127.0.0.2'
+    refute @controller.send(:auth_smart_proxy)
+  end
 end
 
 class SmartProxyAuthWebUITest < ActionController::TestCase


### PR DESCRIPTION
This allows setting trusted_puppet_master_hosts to an IP in the
non-https case. This can e.g. be useful when testing ansible fact
importing from another machine.