### PR TITLE
Fixes #21086 - revert roadie-rails pinning for Ruby <2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'activerecord-session_store', '>= 1.1.0', '< 2'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails', '~> 3.0'
 gem 'responders', '~> 2.0'
-gem 'roadie-rails', '>= 1.1', (RUBY_VERSION < '2.2' ? '< 1.2' : '< 2')
+gem 'roadie-rails', '~> 1.1'
 gem 'x-editable-rails', '~> 1.5.5'
 gem 'deacon', '~> 1.0'
 gem 'webpack-rails', '~> 0.9.8'


### PR DESCRIPTION
This reverts commit 76dd13f7b99c3687629b02383041fbfcda9c969e.