### PR TITLE
fixes #21947 - host scopes include table name

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -78,8 +78,8 @@ class Host::Managed < Host::Base
       :ssh_authorized_keys, :pxe_loader
   end
 
-  scope :recent,      ->(*args) { where(["last_report > ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago)]) }
-  scope :out_of_sync, ->(*args) { where(["last_report < ? and hosts.enabled != ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago), false]) }
+  scope :recent,      ->(*args) { where(["#{Host.table_name}.last_report > ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago)]) }
+  scope :out_of_sync, ->(*args) { where(["#{Host.table_name}.last_report < ? and hosts.enabled != ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago), false]) }
 
   scope :with_status, lambda { |status_type|
     eager_load(:host_statuses).where("host_status.type = '#{status_type}'")


### PR DESCRIPTION
Fixes an `ambiguous column name: last_report` error when a plugin adds a facet that also has a `last_report` column.