### PR TITLE
Fixes #21342 - fix core roles seeding

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -161,6 +161,7 @@ class Role < ApplicationRecord
         filtering = filter.filterings.build
         filtering.filter = filter
         filtering.permission = permission
+        filtering.save! if options[:save!]
       end
     end
   end
@@ -322,7 +323,7 @@ class Role < ApplicationRecord
   end
 
   def permission_records(permissions)
-    collection = Permission.where(:name => permissions).all
+    collection = Permission.where(:name => permissions.flatten).all
     raise ::Foreman::PermissionMissingException.new(N_('some permissions were not found')) if collection.size != permissions.size
     collection
   end

--- a/db/migrate/20170221195674_tidy_current_roles.rb
+++ b/db/migrate/20170221195674_tidy_current_roles.rb
@@ -50,7 +50,7 @@ class TidyCurrentRoles < ActiveRecord::Migration
   end
 
   def create_from_seeds(name, options)
-    SeedHelper.create_role name, options, 0, false
+    SeedHelper.create_role name, options.merge(:update_permissions => false), 0, false
   end
 
   def process_default_role


### PR DESCRIPTION
Core roles should always be up to date based on what's defined in seed files.
Users have no other way to update locked roles in newer Foreman versions.