### PR TITLE
Fixes #21392 - remove active class in secondary menu

### DIFF
--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -2,12 +2,20 @@ import $ from 'jquery';
 
 function markActiveMenu() {
   const link = `[href='${window.location.pathname}']`;
-  const currentLoc = $('#location-dropdown .nav-item-iconic').text().trim();
-  const currentOrg = $('#organization-dropdown .nav-item-iconic').text().trim();
+  const currentLoc = $('#location-dropdown .nav-item-iconic').text();
+  const currentOrg = $('#organization-dropdown .nav-item-iconic').text();
 
-  $('.list-group-item.secondary-nav-item-pf').has(link).addClass('active');
-  $(`.nav-pf-secondary-nav .list-group-item:contains("${currentLoc}")`).addClass('active');
-  $(`.nav-pf-secondary-nav .list-group-item:contains("${currentOrg}")`).addClass('active');
+  $('.list-group-item.secondary-nav-item-pf')
+    .has(link)
+    .addClass('active');
+  currentLoc &&
+    $(
+      `.nav-pf-secondary-nav .list-group-item:contains("${currentLoc.trim()}")`
+    ).addClass('active');
+  currentOrg &&
+    $(
+      `.nav-pf-secondary-nav .list-group-item:contains("${currentOrg.trim()}")`
+    ).addClass('active');
 }
 
 export function init() {
@@ -26,6 +34,12 @@ export function init() {
 export function activate() {
   // a workaround to enable turbolinks works with pf vertical navigation
   $.fn.setupVerticalNavigation.self = undefined;
-  $(document).off('mouseenter.pf.tertiarynav.data-api', '.secondary-nav-item-pf');
-  $(document).off('mouseleave.pf.tertiarynav.data-api', '.secondary-nav-item-pf');
+  $(document).off(
+    'mouseenter.pf.tertiarynav.data-api',
+    '.secondary-nav-item-pf'
+  );
+  $(document).off(
+    'mouseleave.pf.tertiarynav.data-api',
+    '.secondary-nav-item-pf'
+  );
 }

--- a/webpack/assets/javascripts/foreman_navigation.test.js
+++ b/webpack/assets/javascripts/foreman_navigation.test.js
@@ -1,21 +1,14 @@
 jest.unmock('./foreman_navigation');
 import $ from 'jquery';
-import {init} from './foreman_navigation';
+import { init } from './foreman_navigation';
 
 describe('initNavigation', () => {
   Object.defineProperty(window.location, 'pathname', {
     writable: true,
-    value: '/locations/3/select'
+    value: '/locations/1/select'
   });
-  $.fn.setupVerticalNavigation = jest.fn();
-  document.body.innerHTML =
-    `<div>
-         <li class="dropdown org-switcher" id="location-dropdown">
-           <a href="#" class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" >
-             Loc1 <span class="caret"></span>
-           </a>
-         </li>
-       <div id="vertical-nav" class="nav-pf-vertical hover-secondary-nav-pf">    
+  const menuWithoutTaxonomies =
+      `<div id="vertical-nav" class="nav-pf-vertical hover-secondary-nav-pf">    
          <ul class="list-group" >
            <li class="list-group-item secondary-nav-item-pf"
                data-target="location-secondary">  
@@ -34,23 +27,63 @@ describe('initNavigation', () => {
                  <div class="divider"></div>
                  <li class="list-group-item"><a id="menu_item_loc1"
                      data-id="aid_locations_3_select"
-                     href="/locations/3/select"><span class="list-group-item-value">
+                     href="/locations/1/select"><span class="list-group-item-value">
                      Loc1</span></a></li>
-                 <li class="list-group-item"><a id="menu_item_loc2"
-                     data-id="aid_locations_13_select"
-                     href="/locations/13/select"><span class="list-group-item-value">
-                     Loc2</span></a></li>
                </ul>
              </div>  
            </li>
+           <li class="list-group-item secondary-nav-item-pf"
+             data-target="organization-secondary">  
+             <a>
+               <span class="list-group-item-value"> Organization </span> 
+             </a>
+             <div id='organization-secondary' class="nav-pf-secondary-nav">
+               <div class="nav-item-pf-header">
+                 <a class="secondary-collapse-toggle-pf", data-toggle="collapse-secondary-nav" ></a>
+                 <span>Organization</span>
+               </div>
+               <ul class="list-group">
+                 <li class="list-group-item"><a id="menu_item_Any_Organization"
+                     data-id="aid_organizations_clear" href="/organizations/clear">
+                  <span class="list-group-item-value">Any Organization</span></a></li>
+                 <div class="divider"></div>
+                 <li class="list-group-item"><a id="menu_item_org1"
+                     data-id="aid_organizations_1_select"
+                     href="/organizations/1/select"><span class="list-group-item-value">
+                     Org1</span></a></li>
+               </ul>
+             </div>  
+           </li>  
          </ul>     
-       </div>  
-       <div class="container-pf-nav-pf-vertical secondary-visible-pf"></div>    
-       </div>`;
+       </div>
+       <div class="container-pf-nav-pf-vertical secondary-visible-pf"></div>`;
+
+  $.fn.setupVerticalNavigation = jest.fn();
+  document.body.innerHTML = `<div>
+       <li class="dropdown org-switcher" id="location-dropdown">
+         <a href="#" class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" >
+           Loc1 <span class="caret"></span>
+         </a>
+       </li>
+       <li class="dropdown org-switcher" id="organization-dropdown">
+         <a href="#" class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" >
+           Org1 <span class="caret"></span>
+         </a>
+       </li>         
+       ${menuWithoutTaxonomies}
+     </div>`;
   it('Mark current location/organization as active in vertical menu', () => {
     init();
-    expect($('.nav-pf-secondary-nav .list-group-item:contains("Loc1")')
-      .hasClass('active')).toBe(true);
+    expect(
+      $('.nav-pf-secondary-nav .list-group-item:contains("Loc1")').hasClass(
+        'active'
+      )
+    ).toBe(true);
+    expect(
+      $('.nav-pf-secondary-nav .list-group-item:contains("Org1")').hasClass(
+        'active'
+      )
+    ).toBe(true);
   });
 
   it('Mark main menu item as active', () => {
@@ -58,8 +91,25 @@ describe('initNavigation', () => {
   });
 
   it('Should close secondary menu after menu item click', () => {
-    $('#menu_item_loc2').click();
+    $('#menu_item_loc1').click();
     expect($('#vertical-nav').hasClass('hover-secondary-nav-pf')).toBe(false);
-    expect($('.container-pf-nav-pf-vertical').hasClass('secondary-visible-pf')).toBe(false);
+    expect(
+      $('.container-pf-nav-pf-vertical').hasClass('secondary-visible-pf')
+    ).toBe(false);
+  });
+
+  it('Should not set secondary menu as active when taxonomies are off', () => {
+    document.body.innerHTML = menuWithoutTaxonomies;
+    init();
+    expect(
+      $('.nav-pf-secondary-nav .list-group-item:contains("Loc1")').hasClass(
+        'active'
+      )
+    ).toBe(false);
+    expect(
+      $('.nav-pf-secondary-nav .list-group-item:contains("Org1")').hasClass(
+        'active'
+      )
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
when taxonomies are not enabled,  secondary menu gets active class, and  all sub-items there are marked.