### PR TITLE
Fixes #21425 - host selection alert should refer to param per_page

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -207,12 +207,14 @@ function update_counter() {
   if ($.foremanSelectedHosts)
     $(".select_count").text($.foremanSelectedHosts.length);
   var title = "";
-  if (item.attr("checked"))
-    title = $.foremanSelectedHosts.length + " - " + item.attr("uncheck-title");
+  if (item.prop('checked'))
+    title = pagination_metadata().per_page + " - " + item.attr("uncheck-title");
   else
     title = item.attr("check-title");
 
   item.attr("data-original-title", title );
-  item.tooltip();
+  item.tooltip({
+    trigger : 'hover'
+})
   return false;
 }

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -155,7 +155,8 @@ module LayoutHelper
   end
 
   def per_page(collection)
-    [Setting[:entries_per_page], collection.total_entries].min
+    per_page = params[:per_page] ? params[:per_page].to_i : Setting[:entries_per_page]
+    [per_page, collection.total_entries].min
   end
 
   private

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -3,7 +3,7 @@
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
-      <th class="ca" width="40px"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
+      <th class="ca" width="40px"><%= check_box_tag "check_all", "", false, { :onchange => "toggleCheck()", :'check-title' => _("Select all items on this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
       <% if power_status_visible? %>
         <th class="ca" width="5%"><%= _('Power') %></th>
       <% end %>

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -28,6 +28,38 @@ class HostJSTest < IntegrationTestWithJavascript
     SETTINGS[:organizations_enabled] = true
   end
 
+  describe 'multiple hosts selection' do
+    setup do
+      @entries = Setting[:entries_per_page]
+      FactoryBot.create_list(:host, 2)
+    end
+
+    teardown do
+      Setting[:entries_per_page] = @entries
+    end
+
+    test 'hosts counter should refer to per_page value first (max prespective)' do
+      Setting[:entries_per_page] = 2
+      visit hosts_path(per_page: 3)
+      check 'check_all'
+      assert page.has_text?(:all, "All 3 hosts on this page are selected")
+    end
+
+    test 'hosts counter should refer to per_page value first (min prespective)' do
+      Setting[:entries_per_page] = 3
+      visit hosts_path(per_page: 2)
+      check 'check_all'
+      assert page.has_text?(:all, "All 2 hosts on this page are selected")
+    end
+
+    test 'hosts counter should refer to setting- entries_per_page when there is no per_page value' do
+      Setting[:entries_per_page] = 3
+      visit hosts_path()
+      check 'check_all'
+      assert page.has_text?(:all, "All 3 hosts on this page are selected")
+    end
+  end
+
   describe 'edit page' do
     test 'class parameters and overrides are displayed correctly for strings' do
       host = FactoryBot.create(:host, :with_puppetclass)


### PR DESCRIPTION
Multiple host selection alert only mention settings[:per_page],
though pagination has been changed, now the user can change per_page via select box

This may lead to miscount hosts amount :
![hosts_selection](https://user-images.githubusercontent.com/11807069/31888757-f48785e8-b805-11e7-90ee-7fba5e9bee0e.png)
