### PR TITLE
Fixed #21204 - introduced global_setting helper function

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -59,6 +59,8 @@ class Setting::Provisioning < Setting
       self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
       self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
       self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
+      self.set('default_pxe_item_global', N_("Default PXE (PXELinux, PXEGrub, PXEGrub2) menu item in global template - 'local', 'discovery' or custom"), 'local', N_("Default PXE global template entry")),
+      self.set('default_pxe_item_local', N_("Default PXE (PXELinux, PXEGrub2) menu item in local template - 'local_chain_hd0', 'local' or custom"), 'local_chain_hd0', N_("Default PXE local template entry")),
       self.set(
         'excluded_facts',
         N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -315,6 +315,13 @@ module Foreman #:nodoc:
       end
     end
 
+    # List of global settings allowed for templates
+    def allowed_template_global_settings(*settings)
+      in_to_prepare do
+        Foreman::Renderer::ALLOWED_GLOBAL_SETTINGS.concat(settings).uniq!
+      end
+    end
+
     # List of modules which public methods will be available during template rendering
     # including safe mode
     def extend_template_helpers(*mods)

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -359,7 +359,17 @@ attribute75:
   category: Setting::Notification
   default: "http://theforeman.org/feed.xml"
   description: 'Default URL for RSS feed notifications'
-attributes76:
+attribute76:
+  name: default_pxe_item_global
+  category: Setting::Provisioning
+  default: "local"
+  description: 'Default PXE global template entry'
+attribute77:
+  name: default_pxe_item_local
+  category: Setting::Provisioning
+  default: "local_chain_hd0"
+  description: 'Default PXE local template entry'
+attributes78:
   name: excluded_facts
   category: Setting::Provisioning
   default: "['lo', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -206,22 +206,40 @@ class PluginTest < ActiveSupport::TestCase
     end
   end
 
-  def test_register_allowed_template_helpers_and_variables
+  def test_register_allowed_template_helpers
     refute_includes Foreman::Renderer::ALLOWED_HELPERS, :my_helper
-    refute_includes Foreman::Renderer::ALLOWED_VARIABLES, :my_variable
-
     @klass.register :foo do
       allowed_template_helpers :my_helper
+    end
+    # simulate application start
+    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    assert_includes Foreman::Renderer::ALLOWED_HELPERS, :my_helper
+  ensure
+    Foreman::Renderer::ALLOWED_HELPERS.delete(:my_helper)
+  end
+
+  def test_register_allowed_template_variables
+    refute_includes Foreman::Renderer::ALLOWED_VARIABLES, :my_variable
+    @klass.register :foo do
       allowed_template_variables :my_variable
     end
     # simulate application start
     @klass.find(:foo).to_prepare_callbacks.each(&:call)
-
-    assert_includes Foreman::Renderer::ALLOWED_HELPERS, :my_helper
     assert_includes Foreman::Renderer::ALLOWED_VARIABLES, :my_variable
   ensure
-    Foreman::Renderer::ALLOWED_HELPERS.delete(:my_helper)
-    Foreman::Renderer::ALLOWED_HELPERS.delete(:my_variable)
+    Foreman::Renderer::ALLOWED_VARIABLES.delete(:my_variable)
+  end
+
+  def test_register_allowed_global_settings
+    refute_includes Foreman::Renderer::ALLOWED_GLOBAL_SETTINGS, :my_global_setting
+    @klass.register :foo do
+      allowed_template_global_settings :my_global_setting
+    end
+    # simulate application start
+    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    assert_includes Foreman::Renderer::ALLOWED_GLOBAL_SETTINGS, :my_global_setting
+  ensure
+    Foreman::Renderer::ALLOWED_GLOBAL_SETTINGS.delete(:my_global_setting)
   end
 
   def test_extend_rendering_helpers


### PR DESCRIPTION
Locked templates made very difficult to change to discovery in global default templates, user needs to unlock 2+2+2 (PXELinux, Grub, Grub2 template + discovery snippet) and make necessary changes just to change the default menu entry. This can be done via global setting.

This patch adds such a helper function, I am doing changes in community templates to leverage this new function.

Security standpoint - I can't think of any setting that should not be rendered. We do have a root password, but that is already available using the existing helper. Please review with that in mind.