### PR TITLE
fixes #20822 - vm: show link to associated host

### DIFF
--- a/app/views/compute_resources_vms/show.html.erb
+++ b/app/views/compute_resources_vms/show.html.erb
@@ -4,8 +4,6 @@
 
 <%
   all_actions = available_actions(@vm).push(
-                  (link_to_if_authorized(_("Console"), hash_for_console_compute_resource_vm_path.merge(:auth_object => @compute_resource), {:disabled => @vm.nil? || !@vm.ready?, :class => "btn btn-info"}) if @vm.ready?),
-                  display_link_if_authorized(_("Associate VM"), hash_for_associate_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => @vm.identity).merge(:auth_object => @compute_resource, :permission => 'edit_compute_resources'), :title=> _("Associate VM to a Foreman host"), :method => :put, :class=>"btn btn-default"),
-                  link_to(_("Back"), compute_resource_path(@compute_resource), :class=>'btn btn-default'))
+                  link_to(_("Back"), compute_resource_path(@compute_resource), :class => 'btn btn-default'))
   title_actions *all_actions
 %>


### PR DESCRIPTION
This changes the title actions for the compute resources vm show page.

Before:
![image](https://user-images.githubusercontent.com/4107560/29942253-7e5c310a-8e95-11e7-8b68-c560dc3de56d.png)
(Associate VM doesn't work when the VM is already associated to a host)

After (with associated host):
![image](https://user-images.githubusercontent.com/4107560/29942221-63741d08-8e95-11e7-9223-ec32efa546ac.png)
Associated is gone now. Link to host was added.

After (without associated host):
![image](https://user-images.githubusercontent.com/4107560/29942198-549d48ae-8e95-11e7-8840-cb11b55ce89e.png)
Import button was added.