### PR TITLE
Fixes #21444 - change subitems headers style in vertical navigation

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -380,3 +380,12 @@ a.btn-info span {
 .container-pf-nav-pf-vertical.hide-nav-pf {
   display: none !important;
 }
+
+.vertical-sub-header {
+  line-height: 25px;
+  font-size: 12px;
+  margin-left: 20px;
+  padding: 4px 0 2px;
+  font-weight: bold;
+  color: #fff;
+}

--- a/app/views/home/_vertical_menu.html.erb
+++ b/app/views/home/_vertical_menu.html.erb
@@ -15,8 +15,9 @@
         <% when Menu::Item %>
           <%= menu_secondary_item item %>
         <% when Menu::Divider %>
-          <%= content_tag(:div, "", :class => "divider") %>
-          <%= content_tag(:span, _(item.caption), :class => "nav-item-pf-header") if item.caption %>
+          <%= content_tag(:li, :class => "list-group-item") do %>
+            <%= content_tag(:span, _(item.caption), :class => "vertical-sub-header") if item.caption %></a>
+          <% end %>
         <% when Menu::Toggle %>
           <%= content_tag :li, :class => "dropdown-submenu" do %>
             <%= link_to(_(item.caption), "#", :class => "dropdown-toggle", :"data-toggle" => "dropdown") %>


### PR DESCRIPTION
I've decreased font size, it shouldn't be the same as the main header size.

![screenshot from 2017-11-30 15-25-06](https://user-images.githubusercontent.com/11807069/33433113-09dc804c-d5e3-11e7-959c-4a9ca0f54908.png)


before changing:
![screenshot from 2017-11-30 15-25-33](https://user-images.githubusercontent.com/11807069/33433117-0dc05e68-d5e3-11e7-84ef-6c02d8ade6db.png)

