### PR TITLE
Fixes #21496 - Properly fetches permission records

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -323,8 +323,9 @@ class Role < ApplicationRecord
   end
 
   def permission_records(permissions)
-    collection = Permission.where(:name => permissions.flatten).all
-    raise ::Foreman::PermissionMissingException.new(N_('some permissions were not found')) if collection.size != permissions.size
+    perms = permissions.flatten
+    collection = Permission.where(:name => perms).all
+    raise ::Foreman::PermissionMissingException.new(N_('some permissions were not found')) if collection.size != perms.size
     collection
   end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -229,6 +229,10 @@ class RoleTest < ActiveSupport::TestCase
       @role = FactoryGirl.build(:role, :permissions => [])
     end
 
+    it 'should fetch the appropriate permissions' do
+      assert_equal 2, @role.send(:permission_records, [[@permission1.name, @permission2.name]]).size
+    end
+
     it "should build filters with assigned permission" do
       @role.add_permissions [@permission1.name, @permission2.name.to_sym]
       assert @role.filters.all?(&:unlimited?)


### PR DESCRIPTION
The permission records method used to wrongly error out when the
permissions were nested inside an array. Even though the permission list
was returned properly the comparison to raise the PermissionMissing
exception used the wrong logic.