### PR TITLE
Fixes #21055 - use _id attributes for host taxonomy validator

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -284,7 +284,7 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    logger.info "Failed to save: #{hash[:object].errors.full_messages.join(', ')}" if hash[:object].respond_to?(:errors)
+    logger.error "Failed to save: #{hash[:object].errors.full_messages.join(', ')}" if hash[:object].respond_to?(:errors)
     hash[:error_msg] ||= [hash[:object].errors[:base] + hash[:object].errors[:conflict].map{|e| _("Conflict - %s") % e}].flatten
     hash[:error_msg] = [hash[:error_msg]].flatten.to_sentence
     if hash[:render]

--- a/app/validators/belongs_to_host_taxonomy_validator.rb
+++ b/app/validators/belongs_to_host_taxonomy_validator.rb
@@ -13,7 +13,8 @@ class BelongsToHostTaxonomyValidator < ActiveModel::EachValidator
 
     return if host_taxonomy.nil? && attribute_taxonomies.empty?
 
-    record.errors.add(attribute, _("is not defined for host's %s.") % _(taxonomy)) unless include_or_empty?(attribute_taxonomies, host_taxonomy)
+    attribute_name = attribute.to_s.end_with?('_id') ? attribute : "#{attribute}_id"
+    record.errors.add(attribute_name, _("is not defined for host's %s") % _(taxonomy)) unless include_or_empty?(attribute_taxonomies, host_taxonomy)
   end
 
   private

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -135,8 +135,8 @@ class NicTest < ActiveSupport::TestCase
       nic.subnet6 = subnet6
 
       refute nic.valid?, "Can't be valid with mismatching taxonomy: #{nic.errors.messages}"
-      assert_includes nic.errors.keys, :subnet
-      assert_includes nic.errors.keys, :subnet6
+      assert_includes nic.errors.keys, :subnet_id
+      assert_includes nic.errors.keys, :subnet6_id
     end
   end
 


### PR DESCRIPTION
Otherwise, the error messages are not visible.

Also log the host error messages as `error` instead of `info`, as it
should be more appropriate for this case.