### PR TITLE
Fixes #20448 - display selected hosts counter

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -98,22 +98,24 @@ function cleanHostsSelection() {
 function multiple_selection() {
   var total = $("#pagination").data("count");
   var alert_text = Jed.sprintf(n__("Single host is selected in total",
-                                   "All <b> %d </b> hosts are selected.", total), total);
+    "All <b> %d </b> hosts are selected.", total), total);
   var undo_text = __("Undo selection");
   var multiple_alert = $("#multiple-alert");
   multiple_alert.find(".text").html(alert_text + ' <a href="#" onclick="undo_multiple_selection();">' + undo_text + '</a>');
-  multiple_alert.data('multiple', true)
+  multiple_alert.data('multiple', true);
+  $(".select_count").html(total);
 }
 
 function undo_multiple_selection() {
   var pagination = pagination_metadata();
   var alert_text = Jed.sprintf(n__("Single host on this page is selected.",
-                                   "All %s hosts on this page are selected.", pagination.per_page), pagination.per_page);
+    "All %s hosts on this page are selected.", pagination.per_page), pagination.per_page);
   var select_text = Jed.sprintf(n__("Select this host",
-                                    "Select all<b> %s </b> hosts", pagination.total), pagination.total);
+    "Select all<b> %s </b> hosts", pagination.total), pagination.total);
   var multiple_alert = $("#multiple-alert");
   multiple_alert.find(".text").html( alert_text + ' <a href="#" onclick="multiple_selection();">' + select_text + '</a>');
-  multiple_alert.data('multiple', false)
+  multiple_alert.data('multiple', false);
+  $(".select_count").html(pagination.per_page);
 }
 
 function toggleCheck() {
@@ -156,8 +158,8 @@ function submit_modal_form() {
     removeForemanHostsCookie();
   if ($("#multiple-alert").data('multiple')){
     var query = $("<input>")
-            .attr("type", "hidden")
-            .attr("name", "search").val($("#search").val());
+      .attr("type", "hidden")
+      .attr("name", "search").val($("#search").val());
     $("#confirmation-modal form").append(query);
   }
   $("#confirmation-modal form").submit();
@@ -176,17 +178,17 @@ function build_modal(element, url) {
     .append("<div class='modal-spinner spinner spinner-lg'></div>");
   $('#confirmation-modal').modal();
   $("#confirmation-modal .modal-body").load(url + " #content", data,
-      function(response, status, xhr) {
-        $("#loading").hide();
-        $('#submit_multiple').val('');
-        if (is_multiple.data('multiple'))
-          $("#multiple-modal-alert").show();
-        var b = $("#confirmation-modal .btn-primary");
-        if ($(response).find('#content form select').length > 0)
-          b.addClass("disabled").attr("disabled", true);
-        else
-          b.removeClass("disabled").attr("disabled", false);
-      });
+    function(response, status, xhr) {
+      $("#loading").hide();
+      $('#submit_multiple').val('');
+      if (is_multiple.data('multiple'))
+        $("#multiple-modal-alert").show();
+      var b = $("#confirmation-modal .btn-primary");
+      if ($(response).find('#content form select').length > 0)
+        b.addClass("disabled").attr("disabled", true);
+      else
+        b.removeClass("disabled").attr("disabled", false);
+    });
   return false;
 }
 
@@ -215,6 +217,6 @@ function update_counter() {
   item.attr("data-original-title", title );
   item.tooltip({
     trigger : 'hover'
-})
+  })
   return false;
 }

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -1,5 +1,6 @@
 <%= javascript "host_checkbox" %>
 <% title header ||= "" %>
+<span class="pull-right"><%= _("<b class='select_count'>0</b> of <b>#{@hosts.total_entries}</b> selected").html_safe %></span>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
@@ -62,4 +63,4 @@
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
-<%= will_paginate_with_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>
+<%= will_paginate_with_info hosts %>


### PR DESCRIPTION
@Rohoover, what would be the best way to display this information?
with this pr it looks like this - 
![image](https://user-images.githubusercontent.com/15361156/29249647-6ae21110-803c-11e7-8057-a70e64a0198e.png)

so now there's a large space between the search bar and the table
patternfly [Data Table](http://www.patternfly.org/pattern-library/content-views/table-view/#/design) suggestion is pretty similar but it's not exactly what we have (search bar, buttons at the right and no gray background)