### PR TITLE
Fixes #21175 - Unable to add AD LDAP Auth Source

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -168,6 +168,7 @@ class AuthSourceLdap < AuthSource
 
   def sanitize_use_netgroups
     self.use_netgroups = false if server_type.to_s == 'active_directory'
+    true
   end
 
   def set_defaults

--- a/test/models/auth_sources/auth_source_ldap_test.rb
+++ b/test/models/auth_sources/auth_source_ldap_test.rb
@@ -48,6 +48,14 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     assert_equal "following spaces", @auth_source_ldap.attr_mail
   end
 
+  test "it enforces use_netgroups to false for active directory" do
+    @auth_source_ldap.use_netgroups = true
+    @auth_source_ldap.server_type = :active_directory
+
+    assert @auth_source_ldap.valid?
+    refute @auth_source_ldap.use_netgroups
+  end
+
   test "return nil if login is blank or password is blank" do
     assert_nil @auth_source_ldap.authenticate("", "")
   end


### PR DESCRIPTION
The before validation callback `sanitize_use_netgroups` was returning `false` which made the record invalid without any errors.