### PR TITLE
fixes #21330 - http proxies: test connection clears toasts

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -26,9 +26,13 @@ class HttpProxy < ApplicationRecord
   end
 
   def test_connection(url)
-    raise self.errors.full_messages.join("\n") unless self.valid?
-
-    RestClient::Request.execute(method: :head, url: url, proxy: full_url)
+    RestClient::Request.execute(
+      method: :head,
+      url: url,
+      proxy: full_url,
+      timeout: 5,
+      open_timeout: 5
+    )
   rescue Excon::Error::Socket => e
     e.message
   end

--- a/webpack/assets/javascripts/foreman_http_proxies.js
+++ b/webpack/assets/javascripts/foreman_http_proxies.js
@@ -1,11 +1,12 @@
 import $ from 'jquery';
-import { notify } from './foreman_toast_notifications';
+import { notify, clear } from './foreman_toast_notifications';
 
 export function testConnection(item, url) {
   let data = $('form').serialize();
 
   $('#test_connection_indicator').show();
   $(item).addClass('disabled');
+  clear();
   $.ajax({
     url: url,
     type: 'put',


### PR DESCRIPTION
Removed the form validation from the test connection button. Added a short connection timeout so the user's UI does not get blocked for ages when no proxy is configured.
This also clears the toast notifications when a user clicks the test connection button.

cc: @ohadlevy , @jlsherrill 