### PR TITLE
Fixes #21603 - Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+Gemfile         @theforeman/packaging
+Rakefile.dist	@theforeman/packaging
+bundler.d/*.rb  @theforeman/packaging
+package.json    @theforeman/packaging


### PR DESCRIPTION
This is an experiment to implement github code owners[1]. The idea is that the packaging team will be added to any changes to dependencies.  This should allow us to make the packaging changes needed keeping nightlies working.

[1]: https://github.com/blog/2392-introducing-code-owners