### PR TITLE
Fixes #20896 - Remove help button from ptable

### DIFF
--- a/app/views/ptables/index.html.erb
+++ b/app/views/ptables/index.html.erb
@@ -1,7 +1,6 @@
 <% title _("Partition Tables") %>
 <% title_actions new_link(_("Create Partition Table")),
-                 documentation_button('4.4.4PartitionTables'),
-                 help_button %>
+                 documentation_button('4.4.4PartitionTables') %>
 
 <table class="<%= table_css_classes 'table-two-pane table-fixed' %>">
   <thead>


### PR DESCRIPTION
I moved everything in the partition table help page to here:
https://github.com/theforeman/theforeman.org/pull/944