### PR TITLE
Fixes #21563: add babel-plugin-transform-class-properties.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "presets": ["env", "react"],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    "transform-object-assign"
   ]
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
             path.join(__dirname, '..', 'node_modules/babel-preset-env')
           ],
           plugins: [
+            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-class-properties'),
             path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),
             path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-assign')
           ]

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -64,6 +64,7 @@ var config = {
             path.join(__dirname, '..', 'node_modules/babel-preset-env')
           ],
           'plugins': [
+            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-class-properties'),
             path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),
             path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-assign')
           ]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-eslint": "^6.1.2",
     "babel-jest": "^15.0.0",
     "babel-loader": "^7.1.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-polyfill": "^6.13.0",


### PR DESCRIPTION
Add babel-plugin-transform-class-properties to the webpack config
so that we can transform es2015 static class variables into normal
JS.

http://projects.theforeman.org/issues/21563