### PR TITLE
Fixes #20902: ensure 'katello' is webpack bundle name.

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -12,11 +12,12 @@ else
 end
 
 PLUGIN_NAME_REGEXP = /foreman*|katello*/
+REMOVE_BUNDLE_NAME_PLUGINS = /foreman*/
 
 config = { entries: {}, paths: [] }
 specs.each do |dep|
   # skip other rails engines that are not plugins
-  # TOOD: Consider using the plugin registeration api?
+  # TODO: Consider using the plugin registration api?
   if gemfile_in
     next unless dep =~ PLUGIN_NAME_REGEXP
     dep = dep.to_spec
@@ -25,11 +26,11 @@ specs.each do |dep|
   end
   path = "#{dep.to_spec.full_gem_path}/webpack"
   entry = "#{path}/index.js"
-  # some plugings share the same base directory (tasks-core and tasks, REX etc)
+  # some plugins share the same base directory (tasks-core and tasks, REX etc)
   # skip the plugin if its path is already included
   next if config[:paths].include?(path)
   if File.exist?(entry)
-    bundle_name = dep.name.gsub(/-|_|#{PLUGIN_NAME_REGEXP}/,'')
+    bundle_name = dep.name.gsub(/-|_|#{REMOVE_BUNDLE_NAME_PLUGINS}/,'')
     config[:entries][bundle_name] = entry
     config[:paths] << path
   end


### PR DESCRIPTION
We were removing the bundle name for katello and thus making it
difficult to reference the katello bundle.  This commit changes the
script to ensure that the katello bundle name is retained.

http://projects.theforeman.org/issues/20902