### PR TITLE
Fixes #20514 - Accept dollar sign($) in login names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,7 @@ class User < ApplicationRecord
   end
 
   validates :login, :presence => true, :uniqueness => {:case_sensitive => false, :message => N_("already exists")},
-                    :format => {:with => /\A[[:alnum:]_\-@\.]*\Z/}, :length => {:maximum => 100}
+                    :format => {:with => /\A[[:alnum:]_\-@\.\\$]*\Z/}, :length => {:maximum => 100}
   validates :auth_source_id, :presence => true
   validates :password_hash, :presence => true, :if => Proc.new {|user| user.manage_password?}
   validates :password, :confirmation => true, :if => Proc.new {|user| user.manage_password?},


### PR DESCRIPTION
This will allow dollar signs to be valid characters in login names. This facilitates using Active Directory machine SAMaccountNames as valid user accounts.