### PR TITLE
Fixes #20710 - fix view diff width

### DIFF
--- a/app/assets/javascripts/reports.js
+++ b/app/assets/javascripts/reports.js
@@ -13,8 +13,7 @@ function show_diff(item){
   $("#diff-modal-editor")
         .css("position","relative")
         .css("padding-top","0")
-        .height('380')
-        .width('588');
+        .height('380px');
 
   var editor = ace.edit("diff-modal-editor");
   editor.setTheme("ace/theme/clouds");


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/109773/29618985-0ff1a3c0-881a-11e7-88d1-9904366ffb75.png)

after:
![after](https://user-images.githubusercontent.com/109773/29618992-12a92516-881a-11e7-8ff1-41063ee422dd.png)

see https://github.com/theforeman/foreman/pull/810/files and https://github.com/theforeman/foreman/commit/76ab0628 for previous fixes. If someone has an idea how to prevent this in future, I'm happy to improve this PR (unless it's too complicated :-)