### PR TITLE
Fixes #21702 - Add reducer registration to redux

### DIFF
--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -5,6 +5,8 @@ import React from 'react';
 import store from '../redux';
 import componentRegistry from '../components/componentRegistry';
 
+export { default as registerReducer } from '../redux/reducers/registerReducer';
+
 export function mount(component, selector, data) {
   const reactNode = document.querySelector(selector);
 

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { getStore } from '../../../../redux';
+import { generateStore } from '../../../../redux';
 import { vmwareData, hiddenFieldValue } from './StorageContainer.fixtures';
 import StorageContainer from './';
 
@@ -9,7 +9,7 @@ let wrapper = null;
 
 describe('StorageContainer', () => {
   beforeEach(() => {
-    wrapper = mount(<StorageContainer store={getStore()} data={vmwareData} />);
+    wrapper = mount(<StorageContainer store={generateStore()} data={vmwareData} />);
   });
 
   it('render hidden field correctly', () => {

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -5,7 +5,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import { getStore } from '../../redux';
+import { generateStore } from '../../redux';
 import API from '../../API';
 
 import {
@@ -87,7 +87,7 @@ describe('notifications', () => {
   });
 
   it('full flow', () => {
-    const wrapper = mount(<Notifications data={componentMountData} store={getStore()} />);
+    const wrapper = mount(<Notifications data={componentMountData} store={generateStore()} />);
 
     wrapper.find('.fa-bell').simulate('click');
     expect(wrapper.find('.panel-group').length).toEqual(1);
@@ -98,7 +98,7 @@ describe('notifications', () => {
   });
 
   it('mark group as read flow', () => {
-    const wrapper = mount(<Notifications data={componentMountData} store={getStore()} />);
+    const wrapper = mount(<Notifications data={componentMountData} store={generateStore()} />);
     const matcher = '.drawer-pf-action a.btn-link';
 
     wrapper.find('.fa-bell').simulate('click');
@@ -113,12 +113,12 @@ describe('notifications', () => {
     window.location.replace = jest.fn();
     failResponse = { status: 401 };
 
-    mount(<Notifications data={componentMountData} store={getStore()} />);
+    mount(<Notifications data={componentMountData} store={generateStore()} />);
     expect(global.location.replace).toBeCalled();
   });
 
   it('should avoid multiple polling on re-mount', () => {
-    const store = getStore();
+    const store = generateStore();
     const spy = jest.spyOn(API, 'get');
 
     mount(<Notifications data={componentMountData} store={store} />);
@@ -128,7 +128,7 @@ describe('notifications', () => {
   });
 
   it('should close the notification box when click the close button', () => {
-    const wrapper = mount(<Notifications data={componentMountData} store={getStore()} />);
+    const wrapper = mount(<Notifications data={componentMountData} store={generateStore()} />);
     const closeButtonSelector = '.drawer-pf .drawer-pf-title a.drawer-pf-close';
 
     wrapper.find('.fa-bell').simulate('click');
@@ -141,7 +141,7 @@ describe('notifications', () => {
   it('should close the notification box when click outside of the box', () => {
     const wrapper = mount(<div>
       <div className="something-outside" />
-      <Notifications data={componentMountData} store={getStore()} />
+      <Notifications data={componentMountData} store={generateStore()} />
                           </div>);
 
     wrapper.find('.fa-bell').simulate('click');

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -2,7 +2,7 @@ import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
 import { applyMiddleware, createStore } from 'redux';
 
-import reducer from './reducers';
+import reducers from './reducers';
 
 let middleware = [thunk];
 
@@ -10,12 +10,13 @@ if (process.env.NODE_ENV !== 'production' && !global.__testing__) {
   middleware = [...middleware, createLogger()];
 }
 
-const _getStore = () => createStore(
-  reducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
-  applyMiddleware(...middleware),
-);
+export const generateStore = () =>
+  createStore(
+    reducers,
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+    applyMiddleware(...middleware),
+  );
 
-export default _getStore();
+const store = generateStore();
 
-export const getStore = _getStore;
+export default store;

--- a/webpack/assets/javascripts/react_app/redux/reducers/addReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/addReducer.js
@@ -1,0 +1,9 @@
+import store from '../index';
+import { combineReducersAsync } from './index';
+
+const asyncReducers = {};
+
+export default (name, asyncReducer) => {
+  asyncReducers[name] = asyncReducer;
+  store.replaceReducer(combineReducersAsync(asyncReducers));
+};

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -4,9 +4,14 @@ import hosts from './hosts';
 import notifications from './notifications/';
 import toasts from './toasts';
 
-export default combineReducers({
-  statistics,
-  hosts,
-  notifications,
-  toasts,
-});
+export function combineReducersAsync(asyncReducers) {
+  return combineReducers({
+    statistics,
+    hosts,
+    notifications,
+    toasts,
+    ...asyncReducers,
+  });
+}
+
+export default combineReducersAsync();

--- a/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
@@ -1,0 +1,9 @@
+import store from '../index';
+import { combineReducersAsync } from './index';
+
+const asyncReducers = {};
+
+export default (name, asyncReducer) => {
+  asyncReducers[name] = asyncReducer;
+  store.replaceReducer(combineReducersAsync(asyncReducers));
+};

--- a/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.test.js
@@ -1,0 +1,28 @@
+import store from '../index';
+import registerReducer from './registerReducer';
+
+const TEST_REGISTER_REDUCER_ACTION = 'TEST_REGISTER_REDUCER_ACTION';
+
+const exampleReducer = (state = {}, action) => {
+  switch (action.type) {
+    case TEST_REGISTER_REDUCER_ACTION:
+      return Object.assign({}, state, { TEST_REGISTER_REDUCER_ACTION: 'success' });
+
+    default:
+      return state;
+  }
+};
+
+describe('Registering reducers asyncronously.', () => {
+  it('should be able to register reducer after the store was created', () => {
+    registerReducer('test_register_reducer', exampleReducer);
+
+    store.dispatch({ type: TEST_REGISTER_REDUCER_ACTION });
+
+    expect(store.getState()).toMatchObject({
+      test_register_reducer: {
+        TEST_REGISTER_REDUCER_ACTION: 'success',
+      },
+    });
+  });
+});


### PR DESCRIPTION
This enables registering reducers from plugins asynchronously. I put up a gist [here](https://gist.github.com/danseethaler/d745921bebbe5f696c4a316e38d8879f) to see the way it would be used in Katello.

The basic idea is to add the `registerReducer` function which allows you to add registered reducers and then updates the store using redux's [replaceReducer](https://redux.js.org/docs/api/Store.html#replaceReducer) api.

http://projects.theforeman.org/issues/21702