### PR TITLE
Fixes #20929 - Added fact name filtering on import

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -207,12 +207,14 @@ class Setting < ApplicationRecord
     end
   end
 
-  def self.regexp_expand_wildcard_string(string)
-    "\\A#{Regexp.escape(string).gsub('\*', '.*')}\\Z"
+  def self.regexp_expand_wildcard_string(string, options = {})
+    prefix = options[:prefix] || '\A'
+    suffix = options[:suffix] || '\Z'
+    prefix + Regexp.escape(string).gsub('\*', '.*') + suffix
   end
 
-  def self.convert_array_to_regexp(array)
-    Regexp.new(array.map {|string| regexp_expand_wildcard_string(string) }.join('|'))
+  def self.convert_array_to_regexp(array, regexp_options = {})
+    Regexp.new(array.map {|string| regexp_expand_wildcard_string(string, regexp_options) }.join('|'))
   end
 
   def has_readonly_value?

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -58,7 +58,13 @@ class Setting::Provisioning < Setting
       self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),
       self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
       self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
-      self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} })
+      self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
+      self.set(
+        'excluded_facts',
+        N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),
+        default_excluded_facts,
+        N_('Exclude pattern for facts stored in foreman')
+      )
     ] + default_global_templates + default_local_boot_templates
   end
 
@@ -100,5 +106,9 @@ class Setting::Provisioning < Setting
       templates = Proc.new { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).map { |tmpl| [tmpl.name, tmpl.name] }] }
       yield pxe_kind, templates
     end
+  end
+
+  def self.default_excluded_facts(ignored_interfaces = IGNORED_INTERFACES)
+    ignored_interfaces
   end
 end

--- a/app/services/fact_cleaner.rb
+++ b/app/services/fact_cleaner.rb
@@ -2,11 +2,7 @@ class FactCleaner
   delegate :logger, :to => :Rails
 
   def clean!
-    to_delete = find_leaf_orphaned_facts
-    # we also delete all composes that either don't have any descendant or all of them are to be deleted
-    to_delete += find_compose_orphaned_facts(to_delete)
-    delete!(to_delete)
-    @deleted_count = to_delete.count
+    @deleted_count = delete_excluded_facts + delete_orphaned_facts
     self
   end
 
@@ -17,9 +13,17 @@ class FactCleaner
 
   private
 
+  def delete_orphaned_facts
+    to_delete = find_leaf_orphaned_facts
+    # we also delete all composes that either don't have any descendant or all of them are to be deleted
+    to_delete += find_compose_orphaned_facts(to_delete)
+    delete!(to_delete)
+    to_delete.uniq.count
+  end
+
   def find_leaf_orphaned_facts
     result = []
-    logger.info "Searching for leaf orphaned facts..."
+    logger.debug "Searching for leaf orphaned facts..."
     FactName.leaves.includes(:fact_values).find_in_batches do |batch|
       result += batch.select do |fact|
         fact.fact_values.empty?
@@ -29,7 +33,7 @@ class FactCleaner
   end
 
   def find_compose_orphaned_facts(found)
-    logger.info "Searching for compose orphaned facts..."
+    logger.debug "Searching for compose orphaned facts..."
     FactName.composes.find_in_batches do |batch|
       found += batch.select do |compose|
         compose.descendants.all? { |fact| found.include?(fact) }
@@ -39,11 +43,38 @@ class FactCleaner
   end
 
   def delete!(to_delete)
-    logger.info "#{to_delete.size} facts will be removed"
+    logger.debug "#{to_delete.size} facts will be removed"
     to_delete.each do |fact|
       logger.debug { "Removing fact #{fact}" }
       fact.destroy
     end
-    logger.info "Cleanup of facts finished!"
+    logger.debug "Cleanup of facts finished!"
+  end
+
+  def find_excluded_facts
+    logger.debug "Searching for facts that match excluded pattern..."
+    fact_name_ids = []
+
+    excluded_facts_regex = FactImporter.excluded_facts_regex
+
+    FactName.unscoped.find_in_batches(:batch_size => 100) do |names_batch|
+      names_batch.select! { |fact_name| fact_name.name.match(excluded_facts_regex) }
+      fact_name_ids += names_batch.map(&:id)
+    end
+
+    fact_name_ids.uniq
+  end
+
+  def delete_excluded_facts
+    fact_names = find_excluded_facts
+
+    # delete related fact values first
+    logger.debug "Removing values of excluded facts..."
+    deleted_values = FactValue.unscoped.where(:fact_name_id => fact_names).delete_all
+    logger.debug "Removed #{deleted_values} associated fact value records."
+    logger.debug "Removing excluded fact names..."
+    deleted_names = FactName.unscoped.where(:id => fact_names).delete_all
+    logger.debug "Removed #{deleted_names} fact name records."
+    deleted_names
   end
 end

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -34,3 +34,151 @@ module FactImporterFactoryStubber
     @instance_stubs ||= []
   end
 end
+
+module FactsData
+  class FlatFacts
+    def filter
+      ['ignore*', '*_bad', 'filter']
+    end
+
+    def good_facts
+      {
+        'just_a_fact' => 'hello',
+        'nofilter' => 'hello'
+      }
+    end
+
+    def ignored_facts
+      {
+        'ignored_fact' => 'will_not_show',
+        'fact_bad' => 'will_not_show',
+        'filter' => 'will_not_show',
+        'ignore' => 'will_not_show',
+        '_bad' => 'will_not_show'
+      }
+    end
+  end
+
+  class RhsmStyleFacts
+    def filter
+      ['ignore*', '*_bad', 'filter']
+    end
+
+    def good_facts
+      {
+        'something::something_else' => 'hello'
+      }
+    end
+
+    def ignored_facts
+      {
+        'ignored_fact::something' => 'will_not_show',
+        'something::ignored_fact' => 'will_not_show',
+        'something::ignored_fact::something_else' => 'will_not_show',
+        'fact_bad::something' => 'will_not_show',
+        'something::fact_bad' => 'will_not_show',
+        'something::fact_bad::something_else' => 'will_not_show',
+        'filter::something' => 'will_not_show',
+        'something::filter' => 'will_not_show',
+        'something::filter::something_else' => 'will_not_show'
+      }
+    end
+  end
+
+  class FlatPuppetStyleFacts
+    def filter
+      ['ignore*', '*_bad', 'filter']
+    end
+
+    def good_facts
+      {
+        'something_filter_something_else' => 'hello',
+        'fact_bad_something' => 'hello',
+        'filter_something' => 'hello'
+      }
+    end
+
+    def ignored_facts
+      {
+        'ignored_fact_something' => 'will_not_show',
+        'something_ignored_fact' => 'will_not_show',
+        'something_ignored_fact_something_else' => 'will_not_show',
+        'something_fact_bad' => 'will_not_show',
+        'something_filter' => 'will_not_show'
+      }
+    end
+  end
+
+  class HierarchicalPuppetStyleFacts
+    def filter
+      ['ignored*']
+    end
+
+    def good_facts
+      {
+        :good => 'hello',
+        :common_ancestor => {
+          :good_subtree => {
+            :good_key => 'hello'
+          }
+        }
+      }
+    end
+
+    def ignored_facts
+      {
+        :common_ancestor => {
+          :ignored_subtree => {
+            :key1 => 'will_not_show',
+            :key2 => 'will_not_show'
+          }
+        },
+        :empty_ancestor => {
+          :ignored_key => 'will_not_show'
+        },
+        :ignored_value => 'will_not_show'
+      }
+    end
+
+    def flat_result
+      {
+        "good"=>"hello",
+        "common_ancestor::good_subtree::good_key"=>"hello",
+        "common_ancestor::good_subtree"=>nil,
+        "common_ancestor"=>nil
+      }
+    end
+  end
+
+  class DefaultInterfacesFacts
+    def filter
+      Setting[:excluded_facts]
+    end
+
+    def good_facts
+      {
+        'macaddress_virbr4' => 'fe:54:00:59:4e:bf',
+        'mtu_virbr4' => '1500',
+        'net::interface::virbr4::ipv6_address::link' => 'fe80::fc54:ff:fe59:4ebf',
+        'net::interface::virbr4::ipv6_address::link_list' => 'fe80::fc54:ff:fe59:4ebf',
+        'net::interface::virbr4::ipv6_netmask::link' => '64',
+        'net::interface::virbr4::ipv6_netmask::link_list' => '64',
+        'net::interface::virbr4::mac_address' => 'FE:54:00:59:4E:BF',
+        'net::interface::virbr4::permanent_mac_address' => 'Unknown'
+      }
+    end
+
+    def ignored_facts
+      {
+        'macaddress_vnet4' => 'fe:54:00:59:4e:bf',
+        'mtu_vnet4' => '1500',
+        'net::interface::vnet4::ipv6_address::link' => 'fe80::fc54:ff:fe59:4ebf',
+        'net::interface::macvtap1::ipv6_address::link_list' => 'fe80::fc54:ff:fe59:4ebf',
+        'net::interface::veth4::ipv6_netmask::link' => '64',
+        'net::interface::docker4::ipv6_netmask::link_list' => '64',
+        'net::interface::vlinuxbr4::mac_address' => 'FE:54:00:59:4E:BF',
+        'net::interface::usb4::permanent_mac_address' => 'Unknown'
+      }
+    end
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -363,3 +363,8 @@ attribute75:
   category: Setting::Notification
   default: "http://theforeman.org/feed.xml"
   description: 'Default URL for RSS feed notifications'
+attributes76:
+  name: excluded_facts
+  category: Setting::Provisioning
+  default: "['lo', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
+  description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -55,6 +55,55 @@ class FactImporterTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#normalize' do
+    test 'filters regular facts' do
+      data = FactsData::FlatFacts.new
+      Setting.stubs(:[]).with(:excluded_facts).returns(data.filter)
+
+      facts = data.good_facts.merge(data.ignored_facts)
+
+      importer = FactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.good_facts, actual_facts
+    end
+
+    test 'filters a::b facts' do
+      data = FactsData::RhsmStyleFacts.new
+      Setting.stubs(:[]).with(:excluded_facts).returns(data.filter)
+
+      facts = data.good_facts.merge(data.ignored_facts)
+
+      importer = FactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.good_facts, actual_facts
+    end
+
+    test 'filters macaddress_virbr0 facts' do
+      data = FactsData::FlatPuppetStyleFacts.new
+      Setting.stubs(:[]).with(:excluded_facts).returns(data.filter)
+
+      facts = data.good_facts.merge(data.ignored_facts)
+
+      importer = FactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.good_facts, actual_facts
+    end
+
+    test 'filters default interface facts' do
+      data = FactsData::DefaultInterfacesFacts.new
+
+      facts = data.good_facts.merge(data.ignored_facts)
+
+      importer = FactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.good_facts, actual_facts
+    end
+  end
+
   describe '#import!' do
     setup do
       FactoryBot.create(:fact_value, :value => '2.6.9',:host => host,

--- a/test/unit/structured_fact_importer_test.rb
+++ b/test/unit/structured_fact_importer_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'fact_importer_test_helper'
 
 class StructuredFactImporterTest < ActiveSupport::TestCase
   include FactImporterIsolation
@@ -77,6 +78,18 @@ class StructuredFactImporterTest < ActiveSupport::TestCase
     test 'changes non-string values to strings' do
       importer = StructuredFactImporter.new(nil, :a => 1)
       assert_equal({'a' => '1'}, importer.send(:facts))
+    end
+
+    test 'subtrees excluded properly' do
+      data = FactsData::HierarchicalPuppetStyleFacts.new
+      Setting.stubs(:[]).with(:excluded_facts).returns(data.filter)
+
+      facts = data.good_facts.deep_merge(data.ignored_facts)
+
+      importer = StructuredFactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.flat_result, actual_facts
     end
   end
 


### PR DESCRIPTION
Added a setting that will filter out fact names, so they won't be recorded into `fact_names` and `fact_values` tables at all.