### PR TITLE
Fixes #21180 - Enable adding 3rd party libraries from plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ node_modules
 public/webpack
 .env*
 package-lock.json
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ node_js:
   - '6' # current LTS
   - '8' # current stable
 before_install:
-  npm install -g npm@'>=3.0.0, <5.0.0'
+  - cp config/settings.yaml.example config/settings.yaml
+  - bundle install --without console development ec2 fog gce jsonp libvirt mysql2 openid openstack ovirt postgresql rackspace sqlite test vmware
+  - npm install -g npm@'>=3.0.0, <5.0.0'
 script: ./script/travis_run_js_tests.sh

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -6,7 +6,7 @@ var webpack = require('webpack');
 var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CompressionPlugin = require('compression-webpack-plugin');
-var plugins = require('../script/plugin_webpack_directories');
+var pluginUtils = require('../script/plugin_webpack_directories');
 
 // must match config.webpack.dev_server.port
 var devServerPort = 3808;
@@ -16,16 +16,12 @@ var production =
   process.env.RAILS_ENV === 'production' ||
   process.env.NODE_ENV === 'production';
 
-// Create aliases for plugins so that their components are easily accessible.
-// Each alias points to /$path_to_plugin/webpack
-var aliasPlugins  = function (pluginEntries) {
-  var aliases = {};
-  Object.keys(pluginEntries).forEach(function(key) {
-    var pathSplit = pluginEntries[key].split('/');
-    aliases[key] = pathSplit.slice(0, pathSplit.length - 1).join('/');
-  });
-  return aliases;
-}
+var plugins = pluginUtils.getPluginDirs();
+
+var resolveModules = [  path.join(__dirname, '..', 'webpack'),
+                        path.join(__dirname, '..', 'node_modules'),
+                        'node_modules/',
+                     ].concat(pluginUtils.pluginNodeModules(plugins));
 
 var config = {
   entry: Object.assign(
@@ -46,16 +42,13 @@ var config = {
   },
 
   resolve: {
-    modules: [
-      path.join(__dirname, '..', 'webpack'),
-      'node_modules/'
-    ],
+    modules: resolveModules,
     alias: Object.assign({
       foremanReact:
         path.join(__dirname,
-           '../webpack/assets/javascripts/react_app')
-    },
-    aliasPlugins(plugins['entries'])
+           '../webpack/assets/javascripts/react_app'),
+      },
+      pluginUtils.aliasPlugins(plugins['entries'])
     )
   },
 

--- a/package.json
+++ b/package.json
@@ -79,13 +79,14 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ $(./script/foreman_plugins_eslint.js) || exit 0",
+    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ script/ $(./script/foreman_plugins_eslint.js) || exit 0",
     "test": "node node_modules/.bin/jest",
     "test:watch": "node node_modules/.bin/jest --watchAll",
     "test:current": "node node_modules/.bin/jest --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "deploy-storybook": "storybook-to-ghpages"
+    "deploy-storybook": "storybook-to-ghpages",
+    "postinstall": "node ./script/npm_install_plugins.js"
   },
   "jest": {
     "automock": true,
@@ -113,7 +114,8 @@
     },
     "moduleDirectories": [
       "node_modules",
-      "webpack"
+      "webpack",
+      "script"
     ]
   }
 }

--- a/script/foreman_plugins_eslint.js
+++ b/script/foreman_plugins_eslint.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-process.stdout.write(require('./plugin_webpack_directories').paths.join(' '));
+process.stdout.write(require('./plugin_webpack_directories').getPluginDirs().paths.join(' '));

--- a/script/npm_install_plugins.js
+++ b/script/npm_install_plugins.js
@@ -1,0 +1,8 @@
+'use strict';
+/* eslint-disable no-var */
+var childProcess = require('child_process');
+var packageJsonDirs = require('./plugin_webpack_directories').packageJsonDirs;
+
+packageJsonDirs().forEach(function (pluginPath) {
+  childProcess.spawn('npm', ['i'], { env: process.env, cwd: pluginPath, stdio: 'inherit'});
+});

--- a/script/plugin_webpack_directories.js
+++ b/script/plugin_webpack_directories.js
@@ -3,6 +3,7 @@
 
 var execSync = require('child_process').execSync;
 var path = require('path');
+var fs = require('fs');
 
 // If we get multiple lines, then the plugin_webpack_directories.rb script
 // has on the stdout more that just the JSON we want, so we use newline to split and check.
@@ -12,8 +13,52 @@ var sanitizeWebpackDirs = function (pluginDirs) {
   return splitDirs.length > 2 ? splitDirs[1] : pluginDirs;
 };
 
-var webpackDirs = execSync(path.join(__dirname, './plugin_webpack_directories.rb'), {
-  stdio: ['pipe', 'pipe', 'ignore']
-});
+// Get paths that have a specific file or folder
+var pluginPath = function (file) {
+  return function (pluginsObj) {
+    var paths = [];
 
-module.exports = JSON.parse(sanitizeWebpackDirs(webpackDirs));
+    pluginsObj.paths.forEach(function (entry) {
+      var filePath = path.join(path.dirname(entry), file);
+
+      if (fs.existsSync(filePath)) {
+        paths.push(filePath);
+      }
+    });
+    return paths;
+  };
+};
+
+// Create aliases for plugins so that their components are easily accessible.
+// Each alias points to /$path_to_plugin/webpack
+var aliasPlugins = function (pluginEntries) {
+  var aliases = {};
+
+  Object.keys(pluginEntries).forEach(function (key) {
+    aliases[key] = path.dirname(pluginEntries[key]);
+  });
+  return aliases;
+};
+
+var webpackedDirs = function () {
+  return execSync(path.join(__dirname, './plugin_webpack_directories.rb'), {
+    stdio: ['pipe', 'pipe', 'ignore']
+  });
+};
+
+var getPluginDirs = function () {
+  return JSON.parse(sanitizeWebpackDirs(webpackedDirs()));
+};
+
+var packageJsonDirs = function () {
+  return pluginPath('package.json')(getPluginDirs()).map(path.dirname);
+};
+
+module.exports = {
+  getPluginDirs: getPluginDirs,
+  pluginNodeModules: pluginPath('node_modules'),
+  aliasPlugins: aliasPlugins,
+  packageJsonDirs: packageJsonDirs,
+  sanitizeWebpackDirs: sanitizeWebpackDirs,
+  pluginPath: pluginPath
+};

--- a/script/plugin_webpack_directories.test.js
+++ b/script/plugin_webpack_directories.test.js
@@ -1,0 +1,47 @@
+jest.unmock('./plugin_webpack_directories');
+import pluginUtils from './plugin_webpack_directories';
+import path from 'path';
+
+const json = { 'entries':
+               { 'foo': '/some/path/webpack/index.js',
+                 'bar': '/path/to/webpack/index.js'},
+              'paths':
+                ['/some/path/webpack/index.js',
+                 '/path/to/webpack/index.js']
+             };
+
+describe('sanitizeWebpackDirs', () => {
+  it('should return json when debug output is present', () => {
+    const output = ['Warning: this is not a json',
+                    'This is some random text',
+                    JSON.stringify(json), ''].join('\n');
+
+    const res = pluginUtils.sanitizeWebpackDirs(output);
+
+    expect(res).toEqual(JSON.stringify(json));
+  });
+
+  it('should return json when only json is present', () => {
+    const res = pluginUtils.sanitizeWebpackDirs(JSON.stringify(json));
+
+    expect(res).toEqual(JSON.stringify(json));
+  });
+});
+
+describe('aliasPlugins', () => {
+  it('should return aliases for plugins', () => {
+    const res = pluginUtils.aliasPlugins(json.entries);
+
+    expect(res).toEqual({ foo: '/some/path/webpack', bar: '/path/to/webpack' });
+  });
+});
+
+describe('pluginPath', () => {
+  it('should return path if exists', () => {
+    const obj = { 'paths': [__filename, '/path/to/webpack/index.js'] };
+
+    const res = pluginUtils.pluginPath(path.basename(__filename))(obj);
+
+    expect(res).toEqual([__filename]);
+  });
+});


### PR DESCRIPTION
@waldenraines, this should help with additional dependencies.

1) add package.json to your plugin root
2) add dependencies into package.json
3) run `npm install` **in foreman folder**
4) observe dependencies being installed for all plugins with package.json

Dependencies from plugins can be used in the same fashion as the ones from core