### PR TITLE
Fixes #21160: Upgrade to React@16

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Foreman isn't really a node module, these are just dependencies needed to build the webpack bundle. 'dependencies' are the asset libraries in use and 'devDependencies' are used for the build process.",
   "private": true,
   "devDependencies": {
-    "@storybook/addon-actions": "^3.1.8",
-    "@storybook/react": "^3.1.8",
+    "@storybook/addon-actions": "^3.2.12",
+    "@storybook/react": "^3.2.12",
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.26.0",
@@ -23,8 +23,8 @@
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",
     "enzyme": "^3.0.0",
-    "enzyme-adapter-react-15": "^1.0.0",
     "enzyme-to-json": "^3.0.1",
+    "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
     "expose-loader": "~0.6.0",
@@ -35,7 +35,7 @@
     "nock": "^9.0.14",
     "node-sass": "^4.5.0",
     "react-addons-test-utils": "^15.3.1",
-    "react-test-renderer": "^15.5.4",
+    "react-test-renderer": "^16.0.0",
     "redux-mock-store": "^1.2.2",
     "sass-loader": "~6.0.6",
     "style-loader": "^0.13.1",
@@ -65,9 +65,10 @@
     "lodash": "~4.15.0",
     "multiselect": "~0.9.12",
     "prop-types": "^15.6.0",
-    "react": "^15.6.2",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
     "react-bootstrap": "^0.31.0",
-    "react-dom": "^15.6.2",
+    "react-dom": "^16.0.0",
     "react-numeric-input": "^2.0.7",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
@@ -119,6 +120,9 @@
       "node_modules",
       "webpack",
       "script"
+    ],
+    "setupFiles": [
+      "raf/polyfill"
     ]
   }
 }

--- a/webpack/assets/javascripts/react_app/components/common/Alert/Alert.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/Alert.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./');

--- a/webpack/assets/javascripts/react_app/components/common/Loader.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Loader.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./Loader');

--- a/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./MessageBox');

--- a/webpack/assets/javascripts/react_app/components/common/Panel/Panel.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Panel/Panel.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./Panel');

--- a/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./Chart');

--- a/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/common/forms/Actions.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Actions.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/common/forms/Button.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Button.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/common/forms/Form.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Form.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/common/forms/TextField.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/TextField.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./');

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./ChartBox');

--- a/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
@@ -1,6 +1,6 @@
 // Configure Enzyme
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 jest.unmock('./');


### PR DESCRIPTION
The current Foreman code is compliant with React@15.6.2
which means everything should work with React@16.

I've looked through all the npm peer dependency errors
and made a status report for each:

- react-komposer - PR open [here](https://github.com/arunoda/react-komposer/pull/169)
- radium - PR open [here](https://github.com/FormidableLabs/radium/pull/930)
- react-addons-test-utils - moved to `react-dom/test-utils`
- react-icons - PR open [here](https://github.com/gorangajic/react-icons/pull/117)
- react-modal - No pending PR - likely a good idea to use a package that utilizes the React@16 portal functionality. [this may work](https://www.npmjs.com/package/react-portal)
- react-simple-di - PR open [here](https://github.com/kadirahq/react-simple-di/pull/13)
- react-test-renderer - This is part of React itself
- react-transition-group - Upgraded to 1.2.1 to support React@16
- react-treebeard - 2.0.3 should accept React@16. not sure why we're getting a peer dependency error
- react-stubber - PR open [here](https://github.com/kadirahq/react-stubber/pull/4)

http://projects.theforeman.org/issues/21160