### PR TITLE
Fixes #21462: Update babel preset to `env`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": ["env", "react"],
   "plugins": [
     "transform-object-rest-spread"
   ]

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -61,7 +61,7 @@ var config = {
         options: {
           'presets': [
             path.join(__dirname, '..', 'node_modules/babel-preset-react'),
-            path.join(__dirname, '..', 'node_modules/babel-preset-es2015')
+            path.join(__dirname, '..', 'node_modules/babel-preset-env')
           ],
           'plugins': [
             path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "~6.6.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.9.0",
     "compression-webpack-plugin": "~0.3.1",


### PR DESCRIPTION
Updating to the current recommended babel-preset-env to replace
the es20xx presets. This gives greater control over build targets
and makes ongoing maintenance easier.

http://projects.theforeman.org/issues/21462