### PR TITLE
Fixes #21133 - Change the color of pficon-info to black

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -1,6 +1,7 @@
 @import "colors";
 
 $navbar-default-bg: $primary_color;
+$pf-blue-500: #00659c;
 
 .control-label {
   text-align: left;
@@ -247,7 +248,11 @@ div.form-group .glyphicon-info-sign {
   color: black;
 }
 
-div.form-group .pficon-info {
+form .pficon-info {
+  color: $pf-blue-500;
+}
+
+form .fa-info-circle {
   color: black;
 }
 

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -102,7 +102,8 @@ module LookupKeysHelper
     popover('', description.prepend(warnings[:text]),
             :data => { :placement => 'top' },
             :title => _("Original value info"),
-            :icon => warnings[:icon])
+            :icon => "info-circle",
+            :kind => "fa")
   end
 
   def lookup_key_description(lookup_key, matcher, inherited_value)


### PR DESCRIPTION
@Rohoover,
please let me know what do you feel about this:
![image](https://user-images.githubusercontent.com/5609929/31949375-d985163e-b8e1-11e7-83e8-db9c0c92e8e5.png)

I wasn't sure if you wanted to change all the icons to black.