### PR TITLE
 fixes #21762 - Add disk options to oVirt provider 

### DIFF
--- a/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
@@ -7,6 +7,10 @@
 <%= f.hidden_field :id %>
 
 <%= checkbox_f f, :preallocate, { :checked => f.object.sparse == 'false', :help_inline => _('Uses thin provisioning if unchecked'), :label => _('Preallocate disk'), :label_size => "col-md-2" } %>
+<%= checkbox_f f, :wipe_after_delete, { :checked => f.object.wipe_after_delete == 'true', :label => _('Wipe disk after delete'), :label_size => "col-md-2" } %>
+<%= select_f f, :interface, [OpenStruct.new({:id =>'virtio', :name =>'VirtIO'}), OpenStruct.new({:id =>'virtio_scsi', :name =>'VirtIO SCSI'}), OpenStruct.new({:id =>'ide', :name =>'IDE'})],
+             :id, :name, { :include_blank => true }, :label => _('Disk interface'), :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2" %>
+<%= f.hidden_field :interface if !new_vm %>
 
 <%= field(f, :bootable, :label => _('Bootable'), :label_size => "col-md-2") do
     radio_button_f f, :bootable, {:disabled => !new_vm, :value=>'true', :checked => (f.object.bootable == 'true'), :onclick => 'tfm.computeResource.ovirt.bootableRadio(this)',

--- a/webpack/assets/javascripts/compute_resource/ovirt.js
+++ b/webpack/assets/javascripts/compute_resource/ovirt.js
@@ -27,6 +27,8 @@ export function templateSelected(item) {
         });
         $('#storage_volumes .children_fields >.fields').remove();
         $.each(result.volumes, function () {
+          // Change variable name because 'interface' is a reserved keyword.
+          this.disk_interface = this['interface'];
           addVolume(this);
         });
         const templateSelector = $('#host_compute_attributes_template');
@@ -88,13 +90,15 @@ function addNetworkInterface({ name, network }) {
 // fill in the template volumes.
 // eslint-disable-next-line camelcase
 function addVolume({
-  size_gb, storage_domain, bootable, id,
+  size_gb, storage_domain, bootable, id, disk_interface, wipe_after_delete,
 }) {
   // eslint-disable-next-line no-undef
   const newId = add_child_node($('#storage_volumes .add_nested_fields'));
 
   disableElement($(`[id$=${newId}_size_gb]`).val(size_gb));
   disableElement($(`[id$=${newId}_storage_domain]`).val(storage_domain));
+  disableElement($(`[id$=${newId}_wipe_after_delete]`).val(wipe_after_delete));
+  disableElement($(`[id$=${newId}_interface]`).val(disk_interface));
   disableElement($(`[id$=${newId}_bootable_true]`).attr('checked', bootable));
   if (id) {
     $(`[id$=${newId}_id]`).val(id);


### PR DESCRIPTION
Add two disk options for oVirt provider:
* The possibility to choose disk interface (VirtIO, VirtIO-SCSI, IDE)
* The possibility to tell to oVirt to wipe the disk when deleted

Tested on oVirt 4.1 with APIv3