### PR TITLE
Fixes #21626 - "Domain Users" are not a valid AD group

### DIFF
--- a/test/models/external_usergroup_test.rb
+++ b/test/models/external_usergroup_test.rb
@@ -5,4 +5,13 @@ class ExternalUsergroupTest < ActiveSupport::TestCase
     eug = FactoryBot.build(:external_usergroup, :auth_source => AuthSourceHidden.first)
     refute_valid eug, :auth_source, /permitted/
   end
+
+  test 'should not allow "Domain Users" as name for AD sources' do
+    auth_source = FactoryBot.build(:auth_source_ldap, :active_directory)
+    eug = FactoryBot.build(:external_usergroup,
+                           :name => 'Domain Users',
+                           :auth_source => auth_source)
+    eug.valid?
+    assert_match(/special/, eug.errors[:name].first)
+  end
 end


### PR DESCRIPTION
'Domain Users' is a special group in AD. This group users' cannot
be queried through regular LDAP, it can only be seen on the Windows
AD UI.

This confuses people who think that could add this group but they
find that no users are found after adding this group.

This PR adds a warning when you try to do that, so that hopefully we
don't get more bug reports about this.