### PR TITLE
Fixes #20628 - cloned host/hostgroup should copy root pass

### DIFF
--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -60,7 +60,8 @@
 
     <div class="tab-pane" id="os">
       <%= render "common/os_selection/initial", :item=> @hostgroup %>
-      <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more").html_safe, :unset => action_name == "edit" %>
+      <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more").html_safe,
+                     :unset => action_name == "edit", :keep_value => action_name == "clone"  %>
     </div>
 
     <div class="tab-pane" id="params">

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -22,7 +22,8 @@
 <% end %>
 
 <div id='root_password'>
-  <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more"), :required => true, :unset => action_name == "edit" %>
+  <%= password_f f, :root_pass, :help_inline => _("Password must be 8 characters or more"), :required => true,
+                 :unset => action_name == "edit", :keep_value => action_name == "clone"  %>
 </div>
 <!-- this section is used for displaying the provisioning scripts-->
 <div class="form-group">

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -135,6 +135,15 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       assert page.has_no_selector?('#params .has-error')
     end
 
+    test 'clones root_pass' do
+      host = FactoryGirl.create(:host, :managed)
+      visit clone_host_path(host)
+      assert page.has_link?('Operating System', :href => '#os')
+      click_link 'Operating System'
+      root_pass = page.find("#host_root_pass")
+      assert_equal host.root_pass, root_pass.value
+    end
+
     test 'build mode is enabled for managed hosts' do
       host = FactoryGirl.create(:host, :managed)
       visit clone_host_path(host)

--- a/test/integration/hostgroup_test.rb
+++ b/test/integration/hostgroup_test.rb
@@ -69,6 +69,15 @@ class HostgroupIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal lookup_value.value, a.value
   end
 
+  test 'clones root_pass' do
+    group = FactoryGirl.create(:hostgroup, :with_rootpass)
+    visit clone_hostgroup_path(group)
+    assert page.has_link?('Operating System', :href => '#os')
+    click_link 'Operating System'
+    root_pass = page.find("#hostgroup_root_pass")
+    assert_equal group.root_pass, root_pass.value
+  end
+
   test 'clone shows no errors on lookup values' do
     group = FactoryGirl.create(:hostgroup, :with_puppetclass)
     FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param, :with_override, :path => "hostgroup\ncomment",


### PR DESCRIPTION
When cloning host/hostgroup, root pass field should be copied too