### PR TITLE
Refs #18292 - refactors building actions

### DIFF
--- a/app/services/ui_notifications/actions_builder.rb
+++ b/app/services/ui_notifications/actions_builder.rb
@@ -1,0 +1,24 @@
+module UINotifications
+  class ActionsBuilder
+    def initialize
+      @actions = []
+    end
+
+    def push(url, title, external)
+      @actions << [url, title, external]
+      self
+    end
+
+    def build
+      result = {:links => []}
+      @actions.each do |url, title, external|
+        result[:links] << {
+          :href => url,
+          :title => title,
+          :external => external
+        }
+      end
+      result
+    end
+  end
+end

--- a/app/services/ui_notifications/rss_notifications_checker.rb
+++ b/app/services/ui_notifications/rss_notifications_checker.rb
@@ -43,20 +43,13 @@ module UINotifications
         if notification_already_exists?(item)
           next unless @force_repost
         end
-        Notification.create(
+        action_builder = ActionsBuilder.new.push(item.link, _('Open'), true)
+        Notification.create!(
           :initiator => User.anonymous_admin,
           :audience => @audience,
           :message => item.title,
           :notification_blueprint => blueprint,
-          :actions => {
-            :links => [
-              {
-                :href => item.link,
-                :title => _('Open'),
-                :external => true
-              }
-            ]
-          }
+          :actions => action_builder.build
         )
       end
     end

--- a/test/unit/ui_notifications/actions_builder_test.rb
+++ b/test/unit/ui_notifications/actions_builder_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ActionsBuilderTest < ActiveSupport::TestCase
+  def setup
+    @builder = UINotifications::ActionsBuilder.new
+  end
+
+  test 'multiple actions can be pushed in chain' do
+    @builder.push('a', 'b', true).push('c','d',false)
+    assert_equal 2, @builder.instance_variable_get('@actions').size
+  end
+
+  test 'actions are built in desired format' do
+    result = @builder.push('a', 'b', true).push('c','d',false).build
+    expected = {
+      :links => [
+        { :href => 'a', :title => 'b', :external => true },
+        { :href => 'c', :title => 'd', :external => false }
+      ]
+    }
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
Before I add tests for ActionsBuilder, @ohadlevy is this what you had in mind? Or do you want to explicitly disable passing hash to notification and always just provide ActionsBuilder instance which would be the only way to override blueprint actions?