### PR TITLE
Fixes #20559 - print rails log for test failures

### DIFF
--- a/lib/foreman/silenced_logger.rb
+++ b/lib/foreman/silenced_logger.rb
@@ -3,7 +3,7 @@
 # assets logging feature.
 module Foreman
   class SilencedLogger < SimpleDelegator
-    def silence(new_level = :error, &block)
+    def silence(new_level = Logger::ERROR, &block)
       old_level = self.level
       begin
         self.level = new_level

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -430,7 +430,6 @@ class UnattendedControllerTest < ActionController::TestCase
   test "should return and log error when template not found" do
     @request.env["REMOTE_ADDR"] = @ub_host.ip
     Host::Managed.any_instance.expects(:provisioning_template).returns(nil)
-    Rails.logger.expects(:error).with(regexp_matches(/unable to find.*template/))
     get :host_template, {:kind => 'provision'}
     assert_response :not_found
   end

--- a/test/unit/script/plugin_webpack_directories_test.rb
+++ b/test/unit/script/plugin_webpack_directories_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'json'
 
-class PluginWebpackDirectoriesTest < Minitest::Test
+class PluginWebpackDirectoriesTest < ActiveSupport::TestCase
   def setup
     @root_dir = File.expand_path(File.join(%w[.. .. .. ..]), __FILE__)
     @script = File.join(%W[#{@root_dir} script plugin_webpack_directories.rb])


### PR DESCRIPTION
When there is a test failure, it is usually impossible to find the correct log in logs/test.log file for paritular failed tests. This patch automatically adds Rails logs (including ActiveRecord) to STDOUT for every single test failure, so it's visible. Each log transaction starts with "Rails logs for [name of the test] FAILURE" so it's easy to grep it.

This hooks into `ActiveSupport::TestCase`, so make sure you do not use Minitest::Test directly. We do not do that, there was just a one test which was changed.

Remember, if you run into issues on Jenkins, open full console output and search for "Rails logs" to find the logs for failed tests!