### PR TITLE
Fixes #21551 - add user menu to hamburger menu in mobile

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,8 +1,9 @@
 module HomeHelper
-  def render_vertical_menu(menu_name)
+  def render_vertical_menu(menu_name, mobile = false)
     authorized_menu_actions(Menu::Manager.items(menu_name).children).map do |menu|
       items = authorized_menu_actions(menu.children)
-      render "home/vertical_menu", :menu_items => items, :menu_title => _(menu.caption), :menu_icon => menu.icon, :menu_name => menu.name if items.any?
+      render "home/vertical_menu", :menu_items => items, :menu_title => _(menu.caption), :menu_icon => menu.icon,
+                                   :menu_name => menu.name, :mobile_class => mobile ? 'visible-xs-block' : ''  if items.any?
     end.join(' ').html_safe
   end
 

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -9,17 +9,18 @@ module Menu
     def self.load
       Manager.map :header_menu
 
-      Manager.map :user_menu do |menu|
-        menu.item :my_account,
-                  :caption => N_('My Account'),
-                  :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
-        menu.divider
-        menu.item :logout,
-                  :caption => N_('Log Out'),
-                  :html => {:method => :post},
-                  :url_hash => {:controller => '/users', :action => 'logout'}
+      Manager.map :side_menu do |menu|
+        menu.sub_menu :user_menu, :caption => N_('User'), :icon => 'fa fa-user' do
+          menu.item :my_account,
+                    :caption => N_('My Account'),
+                    :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
+          menu.divider
+          menu.item :logout,
+                    :caption => N_('Log Out'),
+                    :html => {:method => :post},
+                    :url_hash => {:controller => '/users', :action => 'logout'}
+        end
       end
-
       Manager.map :admin_menu do |menu|
         menu.sub_menu :administer_menu,  :caption => N_('Administer'), :icon => 'fa fa-cog' do
           menu.item :locations,          :caption => N_('Locations') if SETTINGS[:locations_enabled]

--- a/app/views/home/_navbar.html.erb
+++ b/app/views/home/_navbar.html.erb
@@ -12,5 +12,6 @@
 
     <%= render "home/vertical_taxonomies", :taxonomy_type => "location", :icon_name => "fa fa-globe" if SETTINGS[:locations_enabled]  %>
     <%= render "home/vertical_taxonomies", :taxonomy_type => "organization", :icon_name => "fa fa-building" if SETTINGS[:organizations_enabled]  %>
+    <%= render_vertical_menu :side_menu, true %>
   </ul>
 </div>

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -2,7 +2,7 @@
 <li class="dropdown">
   <%= user_header %>
   <ul class="dropdown-menu pull-right">
-    <% authorized_menu_actions(Menu::Manager.items(:user_menu).children).map do |item| %>
+    <% authorized_menu_actions(Menu::Manager.items(:side_menu)).map do |item| %>
         <% case item %>
         <% when Menu::Item %>
           <%= menu_item_tag item %>

--- a/app/views/home/_vertical_menu.html.erb
+++ b/app/views/home/_vertical_menu.html.erb
@@ -1,4 +1,4 @@
-<li class="list-group-item secondary-nav-item-pf" data-target=<%= "#{menu_name}-secondary" %>>
+<%= content_tag :li, :class => "list-group-item secondary-nav-item-pf #{mobile_class}", "data-target" => "#{menu_name}-secondary" do %> 
   <a id= <%= "#{menu_name}" %>>
   <%= content_tag(:span, '', :class => "#{menu_icon}", "data-toggle" => "tooltip", :title => menu_title) %>
   <%= content_tag(:span, menu_title, :class => "list-group-item-value")   %>
@@ -30,4 +30,4 @@
       <% end %>
     </ul>
   </div>
-</li>
+<% end %>

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -92,5 +92,11 @@ class TopBarIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  #PENDING - click on Menu Bar js
+  test "hamburger menu should have some mobile submenu " do
+    visit root_path
+    mobile_menu = ["Location", "Organization", "User"]
+    all(".visible-xs-block").each_with_index do |el, index|
+      assert el.has_content?(mobile_menu[index])
+    end
+  end
 end


### PR DESCRIPTION
In mobile resolution, the upper user menu is disappeared and re-rendered in hamburger menu:
![nov 1 2017 8-21 pm](https://user-images.githubusercontent.com/11807069/32291628-5071f036-bf46-11e7-9a82-327a7ae640b8.gif)
 