### PR TITLE
fixes #18004 - increase fact value size

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -35,6 +35,7 @@ class FactValue < ApplicationRecord
   scope :with_roots, -> { joins(:fact_name) }
   scope :root_only, -> { with_roots.where(:fact_names => {:ancestry => nil}) }
 
+  validates_lengths_from_database
   validates :fact_name_id, :uniqueness => { :scope => :host_id }
 
   def self.search_by_host_or_hostgroup(key, operator, value)

--- a/db/migrate/20171016202300_increase_fact_value_size.rb
+++ b/db/migrate/20171016202300_increase_fact_value_size.rb
@@ -1,0 +1,5 @@
+class IncreaseFactValueSize < ActiveRecord::Migration
+  def up
+    change_column :fact_values, :value, :text, :limit => 16.megabytes - 1
+  end
+end


### PR DESCRIPTION
fact_values's value column is 1073741824 bytes for postgres, but for mysql it's only 65535 bytes. This PR matches the max length to be 1073741824 bytes for every database type.

Also adds a validation to the model.