### PR TITLE
Fixes #20573 - Include searchbox extension

### DIFF
--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -12,6 +12,7 @@ require('brace/theme/twilight');
 require('brace/theme/clouds');
 require('brace/keybinding/vim');
 require('brace/keybinding/emacs');
+require('brace/ext/searchbox');
 
 let Editor;
 


### PR DESCRIPTION
This includes the searchbox extension and fixes the 404 triggered by CTRL/CMD+F in the ACE editor