### PR TITLE
Fixes #21131 - Change the color of the pficon-info to black

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -247,7 +247,7 @@ div.form-group .glyphicon-info-sign {
   color: black;
 }
 
-div.form-group .pficon-info {
+form .pficon-info {
   color: black;
 }
 


### PR DESCRIPTION
@Rohoover, 
please let me know what do you feel about this:
![image](https://user-images.githubusercontent.com/5609929/31947013-0cef23d0-b8dc-11e7-8fb8-f8656c7785bc.png)

I wasn't sure if you wanted to change all the icons to black.