### PR TITLE
Fixes #20900 - Combine Template editor and template field

### DIFF
--- a/app/assets/stylesheets/editor.scss
+++ b/app/assets/stylesheets/editor.scss
@@ -8,7 +8,7 @@
   width: 100%;
 }
 
-.navbar-nav.navbar-right.navbar-editor:last-child {
+.navbar-nav.navbar-right.navbar-editor {
   margin-right: 0;
 
   li {

--- a/app/views/common_parameters/_form.html.erb
+++ b/app/views/common_parameters/_form.html.erb
@@ -6,7 +6,7 @@
 
       <div class="col-md-9">
         <div class="editor-container">
-          <%= render :partial => 'editor/toolbar', :locals => {:show_preview => false} %>
+          <%= render :partial => 'editor/toolbar', :locals => { :show_preview => false, :show_import => false} %>
           <% masked = @common_parameter.hidden_value? ? 'masked-input' : '' %>
           <%= f.text_area(:value,
                           :class => "form-control value editor_source #{masked}",

--- a/app/views/editor/_toolbar.html.erb
+++ b/app/views/editor/_toolbar.html.erb
@@ -1,4 +1,5 @@
 <div class="navbar navbar-form navbar-full-width navbar-editor">
+
     <div class="btn-group" data-toggle="buttons" >
       <label class="btn btn-default btn-sm active" onclick="tfm.editor.setCode()">
         <input type="radio" name="options" id="option1" ><%= _("Input") %>
@@ -13,6 +14,12 @@
       <% end %>
     </div>
 
+    <% if show_import %>
+      <a class="btn btn-default btn-sm" onclick="tfm.editor.showImporter()">
+        <%= _("Import") %>
+      </a>
+    <% end %>
+
     <% if show_preview %>
       <%= javascript_tag("$(document).on('ContentLoad', function() { tfm.tools.initTypeAheadSelect($('#preview_host_id')) });"); %>
       <span id="preview_host_selector" style="display:none">
@@ -24,11 +31,11 @@
     <% end %>
 
     <a class="btn btn-default btn-sm btn-fullscreen" href="#" onclick="tfm.editor.enterFullscreen('.editor-container');">
-      <i class="glyphicon glyphicon-resize-full"></i>
+      <%= _('Fullscreen') %>
     </a>
 
     <a class="btn btn-default btn-sm btn-exit-fullscreen hidden" href="#" onclick="tfm.editor.exitFullscreen();">
-      <i class="glyphicon glyphicon-resize-small"></i>
+      <%= _('Exit Fullscreen') %>
     </a>
 
     <ul class="nav navbar-nav navbar-right navbar-editor">
@@ -40,4 +47,8 @@
         <%= select_tag('keybinding', content_tag(:optgroup, options_for_select([_('Default'), 'Vim', 'Emacs']), :label => _('Key Binding')), :class => 'form-control input-sm without_select2') %>
       </li>
     </ul>
+
+    <% if show_import %>
+      <%= file_field_tag :import_file, :class => "hidden editor_file_source", :id => 'import_file' %>
+    <% end %>
 </div>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -38,12 +38,12 @@
 
       <div class='form-group'>
         <div class="col-md-12">
-            <label class="control-label"  for="template"><%= _("Template editor") %></label>
+            <label class="control-label"  for="template"><%= _("Template *") %></label>
         </div>
 
         <div class="col-md-12">
           <div class="editor-container">
-            <%= render :partial => 'editor/toolbar', :locals => {:show_preview => true} %>
+            <%= render :partial => 'editor/toolbar', :locals => { :show_preview => true, :show_import => !@template.locked?} %>
 
             <%= alert :class => 'alert-danger hide', :id => 'preview_error', :close => false %>
             <%= textarea_f f, :template, :class => "editor_source", :label =>:none, :disabled => @template.locked?, :size => "max",
@@ -51,11 +51,6 @@
           </div>
         </div>
       </div>
-
-      <% unless @template.locked? -%>
-        <%= file_field_f f, :template, :class => "editor_file_source",:size => "col-md-10", :id => 'template_file',
-                         :help_block  => _("Selecting a file will override the editor and load the file instead") %>
-      <% end -%>
 
       <%= textarea_f f, :audit_comment, :size => "col-md-10", :rows => 3, :label => _("Audit Comment"),
                      :help_block => _("The Audit Comment field is saved with the template auditing to document the template changes") %>

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -87,6 +87,10 @@ function setMode(mode) {
   session.setMode(mode);
 }
 
+export function showImporter() {
+  $('.editor_file_source').click();
+}
+
 /* eslint-disable max-statements, no-alert */
 function editorFileSource(evt) {
   if (window.File && window.FileList && window.FileReader) {
@@ -110,6 +114,8 @@ function editorFileSource(evt) {
       // Read in the file as text.
       reader.readAsText(f);
       $('.editor_file_source').val('');
+      $('.navbar-editor input[type="radio"]').blur();
+      $('.navbar-editor #option1').click();
     }
   } else {
     // Browser can't read the file content,


### PR DESCRIPTION
To resolve confusion around the template field being required and the template editor, which actually fulfills that this moves the file import into the toolbar as a feature for the editor, that can be turned on and removes the "second" template field.

Before:
![gnome-shell-screenshot-oz3n6y 2](https://user-images.githubusercontent.com/7757/30384976-08b14ba0-98a6-11e7-931a-eca48a7e1f9b.png)

After (in action):

![template-import-demo](https://user-images.githubusercontent.com/7757/30384918-de5e8214-98a5-11e7-9f2f-e6467e89e47b.gif)

