### PR TITLE
Fixes #20499 - Import ConfigReports asynchronously

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -139,8 +139,8 @@ module Api
       end
     end
 
-    def process_success(response = nil)
-      render_status = request.post? ? :created : :ok
+    def process_success(response = nil, render_status = nil)
+      render_status ||= request.post? ? :created : :ok
       response ||= get_resource
       respond_with response, :responder => ApiResponder, :status => render_status
     end

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -37,10 +37,8 @@ module Api
       param_group :config_report, :as => :create
 
       def create
-        @config_report = ConfigReport.import(params[:config_report], detected_proxy.try(:id))
-        process_response @config_report.errors.empty?
-      rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        job = ImportConfigReport.perform_later(params[:config_report], detected_proxy.try(:id))
+        process_success _('Report import has been enqueued as job %s') % job.job_id, :accepted
       end
 
       api :DELETE, "/config_reports/:id/", N_("Delete a report")

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -37,10 +37,8 @@ module Api
       param_group :report, :as => :create
 
       def create
-        @report = resource_class.import(params[:report], detected_proxy.try(:id))
-        process_response @report.errors.empty?
-      rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        job = ImportConfigReport.perform_later(params[:report], detected_proxy.try(:id))
+        process_success _('Report import has been enqueued as job %s') % job.job_id, :accepted
       end
 
       api :DELETE, "/reports/:id/", N_("Delete a report")

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/import_config_report.rb
+++ b/app/jobs/import_config_report.rb
@@ -1,0 +1,9 @@
+class ImportConfigReport < ApplicationJob
+  def perform(config_report, proxy)
+    ConfigReport.import(config_report, proxy)
+  end
+
+  rescue_from ::Foreman::Exception do |e|
+    logger.warn("Error importing report #{e} - #{self.job_id}")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -243,10 +243,10 @@ module Foreman
     def dynflow
       return @dynflow if @dynflow.present?
       @dynflow =
-        if defined?(ForemanTasks)
-          ForemanTasks.dynflow
+        if defined?(::ForemanTasks)
+          ::ForemanTasks.dynflow
         else
-          Dynflow::Rails.new(Foreman::Dynflow::Configuration.new)
+          ::Dynflow::Rails.new(::Foreman::Dynflow::Configuration.new)
         end
       @dynflow.require!
       @dynflow.initialize!

--- a/test/controllers/api/v2/reports_controller_test.rb
+++ b/test/controllers/api/v2/reports_controller_test.rb
@@ -3,6 +3,7 @@ require 'controllers/shared/report_host_permissions_test'
 
 class Api::V2::ReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
+  include ::ActiveJob::TestHelper
 
   setup do
     Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/reports were moved to /config_reports}))
@@ -19,23 +20,28 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
 
     def test_create_valid
       User.current=nil
-      post :create, {:report => create_a_puppet_transaction_report }, set_session_user
-      assert_response :success
+      assert_enqueued_with(:job => ImportConfigReport) do
+        post :create, {:report => create_a_puppet_transaction_report }, set_session_user
+      end
+      assert_response :accepted
     end
 
     def test_create_invalid
       User.current=nil
-      post :create, {:report => ["not a hash", "throw an error"] }, set_session_user
-      assert_response :unprocessable_entity
+      perform_enqueued_jobs do
+        post :create, {:report => ["not a hash", "throw an error"] }, set_session_user
+      end
+      assert_performed_jobs 1
+      assert_response :accepted
     end
 
     def test_create_duplicate
       User.current=nil
       post :create, {:report => create_a_puppet_transaction_report }, set_session_user
-      assert_response :success
+      assert_response :accepted
       Foreman::Deprecation.expects(:api_deprecation_warning)
       post :create, {:report => create_a_puppet_transaction_report }, set_session_user
-      assert_response :unprocessable_entity
+      assert_response :accepted
     end
 
     test 'when ":restrict_registered_smart_proxies" is false, HTTP requests should be able to create a report' do
@@ -45,7 +51,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       Resolv.any_instance.stubs(:getnames).returns(['else.where'])
       post :create, {:report => create_a_puppet_transaction_report }
       assert_nil @controller.detected_proxy
-      assert_response :created
+      assert_response :accepted
     end
 
     test 'hosts with a registered smart proxy on should create a report successfully' do
@@ -58,7 +64,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       Resolv.any_instance.stubs(:getnames).returns([host])
       post :create, {:report => create_a_puppet_transaction_report }
       assert_equal proxy, @controller.detected_proxy
-      assert_response :created
+      assert_response :accepted
     end
 
     test 'hosts without a registered smart proxy on should not be able to create a report' do
@@ -78,7 +84,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
       @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
       post :create, {:report => create_a_puppet_transaction_report }
-      assert_response :created
+      assert_response :accepted
     end
 
     test 'hosts without a registered smart proxy but with an SSL cert should not be able to create a report' do
@@ -121,7 +127,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
 
       Resolv.any_instance.stubs(:getnames).returns(['else.where'])
       post :create, {:report => create_a_puppet_transaction_report }
-      assert_response :created
+      assert_response :accepted
     end
   end
 


### PR DESCRIPTION
Moves the content of the POST calls to create a report to an
asynchronous job to be run by the ActiveJob executor (Dynflow by
default).

Something like this is what's logged when a report is imported.

```
2017-08-03T15:14:40  [app] [I] processing report for lenovolobato.lobatolan.home
2017-08-03T15:14:40  [app] [D] Report: {"reported_at"=>"2017-08-03 17:14:39 594274", "metrics"=>{"time"=>{"total"=>0, "_aj_hash_with_indifferent_access"=>true}, "_aj_hash_with_indifferent_access"=>true}, "host"=>"lenovolobato.lobatolan.home", "status"=>{"applied"=>0, "failed"=>1, "skipped"=>0, "_aj_hash_with_indifferent_access"=>true}, "logs"=>[{"log"=>{"sources"=>{"source"=>"Gathering Facts", "_aj_hash_with_indifferent_access"=>true}, "messages"=>{"message"=>"{\"msg\": \"Failed to connect to the host via ssh: ssh: connect to host lenovolobato.lobatolan.home port 22: Connection refused\\r\\n\", \"unreachable\": true, \"changed\": false}", "_aj_hash_with_indifferent_access"=>true}, "level"=>"info", "_aj_hash_with_indifferent_access"=>true}, "_aj_hash_with_indifferent_access"=>true}], "_aj_hash_with_indifferent_access"=>true}
2017-08-03T15:14:40 4985e809 [dynflow] [D] ExecutionPlan d4d5e0f6-2c85-43e0-bf87-cb28d7d24bda      pending >>  planning
2017-08-03T15:14:40  [permissions] [D] verifying the transaction by permission edit_hosts for class Host::Managed
2017-08-03T15:14:40  [app] [I] Performed ImportConfigReport from Dynflow(default) in 161.41ms
```