### PR TITLE
Fixes #20521 - better subnet prefix label

### DIFF
--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -3,7 +3,7 @@
 
 <%= subnet_type_f f %>
 <%= text_f f, :network, :label => _("Network Address") %>
-<%= text_f f, :cidr, :label => _("Network Prefix"), :help_inline => _("Suffix or prefix length for this subnet, e.g. 32") %>
+<%= text_f f, :cidr, :label => _("Network Prefix"), :help_inline => _("Prefix length for this subnet, e.g. 24") %>
 <%= text_f f, :mask, :label => _("Network Mask"), :help_inline => _("Netmask for this subnet"), :wrapper_class => "form-group #{'hide' unless f.object.show_mask?}" %>
 <%= text_f f, :gateway, :label => _("Gateway Address"), :help_inline => _("Optional: Gateway for this subnet") %>
 <%= text_f f, :dns_primary, :label => _("Primary DNS Server"), :help_inline => _("Optional: Primary DNS for this subnet") %>


### PR DESCRIPTION
There is a network prefix field which is to input the IP network prefix (ie the short form of the subnet mask /24 instead of 255.255.255.0). 

The description of this field is "Suffix or prefix length for this subnet, e.g. 32" 

Using the term suffix here is incorrect, since it's talking about the network portion of the address. 

Seen on IPv4 and IPv6 pages.

Also, while 32 is probably a bad example, since it is not (or rarely) used as a subnet prefix. 24 is a better example for IPv4 and 64 for IPv6.