### PR TITLE
Fixes #20846 - Include babel-polyfill to support ES6 Map

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015", "react"],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "~6.6.0",
     "babel-preset-react": "^6.5.0",
@@ -46,6 +47,7 @@
     "phantomjs-prebuilt": "^2.1.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "brace": "^0.10.0",
     "c3": "^0.4.11",
     "datatables.net": "~1.10.12",


### PR DESCRIPTION
Currently CI develop is failing[1], since it's browser does not support ES6 Maps.
Including 'babel-polyfill' will include Map support and test should pass again.

[1] http://ci.theforeman.org/view/Core/job/test_develop/database=postgresql,ruby=2.1,slave=fast/lastBuild/testReport/(root)/AboutIntegrationTest/test_0001_about_page/