### PR TITLE
Fixes #21162 - Handles any error thrown while connecting via ssh

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -72,21 +72,19 @@ class Foreman::Provision::SSH
   end
 
   def initiate_connection!
-    begin
-      Timeout.timeout(360) do
-        begin
-          Timeout.timeout(8) do
-            ssh.run('pwd')
-          end
-        rescue => e
-          logger.debug "Error occured while connecting \"#{e.inspect}\", retrying"
-          sleep(2)
-          retry
+    Timeout.timeout(360) do
+      begin
+        Timeout.timeout(8) do
+          ssh.run('pwd')
         end
+      rescue => e
+        logger.debug "Error occured while connecting \"#{e.inspect}\", retrying"
+        sleep(2)
+        retry
       end
-    rescue => e
-      Foreman::Logging.exception("Error connecting over SSH, reached max timeout of 360 seconds", e)
     end
+  rescue => e
+    Foreman::Logging.exception("Error connecting over SSH, reached max timeout of 360 seconds", e)
   end
 
   def ssh

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -81,14 +81,13 @@ class Foreman::Provision::SSH
         rescue => e
           logger.debug "Error occured while connecting \"#{e.inspect}\", retrying"
           sleep(2)
-          retry 
+          retry
         end
       end
     rescue => e
       Foreman::Logging.exception("Error connecting over SSH, reached max timeout of 360 seconds", e)
     end
   end
-
 
   def ssh
     Fog::SSH.new(address, username, options.merge(:timeout => 4))

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -78,13 +78,14 @@ class Foreman::Provision::SSH
           ssh.run('pwd')
         end
       rescue => e
-        logger.debug "Error occured while connecting \"#{e.inspect}\", retrying"
+        logger.info "An error occured while connecting before timeout occured \"#{e.inspect}\", retrying"
+        logger.debug "Full stacktrace of exception: \n  #{e.backtrace.join("\n  ")}"
         sleep(2)
         retry
       end
     end
-  rescue => e
-    Foreman::Logging.exception("Error connecting over SSH, reached max timeout of 360 seconds", e)
+  rescue Timeout::Error
+    Foreman::Logging.exception("Error connecting over SSH, reached max timeout of 360 seconds")
   end
 
   def ssh


### PR DESCRIPTION
Removes unnecessary rescue/debug messages and handles all exceptions the same until the timeout occurs. This ensures that we attempt to connect until the complete timeout occurs. 