### PR TITLE
Fixes #21815 - Do not search for permissions when db is empty

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -270,6 +270,7 @@ module Foreman #:nodoc:
     # Add plugin permissions to Manager and Viewer roles. Use this method if there are no special cases that need to be taken care of.
     # Otherwise add_permissions_to_default_roles or add_resource_permissions_to_default_roles might be the methods you are looking for.
     def add_all_permissions_to_default_roles
+      return if Foreman.in_rake?('db:migrate')
       Plugin::RbacSupport.new.add_all_permissions_to_default_roles(Permission.where(:name => @rbac_registry.permission_names))
     end
 

--- a/app/registries/foreman/plugin/rbac_support.rb
+++ b/app/registries/foreman/plugin/rbac_support.rb
@@ -5,7 +5,6 @@ module Foreman
       AUTO_EXTENDED_ROLES = [ Role::VIEWER, Role::MANAGER, Role::ORG_ADMIN ]
 
       def add_all_permissions_to_default_roles(all_permissions)
-        return if Foreman.in_rake?('db:migrate')
         view_permissions = all_permissions.where("name LIKE :name", :name => "view_%")
         org_admin_permissions = all_permissions.where('resource_type <> :resource_type OR resource_type IS NULL', { :resource_type => "Organization" })
         Role.transaction do


### PR DESCRIPTION
To be merged after we move to Rails 5.1 if the issue manifests itself.