### PR TITLE
fixes #10982 - configure RestClient log to 'proxy' logger

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,7 @@ require_dependency File.expand_path('../../lib/core_extensions', __FILE__)
 require_dependency File.expand_path('../../lib/foreman/logging', __FILE__)
 require_dependency File.expand_path('../../lib/middleware/catch_json_parse_errors', __FILE__)
 require_dependency File.expand_path('../../lib/middleware/tagged_logging', __FILE__)
+require_dependency File.expand_path('../../lib/middleware/session_safe_logging', __FILE__)
 
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
@@ -177,6 +178,7 @@ module Foreman
 
     # Record request ID in logging MDC storage
     config.middleware.insert_before Rails::Rack::Logger, Middleware::TaggedLogging
+    config.middleware.insert_after ActionDispatch::Session::ActiveRecordStore, Middleware::SessionSafeLogging
 
     # Add apidoc hash in headers for smarter caching
     config.middleware.use Apipie::Middleware::ChecksumInHeaders
@@ -199,6 +201,7 @@ module Foreman
       :audit => {:enabled => true},
       :ldap => {:enabled => false},
       :permissions => {:enabled => false},
+      :proxy => {:enabled => false},
       :sql => {:enabled => false},
       :templates => {:enabled => true},
       :notifications => {:enabled => true},

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -47,6 +47,8 @@
 #     [%M] method name where the logging request was issued
 #     [%X{request}] request-ID set in HTTP headers, or random UUID
 #     [%X{session}] session ID from cookies, else the request-ID
+#     [%X{session_safe}] random ID assigned per session, not available early on during
+#                        request logging, but prevents disclosure of the session ID
 #     [%X{string}] variable set using ::Logging.mdc['string'] =
 
 :default:

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -54,6 +54,8 @@
 #    :enabled: false
 #  :permissions:
 #    :enabled: false
+#  :proxy:
+#    :enabled: false
 #  :sql:
 #    :enabled: false
 #  :templates:

--- a/lib/middleware/session_safe_logging.rb
+++ b/lib/middleware/session_safe_logging.rb
@@ -1,0 +1,22 @@
+require 'securerandom'
+
+module Middleware
+  class SessionSafeLogging
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      session = env['rack.session']
+
+      # Store a UUID in the session to be used as an alternative to the session
+      # ID itself in logs, which might be hijacked.
+      session['session_safe'] ||= SecureRandom.hex(32)
+      ::Logging.mdc['session_safe'] = session['session_safe']
+
+      @app.call(env)
+    ensure
+      ::Logging.mdc.delete('session_safe')
+    end
+  end
+end

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module ProxyAPI
   class Resource
     attr_reader :url
@@ -5,22 +7,12 @@ module ProxyAPI
     def initialize(args)
       raise("Must provide a protocol and host when initialising a smart-proxy connection") unless (url =~ /^http/)
 
-      @connect_params = {:timeout => Setting[:proxy_request_timeout], :open_timeout => 10, :headers => { :accept => :json },
-                        :user => args[:user], :password => args[:password]}
+      @connect_params = {:timeout => Setting[:proxy_request_timeout], :open_timeout => 10,
+                         :headers => { :accept => :json, :x_request_id => request_id },
+                         :user => args[:user], :password => args[:password]}
 
       # We authenticate only if we are using SSL
-      if url =~ /^https/i
-        cert         = Setting[:ssl_certificate]
-        ca_cert      = Setting[:ssl_ca_file]
-        hostprivkey  = Setting[:ssl_priv_key]
-
-        @connect_params.merge!(
-          :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read(cert)),
-          :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read(hostprivkey)),
-          :ssl_ca_file      =>  ca_cert,
-          :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
-        ) unless Rails.env == "test"
-      end
+      @connect_params.merge!(ssl_auth_params) if if url =~ /\Ahttps/i && !Rails.env.test?
     end
 
     protected
@@ -40,7 +32,9 @@ module ProxyAPI
       @resource                  = nil
     end
 
-    def logger; Rails.logger; end
+    def logger
+      Foreman::Logging.logger('proxy')
+    end
 
     private
 
@@ -62,27 +56,72 @@ module ProxyAPI
 
     # Perform GET operation on the supplied path
     def get(path = nil, payload = {})
-      # This ensures that an extra "/" is not generated
-      if path
-        resource[URI.escape(path)].get payload
-      else
-        resource.get payload
+      with_logger do
+        # This ensures that an extra "/" is not generated
+        if path
+          resource[URI.escape(path)].get payload
+        else
+          resource.get payload
+        end
       end
     end
 
     # Perform POST operation with the supplied payload on the supplied path
     def post(payload, path = "")
-      resource[path].post payload
+      logger.debug("POST request payload: #{payload}")
+      with_logger do
+        resource[path].post payload
+      end
     end
 
     # Perform PUT operation with the supplied payload on the supplied path
     def put(payload, path = "")
-      resource[path].put payload
+      logger.debug("PUT request payload: #{payload}")
+      with_logger do
+        resource[path].put payload
+      end
     end
 
     # Perform DELETE operation on the supplied path
     def delete(path)
-      resource[path].delete
+      with_logger do
+        resource[path].delete
+      end
+    end
+
+    def with_logger
+      old_logger = RestClient.log
+      RestClient.log = RestClientLogger.new(logger)
+      yield
+    ensure
+      RestClient.log = old_logger
+    end
+
+    def request_id
+      ::Logging.mdc['session_safe'] || SecureRandom.hex(32)
+    end
+
+    def ssl_auth_params
+      cert         = Setting[:ssl_certificate]
+      ca_cert      = Setting[:ssl_ca_file]
+      hostprivkey  = Setting[:ssl_priv_key]
+
+      {
+        :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read(cert)),
+        :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read(hostprivkey)),
+        :ssl_ca_file      =>  ca_cert,
+        :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER
+      }
+    end
+  end
+
+  class RestClientLogger
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def <<(msg)
+      @logger.debug(msg.chomp)
     end
   end
 end

--- a/test/unit/proxy_api/resource_test.rb
+++ b/test/unit/proxy_api/resource_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class ProxyApiResourceTest < ActiveSupport::TestCase
+  setup do
+    ProxyAPI::Resource.any_instance.stubs(:url).returns('http://proxy.example.com')
+  end
+
+  test "connect_params includes x_request_id header" do
+    assert ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id].present?
+  end
+
+  test "connect_params sets x_request_id to logger safe session ID" do
+    begin
+      ::Logging.mdc['session_safe'] = 'test'
+      assert_equal 'test', ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id]
+    ensure
+      ::Logging.mdc.delete('session_safe')
+    end
+  end
+
+  test "with_logger sets RestClient.log" do
+    refute RestClient.log
+    ProxyAPI::Resource.new({}).send(:with_logger) do
+      assert_respond_to RestClient.log, :<<
+    end
+    refute RestClient.log
+  end
+
+  test "RestClientLogger#<< logs messages" do
+    logger = mock('logger')
+    logger.expects(:debug).with('test')
+    ProxyAPI::RestClientLogger.new(logger) << "test\n"
+  end
+end


### PR DESCRIPTION
Request/response information is sent to the proxy logger, showing the
URLs called, headers, request body etc.

The X-Request-ID header is now also set in the proxy requests to a
random ID stored in the session, to prevent the user's real session ID
being hijacked from the proxy request data. The ID should be correlated
against the proxy logger.