### PR TITLE
Fixes #21447 - The login page should be based on patternfly

### DIFF
--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -32,3 +32,6 @@ $nav-pf-vertical-secondary-active-bg-color: #024d6c;
 $nav-pf-vertical-icon-color: #c7c7c7;
 $nav-pf-vertical-secondary-indicator-color: #d1d1d1;
 $nav-pf-vertical-bg-color: #024d6c;
+
+$login-bg-color: $primary_color;
+$login-container-bg-color-rgba: rgba(0, 0, 0, 0.3);

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -1,101 +1,54 @@
 @import "colors";
+@import "bootstrap/mixins";
 
-@media (min-width: 768px) {
-  .login-page #brand {
-    position: relative;
-    top: -52px;
+.login-pf {
+  body {
+    background: $login-bg-color;
+
+    .login-page {
+      height: 100%;
+      background: $login-bg-color;
+
+      #brand {
+        top: -52px;
+        height: 40px;
+
+        img {
+          height: 84px;
+          margin: 0;
+        }
+      }
+
+      .container {
+        padding-top: 0;
+
+        .form-horizontal {
+          .control-label {
+            padding-left: 20px;
+          }
+        }
+      }
+    }
   }
 }
 
-.login-page #brand img {
-  display: block;
-  height: 84px;
-  margin: 0;
-  max-width: 100%;
-}
-
-@media (min-width: 768px) {
-  .login-page #brand img {
-    text-align: left;
-  }
-}
-
-.login-page {
-  height: auto;
-  background: $primary_color;
-  background-size: 100% auto;
-  color: #fff;
-}
-
-.login-page .container {
-  background-color: rgba(0, 0, 0, 0.3);
-  clear: right;
-  padding-bottom: 40px;
-  width: auto;
-}
-
-@media (min-width: 768px) {
-  .login-page .container {
-    bottom: 13%;
-    padding-left: 80px;
-    position: absolute;
-    width: 100%;
+// This fix the transparent background issue in patternfly
+// When patternfly-sass will fix this issue we should remove this code
+// https://github.com/patternfly/patternfly/issues/804
+.login-pf .login-page .container {
+  .alert-success {
+    @include alert-variant($alert-success-bg, $alert-success-border, $alert-success-text);
   }
 
-  .login-page {
-    height: 100%;
-  }
-}
-
-.login-page .container .details p:first-child {
-  border-top: 1px solid #474747;
-  padding-top: 25px;
-  margin-top: 25px;
-}
-
-@media (min-width: 768px) {
-  .login-page .container .details {
-    border-left: 1px solid #474747;
-    padding-left: 40px;
+  .alert-info {
+    @include alert-variant($alert-info-bg, $alert-info-border, $alert-info-text);
   }
 
-  .login-page .container .details p:first-child {
-    border-top: 0;
-    padding-top: 0;
-    margin-top: 0;
-  }
-}
-
-.login-page .container .details p {
-  margin-bottom: 2px;
-}
-
-.login-page .container .form-horizontal .control-label {
-  font-weight: 400;
-  padding-left: 20px;
-  text-align: left;
-}
-
-.login-page .container .form-horizontal .form-group:last-child,
-.login-page .container .form-horizontal .form-group:last-child .help-block:last-child {
-  margin-bottom: 0;
-}
-
-.login-page .container .help-block {
-  color: #fff;
-}
-
-@media (min-width: 768px) {
-  .login-page .container .login {
-    padding-right: 40px;
+  .alert-warning {
+    @include alert-variant($alert-warning-bg, $alert-warning-border, $alert-warning-text);
   }
 
-  #login_text {
-    max-height: 17em;
-    overflow-y: auto;
+  .alert-danger {
+    @include alert-variant($alert-danger-bg, $alert-danger-border, $alert-danger-text);
   }
-}
-
-.login-page .container .submit {
-  text-align: right;
 }

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" class="<%= User.current ? "layout-pf layout-pf-fixed" : "no-js"%>">
+<html lang="<%= I18n.locale %>" class="<%= User.current ? "layout-pf layout-pf-fixed" : "login-pf no-js"%>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, _('Login') %>
+<span id="badge"></span>
 <div id="login" class="container">
   <div class="row">
     <div class="col-sm-12">


### PR DESCRIPTION
The `login.scss` used to be a compiled version of the patternfly `login.scss`
https://github.com/patternfly/patternfly-sass/blob/master/assets/stylesheets/patternfly/_login.scss

**This change is breaking the `foreman_theme_satellite` project so we will need to update the relevant files there.**

**Before the changes:**
![screenshot-2017-10-25 login 7](https://user-images.githubusercontent.com/1262502/31990450-d48923d6-b97d-11e7-9780-78816d601400.png)
![screenshot-2017-10-25 login 6](https://user-images.githubusercontent.com/1262502/31990452-d4abed26-b97d-11e7-8427-b10b9f19a57e.png)
![screenshot-2017-10-25 login 5](https://user-images.githubusercontent.com/1262502/31990453-d4cf1b98-b97d-11e7-82f3-17531f43eda4.png)
![screenshot-2017-10-25 login 4](https://user-images.githubusercontent.com/1262502/31990455-d4f9c7ee-b97d-11e7-9dc5-e2d57172405d.png)

**After the changes:**
![screenshot-2017-10-25 login 3](https://user-images.githubusercontent.com/1262502/31990363-9030d8c8-b97d-11e7-970a-d1c039c55cce.png)
![screenshot-2017-10-25 login 2](https://user-images.githubusercontent.com/1262502/31990364-90503128-b97d-11e7-9483-6f2f0dab0da6.png)
![screenshot-2017-10-25 login 1](https://user-images.githubusercontent.com/1262502/31990365-906dbe3c-b97d-11e7-83e7-a31ef0869723.png)
![screenshot-2017-10-25 login](https://user-images.githubusercontent.com/1262502/31990366-908df33c-b97d-11e7-9053-c0fbd75eb1b9.png)

Notice that the alert styling changed to the way that patternfly designed them for the login page:
https://github.com/patternfly/patternfly-sass/blob/master/assets/stylesheets/patternfly/_login.scss#L52-L55