### PR TITLE
Fixes #21629 - display error for taxonomy selectors

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -75,7 +75,8 @@ module FormHelper
 
     unauthorized = selected_ids.blank? ? [] : selected_ids - authorized.map(&:id)
     field(f, attr, options) do
-      attr_ids = (attr.to_s.singularize+"_ids").to_sym
+      attr_ids = attr.to_s
+      attr_ids = (attr_ids.singularize + '_ids').to_sym unless attr_ids.end_with?('_ids')
       hidden_fields = ''
       html_options["data-useds"] ||= "[]"
       JSON.parse(html_options["data-useds"]).each do |disabled_value|

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -112,7 +112,7 @@ module TaxonomyHelper
   def taxonomy_selects(f, selected_ids, taxonomy, label, options = {}, options_html = {})
     options[:disabled] = Array.wrap(options[:disabled])
     options[:label]    ||= _(label)
-    multiple_selects f, label.downcase, taxonomy.authorized("assign_#{label.downcase}", taxonomy), selected_ids, options, options_html
+    multiple_selects f, label.downcase.singularize + '_ids', taxonomy.authorized("assign_#{label.downcase}", taxonomy), selected_ids, options, options_html
   end
 
   def all_checkbox(f, resource)


### PR DESCRIPTION
before:
![a_no_error](https://user-images.githubusercontent.com/109773/32666662-7e53b838-c638-11e7-9c2c-aa90ea660dde.png)

after:
![a_error](https://user-images.githubusercontent.com/109773/32666640-65b64ab6-c638-11e7-8e16-0efd8acf309f.png)

reproducing steps provided in redmine issue, the issue is that we passed 'organizations' as attr, in field helper we do f.object.errors[attr] so it needs to be 'organization_ids'