### PR TITLE
Fixes #21325 - Updating custom facts with booleans through api

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -33,7 +33,7 @@ class FactImporter
   def initialize(host, facts = {})
     @error    = false
     @host     = host
-    @facts    = normalize(facts)
+    @facts    = stringify(facts)
     @counters = {}
   end
 
@@ -115,7 +115,7 @@ class FactImporter
     end
   end
 
-  def normalize(facts)
+  def stringify(facts)
     # convert all structures to simple strings
     facts = Hash[facts.map {|k, v| [k.to_s, v.to_s]}]
     # and remove empty values


### PR DESCRIPTION
As described in the issue, currently it's not possible to upload facts with
false booleans to foreman through its api. This commit simply fixes this by
renaming the function that handles the "normalization" of the incomming facts
hash.