### PR TITLE
Fixes #21599 - explicit transaction for import dropped

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -39,11 +39,9 @@ class FactImporter
 
   # expect a facts hash
   def import!
-    ActiveRecord::Base.transaction do
-      delete_removed_facts
-      update_facts
-      add_new_facts
-    end
+    delete_removed_facts
+    update_facts
+    add_new_facts
 
     if @error
       Foreman::Logging.exception("Error during fact import for #{@host.name}", @error)


### PR DESCRIPTION
This small change fixes the following symptoms described in the ticket are that PostgreSQL is encountering blocked transactions causing some operations during fact import to fail:

* deadlock detected
* duplicate key value violates unique constraint "index_fact_names_on_name_and_type" on simulatenous host register
* Process xxx waits for ShareLock on transaction yyy; blocked by process zzz.
* current transaction is aborted, commands ignored until end of transaction block

Those errors are usually accompanied with SQL SELECT, UPDATE or DELETE statements on fact_name and they can be triggered by any fact operation (facts upload, rhsm register/refresh/fact update).

I am able to verify with this script that simply commenting out the transaction block (keeping the statements there) helps:

https://gist.github.com/lzap/c84107e245250bf287f09c4f87d8b67c

With the explicit SQL transaction block which was added sometime around Foreman 1.13-1.14 my instances are hitting one of the four problems above. Depending on how you update script, you can hit various issues (all workers update same host, all workers updates same facts names or all workers creates random fact name/values).

Without SQL transaction, my instance settles down with the very same processing times and I am not running into any concurrency issues at all. I was testing this with up to 8 concurrent processes.

This PR replaces https://github.com/theforeman/foreman/pull/4996 and the other one should have a separate RedMine ticket.