### PR TITLE
Refs #21329 - Allow referencing node_modules with full path as well

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,8 @@ var config = {
   resolve: {
     modules: [
       path.join(__dirname, '..', 'webpack'),
-      'node_modules/'
+      'node_modules/',
+      path.join(__dirname, '..', 'node_modules')
     ],
     alias: Object.assign({
       foremanReact:


### PR DESCRIPTION
Based on discussions from #4913 around how plugins use of assets would be broken, I am proposing to support both paths. Now that the PR job should be testing the webpack compile the same as the RPM, we will at least know whether this breaks RPM builds.

What I do not know is how do I test that plugin assets continue to work @ohadlevy ?

Consider this a WIP until we resolve both aspects.