### PR TITLE
Fixes #20541 - Include nested facts in CSV export

### DIFF
--- a/app/controllers/fact_values_controller.rb
+++ b/app/controllers/fact_values_controller.rb
@@ -3,24 +3,9 @@ class FactValuesController < ApplicationController
   include Foreman::Controller::CsvResponder
 
   before_action :setup_search_options, :only => :index
+  before_action :find_facts, :only => :index
 
   def index
-    values = resource_base_search_and_page.my_facts
-
-    conds = (original_search_parameter || '').split(/AND|OR/i)
-    conds = conds.flatten.reject { |c| c.include?('host') }
-
-    if (parent = params[:parent_fact]).present? && (@parent = ::FactName.where(:name => parent)).present?
-      values = values.with_fact_parent_id(@parent.map(&:id))
-      @parent = @parent.first
-    elsif conds.present?
-      values
-    else
-      values = values.root_only
-    end
-
-    @fact_values = values.no_timestamp_facts
-
     respond_to do |format|
       format.html do
         @fact_values = @fact_values.preload(related_tables).paginate(:page => params[:page], :per_page => params[:per_page])
@@ -37,6 +22,25 @@ class FactValuesController < ApplicationController
   end
 
   private
+
+  def find_facts
+    @parent = FactName.where(:name => params[:parent_fact]).first
+    values = resource_base_search_and_page.my_facts.no_timestamp_facts
+
+    @fact_values = if @parent
+                     values.with_fact_parent_id(@parent)
+                   elsif has_conditions? || request.format.csv?
+                     values
+                   else
+                     values.root_only
+                   end
+  end
+
+  def has_conditions?
+    (original_search_parameter || '').split(/AND|OR/i)
+      .flatten.reject { |c| c.include?('host') }
+      .present?
+  end
 
   def controller_permission
     'facts'

--- a/test/controllers/fact_values_controller_test.rb
+++ b/test/controllers/fact_values_controller_test.rb
@@ -1,8 +1,14 @@
 require 'test_helper'
 
 class FactValuesControllerTest < ActionController::TestCase
+  let(:host) { FactoryGirl.create(:host) }
+  let(:fact_name) { FactoryGirl.create(:fact_name)}
+  let(:fact_value) do
+    FactoryGirl.create(:fact_value, :fact_name => fact_name, :host => host)
+  end
+
   def setup
-    FactoryGirl.create(:fact_value)
+    fact_value.save!
     User.current = nil
   end
 
@@ -11,12 +17,6 @@ class FactValuesControllerTest < ActionController::TestCase
     assert_response :success
     assert_template FactValue.unconfigured? ? 'welcome' : 'index'
     assert_not_nil :fact_values
-  end
-
-  test 'csv export works' do
-    get :index, {format: :csv}, set_session_user
-    assert_response :success
-    assert_equal 2, response.body.lines.size
   end
 
   test 'user with viewer rights should succeed in viewing facts' do
@@ -34,5 +34,30 @@ class FactValuesControllerTest < ActionController::TestCase
     assert_not_nil :fact_values
     get :index, {order: 'wrong ASC'}, set_session_user
     assert_response :redirect
+  end
+
+  describe 'CSV Export' do
+    test 'csv export works' do
+      get :index, {format: :csv}, set_session_user
+      assert_response :success
+      body = response.body
+      assert_equal 2, body.lines.size
+      assert_match fact_name.name, body
+    end
+
+    test 'csv exports nested values ' do
+      child_fact_name_name = [fact_name.name, "child"].join(FactName::SEPARATOR)
+      as_admin do
+        child_fact = FactoryGirl.create(:fact_name, :parent => fact_name,
+                                        :name => child_fact_name_name)
+        fact_name.update_attribute(:compose, true)
+        fact_value.update_attribute(:fact_name, child_fact)
+      end
+      get :index, {format: :csv}, set_session_user
+      body = response.body
+      assert_response :success
+      assert_equal 2, body.lines.size
+      assert_match child_fact_name_name, body.to_s
+    end
   end
 end


### PR DESCRIPTION
Nested Facts will be exported to CSV like you would see when expanded:
```
callisto.local,ansible_lo::ipv4,,foreman_ansible/Ansible,2017-09-08 15:25:59 UTC
callisto.local,ansible_lo::ipv4::broadcast,host,foreman_ansible/Ansible,2017-09-08 15:25:59 UTC
callisto.local,ansible_lo::ipv4::netmask,255.0.0.0,foreman_ansible/Ansible,2017-09-08 15:25:59 UTC
callisto.local,ansible_lo::ipv4::network,127.0.0.0,foreman_ansible/Ansible,2017-09-08 15:25:59 UTC
callisto.local,ansible_lo::ipv4::address,127.0.0.1,foreman_ansible/Ansible,2017-09-08 15:25:59 UTC
```