### PR TITLE
Fixes #21833 - added bootsnap development dependency

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -15,4 +15,9 @@ group :development do
   gem 'spring', '>= 1.0', '< 3'
   gem 'benchmark-ips'
   gem 'foreman'
+  begin
+    gem('bootsnap', :require => false) if RUBY_VERSION >= '2.3'
+  rescue LoadError
+    # pass
+  end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,5 +2,7 @@ require 'rubygems'
 
 unless File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
   ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-  require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+  # Set up boootsnap on Ruby 2.3+ in development env with Budler enabled and development group
+  early_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+  require('bootsnap/setup') if RUBY_VERSION >= '2.3' && early_env == "development" && File.exist?(ENV['BUNDLE_GEMFILE']) && !Gem::Specification.stubs_for("bootsnap").empty?
 end


### PR DESCRIPTION
This speeds up booting times on dev setup from 10s to 6s on my system. This gem will be included in Rails 5.2, but it does work today with any Rails version (I tested with 5.1). See the issue link for more info and links. Ruby 2.3 is needed.

Although this could be useful also in production, we do not use Bundler in production (but the BundlerExt replacement) which is unfortunately not compatible with Bootsnap. If anyone wan's to try on Debian production deployment, feel free to send me patch how to enable it for Debian only.

Two new dependencies are introduced by this:

* bootsnap
* msgpack

Cache files are held in `tmp/cache/bootsnap*` for your information.