### PR TITLE
fixes #21579 - pagelets for host show

### DIFF
--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -20,6 +20,7 @@
         </tr>
       </tbody>
     </table>
+
     <ul id="myTab" class="nav nav-tabs">
       <li class="active"><a href="#properties" data-toggle="tab"><%= _('Properties') %></a></li>
       <li><a href="#metrics" data-toggle="tab"><%= _('Metrics') %></a></li>
@@ -33,6 +34,7 @@
         <li><a href="#bmc" data-toggle="tab"><%= _('BMC') %></a></li>
       <% end %>
       <li><a href="#nics" data-toggle="tab"><%= _('NICs') %></a></li>
+      <%= render_tab_header_for(:main_tabs, :subject => @host) %>
     </ul>
     <div id="myTabContent" class="tab-content">
       <div class="tab-pane active in" id="properties" data-ajax-url='<%= overview_host_path(@host)%>'>
@@ -53,7 +55,7 @@
       <% end %>
       <%  if @host.compute_resource_id %>
         <div class="tab-pane" id="vm" data-ajax-url='<%= vm_host_path(@host)%>' data-on-complete='setPowerState'>
-        <%= spinner(_('Loading VM information ...')) %>
+          <%= spinner(_('Loading VM information ...')) %>
         </div>
       <% end %>
       <div id="nics" class="tab-pane" data-ajax-url='<%= nics_host_path(@host)%>' data-on-complete='tfm.tools.activateTooltips'>
@@ -64,8 +66,9 @@
           <%= spinner(_('Loading BMC information ...')) %>
         </div>
       <% end %>
-       </div>
+      <%= render_tab_content_for(:main_tabs, :subject => @host) %>
     </div>
+  </div>
 
   <div class="col-md-8">
     <div class="stats-well">

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'pagelets_test_helper'
 
 class HostsControllerTest < ActionController::TestCase
+  include PageletsIsolation
+
   setup :initialize_host
 
   basic_pagination_rendered_test
@@ -1625,6 +1628,21 @@ class HostsControllerTest < ActionController::TestCase
       not_expected = {'id' => host2.id, 'name' => host2.name}
       assert_includes response, expected
       assert_not_includes response, not_expected
+    end
+  end
+
+  context 'with pagelets' do
+    setup do
+      @controller.prepend_view_path File.expand_path('../../static_fixtures', __FILE__)
+      Pagelets::Manager.add_pagelet('hosts/show', :main_tabs,
+                                    :name => 'TestTab',
+                                    :id => 'my-special-id',
+                                    :partial => 'views/test')
+    end
+
+    test '#show renders a pagelet tab' do
+      get :show, {:id => Host.first.name}, set_session_user
+      assert @response.body.match /id='my-special-id'/
     end
   end
 


### PR DESCRIPTION
This PR adds a pagelets extension point for the host show page (just two more lines). Also, fixes indentation.

Any chance this can still get into 1.16?

Tested with 

```ruby
       extend_page('hosts/show') do |context|
          context.add_pagelet :main_tabs,
            :name => N_('Omaha'),
            :partial => 'hosts/omaha_tab',
            :onlyif => proc { |host| host.omaha_facet }
        end
```

which leads to:

![image](https://user-images.githubusercontent.com/4107560/32418192-71cf199e-c265-11e7-9465-677244b910f6.png)
