### PR TITLE
Fixes #20537: Monospace fonts in fullscreen editor

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -489,6 +489,7 @@ table {
   height: 100vh !important;
   position: fixed !important;
   width: 100vw !important;
+  font-family: monospace;
 }
 
 .select2-arrow > b {


### PR DESCRIPTION
The fullscreen editor is used to edit parameters which can be in YAML.
Since YAML is an indentation sensitive format, monospaced fonts makes
for easier editing.