### PR TITLE
fixes #21592 - uses headless chrome instead of phantomjs

### DIFF
--- a/app/views/nic/_hidden_layout.html.erb
+++ b/app/views/nic/_hidden_layout.html.erb
@@ -1,6 +1,6 @@
 
 <div class="hidden" id="interfaceHidden<%= local_assigns[:id] %>" data-interface-id="<%= local_assigns[:id] %>">
-  <%= field_set_tag "", :id => "interface", :'data-url' => new_interface_path do %>
+  <%= field_set_tag "", :id => "interface + #{local_assigns[:id]}", :'data-url' => new_interface_path do %>
     <%= f.hidden_field(:_destroy, :class => :destroyFlag, :value => (local_assigns[:id].nil? ? 1 : 0)) %>
     <%= yield %>
   <% end %>

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -7,12 +7,12 @@ group :test do
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 3.0', :require => false
   gem 'puma', :require => false
+  gem 'selenium-webdriver', :require => false
   gem 'show_me_the_cookies', '~> 4.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'
   gem 'factory_bot_rails', '~> 4.5', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
-  gem 'poltergeist', '>= 1.18.0', :require => false
   gem 'shoulda-matchers', '~> 3.0'
   gem 'shoulda-context', '~> 1.2'
   gem 'as_deprecation_tracker', '~> 1.4'

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -12,6 +12,11 @@
     in the next version of Rails. The new return value will reflect the behavior of
     calling the method after `save` returned (e.g. the opposite of what it returns
     now). To maintain the current behavior, use `saved_change_to_attribute` instead.
+  callstack: app/models/concerns/strip_leading_and_trailing_dot.rb:23:in `strip_dots'
+- message: The behavior of `attribute_change` inside of after callbacks will be changing
+    in the next version of Rails. The new return value will reflect the behavior of
+    calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute` instead.
   callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
 - message: The behavior of `attribute_changed?` inside of after callbacks will be
     changing in the next version of Rails. The new return value will reflect the behavior
@@ -22,18 +27,75 @@
     changing in the next version of Rails. The new return value will reflect the behavior
     of calling the method after `save` returned (e.g. the opposite of what it returns
     now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/foreman/sti.rb:24:in `save'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/nested_ancestry_common.rb:83:in `set_title'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/concerns/strip_leading_and_trailing_dot.rb:23:in `strip_dots'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
   callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/template.rb:10:in `block in <class:Template>'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/user.rb:677:in `hidden_authsource_restricted'
+- message: The behavior of `attribute_changed?` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_change_to_attribute?` instead.
+  callstack: app/models/user.rb:683:in `check_permissions_for_changing_login'
+- message: The behavior of `changed_attributes` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_changes.transform_values(&:first)`
+    instead.
+  callstack: app/models/concerns/strip_leading_and_trailing_dot.rb:23:in `strip_dots'
 - message: The behavior of `changed_attributes` inside of after callbacks will be
     changing in the next version of Rails. The new return value will reflect the behavior
     of calling the method after `save` returned (e.g. the opposite of what it returns
     now). To maintain the current behavior, use `saved_changes.transform_values(&:first)`
     instead.
   callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `changed_attributes` inside of after callbacks will be
+    changing in the next version of Rails. The new return value will reflect the behavior
+    of calling the method after `save` returned (e.g. the opposite of what it returns
+    now). To maintain the current behavior, use `saved_changes.transform_values(&:first)`
+    instead.
+  callstack: app/models/taxonomy.rb:33:in `block in <class:Taxonomy>'
+- message: The behavior of `changed` inside of after callbacks will be changing in
+    the next version of Rails. The new return value will reflect the behavior of calling
+    the method after `save` returned (e.g. the opposite of what it returns now). To
+    maintain the current behavior, use `saved_changes.keys` instead.
+  callstack: app/models/concerns/strip_leading_and_trailing_dot.rb:23:in `strip_dots'
 - message: The behavior of `changed` inside of after callbacks will be changing in
     the next version of Rails. The new return value will reflect the behavior of calling
     the method after `save` returned (e.g. the opposite of what it returns now). To
     maintain the current behavior, use `saved_changes.keys` instead.
   callstack: app/models/concerns/strip_whitespace.rb:9:in `strip_spaces'
+- message: The behavior of `changed` inside of after callbacks will be changing in
+    the next version of Rails. The new return value will reflect the behavior of calling
+    the method after `save` returned (e.g. the opposite of what it returns now). To
+    maintain the current behavior, use `saved_changes.keys` instead.
+  callstack: app/models/taxonomy.rb:33:in `block in <class:Taxonomy>'
+- message: The behavior of `changes` inside of after callbacks will be changing in
+    the next version of Rails. The new return value will reflect the behavior of calling
+    the method after `save` returned (e.g. the opposite of what it returns now). To
+    maintain the current behavior, use `saved_changes` instead.
+  callstack: app/models/concerns/strip_leading_and_trailing_dot.rb:23:in `strip_dots'
 - message: The behavior of `changes` inside of after callbacks will be changing in
     the next version of Rails. The new return value will reflect the behavior of calling
     the method after `save` returned (e.g. the opposite of what it returns now). To

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "optionalDependencies": {
-    "phantomjs-prebuilt": "^2.1.0"
+    "chromedriver": "^2.36.0"
   },
   "dependencies": {
     "axios": "^0.17.1",

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -314,7 +314,7 @@ class HostJSTest < IntegrationTestWithJavascript
   describe "hosts index multiple actions" do
     test 'show action buttons' do
       visit hosts_path
-      page.find('#check_all').trigger('click')
+      page.find('#check_all').click
 
       # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
       assert page.has_no_selector?('input.host_select_boxes:not(:checked)')
@@ -343,7 +343,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
     test 'redirect js' do
       visit hosts_path
-      page.find('#check_all').trigger('click')
+      page.find('#check_all').click
 
       # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
       assert page.has_no_selector?('input.host_select_boxes:not(:checked)')

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -109,7 +109,7 @@ class HostgroupJSTest < IntegrationTestWithJavascript
     click_link 'Parameters'
     assert page.has_no_selector?("#inherited_parameters #name_x")
 
-    click_link 'Hostgroup'
+    click_link 'HostGroup'
     select2(group.name, :from => 'hostgroup_parent_id')
     wait_for_ajax
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -4,10 +4,10 @@ require 'rails/test_help'
 require 'mocha/mini_test'
 require 'capybara/rails'
 require 'factory_bot_rails'
-require 'capybara/poltergeist'
 require 'show_me_the_cookies'
 require 'database_cleaner'
 require 'active_support_test_case_helper'
+require 'selenium/webdriver'
 require 'minitest/retry'
 Minitest::Retry.use!
 
@@ -15,21 +15,20 @@ Minitest::Retry.on_consistent_failure do |klass, test_name|
   Rails.logger.error("DO NOT IGNORE - Consistent failure - #{klass} #{test_name}")
 end
 
-Capybara.register_driver :poltergeist do |app|
-  opts = {
-    # To enable debugging uncomment `:inspector => true` and
-    # add `page.driver.debug` in code to open webkit inspector
-    # :inspector => true
-    :js_errors => true,
-    :timeout => 60,
-    :extensions => ["#{Rails.root}/test/integration/support/poltergeist_onload_extensions.js"],
-    :phantomjs => File.join(Rails.root, 'node_modules', '.bin', 'phantomjs')
-  }
-  Capybara::Poltergeist::Driver.new(app, opts)
+Selenium::WebDriver::Chrome.driver_path = File.join(Rails.root, 'node_modules', '.bin', 'chromedriver')
+Capybara.register_driver :selenium_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+
+    desired_capabilities: capabilities
 end
 
-Capybara.default_max_wait_time = 30
-Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 5
+Capybara.javascript_driver = :selenium_chrome
 
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
@@ -211,6 +210,7 @@ class ActionDispatch::IntegrationTest
 
   def login_admin
     SSO.register_method(TestSSO)
+    visit '/'
     set_request_user(:admin)
   end
 


### PR DESCRIPTION
it seems that we can also cut down the default waiting time
which hopefully will speed up our tests.