### PR TITLE
Fixes #21448 - execute npm run lint from context of plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ script/ $(./script/foreman_plugins_eslint.js) || exit 0",
+    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ script/ || exit 0",
+    "postlint": "node ./script/npm_lint_plugins.js",
     "test": "node node_modules/.bin/jest",
     "test:watch": "node node_modules/.bin/jest --watchAll",
     "test:current": "node node_modules/.bin/jest --watch",

--- a/script/foreman_plugins_eslint.js
+++ b/script/foreman_plugins_eslint.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-process.stdout.write(require('./plugin_webpack_directories').getPluginDirs().paths.join(' '));

--- a/script/npm_lint_plugins.js
+++ b/script/npm_lint_plugins.js
@@ -1,0 +1,23 @@
+'use strict';
+/* eslint-disable no-var */
+
+var fs = require('fs');
+
+var childProcess = require('child_process');
+var packageJsonDirs = require('./plugin_webpack_directories').packageJsonDirs;
+
+var pluginDefinesLint = function (pluginPath) {
+  var packageData = JSON.parse(fs.readFileSync(pluginPath + '/package.json'));
+
+  return (packageData.scripts && packageData.scripts.lint);
+};
+
+packageJsonDirs().forEach(function (pluginPath) {
+  if (pluginDefinesLint(pluginPath)) {
+    childProcess.spawn('npm', ['run', 'lint'], {
+      env: process.env,
+      cwd: pluginPath,
+      stdio: 'inherit'
+    });
+  }
+});


### PR DESCRIPTION
Moves linting of plugins to a postlint script similar to how we do npm install for plugins.