### PR TITLE
Refs #20800 - Align "session timed out" warning with login messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,16 +169,25 @@ class ApplicationController < ActionController::Base
     flash_message(:error, message, now)
   end
 
-  def inline_error(message, now = false)
-    flash[:inline] = { :error => CGI.escapeHTML(message) }
-  end
-
-  def inline_success(message, now = false)
-    flash[:inline] = { :success => CGI.escapeHTML(message) }
-  end
-
   def warning(message, now = false)
     flash_message(:warning, message, now)
+  end
+
+  def inline_error(message)
+    inline_flash_message(:error, message)
+  end
+
+  def inline_success(message)
+    inline_flash_message(:success, message)
+  end
+
+  def inline_warning(message)
+    inline_flash_message(:warning, message)
+  end
+
+  def inline_flash_message(type, message)
+    flash[:inline] ||= {}
+    flash[:inline][type] = CGI.escapeHTML(message)
   end
 
   def flash_message(type, message, now = false)

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -37,7 +37,7 @@ module Foreman::Controller::Session
     else
       sso = get_sso_method
       if sso.nil? || !sso.support_expiration?
-        warning _("Your session has expired, please login again")
+        inline_warning _("Your session has expired, please login again")
         redirect_to main_app.login_users_path
       else
         redirect_to sso.expiration_url

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -78,7 +78,7 @@ class LocationsControllerTest < ActionController::TestCase
 
     # session is reset, redirected to login, but org id remains
     assert_redirected_to "/users/login"
-    assert_match /Your session has expired, please login again/, flash[:warning]
+    assert_match /Your session has expired, please login again/, flash[:inline][:warning]
     assert_equal session[:location_id], taxonomies(:location1).id
   end
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -90,7 +90,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
     # session is reset, redirected to login, but org id remains
     assert_redirected_to "/users/login"
-    assert_match /Your session has expired, please login again/, flash[:warning]
+    assert_match /Your session has expired, please login again/, flash[:inline][:warning]
     assert_equal session[:organization_id], taxonomies(:organization1).id
   end
 


### PR DESCRIPTION
The session timed out message was missed for #4796. It is now also inline as the other two:

![gnome-shell-screenshot-sejn7y](https://user-images.githubusercontent.com/7757/31346385-3dcd38a8-ad19-11e7-9b21-a25e5aa10001.png)
