### PR TITLE
Fixes #19730 - Add vendor to provisioning templates

### DIFF
--- a/db/seeds.d/07-provisioning_templates.rb
+++ b/db/seeds.d/07-provisioning_templates.rb
@@ -6,9 +6,10 @@ ProvisioningTemplate.without_auditing do
     contents = File.read(File.join("#{Rails.root}/app/views/unattended/provisioning_templates", input[:source]))
 
     if (t = ProvisioningTemplate.unscoped.find_by_name(input[:name])) && !SeedHelper.audit_modified?(ProvisioningTemplate, input[:name])
-      if t.template != contents
+      if t.template != contents || t.vendor != 'Foreman'
         t.template = contents
         t.locked = true
+        t.vendor = 'Foreman'
         t.ignore_locking do
           t.ignore_default do
             raise "Unable to update template #{t.name}: #{format_errors t}" unless t.save
@@ -23,7 +24,8 @@ ProvisioningTemplate.without_auditing do
                                         :default => true,
                                         :name => input[:name],
                                         :template_kind => input[:template_kind],
-                                        :snippet => input[:snippet] || false
+                                        :snippet => input[:snippet] || false,
+                                        :vendor => 'Foreman'
                                       })
 
       t.organizations = organizations if SETTINGS[:organizations_enabled]


### PR DESCRIPTION
Before unlocking a provisioning template, a warning is shown on the
screen. This warning should contain the vendor that provided the
template (normally Foreman or Katello).

This works for new installations. For existing installations, I'm not quite sure how can we add this flag. Matching by name with templates in app/views/ unattended would certainly NOT work - maybe matching by content and name would. Is it worth the effort?

![screenshot from 2017-09-07 18-39-11](https://user-images.githubusercontent.com/598891/30174699-4140ca30-93fc-11e7-85b1-cd55b8eb844d.png)