### PR TITLE
Fixes #21266 - enabled all PXE loaders for SUSE

### DIFF
--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -14,6 +14,10 @@ class Suse < Operatingsystem
     "boot/$arch/loader"
   end
 
+  def available_loaders
+    self.class.all_loaders
+  end
+
   def url_for_boot(file)
     pxedir + "/" + PXEFILES[file]
   end


### PR DESCRIPTION
We intentionally enable only those loaders we know they are working. Looks like we missed SUSE OS.