### PR TITLE
Fixes #20783 - Move Inline messaging regarding user saving first within "Notification" fieldset

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -61,13 +61,16 @@
         </div>
       <% end %>
       </br>
-      <% if @user.new_record? %>
-        <%= alert :class => 'alert-warning', :header => '', :text => _("Please save the user first before assigning mail notifications.") %>
-      <% else %>
-        <%= field_set_tag _("Notifications") do %>
+
+      <%= field_set_tag _("Notifications") do %>
+        <% if @user.new_record? %>
+          <%= alert :class => 'alert-warning', :header => '', :text => _("Please save the user first before assigning mail notifications."), :close => false %>
+        <% elsif !@user.user_mail_notifications.empty? %>
           <%= f.fields_for :user_mail_notifications do |mail_form| %>
             <%= render :partial => "users/mail_notifications", :locals => { :f => mail_form }  %>
           <% end %>
+        <% else %>
+          <%= alert :class => 'alert-info', :header => '', :text => _("Notifications can't be assigned to this user."), :close => false %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
The warning looked out of place, moving it above all content would not have been right either.

![gnome-shell-screenshot-dut25y](https://user-images.githubusercontent.com/7757/29815516-311f7018-8cb1-11e7-94ca-ff0198692e13.png)

Within a Notification fieldset, that will also appear when there are notifications to set, gives it context and the warning can stay where it is.

![gnome-shell-screenshot-6iev5y](https://user-images.githubusercontent.com/7757/29815560-60c84e5c-8cb1-11e7-8fd4-bd45f28bd296.png)

I've also remove the dismissable, since it will be gone once the user is saved and notifications can be set.