### PR TITLE
Fixes #20511 - Webpack config should look for nested deps

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -50,7 +50,7 @@ var config = {
   resolve: {
     modules: [
       path.join(__dirname, '..', 'webpack'),
-      path.join(__dirname, '..', 'node_modules')
+      'node_modules/'
     ],
     alias: {
       foremanReact:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stylelint": "^7.13.0",
     "stylelint-config-standard": "^16.0.0",
     "url-loader": "^0.5.7",
-    "webpack": "^3.0.0",
+    "webpack": "^3.4.1",
     "webpack-dev-server": "^2.5.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
The current value of resolve.modules in config/webpack.config.js is
"path.join....'node_modules'"".
This value doesn't work when dependencies have been installed using
global style (npm install --global-style true).

In this style, which is what foreman-packaging uses, dependencies of
dependencies get nested like:

node_modules/dependencyA/node_modules/dependencyB

in a tree like structure. foreman-packaging needs to install in this
mode because the npm cache is stored
like a tree.

The solution I've been given in #webpack IRC is to use a string
'node_modules' instead of path.join. The reason is that
webpack purposefully looks for nested dependencies in that case, but not
if you provide the full path. It works for any string, e.g: "browserify" will look for "browserify"/dep1/"browserify"/dep2/"browserify"....