### PR TITLE
fixes #20649 - add vmware WebMKS console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bundler.d/*.local.rb
 *.pyc
 public/apipie-cache
 public/assets
+public/webmks
 .DS_Store
 foreman_client
 doc/

--- a/app/controllers/concerns/foreman/controller/console_common.rb
+++ b/app/controllers/concerns/foreman/controller/console_common.rb
@@ -1,11 +1,18 @@
 module Foreman::Controller::ConsoleCommon
   def console
     @encrypt = Setting[:websockets_encrypt]
+    if @console[:extend_content_security_policy].present?
+      append_content_security_policy_directives(
+        :connect_src => @console[:extend_content_security_policy]
+      )
+    end
     render case @console[:type]
              when 'spice'
                'hosts/console/spice'
              when 'vnc'
                'hosts/console/vnc'
+             when 'webmks'
+               'hosts/console/webmks'
              when 'vmrc'
                'hosts/console/vmrc'
              else

--- a/app/helpers/consoles_helper.rb
+++ b/app/helpers/consoles_helper.rb
@@ -1,0 +1,5 @@
+module ConsolesHelper
+  def webmks_assets_provided?
+    Rails.root.join('public', 'webmks').exist?
+  end
+end

--- a/app/views/hosts/console/webmks.html.erb
+++ b/app/views/hosts/console/webmks.html.erb
@@ -1,0 +1,36 @@
+<% title "#{@console[:name]}" %>
+<% if webmks_assets_provided? %>
+  <%= stylesheet_link_tag '/webmks/css/wmks-all.css' %>
+  <%= javascript_include_tag '/webmks/wmks.min.js' %>
+  <%= javascript_tag("$(document).on('ContentLoad', function() { tfm.webmksConsole.initConsole() });"); %>
+
+  <%= title_actions(
+    button_group(
+      link_to("Ctrl-Alt-Del", "#", :id => "sendCtrlAltDelButton", :class => "btn btn-default", :disabled => true),
+      link_to(_("Full Screen"), "#", :id => "enterFullScreenButton", :class => "btn btn-default", :disabled => true),
+      if @host
+        link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')
+      end
+    )
+  ) %>
+
+  <p><%= (_('The VM is running on host %s.') % link_to(@console[:host], @console[:host_url])).html_safe %></p>
+
+  <div style="text-align: center;"><span class="label label-info" id="wmksStatus"><%= _('Connecting...') %></span></div>
+  <div id="wmksError" style="display: none;"></div>
+  <div id="wmksContainer" style="position: absolute; width: 99%; height: 99%; display: none;" data-url="<%= @console[:console_url] %>"></div>
+<% else %>
+  <div class="blank-slate-pf">
+    <div class="blank-slate-pf-icon">
+      <%= icon_text('screen', '', :kind => 'pficon') %>
+    </div>
+    <h1><%= _('WebMKS Console') %></h1>
+    <p><%= _('The WebMKS console is not available because the required libraries are not installed.') %></p>
+    <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("5.2.9VMwareNotes")%></p>
+    <div class="blank-slate-pf-main-action">
+      <% if @host %>
+        <%= link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-primary btn-lg') %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jquery": "~2.2.4",
     "jquery-flot": "~0.8.3",
+    "jquery-ui": "^1.12.1",
     "jquery-ujs": "~1.2.0",
     "jquery.cookie": "~1.4.1",
     "jstz": "~1.0.7",

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -33,6 +33,7 @@ window.tfm = Object.assign(window.tfm || {}, {
   numFields: require('./jquery.ui.custom_spinners'),
   reactMounter: require('./react_app/common/MountingService'),
   editor: require('./foreman_editor'),
+  webmksConsole: require('./foreman_webmks_console'),
   nav: require('./foreman_navigation'),
   medium: require('./foreman_medium'),
 });

--- a/webpack/assets/javascripts/foreman_webmks_console.js
+++ b/webpack/assets/javascripts/foreman_webmks_console.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-console, max-len, no-undef */
+import $ from 'jquery';
+import { showSpinner, hideSpinner, iconText } from './foreman_tools';
+
+require('jquery-ui/ui/widgets/dialog');
+
+let wmks;
+
+export function initConsole() {
+  wmks = WMKS.createWMKS('wmksContainer', {})
+    .register(WMKS.CONST.Events.CONNECTION_STATE_CHANGE, (event, data) => {
+      switch (data.state) {
+        case WMKS.CONST.ConnectionState.CONNECTING:
+          console.log('wmks: connection state change: connecting');
+          showSpinner();
+          $('#wmksStatus').show();
+          $('#wmksError').hide();
+          $('#sendCtrlAltDelButton').prop('disabled', 'disabled');
+          $('#enterFullScreenButton').prop('disabled', 'disabled');
+          break;
+        case WMKS.CONST.ConnectionState.CONNECTED:
+          console.log('wmks: connection state change: connected');
+          hideSpinner();
+          $('#wmksContainer').fadeIn();
+          $('#wmksStatus').hide();
+          $('#wmksError').hide();
+          $('#sendCtrlAltDelButton').removeAttr('disabled');
+          $('#enterFullScreenButton').removeAttr('disabled');
+          break;
+        case WMKS.CONST.ConnectionState.DISCONNECTED:
+          console.log('wmks: connection state change: disconnected');
+          hideSpinner();
+          $('#wmksContainer').hide();
+          $('#wmksStatus').hide();
+          $('#sendCtrlAltDelButton').prop('disabled', 'disabled');
+          $('#enterFullScreenButton').prop('disabled', 'disabled');
+          $('#wmksError').html(`<div class="alert alert-danger alert-dismissable">
+            ${iconText('error-circle-o', '', 'pficon')}
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            ${__('The console connection was lost.')}
+            ${__('Please check if you can access the hypervisor host via https by clicking the link above.')}
+            </div>`).fadeIn();
+          break;
+        default:
+      }
+    });
+
+  wmks.connect($('#wmksContainer').data('url'));
+
+  $(document).on('click', '#sendCtrlAltDelButton', () => {
+    console.log('wmks: sending ctrl + alt + delete');
+    wmks.sendKeyCodes([17, 18, 46]); // Ctrl + Alt + Delete
+  });
+
+  $(document).on('click', '#enterFullScreenButton', () => {
+    console.log('wmks: entering full screen');
+    wmks.enterFullScreen();
+  });
+}


### PR DESCRIPTION
This adds support for the VMWare WebMKS SDK Console to Foreman. The "old" VNC console is not supported anymore with vSphere 6.5 and greater. This is a suitable replacement. And it works so much better then the VNC console. And it does not need any firewall changes on the esxi server. All in all: This is great news for users.

Unfortunately, this means adding some stuff to the rails asset pipeline. I created a gem asset for this so hound 🐕 stops barking here.

This works by acquiring a ticket from vSphere using rbvmomi. I chose rbvmomi because fog doesn't support this and pure rbvmomi is faster anyways. The ticket can then be used to access the console via a websocket connection. VMWare ships a JavaScript framework to show the console in the browser.

One caveat is, that the esxi servers need to have a valid ssl certificate or the websocket connection fails. This can be worked around by accessing the esxi server via https and adding a browser side exception for the esxi host.
An alternative to this would be proxying the websocket connection through Foreman. But this is impossible with Passenger to my knowledge.

![image](https://user-images.githubusercontent.com/4107560/29479614-9aef60d4-8473-11e7-9a8c-15b097f0904e.png)
