### PR TITLE
Fixes #20591 - full ovirt cloud-init support

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -207,7 +207,7 @@ module Foreman::Model
     def start_vm(uuid)
       vm = find_vm_by_uuid(uuid)
       if vm.comment.include? "cloud-config"
-        vm.start_with_cloudinit(:blocking => true, :user_data => vm.comment)
+        vm.start_with_cloudinit(:blocking => true, :user_data => vm.comment, :use_custom_script => true)
         vm.comment = ''
         vm.save
       else
@@ -216,7 +216,7 @@ module Foreman::Model
     end
 
     def start_with_cloudinit(uuid, user_data = nil)
-      find_vm_by_uuid(uuid).start_with_cloudinit(:blocking => true, :user_data => user_data)
+      find_vm_by_uuid(uuid).start_with_cloudinit(:blocking => true, :user_data => user_data, :use_custom_script => true)
     end
 
     def sanitize_inherited_vm_attributes(args)


### PR DESCRIPTION
Currently, the cloud-init integration supports only a sub-set of
cloud-init commands. With `custom_script` support, one can pass
arbitrary cloud-init yaml to the managed host and make sure
the provisioned host will get it unchanged (which is not the case
when passing the user data currently, as the rbovirt parses into
ovirt-specific keys)

After the change, we would pass the cloud-init template to the ovirt as
is via `custom_script` ovirt functionality, and it would get to the
cloud-init directly, without any ovirt pre-processing.

Depends on https://github.com/fog/fog/pull/3961