### PR TITLE
Fixes #16835 - Allow implicit search with org_id

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -13,9 +13,9 @@ module Taxonomix
              :validate => false
     after_initialize :set_current_taxonomy
 
-    scoped_search :relation => :locations, :on => :name, :rename => :location, :complete_value => true
+    scoped_search :relation => :locations, :on => :name, :rename => :location, :complete_value => true, :only_explicit => true
     scoped_search :relation => :locations, :on => :id, :rename => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-    scoped_search :relation => :organizations, :on => :name, :rename => :organization, :complete_value => true
+    scoped_search :relation => :organizations, :on => :name, :rename => :organization, :complete_value => true, :only_explicit => true
     scoped_search :relation => :organizations, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
     dirty_has_many_associations :organizations, :locations

--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -162,4 +162,14 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     assert_equal taxonomies(:location2).domains.length, assigns(:domains).length
     assert_equal assigns(:domains), taxonomies(:location2).domains
   end
+
+  test "should get domains when searching with organization_id" do
+    domain = FactoryGirl.create(:domain)
+    org = FactoryGirl.create(:organization)
+    org.domain_ids = [domain.id]
+    get :index, {:search => domain.name, :organization_id => org.id }
+    assert_response :success
+    assert_equal org.domains.length, assigns(:domains).length
+    assert_equal assigns(:domains), org.domains
+  end
 end


### PR DESCRIPTION
Previously, any resource with many taxonomies would fail when using
implicit search when passing organization_id parameter to the api. This
is due to scoped_search incorrectly adding the taxonomy table to search
on, which was conflicting with the current taxonomy scope. Removing the
implicit search on taxonomies fixes the issue while still allowing users
to explicitly search on location or organization if they want to
(although it makes no sense to use both options).