### PR TITLE
Fixes #21637 - fallback to default locale when I18n translation is missing

### DIFF
--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -9,6 +9,7 @@ Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
 
 I18n.config.enforce_available_locales = false
 I18n.config.available_locales = FastGettext.default_available_locales.map { |loc| loc.tr('_', '-') }
+I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
 
 FastGettext.default_text_domain = locale_domain
 FastGettext.default_locale = "en"


### PR DESCRIPTION
This makes the I18n behavior closer to the gettext one, and prevents
some ugly 'missing_translation' messages in the UI (for example in
apipie, that uses the I18n backend for it's strings).