### PR TITLE
Fixes #20622 - puppet import does not refresh all statuses

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -734,8 +734,8 @@ class Host::Managed < Host::Base
     save!(:validate => false)
   end
 
-  def refresh_statuses
-    HostStatus.status_registry.each do |status_class|
+  def refresh_statuses(which = HostStatus.status_registry)
+    which.each do |status_class|
       status = get_status(status_class)
       status.refresh! if status.relevant?
     end

--- a/app/services/config_report_importer.rb
+++ b/app/services/config_report_importer.rb
@@ -23,4 +23,8 @@ class ConfigReportImporter < ReportImporter
   def report_status
     ConfigReportStatusCalculator.new(:counters => raw['status']).calculate
   end
+
+  def statuses_for_refresh
+    [HostStatus.find_status_by_humanized_name("configuration")]
+  end
 end

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -33,13 +33,14 @@ class ReportImporter
   end
 
   def import
-    start_time = Time.now.utc
-    logger.info "processing report for #{name}"
-    logger.debug { "Report: #{raw.inspect}" }
+    start_time = Time.now
+    logger.debug { "Processing report: #{raw.inspect}" }
     create_report_and_logs
     if report.persisted?
-      logger.info("Imported report for #{name} in #{(Time.now.utc - start_time).round(2)} seconds")
-      host.refresh_statuses
+      imported_time = Time.now
+      host.refresh_statuses(statuses_for_refresh)
+      refreshed_time = Time.now
+      logger.info("Imported report for #{name} in #{(imported_time - start_time).round(2)} seconds, status refreshed in #{(refreshed_time - imported_time).round(2)} seconds")
     end
   end
 
@@ -86,6 +87,10 @@ class ReportImporter
 
   def report_status
     raise NotImplementedError
+  end
+
+  def statuses_for_refresh
+    HostStatus.status_registry
   end
 
   def notify_on_report_error(mail_error_state)

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -114,6 +114,24 @@ class ReportImporterTest < ActiveSupport::TestCase
     host = reporter.send(:host)
     assert_equal host, db_host
   end
+
+  test 'it should refresh all statuses' do
+    host = FactoryGirl.create(:host)
+    report = read_json_fixture('reports/applied.json')
+    report["host"] = host.name
+    reporter = TestReportImporter.new(report)
+    reporter.send(:host).expects(:refresh_statuses).with(HostStatus.status_registry)
+    reporter.import
+  end
+
+  test 'it should refresh zero statuses' do
+    host = FactoryGirl.create(:host)
+    report = read_json_fixture('reports/applied.json')
+    report["host"] = host.name
+    reporter = TestNoStatusUpdateReportImporter.new(report)
+    reporter.send(:host).expects(:refresh_statuses).with([])
+    reporter.import
+  end
 end
 
 class TestReportImporter < ReportImporter
@@ -123,5 +141,11 @@ class TestReportImporter < ReportImporter
 
   def report_name_class
     Report
+  end
+end
+
+class TestNoStatusUpdateReportImporter < TestReportImporter
+  def statuses_for_refresh
+    []
   end
 end


### PR DESCRIPTION
It appears that puppet reports cause all statuses to be updated:

https://github.com/theforeman/foreman/blob/develop/app/services/report_importer.rb#L42

On a heavily loaded system this could mean this is being called 100s of times per second. This is a fairly slow operation to be doing when not necessary.

Puppet reports should only refresh statuses that are relevant to them.