### PR TITLE
Fixes #21725 - Move test config to setup file

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
       "script"
     ],
     "setupFiles": [
-      "raf/polyfill"
+      "raf/polyfill",
+      "./webpack/test_setup.js"
     ]
   }
 }

--- a/webpack/assets/javascripts/react_app/components/common/Alert/Alert.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/Alert.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Alert from './';
-
-configure({ adapter: new Adapter() });
 
 describe('alerts', () => {
   it('can include a title', () => {

--- a/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Icon/Icon.test.js
@@ -1,11 +1,7 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Icon from './';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./');
 

--- a/webpack/assets/javascripts/react_app/components/common/Loader.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Loader.test.js
@@ -1,14 +1,9 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow, mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import { STATUS } from '../../constants';
-
 import Loader from './Loader';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./Loader');
 

--- a/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/MessageBox.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import MessageBox from './MessageBox';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./MessageBox');
 

--- a/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/Chart.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
 import c3 from 'c3';
-import Adapter from 'enzyme-adapter-react-16';
-import { configure, shallow, mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 import Chart from './Chart';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./Chart');
 jest.unmock('../MessageBox');

--- a/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/PieChart/PieChart.test.js
@@ -1,13 +1,9 @@
-// Configure Enzyme
 import c3 from 'c3';
-import Adapter from 'enzyme-adapter-react-16';
-import { configure, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import chartData from './PieChart.fixtures';
 import PieChart from './';
-
-configure({ adapter: new Adapter() });
 
 jest.mock('c3');
 jest.unmock('../../../../../services/ChartService');

--- a/webpack/assets/javascripts/react_app/components/common/forms/Actions.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Actions.test.js
@@ -1,18 +1,10 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Actions from './Actions';
 
-configure({ adapter: new Adapter() });
-
 describe('actions', () => {
-  beforeEach(() => {
-    global.__ = str => str;
-  });
-
   it('should include a cancel / submit buttons', () => {
     const wrapper = shallow(<Actions />);
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/Button.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Button.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Button from './Button';
-
-configure({ adapter: new Adapter() });
 
 describe('buttons', () => {
   it('should default to button type', () => {

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.test.js
@@ -1,17 +1,10 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import CommonForm from './CommonForm';
 
-configure({ adapter: new Adapter() });
-
 describe('common Form', () => {
-  beforeEach(() => {
-    global.__ = str => str;
-  });
   it('should display a label field', () => {
     const wrapper = shallow(<CommonForm label="my label" />);
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/Form.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Form.test.js
@@ -1,17 +1,10 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Form from './Form';
 
-configure({ adapter: new Adapter() });
-
 describe('Form', () => {
-  beforeEach(() => {
-    global.__ = str => str;
-  });
   it('should render a form', () => {
     const wrapper = shallow(<Form />);
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/TextField.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/TextField.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import TextField from './TextField';
-
-configure({ adapter: new Adapter() });
 
 describe('TextField', () => {
   it('should default to a text field', () => {

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.test.js
@@ -1,16 +1,11 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { pendingState, errorState, resolvedState } from './PowerStatus.fixtures';
-
 import PowerStatus from './';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./');
 

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/StorageContainer.test.js
@@ -1,19 +1,14 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
-import { configure, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import { getStore } from '../../../../redux';
 import { vmwareData, hiddenFieldValue } from './StorageContainer.fixtures';
 import StorageContainer from './';
 
-configure({ adapter: new Adapter() });
-
 let wrapper = null;
 
 describe('StorageContainer', () => {
   beforeEach(() => {
-    global.__ = str => str;
     wrapper = mount(<StorageContainer store={getStore()} data={vmwareData} />);
   });
 

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/controller.test.js
@@ -1,22 +1,13 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import { props } from './controller.fixtures';
-
 import Controller from './';
-
-configure({ adapter: new Adapter() });
 
 let wrapper = null;
 
 describe('StorageContainer', () => {
-  beforeAll(() => {
-    global.__ = str => str;
-  });
-
   beforeEach(() => {
     wrapper = shallow(<Controller {...props} />);
   });

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
@@ -1,19 +1,10 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import { props } from './disk.fixtures';
-
 import Disk from './';
 
-configure({ adapter: new Adapter() });
-
 describe('StorageContainer', () => {
-  beforeEach(() => {
-    global.__ = str => str;
-  });
-
   it('renders controller correctly', () => {
     const wrapper = shallow(<Disk {...props} />);
 

--- a/webpack/assets/javascripts/react_app/components/notifications/drawer/NotificationDropdown.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/drawer/NotificationDropdown.test.js
@@ -1,13 +1,9 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import NotificationDropdown from './NotificationDropdown';
 import { propsWithLinks } from './NotificationDropdown.fixtures';
-
-configure({ adapter: new Adapter() });
 
 describe('Notification dropdown', () => {
   it('Renders links provided', () => {

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -1,7 +1,5 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow, mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import $ from 'jquery';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
@@ -20,8 +18,6 @@ import {
 } from './notifications.fixtures';
 
 import Notifications from './';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('jquery');
 const mockStore = configureMockStore([thunk]);
@@ -44,7 +40,6 @@ function mockjqXHR() {
 
 describe('notifications', () => {
   beforeEach(() => {
-    global.__ = str => str;
     global.tfm = {
       tools: {
         activateTooltips: () => {},

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
@@ -1,12 +1,8 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import ChartBox from './ChartBox';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./ChartBox');
 jest.unmock('../../../services/ChartService');

--- a/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.test.js
@@ -1,7 +1,5 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -10,15 +8,9 @@ import immutable from 'seamless-immutable';
 import StatisticsChartsList from './StatisticsChartsList';
 import { statisticsData } from './StatisticsChartsList.fixtures';
 
-configure({ adapter: new Adapter() });
-
 const mockStore = configureMockStore([thunk]);
 
 describe('StatisticsChartsList', () => {
-  beforeEach(() => {
-    global.__ = str => str;
-  });
-
   it('should render no panels for empty data', () => {
     const store = mockStore({
       statistics: immutable({ charts: [] }),

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/ToastsList.test.js
@@ -1,7 +1,5 @@
-// Configure Enzyme
-import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
-import { configure, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -13,8 +11,6 @@ import {
 } from './ToastList.fixtures';
 
 import ToastList from './';
-
-configure({ adapter: new Adapter() });
 
 jest.unmock('./');
 

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
@@ -14,7 +14,6 @@ describe('form actions', () => {
   beforeEach(() => {
     document.head.innerHTML = `<meta name="csrf-param" content="authenticity_token" />
      <meta name="csrf-token" content="token123" />`;
-    global.__ = str => str;
   });
   afterEach(() => {
     nock.cleanAll();

--- a/webpack/test_setup.js
+++ b/webpack/test_setup.js
@@ -1,0 +1,7 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+
+// Mocking translation function
+global.__ = str => str; // eslint-disable-line


### PR DESCRIPTION
This moves the redundant test setup code to a single file. Thanks @waldenraines for pointing this out!

http://projects.theforeman.org/issues/21725