### PR TITLE
Fixes #19742 - cache hosts for fact values

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -79,10 +79,12 @@ class FactValue < ApplicationRecord
   end
 
   def self.build_facts_hash(facts)
+    hosts = Host.where(:id => facts.group_by(&:host_id).keys).all
+
     hash = {}
     facts.each do |fact|
-      hash[fact.host.to_s] ||= {}
-      hash[fact.host.to_s].update({fact.name.to_s => fact.value})
+      hash[hosts.detect {|h| h.id == fact.host_id}.to_s] ||= {}
+      hash[hosts.detect {|h| h.id == fact.host_id}.to_s].update({fact.name.to_s => fact.value})
     end
     hash
   end

--- a/test/models/fact_value_test.rb
+++ b/test/models/fact_value_test.rb
@@ -12,6 +12,11 @@ class FactValueTest < ActiveSupport::TestCase
     end
   end
 
+  test ".build_facts_hash returns a hash with host name" do
+    hash = { @host.to_s => { @fact_name.name => @fact_value.value } }
+    assert_equal hash, FactValue.build_facts_hash([ @fact_value ])
+  end
+
   test "should return the count of each fact" do
     h = [{:label=>"some value", :data=>1}]
     assert_equal h, FactValue.count_each("my_facting_name")


### PR DESCRIPTION
When we generate fact values hash we always loaded a host for a given
fact. This in combination with taxonomies queryies that are
automatically generated caused roughly 6N+1 issue. We can preload all
hosts that are required and use this in-memory cache for generating the
hash.