### PR TITLE
Fixes #21454 - fix editor in fullscreen mode

### DIFF
--- a/app/assets/stylesheets/editor.scss
+++ b/app/assets/stylesheets/editor.scss
@@ -16,7 +16,8 @@
   }
 }
 
-.fullscreen {
+.editor-container.fullscreen {
+  height: 82vh !important;
   .navbar-editor {
     margin: 0;
   }

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -314,10 +314,8 @@ export function enterFullscreen(element, relativeTo) {
   $element.data('origin', $element.parent())
           .data('position', $(window).scrollTop())
           .addClass('fullscreen')
-          .appendTo($('body'))
+          .appendTo($('.container-pf-nav-pf-vertical'))
           .resize();
-
-  $('.navbar').not('.navbar-editor').addClass('hidden');
   $('.btn-fullscreen').addClass('hidden');
   $('.btn-exit-fullscreen').removeClass('hidden');
 
@@ -334,7 +332,6 @@ export function exitFullscreen() {
   let element = $('.fullscreen');
 
   $('#content').removeClass('hidden');
-  $('.navbar').removeClass('hidden');
   element.removeClass('fullscreen')
          .prependTo(element.data('origin'))
          .resize();


### PR DESCRIPTION
Vertical navigation overrides part of the ace editor:
![editor_bug](https://user-images.githubusercontent.com/11807069/32143705-49f8436e-bcb6-11e7-8102-2e21ff19ab25.png)

after: 
![oct 29 2017 2-35 pm](https://user-images.githubusercontent.com/11807069/32143722-9e1c3252-bcb6-11e7-90d6-aab48724e476.gif)

