### PR TITLE
Fixes #21654 - create registry for importers

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -15,7 +15,7 @@ module Api
       check_permissions_for %w{power boot}
       before_action :process_parameter_attributes, :only => %w{update}
 
-      add_smart_proxy_filters :facts, :features => Proc.new { FactImporter.fact_features }
+      add_smart_proxy_filters :facts, :features => Proc.new { Foreman::Plugin.fact_importer_registry.fact_features }
 
       add_scope_for(:index) do |base_scope|
         base_scope.preload([:host_statuses, :compute_resource, :hostgroup, :operatingsystem,

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -142,10 +142,10 @@ module Host
       facts[:domain] = facts[:domain].downcase if facts[:domain].present?
 
       type = facts.delete(:_type)
-      importer = FactImporter.importer_for(type).new(self, facts)
+      facts_importer = Foreman::Plugin.fact_importer_registry.get(type).new(self, facts)
       telemetry_observe_histogram(:importer_facts_import_duration, facts.size, type: type)
       telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
-        importer.import!
+        facts_importer.import!
       end
 
       save(:validate => false)

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -21,6 +21,7 @@ require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
 require_dependency 'foreman/plugin/report_origin_registry'
 require_dependency 'foreman/plugin/medium_providers_registry'
+require_dependency 'foreman/plugin/fact_importer_registry'
 
 module Foreman #:nodoc:
   class PluginNotFound < Foreman::Exception; end
@@ -39,6 +40,7 @@ module Foreman #:nodoc:
   class Plugin
     @registered_plugins = {}
     @tests_to_skip = {}
+    @fact_importer_registry = Plugin::FactImporterRegistry.new
     @report_scanner_registry = Plugin::ReportScannerRegistry.new
     @report_origin_registry = Plugin::ReportOriginRegistry.new
     @medium_providers = Plugin::MediumProvidersRegistry.new
@@ -48,7 +50,7 @@ module Foreman #:nodoc:
       attr_reader   :registered_plugins
       attr_accessor :tests_to_skip, :report_scanner_registry,
         :report_origin_registry, :medium_providers,
-        :graphql_types_registry
+        :graphql_types_registry, :fact_importer_registry
       private :new
 
       def def_field(*names)
@@ -151,6 +153,10 @@ module Foreman #:nodoc:
       @renderer_variable_loaders = []
       @ping_extension = nil
       @status_extension = nil
+    end
+
+    def fact_importer_registry
+      self.class.fact_importer_registry
     end
 
     def report_scanner_registry

--- a/app/registries/foreman/plugin/fact_importer_registry.rb
+++ b/app/registries/foreman/plugin/fact_importer_registry.rb
@@ -1,0 +1,24 @@
+module Foreman
+  class Plugin
+    class FactImporterRegistry
+      attr_accessor :importers
+
+      def initialize
+        @importers = {}.with_indifferent_access
+      end
+
+      def register(key, klass, default = false)
+        @importers.default = klass.to_s if default
+        @importers[key.to_sym] = klass.to_s
+      end
+
+      def get(key)
+        @importers[key].constantize
+      end
+
+      def fact_features
+        @importers.values.map { |importer| importer.constantize.authorized_smart_proxy_features }.compact.flatten.uniq
+      end
+    end
+  end
+end

--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -5,21 +5,23 @@ class FactImporter
   attr_reader :counters
 
   def self.importer_for(type)
-    importers[type.to_s]
+    Foreman::Deprecation.deprecation_warning('2.2', 'Use FactImporterRegistry#get or Foreman::Plugin.importer_registry.get methods instead of FactImporter.importer_for')
+    Foreman::Plugin.fact_importer_registry.get(type)
   end
 
   def self.importers
-    @importers ||= {}.with_indifferent_access
+    Foreman::Deprecation.deprecation_warning('2.2', 'Use FactImporterRegistry#importers or Foreman::Plugin.importer_registry.importers method instead of FactImporter.importers')
+    Foreman::Plugin.fact_importer_registry.importers
   end
 
   def self.register_fact_importer(key, klass, default = false)
-    importers.default = klass if default
-
-    importers[key.to_sym] = klass
+    Foreman::Deprecation.deprecation_warning('2.2', 'Use FactImporterRegistry#register or Foreman::Plugin.importer_registry.register method instead of FactImporter.register_fact_importer')
+    Foreman::Plugin.fact_importer_registry.register(key, klass, default)
   end
 
   def self.fact_features
-    importers.map { |_type, importer| importer.authorized_smart_proxy_features }.compact.flatten.uniq
+    Foreman::Deprecation.deprecation_warning('2.2', 'Use FactImporterRegistry#fact_features or Foreman::Plugin.importer_registry.fact_features method instead of FactImporter.fact_features')
+    Foreman::Plugin.fact_importer_registry.fact_features
   end
 
   def self.support_background

--- a/config/initializers/puppet.rb
+++ b/config/initializers/puppet.rb
@@ -12,7 +12,7 @@ Pagelets::Manager.with_key "hosts/_form" do |mgr|
     :priority => 100
 end
 
-FactImporter.register_fact_importer :puppet, PuppetFactImporter, true
+Foreman::Plugin.fact_importer_registry.register(:puppet, PuppetFactImporter, true)
 FactParser.register_fact_parser :puppet, PuppetFactParser, true
 
 # The module should be included after the class is constructed,

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -7,7 +7,7 @@ module FactImporterIsolation
   end
 
   def allow_transactions_for_any_importer
-    FactImporter.importers.values.each do |importer|
+    Foreman::Plugin.fact_importer_registry.importers.values.map(&:constantize).each do |importer|
       allow_transactions_for(importer.any_instance)
     end
   end

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -13,13 +13,14 @@ class FactImporterTest < ActiveSupport::TestCase
   end
 
   let(:host) { FactoryBot.create(:host) }
+  let(:fact_importer_registry) { Foreman::Plugin.fact_importer_registry }
 
   test "default importers" do
-    assert_includes FactImporter.importers.keys, 'puppet'
-    assert_equal PuppetFactImporter, FactImporter.importer_for(:puppet)
-    assert_equal PuppetFactImporter, FactImporter.importer_for('puppet')
-    assert_equal PuppetFactImporter, FactImporter.importer_for(:whatever)
-    assert_equal PuppetFactImporter, FactImporter.importer_for('whatever')
+    assert_includes fact_importer_registry.importers.keys, 'puppet'
+    assert_equal PuppetFactImporter, fact_importer_registry.get(:puppet)
+    assert_equal PuppetFactImporter, fact_importer_registry.get('puppet')
+    assert_equal PuppetFactImporter, fact_importer_registry.get(:whatever)
+    assert_equal PuppetFactImporter, fact_importer_registry.get('whatever')
   end
 
   test 'importer API defines background processing support' do
@@ -28,15 +29,15 @@ class FactImporterTest < ActiveSupport::TestCase
 
   context 'when using a custom importer' do
     setup do
-      FactImporter.register_fact_importer :custom_importer, CustomImporter
+      fact_importer_registry.register :custom_importer, CustomImporter
     end
 
     test ".register_custom_importer" do
-      assert_equal CustomImporter, FactImporter.importer_for(:custom_importer)
+      assert_equal CustomImporter, fact_importer_registry.get(:custom_importer)
     end
 
     test 'importers without authorized_smart_proxy_features return empty set of features' do
-      assert_equal [], FactImporter.importer_for(:custom_importer).authorized_smart_proxy_features
+      assert_equal [], fact_importer_registry.get(:custom_importer).authorized_smart_proxy_features
     end
 
     context 'importing facts' do

--- a/test/unit/plugin/importer_registry_test.rb
+++ b/test/unit/plugin/importer_registry_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class FactImporterRegistry < ActiveSupport::TestCase
+  class TestClass
+  end
+
+  def test_register
+    fact_importer = Foreman::Plugin::FactImporterRegistry.new
+    fact_importer.register(:test_class, TestClass, false)
+    assert_equal fact_importer.importers[:test_class], "FactImporterRegistry::TestClass"
+  end
+
+  def test_register_default
+    fact_importer = Foreman::Plugin::FactImporterRegistry.new
+    fact_importer.register(:test_class, TestClass, true)
+    assert_equal fact_importer.importers[:test_class], "FactImporterRegistry::TestClass"
+    assert_equal fact_importer.importers[:random_key], "FactImporterRegistry::TestClass"
+  end
+
+  def test_get
+    fact_importer = Foreman::Plugin::FactImporterRegistry.new
+    fact_importer.register(:test_class, TestClass, false)
+    assert_equal fact_importer.get(:test_class), TestClass
+  end
+
+  def test_get_default
+    fact_importer = Foreman::Plugin::FactImporterRegistry.new
+    fact_importer.register(:test_class, TestClass, true)
+    assert_equal fact_importer.get(:random_key), TestClass
+  end
+
+  def test_fact_features
+    fact_importer = Foreman::Plugin::FactImporterRegistry.new
+    fact_importer.register(:test_class, TestClass, true)
+    FactImporterRegistry::TestClass.expects(:authorized_smart_proxy_features).returns([:test_feature])
+    assert_equal :test_feature, fact_importer.fact_features.first
+  end
+end


### PR DESCRIPTION
The facts impoter must have been initialized when the server restarts
as it is a part of the puppet.rb(https://github.com/theforeman/foreman/blob/0b6ec11eea13927de6ae3697d704e70d6206d15d/config/initializers/puppet.rb#L15) but it does not therefore i have added it manually.

This might not be the accurate way but hosts are getting discovered with this change.