### PR TITLE
Fixes #20957 - Replace alias_method_chain with Module prepend

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -14,14 +14,21 @@ module Foreman::Controller::SmartProxyAuth
       before_action(:only => actions) { require_smart_proxy_or_login(options[:features]) }
       attr_reader :detected_proxy
 
-      define_method(:require_ssl_with_smart_proxy_filters?) do
-        if [actions].flatten.map(&:to_s).include?(self.action_name)
-          false
-        else
-          require_ssl_without_smart_proxy_filters?
-        end
+      cattr_accessor :smart_proxy_filter_actions
+      self.smart_proxy_filter_actions ||= []
+      self.smart_proxy_filter_actions.push(*actions)
+
+      prepend SmartProxyRequireSsl
+    end
+  end
+
+  module SmartProxyRequireSsl
+    def require_ssl?
+      if [self.smart_proxy_filter_actions].flatten.map(&:to_s).include?(self.action_name)
+        false
+      else
+        super
       end
-      alias_method_chain :require_ssl?, :smart_proxy_filters
     end
   end
 

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -4,13 +4,7 @@ class UnattendedController < ApplicationController
   layout false
 
   # We dont require any of these methods for provisioning
-  FILTERS = [:require_login, :session_expiry, :update_activity_time, :set_taxonomy, :authorize]
-  FILTERS.each do |f|
-    define_method("#{f}_with_unattended") do
-      send("#{f}_without_unattended") if preview?
-    end
-    alias_method_chain f, :unattended
-  end
+  skip_before_action :require_login, :session_expiry, :update_activity_time, :set_taxonomy, :authorize, :unless => Proc.new { preview? }
 
   before_action :set_admin_user, :unless => Proc.new { preview? }
   # We want to find out our requesting host

--- a/app/models/concerns/dirty_associations.rb
+++ b/app/models/concerns/dirty_associations.rb
@@ -19,45 +19,47 @@ module DirtyAssociations
     #   class Model
     #     dirty_has_many_associations :organizations, :locations
     def dirty_has_many_associations(*args)
-      args.each do |association|
-        association_ids = association.to_s.singularize + '_ids'
+      extension = Module.new do
+        args.each do |association|
+          association_ids = association.to_s.singularize + '_ids'
 
-        # result for :organizations
-        #   def organization_ids_with_change_detection=(organizations)
-        #     organizations ||= []
-        #     @organization_ids_changed = organizations.uniq.select(&:present?).map(&:to_i).sort != organization_ids.sort
-        #     @organization_ids_was = organization_ids.clone
-        #     self.organization_ids_without_change_detection = organizations
-        #   end
-        define_method "#{association_ids}_with_change_detection=" do |collection|
-          collection ||= [] # in API, #{association}_ids is converted to nil if user sent empty array
-          instance_variable_set("@#{association_ids}_changed", collection.uniq.select(&:present?).map(&:to_i).sort != self.send(association_ids).sort)
-          instance_variable_set("@#{association_ids}_was", self.send(association_ids).clone)
-          self.send("#{association_ids}_without_change_detection=", collection)
-        end
-        alias_method_chain("#{association_ids}=", :change_detection)
+          # result for :organizations
+          #   def organization_ids_with_change_detection=(organizations)
+          #     organizations ||= []
+          #     @organization_ids_changed = organizations.uniq.select(&:present?).map(&:to_i).sort != organization_ids.sort
+          #     @organization_ids_was = organization_ids.clone
+          #     self.organization_ids_without_change_detection = organizations
+          #   end
+          define_method "#{association_ids}=" do |collection|
+            collection ||= [] # in API, #{association}_ids is converted to nil if user sent empty array
+            instance_variable_set("@#{association_ids}_changed", collection.uniq.select(&:present?).map(&:to_i).sort != self.send(association_ids).sort)
+            instance_variable_set("@#{association_ids}_was", self.send(association_ids).clone)
+            super(collection)
+          end
 
-        # result for :organizations
-        #   def organization_ids_changed?
-        #     @organization_ids_changed
-        #   end
-        define_method "#{association_ids}_changed?" do
-          instance_variable_get("@#{association_ids}_changed")
-        end
+          # result for :organizations
+          #   def organization_ids_changed?
+          #     @organization_ids_changed
+          #   end
+          define_method "#{association_ids}_changed?" do
+            instance_variable_get("@#{association_ids}_changed")
+          end
 
-        # result for :organizations
-        #   def organization_ids_was
-        #     @organization_ids_was ||= organization_ids
-        #   end
-        define_method "#{association_ids}_was" do
-          value = instance_variable_get("@#{association_ids}_was")
-          if value.nil?
-            instance_variable_set("@#{association_ids}_was", self.send(association_ids))
-          else
-            value
+          # result for :organizations
+          #   def organization_ids_was
+          #     @organization_ids_was ||= organization_ids
+          #   end
+          define_method "#{association_ids}_was" do
+            value = instance_variable_get("@#{association_ids}_was")
+            if value.nil?
+              instance_variable_set("@#{association_ids}_was", self.send(association_ids))
+            else
+              value
+            end
           end
         end
       end
+      self.prepend(extension)
     end
   end
 end

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -46,7 +46,7 @@ if Foreman::Model::Openstack.available?
   require 'fog/compute/openstack'
   Fog::Compute::OpenStack::Real.send(:include, FogExtensions::Openstack::Core)
   require 'fog/compute/openstack/models/server'
-  Fog::Compute::OpenStack::Server.send(:include, FogExtensions::Openstack::Server)
+  Fog::Compute::OpenStack::Server.send(:prepend, FogExtensions::Openstack::Server)
   require 'fog/compute/openstack/models/flavor'
   Fog::Compute::OpenStack::Flavor.send(:include, FogExtensions::Openstack::Flavor)
 end

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -1,13 +1,12 @@
 module FogExtensions
   module Openstack
     module Server
-      extend ActiveSupport::Concern
-
-      included do
-        alias_method_chain :security_groups, :no_id
-        attr_reader :nics
-        attr_accessor :boot_from_volume, :size_gb, :scheduler_hint_filter
-        attr_writer :security_group, :network # floating IP
+      def self.prepended(base)
+        class << base
+          attr_reader :nics
+          attr_accessor :boot_from_volume, :size_gb, :scheduler_hint_filter
+          attr_writer :security_group, :network # floating IP
+        end
       end
 
       def to_s
@@ -43,10 +42,9 @@ module FogExtensions
       end
 
       # the original method requires a server ID, however we want to be able to call this method on new instances too
-      def security_groups_with_no_id
+      def security_groups
         return [] if id.nil?
-
-        security_groups_without_no_id
+        super
       end
 
       def boot_from_volume

--- a/app/models/concerns/fog_extensions/ovirt/server.rb
+++ b/app/models/concerns/fog_extensions/ovirt/server.rb
@@ -7,18 +7,8 @@ module FogExtensions
 
       attr_accessor :image_id
 
-      # locked_with_refresh? is only needed until 1989e915ff9487fb5fbfd3dae1964db4c289cb1f is included in fog release (1.23)
-      included do
-        alias_method_chain :locked?, :refresh
-      end
-
       def to_s
         name
-      end
-
-      def locked_with_refresh?
-        @volumes = nil # force reload volumes
-        locked_without_refresh?
       end
 
       def state

--- a/app/models/concerns/foreman/sti.rb
+++ b/app/models/concerns/foreman/sti.rb
@@ -1,17 +1,14 @@
 module Foreman
   module STI
-    extend ActiveSupport::Concern
-
-    included do
-      singleton_class.class_eval do
-        alias_method_chain :new, :cast
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
       end
-      alias_method_chain :save, :type
     end
 
     module ClassMethods
       # ensures that the correct STI object is created when :type is passed.
-      def new_with_cast(*attributes, &block)
+      def new(*attributes, &block)
         if (h = attributes.first).is_a?(Hash) && (type = h.with_indifferent_access.delete(:type)) && !type.empty?
           if (klass = type.constantize) != self
             raise "Invalid type #{type}" unless klass <= self
@@ -19,14 +16,14 @@ module Foreman
           end
         end
 
-        new_without_cast(*attributes, &block)
+        super
       end
     end
 
-    def save_with_type(*args)
+    def save(*args)
       type_changed = self.type_changed?
       self.class.instance_variable_set("@finder_needs_type_condition", :false) if type_changed
-      save_without_type(*args)
+      super
     ensure
       self.class.instance_variable_set("@finder_needs_type_condition", :true) if type_changed
     end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -1,6 +1,6 @@
 module Host
   class Base < ApplicationRecord
-    include Foreman::STI
+    prepend Foreman::STI
     include Authorizable
     include Parameterizable::ByName
     include DestroyFlag

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -1,6 +1,6 @@
 module HostStatus
   class Status < ApplicationRecord
-    include Foreman::STI
+    prepend Foreman::STI
 
     self.table_name = 'host_status'
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -2,7 +2,7 @@
 # This class is the both parent
 module Nic
   class Base < ApplicationRecord
-    include Foreman::STI
+    prepend Foreman::STI
     include Encryptable
     encrypts :password
 

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -31,14 +31,13 @@ module Nic
 
     # this ensures we can create an interface even when there is no host queue
     # e.g. outside to Host nested attributes
-    def queue_with_host
+    def queue
       if host && host.respond_to?(:queue)
         host.queue
       else
-        queue_without_host
+        super
       end
     end
-    alias_method_chain :queue, :host
 
     def progress_report_id
       if host && host.respond_to?(:progress_report_id)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,7 +1,7 @@
 class Report < ApplicationRecord
   LOG_LEVELS = %w[debug info notice warning err alert emerg crit]
 
-  include Foreman::STI
+  prepend Foreman::STI
   include Authorizable
   include ConfigurationStatusScopedSearch
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -7,7 +7,7 @@ class Subnet < ApplicationRecord
   BOOT_MODES = {:static => N_('Static'), :dhcp => N_('DHCP')}
 
   include Authorizable
-  include Foreman::STI
+  prepend Foreman::STI
   extend FriendlyId
   friendly_id :name
   include Taxonomix
@@ -279,12 +279,11 @@ class Subnet < ApplicationRecord
     end
 
     # This casts Subnet to Subnet::Ipv4 if no type is set
-    def new_with_default_type(*attributes, &block)
+    def new(*attributes, &block)
       type = attributes.first.with_indifferent_access.delete(:type) if attributes.first.is_a?(Hash)
-      return Subnet::Ipv4.new_without_cast(*attributes, &block) if self == Subnet && type.nil?
-      new_without_default_type(*attributes, &block)
+      return Subnet::Ipv4.new(*attributes, &block) if self == Subnet && type.nil?
+      super
     end
-    alias_method_chain :new, :default_type
 
     # allows to create a specific subnet class based on the network_type.
     # network_type is more user friendly than the class names

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -7,50 +7,15 @@
     removed in Rails 5.2.
   callstack: config/routes.rb:19:in `block in <top (required)>'
 # Caused by turbolinks (classic) dependency
+- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
+    module, you can access the original method using super.
+  callstack: config/environment.rb:5:in `<top (required)>'
 - message: after_filter is deprecated and will be removed in Rails 5.1. Use after_action
     instead.
   callstack: config/environment.rb:5:in `<top (required)>'
 - message: before_filter is deprecated and will be removed in Rails 5.1. Use before_action
     instead.
   callstack: config/environment.rb:5:in `<top (required)>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/controllers/concerns/foreman/controller/smart_proxy_auth.rb:24:in
-    `add_smart_proxy_filters'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/controllers/unattended_controller.rb:12:in `block in <class:UnattendedController>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/dirty_associations.rb:38:in `block in dirty_has_many_associations'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/fog_extensions/openstack/server.rb:7:in `block in
-    <module:Server>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/fog_extensions/ovirt/server.rb:12:in `block in <module:Server>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/foreman/sti.rb:7:in `block (2 levels) in <module:STI>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/foreman/sti.rb:9:in `block in <module:STI>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/nic/managed.rb:44:in `<class:Managed>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/subnet.rb:287:in `singleton class'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: app/models/concerns/facets/managed_host_extensions.rb:51:in `block in register_facet_relation'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: config/environment.rb:5:in `<top (required)>'
-- message: alias_method_chain is deprecated. Please, use Module#prepend instead. From
-    module, you can access the original method using super.
-  callstack: config/initializers/rabl_init.rb:23:in `<class:Engine>'
 
 # Not a "true" deprecation, no action required, it's being used correctly.
 - message: "#table_exists? currently checks both tables and views. This behavior is

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -6,8 +6,10 @@ module Rabl
     attr_accessor :use_controller_name_as_json_root
     attr_accessor :json_root_default_name
   end
+end
 
-  class Engine
+module Foreman
+  module RablEngineExt
     def api_version
       respond_to?(:response) ? response.headers["Foreman_api_version"] : '1'
     end
@@ -17,10 +19,9 @@ module Rabl
       {}
     end
 
-    def collection_with_defaults(data, options = default_options)
-      collection_without_defaults(data, options)
+    def collection(data, options = default_options)
+      super(data, options)
     end
-    alias_method_chain :collection, :defaults
 
     # extending this helper defined in module Rabl::Helpers allows users to
     # overwrite the object root name in show rabl views.  Two options:
@@ -36,6 +37,7 @@ module Rabl
     end
   end
 end
+Rabl::Engine.send(:prepend, Foreman::RablEngineExt)
 
 Rabl.configure do |config|
   # Commented as these are defaults

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1318,27 +1318,30 @@ class HostsControllerTest < ActionController::TestCase
     assert_template :partial => '_form'
   end
 
-  def test_submit_multiple_rebuild_config_optimistic
-    @request.env['HTTP_REFERER'] = hosts_path
-    Host.any_instance.expects(:recreate_config).returns({"TFTP" => true, "DHCP" => true, "DNS" => true})
-    h = as_admin { FactoryGirl.create(:host) }
+  context 'test submit multiple rebuild config' do
+    def test_submit_multiple_rebuild_config_optimistic
+      @request.env['HTTP_REFERER'] = hosts_path
+      Host.any_instance.expects(:recreate_config).returns({"TFTP" => true, "DHCP" => true, "DNS" => true})
+      h = as_admin {FactoryGirl.create(:host)}
 
-    post :submit_rebuild_config, {:host_ids => [h.id]}, set_session_user
+      post :submit_rebuild_config, {:host_ids => [h.id]}, set_session_user
 
-    assert_response :found
-    assert_redirected_to hosts_path
-    assert_not_nil flash[:notice]
-  end
+      assert_response :found
+      assert_redirected_to hosts_path
+      assert_not_nil flash[:notice]
+    end
 
-  def test_submit_multiple_rebuild_config_pessimistic
-    @request.env['HTTP_REFERER'] = hosts_path
-    Host.any_instance.expects(:recreate_config).returns({"TFTP" => false, "DHCP" => false, "DNS" => false})
-    h = as_admin { FactoryGirl.create(:host) }
-    post :submit_rebuild_config, {:host_ids => [h.id]}, set_session_user
+    def test_submit_multiple_rebuild_config_pessimistic
+      @request.env['HTTP_REFERER'] = hosts_path
+      Host.any_instance.expects(:recreate_config).returns({"TFTP" => false, "DHCP" => false, "DNS" => false})
+      h = as_admin {FactoryGirl.create(:host)}
 
-    assert_response :found
-    assert_redirected_to hosts_path
-    assert_not_nil flash[:error]
+      post :submit_rebuild_config, {:host_ids => [h.id]}, set_session_user
+
+      assert_response :found
+      assert_redirected_to hosts_path
+      assert_not_nil flash[:error]
+    end
   end
 
   context 'openstack-fog.mock!' do


### PR DESCRIPTION
Deprecated in Rails 5.0 and will be removed in 5.1. Some instances of
classes overwriting existing methods can be handled with `super`, other
concerns or modules are changed to use prepend instead of include.

Note: no ActiveSupport::Concern support for prepends, so load class
methods the pure Ruby way.