### PR TITLE
Fixes #20516 - GET hosts API displays owner_name attribute

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -20,7 +20,7 @@ module Api
 
       add_smart_proxy_filters :facts, :features => Proc.new { FactImporter.fact_features }
 
-      add_scope_for(:index) { |base_scope| base_scope.preload([:host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token]) }
+      add_scope_for(:index) { |base_scope| base_scope.preload([:host_statuses, :compute_resource, :hostgroup, :operatingsystem, :interfaces, :token, :owner]) }
 
       api :GET, "/hosts/", N_("List all hosts")
       api :GET, "/hostgroups/:hostgroup_id/hosts", N_("List all hosts for a host group")

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -221,6 +221,10 @@ class Host::Managed < Host::Base
     self.name <=> other.name
   end
 
+  def owner_name
+    owner.try(:name)
+  end
+
   def self.model_name
     ActiveModel::Name.new(Host)
   end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -11,7 +11,7 @@ extends "api/v2/smart_proxies/children_nodes"
 attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :realm_id, :realm_name,
            :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
            :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :pxe_loader,
-           :build, :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_type,
+           :build, :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_name, :owner_type,
            :enabled, :managed, :use_image, :image_file, :uuid,
            :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -173,6 +173,15 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal model.name, show_response['model_name']
   end
 
+  test "should show host owner name" do
+    owner = User.first
+    host = FactoryGirl.create(:host, :owner => owner)
+    get :show, {:id => host.id}, set_session_user
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal owner.name, response["owner_name"]
+  end
+
   test "should create host" do
     disable_orchestration
     assert_difference('Host.count') do


### PR DESCRIPTION
GET hosts API now returns owner_name attribute
