### PR TITLE
dnm - load dynflow via Procfile in development

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,4 @@
 rails: [ -n "$RAILS_STARTUP" ] && env PRY_WARNING=1 $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || env PRY_WARNING=1 bin/rails server
 # you can use WEBPACK_OPTS to customize webpack server, e.g. 'WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start '
 webpack: ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS
+dynflow: bin/rake dynflow:executor

--- a/config/application.rb
+++ b/config/application.rb
@@ -256,6 +256,7 @@ module Foreman
     config.after_initialize do
       dynflow = Rails.application.dynflow
       dynflow.eager_load_actions!
+      dynflow.config.remote = false
       dynflow.config.increase_db_pool_size
 
       unless dynflow.config.lazy_initialization

--- a/lib/tasks/dynflow.rake
+++ b/lib/tasks/dynflow.rake
@@ -4,7 +4,7 @@ In development mode, the Dynflow executor is part of the web server process. How
 
 The executor process needs to be executed before the web server. You can run it by:
 
-  foreman-rake foreman_tasks:dynflow:executor
+  foreman-rake dynflow:executor
 
 END_DESC
   task :executor => :environment do


### PR DESCRIPTION
I was always bothered by the fact that dynflow works in the same
process as foreman (in dev mode), this patch allows to load dynflow
as a seperate proccess instead.

the motiviation is to stop loading all of the gems all the time in
both foreman and dynflow, where they are not really required in many
cases, for example, dynflow doesn't need all of our UI/API, doesn't
require mime types or safemode etc - all of which consume a lot of
memory and adds a lot of startup time.

I'm pretty sure my implementation is wrong, and also looking
for ack/nack/comments in general for this approch.