### PR TITLE
Fixes #20800 - Comply with Patternfly login page recommendations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
   prepend_before_action :allow_webpack, if: -> { Rails.configuration.webpack.dev_server.enabled }
   around_action :set_timezone
   layout :display_layout?
+  add_flash_types :inline
 
   attr_reader :original_search_parameter
 
@@ -166,6 +167,14 @@ class ApplicationController < ActionController::Base
 
   def error(message, now = false)
     flash_message(:error, message, now)
+  end
+
+  def inline_error(message, now = false)
+    flash[:inline] = { :error => CGI.escapeHTML(message) }
+  end
+
+  def inline_success(message, now = false)
+    flash[:inline] = { :success => CGI.escapeHTML(message) }
   end
 
   def warning(message, now = false)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,7 +74,7 @@ class UsersController < ApplicationController
       end
       if user.nil?
         #failed to authenticate, and/or to generate the account on the fly
-        error _("Incorrect username or password")
+        inline_error _("Incorrect username or password")
         redirect_to login_users_path
       else
         #valid user
@@ -113,7 +113,7 @@ class UsersController < ApplicationController
       flash.keep
     else
       session.clear
-      notice _("Logged out - See you soon")
+      inline_success _("Logged out - See you soon")
     end
     redirect_to sso_logout_path || login_users_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -516,9 +516,22 @@ module ApplicationHelper
   end
 
   def notifications
-    content_tag :div, :id => 'notifications', :'data-flash' => flash.to_json.html_safe do
+    content_tag :div, :id => 'notifications', :'data-flash' => flash_notifiations.to_json.html_safe do
       mount_react_component('ToastNotifications', '#notifications')
     end
+  end
+
+  def flash_notifiations
+    flash.select { |key, _| key != 'inline' }
+  end
+
+  def flash_inline
+    flash['inline'] || {}
+  end
+
+  def alert_class(type)
+    type = :danger if type == :error
+    "alert-#{type}"
   end
 
   def current_url_params(permitted: [])

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -6,6 +6,17 @@
         <%= image_tag("login_logo.png") %>
       </div><!--/#brand-->
     </div>
+    <% if flash_inline.any? %>
+      <div class="col-sm-12">
+        <% flash_inline.each do |type, message| %>
+          <div class="alert <%= alert_class(type) %>">
+            <% header = _('Success!') if type == :success %>
+            <%= alert_header(header || "", alert_class(type)) %>
+            <%= message %>
+          </div>
+        <% end %>
+      </div>
+    <% end  %>
     <div class="col-sm-7 col-md-6 col-lg-5 login">
       <%= form_tag login_users_path, :id => "login-form", :class=>"form-horizontal" do %>
           <div class="form-group">
@@ -24,7 +35,7 @@
           </div>
           <div class="form-group">
             <div class="col-xs-offset-8 col-xs-4 submit">
-              <%= submit_tag(_("Log In").html_safe, :class => "btn btn-primary", :data => { :disable_with => _("Please wait...") }) %>
+              <%= submit_tag(_("Log In").html_safe, :class => "btn btn-primary", :data => { :disable_with => _("Log In") }) %>
             </div>
           </div>
       <% end %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -332,7 +332,7 @@ class UsersControllerTest < ActionController::TestCase
     User.expects(:try_to_login).with(u.login, 'password').returns(nil)
     post :login, {:login => {'login' => u.login, 'password' => 'password'}}
     assert_redirected_to login_users_path
-    assert flash[:error].present?
+    assert flash[:inline][:error].present?
   end
 
   test "#login retains taxonomy session attributes in new session" do


### PR DESCRIPTION
To comply more with the Patternfly recommendations for login pages described on http://www.patternfly.org/pattern-library/application-framework/login-page/#/design this:

* Moves alerts inline above form

![gnome-shell-screenshot-bcem5y](https://user-images.githubusercontent.com/7757/29855699-08082394-8d4e-11e7-9963-1aa38e706f29.png)

![gnome-shell-screenshot-3ido5y](https://user-images.githubusercontent.com/7757/29855701-0b1d0f0e-8d4e-11e7-838b-6f2e1c36ab68.png)

* Makes the submit button not show a "loading" state (but is still disabled, to prevent resubmitting)

![gnome-shell-screenshot-qu725y](https://user-images.githubusercontent.com/7757/29855718-2c1b8924-8d4e-11e7-865b-6f4a1260ec9a.png)

The described warning on caps-lock is not yet implemented, as it is more a nice to have.