### PR TITLE
Fixes #21112 - Only initialize host preview once

### DIFF
--- a/app/views/editor/_toolbar.html.erb
+++ b/app/views/editor/_toolbar.html.erb
@@ -21,7 +21,6 @@
     <% end %>
 
     <% if show_preview %>
-      <%= javascript_tag("$(document).on('ContentLoad', function() { tfm.tools.initTypeAheadSelect($('#preview_host_id')) });"); %>
       <span id="preview_host_selector" style="display:none">
         <%= text_field_tag :preview_host_id, nil,
             :'data-url' => preview_host_collection_hosts_path,

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -13,12 +13,11 @@ require('brace/theme/clouds');
 require('brace/keybinding/vim');
 require('brace/keybinding/emacs');
 require('brace/ext/searchbox');
+import { initTypeAheadSelect } from './foreman_tools';
 
 let Editor;
 
-$(document).on('ContentLoad', function () {
-  onEditorLoad();
-});
+$(document).on('ContentLoad', onEditorLoad);
 
 $(document).on('click', '#editor_submit', function () {
   if ($('.diffMode').exists()) {
@@ -51,6 +50,8 @@ function onEditorLoad() {
       setEditMode(editorSource);
     }
   }
+
+  initTypeAheadSelect($('#preview_host_id'));
 }
 
 function setKeybinding() {


### PR DESCRIPTION
Instead of adding the event every time the form is loaded, only do it
once when the editor is initialized.