### PR TITLE
fixes #20820 - set ajax vars for cr host import

### DIFF
--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -1,6 +1,7 @@
 class ComputeResourcesVmsController < ApplicationController
   include Foreman::Controller::ComputeResourcesCommon
   include ::Foreman::Controller::ActionPermissionDsl
+  include ::Foreman::Controller::HostFormCommon
 
   before_action :find_compute_resource
   before_action :find_vm, :only => [:import, :associate, :show, :console, :pause, :power]
@@ -100,6 +101,7 @@ class ComputeResourcesVmsController < ApplicationController
       :compute_resource => @compute_resource,
       :vm => @vm
     ).host
+    load_vars_for_ajax
   end
 
   private

--- a/app/controllers/concerns/foreman/controller/host_form_common.rb
+++ b/app/controllers/concerns/foreman/controller/host_form_common.rb
@@ -1,0 +1,50 @@
+module Foreman::Controller::HostFormCommon
+  extend ActiveSupport::Concern
+
+  included do
+    define_callbacks :set_class_variables
+  end
+
+  private
+
+  def load_vars_for_ajax
+    return unless @host
+
+    taxonomy_scope
+    if @host.compute_resource_id && params[:host] && params[:host][:compute_attributes]
+      @host.compute_attributes = params[:host][:compute_attributes]
+    end
+
+    set_class_variables(@host)
+  end
+
+  def set_class_variables(host)
+    run_callbacks :set_class_variables do
+      @architecture    = host.architecture
+      @operatingsystem = host.operatingsystem
+      @domain          = host.domain
+      @subnet          = host.subnet
+      @compute_profile = host.compute_profile
+      @realm           = host.realm
+      @hostgroup       = host.hostgroup
+    end
+  end
+
+  def taxonomy_scope
+    if params[:host]
+      @organization = Organization.find_by_id(params[:host][:organization_id])
+      @location = Location.find_by_id(params[:host][:location_id])
+    end
+
+    if @host
+      @organization ||= @host.organization
+      @location     ||= @host.location
+    end
+
+    @organization ||= Organization.find_by_id(params[:organization_id]) if params[:organization_id]
+    @location     ||= Location.find_by_id(params[:location_id])         if params[:location_id]
+
+    @organization ||= Organization.current if SETTINGS[:organizations_enabled]
+    @location     ||= Location.current     if SETTINGS[:locations_enabled]
+  end
+end


### PR DESCRIPTION
When importing a host from a compute resource, the "ajax fields" architecture / os / os media etc. don't work correctly because they rely on e.g. `@architecture` being set. This moves the code from the hosts controller to a shared concern so the methods are available for `hosts_controller` and `compute_resources_vms_controller`.