### PR TITLE
Fixes #21578 - Cmp.PropTypes to Cmp.propTypes

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/charts/Chart.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/Chart.js
@@ -52,11 +52,9 @@ class Chart extends React.Component {
   }
 }
 
-Chart.PropTypes = {
+Chart.propTypes = {
   config: PropTypes.object.isRequired,
-  id: PropTypes.string.isRequired,
   noDataMsg: PropTypes.string,
-  cssClass: PropTypes.string,
   setTitle: PropTypes.func
 };
 

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
@@ -93,7 +93,7 @@ class ChartBox extends React.Component {
   }
 }
 
-ChartBox.PropTypes = {
+ChartBox.propTypes = {
   status: PropTypes.string.isRequired,
   config: PropTypes.object,
   modalConfig: PropTypes.object,

--- a/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.js
@@ -50,7 +50,7 @@ class StatisticsChartsList extends React.Component {
   }
 }
 
-StatisticsChartsList.PropTypes = {
+StatisticsChartsList.propTypes = {
   data: PropTypes.array.isRequired
 };
 


### PR DESCRIPTION
Chart, ChartBox and StatisticsChartsList are using prop-types in a wrong
way.

Chart is declaring about prop-types it is never used.

http://projects.theforeman.org/issues/21578