### PR TITLE
Fixes #20678 - Improve provisioning templates history

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -361,3 +361,7 @@ a.btn-info span {
 .gridster .gs-w {
   z-index: auto !important;
 }
+
+#history a .glyphicon {
+  color: #4d5258;
+}

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -2,6 +2,7 @@ class TemplatesController < ApplicationController
   include UnattendedHelper # includes also Foreman::Renderer
   include Foreman::Controller::ProvisioningTemplates
   include Foreman::Controller::AutoCompleteSearch
+  include AuditsHelper
 
   before_action :handle_template_upload, :only => [:create, :update]
   before_action :find_resource, :only => [:edit, :update, :destroy, :clone_template, :lock, :unlock, :export]
@@ -134,7 +135,11 @@ class TemplatesController < ApplicationController
 
   def load_history
     return unless @template
-    @history = Audit.descending.where(:auditable_id => @template.id, :auditable_type => @template.class.base_class, :action => 'update')
+    @history = Audit.descending
+                    .where(:auditable_id => @template.id,
+                           :auditable_type => @template.class.base_class,
+                           :action => 'update')
+                    .select { |audit| audit_template? audit }
   end
 
   def action_permission

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -62,24 +62,7 @@
     </div>
 
     <div class="tab-pane" id="history">
-      <% if @history.try(:any?) %>
-        <% @history.each do |audit| %>
-          <% next unless audit_template? audit %>
-          <div class='row'>
-            <div class='col-md-6'>
-              <b><%= audit_user(audit) %> <%= audit.comment %></b>
-            </div>
-            <div class='col-md-2 ra'><h6><%= audit_time audit %></h6></div>
-            <div class='col-md-8 audit-content'>
-              <%= link_to_function icon_text("retweet", _("Revert")), "tfm.editor.revertTemplate(this)", :data => {:url => revision_provisioning_templates_url, :version => audit.id } %>
-              <%= link_to icon_text("eye-open", _("Show Diff")), audit_path(audit), :rel => 'external' %>
-            </div>
-          </div>
-        <% end %>
-      <% else %>
-        <%= alert(:class => 'alert-info', :header => _('No history found'),
-                  :text => _('Save something and try again')) %>
-      <% end %>
+      <%= render :partial => 'history', :locals => { history: @history } %>
     </div>
 
     <div class="tab-pane" id="help">

--- a/app/views/templates/_history.html.erb
+++ b/app/views/templates/_history.html.erb
@@ -1,0 +1,24 @@
+<% unless history.empty? %>
+  <% history.each do |audit| %>
+    <div class='row'>
+      <div class='col-md-6'>
+        <strong><%= audit_user(audit) %></strong>
+        <p>
+          <% unless audit.comment.blank? %>
+            <%= audit.comment %>
+          <% else %>
+            <em><%= _('No comment provided') %></em>
+          <% end %>
+        </p>
+      </div>
+      <div class='col-md-2 ra'><h6><%= audit_time audit %></h6></div>
+      <div class='col-md-8 audit-content ra'>
+        <%= link_to_function icon_text("restart", _("Revert"), :kind => 'pficon'), "tfm.editor.revertTemplate(this)", :class => 'btn btn-default', :data => {:url => revision_provisioning_templates_url, :version => audit.id } %>
+        <%= link_to icon_text("eye-open", _("Show Diff")), audit_path(audit), :rel => 'external', :class => 'btn btn-default' %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <%= alert(:class => 'alert-info', :header => _('No history found'),
+            :text => _('Save something and try again')) %>
+<% end %>


### PR DESCRIPTION
* Make glyphicons the default text color
* Add "No comment provided" when it is empty
* Change link actions to buttons

Before:
![gnome-shell-screenshot-ivrg5y](https://user-images.githubusercontent.com/7757/29521066-2c2d15e8-8684-11e7-8e64-253102233111.png)


After:
![gnome-shell-screenshot-1z054y](https://user-images.githubusercontent.com/7757/29521047-12ae40a6-8684-11e7-8439-87a0924c74ba.png)
