### PR TITLE
Fixes #21223: add experimental UI menu to foreman.

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -21,7 +21,8 @@ class Setting::General < Setting
       self.set('login_text', N_("Text to be shown in the login-page footer"), nil, N_('Login page footer text')),
       self.set('host_power_status', N_("Show power status on host index page. This feature calls to compute resource providers which may lead to decreased performance on host listing page."), true, N_('Show host power status')),
       self.set('http_proxy', N_('Sets a proxy for all outgoing HTTP connections.'), nil, N_('HTTP(S) proxy')),
-      self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied'), [], N_('HTTP(S) proxy except hosts'))
+      self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied'), [], N_('HTTP(S) proxy except hosts')),
+      self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs'))
     ]
   end
 

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -92,6 +92,10 @@ module Menu
           end
         end
       end
+
+      Manager.map :labs_menu do |menu|
+        menu.sub_menu :lab_features_menu, :caption => N_('Lab Features'), :icon => 'fa fa-flask'
+      end
     end
   end
 end

--- a/app/views/home/_navbar.html.erb
+++ b/app/views/home/_navbar.html.erb
@@ -3,7 +3,13 @@
   nav-pf-persistent-secondary">
   <ul class="list-group">
     <%= render_vertical_menu :top_menu %>
+
+    <% if Setting[:lab_features] %>
+      <%= render_vertical_menu :labs_menu %>
+    <% end %>
+
     <%= render_vertical_menu :admin_menu %>
+
     <%= render "home/vertical_taxonomies", :taxonomy_type => "location", :icon_name => "fa fa-globe" if SETTINGS[:locations_enabled]  %>
     <%= render "home/vertical_taxonomies", :taxonomy_type => "organization", :icon_name => "fa fa-building" if SETTINGS[:organizations_enabled]  %>
   </ul>

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -14,12 +14,12 @@
   <ul class="nav navbar-nav navbar-left navbar-iconic navbar-utility">
     <%= render "home/org_switcher" %>
   </ul>
-      <% if User.current %>
-          <nav class="collapse navbar-collapse">
-            <div id="turbolinks-progress"><div class="spinner spinner-inverse"></div></div>
-            <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
-            <%= render 'home/user_dropdown' if SETTINGS[:login] %>
-            </ul>
-        </nav>
-      <% end %>
+  <% if User.current %>
+      <nav class="collapse navbar-collapse">
+        <div id="turbolinks-progress"><div class="spinner spinner-inverse"></div></div>
+        <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
+        <%= render 'home/user_dropdown' if SETTINGS[:login] %>
+        </ul>
+    </nav>
+  <% end %>
 </nav>


### PR DESCRIPTION
Add an experimental UI setting to foreman so we can show new UI pages
while maintaining the old ones. This will allow us to showcase our new
UIs for the users and then eventually remove the old pages and replace
them with the new ones once they have been vetted.

http://projects.theforeman.org/issues/21223