### PR TITLE
Fixes #20461 - csv_exporter results in empty rows

### DIFF
--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -4,12 +4,12 @@ module CsvExporter
   def self.export(resources, columns, header = nil)
     header ||= default_header(columns)
     raise ArgumentError, "Columns and header row aren't the same length" unless columns.length == header.length
+    columns.map!{|c| c.to_s.split('.').map(&:to_sym)}
     # need to save the current context as the enumerator is executed by a separate thread
     context = Foreman::ThreadSession::Context.get
     Enumerator.new do |csv|
       Foreman::ThreadSession::Context.set(context)
       csv << CSV.generate_line(header)
-      columns.map!{|c| c.to_s.split('.').map(&:to_sym)}
       resources.uncached do
         resources.reorder(nil).limit(nil).find_each do |obj|
           csv << CSV.generate_line(columns.map{|c| c.inject(obj, :try)})


### PR DESCRIPTION
While trying to extend csv export functionality to katello pages, we observed that the csv_exporter was rendering empty rows in the exported csv.
The root cause is the line "columns.map!{|c| c.to_s.split('.').map(&:to_sym)}" getting executed more than once in the enumerator block causing the column names to be prepended with multiple ' : '