### PR TITLE
Fixes #21499 - org/loc switchers are now visible

### DIFF
--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -52,7 +52,7 @@
 }
 
 .org-switcher {
-  @media (max-width: 768px) {
+  @media (max-width: 767px) {
     display: none !important;
   }
 }


### PR DESCRIPTION
In a specific resolution (Tablet), org/loc switchers do not visible, not in topbar navigation or in hamburger menu.
This happens because of using `.visible-xs-block` bootstrap class on loc/org submenu in the hamburger menu. which is become visible only under 767px width

### without loc/org switchers:
![no_taxonomies](https://user-images.githubusercontent.com/11807069/32143796-cebcda1e-bcb7-11e7-91bb-7a2edf0be338.png)

### with loc/org switchers:
![with_taxonomies](https://user-images.githubusercontent.com/11807069/32143798-d2936c5c-bcb7-11e7-8bdb-dbd6ddc1e84b.png)

 