### PR TITLE
Fixes #21200 - gracefully handle long welcome text

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -21,7 +21,7 @@
 }
 
 .login-page {
-  height: 100%;
+  height: auto;
   background: $primary_color;
   background-size: 100% auto;
   color: #fff;
@@ -40,6 +40,10 @@
     padding-left: 80px;
     position: absolute;
     width: 100%;
+  }
+
+  .login-page {
+    height: 100%;
   }
 }
 
@@ -84,6 +88,11 @@
 @media (min-width: 768px) {
   .login-page .container .login {
     padding-right: 40px;
+  }
+
+  #login_text {
+    max-height: 17em;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
Fixes login page layout when the welcome text is too long.

**At wider screens**:
The welcome text is limited to 10 lines, scrollbar is displayed for longer texts.
before:
![wide_before](https://user-images.githubusercontent.com/1186631/31611802-c1ebd72a-b27d-11e7-91fa-9460986e9585.png)
after:
![wide_after](https://user-images.githubusercontent.com/1186631/31611805-c535ddb8-b27d-11e7-8cf6-5d9b4318ca61.png)

**At narrow screens:**
The login page is extended according to the welcome message's length (the logo with helmet is scrolled up outside of the viewport at the screenshots).
before:
![narrow_before](https://user-images.githubusercontent.com/1186631/31611809-c7dcef3e-b27d-11e7-9730-4edb7a9cdc34.png)
after:
![narrow_after](https://user-images.githubusercontent.com/1186631/31611810-c98a560a-b27d-11e7-952f-7a07eb628ffe.png)
