### PR TITLE
fixes #20485 - cache notification indicator in local storage

### DIFF
--- a/webpack/assets/javascripts/react_app/common/sessionStorage.js
+++ b/webpack/assets/javascripts/react_app/common/sessionStorage.js
@@ -19,5 +19,7 @@ export const notificationsDrawer = {
   getIsOpened: () => getValue('isDrawerOpen'),
   setIsOpened: value => setValue('isDrawerOpen', value),
   getExpandedGroup: () => getValue('expandedGroup'),
-  setExpandedGroup: value => setValue('expandedGroup', value)
+  setExpandedGroup: value => setValue('expandedGroup', value),
+  getHasUnreadMessages: () => getValue('hasUnreadMessages'),
+  setHasUnreadMessages: value => setValue('hasUnreadMessages', value)
 };

--- a/webpack/assets/javascripts/react_app/components/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/index.js
@@ -4,7 +4,7 @@ import * as NotificationActions from '../../redux/actions/notifications';
 import './notifications.scss';
 import ToggleIcon from './toggleIcon/';
 import Drawer from './drawer/';
-import { groupBy, some, isUndefined } from 'lodash';
+import { groupBy, isUndefined } from 'lodash';
 
 class notificationContainer extends React.Component {
   componentDidMount() {
@@ -53,7 +53,8 @@ const mapStateToProps = state => {
     notifications,
     isDrawerOpen,
     expandedGroup,
-    isPolling
+    isPolling,
+    hasUnreadMessages
   } = state.notifications;
 
   return {
@@ -62,7 +63,7 @@ const mapStateToProps = state => {
     notifications: groupBy(notifications, 'group'),
     expandedGroup,
     isReady: !isUndefined(notifications),
-    hasUnreadMessages: some(notifications, n => !n.seen)
+    hasUnreadMessages
   };
 };
 

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.fixtures.js
@@ -43,7 +43,8 @@ export const stateWithNotifications = immutable({
           ]
         }
       }
-    }
+    },
+    hasUnreadMessages: true
   }
 });
 
@@ -77,7 +78,8 @@ export const stateWithUnreadNotifications = immutable({
           ]
         }
       }
-    }
+    },
+    hasUnreadMessages: true
   }
 });
 

--- a/webpack/assets/javascripts/react_app/redux/reducers/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/notifications/index.js
@@ -8,12 +8,25 @@ import {
 } from '../../consts';
 import Immutable from 'seamless-immutable';
 import { notificationsDrawer } from '../../../common/sessionStorage';
+import { some } from 'lodash';
 
 const initialState = Immutable({
   isDrawerOpen: notificationsDrawer.getIsOpened(),
   expandedGroup: notificationsDrawer.getExpandedGroup(),
-  isPolling: false
+  isPolling: false,
+  hasUnreadMessages: notificationsDrawer.getHasUnreadMessages() || false
 });
+
+const hasUnreadMessages = notifications => {
+  const result = some(notifications, n => !n.seen);
+
+  // store indicator in sessionStorage.
+  // TODO: consider moving this either to a reselect
+  // ,store.subscribe OR to a distint redux action
+  // leaving it here as it makes the most sense to me.
+  notificationsDrawer.setHasUnreadMessages(result);
+  return result;
+};
 
 export default (state = initialState, action) => {
   const { payload } = action;
@@ -22,29 +35,31 @@ export default (state = initialState, action) => {
     case NOTIFICATIONS_POLLING_STARTED:
       return state.set('isPolling', true);
     case NOTIFICATIONS_GET_NOTIFICATIONS:
-      return state.set(
-        'notifications', payload.notifications
-      );
+      return state
+        .set('notifications', payload.notifications)
+        .set('hasUnreadMessages', hasUnreadMessages(payload.notifications));
     case NOTIFICATIONS_TOGGLE_DRAWER:
       return state.set('isDrawerOpen', payload.value);
     case NOTIFICATIONS_SET_EXPANDED_GROUP:
       return state.set('expandedGroup', payload.group);
-    case NOTIFICATIONS_MARK_AS_READ:
-    return state.set(
-      'notifications',
-      state.notifications.map(
-        n => n.id === payload.id ?
-          Object.assign({}, n, {seen: true}) : n
-      )
-    );
-    case NOTIFICATIONS_MARK_GROUP_AS_READ:
-      return state.set(
-        'notifications',
-        state.notifications.map(
-          n => n.group === payload.group ?
-            Object.assign({}, n, {seen: true}) : n
-        )
+    case NOTIFICATIONS_MARK_AS_READ: {
+      const notifications = state.notifications.map(
+        n => (n.id === payload.id ? Object.assign({}, n, { seen: true }) : n)
       );
+
+      return state
+        .set('notifications', notifications)
+        .set('hasUnreadMessages', hasUnreadMessages(notifications));
+    }
+    case NOTIFICATIONS_MARK_GROUP_AS_READ: {
+      const notifications = state.notifications.map(
+        n => (n.group === payload.group ? Object.assign({}, n, { seen: true }) : n)
+      );
+
+      return state
+        .set('notifications', notifications)
+        .set('hasUnreadMessages', hasUnreadMessages(notifications));
+    }
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/redux/reducers/notifications/notifications.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/notifications/notifications.fixtures.js
@@ -4,13 +4,15 @@ export const initialState = Immutable(
   {
     expandedGroup: null,
     isDrawerOpen: null,
-    isPolling: false
+    isPolling: false,
+    hasUnreadMessages: false
   });
 
 export const stateWithNotifications = Immutable(
   {
     isDrawerOpen: true,
     expandedGroup: 'Hosts',
+    hasUnreadMessages: true,
     notifications: [
       {
         id: 52435,
@@ -49,6 +51,7 @@ export const response = Immutable(
   {
     isDrawerOpen: true,
     expandedGroup: 'Hosts',
+    hasUnreadMessages: true,
     notifications: [
       {
         id: 52435,


### PR DESCRIPTION
this ensures that the toggle icon is not swapping between different page loads.

long term maybe we should cache the entire notifications