### PR TITLE
Fixes #21120 - orchestration tasks are added only once

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -142,17 +142,14 @@ module Orchestration::DHCP
 
   def queue_dhcp_create
     logger.debug "Scheduling new DHCP reservations for #{self}"
-    queue.create(:name   => _("Create DHCP Settings for %s") % self, :priority => 10,
-                 :action => [self, :set_dhcp]) if dhcp?
+    queue.create(id: "dhcp_create_#{self.mac}", name: _("Create DHCP Settings for %s") % self, priority: 10, action: [self, :set_dhcp]) if dhcp?
   end
 
   def queue_dhcp_update
     return unless dhcp_update_required?
     logger.debug("Detected a changed required for DHCP record")
-    remove_name = _("Remove DHCP Settings for %s") % old
-    create_name = _("Create DHCP Settings for %s") % self
-    queue.create(:name => remove_name, :priority => 5, :action => [old, :del_dhcp]) if old.dhcp? && queue.items.select{|t| t.name == remove_name}.empty?
-    queue.create(:name => create_name, :priority => 9, :action => [self, :set_dhcp]) if dhcp? && queue.items.select{|t| t.name == create_name}.empty?
+    queue.create(id: "dhcp_remove_#{old.mac}", name: _("Remove DHCP Settings for %s") % old, priority: 5, action: [old, :del_dhcp]) if old.dhcp?
+    queue.create(id: "dhcp_create_#{self.mac}", name: _("Create DHCP Settings for %s") % self, priority: 9, action: [self, :set_dhcp]) if dhcp?
   end
 
   # do we need to update our dhcp reservations
@@ -177,8 +174,7 @@ module Orchestration::DHCP
 
   def queue_dhcp_destroy
     return unless dhcp? && errors.empty?
-    queue.create(:name   => _("Remove DHCP Settings for %s") % self, :priority => 5,
-                 :action => [self, :del_dhcp])
+    queue.create(id: "dhcp_remove_#{self.mac}", name: _("Remove DHCP Settings for %s") % self, priority: 5, action: [self, :del_dhcp])
     true
   end
 
@@ -186,8 +182,7 @@ module Orchestration::DHCP
     return if !dhcp? || !overwrite?
 
     logger.debug "Scheduling DHCP conflicts removal"
-    queue.create(:name   => _("DHCP conflicts removal for %s") % self, :priority => 5,
-                 :action => [self, :del_dhcp_conflicts])
+    queue.create(id: "dhcp_conflicts_remove_#{self.mac}", name: _("DHCP conflicts removal for %s") % self, priority: 5, action: [self, :del_dhcp_conflicts])
   end
 
   def dhcp_conflict_detected?

--- a/app/services/orchestration/queue.rb
+++ b/app/services/orchestration/queue.rb
@@ -4,9 +4,9 @@ module Orchestration
   # Represents tasks queue for orchestration
   class Queue
     attr_reader :items, :name
-    STATUS = %w[ pending running failed completed rollbacked conflict canceled]
+    STATUS = %w[pending running failed completed rollbacked conflict canceled]
 
-    delegate :count, :empty?, :to => :items
+    delegate :count, :size, :empty?, :to => :items
     delegate :to_json, :to => :all
     delegate :to_s, :to => :name
 
@@ -17,8 +17,14 @@ module Orchestration
 
     def create(options)
       options[:status] ||= default_status
-      Rails.logger.debug "Enqueued task '#{options[:name]}' to '#{name}' queue"
-      items << Task.new(options)
+      new_task = Task.new(options)
+      if items.include? new_task
+        # Two tasks with same :name are not allowed. Use two different :id options for multiple instances.
+        Rails.logger.debug "Task '#{new_task.id || new_task.name || ''}' already in '#{name}' queue"
+      else
+        Rails.logger.debug "Enqueued task '#{new_task.id || new_task.name || ''}' to '#{name}' queue"
+        items << new_task
+      end
     end
 
     def delete(item)
@@ -26,11 +32,20 @@ module Orchestration
     end
 
     def find_by_name(name)
-      items.each {|task| return task if task.name == name}
+      items.detect {|task| task.name == name}
+    end
+
+    def find_by_id(id)
+      string_id = id.to_s
+      items.detect {|task| task.id == string_id}
     end
 
     def all
       items.sort
+    end
+
+    def task_ids
+      all.map(&:id)
     end
 
     def clear

--- a/app/services/orchestration/task.rb
+++ b/app/services/orchestration/task.rb
@@ -1,12 +1,15 @@
 module Orchestration
   class Task
-    attr_reader :name, :status, :priority, :action, :timestamp
+    attr_reader :id, :name, :status, :priority, :action, :timestamp, :created
 
     def initialize(opts)
       @name      = opts[:name]
+      @id        = opts[:id].try(:to_s) || @name
       @status    = opts[:status]
       @priority  = opts[:priority] || 0
       @action    = opts[:action]
+      @created   = opts[:created] || Time.now.to_f
+      raise("action must be present for task '#{name}'") if action.nil?
       update_ts
     end
 
@@ -24,11 +27,12 @@ module Orchestration
     end
 
     def to_s
-      "#{name}\t #{priority}\t #{status}\t #{action}"
+      tid = id.nil? ? '' : " (#{id})"
+      "#{name}#{tid}\t #{priority}\t #{status}\t #{action}"
     end
 
     def as_json(options = {})
-      { :name => name, :timestamp => timestamp, :status => status, :priority => priority }
+      { :id => id, :name => name, :timestamp => timestamp, :status => status, :priority => priority, :created => created }
     end
 
     private
@@ -39,7 +43,13 @@ module Orchestration
 
     # sort based on priority
     def <=>(other)
+      return self.created <=> other.created if self.priority == other.priority
       self.priority <=> other.priority
+    end
+
+    def ==(other)
+      return false unless other.is_a?(Task)
+      self.id == other.id
     end
   end
 end

--- a/test/unit/orchestration/queue_test.rb
+++ b/test/unit/orchestration/queue_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class QueueTest < ActiveSupport::TestCase
+  before do
+    @queue = Orchestration::Queue.new
+  end
+
+  test 'a task can be added to queue' do
+    assert_equal 1, @queue.create(name: "t1", id: "i1", action: [:blah]).count
+  end
+
+  test 'a task can be added to queue without id (deprecated behavior)' do
+    assert_equal 1, @queue.create(name: "t1", action: [:blah]).count
+  end
+
+  test 'a task can be serialized to json' do
+    @queue.create(name: "t1", id: "i1", action: [:blah], created: 1513246009.9976416)
+    json = @queue.all.first.as_json
+    assert_equal "i1", json[:id]
+    assert_equal "t1", json[:name]
+    assert_equal 1513246009.9976416, json[:created]
+  end
+
+  test 'a task can be searched by name' do
+    @queue.create(name: "t1", id: "i1", action: [:blah])
+    assert_nil @queue.find_by_name("")
+    assert @queue.find_by_name("t1")
+    assert_equal "t1", @queue.find_by_name("t1").name
+  end
+
+  test 'a task can be searched by id' do
+    @queue.create(name: "t1", id: "i1", action: [:blah])
+    assert_nil @queue.find_by_id("")
+    assert @queue.find_by_id("i1")
+    assert_equal "t1", @queue.find_by_id("i1").name
+  end
+
+  test 'a task can be searched by id as symbol' do
+    @queue.create(name: "t1", id: :i1, action: [:blah])
+    assert_equal "t1", @queue.find_by_id("i1").name
+    assert_equal "t1", @queue.find_by_id(:i1).name
+  end
+
+  test 'two tasks with same id are not added' do
+    @queue.create(id: "t1", action: [:blah])
+    @queue.create(id: "t1", action: [:blah, :blah])
+    assert_equal 1, @queue.count
+  end
+
+  test 'two tasks with same name are not added' do
+    @queue.create(name: "t1", action: [:blah])
+    @queue.create(name: "t1", action: [:blah, :blah])
+    assert_equal 1, @queue.count
+  end
+
+  test 'two tasks with same name but different id are added' do
+    @queue.create(name: "t1", id: "i1", action: [:blah])
+    @queue.create(name: "t1", id: "i2", action: [:blah, :blah])
+    assert_equal 2, @queue.count
+  end
+
+  test 'tasks with same priroity are sorted in stable order' do
+    @queue.create(name: "t1", id: "i1", action: [:blah], priority: 2)
+    @queue.create(name: "t2", id: "i2", action: [:blah], priority: 1)
+    @queue.create(name: "t9", id: "i9", action: [:blah], priority: 2)
+    @queue.create(name: "t8", id: "i8", action: [:blah], priority: 1)
+    assert_equal ["i2", "i8", "i1", "i9"], @queue.task_ids
+  end
+
+  test 'tasks with same priroity are sorted by creation time' do
+    @queue.create(name: "t1", id: "i1", action: [:blah], priority: 1, created: 100.5)
+    @queue.create(name: "t2", id: "i2", action: [:blah], priority: 1, created: 50.5)
+    assert_equal ["i2", "i1"], @queue.task_ids
+  end
+end


### PR DESCRIPTION
Previously, our orchestration task engine was accepting multiple instances of same tasks. Foreman is then orchestrating various actions multiple times and this misbehavior is with us for years. All our backend services were idempotent, until we added PXELoader flag which caused DHCP to error out with conflicts, because filename option treated separately in ISC DHCP.

Without this patch, DHCP orchestration of host edit had four steps:

* delete DHCP entry
* delete DHCP entry
* add DHCP entry
* add DHCP entry

This patch will not add orchestration tasks with the same name twice. If you grep in our codebase for `queue.create` you can see that we don't have any task with same name, so `name` is good field to check for. I considered checking `action` but it contain active record reference which changes over time.

Now, `name` is a free form string and it is also being translated, so it is not ideal. There might be cases when multiple tasks must be scheduled. In that case, new field was introduced called `id` and if that's supplied (symbol or string), it is considered as the identifier for searching for duplicite entries.

With the patch, it's now correct:

* delete DHCP entry
* add DHCP entry

If needed, I can also add `id` field to all core tasks and add a deprecation warning for plugins which does not provide it so plugin authors have time to fix their code until we enforce presence of id.