### PR TITLE
Realign Administer menu, move User menu down

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -20,24 +20,6 @@ module Menu
                   :url_hash => {:controller => '/users', :action => 'logout'}
       end
 
-      Manager.map :admin_menu do |menu|
-        menu.sub_menu :administer_menu,  :caption => N_('Administer') do
-          menu.item :locations,          :caption => N_('Locations') if SETTINGS[:locations_enabled]
-          menu.item :organizations,      :caption => N_('Organizations') if SETTINGS[:organizations_enabled]
-          menu.divider
-          if SETTINGS[:login]
-            menu.item :auth_source_ldaps,:caption => N_('LDAP Authentication')
-            menu.item :users,            :caption => N_('Users')
-            menu.item :usergroups,       :caption => N_('User Groups')
-            menu.item :roles,            :caption => N_('Roles')
-          end
-          menu.divider
-          menu.item :bookmarks,          :caption => N_('Bookmarks')
-          menu.item :settings,           :caption => N_('Settings')
-          menu.item :about_index,        :caption => N_('About')
-        end
-      end
-
       Manager.map :top_menu do |menu|
         menu.sub_menu :monitor_menu,    :caption => N_('Monitor') do
           menu.item :dashboard,         :caption => N_('Dashboard')
@@ -90,6 +72,22 @@ module Menu
             menu.item :http_proxies,      :caption => N_('HTTP Proxies')
             menu.item :realms,            :caption => N_('Realms')
           end
+        end
+
+        menu.sub_menu :administer_menu,  :caption => N_('Administer') do
+          menu.item :locations,          :caption => N_('Locations') if SETTINGS[:locations_enabled]
+          menu.item :organizations,      :caption => N_('Organizations') if SETTINGS[:organizations_enabled]
+          menu.divider
+          if SETTINGS[:login]
+            menu.item :auth_source_ldaps,:caption => N_('LDAP Authentication')
+            menu.item :users,            :caption => N_('Users')
+            menu.item :usergroups,       :caption => N_('User Groups')
+            menu.item :roles,            :caption => N_('Roles')
+          end
+          menu.divider
+          menu.item :bookmarks,          :caption => N_('Bookmarks')
+          menu.item :settings,           :caption => N_('Settings')
+          menu.item :about_index,        :caption => N_('About')
         end
       end
     end

--- a/app/views/home/_notifications.html.erb
+++ b/app/views/home/_notifications.html.erb
@@ -1,0 +1,3 @@
+<li id='notifications_container' class="drawer-pf-trigger dropdown"> </li>
+
+<%= mount_react_component('NotificationContainer','#notifications_container',{:url => notification_recipients_path}.to_json) %>

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -10,7 +10,7 @@
         <div>
           <ul class="nav navbar-nav navbar-right navbar-header-menu navbar-collapse collapse" id="menu4">
             <%= render_menu :header_menu %>
-            <%= render 'home/user_dropdown' if SETTINGS[:login] %>
+            <%= render 'home/notifications' if SETTINGS[:login] %>
           </ul>
           <% if SETTINGS[:login] %>
             <div id='notification_drawer'> </div>
@@ -41,7 +41,7 @@
           <%= render_menu :top_menu %>
         </ul>
         <ul class="nav navbar-nav navbar-admin navbar-right navbar-collapse collapse" id="menu2">
-          <%= render_menu :admin_menu %>
+          <%= render "home/user_dropdown" if SETTINGS[:login] %>
         </ul>
       <% end %>
     <% end %>

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -1,4 +1,3 @@
-<li id='notifications_container' class="drawer-pf-trigger dropdown"> </li>
 <li class="dropdown menu_tab_dropdown">
   <%= user_header %>
   <ul class="dropdown-menu pull-right">
@@ -12,5 +11,3 @@
     <% end %>
   </ul>
 </li>
-
-<%= mount_react_component('NotificationContainer','#notifications_container',{:url => notification_recipients_path}.to_json) %>


### PR DESCRIPTION
This PR fixes a usability issue with the "double menu", one on top of the other, on the right-hand side of the top menu.

Now,

- the _Administer_ menu is aligned normally with all the other menu items of the top menu,
- the _User (Account)_ menu is where any user would expect it -- on the right-hand side, and
- the _Notifications_ area is on top of the _User (Account)_ menu -- a natural place to draw attention.

![foreman-administer-user-menu-fixed](https://user-images.githubusercontent.com/665072/31508084-475e8eb0-af7d-11e7-83a2-697122de5b59.png)

Note: The screenshot was made from an account with restricted permissions (i.e. not Administrator permissions).

More Potential (optional)
-------------------

What could be done in addition is make the font a bit bigger for the user name (in the Account menu caption). I refrained from doing now that to keep the PR small.

Would be happy if this PR were accepted, thanks!