### PR TITLE
refs #20201: update dependency to rest-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ else
   raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"
 end
 
-gem 'rest-client', '>= 1.8.0', '< 3', :require => 'rest_client'
+gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '~> 4.3'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '>= 2.0', '< 4'


### PR DESCRIPTION
PR #4640 uses proxy_uri from rest-client which was introduced in 2.0.0