### PR TITLE
Fixes #20739 - use unique user label in select

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -85,7 +85,7 @@ module FormHelper
         hidden_fields += f.hidden_field(attr_ids, :multiple => true, :value => unauthorized_value, :id=>'')
       end
       hidden_fields + f.collection_select(attr_ids, authorized.sort_by { |a| a.to_s },
-                                          :id, :to_label, options.merge(:selected => selected_ids),
+                                          :id, options.delete(:object_label_method) || :to_label, options.merge(:selected => selected_ids),
                                           html_options.merge(:multiple => true))
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -174,7 +174,8 @@ class User < ApplicationRecord
   end
 
   def to_label
-    (firstname.present? || lastname.present?) ? "#{firstname} #{lastname}" : login
+    name = [firstname, lastname].join(' ')
+    name.present? ? name : login
   end
   alias_method :name, :to_label
 
@@ -188,7 +189,8 @@ class User < ApplicationRecord
 
   # The text item to see in a select dropdown menu
   def select_title
-    to_label + " (#{login})"
+    name = [firstname, lastname].join(' ')
+    name.present? ? "#{name} (#{login})" : login
   end
 
   def self.anonymous_admin

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -11,7 +11,7 @@
     <div class="tab-pane active" id="primary">
       <%= text_f f, :name %>
       <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
-      <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden, :label => _("Users") %>
+      <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden, :label => _("Users"), :object_label_method => :select_title %>
     </div>
     <div class="tab-pane" id="roles">
       <%= checkbox_f f, :admin if User.current.can_change_admin_flag? %>


### PR DESCRIPTION
With this PR `multiple_checkboxes` can use custom method for generating object label, it was hardcoded to `to_label` so for users, the items were not unique

before
![before](https://user-images.githubusercontent.com/109773/29712871-49a0dbee-899c-11e7-9258-0a6cc836ae6f.png)

after
![after](https://user-images.githubusercontent.com/109773/29712919-7ba1a236-899c-11e7-906a-c809490338b7.png)
