### PR TITLE
Fixes #20543 - implement asset_path for plugin_assets

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -77,6 +77,12 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
           env.append_path path
         end
 
+        env.context_class.class_eval do
+          def asset_path(path, options = {})
+            ActionController::Base.helpers.asset_path(path, options)
+          end
+        end
+
         env.version = [
           'production',
           config.assets.version,


### PR DESCRIPTION
Sprockets runs on its own context in the task plugin_assets.rake since
 #20287. This means that the asset paths are not visible to it
immediately, the way we provide that functionality is by overriding a
method in Sprockets that gets the paths from the Rails app since we're
on Rake context.

This is provided by https://github.com/petebrowne/sprockets-helpers but our use case is so limited I think it's better to just put it there ourselves. 

You will see a deprecation warning, which is fixed by https://github.com/theforeman/foreman/pull/4730