### PR TITLE
Fixes #21442 - Load puppetclass params on new host form

### DIFF
--- a/app/controllers/puppetclasses_controller.rb
+++ b/app/controllers/puppetclasses_controller.rb
@@ -59,8 +59,8 @@ class PuppetclassesController < ApplicationController
   private
 
   def get_host_or_hostgroup
-    # params['host_id'] = 'null' if NEW since hosts/form and hostgroups/form has data-id="null"
-    if params['host_id'] == 'null'
+    # params['host_id'] = 'undefined' if NEW since hosts/form and hostgroups/form has no data-id
+    if params['host_id'] == 'undefined'
       @obj = Host::Managed.new(host_params('host')) if params['host']
       @obj ||= Hostgroup.new(hostgroup_params) if params['hostgroup']
     else

--- a/test/controllers/puppetclasses_controller_test.rb
+++ b/test/controllers/puppetclasses_controller_test.rb
@@ -140,7 +140,7 @@ class PuppetclassesControllerTest < ActionController::TestCase
     host = Host::Managed.new(:name => "new_host", :environment_id => environments(:production).id)
     new_host_attributes = host_attributes(host)
     puppetclass = puppetclasses(:two)
-    post :parameters, {:id => puppetclass.id, :host_id => 'null',
+    post :parameters, {:id => puppetclass.id, :host_id => 'undefined',
                        :host => new_host_attributes }, set_session_user
     assert_response :success
     as_admin do
@@ -156,7 +156,7 @@ class PuppetclassesControllerTest < ActionController::TestCase
     new_hostgroup_attributes = hostgroup_attributes(hostgroup)
     puppetclass = puppetclasses(:two)
     # host_id is posted instead of hostgroup_id per host_edit.js#load_puppet_class_parameters
-    post :parameters, {:id => puppetclass.id, :host_id => 'null',
+    post :parameters, {:id => puppetclass.id, :host_id => 'undefined',
                        :hostgroup => new_hostgroup_attributes }, set_session_user
     assert_response :success
     as_admin do


### PR DESCRIPTION
This was caused by a Rails 5 change in ActionView that skips blank
data attributes [1] causing the JS code used to serialize the form[2]
to send `undefined` instead of `null` which was expected previously.

[1] https://github.com/rails/rails/commit/aeee438bf120f44a4402250fa50ef530f3c830a8
[2] https://github.com/theforeman/foreman/blob/develop/app/assets/javascripts/host_edit.js#L204