### PR TITLE
fixes #21657 - remove facets when host is removed

### DIFF
--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -35,7 +35,7 @@ module Facets
       #    host.foo # => will call Host.my_facet.foo
       def register_facet_relation(klass, facet_config)
         klass.class_eval do
-          has_one facet_config.name, :class_name => facet_config.model.name, :foreign_key => :host_id, :inverse_of => :host
+          has_one facet_config.name, :class_name => facet_config.model.name, :foreign_key => :host_id, :inverse_of => :host, :dependent => facet_config.dependent
           accepts_nested_attributes_for facet_config.name, :update_only => true, :reject_if => :all_blank
           if Foreman.in_rake?("db:migrate")
             # To prevent running into issues in old migrations when new facet is defined but not migrated yet.

--- a/app/services/facets/entry.rb
+++ b/app/services/facets/entry.rb
@@ -4,7 +4,7 @@ module Facets
       :api_single_view, :api_list_view,
       :api_param_group_description, :api_param_group, :api_controller,
       :tabs,
-      :compatibility_properties
+      :compatibility_properties, :dependent
 
     def initialize(facet_model, facet_name)
       @compatibility_properties = []
@@ -78,6 +78,13 @@ module Facets
     #  host.foo # => 'bar'
     def template_compatibility_properties(*property_symbols)
       @compatibility_properties = property_symbols
+    end
+
+    # Specify what should happen with the facet when the host object is deleted.
+    # [+:destroy+] The facet object will be deleted by calling the destroy record.
+    # [+:delete+] The facet will be deleted directly from the database without calling their destroy method.
+    def set_dependent_action(value)
+      @dependent = value
     end
 
     def load_api_controller

--- a/test/unit/facet_configuration_test.rb
+++ b/test/unit/facet_configuration_test.rb
@@ -12,10 +12,10 @@ class FacetConfigurationTest < ActiveSupport::TestCase
   module TestHelper
   end
 
-  teardown do
-    Host::Managed.cloned_parameters[:include].delete(:test_model)
-    Host::Managed.cloned_parameters[:include].delete(:test_facet)
-    Host::Managed.cloned_parameters[:include].delete(:facet_name)
+  setup do
+    # Do not mess with the Host::Managed object as
+    # we just want to test the configuration here
+    Facets::ManagedHostExtensions.stubs(:register_facet_relation)
   end
 
   test 'enables block configuration' do
@@ -56,6 +56,7 @@ class FacetConfigurationTest < ActiveSupport::TestCase
         api_view(:single => 'single_view', :list => 'list_view')
         api_docs(:my_group, TestModel, 'my test description')
         template_compatibility_properties :prop1
+        set_dependent_action :restrict_with_exception
       end
       facet_configuration = Facets.registered_facets[:test_model]
       assert_equal :test_model, facet_configuration.name
@@ -69,6 +70,7 @@ class FacetConfigurationTest < ActiveSupport::TestCase
       assert_equal TestModel, facet_configuration.api_controller
       assert_equal 'tab_view', facet_configuration.tabs[:a]
       assert_equal [:prop1], facet_configuration.compatibility_properties
+      assert_equal :restrict_with_exception, facet_configuration.dependent
     end
   end
 end

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -134,6 +134,36 @@ class FacetTest < ActiveSupport::TestCase
       saved_host.update({'test_facet_attributes' => { 'my_attribute' => "val"}})
       assert_not_nil saved_host.test_facet
     end
+
+    test 'facet is not removed when associated host is deleted' do
+      as_admin do
+        saved_host = FactoryBot.create(:host)
+        facet = saved_host.build_test_facet
+        saved_host.save!
+        assert facet.id
+        saved_host.destroy!
+        assert TestFacet.find_by(id: facet.id)
+      end
+    end
+  end
+
+  context 'managed host facet dependent destroy behavior' do
+    setup do
+      Facets.register TestFacet do
+        set_dependent_action :destroy
+      end
+    end
+
+    test 'facet is removed when associated host is deleted' do
+      as_admin do
+        saved_host = FactoryBot.create(:host)
+        facet = saved_host.build_test_facet
+        saved_host.save!
+        assert facet.id
+        saved_host.destroy!
+        refute TestFacet.find_by(id: facet.id)
+      end
+    end
   end
 
   context 'inside db:migrate task' do


### PR DESCRIPTION
Without this, you have to manually delete the facets from the database. There is no automatic cleanup.

cc: @ShimShtein 