### PR TITLE
Refs #20098 - Remove save expectation for templates_used

### DIFF
--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1252,7 +1252,6 @@ class HostsControllerTest < ActionController::TestCase
     setup do
       @host.setBuild
       ActiveRecord::Base.any_instance.expects(:destroy).never
-      ActiveRecord::Base.any_instance.expects(:save).never
       @attrs = host_attributes(@host)
     end
 


### PR DESCRIPTION
In develop, the original #20098 change worked well because #20708 was
merged before. However in 1.15-stable, there are two tests that call
.save on an ActiveRecord model (Audited). This makes tests fail:

HostsControllerTest::#template_used.test_submit_multiple_rebuild_config_optimistic
HostsControllerTest::#template_used.test_submit_multiple_rebuild_config_pessimistic

http://ci.theforeman.org/view/Core/job/test_1_15_stable/database=sqlite3,ruby=2.2,slave=fast/34/

This PR goes straight to 1.15.4 - no need for this on develop.