### PR TITLE
Fixes #20410 - normal user now can send test email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -371,7 +371,7 @@ class User < ApplicationRecord
 
   def editing_self?(options = {})
     options[:controller].to_s == 'users' &&
-      options[:action] =~ /edit|update/ &&
+      options[:action] =~ /edit|update|test_email/ &&
       options[:id].to_i == self.id ||
     options[:controller].to_s =~ /\Aapi\/v\d+\/users\Z/ &&
       options[:action] =~ /show|update/ &&

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -402,6 +402,16 @@ class UsersControllerTest < ActionController::TestCase
     assert_equal user.mail, mail.to[0]
   end
 
+  test "test email should be delivered even when user has read only role" do
+    user = users(:one)
+    user.roles = [Role.find_by_name('Viewer')]
+    User.current = user
+    put :test_mail, { :id => user.id, :user => {:login => user.login} }, set_session_user
+    mail = ActionMailer::Base.deliveries.last
+    assert mail.subject.include? "Foreman test email"
+    assert_equal user.mail, mail.to[0]
+  end
+
   context "when user is logged in" do
     test "#login redirects to previous url" do
       @previous_url = "/bookmarks"


### PR DESCRIPTION
A user with "viewer" role is unable to send a test email previously. Test email would only have triggered if an user has "edit_users" role. 

With this patch, test email can be triggered with "viewer" only role. 