### PR TITLE
Fixes #20801 - Put granularity info into alert box

### DIFF
--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -35,11 +35,14 @@
 
       <%= hidden_field_tag :role_id, @role.try(:id) %>
 
-
-      <div class="controls" id="granular_warning" style="<%= f.object.granular? ? 'display:none' : '' %>">
-          <span class="help-block">
-            <strong><%= _("Selected resource type does not support granular filtering, therefore you can't configure granularity") %></strong>
-          </span>
+      <div class="clearfix">
+        <div class="controls" id="granular_warning" style="<%= f.object.granular? ? 'display:none' : '' %>">
+          <div class="col-md-2"></div>
+            <div class="col-sm-10 alert alert-info">
+              <span class="pficon pficon-info"></span>
+              <%= _("Selected resource type does not support granular filtering, therefore you can't configure granularity") %>
+            </div>
+        </div>
       </div>
 
       <div id="override_taxonomy_form" class="<%= f.object.allows_taxonomies_filtering? && Taxonomy.enabled_taxonomies.any? ? '' : 'hidden' %>">


### PR DESCRIPTION
This changes the granularity info into a box as suggested in the UX discussion on 'Roles and Permissions'[1]

![gnome-shell-screenshot-ul2i5y](https://user-images.githubusercontent.com/7757/29857306-561d6864-8d58-11e7-90a2-15efa6286160.png)

[1] https://groups.google.com/forum/?fromgroups#!searchin/foreman-dev/Weekly$20Dev$2FDesign|sort:relevance/foreman-dev/Gx69q6ZRB3s/AWusOVboBgAJ