### PR TITLE
fixes #20882 - show template kind names from plugins

### DIFF
--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -28,7 +28,12 @@ class TemplateKind < ApplicationRecord
     Foreman::Plugin.all.map(&:get_template_labels).inject({}, :merge)
   end
 
+  def humanized_name
+    [self.class.default_template_labels[name], self.class.plugin_template_labels[name]].detect(&:present?)
+  end
+
   def to_s
-    _(self.class.default_template_labels[name]) || _(self.class.plugin_template_labels[name]) || name
+    return _(humanized_name) if humanized_name.present?
+    name
   end
 end

--- a/test/models/template_kind_test.rb
+++ b/test/models/template_kind_test.rb
@@ -7,7 +7,9 @@ class TemplateKindTest < ActiveSupport::TestCase
 
   test '#to_s returns English string from plugin registration' do
     kind = FactoryBot.build(:template_kind)
-    Foreman::Plugin.expects(:all).returns([mock('plugin', :get_template_labels => {kind.name => 'Plugin kind'})])
+    mock_plugin = mock('plugin')
+    mock_plugin.expects(:get_template_labels).at_least_once.returns({kind.name => 'Plugin kind'})
+    Foreman::Plugin.expects(:all).at_least_once.returns([mock_plugin])
     assert_equal 'Plugin kind', kind.to_s
   end
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4107560/30211277-9d06bccc-94a0-11e7-8aa9-ee695722118a.png)

After:
![image](https://user-images.githubusercontent.com/4107560/30211256-8cf383a6-94a0-11e7-8314-31dc03682a4b.png)
