### PR TITLE
Fixes #21669 - Use $major on CentOS media, $version deprecated

### DIFF
--- a/db/migrate/20171121082256_update_centos_installation_media.rb
+++ b/db/migrate/20171121082256_update_centos_installation_media.rb
@@ -1,0 +1,9 @@
+class UpdateCentosInstallationMedia < ActiveRecord::Migration
+  def change
+    Medium.unscoped.where(
+      :name => 'CentOS mirror',
+      :os_family => 'Redhat',
+      :path => 'http://mirror.centos.org/centos/$version/os/$arch'
+    ).update_all(:path => 'http://mirror.centos.org/centos/$major/os/$arch')
+  end
+end

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -3,7 +3,7 @@ os_suse = Operatingsystem.unscoped.where(:type => "Suse") || Operatingsystem.uns
 # Installation media: default mirrors
 Medium.without_auditing do
   [
-    { :name => "CentOS mirror",        :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$version/os/$arch" },
+    { :name => "CentOS mirror",        :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/os/$arch" },
     { :name => "Debian mirror",        :os_family => "Debian",  :path => "http://ftp.debian.org/debian" },
     { :name => "Fedora mirror",        :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/" },
     { :name => "Fedora Atomic mirror", :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/$arch/os/" },


### PR DESCRIPTION
As we can see, CentOS fixed their repos so that
http://mirror.centos.org/centos/7 returns the latest version we need for
vmlinuz, etc..
For a long time they only offered these files under specific version
dirs, but now they have deprecated this and we should just refer to
$major, not $major.$minor
See the notice at http://mirror.centos.org/centos/7.3.1611/readme

I'm not 100% sure we should change in a migration "CentOS mirror", so let me know if you think that'd be OK to fix previous installations like that.