### PR TITLE
Fixes #21202 - Add close button to notifications drawer

### DIFF
--- a/webpack/assets/javascripts/react_app/components/notifications/__snapshots__/notifications.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/notifications/__snapshots__/notifications.test.js.snap
@@ -44,6 +44,378 @@ exports[`notifications empty state 1`] = `
 />
 `;
 
+exports[`notifications should close the notification box when click the close button 1`] = `
+<Connect(notificationContainer)
+  data={
+    Object {
+      "url": "/notification_recipients",
+    }
+  }
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <notificationContainer
+    data={
+      Object {
+        "url": "/notification_recipients",
+      }
+    }
+    expandGroup={[Function]}
+    expandedGroup={null}
+    hasUnreadMessages={true}
+    isDrawerOpen={true}
+    isPolling={true}
+    isReady={true}
+    notifications={
+      Object {
+        "React devs": Array [
+          Object {
+            "actions": Object {},
+            "created_at": "2017-02-23T05:00:28.715Z",
+            "group": "React devs",
+            "id": 1,
+            "level": "info",
+            "seen": true,
+            "text": null,
+          },
+          Object {
+            "actions": Object {},
+            "created_at": "2017-02-23T05:00:28.715Z",
+            "group": "React devs",
+            "id": 2,
+            "level": "info",
+            "seen": false,
+            "text": null,
+          },
+        ],
+      }
+    }
+    onClickedLink={[Function]}
+    onMarkAsRead={[Function]}
+    onMarkGroupAsRead={[Function]}
+    startNotificationsPolling={[Function]}
+    store={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+    toggleDrawer={[Function]}
+  >
+    <div
+      id="notifications_container"
+    >
+      <Component
+        hasUnreadMessages={true}
+        onClick={[Function]}
+      >
+        <OverlayTrigger
+          defaultOverlayShown={false}
+          id="notifications-toggle-icon"
+          overlay={
+            <Tooltip
+              bsClass="tooltip"
+              id="tooltip"
+              placement="right"
+            >
+              Notifications
+            </Tooltip>
+          }
+          placement="bottom"
+          trigger={
+            Array [
+              "hover",
+              "focus",
+            ]
+          }
+        >
+          <span
+            aria-describedby="tooltip"
+            className="fa fa-bell"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          />
+        </OverlayTrigger>
+      </Component>
+      <Component
+        expandedGroup={null}
+        notificationGroups={
+          Object {
+            "React devs": Array [
+              Object {
+                "actions": Object {},
+                "created_at": "2017-02-23T05:00:28.715Z",
+                "group": "React devs",
+                "id": 1,
+                "level": "info",
+                "seen": true,
+                "text": null,
+              },
+              Object {
+                "actions": Object {},
+                "created_at": "2017-02-23T05:00:28.715Z",
+                "group": "React devs",
+                "id": 2,
+                "level": "info",
+                "seen": false,
+                "text": null,
+              },
+            ],
+          }
+        }
+        onClickedLink={[Function]}
+        onExpandGroup={[Function]}
+        onMarkAsRead={[Function]}
+        onMarkGroupAsRead={[Function]}
+        toggleDrawer={[Function]}
+      >
+        <div
+          className="drawer-pf drawer-pf-notifications-non-clickable"
+        >
+          <div
+            className="drawer-pf-title"
+          >
+            <a
+              className="drawer-pf-close pficon pficon-close"
+              onClick={[Function]}
+            />
+            <h3
+              className="text-center"
+            >
+              Notifications
+            </h3>
+          </div>
+          <div
+            className="panel-group"
+            id="notification-drawer-accordion"
+          >
+            <Component
+              group="React devs"
+              isExpanded={false}
+              key="React devs"
+              notifications={
+                Array [
+                  Object {
+                    "actions": Object {},
+                    "created_at": "2017-02-23T05:00:28.715Z",
+                    "group": "React devs",
+                    "id": 1,
+                    "level": "info",
+                    "seen": true,
+                    "text": null,
+                  },
+                  Object {
+                    "actions": Object {},
+                    "created_at": "2017-02-23T05:00:28.715Z",
+                    "group": "React devs",
+                    "id": 2,
+                    "level": "info",
+                    "seen": false,
+                    "text": null,
+                  },
+                ]
+              }
+              onClickedLink={[Function]}
+              onExpand={[Function]}
+              onMarkAsRead={[Function]}
+              onMarkGroupAsRead={[Function]}
+            >
+              <div
+                className="panel panel-default "
+              >
+                <div
+                  className="panel-heading"
+                  onClick={[Function]}
+                >
+                  <h4
+                    className="panel-title"
+                  >
+                    <a
+                      className="collapsed"
+                    >
+                      React devs
+                    </a>
+                  </h4>
+                  <span
+                    className="panel-counter"
+                  >
+                    1 New Event
+                  </span>
+                </div>
+              </div>
+            </Component>
+          </div>
+        </div>
+      </Component>
+    </div>
+  </notificationContainer>
+</Connect(notificationContainer)>
+`;
+
+exports[`notifications should close the notification box when click the close button 2`] = `
+<Connect(notificationContainer)
+  data={
+    Object {
+      "url": "/notification_recipients",
+    }
+  }
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <notificationContainer
+    data={
+      Object {
+        "url": "/notification_recipients",
+      }
+    }
+    expandGroup={[Function]}
+    expandedGroup={null}
+    hasUnreadMessages={true}
+    isDrawerOpen={false}
+    isPolling={true}
+    isReady={true}
+    notifications={
+      Object {
+        "React devs": Array [
+          Object {
+            "actions": Object {},
+            "created_at": "2017-02-23T05:00:28.715Z",
+            "group": "React devs",
+            "id": 1,
+            "level": "info",
+            "seen": true,
+            "text": null,
+          },
+          Object {
+            "actions": Object {},
+            "created_at": "2017-02-23T05:00:28.715Z",
+            "group": "React devs",
+            "id": 2,
+            "level": "info",
+            "seen": false,
+            "text": null,
+          },
+        ],
+      }
+    }
+    onClickedLink={[Function]}
+    onMarkAsRead={[Function]}
+    onMarkGroupAsRead={[Function]}
+    startNotificationsPolling={[Function]}
+    store={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "dispatch": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+          Symbol(observable): [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+    toggleDrawer={[Function]}
+  >
+    <div
+      id="notifications_container"
+    >
+      <Component
+        hasUnreadMessages={true}
+        onClick={[Function]}
+      >
+        <OverlayTrigger
+          defaultOverlayShown={false}
+          id="notifications-toggle-icon"
+          overlay={
+            <Tooltip
+              bsClass="tooltip"
+              id="tooltip"
+              placement="right"
+            >
+              Notifications
+            </Tooltip>
+          }
+          placement="bottom"
+          trigger={
+            Array [
+              "hover",
+              "focus",
+            ]
+          }
+        >
+          <span
+            aria-describedby="tooltip"
+            className="fa fa-bell"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          />
+        </OverlayTrigger>
+      </Component>
+    </div>
+  </notificationContainer>
+</Connect(notificationContainer)>
+`;
+
 exports[`notifications should render empty html for state before notifications 1`] = `
 <notificationContainer
   expandGroup={[Function]}

--- a/webpack/assets/javascripts/react_app/components/notifications/drawer/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/drawer/index.js
@@ -5,6 +5,7 @@ export default (
   {
     notificationGroups,
     expandedGroup,
+    toggleDrawer,
     onExpandGroup,
     onMarkAsRead,
     onMarkGroupAsRead,
@@ -33,6 +34,7 @@ export default (
   return (
     <div className="drawer-pf drawer-pf-notifications-non-clickable">
       <div className="drawer-pf-title">
+        <a className="drawer-pf-close pficon pficon-close" onClick={toggleDrawer}></a>
         <h3 className="text-center">{__('Notifications')}</h3>
       </div>
       <div className="panel-group" id="notification-drawer-accordion">

--- a/webpack/assets/javascripts/react_app/components/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/index.js
@@ -42,6 +42,7 @@ class notificationContainer extends React.Component {
             onMarkGroupAsRead={onMarkGroupAsRead}
             expandedGroup={expandedGroup}
             notificationGroups={notifications}
+            toggleDrawer={toggleDrawer}
           />}
       </div>
     );

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.scss
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.scss
@@ -36,6 +36,29 @@
       position: static;
     }
 
+    .drawer-pf-close,
+    .drawer-pf-toggle-expand {
+      color: inherit;
+      cursor: pointer;
+      line-height: inherit;
+      padding: 2px 10px;
+      position: absolute;
+
+      &:hover,
+      &:focus {
+        color: inherit;
+        text-decoration: none;
+      }
+    }
+
+    .drawer-pf-close {
+      right: 0;
+    }
+
+    .drawer-pf-toggle-expand {
+      left: 0;
+    }
+
     .panel-group {
       flex: 1;
       display: flex;

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -124,4 +124,15 @@ describe('notifications', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should close the notification box when click the close button', () => {
+    const wrapper = mount(<Notifications data={componentMountData} store={getStore()} />);
+    const closeButtonSelector = '.drawer-pf .drawer-pf-title a.drawer-pf-close';
+
+    wrapper.find('.fa-bell').simulate('click');
+    expect(toJson(wrapper)).toMatchSnapshot();
+
+    wrapper.find(closeButtonSelector).simulate('click');
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
The notifications panel can get close now by clicking on the new x (close) button

https://trello.com/c/CGasKNOB/61-21202-add-close-button-to-notifications-drawer