### PR TITLE
Fixes #20680 - Use default button style for "Add Combination"

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -355,7 +355,7 @@ module FormHelper
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
       render((partial.nil? ? association.to_s.singularize + "_fields" : partial), :f => builder)
     end
-    options[:class] = "btn btn-primary #{options[:class]}"
+    options[:class] = link_to_add_fields_classes(options)
     link_to_function(name, ("add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}')").html_safe, options)
   end
 
@@ -400,5 +400,13 @@ module FormHelper
     if request.headers["X-Foreman-Layout"] == 'two-pane'
       content_tag(:input, '', {:type => "hidden", :name => "_ie_support"})
     end
+  end
+
+  private
+
+  def link_to_add_fields_classes(options = {})
+    classes = "btn btn-default #{options[:class]}"
+    classes << ' btn-primary' if options.fetch(:primary_button, true)
+    classes
   end
 end

--- a/app/views/provisioning_templates/_combinations.html.erb
+++ b/app/views/provisioning_templates/_combinations.html.erb
@@ -3,4 +3,4 @@
     <%= render 'provisioning_templates/combination', :f => builder %>
   <% end %>
 <% end %>
-<p><%= link_to_add_fields('+ ' + _("Add Combination"), f, :template_combinations, "provisioning_templates/combination", :target => '#template_combination') %></p>
+<p><%= link_to_add_fields('+ ' + _("Add Combination"), f, :template_combinations, "provisioning_templates/combination", { :target => '#template_combination', :primary_button => false }) %></p>


### PR DESCRIPTION
Before:
![gnome-shell-screenshot-ghl04y](https://user-images.githubusercontent.com/7757/29524547-67dfdc40-8690-11e7-9704-a5a7ef3c05d9.png)

After:
![gnome-shell-screenshot-1pug5y](https://user-images.githubusercontent.com/7757/29524643-a63feb4c-8690-11e7-9ec3-a896f63d5a4c.png)

