### PR TITLE
Refs #19050 - Use Rails 4.2 on Ruby 2.3

### DIFF
--- a/config/boot_settings.rb
+++ b/config/boot_settings.rb
@@ -7,5 +7,5 @@ SETTINGS = File.exist?(dist_settings_file) ? YAML.load(ERB.new(File.read(dist_se
 settings_file = File.expand_path('../settings.yaml', __FILE__)
 settings = YAML.load(ERB.new(File.read(settings_file)).result)
 SETTINGS[:rails] = settings[:rails] if settings[:rails]
-SETTINGS[:rails] ||= RUBY_VERSION < '2.3' ? '4.2' : '5.0'
+SETTINGS[:rails] ||= RUBY_VERSION < '2.4' ? '4.2' : '5.0'
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value


### PR DESCRIPTION
This unbreaks Ubuntu/xenial and Debian/stretch nightlies