### PR TITLE
Refs #21424 - Pin factory_girl_rails to ~> 4.8.0

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -9,7 +9,7 @@ group :test do
   gem 'show_me_the_cookies', '~> 3.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'
-  gem 'factory_girl_rails', '~> 4.5', :require => false
+  gem 'factory_girl_rails', '~> 4.8.0', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem "poltergeist", :require => false
   gem 'shoulda-matchers', '~> 3.0'


### PR DESCRIPTION
Version 4.9.0 emits a deprecation warning which breaks the CI tests.
Rather than upgrade the stable branch it's easier and less disruptive to
pin.