### PR TITLE
Fixes #21026 - Clear cached notifications properly

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,7 +15,7 @@ class Notification < ApplicationRecord
   belongs_to :notification_blueprint
   belongs_to :initiator, :class_name => 'User', :foreign_key => 'user_id'
   belongs_to :subject, :polymorphic => true
-  has_many :notification_recipients, :dependent => :delete_all
+  has_many :notification_recipients, :dependent => :destroy
   has_many :recipients, :class_name => 'User', :through => :notification_recipients, :source => :user
   store :actions, :accessors => [:links], :coder => JSON
 

--- a/app/models/notification_recipient.rb
+++ b/app/models/notification_recipient.rb
@@ -7,7 +7,7 @@ class NotificationRecipient < ApplicationRecord
   validates :user, :presence => true
 
   scope :unseen, -> { where(:seen => false) }
-  after_save :delete_user_cache
+  after_commit :delete_user_cache
 
   def payload
     {

--- a/app/services/ui_notifications/cache_handler.rb
+++ b/app/services/ui_notifications/cache_handler.rb
@@ -22,6 +22,7 @@ module UINotifications
     end
 
     def clear
+      logger.debug("Clearing Cache: notification, clearing cache for #{cache_key}")
       cache.delete(cache_key)
     end
 

--- a/test/models/notification_recipient_test.rb
+++ b/test/models/notification_recipient_test.rb
@@ -13,4 +13,11 @@ class NotificationRecipientTest < ActiveSupport::TestCase
     id = FactoryGirl.create(:notification_recipient).id
     assert NotificationRecipient.unseen.pluck(:id).include?(id)
   end
+
+  test "destroying triggers clearing user cache" do
+    recipient = FactoryGirl.create(:notification_recipient)
+    UINotifications::CacheHandler.any_instance
+                                 .expects(:clear)
+    recipient.destroy
+  end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -9,6 +9,8 @@ class NotificationTest < ActiveSupport::TestCase
   should validate_presence_of(:notification_blueprint)
   should validate_presence_of(:audience)
 
+  should have_many(:notification_recipients).dependent(:destroy)
+
   test 'should be able to create notification' do
     blueprint = FactoryGirl.create(
       :notification_blueprint,


### PR DESCRIPTION
Using `delete_all` for has_many does not trigger callbacks
on the associated objects, `dependent: :destroy` does.

Clearing the cache needs to happen anytime a notification
gets created, modified and destroyed, `after_commit` will
be triggered on all o these occasions.