### PR TITLE
Fixes #20469 - Register react components from plugins

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -4,4 +4,31 @@ module ReactjsHelper
       "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}));".html_safe
     end
   end
+
+  def webpacked_plugins_js_for(*plugin_names)
+    tags = create_tags(plugin_names)
+    return nil if tags.empty?
+    tags.inject(&:concat).html_safe
+  end
+
+  def create_tags(plugin_names)
+    js_tags_for select_requested_plugins(all_webpacked_plugins.map(&:id), plugin_names)
+  end
+
+  def select_requested_plugins(webpacked_plugin_ids, plugin_names)
+    plugin_names.select { |plugin_name| webpacked_plugin_ids.include?(plugin_name) }
+  end
+
+  def all_webpacked_plugins
+    Foreman::Plugin.registered_plugins.values.select do |plugin|
+      File.exist? File.join(plugin.path, 'webpack/index.js')
+    end
+  end
+
+  def js_tags_for(requested_plugins)
+    requested_plugins.map do |plugin|
+      bundle_name = Foreman::Plugin.bundle_name plugin
+      javascript_include_tag(*webpack_asset_paths(bundle_name, :extension => 'js'), "data-turbolinks-track" => true)
+    end
+  end
 end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -40,6 +40,7 @@ module Foreman #:nodoc:
       attr_reader   :registered_plugins
       attr_accessor :tests_to_skip
       private :new
+      include Foreman::WebpackAssets
 
       def def_field(*names)
         class_eval do

--- a/app/registries/foreman/webpack_assets.rb
+++ b/app/registries/foreman/webpack_assets.rb
@@ -1,0 +1,15 @@
+module Foreman
+  module WebpackAssets
+    def bundle_name(plugin_name)
+      plugin_name.to_s.gsub(/core$/, '').gsub(/-|_|#{remove_bundle_name_plugins}/,'')
+    end
+
+    def plugin_name_regexp
+      /foreman*|katello*/
+    end
+
+    def remove_bundle_name_plugins
+      /foreman*/
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ || exit 0",
+    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ $(./script/foreman_plugins_eslint.js) || exit 0",
     "test": "node node_modules/.bin/jest",
     "test:watch": "node node_modules/.bin/jest --watchAll",
     "storybook": "start-storybook -p 6006",

--- a/script/foreman_plugins_eslint.js
+++ b/script/foreman_plugins_eslint.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+process.stdout.write(require('./plugin_webpack_directories').paths.join(' '));

--- a/script/plugin_webpack_directories.js
+++ b/script/plugin_webpack_directories.js
@@ -1,0 +1,19 @@
+'use strict';
+/* eslint-disable no-var*/
+
+var execSync = require('child_process').execSync;
+var path = require('path');
+
+// If we get multiple lines, then the plugin_webpack_directories.rb script
+// has on the stdout more that just the JSON we want, so we use newline to split and check.
+var sanitizeWebpackDirs = function (pluginDirs) {
+  var splitDirs = pluginDirs.toString().split('\n').reverse();
+
+  return splitDirs.length > 2 ? splitDirs[1] : pluginDirs;
+};
+
+var webpackDirs = execSync(path.join(__dirname, './plugin_webpack_directories.rb'), {
+  stdio: ['pipe', 'pipe', 'ignore']
+});
+
+module.exports = JSON.parse(sanitizeWebpackDirs(webpackDirs));

--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'json'
+require_relative '../app/registries/foreman/webpack_assets'
 
 if File.exist?(File.expand_path(File.join(%w[.. .. Gemfile.in]), __FILE__))
   require 'bundler_ext'
@@ -11,27 +12,26 @@ else
   specs = Bundler.load.specs
 end
 
-PLUGIN_NAME_REGEXP = /foreman*|katello*/
-REMOVE_BUNDLE_NAME_PLUGINS = /foreman*/
+include Foreman::WebpackAssets
 
 config = { entries: {}, paths: [] }
 specs.each do |dep|
   # skip other rails engines that are not plugins
   # TODO: Consider using the plugin registration api?
   if gemfile_in
-    next unless dep =~ PLUGIN_NAME_REGEXP
+    next unless dep =~ plugin_name_regexp
     dep = dep.to_spec
   else
-    next unless dep.name =~ PLUGIN_NAME_REGEXP
+    next unless dep.name =~ plugin_name_regexp
   end
+
   path = "#{dep.to_spec.full_gem_path}/webpack"
   entry = "#{path}/index.js"
   # some plugins share the same base directory (tasks-core and tasks, REX etc)
   # skip the plugin if its path is already included
   next if config[:paths].include?(path)
   if File.exist?(entry)
-    bundle_name = dep.name.gsub(/-|_|#{REMOVE_BUNDLE_NAME_PLUGINS}/,'')
-    config[:entries][bundle_name] = entry
+    config[:entries][bundle_name dep.name] = entry
     config[:paths] << path
   end
 end

--- a/test/helpers/reactjs_helper_test.rb
+++ b/test/helpers/reactjs_helper_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ReactjsHelperTest < ActionView::TestCase
+  include ReactjsHelper
+
+  def webpack_asset_paths(bundle_name, opts)
+    ["<script src=\"https://foreman.example.com:3808/webpack/#{bundle_name}.js\"></script>"]
+  end
+
+  setup do
+    Foreman::Plugin.register(:foreman_react) {}
+    Foreman::Plugin.register(:foreman_angular) {}
+    @plugins = [Foreman::Plugin.find(:foreman_react), Foreman::Plugin.find(:foreman_angular)]
+    self.stubs(:all_webpacked_plugins).returns(@plugins)
+  end
+
+  test "should select requested plugins" do
+    plugin_names = [:foreman_react, :foreman_backbone]
+    selected_plugins = select_requested_plugins(all_webpacked_plugins.map(&:id), plugin_names)
+    assert selected_plugins.include?(:foreman_react)
+    assert_equal 1, selected_plugins.size
+  end
+
+  test "should create js tags" do
+    tags = js_tags_for [:foreman_react, :foreman_angular]
+    assert_equal 2, tags.size
+  end
+
+  test "should not create js for plugins without webpacked js" do
+    refute webpacked_plugins_js_for(:foreman_meteor)
+  end
+
+  test "should create js for plugins with webpacked js" do
+    res = webpacked_plugins_js_for(:foreman_react, :foreman_angular)
+    assert res.include?('webpack/react.js')
+    assert res.include?('webpack/angular.js')
+  end
+end

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -1,50 +1,15 @@
-import React from 'react';
-import StatisticsChartsList from '../components/statistics/StatisticsChartsList';
-import PowerStatus from '../components/hosts/powerStatus/';
-import NotificationContainer from '../components/notifications/';
-import ToastsList from '../components/toastNotifications/';
-import PieChart from '../components/common/charts/PieChart/';
-import StorageContainer from '../components/hosts/storage/vmware/';
 import ReactDOM from 'react-dom';
 import store from '../redux';
+import componentRegistry from '../components/componentRegistry';
 
 export function mount(component, selector, data) {
-  const components = {
-    PieChart: {
-      type: PieChart,
-      markup: <PieChart data={ data } />
-    },
-    StatisticsChartsList: {
-      type: StatisticsChartsList,
-      markup: <StatisticsChartsList store={store} data={data}/>
-    },
-    PowerStatus: {
-      type: PowerStatus,
-      markup: <PowerStatus store={store} data={data}/>
-    },
-    NotificationContainer: {
-      type: NotificationContainer,
-      markup: <NotificationContainer store={store} data={data} />
-    },
-    ToastNotifications: {
-      type: ToastsList,
-      markup: <ToastsList store={store} />
-    },
-    StorageContainer: {
-      type: StorageContainer,
-      markup: <StorageContainer store={store} data={data} />
-    }
-  };
-
   const reactNode = document.querySelector(selector);
 
   if (reactNode) {
     ReactDOM.unmountComponentAtNode(reactNode);
-    ReactDOM.render(components[component].markup, reactNode);
+    ReactDOM.render(componentRegistry.markup(component, data, store), reactNode);
   } else {
-    const componentName = components[component].type.name;
-
     // eslint-disable-next-line no-console
-    console.log(`Cannot find \'${selector}\' element for mounting the \'${componentName}\'`);
+    console.log(`Cannot find \'${selector}\' element for mounting the \'${component}\'`);
   }
 }

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PieChart from './common/charts/PieChart/';
+import StatisticsChartsList from './statistics/StatisticsChartsList';
+import PowerStatus from './hosts/powerStatus/';
+import NotificationContainer from './notifications/';
+import ToastsList from './toastNotifications/';
+import StorageContainer from './hosts/storage/vmware/';
+import forEach from 'lodash/forEach';
+import map from 'lodash/map';
+
+const componentRegistry = {
+  registry: {},
+
+  register({ name = null, type = null, store = true, data = true }) {
+    if (!name || !type) {
+      throw new Error('Component name or type is missing');
+    }
+    if (this.registry[name]) {
+      throw new Error(`Component name already taken: ${name}`);
+    }
+
+    this.registry[name] = { type, store, data };
+    return this.registry;
+  },
+
+  registerMultiple(componentObjs) {
+    return forEach(componentObjs, (obj) => {
+      return this.register(obj);
+    });
+  },
+
+  getComponent(name) {
+    return this.registry[name];
+  },
+
+  registeredComponents() {
+    return map(this.registry, (value, key) => {
+      return key;
+    }).join(', ');
+  },
+
+  markup(name, data, store) {
+    const currentComponent = this.getComponent(name);
+
+    if (!currentComponent) {
+      throw new Error(`Component not found:  ${name} among ${this.registeredComponents()}`);
+    }
+    const ComponentName = currentComponent.type;
+
+    return (<ComponentName data={ currentComponent.data ? data : undefined }
+                           store={ currentComponent.store ? store : undefined } />);
+  }
+};
+
+const coreComponets = [
+  { name: 'PieChart', type: PieChart },
+  { name: 'StatisticsChartsList', type: StatisticsChartsList },
+  { name: 'PowerStatus', type: PowerStatus },
+  { name: 'NotificationContainer', type: NotificationContainer },
+  { name: 'ToastNotifications', type: ToastsList, data: false },
+  { name: 'StorageContainer', type: StorageContainer }
+];
+
+componentRegistry.registerMultiple(coreComponets);
+
+export default componentRegistry;

--- a/webpack/assets/javascripts/react_app/components/compontentRegistry.test.js
+++ b/webpack/assets/javascripts/react_app/components/compontentRegistry.test.js
@@ -1,0 +1,59 @@
+jest.unmock('./componentRegistry');
+import React from 'react';
+import componentRegistry from './componentRegistry';
+
+class FakeComponent extends React.Component {}
+
+describe('Component registry', () => {
+
+  it('should register a component', () => {
+    const name = 'TestComponent';
+
+    componentRegistry.register({ name, type: FakeComponent });
+    const comp = componentRegistry.getComponent(name);
+
+    expect(comp).toBeTruthy();
+    expect(comp.store).toBeTruthy();
+    expect(comp.data).toBeTruthy();
+  });
+
+  it('should not register a component twice', () => {
+    const name = 'TwiceComponent';
+
+    componentRegistry.register({ name, type: FakeComponent });
+    expect(() =>
+      componentRegistry.register({ name, type: FakeComponent })
+    ).toThrow('Component name already taken: TwiceComponent');
+  });
+
+  it('should not register a component without a name', () => {
+    expect(() =>
+      componentRegistry.register({ type: FakeComponent })
+    ).toThrow('Component name or type is missing');
+  });
+
+  it('should not register a component without a type', () => {
+    expect(() =>
+      componentRegistry.register({ name: 'SadComponent' })
+    ).toThrow('Component name or type is missing');
+  });
+
+  it('should register multiple components', () => {
+    const first = 'FirstComponent',
+          second = 'SecondComponent';
+
+    componentRegistry.registerMultiple([{ name: first, type: FakeComponent },
+                                        { name: second, type: FakeComponent }]);
+    expect(componentRegistry.getComponent(first)).toBeTruthy();
+    expect(componentRegistry.getComponent(second)).toBeTruthy();
+  });
+
+  it('should return component markup', () => {
+    const name = 'MarkupComponent';
+
+    componentRegistry.register({ name, type: FakeComponent, store: false });
+    const markup = componentRegistry.markup(name, { fakeData: true }, {});
+
+    expect(markup).toEqual(<FakeComponent data={{'fakeData': true}} store={undefined} />);
+  });
+});


### PR DESCRIPTION
Plugins can register their own react components so that `MountingService` is aware of them.

```js
//foreman_myplugin/webpack/index.js

import componentRegistry from 'foremanReact/components/componentRegistry';
import MyComponent from './components/MyComponent';
import MyOtherComponent from './components/MyOtherComponent';

componentRegistry.register({ name: 'MyComponent', type: MyComponent });
// store and data attributes are true by default
componentRegistry.register({ name: 'MyOtherComponent', type: MyOtherComponent, store: false, data: false });

// or to register multiple components:
componentRegistry.registerMultiple([
  { name: 'MyComponent', type: MyComponent },
  { name: 'MyOtherComponent', type: MyOtherComponent, store: false, data: false }
]);
```

components from plugins can be imported using an alias, so plugins can use components from other plugins:

```js
// somewhere in foreman_somename/webpack/
import OtherComponent from 'myplugin/OtherComponent';
```

If you are not sure about alias for plugin, run `script/plugin_webpack_directories.rb`

We do not load all js on each page, plugins must make sure their js files are present.
The arguments of helper are ids that plugins use when registering:

```erb
# my_view.erb
<%= webpacked_plugins_js_for :foreman_ansible, :foreman_openscap %>
```



TODO:
* [x] Stylesheets in components are ignored for unknown reason, so Statistics page looks strange
* [x] register multiple components with one call
