### PR TITLE
Fixes #20553 - br tag now renders to new line

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -5,7 +5,7 @@ module Api
 
       resource_description do
         api_version "v1"
-        app_info N_("<b>Foreman API v1 is deprecated. Please use v2.</b><br />If you still need to use v1, you may do so by either passing 'version=1' in the Accept Header or using api/v1/ in the URL.")
+        app_info N_("<b>Foreman API v1 is deprecated. Please use v2.</b><br>If you still need to use v1, you may do so by either passing 'version=1' in the Accept Header or using api/v1/ in the URL.")
       end
     end
   end


### PR DESCRIPTION
 br tag is shown in v1 of apidoc, now renders to a new line.