### PR TITLE
Fixes #21675 - OpenStack create host tab fails to load

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -228,7 +228,7 @@ module Foreman::Model
     end
 
     def vm_instance_defaults
-      super.merge(:key_name => key_pair.name)
+      super.merge(:key_name => key_pair.name, :metadata => {})
     end
 
     def assign_floating_ip(address, vm)

--- a/app/models/concerns/fog_extensions/openstack/server.rb
+++ b/app/models/concerns/fog_extensions/openstack/server.rb
@@ -1,13 +1,9 @@
 module FogExtensions
   module Openstack
     module Server
-      def self.prepended(base)
-        class << base
-          attr_reader :nics
-          attr_accessor :boot_from_volume, :size_gb, :scheduler_hint_filter
-          attr_writer :security_group, :network # floating IP
-        end
-      end
+      attr_reader :nics
+      attr_writer :security_group, :network # floating IP
+      attr_accessor :boot_from_volume, :size_gb, :scheduler_hint_filter
 
       def to_s
         name
@@ -48,11 +44,11 @@ module FogExtensions
       end
 
       def boot_from_volume
-        attr[:boot_from_volume]
+        attributes[:boot_from_volume]
       end
 
       def size_gb
-        attr[:size_gb]
+        attributes[:size_gb]
       end
 
       def network


### PR DESCRIPTION
Currently the tab is not loading as there are a few methods that are not
being overridden properly by the FogExtension.

After fixing that and adding the metadata key the tab loads.

Before:
![screenshot from 2017-11-15 13-35-34](https://user-images.githubusercontent.com/598891/32837973-cc241eb0-ca0f-11e7-8129-40789b875a3f.png)

After:

![screenshot from 2017-11-15 14-13-29](https://user-images.githubusercontent.com/598891/32837959-c1eb6f70-ca0f-11e7-80f5-8e0274171f53.png)

----------------------------------

Note there is some problem in OpenStack now that you cannot set the availability zone to "none" - I can fix that on another PR.

![screenshot from 2017-11-15 14-17-01](https://user-images.githubusercontent.com/598891/32838012-e80febf4-ca0f-11e7-9b19-c05e88458662.png)
