### PR TITLE
Fixes #21179: Upgrade to enzyme@3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "compression-webpack-plugin": "~0.3.1",
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",
-    "enzyme": "^2.4.1",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-15": "^1.0.0",
+    "enzyme-to-json": "^3.0.1",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
     "expose-loader": "~0.6.0",
@@ -80,6 +82,7 @@
     "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ || exit 0",
     "test": "node node_modules/.bin/jest",
     "test:watch": "node node_modules/.bin/jest --watchAll",
+    "test:current": "node node_modules/.bin/jest --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages"

--- a/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
@@ -1,3 +1,8 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./');
 
 import React from 'react';

--- a/webpack/assets/javascripts/react_app/components/common/Loader.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Loader.test.js
@@ -1,7 +1,13 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./Loader');
 
 import React from 'react';
 import {shallow, mount} from 'enzyme';
+import toJson from 'enzyme-to-json';
 import Loader from './Loader';
 import {STATUS} from '../../constants';
 
@@ -24,37 +30,31 @@ describe('Loader', () => {
     it('success', () => {
       const wrapper = setup(STATUS.RESOLVED);
 
-      expect(wrapper.children().length).toBe(1);
-      expect(wrapper.children().equals(<div key="0" className="success">Success</div>)).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('failure', () => {
       const wrapper = setup(STATUS.ERROR);
 
-      expect(wrapper.children().length).toBe(1);
-      expect(wrapper.children().equals(<div key="1" className="failure">Failure</div>)).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('pending', () => {
       const wrapper = setup(STATUS.PENDING);
 
-      expect(wrapper.children().length).toBe(1);
-      expect(wrapper.children().equals(<div className="spinner spinner-lg"></div>)).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('pending-different-spinner', () => {
       const wrapper = setup(STATUS.PENDING, 'xs');
 
-      expect(wrapper.children().length).toBe(1);
-      expect(wrapper.children().equals(<div className="spinner spinner-xs"></div>)).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('default case', () => {
-      const wrapper = mount(<Loader>
-      </Loader>);
+      const wrapper = mount(<Loader />);
 
-      expect(wrapper.children().children().at(0).is('.pficon.pficon-error-circle-o')).toBe(true);
-      expect(wrapper.children().children().at(1).text()).toBe('Invalid Status');
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
@@ -1,44 +1,45 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./MessageBox');
 
 import React from 'react';
 import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import MessageBox from './MessageBox';
 
 function setup(msg, type) {
-  return shallow(<MessageBox msg={msg}
-                             icontype={type}></MessageBox>);
+  return shallow(<MessageBox msg={msg} icontype={type} />);
 }
 
 describe('MessageBox', () => {
   describe('the message', () => {
     it('displays this is some text', () => {
       const wrapper = setup('this is some text', 'info');
-      const message = wrapper.childAt(1);
 
-      expect(message.text()).toBe('this is some text');
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('displays This is another message', () => {
       const wrapper = setup('This is another message', 'warning');
-      const message = wrapper.childAt(1);
 
-      expect(message.text()).toBe('This is another message');
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
   });
 
   describe('the icon', () => {
     it('has pficon and pficon-info classes', () => {
       const wrapper = setup('this is some text', 'info');
-      const icon = wrapper.childAt(0);
 
-      expect(icon.is('.pficon.pficon-info')).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('has pficon and pficon-info classes', () => {
       const wrapper = setup('this is some text', 'error-circle-o');
-      const icon = wrapper.childAt(0);
 
-      expect(icon.is('.pficon-error-circle-o.pficon')).toBe(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/Panel/Panel.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Panel/Panel.test.js
@@ -1,7 +1,13 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./Panel');
 
 import React from 'react';
 import {mount, shallow} from 'enzyme';
+import toJson from 'enzyme-to-json';
 import Panel from './Panel';
 import PanelHeading from './PanelHeading';
 import PanelTitle from './PanelTitle';
@@ -39,7 +45,7 @@ describe('Panel', () => {
     it('Panel composition', () => {
       const wrapper = mountPanel();
 
-      expect(wrapper.children().length).toBe(3);
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
     it('Panel component', () => {
       const wrapper = getPanel();
@@ -128,21 +134,10 @@ describe('Panel', () => {
       );
     }
 
-    it('renders correct text', () => {
+    it('renders correct text, style, and children', () => {
       const footer = getFooter();
 
-      expect(footer.text()).toBe('This is the footer');
-    });
-    it('has no children', () => {
-      const footer = getFooter();
-
-      expect(footer.children().length).toBe(1);
-      expect(footer.childAt(0).node).toBe('This is the footer');
-    });
-    it('is styled correctly', () => {
-      const footer = getFooter();
-
-      expect(footer.is('.panel-footer')).toBe(true);
+      expect(toJson(footer)).toMatchSnapshot();
     });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/Panel/__snapshots__/Panel.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Panel/__snapshots__/Panel.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Panel Panel and composition Panel composition 1`] = `
+<Panel
+  type=""
+>
+  <div
+    className="panel panel-default "
+  >
+    <PanelHeading>
+      <div
+        className="panel-heading "
+        data-toggle="tooltip"
+        onClick={undefined}
+        title={undefined}
+      >
+        <PanelTitle
+          text="Title"
+        >
+          <h3
+            className="panel-title "
+          >
+            Title
+          </h3>
+        </PanelTitle>
+      </div>
+    </PanelHeading>
+    <PanelBody>
+      <div
+        className="panel-body "
+      >
+        <ul>
+          <li>
+            1
+          </li>
+          <li>
+            2
+          </li>
+          <li>
+            3
+          </li>
+        </ul>
+      </div>
+    </PanelBody>
+    <PanelFooter>
+      <div
+        className="panel-footer "
+      >
+        This is the footer
+      </div>
+    </PanelFooter>
+  </div>
+</Panel>
+`;
+
+exports[`Panel PanelFooter renders correct text, style, and children 1`] = `
+<div
+  className="panel-footer "
+>
+  This is the footer
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/common/__snapshots__/Loader.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/__snapshots__/Loader.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loader renders correct content based on status default case 1`] = `
+<Loader>
+  <div
+    className="loader-root"
+  >
+    <MessageBox
+      icontype="error-circle-o"
+      msg="Invalid Status"
+    >
+      <div
+        className="message-box-root"
+      >
+        <div
+          className="pficon pficon-error-circle-o message-box-content message-box-icon"
+        />
+        <div
+          className="message-box-content message-box-message"
+        >
+          Invalid Status
+        </div>
+      </div>
+    </MessageBox>
+  </div>
+</Loader>
+`;
+
+exports[`Loader renders correct content based on status failure 1`] = `
+<div
+  className="loader-root"
+>
+  <div
+    className="failure"
+    key="1"
+  >
+    Failure
+  </div>
+</div>
+`;
+
+exports[`Loader renders correct content based on status pending 1`] = `
+<div
+  className="loader-root"
+>
+  <div
+    className="spinner spinner-lg"
+  />
+</div>
+`;
+
+exports[`Loader renders correct content based on status pending-different-spinner 1`] = `
+<div
+  className="loader-root"
+>
+  <div
+    className="spinner spinner-xs"
+  />
+</div>
+`;
+
+exports[`Loader renders correct content based on status success 1`] = `
+<div
+  className="loader-root"
+>
+  <div
+    className="success"
+    key="0"
+  >
+    Success
+  </div>
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/common/__snapshots__/MessageBox.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/__snapshots__/MessageBox.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MessageBox the icon has pficon and pficon-info classes 1`] = `
+<div
+  className="message-box-root"
+>
+  <div
+    className="pficon pficon-info message-box-content message-box-icon"
+  />
+  <div
+    className="message-box-content message-box-message"
+  >
+    this is some text
+  </div>
+</div>
+`;
+
+exports[`MessageBox the icon has pficon and pficon-info classes 2`] = `
+<div
+  className="message-box-root"
+>
+  <div
+    className="pficon pficon-error-circle-o message-box-content message-box-icon"
+  />
+  <div
+    className="message-box-content message-box-message"
+  >
+    this is some text
+  </div>
+</div>
+`;
+
+exports[`MessageBox the message displays This is another message 1`] = `
+<div
+  className="message-box-root"
+>
+  <div
+    className="pficon pficon-warning message-box-content message-box-icon"
+  />
+  <div
+    className="message-box-content message-box-message"
+  >
+    This is another message
+  </div>
+</div>
+`;
+
+exports[`MessageBox the message displays this is some text 1`] = `
+<div
+  className="message-box-root"
+>
+  <div
+    className="pficon pficon-info message-box-content message-box-icon"
+  />
+  <div
+    className="message-box-content message-box-message"
+  >
+    this is some text
+  </div>
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
@@ -1,3 +1,8 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./Chart');
 jest.unmock('../MessageBox');
 jest.mock('c3');
@@ -20,8 +25,8 @@ describe('Chart', () => {
         <Chart config={config} noDataMsg={'No data here'} />
       );
 
-      expect(chart.node.props.msg).toBe('No data here');
-      expect(chart.node.props.icontype).toBe('info');
+      expect(chart.getElement().props.msg).toBe('No data here');
+      expect(chart.getElement().props.icontype).toBe('info');
     });
 
     it('renders MessageBox with default no data message', () => {
@@ -33,8 +38,8 @@ describe('Chart', () => {
 
       const chart = shallow(<Chart config={config} />);
 
-      expect(chart.node.props.msg).toBe('No data available');
-      expect(chart.node.props.icontype).toBe('info');
+      expect(chart.getElement().props.msg).toBe('No data available');
+      expect(chart.getElement().props.icontype).toBe('info');
     });
 
     it('does not display no data message if hasData is true', () => {
@@ -45,7 +50,7 @@ describe('Chart', () => {
       };
       const chart = shallow(<Chart config={config} />);
 
-      expect(chart.node.type.name).not.toBe('MessageBox');
+      expect(chart.getElement().type.name).not.toBe('MessageBox');
     });
   });
 
@@ -96,7 +101,7 @@ describe('Chart', () => {
 
       expect(chart.is('div[data-id="operatingsystem"]')).toBe(true);
 
-      expect(chart.node.type).toBe('div');
+      expect(chart.getElement().type).toBe('div');
     });
 
     describe('calls c3.generate when appropriate', () => {

--- a/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
@@ -1,3 +1,8 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import PieChart from './';
 import chartData from './PieChart.fixtures';

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
@@ -1,7 +1,13 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./');
 
 import React from 'react';
 import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import PowerStatus from './';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
@@ -9,13 +15,10 @@ import { pendingState, errorState, resolvedState } from './PowerStatus.fixtures'
 const mockStore = configureMockStore([thunk]);
 
 describe('PowerStatus', () => {
-
   it('pending', () => {
     const store = mockStore(pendingState);
 
-    const box = shallow(
-      <PowerStatus store={ store } data={ {id: 1} }/>
-    );
+    const box = shallow(<PowerStatus store={store} data={{ id: 1 }} />);
 
     expect(box.render().find('.spinner.spinner-xs').length).toBe(1);
   });
@@ -23,44 +26,30 @@ describe('PowerStatus', () => {
   it('error', () => {
     const store = mockStore(errorState);
 
-    const box = shallow(
-      <PowerStatus store={ store } data={ {id: 1} }/>
-    );
+    const box = shallow(<PowerStatus store={store} data={{ id: 1 }} />);
 
     const error = box.render();
 
-    expect(error.find('.fa.fa-power-off.host-power-status.na').length).toBe(1);
-    expect(error.find('.fa.fa-power-off.host-power-status.on').length).toBe(0);
-    expect(error.find('.fa.fa-power-off.host-power-status.off').length).toBe(0);
+    expect(toJson(error)).toMatchSnapshot();
   });
 
   it('resolvedWithOn', () => {
     const store = mockStore(resolvedState);
 
-    const resolvedOnBox = shallow(
-      <PowerStatus store={ store } data={ {id: 1} }/>
-    );
+    const resolvedOnBox = shallow(<PowerStatus store={store} data={{ id: 1 }} />);
 
     const resolvedOnBoxRendered = resolvedOnBox.render();
 
-    expect(resolvedOnBoxRendered.find('.fa.fa-power-off.host-power-status.on').length).toBe(1);
-    expect(resolvedOnBoxRendered.find('.fa.fa-power-off.host-power-status.off').length).toBe(0);
-    expect(resolvedOnBoxRendered.find('.fa.fa-power-off.host-power-status.na').length).toBe(0);
-    expect(resolvedOnBoxRendered.find('[title=On]').length).toBe(1);
+    expect(toJson(resolvedOnBoxRendered)).toMatchSnapshot();
   });
 
   it('resolvedWithOff', () => {
     const store = mockStore(resolvedState);
 
-    const resolvedOnBox = shallow(
-      <PowerStatus store={ store } data={ {id: 2} }/>
-    );
+    const resolvedOnBox = shallow(<PowerStatus store={store} data={{ id: 2 }} />);
 
     const resolvedOffBoxRendered = resolvedOnBox.render();
 
-    expect(resolvedOffBoxRendered.find('.fa.fa-power-off.host-power-status.on').length).toBe(0);
-    expect(resolvedOffBoxRendered.find('.fa.fa-power-off.host-power-status.off').length).toBe(1);
-    expect(resolvedOffBoxRendered.find('.fa.fa-power-off.host-power-status.na').length).toBe(0);
-    expect(resolvedOffBoxRendered.find('[title=Off]').length).toBe(1);
+    expect(toJson(resolvedOffBoxRendered)).toMatchSnapshot();
   });
 });

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/__snapshots__/PowerStatus.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/__snapshots__/PowerStatus.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PowerStatus error 1`] = `
+<span
+  class="fa fa-power-off host-power-status na"
+  title="undefined undefined"
+>
+  
+</span>
+`;
+
+exports[`PowerStatus resolvedWithOff 1`] = `
+<span
+  class="fa fa-power-off host-power-status off"
+  title="Off"
+>
+  
+</span>
+`;
+
+exports[`PowerStatus resolvedWithOn 1`] = `
+<span
+  class="fa fa-power-off host-power-status on"
+  title="On"
+>
+  
+</span>
+`;

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
@@ -1,3 +1,8 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import { mount } from 'enzyme';
 import { vmwareData, hiddenFieldValue } from './StorageContainer.fixtures';
@@ -27,7 +32,7 @@ describe('StorageContainer', () => {
       wrapper.render().find('.disk-container').length
     ).toEqual(1);
 
-    wrapper.find('.btn-add-disk').simulate('click');
+    wrapper.find('button.btn-add-disk').simulate('click');
 
     expect(
       wrapper.render().find('.disk-container').length
@@ -39,7 +44,7 @@ describe('StorageContainer', () => {
       wrapper.render().find('.controller-container').length
     ).toEqual(1);
 
-    wrapper.find('.btn-add-controller').simulate('click');
+    wrapper.find('button.btn-add-controller').simulate('click');
 
     expect(
       wrapper.render().find('.controller-container').length
@@ -51,7 +56,7 @@ describe('StorageContainer', () => {
       wrapper.render().find('.controller-container').length
     ).toEqual(1);
 
-    wrapper.find('.btn-remove-controller').simulate('click');
+    wrapper.find('button.btn-remove-controller').simulate('click');
 
     expect(
       wrapper.render().find('.controller-container').length
@@ -63,7 +68,7 @@ describe('StorageContainer', () => {
       wrapper.render().find('.controller-container').length
     ).toEqual(1);
 
-    wrapper.find('.btn-remove-controller').simulate('click');
+    wrapper.find('button.btn-remove-controller').simulate('click');
 
     expect(
       wrapper.render().find('.controller-container').length

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StorageContainer should render controller 1`] = `
+<div
+  className="controller-container"
+>
+  <div
+    className="controller-header"
+  >
+    <div
+      className="control-label col-md-2 controller-selected-container"
+    >
+      <label>
+        Create SCSI controller
+      </label>
+    </div>
+    <div
+      className="controller-type-container col-md-4"
+    >
+      <Select
+        onChange={[Function]}
+        options={
+          Object {
+            "ParaVirtualSCSIController": "VMware Paravirtual",
+            "VirtualBusLogicController": "Bus Logic Parallel",
+            "VirtualLsiLogicController": "LSI Logic Parallel",
+            "VirtualLsiLogicSASController": "LSI Logic SAS",
+          }
+        }
+        value="VirtualLsiLogicController"
+      />
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-add-disk"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Add volume
+      </Button>
+    </div>
+    <div
+      className="delete-controller-container"
+    >
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-remove-controller"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Delete Controller
+      </Button>
+    </div>
+  </div>
+  <div
+    className="disks-container"
+  >
+    <Disk
+      config={
+        Object {
+          "controllerTypes": Object {
+            "ParaVirtualSCSIController": "VMware Paravirtual",
+            "VirtualBusLogicController": "Bus Logic Parallel",
+            "VirtualLsiLogicController": "LSI Logic Parallel",
+            "VirtualLsiLogicSASController": "LSI Logic SAS",
+          },
+          "datastores": Object {
+            "cfme-esx-55-01-local": "cfme-esx-55-01-local (free: 524 GB, prov: 465 GB, total: 924 GB)",
+            "cfme-esx-55-03-local": "cfme-esx-55-03-local (free: 898 GB, prov: 165 GB, total: 924 GB)",
+            "cfme-esx-55-04-local": "cfme-esx-55-04-local (free: 250 GB, prov: 681 GB, total: 924 GB)",
+            "cfme-esx-55-na01a": "cfme-esx-55-na01a (free: 448 GB, prov: 8.56 TB, total: 4 TB)",
+            "cfme-esx-55-na01b": "cfme-esx-55-na01b (free: 587 GB, prov: 7.25 TB, total: 4.5 TB)",
+            "cfme-esx-admin-lun-na01b": "cfme-esx-admin-lun-na01b (free: 553 GB, prov: 519 GB, total: 1020 GB)",
+            "cfme-esx-glob-na01a-s": "cfme-esx-glob-na01a-s (free: 1.45 TB, prov: 3.49 TB, total: 1.9 TB)",
+            "cfme-esx-glob-na01b-s": "cfme-esx-glob-na01b-s (free: 1.37 TB, prov: 2.22 TB, total: 1.9 TB)",
+            "cfme-iso-glob-na01a-s": "cfme-iso-glob-na01a-s (free: 341 GB, prov: 134 GB, total: 475 GB)",
+            "do-not-use-datastore": "do-not-use-datastore (free: 462 GB, prov: 12.6 GB, total: 475 GB)",
+            "do-not-use-host-prov": "do-not-use-host-prov (free: 0 Bytes, prov: 973 MB, total: 973 MB)",
+            "master_iso_rdu": "master_iso_rdu (free: 689 GB, prov: 289 GB, total: 973 GB)",
+            "temp_store": "temp_store (free: 475 GB, prov: 19.5 MB, total: 475 GB)",
+            "vsanDatastore": "vsanDatastore (free: 207 GB, prov: 26.1 GB, total: 233 GB)",
+          },
+          "diskModeTypes": Object {
+            "independent_nonpersistent": "Independent - Nonpersistent",
+            "independent_persistent": "Independent - Persistent",
+            "persistent": "Persistent",
+          },
+          "storagePods": Object {
+            "StorageCluster": "StorageCluster (free: 1.01 TB, prov: 7.49 TB, total: 8.5 TB)",
+          },
+        }
+      }
+      controllerKey={1000}
+      id="e86728ee-dbde-ad59-13d6-0c5488635e73"
+      key="e86728ee-dbde-ad59-13d6-0c5488635e73"
+      mode="persistent"
+      name="Hard disk"
+      removeDisk={[Function]}
+      sizeGb={10}
+      thin={true}
+      updateDisk={[Function]}
+    />
+  </div>
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
@@ -1,5 +1,11 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import { props } from './controller.fixtures';
 import Controller from './';
 
@@ -15,6 +21,6 @@ describe('StorageContainer', () => {
   });
 
   it('should render controller', () => {
-    expect(wrapper.render().find('.controller-container').length).toEqual(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
@@ -1,3 +1,8 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import { shallow } from 'enzyme';
 import { props } from './disk.fixtures';

--- a/webpack/assets/javascripts/react_app/components/notifications/__snapshots__/notifications.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/notifications/__snapshots__/notifications.test.js.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`notifications empty state 1`] = `
+<notificationContainer
+  expandGroup={[Function]}
+  isReady={false}
+  notifications={Object {}}
+  onClickedLink={[Function]}
+  onMarkAsRead={[Function]}
+  onMarkGroupAsRead={[Function]}
+  startNotificationsPolling={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  toggleDrawer={[Function]}
+/>
+`;
+
+exports[`notifications should render empty html for state before notifications 1`] = `
+<notificationContainer
+  expandGroup={[Function]}
+  expandedGroup="React devs2"
+  isDrawerOpen={true}
+  isReady={false}
+  notifications={Object {}}
+  onClickedLink={[Function]}
+  onMarkAsRead={[Function]}
+  onMarkGroupAsRead={[Function]}
+  startNotificationsPolling={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  toggleDrawer={[Function]}
+/>
+`;
+
+exports[`notifications should render full html on a state with notifications 1`] = `
+<notificationContainer
+  expandGroup={[Function]}
+  expandedGroup="React devs2"
+  hasUnreadMessages={true}
+  isDrawerOpen={true}
+  isReady={true}
+  notifications={
+    Object {
+      "React devs": Array [
+        Object {
+          "actions": Object {},
+          "created_at": "2017-02-23T05:00:28.715Z",
+          "group": "React devs",
+          "id": 1,
+          "level": "info",
+          "seen": true,
+          "text": null,
+        },
+      ],
+      "React devs2": Array [
+        Object {
+          "actions": Object {
+            "links": Array [
+              Object {
+                "href": "https://theforeman.org/blog",
+                "title": "Link to blog",
+              },
+            ],
+          },
+          "created_at": "2017-03-14T11:25:07.138Z",
+          "group": "React devs2",
+          "id": 6,
+          "level": "info",
+          "seen": true,
+          "text": "Hi! This is a notification message",
+        },
+      ],
+    }
+  }
+  onClickedLink={[Function]}
+  onMarkAsRead={[Function]}
+  onMarkGroupAsRead={[Function]}
+  startNotificationsPolling={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  toggleDrawer={[Function]}
+/>
+`;

--- a/webpack/assets/javascripts/react_app/components/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/index.js
@@ -30,7 +30,7 @@ class notificationContainer extends React.Component {
     return (
       <div id="notifications_container">
         <ToggleIcon
-          hsUnreadMessages={hasUnreadMessages}
+          hasUnreadMessages={hasUnreadMessages}
           onClick={toggleDrawer}
         />
         {isReady &&

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -1,12 +1,17 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import {shallow, mount} from 'enzyme';
+import toJson from 'enzyme-to-json';
 import Notifications from './';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import {getStore} from '../../redux';
 import {
   emptyState,
-  emptyHtml,
   componentMountData,
   stateWithoutNotifications,
   stateWithNotifications,
@@ -54,7 +59,7 @@ describe('notifications', () => {
 
     const box = shallow(<Notifications store={store} />);
 
-    expect(box.render().html()).toEqual(emptyHtml);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('should render empty html for state before notifications', () => {
@@ -62,14 +67,14 @@ describe('notifications', () => {
 
     const box = shallow(<Notifications store={store} />);
 
-    expect(box.render().find('.drawer-pf').length).toEqual(0);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('should render full html on a state with notifications', () => {
     const store = mockStore(stateWithNotifications);
     const box = shallow(<Notifications store={store} />);
 
-    expect(box.render().find('.drawer-pf-notification').length).toEqual(1);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('should display full bell on a state with unread notifications', () => {

--- a/webpack/assets/javascripts/react_app/components/notifications/toggleIcon/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/toggleIcon/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
-export default ({ hsUnreadMessages, onClick }) => {
-  const iconType = hsUnreadMessages ? 'fa-bell' : 'fa-bell-o';
+export default ({ hasUnreadMessages, onClick }) => {
+  const iconType = hasUnreadMessages ? 'fa-bell' : 'fa-bell-o';
   const tooltip = <Tooltip id="tooltip">Notifications</Tooltip>;
 
    return (

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
@@ -1,8 +1,14 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./ChartBox');
 jest.unmock('../../../services/ChartService');
 
 import React from 'react';
 import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import ChartBox from './ChartBox';
 global.patternfly = {
   pfSetDonutChartTitle: jest.fn()
@@ -30,7 +36,7 @@ describe('ChartBox', () => {
       />
     );
 
-    expect(box.find('.spinner.spinner-lg').length).toBe(1);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('error', () => {
@@ -44,7 +50,7 @@ describe('ChartBox', () => {
       />
     );
 
-    expect(box.find('.pficon.pficon-error-circle-o').length).toBe(1);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('resolved', () => {
@@ -58,6 +64,6 @@ describe('ChartBox', () => {
       />
     );
 
-    expect(box.find('.c3-statistics-pie.small').length).toBe(1);
+    expect(box.find('.c3-statistics-pie.small').at(0).length).toBe(1);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
@@ -1,5 +1,11 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 import React from 'react';
 import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import StatisticsChartsList from './StatisticsChartsList';
 import { statisticsData } from './StatisticsChartsList.fixtures';
 import thunk from 'redux-thunk';
@@ -20,9 +26,8 @@ describe('StatisticsChartsList', () => {
       <StatisticsChartsList store={store} data={statisticsData} />
     );
 
-    expect(
-      wrapper.render().find('.statistics-charts-list-panel').length
-    ).toEqual(0);
+    expect(toJson(wrapper)).toMatchSnapshot();
+
   });
 
   it('should render two panels for fixtures data', () => {

--- a/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChartBox error 1`] = `
+<ChartBox
+  chart={
+    Object {
+      "id": "2",
+    }
+  }
+  errorText="some error"
+  id="2"
+  noDataMsg="no data"
+  status="ERROR"
+>
+  <Panel
+    className="statistics-charts-list-panel"
+    key="2"
+  >
+    <div
+      className="panel panel-default statistics-charts-list-panel"
+    >
+      <PanelHeading
+        className="statistics-charts-list-heading"
+        data-placement="top"
+        data-toggle="tooltip"
+        onClick={[Function]}
+        title={undefined}
+      >
+        <div
+          className="panel-heading statistics-charts-list-heading"
+          data-toggle="tooltip"
+          onClick={[Function]}
+          title={undefined}
+        >
+          <PanelTitle
+            text={undefined}
+          >
+            <h3
+              className="panel-title "
+            />
+          </PanelTitle>
+        </div>
+      </PanelHeading>
+      <PanelBody
+        className="statistics-charts-list-body"
+      >
+        <div
+          className="panel-body statistics-charts-list-body"
+        >
+          <Loader
+            status="ERROR"
+          >
+            <div
+              className="loader-root"
+            >
+              <MessageBox
+                icontype="error-circle-o"
+                key="2-error"
+                msg="some error"
+              >
+                <div
+                  className="message-box-root"
+                >
+                  <div
+                    className="pficon pficon-error-circle-o message-box-content message-box-icon"
+                  />
+                  <div
+                    className="message-box-content message-box-message"
+                  >
+                    some error
+                  </div>
+                </div>
+              </MessageBox>
+            </div>
+          </Loader>
+          <ChartModal
+            chart={
+              Object {
+                "id": "2",
+              }
+            }
+            config={Object {}}
+            errorText="some error"
+            id="2"
+            noDataMsg="no data"
+            onEnter={undefined}
+            onHide={[Function]}
+            show={false}
+            status="ERROR"
+            title={undefined}
+          >
+            <Modal
+              animation={true}
+              autoFocus={true}
+              backdrop={true}
+              bsClass="modal"
+              dialogComponentClass={[Function]}
+              enforceFocus={true}
+              keyboard={true}
+              manager={
+                ModalManager {
+                  "add": [Function],
+                  "containers": Array [],
+                  "data": Array [],
+                  "handleContainerOverflow": true,
+                  "hideSiblingNodes": true,
+                  "isTopModal": [Function],
+                  "modals": Array [],
+                  "remove": [Function],
+                }
+              }
+              onEnter={[Function]}
+              onHide={[Function]}
+              renderBackdrop={[Function]}
+              restoreFocus={true}
+              show={false}
+            >
+              <Modal
+                autoFocus={true}
+                backdrop={true}
+                backdropClassName="modal-backdrop"
+                backdropTransitionTimeout={150}
+                containerClassName="modal-open"
+                dialogTransitionTimeout={300}
+                enforceFocus={true}
+                keyboard={true}
+                manager={
+                  ModalManager {
+                    "add": [Function],
+                    "containers": Array [],
+                    "data": Array [],
+                    "handleContainerOverflow": true,
+                    "hideSiblingNodes": true,
+                    "isTopModal": [Function],
+                    "modals": Array [],
+                    "remove": [Function],
+                  }
+                }
+                onEnter={[Function]}
+                onEntering={[Function]}
+                onExited={[Function]}
+                onHide={[Function]}
+                renderBackdrop={[Function]}
+                restoreFocus={true}
+                show={false}
+                transition={[Function]}
+              />
+            </Modal>
+          </ChartModal>
+        </div>
+      </PanelBody>
+    </div>
+  </Panel>
+</ChartBox>
+`;
+
+exports[`ChartBox pending 1`] = `
+<ChartBox
+  chart={
+    Object {
+      "id": "2",
+    }
+  }
+  errorText="some error"
+  id="2"
+  noDataMsg="no data"
+  status="PENDING"
+>
+  <Panel
+    className="statistics-charts-list-panel"
+    key="2"
+  >
+    <div
+      className="panel panel-default statistics-charts-list-panel"
+    >
+      <PanelHeading
+        className="statistics-charts-list-heading"
+        data-placement="top"
+        data-toggle="tooltip"
+        onClick={[Function]}
+        title={undefined}
+      >
+        <div
+          className="panel-heading statistics-charts-list-heading"
+          data-toggle="tooltip"
+          onClick={[Function]}
+          title={undefined}
+        >
+          <PanelTitle
+            text={undefined}
+          >
+            <h3
+              className="panel-title "
+            />
+          </PanelTitle>
+        </div>
+      </PanelHeading>
+      <PanelBody
+        className="statistics-charts-list-body"
+      >
+        <div
+          className="panel-body statistics-charts-list-body"
+        >
+          <Loader
+            status="PENDING"
+          >
+            <div
+              className="loader-root"
+            >
+              <div
+                className="spinner spinner-lg"
+              />
+            </div>
+          </Loader>
+          <ChartModal
+            chart={
+              Object {
+                "id": "2",
+              }
+            }
+            config={Object {}}
+            errorText="some error"
+            id="2"
+            noDataMsg="no data"
+            onEnter={undefined}
+            onHide={[Function]}
+            show={false}
+            status="PENDING"
+            title={undefined}
+          >
+            <Modal
+              animation={true}
+              autoFocus={true}
+              backdrop={true}
+              bsClass="modal"
+              dialogComponentClass={[Function]}
+              enforceFocus={true}
+              keyboard={true}
+              manager={
+                ModalManager {
+                  "add": [Function],
+                  "containers": Array [],
+                  "data": Array [],
+                  "handleContainerOverflow": true,
+                  "hideSiblingNodes": true,
+                  "isTopModal": [Function],
+                  "modals": Array [],
+                  "remove": [Function],
+                }
+              }
+              onEnter={[Function]}
+              onHide={[Function]}
+              renderBackdrop={[Function]}
+              restoreFocus={true}
+              show={false}
+            >
+              <Modal
+                autoFocus={true}
+                backdrop={true}
+                backdropClassName="modal-backdrop"
+                backdropTransitionTimeout={150}
+                containerClassName="modal-open"
+                dialogTransitionTimeout={300}
+                enforceFocus={true}
+                keyboard={true}
+                manager={
+                  ModalManager {
+                    "add": [Function],
+                    "containers": Array [],
+                    "data": Array [],
+                    "handleContainerOverflow": true,
+                    "hideSiblingNodes": true,
+                    "isTopModal": [Function],
+                    "modals": Array [],
+                    "remove": [Function],
+                  }
+                }
+                onEnter={[Function]}
+                onEntering={[Function]}
+                onExited={[Function]}
+                onHide={[Function]}
+                renderBackdrop={[Function]}
+                restoreFocus={true}
+                show={false}
+                transition={[Function]}
+              />
+            </Modal>
+          </ChartModal>
+        </div>
+      </PanelBody>
+    </div>
+  </Panel>
+</ChartBox>
+`;

--- a/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/StatisticsChartsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/StatisticsChartsList.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatisticsChartsList should render no panels for empty data 1`] = `
+<StatisticsChartsList
+  charts={Array []}
+  data={
+    Array [
+      Object {
+        "id": "operatingsystem",
+        "search": "/hosts?search=os_title=~VAL~",
+        "title": "OS Distribution",
+        "url": "statistics/operatingsystem",
+      },
+      Object {
+        "id": "architecture",
+        "search": "/hosts?search=facts.architecture=~VAL~",
+        "title": "Architecture Distribution",
+        "url": "statistics/architecture",
+      },
+    ]
+  }
+  getStatisticsData={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+/>
+`;

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/ToastList.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/ToastList.fixtures.js
@@ -6,7 +6,6 @@ export const initialState = Immutable({
   }
 });
 
-export const emptyHtml = '<div class="toast-notifications-list-pf"></div>';
 export const singleMessageState = Immutable({
   toasts: {
     messages: {

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
@@ -1,13 +1,18 @@
+// Configure Enzyme
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+configure({ adapter: new Adapter() });
+
 jest.unmock('./');
 
 import React from 'react';
 import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
 import ToastList from './';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import {
   initialState,
-  emptyHtml,
   singleMessageState,
   singleMessageWithLinkState
 } from './ToastList.fixtures';
@@ -18,7 +23,7 @@ describe('ToastList', () => {
     const store = mockStore(initialState);
     const box = mount(<ToastList store={store} />);
 
-    expect(box.render().html()).toBe(emptyHtml);
+    expect(toJson(box)).toMatchSnapshot();
   });
 
   it('single message state', () => {

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/__snapshots__/ToastsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/__snapshots__/ToastsList.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToastList emptyState 1`] = `
+<Connect(ToastsList)
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <ToastsList
+    addToast={[Function]}
+    clearToasts={[Function]}
+    deleteToast={[Function]}
+    messages={Object {}}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+  >
+    <div
+      className="toast-notifications-list-pf"
+    />
+  </ToastsList>
+</Connect(ToastsList)>
+`;

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/index.js
@@ -5,19 +5,14 @@ import { connect } from 'react-redux';
 import { map } from 'lodash';
 
 class ToastsList extends Component {
-
   render() {
     const { messages, deleteToast } = this.props;
 
     return (
       <div className="toast-notifications-list-pf">
-        {
-          map(
-            messages,
-            toast => <Toast {...toast}
-                      dismiss={deleteToast.bind(this, toast.key)} />
-          )
-        }
+        {map(messages, (toast, key) => (
+          <Toast {...toast} key={key} dismiss={deleteToast.bind(this, toast.key)} />
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
Enzyme needs to be upgraded to support react@16. In upgrading I
found that using jest's snapshot feature would greatly improve
several of the tests that were in place. I've changed these
tests to use snapshots and added enzyme-to-json to support
snapshot testing with enzyme wrappers. I've also added 
enzyme-adapter-react-15 as a required adapter for react
in enzyme@3.0.0. This will be changed to enzyme-adapter-react-16
once we upgrade to react@16.

http://projects.theforeman.org/issues/21179