### PR TITLE
Fixes #21269 - fixed dns_lookup with address resolution

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -183,8 +183,8 @@ module Foreman
       resolver = Resolv::DNS.new
       Timeout.timeout(Setting[:dns_conflict_timeout]) do
         begin
-          resolver.getname(IPAddr.new(name_or_ip))
-        rescue IPAddr::Error
+          resolver.getname(name_or_ip)
+        rescue Resolv::ResolvError
           resolver.getaddress(name_or_ip)
         end
       end


### PR DESCRIPTION
Although this was covered with tests, network things are stubbed for obvious reasons so we did not catch this. Method resolver.getname requires string and not IPAddress instance.