### PR TITLE
Fixes #22038 - Fix color for link in action button

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -377,6 +377,12 @@ a.btn-info span {
   }
 }
 
-.container-pf-nav-pf-vertical.hide-nav-pf {
-  display: none !important;
+span.btn-action a {
+  display: block;
+  margin: -2px -6px;
+  padding: 2px 6px;
+}
+
+span.btn-action.btn-primary a {
+  color: #fff;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -326,7 +326,7 @@ module ApplicationHelper
     # the no-buttons code is needed for users with less permissions
     args = args.flatten.select(&:present?)
     return if args.blank?
-    button_classes = %w(btn btn-default)
+    button_classes = %w(btn btn-default btn-action)
     button_classes << 'btn-primary' if options[:primary]
 
     content_tag(:div, options.merge(:class=>'btn-group')) do


### PR DESCRIPTION
This addresses the issue introduced by allowing primary action buttons, which does not set the right color when links are used inside. Like the import roles button in foreman_ansible.

Before:

![gnome-shell-screenshot-h06q9y](https://user-images.githubusercontent.com/7757/32715499-e3d931da-c852-11e7-9108-844b2f1f6635.png)

![gnome-shell-screenshot-ukgf9y](https://user-images.githubusercontent.com/7757/32715514-ef83fd8a-c852-11e7-8e72-525a576f1ac8.png)

After:
![gnome-shell-screenshot-edoc9y](https://user-images.githubusercontent.com/7757/32715506-e67049e2-c852-11e7-9c7b-ff8c8fc38643.png)
![gnome-shell-screenshot-bpat9y](https://user-images.githubusercontent.com/7757/32715525-fd11aede-c852-11e7-9753-2a9794f71256.png)
