### PR TITLE
Fixes #10726 - NIC types are immutable

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -331,15 +331,15 @@ Return the host's compute attributes that can be used to create a clone of this 
           end
           # map interface types
           params[:interfaces_attributes] = params[:interfaces_attributes].map do |nic_attr|
-            interface_attributes(nic_attr)
+            interface_attributes(nic_attr, allow_nil_type: host.nil?)
           end
         end
         params = host.apply_inherited_attributes(params) if host
         params
       end
 
-      def interface_attributes(params)
-        params[:type] = InterfaceTypeMapper.map(params[:type])
+      def interface_attributes(params, allow_nil_type: false)
+        params[:type] = InterfaceTypeMapper.map(params[:type]) if params.has_key?(:type) || allow_nil_type
         params
       end
 

--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -104,7 +104,9 @@ module Api
       end
 
       def convert_type
-        params[:interface][:type] = InterfaceTypeMapper.map(params[:interface][:type])
+        if params[:action] != 'update' || params[:interface].has_key?(:type)
+          params[:interface][:type] = InterfaceTypeMapper.map(params[:interface][:type])
+        end
       rescue InterfaceTypeMapper::UnknownTypeExeption => e
         render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => e.to_s }
       end

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -35,6 +35,7 @@ module Nic
     validates :ip6, :presence => true, :if => Proc.new { |nic| nic.host_managed? && nic.require_ip6_validation? }
 
     validate :validate_subnet_types
+    validate :validate_updating_types
 
     # Validate that subnet's taxonomies are defined for nic's host
     Taxonomy.enabled_taxonomies.map(&:singularize).map(&:to_sym).each do |taxonomy|
@@ -257,6 +258,11 @@ module Nic
 
     def validate_mac_is_unicast
       errors.add(:mac, _('must be a unicast MAC address')) if Net::Validations.multicast_mac?(mac) || Net::Validations.broadcast_mac?(mac)
+    end
+
+    def validate_updating_types
+      sti_type = self.type || 'Nic::Base'
+      errors.add(:type, _("can't be changed once the interface is saved")) if self.persisted? && (self.class.name != sti_type)
     end
 
     def mac_addresses_for_provisioning

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -56,6 +56,13 @@ class NicTest < ActiveSupport::TestCase
     assert_equal "123.1.2.3", interface.ip
   end
 
+  test "type can't by updated" do
+    interface = FactoryGirl.create(:nic_managed, :host => FactoryGirl.create(:host))
+    interface.type = 'Nic::BMC'
+    interface.valid?
+    assert_includes interface.errors.keys, :type
+  end
+
   test "managed nic should generate progress report uuid" do
     uuid = '710d4a8f-b1b6-47f5-9ef5-5892a19dabcd'
     Foreman.stubs(:uuid).returns(uuid)


### PR DESCRIPTION
- Adds validation of changing NIC types
- Fences out using default type in update actions of Hosts and Interfaces API controller (UI handles this situation with disabling the type select box)