### PR TITLE
Fixes #21502 - Allow internal users in group with external groups

### DIFF
--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -38,6 +38,13 @@ module Api
       end
 
       api :PUT, "/usergroups/:id/", N_("Update a user group")
+      description <<-DOC
+        User groups linked to external groups (LDAP) are automatically synced
+        with these groups on update. Remember this synchronization will remove
+        any LDAP users manually added to the Foreman user group. Only LDAP
+        users in the external groups will remain. Internal users can be added
+        or removed freely.
+      DOC
       param :id, String, :required => true
       param_group :usergroup
 

--- a/app/models/external_usergroup.rb
+++ b/app/models/external_usergroup.rb
@@ -16,6 +16,8 @@ class ExternalUsergroup < ApplicationRecord
     return false unless auth_source.respond_to?(:users_in_group)
 
     current_users = usergroup.users.map(&:login)
+    internal_users = usergroup.users.
+      where(:auth_source => AuthSourceInternal.first).map(&:login)
     my_users = users
     all_other_users = (usergroup.external_usergroups - [self]).map(&:users)
     all_users = (all_other_users + my_users).flatten.uniq
@@ -23,7 +25,7 @@ class ExternalUsergroup < ApplicationRecord
     # We need to make sure when we refresh a external_usergroup
     # other external_usergroup users remain in. Otherwise refreshing
     # a external user group with no users in will empty the user group.
-    old_users = current_users - all_users
+    old_users = current_users - all_users - internal_users
     new_users = my_users - current_users
 
     usergroup.remove_users(old_users)

--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -9,9 +9,22 @@
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
+      <% if @usergroup.external_usergroups.any? %>
+        <h5>
+          <%= _('Only internal (non-LDAP) users can be added manually. LDAP users
+                are automatically synced from the External Groups list.') %>
+        </h5>
+        <h5>
+          <%= _('To refresh the list of users, click on the tab "External
+                groups" then "Refresh".') %>
+        </h5>
+        <hr>
+      <% end %>
       <%= text_f f, :name %>
-      <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup, :label => _("User Groups") %>
-      <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden, :label => _("Users"), :object_label_method => :select_title %>
+      <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup,
+        { :label => _("User Groups") } %>
+      <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden,
+        :label => _("Users"), :object_label_method => :select_title %>
     </div>
     <div class="tab-pane" id="roles">
       <%= checkbox_f f, :admin if User.current.can_change_admin_flag? %>


### PR DESCRIPTION
Adding Users to User Groups with External User Groups does not
work. Currently the only feedback the user gets is that Users get
automatically removed after the form is submitted - no warning or
mention.

In order not to confuse the user or make the user waste their time
adding users, we should display a warning when there are External User
Groups linked to a User Group.

------------------------------------

This should contain tests and should not be merged as is, just opening it to keep track of it and maybe get early feedback