### PR TITLE
Fixes #19047 - unify date formats

### DIFF
--- a/app/assets/javascripts/proxy_status/logs.js
+++ b/app/assets/javascripts/proxy_status/logs.js
@@ -30,7 +30,7 @@ function activateLogsDataTable() {
     autoWidth: false,
     columnDefs: [{
       render: function ( data, type, row ) {
-        return new Date(data * 1000).toLocaleString();
+        return data;
       },
       width: "15%",
       targets: 0
@@ -45,9 +45,10 @@ function activateLogsDataTable() {
   $('#logEntryModal').on('show.bs.modal', function (event) {
     var link = $(event.relatedTarget);
     var modal = $(this);
-    var datetime = new Date(link.data('time') * 1000);
-    modal.find('#modal-bt-timegmt').text(datetime.toUTCString());
-    modal.find('#modal-bt-time').text(datetime.toLocaleString());
+    var datetime = link.data('time');
+    var utc_datetime = link.data('utc-time');
+    modal.find('#modal-bt-timegmt').text(utc_datetime);
+    modal.find('#modal-bt-time').text(datetime);
     modal.find('#modal-bt-level').text(link.data('level'));
     if (link.data('message')) modal.find('#modal-bt-message').text(link.data('message'));
     if (link.data('backtrace')) modal.find('#modal-bt-backtrace').text(link.data('backtrace'));

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,35 @@ module ApplicationHelper
     params.key?(:search)
   end
 
+  # this helper should be used to print date time in absolute form
+  # it will also define a title with relative time information
+  # it supports two formats :short and :long
+  # example of long is February 12, 2021 17:13
+  # example of short is Aug 31, 12:52
+  def date_time_absolute(time, format = :short)
+    raise ArgumentError, "unsupported format '#{format}', use :long or :short" unless %w(long short).include?(format.to_s)
+
+    content_tag :span, :title => date_time_relative_value(time) do
+      date_time_absolute_value(time, format)
+    end
+  end
+
+  # this helper should be used to print date time in relative form, e.g. "10 days ago",
+  # it will also define a title with absolute time information
+  def date_time_relative(time)
+    content_tag :span, :title => date_time_absolute_value(time, :long) do
+      date_time_relative_value(time)
+    end
+  end
+
+  def date_time_absolute_value(time, format = :short)
+    l(time, :format => format)
+  end
+
+  def date_time_relative_value(time)
+    (time > Time.now.utc ? _('in %s') : _('%s ago')) % time_ago_in_words(time)
+  end
+
   protected
 
   def contract(model)

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -96,8 +96,7 @@ module AuditsHelper
   end
 
   def audit_time(audit)
-    content_tag :span, _("%s ago") % time_ago_in_words(audit.created_at),
-                { :'data-original-title' => audit.created_at.to_s(:long), :rel => 'twipsy' }
+    date_time_absolute(audit.created_at)
   end
 
   def audited_icon(audit)

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -5,7 +5,7 @@ module DashboardHelper
 
   def dashboard_actions
     [
-      _("Generated at %s") % Time.zone.now.to_s(:short),
+      _("Generated at %s") % date_time_absolute(Time.zone.now),
       select_action_button(
         _('Manage'), {},
         link_to_function(_('Save positions'), "save_position('#{save_positions_widgets_path}')"),

--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -1,6 +1,6 @@
 module FactValuesHelper
   def fact_from(record)
-    _("%s ago") % time_ago_in_words(record.updated_at)
+    date_time_relative(record.updated_at)
   rescue
     _("N/A")
   end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -78,7 +78,7 @@ module HostsHelper
   end
 
   def last_report_column(record)
-    time = record.last_report? ? _("%s ago") % time_ago_in_words(record.last_report): ""
+    time = record.last_report? ? date_time_relative_value(record.last_report) : ""
     link_to_if_authorized(time,
                           hash_for_host_config_report_path(:host_id => record.to_param, :id => "last"),
                           last_report_tooltip(record))
@@ -86,11 +86,12 @@ module HostsHelper
 
   def last_report_tooltip(record)
     opts = { :rel => "twipsy" }
+    date = record.last_report.nil? ? '' : date_time_absolute_value(record.last_report) + ", "
     if @last_report_ids[record.id]
-      opts["data-original-title"] = _("View last report details")
+      opts["data-original-title"] = date + _("view last report details")
     else
       opts.merge!(:disabled => true, :class => "disabled", :onclick => 'return false')
-      opts["data-original-title"] = _("Report Already Deleted") unless record.last_report.nil?
+      opts["data-original-title"] = date + _("report already deleted") unless record.last_report.nil?
     end
     opts
   end

--- a/app/helpers/puppetca_helper.rb
+++ b/app/helpers/puppetca_helper.rb
@@ -10,17 +10,4 @@ module PuppetcaHelper
                                             [[_('all'),'']]),
                :class => "datatable-filter", :id => "puppetca-filter"
   end
-
-  def time_column(time, opts = {})
-    return _("N/A") if time.blank?
-    opts[:tense] ||= :past
-
-    if opts[:tense] == :future
-      _("in %s") % (time_ago_in_words time)
-    elsif opts[:tense] == :past
-      _("%s ago") % (time_ago_in_words time)
-    else
-      time_ago_in_words time
-    end
-  end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 module ReportsHelper
   def reported_at_column(record)
-    link_to(_("%s ago") % time_ago_in_words(record.reported_at), config_report_path(record))
+    link_to date_time_relative(record.reported_at).html_safe, config_report_path(record)
   end
 
   def report_event_column(event, style = "")

--- a/app/views/puppetca/_expiry.html.erb
+++ b/app/views/puppetca/_expiry.html.erb
@@ -6,7 +6,7 @@
     <div class="card-pf-body">
       <p class="card-pf-aggregate-status-notifications">
         <% if expiry.is_a? Time %>
-          <%= time_column expiry, :tense => :future %>
+          <%= date_time_relative(expiry) %>
         <% else %>
           <%= expiry %>
         <% end %>

--- a/app/views/puppetca/_list.html.erb
+++ b/app/views/puppetca/_list.html.erb
@@ -17,8 +17,8 @@
       <tr>
         <td class="ellipsis"><%= cert.name %></td>
         <td><%= _(cert.state) %></td>
-        <td><%= time_column cert.valid_from %></td>
-        <td><%= time_column cert.expires_at, :tense => :future %></td>
+        <td><%= date_time_relative cert.valid_from %></td>
+        <td><%= date_time_relative cert.expires_at %></td>
         <td class="ellipsis"><%= cert.fingerprint %></td>
         <td>
           <%= action_buttons(

--- a/app/views/smart_proxies/logs/_list.html.erb
+++ b/app/views/smart_proxies/logs/_list.html.erb
@@ -20,12 +20,14 @@
   <tbody>
     <% log_entries.each do |log| %>
       <tr class="<%= logs_color_map[log['level']] || '' %>">
-        <td class="ca col-md-2 hidden-xs nbsp"><%= log['timestamp'] %></td>
+        <% timestamp = Time.at(log['timestamp']) %>
+        <td class="ca col-md-2 hidden-xs nbsp"><%= date_time_absolute(timestamp) %></td>
         <td class="ca col-md-1 hidden-sm hidden-xs nbsp">
           <a href="#"
             data-toggle="modal"
             data-target="#logEntryModal"
-            data-time="<%= log['timestamp'] %>"
+            data-time="<%= date_time_absolute_value(timestamp) %>"
+            data-utc-time="<%= date_time_absolute_value(timestamp.utc) %>"
             data-level="<%= log['level'] %>"
             data-message="<%= log['message'] %>"
             data-backtrace="<%= log['backtrace'] %>">

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -35,5 +35,5 @@
 </table>
 <%= will_paginate_with_info @trends %>
 <% unless TrendCounter.unconfigured? %>
-  <%= _("Last updated %s ago") % (time_ago_in_words TrendCounter.order(:created_at).last.created_at) %>
+  <%= (_("Last update: %s") % (date_time_relative(TrendCounter.order(:created_at).last.created_at)) ).html_safe %>
 <% end %>

--- a/test/controllers/puppetca_controller_test.rb
+++ b/test/controllers/puppetca_controller_test.rb
@@ -16,7 +16,7 @@ class PuppetcaControllerTest < ActionController::TestCase
 
   test 'index encodes any CN to an url safe string' do
     cert = SmartProxies::PuppetCACertificate.new(
-      ['mcollective/OL=mcollective', 'pending'])
+      ['mcollective/OL=mcollective', 'pending', 'fingerprint', '2000-01-01 00:00:00', '3000-01-01 00:00:00'])
     ProxyStatus::PuppetCA.any_instance.expects(:certs).returns([cert])
     assert_nothing_raised do
       get :index, { :smart_proxy_id => @proxy.id }, set_session_user


### PR DESCRIPTION
This introduces two new helpers for printing date in absolute and
relative format. Helper for absolute accepts also a parameter to choose
between long and short variant. The long one includes the year. The date
also has a title so you see the other format after hovering mouse
cursor.

---
replaces #4419, updated all pages, see all affected on screenshots, I'll update foreman plugin writing instructions and open issues or PRs to plugins after this gets in

pinging people who participated in previous discussions: @iNecas @ekohl @timogoebel @dLobatog @ohadlevy @lzap and of course @Rohoover, thumbs up/down appreciated, full review from one of you is enough :-)

reports
![dates1](https://user-images.githubusercontent.com/109773/30215416-3d208fd0-94b0-11e7-8a7b-bc0e042bb1bf.png)
dashboard
![dates2](https://user-images.githubusercontent.com/109773/30215423-3d59b44a-94b0-11e7-8b4e-5a3738383691.png)
proxy logs
![dates3](https://user-images.githubusercontent.com/109773/30215414-3d192f56-94b0-11e7-91a4-6169ff0beacb.png)
proxy log detal
![dates4](https://user-images.githubusercontent.com/109773/30215415-3d199ff4-94b0-11e7-8be0-fcab104e4bb4.png)
puppet ca expiration
![dates5](https://user-images.githubusercontent.com/109773/30215417-3d20e98a-94b0-11e7-90e1-18c1efcd7ea4.png)
audits
![dates6](https://user-images.githubusercontent.com/109773/30215418-3d22ef14-94b0-11e7-979c-b7c87281ee96.png)
facts
![dates7](https://user-images.githubusercontent.com/109773/30215419-3d3134de-94b0-11e7-8219-ca520964d947.png)
hosts
![dates8](https://user-images.githubusercontent.com/109773/30215420-3d34af1a-94b0-11e7-98a7-120e6aa41de4.png)
report detail
![dates9](https://user-images.githubusercontent.com/109773/30215422-3d3a9394-94b0-11e7-823b-019a907e8198.png)
trends index
![dates10](https://user-images.githubusercontent.com/109773/30215421-3d3b1cb0-94b0-11e7-9a0b-f6d810cebadd.png)
