### PR TITLE
Fixes #19912 - Allow all styles of word arrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,3 +50,7 @@ Performance/RedundantMerge:
 
 Rails/Blank:
   UnlessPresent: false
+
+#Allow both ['a', 'b'], %w[a b] and %w(a b) style arrays
+Style/WordArray:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -818,9 +818,3 @@ Style/UnlessElse:
 Style/VariableNumber:
   Enabled: false
 
-# Offense count: 313
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  Enabled: false


### PR DESCRIPTION
Following discussion in GH-4603 we should permanently disable this cop.