### PR TITLE
fixes #5441 - Add instance_type support to oVirt provider

### DIFF
--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -2,7 +2,7 @@ class ComputeResourcesController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::Parameters::ComputeResource
 
-  AJAX_REQUESTS = [:template_selected, :cluster_selected, :resource_pools]
+  AJAX_REQUESTS = [:template_selected, :instance_type_selected, :cluster_selected, :resource_pools]
   before_action :ajax_request, :only => AJAX_REQUESTS
   before_action :find_resource, :only => [:show, :edit, :associate, :update, :destroy, :ping, :refresh_cache] + AJAX_REQUESTS
 
@@ -118,6 +118,13 @@ class ComputeResourcesController < ApplicationController
     end
   end
 
+  def instance_type_selected
+    compute = @compute_resource.instance_type(params[:instance_type_id])
+    respond_to do |format|
+      format.json { render :json => compute }
+    end
+  end
+
   def cluster_selected
     networks = @compute_resource.networks(:cluster_id => params[:cluster_id])
     respond_to do |format|
@@ -139,7 +146,7 @@ class ComputeResourcesController < ApplicationController
     case params[:action]
       when 'associate'
         'edit'
-      when 'ping', 'template_selected', 'cluster_selected', 'resource_pools', 'refresh_cache'
+      when 'ping', 'template_selected', 'instance_type_selected', 'cluster_selected', 'resource_pools', 'refresh_cache'
         'view'
       else
         super

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -338,7 +338,7 @@ Foreman::AccessControl.map do |permission_set|
                     :hostgroup_or_environment_selected, :medium_selected, :os_selected, :use_image_selected, :process_hostgroup,
                     :process_taxonomy, :current_parameters, :puppetclass_parameters, :template_used, :interfaces, :scheduler_hint_selected,
                     :random_name]
-    cr_ajax_actions = [:cluster_selected, :template_selected, :provider_selected, :resource_pools]
+    cr_ajax_actions = [:cluster_selected, :template_selected, :instance_type_selected, :provider_selected, :resource_pools]
     pc_ajax_actions = [:parameters]
     subnets_ajax_actions = [:freeip]
     tasks_ajax_actions = [:show]

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -8,6 +8,7 @@
                :help_inline => :indicator,
                :label      => _('Cluster'), :label_size => "col-md-2" } %>
 <%= f.hidden_field :cluster if !new_vm %>
+
 <%= select_f f, :template, compute_resource.templates, :id, :full_name, {:include_blank => _("Select template")},
              { :disabled    => !new_vm, :'data-url' => template_selected_compute_resource_path(compute_resource),
                :onchange    => 'tfm.computeResource.ovirt.templateSelected(this);',
@@ -15,6 +16,14 @@
                :help_block  => _("oVirt/RHEV template to use"),
                :label       => _('Template'), :label_size => "col-md-2" } %>
 <%= f.hidden_field :template if !new_vm %>
+
+<%= select_f f, :instance_type, compute_resource.instance_types, :id, :name, {:include_blank => _("Select instance type")},
+             { :disabled    => !new_vm, :'data-url' => instance_type_selected_compute_resource_path(compute_resource),
+               :onchange    => 'tfm.computeResource.ovirt.instanceTypeSelected(this);',
+               :help_inline => :indicator,
+               :help_block  => _("oVirt/RHEV instance type"),
+               :label       => _('Instance type'), :label_size => "col-md-2" } %>
+<%= f.hidden_field :instance_type if !new_vm %>
 
 <% selected_cluster ||= params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,6 +402,7 @@ Foreman::Application.routes.draw do
       resources :compute_resources do
         member do
           post 'template_selected'
+          post 'instance_type_selected'
           post 'cluster_selected'
           get 'resource_pools'
           post 'ping'

--- a/webpack/assets/javascripts/compute_resource/ovirt.js
+++ b/webpack/assets/javascripts/compute_resource/ovirt.js
@@ -15,8 +15,12 @@ export function templateSelected(item) {
       url,
       data: `template_id=${template}`,
       success(result) {
-        $('[id$=_memory]').val(result.memory);
-        $('[id$=_cores]').val(result.cores);
+        // As Instance Type values will take precence over templates values,
+        // we don't update memory/cores values if  instance type is already selected
+        if (!$('#host_compute_attributes_instance_type').val()) {
+          $('[id$=_memory]').val(result.memory);
+          $('[id$=_cores]').val(result.cores);
+        }
         $('#network_interfaces').children('.fields').remove();
         $.each(result.interfaces, function () {
           addNetworkInterface(this);
@@ -29,6 +33,34 @@ export function templateSelected(item) {
 
         if (templateSelector.is(':disabled')) {
           templateSelector.val(result.id).trigger('change');
+        }
+      },
+      complete() {
+        // eslint-disable-next-line no-undef
+        reloadOnAjaxComplete(item);
+      },
+    });
+  }
+}
+
+export function instanceTypeSelected(item) {
+  const instanceType = $(item).val();
+
+  if (!item.disabled) {
+    const url = $(item).attr('data-url');
+
+    showSpinner();
+    $.ajax({
+      type: 'post',
+      url,
+      data: `instance_type_id=${instanceType}`,
+      success(result) {
+        $('[id$=_memory]').val(result.memory);
+        $('[id$=_cores]').val(result.cores);
+        const instanceTypeSelector = $('#host_compute_attributes_instance_type');
+
+        if (instanceTypeSelector.is(':disabled')) {
+          instanceTypeSelector.val(result.id).trigger('change');
         }
       },
       complete() {


### PR DESCRIPTION
Add Instance type / flavor support for oVirt compute resource provider.
Instance type values take precedence on templates values.