### PR TITLE
Fixes #20966 - Added fast return to host power api

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -251,6 +251,10 @@ Return the host's compute attributes that can be used to create a clone of this 
       param :power_action, String, :required => true, :desc => N_("power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)")
 
       def power
+        unless @host.supports_power?
+          return render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => _('Power operations are not enabled on this host.') }
+        end
+
         valid_actions = PowerManager::SUPPORTED_ACTIONS
         if valid_actions.include? params[:power_action]
           render :json => { :power => @host.power.send(params[:power_action]) }, :status => :ok


### PR DESCRIPTION
If the host does not support power actions (no BMC and the VM does not support it - return `unprocessable_entity` and exit with a message.