### PR TITLE
Fixes #20940 - Interfaces shows extra fields in API /api/hosts/id

### DIFF
--- a/app/views/api/v2/interfaces/base.json.rabl
+++ b/app/views/api/v2/interfaces/base.json.rabl
@@ -1,6 +1,6 @@
 object @interface
 
-attributes :id, :name, :ip, :ip6, :mac, :fqdn, :identifier, :primary, :provision
+attributes :id, :name, :ip, :ip6, :mac, :fqdn, :identifier, :managed, :primary, :provision, :virtual, :created_at, :updated_at, :domain_id, :domain_name, :subnet_id, :subnet_name
 node :type do |i|
   next if i.is_a? Symbol
   i.class.humanized_name.downcase


### PR DESCRIPTION
This fix is to have a consistency between REST API `/api/hosts/:id` and `/api/hosts/:id/interfaces` where many important flags such as `managed`, `virtual`  are hidden in the former call and shows additional details in interfaces API call.
