### PR TITLE
fixes #21825 - external nodes html content type

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -203,7 +203,7 @@ class HostsController < ApplicationController
       respond_to do |format|
         # don't break lines in yaml to support Ruby < 1.9.3
         host_info_yaml = @host.info.to_yaml(:line_width => -1)
-        format.html { render :plain => "<pre>#{ERB::Util.html_escape(host_info_yaml)}</pre>" }
+        format.html { render :html => "<pre>#{ERB::Util.html_escape(host_info_yaml)}</pre>".html_safe }
         format.yml { render :plain => host_info_yaml }
       end
     rescue => e


### PR DESCRIPTION
Changes the content type from
`Content-Type: text/plain; charset=utf-8`
to
`Content-Type: text/html; charset=utf-8` for html. This causes the page to be rendered correctly.
