### PR TITLE
Fixes #21037 - use Host::Base as auditable_type

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -64,9 +64,13 @@ module Api
 
       return resource_class.where(nil) unless scope
 
-      association = resource_class.reflect_on_all_associations.find {|assoc| assoc.plural_name == parent_name.pluralize}
+      association = resource_class.reflect_on_all_associations.detect {|assoc| assoc.plural_name == parent_name.pluralize}
       #if couldn't find an association by name, try to find one by class
-      association ||= resource_class.reflect_on_all_associations.find {|assoc| assoc.class_name == parent_name.camelize}
+      association ||= resource_class.reflect_on_all_associations.detect {|assoc| assoc.class_name == parent_name.camelize}
+      if association.nil? && parent_name == 'host'
+        association = resource_class.reflect_on_all_associations.detect {|assoc| assoc.class_name == 'Host::Base'}
+      end
+      raise "Association not found for #{parent_name}" unless association
       result_scope = resource_class_join(association, scope)
       # Check that the scope resolves before return
       result_scope if result_scope.to_a

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -1,5 +1,5 @@
 module AuditsHelper
-  MAIN_OBJECTS = %w(Host Hostgroup User Operatingsystem Environment Puppetclass Parameter Architecture ComputeResource ProvisioningTemplate ComputeProfile ComputeAttribute
+  MAIN_OBJECTS = %w(Host::Base Hostgroup User Operatingsystem Environment Puppetclass Parameter Architecture ComputeResource ProvisioningTemplate ComputeProfile ComputeAttribute
                     Location Organization Domain Subnet SmartProxy AuthSource Image Role Usergroup Bookmark ConfigGroup Ptable)
 
   # lookup the Model representing the numerical id and return its label
@@ -129,6 +129,8 @@ module AuditsHelper
 
   def audited_type(audit)
     type_name = case audit.auditable_type
+                  when 'Host::Base'
+                    'Host'
                   when 'HostClass'
                     'Puppet Class'
                   when 'Parameter'
@@ -161,6 +163,7 @@ module AuditsHelper
   private
 
   def main_object?(audit)
+    return true if MAIN_OBJECTS.include?(audit.auditable_type)
     type = audit.auditable_type.split("::").last rescue ''
     MAIN_OBJECTS.include?(type)
   end

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -103,8 +103,8 @@ module AuditExtensions
 
   def fix_auditable_type
     # STI Host class should use the stub module instead of Host::Base
-    self.auditable_type = "Host::Base"          if auditable_type =~  /Host::/
-    self.associated_type = "Host::Base"         if associated_type =~ /Host::/
+    self.auditable_type = "Host::Base" if auditable_type =~  /Host::/
+    self.associated_type = "Host::Base" if associated_type =~ /Host::/
     self.auditable_type = auditable.type if ["Taxonomy", "LookupKey"].include?(auditable_type) && auditable
     self.associated_type = associated.type if ["Taxonomy", "LookupKey"].include?(associated_type) && associated
   end

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -13,7 +13,7 @@ module AuditExtensions
         :compute_resource => 'ComputeResource',
         :config_group => 'ConfigGroup',
         :domain => 'Domain',
-        :host => 'Host',
+        :host => 'Host::Base',
         :hostgroup => 'Hostgroup',
         :image => 'Image',
         :location => 'Location',
@@ -40,8 +40,8 @@ module AuditExtensions
 
     belongs_to :user, :class_name => 'User'
     belongs_to :search_users, :class_name => 'User', :foreign_key => :user_id
-    belongs_to :search_hosts, -> { where(:audits => { :auditable_type => 'Host' }) },
-      :class_name => 'Host', :foreign_key => :auditable_id
+    belongs_to :search_hosts, -> { where(:audits => { :auditable_type => 'Host::Base' }) },
+      :class_name => 'Host::Base', :foreign_key => :auditable_id
     belongs_to :search_hostgroups, :class_name => 'Hostgroup', :foreign_key => :auditable_id
     belongs_to :search_parameters, :class_name => 'Parameter', :foreign_key => :auditable_id
     belongs_to :search_templates, :class_name => 'ProvisioningTemplate', :foreign_key => :auditable_id
@@ -103,8 +103,8 @@ module AuditExtensions
 
   def fix_auditable_type
     # STI Host class should use the stub module instead of Host::Base
-    self.auditable_type = "Host"          if auditable_type =~  /Host::/
-    self.associated_type = "Host"         if associated_type =~ /Host::/
+    self.auditable_type = "Host::Base"          if auditable_type =~  /Host::/
+    self.associated_type = "Host::Base"         if associated_type =~ /Host::/
     self.auditable_type = auditable.type if ["Taxonomy", "LookupKey"].include?(auditable_type) && auditable
     self.associated_type = associated.type if ["Taxonomy", "LookupKey"].include?(associated_type) && associated
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -154,7 +154,7 @@ class Host::Managed < Host::Base
   audited :except => [:last_report, :last_compile, :lookup_value_matcher]
   has_associated_audits
   #redefine audits relation because of the type change (by default the relation will look for auditable_type = 'Host::Managed')
-  has_many :audits, -> { where(:auditable_type => 'Host') }, :foreign_key => :auditable_id,
+  has_many :audits, -> { where(:auditable_type => 'Host::Base') }, :foreign_key => :auditable_id,
     :class_name => 'Audited::Audit'
 
   # some shortcuts

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -3,7 +3,7 @@
 <%= title_actions link_to_if_authorized(_("Host details"),
                                         hash_for_host_path(:id => @audit.auditable.to_param).merge(:auth_object => @audit.auditable, :auth_action => 'view'),
                                         :title => _("Host details"),
-                                        :class => 'btn btn-info') if @audit.auditable_type == 'Host' && @audit.auditable %>
+                                        :class => 'btn btn-info') if @audit.auditable_type == 'Host::Base' && @audit.auditable %>
 <%= title_actions link_to 'Back', :back, :class=>'btn btn-default' %>
 <% tmplt = audit_template?(@audit) %>
 

--- a/db/migrate/20170920211135_fix_host_auditable_type.rb
+++ b/db/migrate/20170920211135_fix_host_auditable_type.rb
@@ -1,0 +1,9 @@
+class FixHostAuditableType < ActiveRecord::Migration
+  def up
+    Audit.where(:auditable_type => 'Host').update_all(:auditable_type => 'Host::Base')
+  end
+
+  def down
+    Audit.where(:auditable_type => 'Host::Base').update_all(:auditable_type => 'Host')
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2251,7 +2251,8 @@ class HostTest < ActiveSupport::TestCase
         def to_managed!
           host       = self.becomes(::Host::Managed)
           host.type  = 'Host::Managed'
-          host.build = true
+          host.name  = "#{host.name}-Managed"
+          host.save
           host
         end
       end


### PR DESCRIPTION
Otherwise, we are hitting "Invalid single-table inheritance type:
Host::Discovered is not a subclass of Host::Managed" when converting the
host from discovered to managed.