### PR TITLE
Fixes #21682 - Add Domain to Compute Resource API (OpenStack)

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -37,6 +37,7 @@ module Api
           param :datacenter, String, :desc => N_("for oVirt, VMware Datacenter")
           param :region, String, :desc => N_("for EC2 only")
           param :tenant, String, :desc => N_("for OpenStack only")
+          param :domain, String, :desc => N_("for OpenStack only")
           param :server, String, :desc => N_("for VMware")
           param :set_console_password, :bool, :desc => N_("for Libvirt and VMware only")
           param :display_type, %w(VNC SPICE), :desc => N_('for Libvirt only')

--- a/app/views/api/v2/compute_resources/openstack.json.rabl
+++ b/app/views/api/v2/compute_resources/openstack.json.rabl
@@ -1,1 +1,1 @@
-attributes :user, :tenant
+attributes :user, :tenant, :domain


### PR DESCRIPTION
The Domain field was added to the Compute Resources table in #12054 as
part of the Openstack v3 support. This field needs to appear in the
APIdoc to be able to use it and in the RABL to read it.