### PR TITLE
Fixes #20736 - improve bookmark permissions

### DIFF
--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -17,8 +17,10 @@
           <li><%= link_to_if_authorized bookmark.name, send("hash_for_#{bookmark.controller}_path").merge(:search => bookmark.query) %></li>
         <% end %>
         <li class="divider"></li>
-        <li><%= link_to_function _('Bookmark this search'), "$('#bookmarks-modal').modal();",
-                                 {:id => "bookmark", :"data-url"=> main_app.new_bookmark_path(:kontroller => auto_complete_controller_name)} %></li>
+        <% if authorizer.can?(:create_bookmarks) %>
+          <li><%= link_to_function _('Bookmark this search'), "$('#bookmarks-modal').modal();",
+                                   {:id => "bookmark", :"data-url" => main_app.new_bookmark_path(:kontroller => auto_complete_controller_name)} %></li>
+        <% end %>
         <li><%= link_to(icon_text('question-sign', _('Documentation'), :class => 'icon-black'), documentation_url("4.1.5Searching"), :rel => 'external', :target => '_blank') %></li>
       </ul>
     </span>

--- a/db/seeds.d/02-roles_list.rb
+++ b/db/seeds.d/02-roles_list.rb
@@ -21,7 +21,8 @@ class RolesList
                                     :view_smart_proxies, :edit_smart_proxies, :view_subnets, :edit_subnets,
                                     :view_statistics, :view_usergroups, :create_usergroups, :edit_usergroups,
                                     :destroy_usergroups, :view_users, :edit_users, :view_realms, :view_mail_notifications,
-                                    :view_params, :view_ssh_keys]
+                                    :view_params, :view_ssh_keys],
+      'Bookmarks manager'       => [:view_bookmarks, :create_bookmarks, :edit_bookmarks, :destroy_bookmarks]
       }
     end
 


### PR DESCRIPTION
Adds a new role "Bookmark user" granting all bookmarks permissions. This is useful for users to be able to bookmark searches. This also fixes the bug that we show "Bookmark this search" for users without "create_bookmarks" permission.

Steps to reproduce:
1. create a user with Viewer role
2. login as that user, navigate to hosts page
3. use some filter, e.g. name ~ *
4. on search button, click the down arrow and select "Bookmark this search"
5. empty modal window opens, submitting does not work

Testing the fix
6. user should not see "Bookmark this search" item
7. rake db:seed
8. assign Bookmark user role to the same user
9. retry step 4, now the user can see the link and is able to submit the form which creates the bookmark