### PR TITLE
fixes #20653 - ui notifications for hosts with usergroup owner

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -53,6 +53,7 @@ module Host
     scope :no_organization, -> { rewhere(:organization_id => nil) }
 
     delegate :ssh_authorized_keys, :to => :owner, :allow_nil => true
+    delegate :notification_recipients_ids, :to => :owner, :allow_nil => true
 
     PRIMARY_INTERFACE_ATTRIBUTES = [:name, :ip, :ip6, :mac,
                                     :subnet, :subnet_id, :subnet_name,

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -210,6 +210,10 @@ class Taxonomy < ApplicationRecord
     (self.send("#{type.downcase}_parameters".to_sym).authorized(:view_params) + taxonomy_inherited_params_objects.to_a.reverse!).uniq {|param| param.name}
   end
 
+  def notification_recipients_ids
+    self.subtree.flat_map(&:users).map(&:id).uniq
+  end
+
   private
 
   delegate :need_to_be_selected_ids, :selected_ids, :used_and_selected_ids, :mismatches, :missing_ids, :check_for_orphans,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -527,6 +527,10 @@ class User < ApplicationRecord
     { login => super }
   end
 
+  def notification_recipients_ids
+    [self.id]
+  end
+
   private
 
   def prepare_password

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -87,6 +87,10 @@ class Usergroup < ApplicationRecord
     all_users.flat_map(&:ssh_keys)
   end
 
+  def notification_recipients_ids
+    all_users.map(&:id)
+  end
+
   protected
 
   # Recurses down the tree of usergroups and finds the users

--- a/app/services/ui_notifications.rb
+++ b/app/services/ui_notifications.rb
@@ -9,6 +9,7 @@ module UINotifications
       # Do not break actions using notifications even if there is a failure.
       logger.warn("Failed to handle notifications - this is most likely a bug: #{e}")
       logger.debug(e.backtrace.join("\n"))
+      false
     end
 
     def self.logger

--- a/app/services/ui_notifications/hosts.rb
+++ b/app/services/ui_notifications/hosts.rb
@@ -2,7 +2,7 @@ module UINotifications
   module Hosts
     class Base < UINotifications::Base
       def deliver!
-        if audience.nil? || initiator.nil?
+        unless subject.owner
           logger.warn("Invalid owner for #{subject}, unable to send notifications")
           # add notification for missing owner
           UINotifications::Hosts::MissingOwner.deliver!(subject)
@@ -14,12 +14,7 @@ module UINotifications
       protected
 
       def audience
-        case subject.owner_type
-        when 'User'
-          ::Notification::AUDIENCE_USER
-        when 'Usergroup'
-          ::Notification::AUDIENCE_GROUP
-        end
+        ::Notification::AUDIENCE_SUBJECT if subject.owner
       end
 
       def initiator

--- a/app/services/ui_notifications/hosts/destroy.rb
+++ b/app/services/ui_notifications/hosts/destroy.rb
@@ -10,10 +10,19 @@ module UINotifications
         Notification.create!(
           initiator: initiator,
           audience: audience,
-          # note we do not store the subject, as the object is being deleted.
+          subject: subject.owner, # note we store the host owner, as the host object is being deleted.
           message: StringParser.new(blueprint.message, {subject: subject}),
           notification_blueprint: blueprint
         )
+      end
+
+      def audience
+        case subject.owner_type
+        when 'User'
+          ::Notification::AUDIENCE_USER
+        when 'Usergroup'
+          ::Notification::AUDIENCE_USERGROUP
+        end
       end
 
       def delete_others

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -34,48 +34,49 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test 'user notifications should subscribe only to itself' do
-    notification = FactoryGirl.build(:notification,
-                                     :audience => Notification::AUDIENCE_USER)
-    assert_equal [notification.initiator.id], notification.subscriber_ids
+    notification = FactoryGirl.create(:notification,
+                                      :subject => User.current,
+                                      :audience => Notification::AUDIENCE_USER)
+    assert_equal [User.current.id], notification.subscriber_ids
   end
 
   test 'usergroup notifications should subscribe to all of its members' do
     group = FactoryGirl.create(:usergroup)
     group.users = FactoryGirl.create_list(:user,25)
     notification = FactoryGirl.build(:notification,
-                                     :audience => Notification::AUDIENCE_GROUP)
+                                     :audience => Notification::AUDIENCE_USERGROUP)
     notification.subject = group
     assert group.all_users.any?
-    assert_equal group.all_users.map(&:id),
-      notification.subscriber_ids
+    assert_equal group.all_users.map(&:id).sort,
+      notification.subscriber_ids.sort
   end
 
   test 'Organization notifications should subscribe to all of its members' do
     org = FactoryGirl.create(:organization)
     org.users = FactoryGirl.create_list(:user,25)
     notification = FactoryGirl.build(:notification,
-                                     :audience => Notification::AUDIENCE_TAXONOMY)
+                                     :audience => Notification::AUDIENCE_SUBJECT)
     notification.subject = org
     assert org.user_ids.any?
-    assert_equal org.user_ids, notification.subscriber_ids
+    assert_equal org.user_ids.sort, notification.subscriber_ids.sort
   end
 
   test 'Location notifications should subscribe to all of its members' do
     loc = FactoryGirl.create(:location)
     loc.users = FactoryGirl.create_list(:user,25)
     notification = FactoryGirl.build(:notification,
-                                     :audience => Notification::AUDIENCE_TAXONOMY)
+                                     :audience => Notification::AUDIENCE_SUBJECT)
     notification.subject = loc
     assert loc.user_ids.any?
-    assert_equal loc.user_ids, notification.subscriber_ids
+    assert_equal loc.user_ids.sort, notification.subscriber_ids.sort
   end
 
   test 'Global notifications should subscribe to all users' do
     notification = FactoryGirl.build(:notification,
                                      :audience => Notification::AUDIENCE_GLOBAL)
     assert User.count > 0
-    assert_equal User.reorder('').pluck(:id),
-      notification.subscriber_ids
+    assert_equal User.reorder('').pluck(:id).sort,
+      notification.subscriber_ids.sort
   end
 
   test 'Admin notifications should subscribe to all admin users except hidden' do


### PR DESCRIPTION
@ohadlevy: This is just a test to demonstrate the error. My suggestion would be to introduce an explicit recipient for a notification so that `subject` and `recipient` aren't automatically related anymore.
Maybe we should allow to pass an arbitrary object as audience. So you can write
```ruby
Notification.create!(
   audience: User.current, # or: Host.find_by_name('server1.example.com').owner
)
```

The test failure happening now:
```
NoMethodError: undefined method `all_users' for #&lt;Host::Managed:0x007f89bdbc91e0&gt;
    app/models/notification.rb:49:in `subscriber_ids'
```