### PR TITLE
Fixes #20452 - Keep password value after validation in ovirt CR

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -17,11 +17,13 @@ module FormHelper
 
   def password_f(f, attr, options = {})
     unset_button = options.delete(:unset)
-    password_field_tag(:fakepassword, nil, :style => 'display: none') +
+    value = f.object[attr] if options.delete(:keep_value)
+    password_field_tag(:fakepassword, value, :style => 'display: none') +
         field(f, attr, options) do
           options[:autocomplete]   ||= 'off'
           options[:placeholder]    ||= password_placeholder(f.object, attr)
           options[:disabled] = true if unset_button
+          options[:value] = value if value.present?
           addClass options, 'form-control'
           pass = f.password_field(attr, options) +
               '<span class="glyphicon glyphicon-warning-sign input-addon"

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -6,7 +6,7 @@ module Foreman::Model
     validates :url, :format => { :with => URI.regexp }
     validates :user, :password, :presence => true
     before_create :update_public_key
-    before_validation :update_available_operating_systems unless Rails.env.test?
+    after_validation :update_available_operating_systems unless Rails.env.test?
 
     alias_attribute :datacenter, :uuid
 

--- a/app/views/compute_resources/form/_ovirt.html.erb
+++ b/app/views/compute_resources/form/_ovirt.html.erb
@@ -1,6 +1,6 @@
 <%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. https://ovirt.example.com/api"), :help_inline => documentation_button('5.2.7oVirt/RHEVNotes') %>
 <%= text_f f, :user, :help_block => _("e.g. admin@internal") %>
-<%= password_f f, :password, :unset => unset_password? %>
+<%= password_f f, :password, :keep_value => true, :unset => unset_password? %>
 <% datacenters = (f.object.uuid.nil? && controller.action_name != 'test_connection')  ? [] : f.object.datacenters rescue []%>
 <%= selectable_f(f, :uuid, datacenters, {}, {:label => _('Datacenter'),
                  :onchange => 'ovirt_datacenterSelected();',


### PR DESCRIPTION
Every time a validation error appears the form refreshes and the password is deleted.
Fixing the validation without entering the password again and trying to save will call `update_available_operating_systems` which will try to connect to ovirt using the empty password.
As a result ovirt returns unauthorized.
With this change the password is kept and there is no need to enter it again if there are validation errors.

 