### PR TITLE
fixes #20646 - clear host_id during interface cloning

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -123,7 +123,7 @@ module Nic
 
     def clone
       # do not copy system specific attributes
-      self.deep_clone(:except  => [:name, :mac, :ip, :ip6])
+      self.deep_clone(:except  => [:name, :mac, :ip, :ip6, :host_id])
     end
 
     # if this interface does not have MAC and is attached to other interface,

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2620,7 +2620,7 @@ class HostTest < ActiveSupport::TestCase
       assert copy.last_report.blank?
     end
 
-    test 'clone host should copy interfaces without name, mac and ip' do
+    test 'clone host should copy interfaces without name, mac, host_id and ips' do
       host = FactoryGirl.create(:host, :with_config_group, :with_puppetclass, :with_parameter, :dualstack)
       copy = host.clone
 
@@ -2631,6 +2631,7 @@ class HostTest < ActiveSupport::TestCase
       assert interface.mac.blank?
       assert interface.ip.blank?
       assert interface.ip6.blank?
+      assert interface.host_id.blank?
     end
 
     test 'without save makes no changes' do
@@ -2639,6 +2640,15 @@ class HostTest < ActiveSupport::TestCase
       ActiveRecord::Base.any_instance.expects(:destroy).never
       ActiveRecord::Base.any_instance.expects(:save).never
       host.clone
+    end
+
+    test 'clone host with identifier should be valid' do
+      interface = FactoryGirl.build(:nic_primary_and_provision, :identifier => 'eth0')
+      host = FactoryGirl.create(:host, :interfaces => [ interface ])
+      copy = host.clone
+
+      cloned_interface = copy.interfaces.first
+      assert_valid cloned_interface
     end
   end
 


### PR DESCRIPTION
To reproduce: Clone a Host that has an nic identifier set. The device identifier field will show a validation error: "has already been taken".
The Redmine issue has more details.