### PR TITLE
fixes #21333 - http proxies: remove rails js

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,7 +17,6 @@ Foreman::Application.configure do |app|
                   host_edit_interfaces
                   hosts
                   host_checkbox
-                  http_proxy
                   nfs_visibility
                   noVNC/base64
                   noVNC/des


### PR DESCRIPTION
I missed that during review. Furtunately an easy fix :-D This is not required as the code is completely in webpack.

cc: @ohadlevy