### PR TITLE
Fixes #20673 - Move locked warning on template editing

### DIFF
--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -21,6 +21,8 @@
 
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
+      <%= render_if_exists "#{@type_name_plural}/_alerts" %>
+
       <%= text_f f, :name, :disabled => @template.locked? %>
 
       <% if show_default? %>
@@ -28,7 +30,6 @@
       <% end -%>
 
       <%= render "custom_tabs", :f => f if type == 'ptable' %>
-      <%= render_if_exists "#{@type_name_plural}/_alerts" %>
 
       <% if pxe_with_building_hosts?(@template) -%>
         <% warning_text = (_("The template is associated to at least one host in build mode. To apply the change, disable and enable build mode on hosts to update the live templates or choose to %s their configuration from 'Select Action' menu") % link_to(_('recreate'), building_hosts_path(@template))).html_safe %>


### PR DESCRIPTION
Moving it to the top above name to be more visible.

Before:
![screenshot from 2017-08-21 14-03-34](https://user-images.githubusercontent.com/7757/29518432-929121ea-8679-11e7-9213-5b07f5d624d3.png)

After:
![screenshot from 2017-08-21 13-51-32](https://user-images.githubusercontent.com/7757/29518210-be663b62-8678-11e7-8714-897ff298b478.png)
