### PR TITLE
Fixes #19529: Use main_app for redirect in case of plugins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
         format.html do
           error msg
           flash.keep # keep any warnings added by the user login process, they may explain why this occurred
-          redirect_to edit_user_path(:id => User.current)
+          redirect_to main_app.edit_user_path(:id => User.current)
         end
         format.text do
           render :text => msg, :status => :unprocessable_entity, :content_type => Mime::TEXT


### PR DESCRIPTION
Sometimes when entering the require_mail filter, the plugins context
is carried over and the route cannot be matched. Using main_app ensures
that it will resolve the path from the proper context.