### PR TITLE
Refs #19554 - Rewrite to use an Object and not Map

### DIFF
--- a/webpack/assets/javascripts/foreman_hosts.js
+++ b/webpack/assets/javascripts/foreman_hosts.js
@@ -10,16 +10,17 @@ let pluginEditAttributes = {
 export function registerPluginAttributes(componentType, attributes) {
   if (pluginEditAttributes[componentType] !== undefined) {
     pluginEditAttributes[componentType] = _.uniq(
-      pluginEditAttributes[componentType].concat(attributes));
+      pluginEditAttributes[componentType].concat(attributes)
+    );
   }
 }
 
 export function getAttributesToPost(componentType) {
   const defaultAttributes = {
-    'architecture': ['architecture_id', 'organization_id', 'location_id'],
-    'os': ['operatingsystem_id', 'organization_id', 'location_id'],
-    'medium': ['medium_id', 'operatingsystem_id', 'architecture_id'],
-    'image': ['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']
+    architecture: ['architecture_id', 'organization_id', 'location_id'],
+    os: ['operatingsystem_id', 'organization_id', 'location_id'],
+    medium: ['medium_id', 'operatingsystem_id', 'architecture_id'],
+    image: ['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id']
   };
   let attrsToPost = defaultAttributes[componentType];
 
@@ -27,7 +28,7 @@ export function getAttributesToPost(componentType) {
     return [];
   }
   if (pluginEditAttributes[componentType] !== undefined) {
-      attrsToPost = attrsToPost.concat(pluginEditAttributes[componentType]);
+    attrsToPost = attrsToPost.concat(pluginEditAttributes[componentType]);
   }
   return _.uniq(attrsToPost);
 }
@@ -48,7 +49,7 @@ class PXECompatibilityCheck {
 
     supportedLoaders = this.__compatibleLoadersFunc(os);
     if (supportedLoaders != null) {
-      return (supportedLoaders.indexOf(pxeLoader) > -1);
+      return supportedLoaders.indexOf(pxeLoader) > -1;
     }
     return null;
   }
@@ -61,12 +62,11 @@ const GRUB_UEFI = 'Grub UEFI';
 const GRUB2_UEFI = 'Grub2 UEFI';
 const GRUB2_UEFI_SB = 'Grub2 UEFI SecureBoot';
 
-export let pxeCompatibility = new Map();
+export let pxeCompatibility = {};
 
 // Ubuntu 10.x or older and Grub1
 // Ubuntu 11.x or newer and Grub2
-pxeCompatibility.set('ubuntu',
-  new PXECompatibilityCheck(
+_.set(pxeCompatibility, 'ubuntu', new PXECompatibilityCheck(
     /ubuntu[^\d]*(\d+)(?:[.]\d+)?/,
     function (os) {
       if (os[1] <= '10') {
@@ -76,15 +76,13 @@ pxeCompatibility.set('ubuntu',
       }
       return null;
     }
-  )
-);
+));
 
 // RHEL 6.x and Grub1
 // RHEL 7.x and Grub2
-pxeCompatibility.set('rhel',
-  new PXECompatibilityCheck(
+_.set(pxeCompatibility, 'rhel', new PXECompatibilityCheck(
     /(?:red[ ]*hat|rhel|cent[ ]*os|scientific|oracle)[^\d]*(\d+)(?:[.]\d+)?/,
-    function (os) {
+    os => {
       if (os[1] === '6') {
         return [PXE_BIOS, GRUB_UEFI];
       } else if (os[1] >= '7') {
@@ -92,13 +90,11 @@ pxeCompatibility.set('rhel',
       }
       return null;
     }
-  )
-);
+));
 
 // Debian 2-6 and Grub1
 // Debian 7+ and Grub2
-pxeCompatibility.set('debian',
-  new PXECompatibilityCheck(
+_.set(pxeCompatibility, 'debian', new PXECompatibilityCheck(
     /debian[^\d]*(\d+)(?:[.]\d+)?/,
     function (os) {
       if (os[1] >= '2' && os[1] <= '6') {
@@ -108,21 +104,21 @@ pxeCompatibility.set('debian',
       }
       return null;
     }
-  )
-);
+));
 
 export function checkPXELoaderCompatibility(osTitle, pxeLoader) {
   if (pxeLoader === 'None' || pxeLoader === '') {
     return null;
   }
+  let compatible = null;
 
   osTitle = osTitle.toLowerCase();
-  for (let check of pxeCompatibility.values()) {
-    let compatible = check.isCompatible(osTitle, pxeLoader);
+  _.forEach(_.values(pxeCompatibility), (check) => {
+    let compatibleCheck = check.isCompatible(osTitle, pxeLoader);
 
-    if (compatible != null) {
-      return compatible;
+    if (compatibleCheck != null) {
+      compatible = compatibleCheck;
     }
-  }
-  return null;
+  });
+  return compatible;
 }

--- a/webpack/assets/javascripts/foreman_hosts.test.js
+++ b/webpack/assets/javascripts/foreman_hosts.test.js
@@ -1,46 +1,52 @@
 jest.unmock('./foreman_hosts');
-const hosts = require('./foreman_hosts');
+import {
+  getAttributesToPost,
+  registerPluginAttributes,
+  checkPXELoaderCompatibility
+} from './foreman_hosts';
 
 describe('getAttributesToPost', () => {
-    beforeEach(() => {
-      window.tfm = {hosts: {pluginEditAttributes: {}}};
+  beforeEach(() => {
+    window.tfm = { hosts: { pluginEditAttributes: {} } };
   });
 
   it('attribute hash holds the default attributes', () => {
-    let ret = hosts.getAttributesToPost('os');
+    const ret = getAttributesToPost('os');
 
     expect(ret).toEqual(['operatingsystem_id', 'organization_id', 'location_id']);
   });
 
   it('adds the plugin_edit_attributes', () => {
-    hosts.registerPluginAttributes('os', ['foo']);
-    expect(hosts.getAttributesToPost('os')).toEqual(
-                 ['operatingsystem_id', 'organization_id', 'location_id', 'foo']);
+    registerPluginAttributes('os', ['foo']);
+    expect(getAttributesToPost('os')).toEqual([
+      'operatingsystem_id',
+      'organization_id',
+      'location_id',
+      'foo'
+    ]);
   });
-
 });
 
-/* eslint-disable max-statements, max-len */
 describe('checkPXELoaderCompatibility', () => {
   function assertCompatibility(osTitle, pxeLoader) {
-    it(osTitle + ' is compatible with ' + pxeLoader, () => {
-      let result = hosts.checkPXELoaderCompatibility(osTitle, pxeLoader);
+    it(`${osTitle} is compatible with ${pxeLoader}`, () => {
+      const result = checkPXELoaderCompatibility(osTitle, pxeLoader);
 
       expect(result).toEqual(true);
     });
   }
 
   function refuteCompatibility(osTitle, pxeLoader) {
-    it(osTitle + ' is incompatible with ' + pxeLoader, () => {
-      let result = hosts.checkPXELoaderCompatibility(osTitle, pxeLoader);
+    it(`${osTitle} is incompatible with ${pxeLoader}`, () => {
+      const result = checkPXELoaderCompatibility(osTitle, pxeLoader);
 
       expect(result).toEqual(false);
     });
   }
 
   function assertUndefinedCompatibility(osTitle, pxeLoader) {
-    it(osTitle + ' has undefined compatibility with ' + pxeLoader, () => {
-      let result = hosts.checkPXELoaderCompatibility(osTitle, pxeLoader);
+    it(`${osTitle} has undefined compatibility with ${pxeLoader}`, () => {
+      const result = checkPXELoaderCompatibility(osTitle, pxeLoader);
 
       expect(result).toEqual(null);
     });
@@ -48,105 +54,140 @@ describe('checkPXELoaderCompatibility', () => {
 
   // RHEL 6.x and Grub1
   // RHEL 7.x and Grub2
-  describe('RHEL', () => {
-    assertUndefinedCompatibility('RHEL 5', 'PXELinux BIOS');
-    assertUndefinedCompatibility('RHEL 5', 'PXELinux UEFI');
-    assertUndefinedCompatibility('RHEL 5', 'Grub UEFI');
-    assertUndefinedCompatibility('RHEL 5', 'Grub2 UEFI');
-    assertUndefinedCompatibility('RHEL 5', 'Grub2 UEFI SecureBoot');
+  describe('pxeLoaderCompatibilityChecks', () => {
+    describe('RHEL 5', () => {
+      assertUndefinedCompatibility('RHEL 5', 'PXELinux BIOS');
+      assertUndefinedCompatibility('RHEL 5', 'PXELinux UEFI');
+      assertUndefinedCompatibility('RHEL 5', 'Grub UEFI');
+      assertUndefinedCompatibility('RHEL 5', 'Grub2 UEFI');
+      assertUndefinedCompatibility('RHEL 5', 'Grub2 UEFI SecureBoot');
+    });
 
-    assertCompatibility('RHEL 6.0', 'PXELinux BIOS');
-    refuteCompatibility('RHEL 6.0', 'PXELinux UEFI');
-    assertCompatibility('RHEL 6.0', 'Grub UEFI');
-    refuteCompatibility('RHEL 6.0', 'Grub2 UEFI');
-    refuteCompatibility('RHEL 6.0', 'Grub2 UEFI SecureBoot');
+    describe('RHEL 6', () => {
+      assertCompatibility('RHEL 6.0', 'PXELinux BIOS');
+      refuteCompatibility('RHEL 6.0', 'PXELinux UEFI');
+      assertCompatibility('RHEL 6.0', 'Grub UEFI');
+      refuteCompatibility('RHEL 6.0', 'Grub2 UEFI');
+      refuteCompatibility('RHEL 6.0', 'Grub2 UEFI SecureBoot');
 
-    assertCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'PXELinux BIOS');
-    refuteCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'PXELinux UEFI');
-    assertCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'Grub UEFI');
-    refuteCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'Grub2 UEFI');
-    refuteCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'Grub2 UEFI SecureBoot');
+      assertCompatibility(
+        'Red Hat Enterprise Linux Server release 6.0 (Santiago)',
+        'PXELinux BIOS'
+      );
+      refuteCompatibility(
+        'Red Hat Enterprise Linux Server release 6.0 (Santiago)',
+        'PXELinux UEFI'
+      );
+      assertCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'Grub UEFI');
+      refuteCompatibility('Red Hat Enterprise Linux Server release 6.0 (Santiago)', 'Grub2 UEFI');
+      refuteCompatibility(
+        'Red Hat Enterprise Linux Server release 6.0 (Santiago)',
+        'Grub2 UEFI SecureBoot'
+      );
+    });
 
-    assertCompatibility('RHEL 7.0', 'PXELinux BIOS');
-    refuteCompatibility('RHEL 7.0', 'PXELinux UEFI');
-    refuteCompatibility('RHEL 7.0', 'Grub UEFI');
-    assertCompatibility('RHEL 7.0', 'Grub2 UEFI');
-    assertCompatibility('RHEL 7.0', 'Grub2 UEFI SecureBoot');
+    describe('RHEL 7', () => {
+      assertCompatibility('RHEL 7.0', 'PXELinux BIOS');
+      refuteCompatibility('RHEL 7.0', 'PXELinux UEFI');
+      refuteCompatibility('RHEL 7.0', 'Grub UEFI');
+      assertCompatibility('RHEL 7.0', 'Grub2 UEFI');
+      assertCompatibility('RHEL 7.0', 'Grub2 UEFI SecureBoot');
+    });
 
-    assertCompatibility('RHEL 8.0', 'PXELinux BIOS');
-    refuteCompatibility('RHEL 8.0', 'PXELinux UEFI');
-    refuteCompatibility('RHEL 8.0', 'Grub UEFI');
-    assertCompatibility('RHEL 8.0', 'Grub2 UEFI');
-    assertCompatibility('RHEL 8.0', 'Grub2 UEFI SecureBoot');
+    describe('RHEL 8', () => {
+      assertCompatibility('RHEL 8.0', 'PXELinux BIOS');
+      refuteCompatibility('RHEL 8.0', 'PXELinux UEFI');
+      refuteCompatibility('RHEL 8.0', 'Grub UEFI');
+      assertCompatibility('RHEL 8.0', 'Grub2 UEFI');
+      assertCompatibility('RHEL 8.0', 'Grub2 UEFI SecureBoot');
+    });
 
-    assertCompatibility('CentOS 7', 'PXELinux BIOS');
-    refuteCompatibility('CentOS 7', 'PXELinux UEFI');
-    refuteCompatibility('CentOS 7', 'Grub UEFI');
-    assertCompatibility('CentOS 7', 'Grub2 UEFI');
-    assertCompatibility('CentOS 7', 'Grub2 UEFI SecureBoot');
-  });
+    describe('CentOS 7', () => {
+      assertCompatibility('CentOS 7', 'PXELinux BIOS');
+      refuteCompatibility('CentOS 7', 'PXELinux UEFI');
+      refuteCompatibility('CentOS 7', 'Grub UEFI');
+      assertCompatibility('CentOS 7', 'Grub2 UEFI');
+      assertCompatibility('CentOS 7', 'Grub2 UEFI SecureBoot');
+    });
 
-  // Debian 2-6 and Grub1
-  // Debian 7+ and Grub2
-  describe('Debian', () => {
-    assertCompatibility('Debian 6', 'PXELinux BIOS');
-    refuteCompatibility('Debian 6', 'PXELinux UEFI');
-    assertCompatibility('Debian 6', 'Grub UEFI');
-    refuteCompatibility('Debian 6', 'Grub2 UEFI');
-    refuteCompatibility('Debian 6', 'Grub2 UEFI SecureBoot');
+    // Debian 2-6 and Grub1
+    // Debian 7+ and Grub2
+    describe('Debian', () => {
+      describe('Debian 6', () => {
+        assertCompatibility('Debian 6', 'PXELinux BIOS');
+        refuteCompatibility('Debian 6', 'PXELinux UEFI');
+        assertCompatibility('Debian 6', 'Grub UEFI');
+        refuteCompatibility('Debian 6', 'Grub2 UEFI');
+        refuteCompatibility('Debian 6', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertCompatibility('Debian 2', 'PXELinux BIOS');
-    refuteCompatibility('Debian 2', 'PXELinux UEFI');
-    assertCompatibility('Debian 2', 'Grub UEFI');
-    refuteCompatibility('Debian 2', 'Grub2 UEFI');
-    refuteCompatibility('Debian 2', 'Grub2 UEFI SecureBoot');
+      describe('Debian 2', () => {
+        assertCompatibility('Debian 2', 'PXELinux BIOS');
+        refuteCompatibility('Debian 2', 'PXELinux UEFI');
+        assertCompatibility('Debian 2', 'Grub UEFI');
+        refuteCompatibility('Debian 2', 'Grub2 UEFI');
+        refuteCompatibility('Debian 2', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertCompatibility('Debian 7.0', 'PXELinux BIOS');
-    refuteCompatibility('Debian 7.0', 'PXELinux UEFI');
-    refuteCompatibility('Debian 7.0', 'Grub UEFI');
-    assertCompatibility('Debian 7.0', 'Grub2 UEFI');
-    assertCompatibility('Debian 7.0', 'Grub2 UEFI SecureBoot');
+      describe('Debian 7', () => {
+        assertCompatibility('Debian 7.0', 'PXELinux BIOS');
+        refuteCompatibility('Debian 7.0', 'PXELinux UEFI');
+        refuteCompatibility('Debian 7.0', 'Grub UEFI');
+        assertCompatibility('Debian 7.0', 'Grub2 UEFI');
+        assertCompatibility('Debian 7.0', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertUndefinedCompatibility('Debian', 'PXELinux BIOS');
-    assertUndefinedCompatibility('Debian', 'PXELinux UEFI');
-    assertUndefinedCompatibility('Debian', 'Grub UEFI');
-    assertUndefinedCompatibility('Debian', 'Grub2 UEFI');
-    assertUndefinedCompatibility('Debian', 'Grub2 UEFI SecureBoot');
-  });
+      describe('Other Debian', () => {
+        assertUndefinedCompatibility('Debian', 'PXELinux BIOS');
+        assertUndefinedCompatibility('Debian', 'PXELinux UEFI');
+        assertUndefinedCompatibility('Debian', 'Grub UEFI');
+        assertUndefinedCompatibility('Debian', 'Grub2 UEFI');
+        assertUndefinedCompatibility('Debian', 'Grub2 UEFI SecureBoot');
+      });
+    });
 
-  // Ubuntu 10.x or older and Grub1
-  // Ubuntu 11.x or newer and Grub2
-  describe('Ubuntu', () => {
-    assertCompatibility('Ubuntu 10.4', 'PXELinux BIOS');
-    refuteCompatibility('Ubuntu 10.4', 'PXELinux UEFI');
-    assertCompatibility('Ubuntu 10.4', 'Grub UEFI');
-    refuteCompatibility('Ubuntu 10.4', 'Grub2 UEFI');
-    refuteCompatibility('Ubuntu 10.4', 'Grub2 UEFI SecureBoot');
+    // Ubuntu 10.x or older and Grub1
+    // Ubuntu 11.x or newer and Grub2
+    describe('Ubuntu', () => {
+      describe('Ubuntu 10.4', () => {
+        assertCompatibility('Ubuntu 10.4', 'PXELinux BIOS');
+        refuteCompatibility('Ubuntu 10.4', 'PXELinux UEFI');
+        assertCompatibility('Ubuntu 10.4', 'Grub UEFI');
+        refuteCompatibility('Ubuntu 10.4', 'Grub2 UEFI');
+        refuteCompatibility('Ubuntu 10.4', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertCompatibility('Ubuntu 11.4', 'PXELinux BIOS');
-    refuteCompatibility('Ubuntu 11.4', 'PXELinux UEFI');
-    refuteCompatibility('Ubuntu 11.4', 'Grub UEFI');
-    assertCompatibility('Ubuntu 11.4', 'Grub2 UEFI');
-    assertCompatibility('Ubuntu 11.4', 'Grub2 UEFI SecureBoot');
+      describe('Ubuntu 11.4', () => {
+        assertCompatibility('Ubuntu 11.4', 'PXELinux BIOS');
+        refuteCompatibility('Ubuntu 11.4', 'PXELinux UEFI');
+        refuteCompatibility('Ubuntu 11.4', 'Grub UEFI');
+        assertCompatibility('Ubuntu 11.4', 'Grub2 UEFI');
+        assertCompatibility('Ubuntu 11.4', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertCompatibility('Ubuntu 11.10', 'PXELinux BIOS');
-    refuteCompatibility('Ubuntu 11.10', 'PXELinux UEFI');
-    refuteCompatibility('Ubuntu 11.10', 'Grub UEFI');
-    assertCompatibility('Ubuntu 11.10', 'Grub2 UEFI');
-    assertCompatibility('Ubuntu 11.10', 'Grub2 UEFI SecureBoot');
+      describe('Ubuntu 11.10', () => {
+        assertCompatibility('Ubuntu 11.10', 'PXELinux BIOS');
+        refuteCompatibility('Ubuntu 11.10', 'PXELinux UEFI');
+        refuteCompatibility('Ubuntu 11.10', 'Grub UEFI');
+        assertCompatibility('Ubuntu 11.10', 'Grub2 UEFI');
+        assertCompatibility('Ubuntu 11.10', 'Grub2 UEFI SecureBoot');
+      });
 
-    assertUndefinedCompatibility('Ubuntu', 'PXELinux BIOS');
-    assertUndefinedCompatibility('Ubuntu', 'PXELinux UEFI');
-    assertUndefinedCompatibility('Ubuntu', 'Grub UEFI');
-    assertUndefinedCompatibility('Ubuntu', 'Grub2 UEFI');
-    assertUndefinedCompatibility('Ubuntu', 'Grub2 UEFI SecureBoot');
-  });
+      describe('Other Ubuntu', () => {
+        assertUndefinedCompatibility('Ubuntu', 'PXELinux BIOS');
+        assertUndefinedCompatibility('Ubuntu', 'PXELinux UEFI');
+        assertUndefinedCompatibility('Ubuntu', 'Grub UEFI');
+        assertUndefinedCompatibility('Ubuntu', 'Grub2 UEFI');
+        assertUndefinedCompatibility('Ubuntu', 'Grub2 UEFI SecureBoot');
+      });
+    });
 
-  describe('unknown os', () => {
-    assertUndefinedCompatibility('Unknown OS', 'PXELinux BIOS');
-    assertUndefinedCompatibility('Unknown OS', 'PXELinux UEFI');
-    assertUndefinedCompatibility('Unknown OS', 'Grub UEFI');
-    assertUndefinedCompatibility('Unknown OS', 'Grub2 UEFI');
-    assertUndefinedCompatibility('Unknown OS', 'Grub2 UEFI SecureBoot');
+    describe('unknown os', () => {
+      assertUndefinedCompatibility('Unknown OS', 'PXELinux BIOS');
+      assertUndefinedCompatibility('Unknown OS', 'PXELinux UEFI');
+      assertUndefinedCompatibility('Unknown OS', 'Grub UEFI');
+      assertUndefinedCompatibility('Unknown OS', 'Grub2 UEFI');
+      assertUndefinedCompatibility('Unknown OS', 'Grub2 UEFI SecureBoot');
+    });
   });
 });


### PR DESCRIPTION
Map is not yet fully supported in all browsers and
would require additional dependencies to be added.

Using a Object with lodash functions achieves the
same and does not require any additional
dependencies.

This also includes fixes from #4810. An unsquashed history can be found here: https://github.com/bastilian/foreman/commits/fix/ref-19554