### PR TITLE
Fixes #21826 - rss notifications are duplicated

### DIFF
--- a/app/services/ui_notifications/rss_notifications_checker.rb
+++ b/app/services/ui_notifications/rss_notifications_checker.rb
@@ -68,7 +68,7 @@ module UINotifications
     end
 
     def notification_already_exists?(item)
-      !!Notification.unscoped.find_by_message(item.summary)
+      !!Notification.unscoped.find_by_message(item.title)
     end
   end
 end


### PR DESCRIPTION
From my understanding `item.summary` isn't passed to the created `Notification` which made it weird why it is used when checking if it exists.

cc @ohadlevy 