### PR TITLE
fixes #21374 - audit host interfaces

### DIFF
--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -4,6 +4,10 @@
                                         hash_for_host_path(:id => @audit.auditable.to_param).merge(:auth_object => @audit.auditable, :auth_action => 'view'),
                                         :title => _("Host details"),
                                         :class => 'btn btn-info') if @audit.auditable_type == 'Host::Base' && @audit.auditable %>
+<%= title_actions link_to_if_authorized(_("Associated Host"),
+                                        hash_for_host_path(:id => @audit.associated.to_param).merge(:auth_object => @audit.associated, :auth_action => 'view'),
+                                        :title => _("Host details"),
+                                        :class => 'btn btn-default') if @audit.auditable_type.match(/^Nic/) && @audit.associated_type == 'Host::Base' && @audit.associated %>
 <%= title_actions link_to 'Back', :back, :class=>'btn btn-default' %>
 <% tmplt = audit_template?(@audit) %>
 

--- a/test/models/audit_test.rb
+++ b/test/models/audit_test.rb
@@ -21,4 +21,30 @@ class AuditTest < ActiveSupport::TestCase
     audits = Audit.search_for "partition_table = #{template.name}"
     assert_not_nil audits.select { |a| a.action.to_s == 'update' && a.audited_changes['template'].last == 'new content' }
   end
+
+  describe 'audited nics' do
+    let(:host) { FactoryBot.create(:host, :managed, :with_auditing) }
+    let(:nic) { host.primary_interface }
+
+    test 'can be found by ip' do
+      nic
+      audit = Audit.search_for("interface_ip = #{nic.ip}").first
+      assert_equal nic.type, audit.auditable_type
+      assert_equal 'create', audit.action
+    end
+
+    test 'can be found by name' do
+      nic
+      audit = Audit.search_for("interface_fqdn = #{nic.name}").first
+      assert_equal nic.type, audit.auditable_type
+      assert_equal 'create', audit.action
+    end
+
+    test 'can be found by mac' do
+      nic
+      audit = Audit.search_for("interface_mac = #{nic.mac}").first
+      assert_equal nic.type, audit.auditable_type
+      assert_equal 'create', audit.action
+    end
+  end
 end


### PR DESCRIPTION
Adds auditing to host interfaces. This is required to e.g. see when the IP address of a host changes.

![image](https://user-images.githubusercontent.com/4107560/31773158-1b087136-b4e2-11e7-94d3-c37f9cdfaee1.png)
