### PR TITLE
Fixes #20665 - make smart proxy delete button grey

### DIFF
--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -55,7 +55,7 @@ module SmartProxiesHelper
       ),
       button_group(
         display_delete_if_authorized(hash_for_smart_proxy_path(:id => proxy).merge(:auth_object => proxy, :authorizer => authorizer),
-                                     :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'btn btn-danger')
+                                     :data => {:confirm => _("Delete %s?") % proxy.name}, :class => 'btn btn-default')
       )
     )
   end


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/109773/29514774-02b84288-866a-11e7-80d2-82856119e7f5.png)
after:
![after](https://user-images.githubusercontent.com/109773/29514736-e1e7dfd2-8669-11e7-8c72-d66771d9eadb.png)
