### PR TITLE
Fixes #21238 - Settings - show defaults on hover

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -4,10 +4,10 @@ module SettingsHelper
       {:title => _("This setting is defined in the configuration file '%{filename}' and is read-only.") % {:filename => setting.class.config_file}, :helper => :show_value}) if setting.readonly?
 
     return edit_select(setting, :value,
-      {:title => _(setting.full_name), :select_values => self.send("#{setting.name}_collection") }) if self.respond_to? "#{setting.name}_collection"
+      {:title => _(setting.full_name_with_default), :select_values => self.send("#{setting.name}_collection") }) if self.respond_to? "#{setting.name}_collection"
 
     return edit_textarea(setting, :value, {:title => _(setting.full_name), :helper => :show_value}) if setting.settings_type == 'array'
-    edit_textfield(setting, :value,{:title => _(setting.full_name), :helper => :show_value})
+    edit_textfield(setting, :value,{:title => _(setting.full_name_with_default), :helper => :show_value})
   end
 
   def show_value(setting)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -285,6 +285,10 @@ class Setting < ApplicationRecord
 
   # End methods for loading default settings
 
+  def full_name_with_default
+    "#{full_name} (Default: #{default})"
+  end
+
   private
 
   def validate_host_owner

--- a/test/helpers/settings_helper_test.rb
+++ b/test/helpers/settings_helper_test.rb
@@ -7,7 +7,7 @@ class SettingsHelperTest < ActionView::TestCase
     options = Setting.set("test_attr", "some_description", "default_value", "full_name", "my_value", { :collection => Proc.new {{:a => "a", :b => "b"}} })
     setting = Setting.create(options)
     assert_equal self.send("#{setting.name}_collection"), { :a => "a", :b => "b" }
-    self.expects(:edit_select).with(setting, :value, :title => setting.full_name, :select_values => { :a => "a", :b => "b" })
+    self.expects(:edit_select).with(setting, :value, :title => setting.full_name_with_default, :select_values => { :a => "a", :b => "b" })
     value(setting)
   end
 
@@ -25,7 +25,7 @@ class SettingsHelperTest < ActionView::TestCase
     FactoryBot.create(:hostgroup, :root_pass => '12345678')
     setting = Setting.create(options)
     assert_equal self.send("#{setting.name}_collection"), { :size => expected_hostgroup_count }
-    self.expects(:edit_select).with(setting, :value, :title => setting.full_name, :select_values => { :size => expected_hostgroup_count })
+    self.expects(:edit_select).with(setting, :value, :title => setting.full_name_with_default, :select_values => { :size => expected_hostgroup_count })
     value(setting)
   end
 end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -600,4 +600,14 @@ class SettingTest < ActiveSupport::TestCase
     refute_empty sorted_list
     assert sorted_list.keys.exclude?(sticky_setting)
   end
+
+  test 'full_name_with_default should include default value' do
+    setting = FactoryBot.build(:setting, :name => 'foo', :value => 'baz', :default => 'boo', :description => 'test foo', :full_name => 'Foo Name')
+    assert_equal('Foo Name (Default: boo)', setting.full_name_with_default)
+  end
+
+  test 'full_name_with_default without default value' do
+    setting = FactoryBot.build(:setting, :name => 'foo', :default => '', :description => 'test foo', :full_name => 'Foo Name')
+    assert_equal('Foo Name (Default: )', setting.full_name_with_default)
+  end
 end


### PR DESCRIPTION
Defaults visible only when default and actual value are different