### PR TITLE
Fixes #20706 - fix template audit messages

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -45,7 +45,7 @@ module AuditsHelper
       audit.audited_changes.map do |name, change|
         next if change.nil? || change.to_s.empty?
         if name == 'template'
-          (_("Provisioning Template content changed %s") % (link_to 'view diff', audit_path(audit))).html_safe if audit_template? audit
+          (_("Template content changed %s") % (link_to 'view diff', audit_path(audit))).html_safe if audit_template? audit
         elsif name == "password_changed"
           _("Password has been changed")
         elsif name == "owner_id" || name == "owner_type"


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/109773/29616950-6a9a53c8-8813-11e7-8f03-d4a05952be3c.png)
after:
![after](https://user-images.githubusercontent.com/109773/29616951-6a9df654-8813-11e7-8b62-a698d3a90ab4.png)
