### PR TITLE
fixes #21956 - apply compute profile only when needed

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -154,7 +154,7 @@ module Api
         @all_parameters = true
 
         @host.attributes = host_attributes(host_params, @host)
-        apply_compute_profile(@host)
+        apply_compute_profile(@host) if (params[:host] && params[:host][:compute_attributes].present?) || @host.compute_profile_id_changed?
 
         process_response @host.save
       rescue InterfaceTypeMapper::UnknownTypeExeption => e


### PR DESCRIPTION
This fixes the root cause of an issue where Foreman schedules an unwanted update of a Virtual Maschine's compute attributes when an API update request just contains an update of another arbitrary field, e.g. something like this:

```
{"id":123,"host":{"comment":"The Foreman development team is awesome."}}
```
Katello uses updates that do not cover all attributes like in the example above throughout the UI.

The issue is, that `host.compute_attributes` is set to the values defined in the compute profile. This causes an unintentional update to be queued and processed.

https://github.com/theforeman/foreman/blob/2dc6e2dd24cbbc45a7a197f26a99a79b2cc4914e/app/models/concerns/orchestration/compute.rb#L217-L222

This patch changes the behavior to only set `host.compute_attributes` if either the update request contains compute attributes changes or the compute profile id is changed.