### PR TITLE
Fixes #20737 - add default description to roles

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -5,7 +5,8 @@
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>
     <tr>
-      <th class="col-md-8"><%= sort :name, :as => s_("Role|Name") %></th>
+      <th class="col-md-2"><%= sort :name, :as => s_("Role|Name") %></th>
+      <th class="col-md-8"><%= sort :description, :as => s_("Role|Description") %></th>
       <th class="col-md-1"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
       <th><%= _('Actions') %></th>
     </tr>
@@ -15,6 +16,9 @@
       <tr>
         <td class="display-two-pane ellipsis">
           <%= role_link(role) %>
+        </td>
+        <td class="ellipsis">
+          <%= role.description %>
         </td>
         <td align='center'><%= locked_icon role.locked?, _("This role is locked for editing.") %>
         <td class='col-md-1'>

--- a/db/migrate/20170221195674_tidy_current_roles.rb
+++ b/db/migrate/20170221195674_tidy_current_roles.rb
@@ -6,23 +6,23 @@ class TidyCurrentRoles < ActiveRecord::Migration
     return if Role.count == 0
     Filter.reset_column_information
     Role.without_auditing do
-      ::RolesList.seeded_roles.each do |name, permission_names|
+      ::RolesList.seeded_roles.each do |name, options|
         role = Role.find_by :name => name
         if role
-          process_existing name, role, permission_names
+          process_existing name, role, options
         else
-          create_from_seeds name, permission_names
+          create_from_seeds name, options
         end
       end
     end
     process_default_role
   end
 
-  def process_existing(original_name, role, permission_names)
-    diff = role.permission_diff permission_names
+  def process_existing(original_name, role, options)
+    diff = role.permission_diff options[:permissions]
     return if diff.empty?
     rename_existing role, original_name
-    create_from_seeds original_name, permission_names
+    create_from_seeds original_name, options
   end
 
   def rename_existing(role, original_name)
@@ -49,8 +49,8 @@ class TidyCurrentRoles < ActiveRecord::Migration
     "#{prefix} #{original_name} #{num}"
   end
 
-  def create_from_seeds(name, permission_names)
-    SeedHelper.create_role name, permission_names, 0, false
+  def create_from_seeds(name, options)
+    SeedHelper.create_role name, options, 0, false
   end
 
   def process_default_role

--- a/db/seeds.d/02-roles_list.rb
+++ b/db/seeds.d/02-roles_list.rb
@@ -53,5 +53,19 @@ class RolesList
     def view_permissions
       PermissionsList.permissions.select { |resource, name| name.start_with?('view_') }.map { |p| p.last.to_sym }
     end
+
+    def roles_descriptions
+      {
+        Role::MANAGER => 'Role granting all available permissions. With this role, user is able to do everything that admin can except for changing Settings.',
+        Role::ORG_ADMIN => 'Role granting all permissions except for managing organizations. It can be used to delegate administration of specific organization to a user. In order to create such role, clone this role and assign desired organizations',
+        'Edit partition tables' => 'Role granting permissions required for managin partition tables',
+        'View hosts' => 'Role granting permission only to view hosts',
+        'Edit hosts' => 'Role granting permissions to update hosts. For features provided by plugins, you might need to combine this role with roles provided by those plugins',
+        Role::VIEWER => 'Role granting read only access. Users with this role can see all data but can not do any modifications',
+        'Site manager' => 'Role granting mostly view permissions but also permissions required for managing hosts in the infrastructure. Users with this role can update puppet parameters, create and edit hosts, manage installation media, subnets, usergroups and edit existing users.',
+        'Bookmarks user' => 'Role granting permissions for managing search bookmarks. Usually useful in combination with Viewer role. This role also grants the permission to update all public bookmarks.',
+        'Default role' => 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody'
+      }
+    end
   end
 end

--- a/db/seeds.d/02-roles_list.rb
+++ b/db/seeds.d/02-roles_list.rb
@@ -3,32 +3,39 @@ require (Rails.root + 'db/seeds.d/02-permissions_list.rb')
 class RolesList
   class << self
     def seeded_roles
-      { Role::MANAGER           => base_manage_permissions + view_permissions + manage_organizations_permissions,
-        Role::ORG_ADMIN         => base_manage_permissions + view_permissions - [:view_organizations],
-        'Edit partition tables' => [:view_ptables, :create_ptables, :edit_ptables, :destroy_ptables],
-        'View hosts'            => [:view_hosts],
-        'Edit hosts'            => [:view_hosts, :edit_hosts, :create_hosts, :destroy_hosts, :build_hosts],
-        Role::VIEWER            => view_permissions,
-        'Site manager'          => [:view_architectures, :view_audit_logs, :view_authenticators, :access_dashboard,
-                                    :view_domains, :view_environments, :import_environments, :view_external_variables,
-                                    :create_external_variables, :edit_external_variables, :destroy_external_variables,
-                                    :view_external_parameters, :create_external_parameters, :edit_external_parameters,
-                                    :destroy_external_parameters, :view_facts, :view_hostgroups, :view_hosts, :view_smart_proxies_puppetca,
-                                    :view_smart_proxies_autosign, :create_hosts, :edit_hosts, :destroy_hosts,
-                                    :build_hosts, :view_media, :create_media, :edit_media, :destroy_media,
-                                    :view_models, :view_operatingsystems, :view_ptables, :view_puppetclasses,
-                                    :import_puppetclasses, :view_config_reports, :destroy_config_reports,
-                                    :view_smart_proxies, :edit_smart_proxies, :view_subnets, :edit_subnets,
-                                    :view_statistics, :view_usergroups, :create_usergroups, :edit_usergroups,
-                                    :destroy_usergroups, :view_users, :edit_users, :view_realms, :view_mail_notifications,
-                                    :view_params, :view_ssh_keys],
-      'Bookmarks manager'       => [:view_bookmarks, :create_bookmarks, :edit_bookmarks, :destroy_bookmarks]
+      {
+        Role::MANAGER => { :permissions => base_manage_permissions + view_permissions + manage_organizations_permissions,
+                           :description => 'Role granting all available permissions. With this role, user is able to do everything that admin can except for changing settings.' },
+        Role::ORG_ADMIN => { :permissions => base_manage_permissions + view_permissions - [:view_organizations],
+                             :description => 'Role granting all permissions except for managing organizations. It can be used to delegate administration of specific organization to a user. In order to create such role, clone this role and assign desired organizations' },
+        'Edit partition tables' => { :permissions => [:view_ptables, :create_ptables, :edit_ptables, :destroy_ptables], :description => 'Role granting permissions required for managin partition tables' },
+        'View hosts' => { :permissions => [:view_hosts],
+                          :description => 'Role granting permission only to view hosts' },
+        'Edit hosts' => { :permissions => [:view_hosts, :edit_hosts, :create_hosts, :destroy_hosts, :build_hosts],
+                          :description => 'Role granting permissions to update hosts. For features provided by plugins, you might need to combine this role with roles provided by those plugins' },
+        Role::VIEWER => { :permissions => view_permissions, :description => 'Role granting read only access. Users with this role can see all data but can not do any modifications' },
+        'Site manager' => { :permissions => [:view_architectures, :view_audit_logs, :view_authenticators, :access_dashboard,
+                                             :view_domains, :view_environments, :import_environments, :view_external_variables,
+                                             :create_external_variables, :edit_external_variables, :destroy_external_variables,
+                                             :view_external_parameters, :create_external_parameters, :edit_external_parameters,
+                                             :destroy_external_parameters, :view_facts, :view_hostgroups, :view_hosts, :view_smart_proxies_puppetca,
+                                             :view_smart_proxies_autosign, :create_hosts, :edit_hosts, :destroy_hosts,
+                                             :build_hosts, :view_media, :create_media, :edit_media, :destroy_media,
+                                             :view_models, :view_operatingsystems, :view_ptables, :view_puppetclasses,
+                                             :import_puppetclasses, :view_config_reports, :destroy_config_reports,
+                                             :view_smart_proxies, :edit_smart_proxies, :view_subnets, :edit_subnets,
+                                             :view_statistics, :view_usergroups, :create_usergroups, :edit_usergroups,
+                                             :destroy_usergroups, :view_users, :edit_users, :view_realms, :view_mail_notifications,
+                                             :view_params, :view_ssh_keys],
+                            :description => 'Role granting mostly view permissions but also permissions required for managing hosts in the infrastructure. Users with this role can update puppet parameters, create and edit hosts, manage installation media, subnets, usergroups and edit existing users.' },
+        'Bookmarks manager' => { :permissions => [:view_bookmarks, :create_bookmarks, :edit_bookmarks, :destroy_bookmarks],
+                                 :description => 'Role granting permissions for managing search bookmarks. Usually useful in combination with Viewer role. This role also grants the permission to update all public bookmarks.' }
       }
     end
 
     def default_role
       {
-        'Default role' => [:view_bookmarks, :view_tasks]
+        'Default role' => { :permissions => [:view_bookmarks, :view_tasks], :description => 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody' }
       }
     end
 
@@ -52,20 +59,6 @@ class RolesList
 
     def view_permissions
       PermissionsList.permissions.select { |resource, name| name.start_with?('view_') }.map { |p| p.last.to_sym }
-    end
-
-    def roles_descriptions
-      {
-        Role::MANAGER => 'Role granting all available permissions. With this role, user is able to do everything that admin can except for changing Settings.',
-        Role::ORG_ADMIN => 'Role granting all permissions except for managing organizations. It can be used to delegate administration of specific organization to a user. In order to create such role, clone this role and assign desired organizations',
-        'Edit partition tables' => 'Role granting permissions required for managin partition tables',
-        'View hosts' => 'Role granting permission only to view hosts',
-        'Edit hosts' => 'Role granting permissions to update hosts. For features provided by plugins, you might need to combine this role with roles provided by those plugins',
-        Role::VIEWER => 'Role granting read only access. Users with this role can see all data but can not do any modifications',
-        'Site manager' => 'Role granting mostly view permissions but also permissions required for managing hosts in the infrastructure. Users with this role can update puppet parameters, create and edit hosts, manage installation media, subnets, usergroups and edit existing users.',
-        'Bookmarks user' => 'Role granting permissions for managing search bookmarks. Usually useful in combination with Viewer role. This role also grants the permission to update all public bookmarks.',
-        'Default role' => 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody'
-      }
     end
   end
 end

--- a/db/seeds.d/03-roles.rb
+++ b/db/seeds.d/03-roles.rb
@@ -2,11 +2,11 @@ require (Rails.root + 'db/seeds.d/02-roles_list.rb')
 
 Role.without_auditing do
   Role.skip_permission_check do
-    RolesList.seeded_roles.each do |role_name, permission_names|
-      SeedHelper.create_role(role_name, permission_names, 0)
+    RolesList.seeded_roles.each do |role_name, options|
+      SeedHelper.create_role(role_name, options, 0)
     end
-    RolesList.default_role.each do |role_name, permission_names|
-      SeedHelper.create_role(role_name, permission_names, Role::BUILTIN_DEFAULT_ROLE)
+    RolesList.default_role.each do |role_name, options|
+      SeedHelper.create_role(role_name, options, Role::BUILTIN_DEFAULT_ROLE)
     end
   end
 end

--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -1,3 +1,5 @@
+require (Rails.root + 'db/seeds.d/02-roles_list.rb')
+
 # methods which are used in seeds and migrations
 class SeedHelper
   class << self
@@ -47,9 +49,18 @@ class SeedHelper
     end
 
     def create_role(role_name, permission_names, builtin, check_audit = true)
-      return if Role.find_by_name(role_name)
+      description = RolesList.roles_descriptions[role_name]
+
+      if existing = Role.find_by_name(role_name)
+        if existing.description != description
+          existing.update_attribute :description, description
+        end
+        return
+      end
+
       return if check_audit && audit_modified?(Role, role_name) && (builtin == 0)
-      role = Role.new(:name => role_name, :builtin => builtin)
+
+      role = Role.new(:name => role_name, :builtin => builtin, :description => description)
       if role.respond_to? :origin
         role.origin = "foreman"
         role.modify_locked = true

--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -48,8 +48,8 @@ class SeedHelper
       end
     end
 
-    def create_role(role_name, permission_names, builtin, check_audit = true)
-      description = RolesList.roles_descriptions[role_name]
+    def create_role(role_name, options, builtin, check_audit = true)
+      description = options[:description]
 
       if existing = Role.find_by_name(role_name)
         if existing.description != description
@@ -66,7 +66,7 @@ class SeedHelper
         role.modify_locked = true
       end
       role.save!
-      permissions = Permission.where(:name => permission_names)
+      permissions = Permission.where(:name => options[:permissions])
       create_filters(role, permissions)
     end
   end

--- a/test/unit/seed_helper_test.rb
+++ b/test/unit/seed_helper_test.rb
@@ -5,7 +5,7 @@ class SeedHelperTest < ActiveSupport::TestCase
     role_name = "Test role"
     permissions_names = [:view_hosts, :destroy_hosts]
     refute Role.find_by(:name => role_name)
-    SeedHelper.create_role role_name, permissions_names, 0
+    SeedHelper.create_role role_name, {:permissions => permissions_names}, 0
     role = Role.find_by(:name => role_name)
     assert role
     assert_equal permissions_names.sort, role.permissions.pluck(:name).sort.map(&:to_sym)
@@ -13,12 +13,10 @@ class SeedHelperTest < ActiveSupport::TestCase
 
   test "should update a description for a role" do
     role_name = 'existing role'
-    SeedHelper.create_role role_name, [], 0
+    SeedHelper.create_role role_name, {:permissions => []}, 0
     role = Role.find_by(:name => role_name)
     refute_equal 'new description', role.description
-    RolesList.stub(:roles_descriptions, {role_name => 'new description'}) do
-      SeedHelper.create_role role_name, [], 0
-    end
+    SeedHelper.create_role role_name, {:permissions => [], :description => 'new description'}, 0
     assert_equal 'new description', role.reload.description
   end
 

--- a/test/unit/seed_helper_test.rb
+++ b/test/unit/seed_helper_test.rb
@@ -11,6 +11,17 @@ class SeedHelperTest < ActiveSupport::TestCase
     assert_equal permissions_names.sort, role.permissions.pluck(:name).sort.map(&:to_sym)
   end
 
+  test "should update a description for a role" do
+    role_name = 'existing role'
+    SeedHelper.create_role role_name, [], 0
+    role = Role.find_by(:name => role_name)
+    refute_equal 'new description', role.description
+    RolesList.stub(:roles_descriptions, {role_name => 'new description'}) do
+      SeedHelper.create_role role_name, [], 0
+    end
+    assert_equal 'new description', role.reload.description
+  end
+
   test "should recognize object was modified" do
     medium = Medium.last
     medium_name = medium.name


### PR DESCRIPTION
it contains #4786 to avoid rebasing conflict later, please only review second commit here

It provides description for built-in roles and displays them on index, since there's no edit page for these roles anymore. I ended up with 2 ways of solving too long descriptions, I prefer the first one
![short](https://user-images.githubusercontent.com/109773/29711914-85e9fdba-8997-11e7-914f-f7d500a88700.png)
![long](https://user-images.githubusercontent.com/109773/29711915-85eb15f6-8997-11e7-939d-d35ebd3ca251.png)

but I'm happy to hear other ideas, @Rohoover might also help.