### PR TITLE
Fixes #20840 - show error on invalid name for any parameter

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -69,6 +69,10 @@ module CommonParametersHelper
   end
 
   def authorized_resource_parameters(resource, type)
-    resource.send(type).authorized(:view_params) + resource.send(type).select(&:new_record?)
+    parameters_by_type = resource.send(type)
+    parameter_ids_to_view = parameters_by_type.authorized(:view_params).map(&:id)
+    resource_parameters = parameters_by_type.select { |p| parameter_ids_to_view.include?(p.id) }
+    resource_parameters += parameters_by_type.select(&:new_record?)
+    resource_parameters
   end
 end

--- a/test/integration/subnet_test.rb
+++ b/test/integration/subnet_test.rb
@@ -14,4 +14,16 @@ class SubnetIntegrationTest < ActionDispatch::IntegrationTest
     assert_submit_button(subnets_path)
     assert page.has_link? 'one-secure'
   end
+
+  test 'edit shows errors on invalid name for parameters values' do
+    subnet = FactoryGirl.create(:subnet_ipv4)
+    subnet.subnet_parameters.create!(:name => "foo_param", :value => "bar", :hidden_value => true)
+    visit edit_subnet_path(subnet)
+    assert page.has_link?('Parameters', :href => '#params')
+    click_link 'Parameters'
+    assert page.has_no_selector?('#params .input-group.has-error')
+    fill_in "subnet_subnet_parameters_attributes_0_name", :with => 'invalid name'
+    click_button('Submit')
+    assert page.has_selector?('#params tr.has-error')
+  end
 end


### PR DESCRIPTION
Updating any type of Parameter such as subnet_parameter/host_parameter with invalid name
doesn't show any error. 
With this commit, it is now showing error on parameters with invalid name.