### PR TITLE
Fixes #21325 - Updating custom facts with booleans

### DIFF
--- a/app/services/structured_fact_importer.rb
+++ b/app/services/structured_fact_importer.rb
@@ -1,7 +1,7 @@
 class StructuredFactImporter < FactImporter
   def normalize(facts)
-    # Remove empty values first, so nil facts added by normalize_recurse imply compose
-    facts = facts.select { |k, v| v.present? }
+    # Make sure to remove empty values, unless it's a bool false,
+    facts = facts.reject {|k, v| v.nil? unless v.class == FalseClass }
     normalize_recurse({}, facts)
   end
 


### PR DESCRIPTION
As described in the issue, currently it's not possible to upload facts
with false booleans to foreman through its API. This commit simply fixes
this by not removing a fact-value that is of type boolean false.