### PR TITLE
Fixes #20098 - Resolve template_used for image provisioning

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -935,7 +935,10 @@ class HostsController < ApplicationController
     # kind of host. For example 'is_owned_by', even if it's in host_params,
     # should be ignored by Host::Discovered or any other Host class that does
     # not have that attribute
-    host_attributes = host.class.attribute_names
+    host_attributes = host.class.attribute_names.dup
+    if host_params["compute_attributes"].present?
+      host_attributes << 'compute_attributes'
+    end
     host_params.select do |k,v|
        host_attributes.include?(k) && !k.end_with?('_ids')
     end.except(:host_parameters_attributes)


### PR DESCRIPTION
At the moment, the method Hostext::OperatingSystem#template_kinds is
unable to handle image-based provisioning. If there is an image, it will
not be able to find it as 'self.compute_attributes' does not exist for
new hosts.

Creating the host always worked well, and the templates can be found
after clicking the 'submit' button. However, when you click on
'Resolve', you get an error 'undefined method []' as compute_attributes
does not exist.

This is fixed by ensuring the controller includes compute_attributes in
the 'temporary' host created to check the templates this.

To reproduce:

 - Click on Hosts > New host
 - Select a Compute Resource
 - Select an OS, choose 'Image based' as provisioning method
 - Select an image
 - Click on 'Resolve' - you will see "No templates were configured"
 - After applying the patch, you should see the finish/userdata template