### PR TITLE
Fixes #21206 - Fix templates taxonomies migration

### DIFF
--- a/db/migrate/20171005114442_fix_taxable_taxonomies_template_types_unscoped.rb
+++ b/db/migrate/20171005114442_fix_taxable_taxonomies_template_types_unscoped.rb
@@ -1,0 +1,10 @@
+class FixTaxableTaxonomiesTemplateTypesUnscoped < ActiveRecord::Migration
+  def up
+    TaxableTaxonomy.unscoped.where(:taxable_type => 'Template', :taxable_id => Ptable.unscoped.pluck(:id)).update_all(:taxable_type => 'Ptable')
+    TaxableTaxonomy.unscoped.where(:taxable_type => 'Template', :taxable_id => ProvisioningTemplate.unscoped.pluck(:id)).update_all(:taxable_type => 'ProvisioningTemplate')
+  end
+
+  def down
+    TaxableTaxonomy.unscoped.where(:taxable_type => ['Ptable', 'ProvisioningTemplate']).update_all(:taxable_type => 'Template')
+  end
+end


### PR DESCRIPTION
In 0969b62, we added a migration to change the type of taxable
taxonomies. Unfortunatelly, it was not working right
as migratios don't run with any user and Ptable.all returned
empty set. We need to make sure to unscope when loading the data.