### PR TITLE
Fixes #21774 - Drop fbjs requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "datatables.net-bs": "~1.10.12",
     "diff": "~3.0.0",
     "extract-text-webpack-plugin": "^3.0.0",
-    "fbjs": "0.8.12",
     "ipaddr.js": "~1.2.0",
     "jquery": "~2.2.4",
     "jquery-flot": "~0.8.3",


### PR DESCRIPTION
This was needed as a [workaround](https://github.com/theforeman/foreman/pull/4514#discussion_r115461654) that's no longer needed.