### PR TITLE
Fixes #21137 - Register reducers from plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "redux": "^3.6.0",
     "redux-form": "^7.0.3",
     "redux-form-validators": "^2.0.1",
+    "redux-injector": "^0.1.0",
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",
     "seamless-immutable": "^7.0.1",

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -1,8 +1,8 @@
 import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
-import { applyMiddleware, createStore } from 'redux';
-
-import reducer from './reducers';
+import { applyMiddleware } from 'redux';
+import { createInjectStore } from 'redux-injector';
+import rootState from './reducers';
 
 let middleware = [thunk];
 
@@ -10,8 +10,8 @@ if (process.env.NODE_ENV !== 'production' && !global.__testing__) {
   middleware = [...middleware, createLogger()];
 }
 
-const _getStore = () => createStore(
-  reducer,
+const _getStore = () => createInjectStore(
+  rootState,
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
   applyMiddleware(...middleware),
 );

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/index.js
@@ -1,8 +1,7 @@
-import { combineReducers } from 'redux';
 import storage from './storage';
 import powerStatus from './powerStatus';
 
-export default combineReducers({
+export default {
   storage,
   powerStatus,
-});
+};

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/index.js
@@ -1,6 +1,3 @@
-import { combineReducers } from 'redux';
 import vmware from './vmware';
 
-export default combineReducers({
-  vmware,
-});
+export default { vmware };

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -1,12 +1,11 @@
-import { combineReducers } from 'redux';
 import statistics from './statistics';
 import hosts from './hosts';
 import notifications from './notifications/';
 import toasts from './toasts';
 
-export default combineReducers({
+export default {
   statistics,
   hosts,
   notifications,
   toasts,
-});
+};


### PR DESCRIPTION
This allows us to register reducers from plugins and hook into different levels of our state tree.

```js
// foreman_plugin/webpack/index.js
import { injectReducer } from 'redux-injector';
import pluginState from './reducers';

injectReducer('hosts.foremanPlugin', pluginState);
```
State tree should be just a simple object (with uncombined reducers in leaves) if we want the states to be extensible. Using `combineReducers` will work as usual, but no one will be able to hook into the states that were combined manually.
