### PR TITLE
Fixes #21718 - Show errors properly when creating new oVirt CR

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -397,6 +397,7 @@ module Foreman::Model
     private
 
     def update_available_operating_systems
+      return false if errors[:url].any?
       ovirt_operating_systems = if client.respond_to?(:operating_systems)
                                   client.operating_systems
                                 elsif rbovirt_client.respond_to?(:operating_systems)

--- a/test/unit/foreman/model/ovirt_test.rb
+++ b/test/unit/foreman/model/ovirt_test.rb
@@ -27,8 +27,18 @@ class OvirtTest < ActiveSupport::TestCase
     original_oses = record.attrs[:available_operating_systems] = { foo: :bar }
 
     assert_nothing_raised do
-      assert record.send(:update_available_operating_systems), 'before validation filter does not return true which would cancel the callback chain'
+      assert record.send(:update_available_operating_systems), 'after validation filter does not return true which would cancel the callback chain'
     end
+
+    assert_equal original_oses, record.attrs[:available_operating_systems]
+
+    record.url = ''
+    refute record.valid?
+
+    assert_nothing_raised do
+      refute record.send(:update_available_operating_systems), 'after validation filter does not return false which would not cancel the callback chain'
+    end
+
     assert_equal original_oses, record.attrs[:available_operating_systems]
   end
 


### PR DESCRIPTION
We try to retrieve available operating systems in an after_validation
hook. Trying to retrieve them makes no sense if the URL isn't
considered valid by us.