### PR TITLE
Fixes #13599 - Wrapped exception truncate moved to client

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -73,6 +73,7 @@ function onContentLoad(){
       if ($(this).data('on-complete')){
         _.get(window, $(this).data('on-complete')).call(null, this, status);
       }
+      tfm.tools.activateTooltips(this)
     });
   });
 

--- a/app/views/common/_ajax_error.html.erb
+++ b/app/views/common/_ajax_error.html.erb
@@ -1,1 +1,1 @@
-<%= alert(:text => _("Failure: %s") % message, :class => 'alert-danger', :header => '', :close => false) %>
+<%= alert(:text => trunc_with_tooltip(_("Failure: %s") % message, 90), :class => 'alert-danger', :header => '', :close => false) %>

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -52,7 +52,7 @@ module Foreman
       super unless @wrapped_exception.present?
 
       cls = @wrapped_exception.class.name
-      msg = @wrapped_exception.message.try(:truncate, 90)
+      msg = @wrapped_exception.message
       super + " ([#{cls}]: #{msg})"
     end
   end


### PR DESCRIPTION
Removed message truncation from server side, and moved it to client side - the message is truncated with ellipsis. On mouse over full message is presented as popover.

This commit required a small change to `data-ajax-url` handler in client to enable proper tooltip presentation in HTML loaded by AJAX.