### PR TITLE
Fixes #21805 - don't list default role

### DIFF
--- a/app/views/api/v2/users/show.json.rabl
+++ b/app/views/api/v2/users/show.json.rabl
@@ -17,7 +17,7 @@ child :mail_notifications do
   extends "api/v2/mail_notifications/base"
 end
 
-child :roles do
+child @user.roles.givable => :roles do
   extends "api/v2/roles/base"
 end
 


### PR DESCRIPTION
to reproduce
```
hammer user info --id 4

Id:                    4
...
Roles:                 
    Default role         # this should not be here, we don't display it in UI either, it's system role
    Viewer
```