### PR TITLE
Fixes #21131 - Change the color of the pficon-info to black

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -247,7 +247,7 @@ div.form-group .glyphicon-info-sign {
   color: black;
 }
 
-div.form-group .pficon-info {
+form .pficon-info {
   color: black;
 }
 


### PR DESCRIPTION
@Rohoover,
please let me know what do you feel about this:
![image](https://user-images.githubusercontent.com/5609929/31948043-759ffdda-b8de-11e7-91d4-38b4d2735b8e.png)

I wasn't sure if you wanted to change all the icons to black.