### PR TITLE
Fixes #21317 - graceful handling of VM association error

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -361,6 +361,10 @@ class ComputeResource < ApplicationRecord
     true
   end
 
+  def supports_host_association?
+    respond_to?(:associated_host)
+  end
+
   protected
 
   def client

--- a/app/services/compute_resource_host_associator.rb
+++ b/app/services/compute_resource_host_associator.rb
@@ -1,0 +1,30 @@
+class ComputeResourceHostAssociator
+  attr_accessor :compute_resource, :hosts, :fail_count
+
+  def initialize(compute_resource)
+    @hosts = []
+    @fail_count = 0
+    self.compute_resource = compute_resource
+  end
+
+  def associate_hosts
+    compute_resource.vms(:eager_loading => true).each do |vm|
+      if Host.for_vm(compute_resource, vm).empty?
+        associate_vm(vm)
+      end
+    end
+  end
+
+  private
+
+  def associate_vm(vm)
+    host = compute_resource.associated_host(vm)
+    if host.present?
+      host.associate!(compute_resource, vm)
+      @hosts << host
+    end
+  rescue StandardError => e
+    @fail_count += 1
+    Foreman::Logging.exception("Could not associate VM #{vm}", e)
+  end
+end

--- a/test/unit/compute_resource_host_associator_test.rb
+++ b/test/unit/compute_resource_host_associator_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ComputeResourceHostAssociatorTest < ActiveSupport::TestCase
+  let(:associator) do
+    ComputeResourceHostAssociator.new(compute_resource)
+  end
+  let(:compute_resource) { FactoryBot.create(:ec2_cr) }
+  let(:vm1) { stub('vm1', :identity => Foreman.uuid) }
+  let(:vm2) { stub('vm2', :identity => Foreman.uuid) }
+  let(:vm3) { stub('vm3', :identity => Foreman.uuid) }
+  let(:vms) { [vm1, vm2, vm3] }
+  let(:host_with_vm) { FactoryBot.create(:host, :compute_resource => compute_resource) }
+  let(:host_without_vm) { FactoryBot.build(:host) }
+
+  test 'associates vm with a host if they match' do
+    host_with_vm.update_attributes!(:uuid => vm2.identity)
+    compute_resource.expects(:vms).returns(vms)
+    compute_resource.stubs(:associated_host).returns(nil)
+    compute_resource.expects(:associated_host).with(vm1).returns(host_without_vm)
+
+    associator.associate_hosts
+
+    host_without_vm.uuid.must_equal(vm1.identity)
+    associator.hosts.must_equal([host_without_vm])
+    associator.fail_count.must_equal 0
+  end
+
+  test 'rescues from errors occurred during the associated_host call ===' do
+    host_with_vm.update_attributes!(:uuid => vm2.identity)
+    compute_resource.expects(:vms).returns(vms)
+    compute_resource.stubs(:associated_host).raises('Error associating a host')
+    compute_resource.expects(:associated_host).with(vm1).returns(host_without_vm)
+
+    associator.associate_hosts
+
+    associator.fail_count.must_equal 1
+  end
+end


### PR DESCRIPTION
Instead of immediate failure, just log the issue and proceed with the
import.