### PR TITLE
Fixes #20240 - fix fullscreen mode in ace editor

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -448,50 +448,6 @@ function exit_fullscreen(){
   $(window).scrollTop(element.data('position'));
 }
 
-function set_fullscreen_editor (element, relativeTo){
-  var $element = $(element);
-
-  if (relativeTo) {
-    $element = $(relativeTo).find(element);
-  }
-
-  $element.children().removeClass('hidden');
-
-  $element.data('origin', $element.parent())
-    .data('position', $(window).scrollTop())
-    .addClass('fullscreen')
-    .appendTo($('body'))
-    .resize();
-
-  $('.navbar').not('.navbar-editor').addClass('hidden');
-
-  $('.btn-fullscreen').addClass("hidden");
-  $('.btn-exit-fullscreen').removeClass("hidden");
-
-  $('#content').addClass('hidden');
-  $(document).on('keyup', function(e) {
-    if (e.keyCode == 27) {    // esc
-      exit_fullscreen_editor();
-    }
-  });
-  Editor.resize(true);
-}
-
-function exit_fullscreen_editor (){
-  var element = $('.fullscreen');
-
-  $('#content').removeClass('hidden');
-  $('.navbar').removeClass('hidden');
-  element.removeClass('fullscreen')
-    .prependTo(element.data('origin'))
-    .resize();
-
-  $('.btn-exit-fullscreen').addClass("hidden");
-  $('.btn-fullscreen').removeClass("hidden");
-  $(window).scrollTop(element.data('position'));
-  Editor.resize(true);
-}
-
 function disableButtonToggle(item, explicit) {
   if (explicit === undefined) {
     explicit = true;

--- a/app/views/editor/_toolbar.html.erb
+++ b/app/views/editor/_toolbar.html.erb
@@ -23,11 +23,11 @@
       </span>
     <% end %>
 
-    <a class="btn btn-default btn-sm btn-fullscreen" href="#" onclick="set_fullscreen_editor('.editor-container');">
+    <a class="btn btn-default btn-sm btn-fullscreen" href="#" onclick="tfm.editor.enterFullscreen('.editor-container');">
       <i class="glyphicon glyphicon-resize-full"></i>
     </a>
 
-    <a class="btn btn-default btn-sm btn-exit-fullscreen hidden" href="#" onclick="exit_fullscreen_editor();">
+    <a class="btn btn-default btn-sm btn-exit-fullscreen hidden" href="#" onclick="tfm.editor.exitFullscreen();">
       <i class="glyphicon glyphicon-resize-small"></i>
     </a>
 

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -296,3 +296,45 @@ export function revertTemplate(item) {
     }
   });
 }
+
+export function enterFullscreen(element, relativeTo) {
+  let $element = $(element);
+
+  if (relativeTo) {
+    $element = $(relativeTo).find(element);
+  }
+
+  $element.children().removeClass('hidden');
+  $element.data('origin', $element.parent())
+          .data('position', $(window).scrollTop())
+          .addClass('fullscreen')
+          .appendTo($('body'))
+          .resize();
+
+  $('.navbar').not('.navbar-editor').addClass('hidden');
+  $('.btn-fullscreen').addClass('hidden');
+  $('.btn-exit-fullscreen').removeClass('hidden');
+
+  $('#content').addClass('hidden');
+  $(document).on('keyup', function (e) {
+      if (e.keyCode === 27) {    // esc
+        exit_fullscreen_editor();
+      }
+  });
+  Editor.resize(true);
+}
+
+export function exitFullscreen() {
+  let element = $('.fullscreen');
+
+  $('#content').removeClass('hidden');
+  $('.navbar').removeClass('hidden');
+  element.removeClass('fullscreen')
+         .prependTo(element.data('origin'))
+         .resize();
+
+  $('.btn-exit-fullscreen').addClass('hidden');
+  $('.btn-fullscreen').removeClass('hidden');
+  $(window).scrollTop(element.data('position'));
+  Editor.resize(true);
+}


### PR DESCRIPTION
When a fullscreen mode is entered, only half of the editor's container shows text, and a scroll is needed unnecessarily.