### PR TITLE
Fixes #20657 - make proxy labels bold

### DIFF
--- a/app/views/smart_proxies/plugins/_dhcp.html.erb
+++ b/app/views/smart_proxies/plugins/_dhcp.html.erb
@@ -4,7 +4,7 @@
 <%= show_feature_version('dhcp') %>
 <div class="row">
   <div class="col-md-4">
-    <%= _('Subnets') %>
+    <strong><%= _('Subnets') %></strong>
   </div>
   <div class="col-md-8">
     <%= generate_links_for(@smart_proxy.subnets).html_safe %>

--- a/app/views/smart_proxies/plugins/_dns.html.erb
+++ b/app/views/smart_proxies/plugins/_dns.html.erb
@@ -4,7 +4,7 @@
 <%= show_feature_version('dns') %>
 <div class="row">
   <div class="col-md-4">
-    <%= _('Domains') %>
+    <strong><%= _('Domains') %></strong>
   </div>
   <div class="col-md-8">
     <%= generate_links_for(@smart_proxy.domains).html_safe %>

--- a/app/views/smart_proxies/plugins/_plugin_version.html.erb
+++ b/app/views/smart_proxies/plugins/_plugin_version.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-4"><%= _('Version') %></div>
+  <div class="col-md-4"><strong><%= _('Version') %></strong></div>
   <div class="col-md-8">
     <span class="plugin-version" data-plugin="<%= feature %>">
       <%= spinner %>

--- a/app/views/smart_proxies/plugins/_puppet.html.erb
+++ b/app/views/smart_proxies/plugins/_puppet.html.erb
@@ -9,7 +9,7 @@
       <div class="col-md-6">
         <%= show_feature_version('puppet') %>
         <div class="row">
-          <div class="col-md-4"><%= _('Hosts managed:') %></div>
+          <div class="col-md-4"><strong><%= _('Hosts managed:') %></strong></div>
           <div class="col-md-8">
             <%= link_to Host::Managed.where(:puppet_proxy_id => @smart_proxy.id).count, hosts_path(:search => "puppetmaster = \"#{@smart_proxy.name}\"") %>
           </div>

--- a/app/views/smart_proxies/plugins/_puppet_ca.html.erb
+++ b/app/views/smart_proxies/plugins/_puppet_ca.html.erb
@@ -13,7 +13,7 @@
       <div class="col-md-6">
         <%= show_feature_version('puppetca') %>
         <div class="row">
-          <div class="col-md-4"><%= _('Hosts managed:') %></div>
+          <div class="col-md-4"><strong><%= _('Hosts managed:') %></strong></div>
           <div class="col-md-8">
             <%= link_to Host::Managed.where(:puppet_ca_proxy_id => @smart_proxy.id).count, hosts_path(:search => "puppet_ca = \"#{@smart_proxy.name}\"") %>
           </div>

--- a/app/views/smart_proxies/plugins/_tftp.html.erb
+++ b/app/views/smart_proxies/plugins/_tftp.html.erb
@@ -4,7 +4,7 @@
 <%= show_feature_version('tftp') %>
 <div class="row">
   <div class="col-md-4">
-    <%= _('TFTP server') %>
+    <strong><%= _('TFTP server') %></strong>
   </div>
   <div class="col-md-8">
     <span class="proxy-tftp" data-url="<%= tftp_server_smart_proxy_path(@smart_proxy) %>">

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="row">
           <div class="col-md-4">
-            <%= _('Communication status') %>
+            <strong><%= _('Communication status') %></strong>
           </div>
           <div class="col-md-8">
             <span class="proxy-show-status">
@@ -32,7 +32,7 @@
         </div>
         <div class="row">
           <div class="col-md-4">
-            <%= _('URL') %>
+            <strong><%= _('URL') %></strong>
           </div>
           <div class="col-md-8">
             <%= @smart_proxy.url %>
@@ -40,7 +40,7 @@
         </div>
         <div class="row">
           <div class="col-md-4">
-            <%= _('Version') %>
+            <strong><%= _('Version') %></strong>
           </div>
           <div class="col-md-8">
             <span class="proxy-version" data-url="<%= ping_smart_proxy_path(@smart_proxy) %>">
@@ -50,7 +50,7 @@
         </div>
         <div class="row">
           <div class="col-md-4">
-            <%= _('Active features') %>
+            <strong><%= _('Active features') %></strong>
           </div>
           <div class="col-md-8">
             <%= @smart_proxy.features.map(&:name).to_sentence %> <%= refresh_proxy_icon(@smart_proxy, authorizer) %>
@@ -58,7 +58,7 @@
         </div>
         <div class="row">
           <div class="col-md-4">
-            <%= _('Hosts managed') %>
+            <strong><%= _('Hosts managed') %></strong>
           </div>
           <div class="col-md-8">
             <%= link_to @smart_proxy.hosts_count, hosts_path(:search => "smart_proxy = \"#{@smart_proxy.name}\"") %>
@@ -67,7 +67,7 @@
         <% if @smart_proxy.has_feature?('Logs') %>
           <div class="row">
             <div class="col-md-4">
-              <%= _('Failed features') %>
+              <strong><%= _('Failed features') %></strong>
             </div>
             <div class="col-md-8">
               <div class="tab-pane" id="failed-modules"


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/109773/29510714-0609f9b6-865d-11e7-9c82-ac850927d8eb.png)
after:
![after](https://user-images.githubusercontent.com/109773/29510715-060ae254-865d-11e7-9ca5-cd6d4eca1554.png)

should be coordinated with plugins PRs