### PR TITLE
Fixes #21699 - fix vertical navigation transition animation glitch

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -377,3 +377,6 @@ a.btn-info span {
   }
 }
 
+.container-pf-nav-pf-vertical.hide-nav-pf {
+  display: none !important;
+}


### PR DESCRIPTION
transitions between pages via the vertical menu in collapse mode look a bit strange, as you can see here: 
![nov 17 2017 12-12 am](https://user-images.githubusercontent.com/11807069/32918967-ddcda118-cb2c-11e7-8304-45e1b09884c6.gif)

transitions should render more fluently:
![nov 17 2017 12-09 am](https://user-images.githubusercontent.com/11807069/32919266-d306441e-cb2d-11e7-9347-f1b9dcf2cbd2.gif)

