### PR TITLE
Fixes #21543 - Tooltip will appear only if the key is too long

### DIFF
--- a/app/views/puppetclasses/_form.html.erb
+++ b/app/views/puppetclasses/_form.html.erb
@@ -49,7 +49,7 @@
           <ul class="nav nav-pills nav-stacked smart-var-tabs" data-tabs="pills">
             <% @puppetclass.class_params.includes(:environments, :environment_classes, :lookup_values).each do |key| %>
               <li data-used-environments=<%= key.environments.map(&:to_s).to_json %> >
-                <a data-toggle="tab" id="pill_<%= key.to_param %>" href="#<%= key.to_param %>" title="<%= key %>">
+                <a data-toggle="tab" id="pill_<%= key.to_param %>" href="#<%= key.to_param %>" title="<%= key.key.size > 43 ? key : "" %>">
                   <div class="clip"><%= icon_text((key.override ? "flag": ""), key.to_s.tr('_',' '), :kind => 'fa') %></div>
                 </a>
               </li>
@@ -79,7 +79,7 @@
         <ul class="nav nav-pills nav-stacked smart-var-tabs" data-tabs="pills">
           <% @puppetclass.lookup_keys.each do |key| %>
             <li>
-              <a data-toggle="tab" id="pill_<%= key.to_param %>" href="#<%= key.to_param %>" title="<%= key %>">
+              <a data-toggle="tab" id="pill_<%= key.to_param %>" href="#<%= key.to_param %>" title="<%= key.key.size > 43 ? key : "" %>">
                 <div class="clip"><%= key.to_s.tr('_',' ') %></div><span class="close pull-right">&times;</span>
               </a>
             </li>


### PR DESCRIPTION
If the key is too long, a tooltip will appear: 
![image](https://user-images.githubusercontent.com/5609929/32277323-bdbf89e0-bf1a-11e7-8d24-448dbc49dcd1.png)

If this key is short, then no tooltip will appear
![image](https://user-images.githubusercontent.com/5609929/32277336-cd0d4400-bf1a-11e7-82e6-f699d0fcc33b.png)
