### PR TITLE
Fixes #20416 - fix UI under email preferences

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,7 +1,8 @@
 #audit_summary_query_builder {
   display: block;
-  top: -14px;
+  top: -6px;
   left: 20%;
+  width: 92%;
 }
 
 #audit_summary_query_builder::before {
@@ -12,7 +13,7 @@
   border-radius: 0 0 0 10px;
   position: absolute;
   left: -15px;
-  top: -11px;
+  top: -15px;
 }
 
 .mail_notification_query {

--- a/app/views/users/_audit_summary_query_builder.html.erb
+++ b/app/views/users/_audit_summary_query_builder.html.erb
@@ -1,3 +1,4 @@
 <div id="audit_summary_query_builder" class="input-group">
-  <%= text_f(f, :mail_query, {:label => '', :help_inline => _('Build a query for %{mailer}') % {:mailer => mailer.humanize.downcase }, :id => 'search',:class => "autocomplete-input", :data => {:url => auto_complete_search_audits_path} }) %>
+  <%= text_f(f, :mail_query, {:no_label => true, :placeholder => _('Mail query'),
+                              :id => 'search',:class => "autocomplete-input", :data => {:url => auto_complete_search_audits_path} }) %>
 </div>

--- a/app/views/users/_mail_notifications.html.erb
+++ b/app/views/users/_mail_notifications.html.erb
@@ -1,5 +1,5 @@
 <%= f.hidden_field :mail_notification_id, :value => f.object.mail_notification.id %>
 <% values = f.object.mail_notification.subscription_type == 'alert' ? f.object.mail_notification.subscription_options : MailNotification::INTERVALS %>
 <%= select_f(f, :interval, values, :to_s, :to_translation, { :include_blank => _('No emails') }, {:label => _(f.object.mail_notification.name.humanize),
-             :help_inline => _(f.object.mail_notification.description)}) %>
+             :label_help => _(f.object.mail_notification.description)}) %>
 <%= mail_notification_query_builder(f.object.mail_notification, f) %>

--- a/db/seeds.d/16-mail_notifications.rb
+++ b/db/seeds.d/16-mail_notifications.rb
@@ -31,7 +31,7 @@ notifications = [
 
   {
     :name               => 'audit_summary',
-    :description        => N_('A summary of audit changes report'),
+    :description        => N_('A summary of audit changes report <br> Filtered by a query if needed'),
     :mailer             => 'AuditMailer',
     :method             => 'summary',
     :subscription_type  => 'report',


### PR DESCRIPTION
Before:
![before_notif](https://user-images.githubusercontent.com/11807069/29124127-aeacb61c-7d20-11e7-882d-598f21f3179f.png)
After:
![notification](https://user-images.githubusercontent.com/11807069/29124152-bffd1d44-7d20-11e7-8e72-d21defb5baee.png)

I've removed the label, and added placeholder text instead. IMO it looks better, less messy.

