### PR TITLE
Fixes #20711 - GET host interface API will show fqdn attribute

### DIFF
--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,6 +1,6 @@
 object @interface
 
-attributes :id, :name, :ip, :ip6, :mac, :identifier, :primary, :provision
+attributes :id, :name, :ip, :ip6, :mac, :fqdn, :identifier, :primary, :provision
 node :type do |i|
   next if i.is_a? Symbol
   i.class.humanized_name.downcase


### PR DESCRIPTION
 GET API call `/api/hosts/:id/interfaces` will now show `fqdn` attribute