### PR TITLE
fixes #3763 - extend rabl templates

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -117,6 +117,7 @@ module Foreman #:nodoc:
       @smart_proxies = {}
       @controller_action_scopes = {}
       @dashboard_widgets = []
+      @rabl_template_extensions = {}
     end
 
     def after_initialize
@@ -408,6 +409,23 @@ module Foreman #:nodoc:
 
     def action_scopes_hash_for(controller_class)
       @controller_action_scopes[controller_class.name] || {}
+    end
+
+    # Extends a rabl template by "including" another template
+    #
+    # Usage:
+    # extend_rabl_template 'api/v2/hosts/main', 'api/v2/hosts/expiration'
+    #
+    # This will call 'extends api/v2/hosts/expiration' inside
+    # the template 'api/v2/hosts/main'
+    #
+    def extend_rabl_template(virtual_path, template)
+      @rabl_template_extensions[virtual_path] ||= []
+      @rabl_template_extensions[virtual_path] << template
+    end
+
+    def rabl_template_extensions(virtual_path)
+      @rabl_template_extensions.fetch(virtual_path, [])
     end
 
     private

--- a/test/static_fixtures/views/api/v2/test/one.json.rabl
+++ b/test/static_fixtures/views/api/v2/test/one.json.rabl
@@ -1,0 +1,7 @@
+object @medium
+
+attributes :id, :name
+
+node :one do
+  '1'
+end

--- a/test/static_fixtures/views/api/v2/test/two.json.rabl
+++ b/test/static_fixtures/views/api/v2/test/two.json.rabl
@@ -1,0 +1,3 @@
+node :two do
+  '2'
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -479,6 +479,14 @@ class PluginTest < ActiveSupport::TestCase
     assert_includes Dashboard::Manager.default_widgets, widget_params
   end
 
+  def test_extend_rabl_template
+    Foreman::Plugin.register :test_extend_rabl_template do
+      extend_rabl_template 'api/v2/hosts/main', 'api/v2/hosts/expiration'
+    end
+    templates = Foreman::Plugin.find(:test_extend_rabl_template).rabl_template_extensions('api/v2/hosts/main')
+    assert_equal ['api/v2/hosts/expiration'], templates
+  end
+
   context "adding permissions" do
     teardown do
       permission = Foreman::AccessControl.permission(:test_permission)

--- a/test/unit/rabl_test.rb
+++ b/test/unit/rabl_test.rb
@@ -23,4 +23,31 @@ class RablTest < ActiveSupport::TestCase
     assert_equal Hash, loaded[0].class
     assert_equal 'foo', loaded[0]['name']
   end
+
+  context 'with plugin' do
+   setup do
+    @klass = Foreman::Plugin
+    @klass.clear
+   end
+
+   teardown do
+     @klass.clear
+   end
+
+   test 'render of extended plugin template' do
+     Foreman::Plugin.register :test_extend_rabl_template do
+       extend_rabl_template 'api/v2/test/one', 'api/v2/test/two'
+     end
+     @media = FactoryBot.build(:medium)
+     rendered = Rabl.render(@media,
+                            'api/v2/test/one',
+                            :format => :json,
+                            :view_path => File.expand_path('../../../test/static_fixtures/views', __FILE__))
+     loaded = JSON.load(rendered)
+     assert_equal Hash, loaded.class
+     assert_equal @media.name, loaded['name']
+     assert_equal '1', loaded['one']
+     assert_equal '2', loaded['two']
+   end
+  end
 end


### PR DESCRIPTION
This should be considered a proposal on how it would be possible for plugins to extend a rabl template to add more attributes to APIv2 responses.

This is still missing tests and inline documentation. I'd love to hear some feedback on this first.

It can be used like this:

lib/foreman_expire_hosts/engine.rb
```ruby
Foreman::Plugin.register :foreman_expire_hosts do
  [...]
  extend_rabl_template 'api/v2/hosts/main', 'api/v2/hosts/expiration'
end
```

app/views/api/v2/hosts/expiration.json.rabl:
```ruby
attribute :expired_on
```