### PR TITLE
Fixes #21580 - normalize compute attributes

### DIFF
--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -28,12 +28,16 @@ class ComputeAttribute < ApplicationRecord
     vm_attrs.has_key?(method.to_s) || super
   end
 
+  def normalized_vm_attrs
+    compute_resource.normalize_vm_attrs(vm_attrs)
+  end
+
   def vm_interfaces
     attribute_values(compute_resource.interfaces_attrs_name)
   end
 
   def new_vm
-    compute_resource.new_vm(vm_attrs) if vm_attrs
+    compute_resource.new_vm(vm_attrs.dup) if vm_attrs
   end
 
   def pretty_vm_attrs

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -364,7 +364,25 @@ class ComputeResource < ApplicationRecord
     respond_to?(:associated_host)
   end
 
+  def normalize_vm_attrs(vm_attrs)
+    vm_attrs
+  end
+
   protected
+
+  def memory_gb_to_bytes(memory_size)
+    memory_size.to_s.gsub(/[^0-9]/, '').to_i * 1.gigabyte
+  end
+
+  def to_bool(value)
+    ['1', 'true'].include?(value.to_s.downcase) unless value.nil?
+  end
+
+  def slice_vm_attributes(vm_attrs, fields)
+    fields.inject({}) do |slice, f|
+      slice.merge({f => (vm_attrs[f].to_s.empty? ? nil : vm_attrs[f])})
+    end
+  end
 
   def client
     raise ::Foreman::Exception.new N_("Not implemented")

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -151,6 +151,22 @@ module Foreman::Model
       client.disks.new(args)
     end
 
+    def normalize_vm_attrs(vm_attrs)
+      normalized = slice_vm_attributes(vm_attrs, ['image_id', 'machine_type', 'network'])
+
+      normalized['external_ip'] = to_bool(vm_attrs['external_ip'])
+      normalized['image_name'] = self.images.find_by(:uuid => vm_attrs['image_id']).try(:name)
+
+      volume_attrs = vm_attrs['volumes_attributes'] || {}
+      normalized['volumes_attributes'] = volume_attrs.each_with_object({}) do |(key, vol), volumes|
+        volumes[key] = {
+          'size' => memory_gb_to_bytes(vol['size_gb']).to_s
+        }
+      end
+
+      normalized
+    end
+
     private
 
     def client

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -197,6 +197,37 @@ module Foreman::Model
       vm_attrs
     end
 
+    def normalize_vm_attrs(vm_attrs)
+      normalized = slice_vm_attributes(vm_attrs, ['cpus', 'memory', 'image_id'])
+
+      normalized['image_name'] = self.images.find_by(:uuid => vm_attrs['image_id']).try(:name)
+
+      volume_attrs = vm_attrs['volumes_attributes'] || {}
+      normalized['volumes_attributes'] = volume_attrs.each_with_object({}) do |(key, vol), volumes|
+        volumes[key] = {
+          'capacity' => memory_gb_to_bytes(vol['capacity']).to_s,
+          'allocation' => memory_gb_to_bytes(vol['allocation']).to_s,
+          'format_type' => vol['format_type'],
+          'pool' => vol['pool_name']
+        }
+      end
+
+      interface_attrs = vm_attrs['nics_attributes'] || {}
+      normalized['interfaces_attributes'] = interface_attrs.each_with_object({}) do |(key, nic), interfaces|
+        interfaces[key] = {
+          'type' => nic['type'],
+          'model' => nic['model']
+        }
+        if nic['type'] == 'network'
+          interfaces[key]['network'] = nic['network']
+        else
+          interfaces[key]['bridge'] = nic['bridge']
+        end
+      end
+
+      normalized
+    end
+
     protected
 
     def client

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -94,6 +94,14 @@ module Foreman::Model
       true
     end
 
+    def normalize_vm_attrs(vm_attrs)
+      normalized = slice_vm_attributes(vm_attrs, ['flavor_id', 'image_id'])
+
+      normalized['flavor_name'] = self.flavors.detect { |f| f.id == normalized['flavor_id'] }.try(:name)
+      normalized['image_name'] = self.images.find_by(:uuid => normalized['image_id']).try(:name)
+      normalized
+    end
+
     private
 
     def client

--- a/app/views/api/v2/compute_attributes/base.json.rabl
+++ b/app/views/api/v2/compute_attributes/base.json.rabl
@@ -2,3 +2,4 @@ object @compute_attribute
 
 attributes :id, :name, :compute_resource_id, :compute_resource_name, :provider_friendly_name,
            :compute_profile_id, :compute_profile_name, :vm_attrs
+attributes :normalized_vm_attrs => :attributes

--- a/test/controllers/api/v2/compute_profiles_controller_test.rb
+++ b/test/controllers/api/v2/compute_profiles_controller_test.rb
@@ -10,6 +10,7 @@ class Api::V2::ComputeProfilesControllerTest < ActionController::TestCase
   end
 
   test "should show individual record" do
+    Foreman::Model::EC2.any_instance.expects(:normalize_vm_attrs).returns({})
     get :show, params: { :id => compute_profiles(:one).to_param }
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
@@ -26,6 +27,7 @@ class Api::V2::ComputeProfilesControllerTest < ActionController::TestCase
   end
 
   test "should update compute_profile" do
+    Foreman::Model::EC2.any_instance.expects(:normalize_vm_attrs).returns({})
     name = 'new name'
     put :update, params: { :id => compute_profiles(:one).to_param, :compute_profile => {:name => name } }
     assert_response :success

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -54,6 +54,14 @@ FactoryBot.define do
       after(:build) { |cr| cr.stubs(:update_public_key) }
     end
 
+    trait :with_images do
+      after(:create) do |cr, evaluator|
+        cr.stubs(:image_exists?).returns(true)
+        FactoryBot.create(:image, :compute_resource => cr)
+        FactoryBot.create(:image, :compute_resource => cr)
+      end
+    end
+
     factory :ec2_cr, :class => Foreman::Model::EC2, :traits => [:ec2]
     factory :gce_cr, :class => Foreman::Model::GCE, :traits => [:gce]
     factory :libvirt_cr, :class => Foreman::Model::Libvirt, :traits => [:libvirt]

--- a/test/models/compute_resources/compute_resource_test_helpers.rb
+++ b/test/models/compute_resources/compute_resource_test_helpers.rb
@@ -19,9 +19,110 @@ module ComputeResourceTestHelpers
     cr
   end
 
+  def mock_cr(cr, attributes)
+    attributes.each do |attr, stubbed_value|
+      cr.stubs(attr).returns(stubbed_value)
+    end
+    cr
+  end
+
   def assert_find_by_uuid_raises(ex_class, cr)
     assert_raises(ex_class) do
       cr.find_vm_by_uuid('abc')
     end
+  end
+
+  def assert_blank_attr_nilified(cr, attr_name)
+    vm_attrs = {
+      attr_name => ''
+    }
+    normalized = cr.normalize_vm_attrs(vm_attrs)
+
+    assert(normalized.has_key?(attr_name))
+    assert_nil(normalized[attr_name])
+  end
+
+  def assert_attrs_mapped(cr, attr_before, attr_after)
+    vm_attrs = {
+      attr_before => 'ATTR_VALUE'
+    }
+    normalized = cr.normalize_vm_attrs(vm_attrs)
+
+    refute(normalized.has_key?(attr_before))
+    assert_equal('ATTR_VALUE', normalized[attr_after])
+  end
+
+  def assert_blank_mapped_attr_nilified(cr, attr_before, attr_after)
+    vm_attrs = {
+      attr_before => ''
+    }
+    normalized = cr.normalize_vm_attrs(vm_attrs)
+
+    refute(normalized.has_key?(attr_before))
+    assert(normalized.has_key?(attr_after))
+    assert_nil(normalized[attr_after])
+  end
+
+  def allowed_vm_attr_names
+    @allowed_vm_attr_names ||= %w(
+      add_cdrom
+      annotation
+      availability_zone
+      boot_from_volume
+      boot_volume_size
+      cluster_id
+      cluster_name
+      cores
+      cores_per_socket
+      cpu_hot_add_enabled
+      cpus
+      external_ip
+      firmware
+      flavor_id
+      flavor_name
+      floating_ip_network
+      folder_name
+      folder_path
+      guest_id
+      guest_name
+      hardware_version_id
+      hardware_version_name
+      image_id
+      image_name
+      interfaces_attributes
+      keys
+      machine_type
+      managed_ip
+      memory
+      memory_hot_add_enabled
+      network
+      resource_pool_id
+      resource_pool_name
+      scheduler_hint_filter
+      scsi_controllers
+      security_groups
+      security_group_id
+      security_group_name
+      subnet_id
+      subnet_name
+      template_id
+      template_name
+      tenant_id
+      tenant_name
+      volumes_attributes
+    )
+  end
+
+  def check_vm_attribute_names(cr)
+    normalized_keys = cr.normalize_vm_attrs({}).keys
+
+    normalized_keys.each do |name|
+      assert(name == name.to_s.underscore, "Attribute '#{name}' breaks naming conventions. All attributes should be in snake_case.")
+    end
+
+    unexpected_names = normalized_keys - (normalized_keys & allowed_vm_attr_names)
+    msg = "Some unexpected attributes detected: #{unexpected_names.join(', ')}."
+    msg += "\nMake user you can't use one of names that already exist. If not, please extend ComputeResourceTestHelpers.allowed_vm_attr_names."
+    assert(unexpected_names.empty?, msg)
   end
 end

--- a/test/models/compute_resources/ec2_test.rb
+++ b/test/models/compute_resources/ec2_test.rb
@@ -36,6 +36,103 @@ module Foreman
           assert_includes(cr.capabilities, :key_pair)
         end
       end
+
+      describe '#normalize_vm_attrs' do
+        let(:cr) do
+          mock_cr(FactoryBot.build(:ec2_cr),
+            :subnets => [
+              stub(:subnet_id => 'sn1', :cidr_block => 'cidr blk 1'),
+              stub(:subnet_id => 'sn2', :cidr_block => 'cidr blk 2')
+            ],
+            :security_groups => [
+              stub(:group_id => 'grp1', :name => 'group 1'),
+              stub(:group_id => 'grp2', :name => 'group 2')
+            ],
+            :flavors => [
+              stub(:id => 'flvr1', :name => 'flavour 1'),
+              stub(:id => 'flvr2', :name => 'flavour 2')
+            ]
+          )
+        end
+
+        test 'nilifies blank flavor_id' do
+          assert_blank_attr_nilified(cr, 'flavor_id')
+        end
+
+        test 'sets flavor_name' do
+          vm_attrs = {
+            'flavor_id' => 'flvr1'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal('flavour 1', normalized['flavor_name'])
+        end
+
+        test 'nilifies blank availability_zone' do
+          assert_blank_attr_nilified(cr, 'availability_zone')
+        end
+
+        test 'nilifies blank subnet_id' do
+          assert_blank_attr_nilified(cr, 'subnet_id')
+        end
+
+        test 'sets subnet_name' do
+          vm_attrs = {
+            'subnet_id' => 'sn1'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal('cidr blk 1', normalized['subnet_name'])
+        end
+
+        test 'sets image_name' do
+          cr = FactoryBot.create(:gce_cr, :with_images)
+
+          vm_attrs = {
+            'image_id' => cr.images.last.uuid
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal(cr.images.last.name, normalized['image_name'])
+        end
+
+        test 'maps security_groups' do
+          vm_attrs = {
+            'security_group_ids' => ['', 'grp1']
+          }
+          expected_attrs = {
+            '0' => {
+              'id' => 'grp1',
+              'name' => 'group 1'
+            }
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal(expected_attrs, normalized['security_groups'])
+        end
+
+        test 'correctly fills empty attributes' do
+          normalized = cr.normalize_vm_attrs({})
+          expected_attrs = {
+            'flavor_id' => nil,
+            'flavor_name' => nil,
+            'image_id' => nil,
+            'image_name' => nil,
+            'availability_zone' => nil,
+            'managed_ip' => nil,
+            'subnet_id' => nil,
+            'subnet_name' => nil,
+            'security_groups' => {}
+          }
+
+          assert_equal(expected_attrs.keys.sort, normalized.keys.sort)
+          assert_equal(expected_attrs, normalized)
+        end
+
+        test 'attribute names' do
+          check_vm_attribute_names(cr)
+        end
+      end
     end
   end
 end

--- a/test/models/compute_resources/gce_test.rb
+++ b/test/models/compute_resources/gce_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+require 'models/compute_resources/compute_resource_test_helpers'
+
+class Foreman::Model::GCETest < ActiveSupport::TestCase
+  include ComputeResourceTestHelpers
+
+  describe '#normalize_vm_attrs' do
+    let(:cr) { FactoryBot.build(:gce_cr) }
+
+    describe 'external_ip' do
+      test 'normalizes 1 to true' do
+        normalized = cr.normalize_vm_attrs({ 'external_ip' => '1' })
+
+        assert_equal(true, normalized['external_ip'])
+      end
+
+      test 'normalizes 0 to false' do
+        normalized = cr.normalize_vm_attrs({ 'external_ip' => '0' })
+
+        assert_equal(false, normalized['external_ip'])
+      end
+    end
+
+    describe 'images' do
+      let(:cr) { FactoryBot.create(:gce_cr, :with_images) }
+
+      test 'adds image name' do
+        vm_attrs = {
+          'image_id' => cr.images.last.uuid
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert_equal(cr.images.last.name, normalized['image_name'])
+      end
+
+      test 'leaves image name empty when image_id is nil' do
+        vm_attrs = {
+          'image_id' => nil
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert(normalized.has_key?('image_name'))
+        assert_nil(normalized['image_name'])
+      end
+
+      test "leaves image name empty when image wasn't found" do
+        vm_attrs = {
+          'image_id' => 'unknown'
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert(normalized.has_key?('image_name'))
+        assert_nil(normalized['image_name'])
+      end
+    end
+
+    describe 'volumes_attributes' do
+      test 'adds volumes_attributes when they were missing' do
+        normalized = cr.normalize_vm_attrs({})
+
+        assert_equal({}, normalized['volumes_attributes'])
+      end
+
+      test 'normalizes volumes_attributes' do
+        vm_attrs = {
+          'volumes_attributes' => {
+            '0' => {
+              'size_gb' => '1GB',
+              'id' => ''
+            }
+          }
+        }
+        expected_attrs = {
+          '0' => {
+            'size' => 1.gigabyte.to_s
+          }
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert_equal(expected_attrs, normalized['volumes_attributes'])
+      end
+    end
+
+    test 'correctly fills empty attributes' do
+      normalized = cr.normalize_vm_attrs({})
+      expected_attrs = {
+        'machine_type' => nil,
+        'network' => nil,
+        'external_ip' => nil,
+        'image_id' => nil,
+        'image_name' => nil,
+        'volumes_attributes' => {}
+      }
+
+      assert_equal(expected_attrs.keys.sort, normalized.keys.sort)
+      assert_equal(expected_attrs, normalized)
+    end
+
+    test 'attribute names' do
+      check_vm_attribute_names(cr)
+    end
+  end
+end

--- a/test/models/compute_resources/openstack_test.rb
+++ b/test/models/compute_resources/openstack_test.rb
@@ -114,6 +114,199 @@ module Foreman
         end
       end
 
+      describe '#normalize_vm_attrs' do
+        let(:cr) do
+          mock_cr(FactoryBot.build(:openstack_cr),
+            :security_groups => [
+              stub(:id => 'grp1', :name => 'group 1'),
+              stub(:id => 'grp2', :name => 'group 2')
+            ],
+            :tenants => [
+              stub(:id => 'tn1', :name => 'tenant 1'),
+              stub(:id => 'tn2', :name => 'tenant 2')
+            ],
+            :flavors => [
+              stub(:id => 'flvr1', :name => 'flavour 1'),
+              stub(:id => 'flvr2', :name => 'flavour 2')
+            ],
+            :internal_networks => [
+              stub(:id => 'nic1', :name => 'default'),
+              stub(:id => 'nic2', :name => 'bridge')
+            ]
+          )
+        end
+
+        test 'maps flavor_ref to flavor_id' do
+          assert_attrs_mapped(cr, 'flavor_ref', 'flavor_id')
+        end
+
+        test 'finds flavor_name' do
+          vm_attrs = {
+            'flavor_ref' => 'flvr1'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal('flavour 1', normalized['flavor_name'])
+        end
+
+        test 'sets blank availability_zone to nil' do
+          assert_blank_attr_nilified(cr, 'availability_zone')
+        end
+
+        test 'sets blank tenant_id to nil' do
+          assert_blank_attr_nilified(cr, 'tenant_id')
+        end
+
+        test 'finds tenant_name' do
+          vm_attrs = {
+            'tenant_id' => 'tn1'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal('tenant 1', normalized['tenant_name'])
+        end
+
+        test 'maps security_groups to security_group_name' do
+          assert_attrs_mapped(cr, 'security_groups', 'security_group_name')
+        end
+
+        test 'sets blank security_group_name to nil' do
+          assert_blank_mapped_attr_nilified(cr, 'security_groups', 'security_group_name')
+        end
+
+        test 'finds security_group_id' do
+          vm_attrs = {
+            'security_groups' => 'group 2'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal('grp2', normalized['security_group_id'])
+        end
+
+        test 'maps network to floating_ip_network' do
+          assert_attrs_mapped(cr, 'network', 'floating_ip_network')
+        end
+
+        test 'nilifies floating_ip_network when network is blank' do
+          assert_blank_mapped_attr_nilified(cr, 'network', 'floating_ip_network')
+        end
+
+        test 'casts boot_from_volume to boolean' do
+          vm_attrs = {
+            'boot_from_volume' => 'true'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal(true, normalized['boot_from_volume'])
+        end
+
+        test 'translates boot_volume_size to bytes' do
+          vm_attrs = {
+            'size_gb' => '2'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal(2.gigabyte.to_s, normalized['boot_volume_size'])
+        end
+
+        test 'maps zero (default) boot_volume_size nil' do
+          vm_attrs = {
+            'size_gb' => '0'
+          }
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_nil(normalized['boot_volume_size'])
+        end
+
+        test 'normalizes nics_attributes' do
+          vm_attrs = {
+            'nics' => ['', 'nic1', 'nic2']
+          }
+          expected_attrs = {
+            '0' => {
+              'id' => 'nic1',
+              'name' => 'default'
+            },
+            '1' => {
+              'id' => 'nic2',
+              'name' => 'bridge'
+            }
+          }
+
+          normalized = cr.normalize_vm_attrs(vm_attrs)
+
+          assert_equal(expected_attrs, normalized['interfaces_attributes'])
+        end
+
+        test 'nilifies blank scheduler_hint_filter' do
+          assert_blank_attr_nilified(cr, 'scheduler_hint_filter')
+        end
+
+        test 'image_ref is mapped to image_id' do
+          assert_attrs_mapped(cr, 'image_ref', 'image_id')
+        end
+
+        describe 'images' do
+          let(:cr) { FactoryBot.create(:gce_cr, :with_images) }
+
+          test 'adds image name' do
+            vm_attrs = {
+              'image_id' => cr.images.last.uuid
+            }
+            normalized = cr.normalize_vm_attrs(vm_attrs)
+
+            assert_equal(cr.images.last.name, normalized['image_name'])
+          end
+
+          test 'leaves image name empty when image_id is nil' do
+            vm_attrs = {
+              'image_id' => nil
+            }
+            normalized = cr.normalize_vm_attrs(vm_attrs)
+
+            assert(normalized.has_key?('image_name'))
+            assert_nil(normalized['image_name'])
+          end
+
+          test "leaves image name empty when image wasn't found" do
+            vm_attrs = {
+              'image_id' => 'unknown'
+            }
+            normalized = cr.normalize_vm_attrs(vm_attrs)
+
+            assert(normalized.has_key?('image_name'))
+            assert_nil(normalized['image_name'])
+          end
+        end
+
+        test 'correctly fills empty attributes' do
+          normalized = cr.normalize_vm_attrs({})
+          expected_attrs = {
+            'availability_zone' => nil,
+            'tenant_id' => nil,
+            'tenant_name' => nil,
+            'boot_from_volume' => nil,
+            'scheduler_hint_filter' => nil,
+            'flavor_id' => nil,
+            'flavor_name' => nil,
+            'security_group_name' => nil,
+            'security_group_id' => nil,
+            'floating_ip_network' => nil,
+            'boot_volume_size' => nil,
+            'interfaces_attributes' => {},
+            'image_id' => nil,
+            'image_name' => nil
+          }
+
+          assert_equal(expected_attrs.keys.sort, normalized.keys.sort)
+          assert_equal(expected_attrs, normalized)
+        end
+
+        test 'attribute names' do
+          check_vm_attribute_names(cr)
+        end
+      end
+
       private
 
       def mocked_key_pair

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -115,4 +115,144 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
       @compute_resource.use_v4?.must_equal false
     end
   end
+
+  describe '#normalize_vm_attrs' do
+    let(:cr) do
+      mock_cr(FactoryBot.build(:ovirt_cr),
+        :clusters => [
+          stub(:id => 'c1', :name => 'cluster 1'),
+          stub(:id => 'c2', :name => 'cluster 2')
+        ],
+        :templates => [
+          stub(:id => 'tpl1', :name => 'template 1'),
+          stub(:id => 'tpl2', :name => 'template 2')
+        ],
+        :networks => [
+          stub(:id => 'net1', :name => 'network 1'),
+          stub(:id => 'net2', :name => 'network 2')
+        ],
+        :storage_domains => [
+          stub(:id => '312f6', :name => 'domain 1'),
+          stub(:id => '382ec', :name => 'domain 2'),
+          stub(:id => '3ea4f', :name => 'domain 3')
+        ]
+      )
+    end
+
+    test 'maps cluster to cluster_id' do
+      assert_attrs_mapped(cr, 'cluster', 'cluster_id')
+    end
+
+    test 'finds cluster_name' do
+      vm_attrs = {
+        'cluster' => 'c2'
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      assert_equal('cluster 2', normalized['cluster_name'])
+    end
+
+    test 'maps template to template_id' do
+      assert_attrs_mapped(cr, 'template', 'template_id')
+    end
+
+    test 'finds template_name' do
+      vm_attrs = {
+        'template' => 'tpl2'
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      assert_equal('template 2', normalized['template_name'])
+    end
+
+    test 'normalizes interfaces_attributes' do
+      vm_attrs = {
+        'interfaces_attributes' => {
+          '0' => {
+            'name' => 'eth0',
+            'network' => 'net1'
+          },
+          '1' => {
+            'name' => 'eth1',
+            'network' => 'net2'
+          }
+        }
+      }
+      expected_attrs = {
+        '0' => {
+          'network_id' => 'net1',
+          'network_name' => 'network 1',
+          'name' => 'eth0'
+        },
+        '1' => {
+          'network_id' => 'net2',
+          'network_name' => 'network 2',
+          'name' => 'eth1'
+        }
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      assert_equal(expected_attrs, normalized['interfaces_attributes'])
+    end
+
+    test 'normalizes volumes_attributes' do
+      vm_attrs = {
+        'volumes_attributes' => {
+          '0' => {
+            'size_gb' => '15',
+            'storage_domain' => '312f6',
+            'id' => '',
+            'preallocate' => '0'
+          },
+          '1' => {
+            'size_gb' => '5',
+            'storage_domain' => '382ec',
+            'id' => '',
+            'preallocate' => '1',
+            'bootable' => 'true'
+          }
+        }
+      }
+      expected_attrs = {
+        '0' => {
+          'size' => 15.gigabyte.to_s,
+          'storage_domain_id' => '312f6',
+          'storage_domain_name' => 'domain 1',
+          'preallocate' => false,
+          'bootable' => nil
+        },
+        '1' => {
+          'size' => 5.gigabyte.to_s,
+          'storage_domain_id' => '382ec',
+          'storage_domain_name' => 'domain 2',
+          'preallocate' => true,
+          'bootable' => true
+        }
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      assert_equal(expected_attrs, normalized['volumes_attributes'])
+    end
+
+    test 'correctly fills empty attributes' do
+      normalized = cr.normalize_vm_attrs({})
+      expected_attrs = {
+        'cores' => nil,
+        'memory' => nil,
+        'cluster_id' => nil,
+        'cluster_name' => nil,
+        'template_id' => nil,
+        'template_name' => nil,
+        'interfaces_attributes' => {},
+        'volumes_attributes' => {}
+      }
+
+      assert_equal(expected_attrs.keys.sort, normalized.keys.sort)
+      assert_equal(expected_attrs, normalized)
+    end
+
+    test 'attribute names' do
+      check_vm_attribute_names(cr)
+    end
+  end
 end

--- a/test/models/compute_resources/rackspace_test.rb
+++ b/test/models/compute_resources/rackspace_test.rb
@@ -24,4 +24,72 @@ class Foreman::Model::RackspaceTest < ActiveSupport::TestCase
       assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
     end
   end
+
+  describe '#normalize_vm_attrs' do
+    let(:base_cr) { FactoryBot.build(:rackspace_cr) }
+    let(:cr) do
+      mock_cr(base_cr,
+        :flavors => [
+          stub(:id => 'flvr1', :name => 'flavour 1'),
+          stub(:id => 'flvr2', :name => 'flavour 2')
+        ]
+      )
+    end
+
+    test 'finds flavor_name' do
+      normalized = cr.normalize_vm_attrs('flavor_id' => 'flvr1')
+
+      assert_equal('flavour 1', normalized['flavor_name'])
+    end
+
+    describe 'images' do
+      let(:base_cr) { FactoryBot.create(:rackspace_cr, :with_images) }
+
+      test 'adds image name' do
+        vm_attrs = {
+          'image_id' => cr.images.last.uuid
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert_equal(cr.images.last.name, normalized['image_name'])
+      end
+
+      test 'leaves image name empty when image_id is nil' do
+        vm_attrs = {
+          'image_id' => nil
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert(normalized.has_key?('image_name'))
+        assert_nil(normalized['image_name'])
+      end
+
+      test "leaves image name empty when image wasn't found" do
+        vm_attrs = {
+          'image_id' => 'unknown'
+        }
+        normalized = cr.normalize_vm_attrs(vm_attrs)
+
+        assert(normalized.has_key?('image_name'))
+        assert_nil(normalized['image_name'])
+      end
+    end
+
+    test 'correctly fills empty attributes' do
+      normalized = cr.normalize_vm_attrs({})
+      expected_attrs = {
+        'flavor_id' => nil,
+        'flavor_name' => nil,
+        'image_name' => nil,
+        'image_id' => nil
+      }
+
+      assert_equal(expected_attrs.keys.sort, normalized.keys.sort)
+      assert_equal(expected_attrs, normalized)
+    end
+
+    test 'attribute names' do
+      check_vm_attribute_names(cr)
+    end
+  end
 end


### PR DESCRIPTION
Normalizes compute attributes in API show actions. For backwards compatibility reasons this patch adds a new rabl node instead of replacing 'vm_attrs'.