### PR TITLE
Fixes #21962 - switch jquery ajax to axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@storybook/addon-actions": "^3.2.12",
     "@storybook/react": "^3.2.12",
     "@storybook/storybook-deployer": "^2.0.0",
+    "axios-mock-adapter": "^1.10.0",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.26.0",
     "babel-eslint": "^6.1.2",
@@ -37,7 +38,6 @@
     "jest-cli": "^20.0.0",
     "jsdom": "^9.5.0",
     "lodash-webpack-plugin": "^0.11.4",
-    "nock": "^9.0.14",
     "node-sass": "^4.5.0",
     "raf": "^3.4.0",
     "react-test-renderer": "^16.2.0",
@@ -55,6 +55,7 @@
     "phantomjs-prebuilt": "^2.1.0"
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
     "brace": "^0.10.0",
     "c3": "^0.4.11",

--- a/webpack/assets/javascripts/react_app/API.js
+++ b/webpack/assets/javascripts/react_app/API.js
@@ -1,37 +1,51 @@
-import $ from 'jquery';
+import axios from 'axios';
+
+const getcsrfToken = () => {
+  const token = document.querySelector('meta[name="csrf-token"]');
+
+  return token ? token.content : '';
+};
+
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+axios.defaults.headers.common['X-CSRF-Token'] = getcsrfToken();
 
 export default {
-  get(url) {
-    $.ajaxPrefilter((options, originalOptions, jqXHR) => {
-      // eslint-disable-next-line no-param-reassign
-      jqXHR.originalRequestOptions = originalOptions;
-    });
-    return $.getJSON(url);
-  },
-  markNotificationAsRead(id) {
-    const data = JSON.stringify({ seen: true });
-
-    $.ajax({
-      url: `/notification_recipients/${id}`,
-      contentType: 'application/json',
-      type: 'put',
-      dataType: 'json',
-      data,
-      error(jqXHR, textStatus, errorThrown) {
-        /* eslint-disable no-console */
-        console.log(jqXHR);
-      },
+  get(url, headers = {}, params = {}) {
+    return axios.get(url, {
+      headers,
+      params,
     });
   },
-  markGroupNotificationAsRead(group) {
-    $.ajax({
-      url: `/notification_recipients/group/${group}`,
-      contentType: 'application/json',
-      type: 'PUT',
-      error(jqXHR, textStatus, errorThrown) {
-        /* eslint-disable no-console */
-        console.log(jqXHR);
+  put(url, data = {}, headers = {}) {
+    return axios.put(
+      url, data,
+      {
+        headers,
       },
-    });
+    );
+  },
+  post(url, data = {}, headers = {}) {
+    return axios.post(
+      url, data,
+      {
+        headers,
+      },
+    );
+  },
+  delete(url, headers = {}) {
+    return axios.delete(
+      url,
+      {
+        headers,
+      },
+    );
+  },
+  patch(url, data = {}, headers = {}) {
+    return axios.patch(
+      url, data,
+      {
+        headers,
+      },
+    );
   },
 };

--- a/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.test.js
@@ -5,14 +5,18 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import BookmarksContainer from './';
+import API from '../../API';
 import {
   initialState,
   afterSuccess,
   afterSuccessNoResults,
   afterRequest,
   afterError,
+  bookmarks,
 } from './bookmarks.fixtures';
 
+jest.mock('../../API');
+API.get = jest.fn(() => Promise.resolve({ results: bookmarks }));
 const mockStore = configureMockStore([thunk]);
 
 function setup() {

--- a/webpack/assets/javascripts/react_app/components/bookmarks/form/form.test.js
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/form/form.test.js
@@ -5,6 +5,10 @@ import { Provider } from 'react-redux';
 import BookmarkForm from './';
 import { generateStore } from '../../../redux';
 import * as FormActions from '../../../redux/actions/common/forms';
+import API from '../../../API';
+
+jest.mock('../../../API');
+API.post = jest.fn(() => Promise.resolve({ id: 1 }));
 
 function setup() {
   const props = {

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.fixtures.js
@@ -83,11 +83,11 @@ export const stateWithUnreadNotifications = immutable({
   },
 });
 
-export const serverResponse = `{ "notifications":[
+export const serverResponse = `{"data": { "notifications":[
   {"id":1,"seen":true,"level":"info","text":null,"created_at":"2017-02-23T05:00:28.715Z",
   "group":"React devs","actions":{}},
   {"id":2,"seen":false,"level":"info","text":null,"created_at":"2017-02-23T05:00:28.715Z",
-  "group":"React devs","actions":{}}]}`;
+  "group":"React devs","actions":{}}]}}`;
 
 export const emptyHtml =
   '<div id="notifications_container">' +

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -1,10 +1,8 @@
 import toJson from 'enzyme-to-json';
 import { shallow, mount } from 'enzyme';
-import $ from 'jquery';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-
 import { generateStore } from '../../redux';
 import API from '../../API';
 
@@ -19,22 +17,20 @@ import {
 
 import Notifications from './';
 
-jest.unmock('jquery');
+jest.mock('../../API');
 const mockStore = configureMockStore([thunk]);
-
-let failResponse = { status: 200 };
+let failResponse = { response: { status: 200 } };
 
 function mockjqXHR() {
   return {
-    done: (callback) => {
+    then: (callback) => {
       callback(JSON.parse(serverResponse));
       return mockjqXHR();
     },
-    fail: (failCallback) => {
+    catch: (failCallback) => {
       failCallback(failResponse);
       return mockjqXHR();
     },
-    always: () => mockjqXHR(),
   };
 }
 
@@ -45,8 +41,7 @@ describe('notifications', () => {
         activateTooltips: () => {},
       },
     };
-
-    $.getJSON = mockjqXHR;
+    API.get = mockjqXHR;
   });
 
   it('empty state', () => {
@@ -88,7 +83,6 @@ describe('notifications', () => {
 
   it('full flow', () => {
     const wrapper = mount(<Notifications data={componentMountData} store={generateStore()} />);
-
     wrapper.find('.fa-bell').simulate('click');
     expect(wrapper.find('.panel-group').length).toEqual(1);
     wrapper.find('.panel-group .panel-heading').simulate('click');
@@ -100,7 +94,6 @@ describe('notifications', () => {
   it('mark group as read flow', () => {
     const wrapper = mount(<Notifications data={componentMountData} store={generateStore()} />);
     const matcher = '.drawer-pf-action a.btn-link';
-
     wrapper.find('.fa-bell').simulate('click');
     wrapper.find('.panel-group .panel-heading').simulate('click');
     expect(wrapper.find(matcher).length).toBe(1);
@@ -111,7 +104,7 @@ describe('notifications', () => {
 
   it('should redirect to login when 401', () => {
     window.location.replace = jest.fn();
-    failResponse = { status: 401 };
+    failResponse = { response: { status: 401 } };
 
     mount(<Notifications data={componentMountData} store={generateStore()} />);
     expect(global.location.replace).toBeCalled();
@@ -133,7 +126,6 @@ describe('notifications', () => {
 
     wrapper.find('.fa-bell').simulate('click');
     expect(toJson(wrapper)).toMatchSnapshot();
-
     wrapper.find(closeButtonSelector).simulate('click');
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/webpack/assets/javascripts/react_app/mockRequests.js
+++ b/webpack/assets/javascripts/react_app/mockRequests.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+const mock = new MockAdapter(axios);
+const methods = {
+  GET: 'onGet',
+  POST: 'onPost',
+  PUT: 'onPut',
+  DELETE: 'onDelete',
+};
+
+export const mockRequest = ({
+  method = 'GET',
+  url,
+  data = null,
+  status = 200,
+  response = null,
+}) => mock[methods[method]](url, data).reply(status, response);
+
+export const mockReset = () => mock.reset();

--- a/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
@@ -9,7 +9,12 @@ export const initialState = immutable({
   },
 });
 
-export const requestData = { url: '/api/bookmarks', controller: 'hosts' };
+export const requestData = {
+  url: '/api/bookmarks',
+  searchRegex: /\/api\/bookmarks\?search=.{13}hosts/,
+  controller: 'hosts',
+  response: { results: bookmarks },
+};
 
 const requestAction = {
   type: types.BOOKMARKS_REQUEST,
@@ -19,7 +24,10 @@ const requestAction = {
 export const onFailureActions = [
   requestAction,
   {
-    payload: { error: {}, item: { controller: 'hosts' } },
+    payload: {
+      error: new Error('Request failed with status code 422'),
+      item: { controller: 'hosts' },
+    },
     type: types.BOOKMARKS_FAILURE,
   },
 ];

--- a/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.test.js
@@ -1,6 +1,5 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import $ from 'jquery';
 import * as actions from './index';
 import * as types from '../../consts';
 import {
@@ -9,36 +8,42 @@ import {
   onFailureActions,
   onSuccessActions,
 } from './bookmarks.fixtures';
-import { bookmarks } from '../../reducers/bookmarks/bookmarks.fixtures';
 import API from '../../../API';
+import { mockRequest, mockReset } from '../../../mockRequests';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+const store = mockStore(initialState);
+
+afterEach(() => {
+  store.clearActions();
+  mockReset();
+});
 
 describe('bookmark actions', () => {
   it('should handle failure to load bookmarks', () => {
-    const store = mockStore(initialState);
-    const { url, controller } = requestData;
+    const { url, controller, searchRegex } = requestData;
 
-    store.dispatch(actions.getBookmarks(url, controller));
-    expect(store.getActions()).toEqual(onFailureActions);
-  });
-  xit('should load bookmarks', () => {
-    const store = mockStore(initialState);
-    const { url, controller } = requestData;
-
-    $.ajax = jest.fn(() => {
-      const ajaxMock = $.Deferred();
-
-      ajaxMock.resolve({ results: bookmarks });
-      return ajaxMock.promise();
+    mockRequest({
+      searchRegex,
+      status: 422,
     });
+    return store.dispatch(actions.getBookmarks(url, controller))
+      .then(() => expect(store.getActions()).toEqual(onFailureActions));
+  });
+  it('should load bookmarks', () => {
+    const {
+      url, controller, response, searchRegex,
+    } = requestData;
 
-    store.dispatch(actions.getBookmarks(url, controller));
-    expect(store.getActions()).toEqual(onSuccessActions);
+    mockRequest({
+      searchRegex,
+      response,
+    });
+    return store.dispatch(actions.getBookmarks(url, controller))
+      .then(() => expect(store.getActions()).toEqual(onSuccessActions));
   });
   it('should load bookmarks with correct search url', () => {
-    const store = mockStore(initialState);
     const { url, controller } = requestData;
     const spy = jest.spyOn(API, 'get');
     const expectedURL = '/api/bookmarks?search=controller%3Dhosts&per_page=100';

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.fixtures.js
@@ -1,0 +1,5 @@
+export const requestData = {
+  values: { a: 1 },
+  url: '/api/resource',
+  item: 'Resource',
+};

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
@@ -1,14 +1,20 @@
-import nock from 'nock';
 import { SubmissionError } from 'redux-form';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-
+import { requestData } from './forms.fixtures';
 import * as types from '../../consts';
-
 import { submitForm } from './forms';
+import { mockRequest, mockReset } from '../../../mockRequests';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+const mockRequestData = {
+  url: requestData.url,
+  method: 'POST',
+  data: {
+    a: 1,
+  },
+};
 
 describe('form actions', () => {
   beforeEach(() => {
@@ -16,8 +22,9 @@ describe('form actions', () => {
      <meta name="csrf-token" content="token123" />`;
   });
   afterEach(() => {
-    nock.cleanAll();
+    mockReset();
   });
+
   it('SubmitForm must include an object item/values', () => {
     expect(() => {
       submitForm();
@@ -33,14 +40,17 @@ describe('form actions', () => {
     }).toThrow();
   });
   it('on failed response raise exception', () => {
-    nock('http://localhost')
-      .post('/api/resource')
-      .reply(500, { message: 'oh snap' });
-
     const store = mockStore({ resources: [] });
 
+    mockRequest({
+      ...mockRequestData,
+      status: 500,
+      response: {
+        message: 'oh snap',
+      },
+    });
     return store
-      .dispatch(submitForm({ values: { a: 1 }, url: 'http://localhost/api/resource', item: 'Resource' }))
+      .dispatch(submitForm(requestData))
       .then(() => {
         throw new Error('Should not hit this then block - test was set up incorrectly');
       })
@@ -49,31 +59,37 @@ describe('form actions', () => {
       });
   });
   it('on failed response handle base errors', () => {
-    nock('http://localhost')
-      .post('/api/resource')
-      .reply(404, { message: 'not found' });
-
     const store = mockStore({ resources: [] });
 
+    mockRequest({
+      ...mockRequestData,
+      status: 404,
+      response: {
+        message: 'not found',
+      },
+    });
     return store
-      .dispatch(submitForm({ values: { a: 1 }, url: 'http://localhost/api/resource', item: 'Resource' }))
+      .dispatch(submitForm(requestData))
       .then(() => {
         throw new Error('Should not hit this then block - test was set up incorrectly');
       })
       .catch((error) => {
         expect(error).toBeInstanceOf(SubmissionError);
-        expect(error.errors).toEqual({ _error: ['Error submitting data: 404 Not Found'] });
+        expect(error.errors._error[0]).toMatch(/Error submitting data: 404*/);
       });
   });
   it('on failed response handle field errors', () => {
-    nock('http://localhost')
-      .post('/api/resource')
-      .reply(422, { error: { errors: { name: 'already used', base: 'some error' } } });
-
     const store = mockStore({ resources: [] });
 
+    mockRequest({
+      ...mockRequestData,
+      status: 422,
+      response: {
+        error: { errors: { name: 'already used', base: 'some error' } },
+      },
+    });
     return store
-      .dispatch(submitForm({ values: { a: 1 }, url: 'http://localhost/api/resource', item: 'Resource' }))
+      .dispatch(submitForm(requestData))
       .then(() => {
         throw new Error('Should not hit this then block - test was set up incorrectly');
       })
@@ -83,29 +99,27 @@ describe('form actions', () => {
       });
   });
   it('on success dispatch actions correctly', () => {
-    nock('http://localhost')
-      .post('/api/resource')
-      .reply(201, {
-        name: 'xc',
-        id: 70,
-      });
-
     const store = mockStore({ resources: [] });
     const expectedAction = {
       type: 'RESOURCE_FORM_SUBMITTED',
-      payload: { item: 'Resource', body: { name: 'xc', id: 70 } },
+      payload: { item: 'Resource', data: { name: 'xc', id: 70 } },
     };
 
-    store
-      .dispatch(submitForm({ values: { a: 1 }, url: 'http://localhost/api/resource', item: 'Resource' }))
+    mockRequest({
+      ...mockRequestData,
+      response: {
+        name: 'xc',
+        id: 70,
+      },
+    });
+
+    return store
+      .dispatch(submitForm(requestData))
       .then(() => {
         // dispatch RESOURCE_FORM_SUBMITTED action
         expect(store.getActions()[0]).toEqual(expectedAction);
         // dispatch toast notifications
         expect(store.getActions()[1].type).toEqual(types.TOASTS_ADD);
-      })
-      .catch(() => {
-        throw new Error('Should not hit this then block - test was set up incorrectly');
       });
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/actions/common/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/index.js
@@ -9,8 +9,7 @@ export const ajaxRequestAction = ({
   item,
 }) => {
   dispatch({ type: requestAction, payload: item });
-  API.get(url).then(
-    result => dispatch({ type: successAction, payload: Object.assign(item, result) }),
-    (jqXHR, textStatus, error) => dispatch({ type: failedAction, payload: { error, item } }),
-  );
+  return API.get(url)
+    .then(({ data }) => dispatch({ type: successAction, payload: { ...item, ...data } }))
+    .catch(error => dispatch({ type: failedAction, payload: { error, item } }));
 };

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
@@ -1,9 +1,30 @@
-export const requestData = { id: 1, url: 'test' };
+const mockSuccessRequests = [
+  {
+    path: '/hosts/:id/power',
+    searchRegex: '/hosts/1/power',
+    response: {
+      id: 1,
+      state: 'na',
+      title: 'N/A',
+    },
+  },
+];
+
+export const requestData = {
+  failRequest: { id: 0, url: '/hosts/0/power' },
+  successRequest: { id: 1, url: '/hosts/1/power' },
+};
 
 export const onFailureActions = [
-  { payload: { id: 1 }, type: 'HOST_POWER_STATUS_REQUEST' },
+  { payload: { id: 0 }, type: 'HOST_POWER_STATUS_REQUEST' },
   {
-    payload: { error: {}, item: { id: 1 } },
+    payload: { error: new Error('Request failed with status code 500'), item: { id: 0 } },
     type: 'HOST_POWER_STATUS_FAILURE',
   },
 ];
+export const onSuccessActions =
+  {
+    payload: mockSuccessRequests[0].response,
+    type: 'HOST_POWER_STATUS_SUCCESS',
+  };
+

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.test.js
@@ -1,22 +1,48 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import immutable from 'seamless-immutable';
-
-import { requestData, onFailureActions } from './powerStatus.fixtures';
-
+import { requestData, onFailureActions, onSuccessActions } from './powerStatus.fixtures';
 import * as actions from './index';
+import { mockRequest, mockReset } from '../../../../mockRequests';
 
 const mockStore = configureMockStore([thunk]);
+const store = mockStore({
+  hosts: {
+    powerStatus: immutable({}),
+  },
+});
 
+afterEach(() => {
+  store.clearActions();
+  mockReset();
+});
 describe('hosts actions', () => {
-  it('creates HOST_POWER_STATUS_REQUEST and fails when http mocking is not applied', () => {
-    const store = mockStore({
-      hosts: {
-        powerStatus: immutable({}),
-      },
-    });
-
-    store.dispatch(actions.getHostPowerState(requestData));
-    expect(store.getActions()).toEqual(onFailureActions);
-  });
+  it(
+    'creates HOST_POWER_STATUS_REQUEST and fails when host not found',
+    () => {
+      mockRequest({
+        url: requestData.failRequest.url,
+        status: 500,
+      });
+      return store.dispatch(actions.getHostPowerState(requestData.failRequest))
+        .then(() =>
+          expect(store.getActions()).toEqual(onFailureActions));
+    },
+  );
+  it(
+    'creates HOST_POWER_STATUS_REQUEST and responds with success',
+    () => {
+      mockRequest({
+        url: requestData.successRequest.url,
+        response: {
+          id: 1,
+          state: 'na',
+          title: 'N/A',
+        },
+      });
+      return store.dispatch(actions.getHostPowerState(requestData.successRequest))
+        .then(() =>
+          expect(store.getActions()[1]).toEqual(onSuccessActions));
+    },
+  );
 });

--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
@@ -19,25 +19,25 @@ const getNotifications = url => (dispatch) => {
 
   if (isDocumentVisible) {
     API.get(url)
-      .done(onGetNotificationsSuccess)
-      .fail(onGetNotificationsFailed)
-      .always(triggerPolling);
+      .then(onGetNotificationsSuccess)
+      .catch(onGetNotificationsFailed)
+      .then(triggerPolling);
   } else {
     // document is not visible, keep polling without api call
     triggerPolling();
   }
 
-  function onGetNotificationsSuccess(response) {
+  function onGetNotificationsSuccess({ data }) {
     dispatch({
       type: NOTIFICATIONS_GET_NOTIFICATIONS,
       payload: {
-        notifications: response.notifications,
+        notifications: data.notifications,
       },
     });
   }
 
   function onGetNotificationsFailed(error) {
-    if (error.status === 401) {
+    if (error.response.status === 401) {
       window.location.replace('/users/login');
     }
   }
@@ -67,7 +67,9 @@ export const onMarkAsRead = (group, id) => (dispatch) => {
       id,
     },
   });
-  API.markNotificationAsRead(id);
+  const url = `/notification_recipients/${id}`;
+  const data = { seen: true };
+  API.put(url, data);
 };
 
 export const onMarkGroupAsRead = group => (dispatch) => {
@@ -77,7 +79,8 @@ export const onMarkGroupAsRead = group => (dispatch) => {
       group,
     },
   });
-  API.markGroupNotificationAsRead(group);
+  const url = `/notification_recipients/group/${group}`;
+  API.put(url);
 };
 
 export const expandGroup = group => (dispatch, getState) => {

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/index.js
@@ -5,15 +5,13 @@ import {
 } from '../../consts';
 import { ajaxRequestAction } from '../common/';
 
-export const getStatisticsData = charts => (dispatch) => {
-  charts.forEach((chart) => {
-    ajaxRequestAction({
-      dispatch,
-      requestAction: STATISTICS_DATA_REQUEST,
-      successAction: STATISTICS_DATA_SUCCESS,
-      failedAction: STATISTICS_DATA_FAILURE,
-      url: chart.url,
-      item: chart,
-    });
-  });
-};
+export const getStatisticsData = charts => dispatch =>
+  Promise.all(charts.map(chart => ajaxRequestAction({
+    dispatch,
+    requestAction: STATISTICS_DATA_REQUEST,
+    successAction: STATISTICS_DATA_SUCCESS,
+    failedAction: STATISTICS_DATA_FAILURE,
+    url: chart.url,
+    item: chart,
+  })));
+

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
@@ -1,4 +1,4 @@
-export const requestData = [
+export const failedRequestData = [
   {
     id: 'operatingsystem',
     title: 'OS Distribution',
@@ -10,6 +10,62 @@ export const requestData = [
     title: 'Architecture Distribution',
     url: 'statistics/architecture',
     search: '/hosts?search=facts.architecture=~VAL~',
+  },
+];
+
+export const successRequestData = [
+  {
+    id: 'operatingsystem',
+    title: 'OS Distribution',
+    url: 'statistics/operatingsystem',
+    search: '/hosts?search=os_title=~VAL~',
+  },
+  {
+    id: 'architecture',
+    title: 'Architecture Distribution',
+    url: 'statistics/architecture',
+    search: '/hosts?search=facts.architecture=~VAL~',
+  },
+];
+
+export const onSuccessActions = [
+  {
+    payload: {
+      id: 'operatingsystem',
+      search: '/hosts?search=os_title=~VAL~',
+      title: 'OS Distribution',
+      url: 'statistics/operatingsystem',
+    },
+    type: 'STATISTICS_DATA_REQUEST',
+  },
+  {
+    payload: {
+      id: 'architecture',
+      search: '/hosts?search=facts.architecture=~VAL~',
+      title: 'Architecture Distribution',
+      url: 'statistics/architecture',
+    },
+    type: 'STATISTICS_DATA_REQUEST',
+  },
+  {
+    payload: {
+      data: [['centOS 7.1', 6]],
+      id: 'operatingsystem',
+      search: '/hosts?search=os_title=~VAL~',
+      title: 'OS Distribution',
+      url: 'statistics/operatingsystem',
+    },
+    type: 'STATISTICS_DATA_SUCCESS',
+  },
+  {
+    payload: {
+      data: [['x86_64', 6]],
+      id: 'architecture',
+      search: '/hosts?search=facts.architecture=~VAL~',
+      title: 'Architecture Distribution',
+      url: 'statistics/architecture',
+    },
+    type: 'STATISTICS_DATA_SUCCESS',
   },
 ];
 
@@ -25,7 +81,16 @@ export const onFailureActions = [
   },
   {
     payload: {
-      error: {},
+      id: 'architecture',
+      search: '/hosts?search=facts.architecture=~VAL~',
+      title: 'Architecture Distribution',
+      url: 'statistics/architecture',
+    },
+    type: 'STATISTICS_DATA_REQUEST',
+  },
+  {
+    payload: {
+      error: new Error('Request failed with status code 422'),
       item: {
         id: 'operatingsystem',
         search: '/hosts?search=os_title=~VAL~',
@@ -37,16 +102,7 @@ export const onFailureActions = [
   },
   {
     payload: {
-      id: 'architecture',
-      search: '/hosts?search=facts.architecture=~VAL~',
-      title: 'Architecture Distribution',
-      url: 'statistics/architecture',
-    },
-    type: 'STATISTICS_DATA_REQUEST',
-  },
-  {
-    payload: {
-      error: {},
+      error: new Error('Request failed with status code 422'),
       item: {
         id: 'architecture',
         search: '/hosts?search=facts.architecture=~VAL~',

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.test.js
@@ -1,21 +1,54 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import immutable from 'seamless-immutable';
-
-import { requestData, onFailureActions } from './statistics.fixtures';
+import { mockRequest, mockReset } from '../../../mockRequests';
+import { failedRequestData, successRequestData, onFailureActions, onSuccessActions } from './statistics.fixtures';
 
 import * as actions from './index';
 
 const mockStore = configureMockStore([thunk]);
+const store = mockStore({ statistics: immutable({}) });
+
+afterEach(() => {
+  store.clearActions();
+  mockReset();
+});
 
 describe('statistics actions', () => {
   it(
-    'creates STATISTICS_DATA_REQUEST and fails when nock is not applied',
+    'creates STATISTICS_DATA_REQUEST and then fails with 422',
     () => {
-      const store = mockStore({ statistics: immutable({}) });
-
-      store.dispatch(actions.getStatisticsData(requestData));
-      expect(store.getActions()).toEqual(onFailureActions);
+      mockRequest({
+        url: '/statistics/architecture',
+        status: 422,
+      });
+      mockRequest({
+        url: '/statistics/operatingsystem',
+        status: 422,
+      });
+      return store.dispatch(actions.getStatisticsData(failedRequestData))
+        .then(() => expect(store.getActions()).toEqual(onFailureActions));
+    },
+  );
+  it(
+    'creates STATISTICS_DATA_REQUEST and ends with success',
+    () => {
+      mockRequest({
+        url: '/statistics/operatingsystem',
+        response: {
+          id: 'operatingsystem',
+          data: [['centOS 7.1', 6]],
+        },
+      });
+      mockRequest({
+        url: '/statistics/architecture',
+        response: {
+          id: 'architecture',
+          data: [['x86_64', 6]],
+        },
+      });
+      return store.dispatch(actions.getStatisticsData(successRequestData))
+        .then(() => expect(store.getActions()).toEqual(onSuccessActions));
     },
   );
 });

--- a/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.test.js
@@ -47,7 +47,7 @@ describe('bookmark reducers', () => {
       type: types.BOOKMARK_FORM_SUBMITTED,
       payload: {
         item: 'Bookmark',
-        body: {
+        data: {
           name: '0test-me',
           controller: 'hosts',
           query: 'mac~aabbccd',

--- a/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/index.js
@@ -39,8 +39,8 @@ export default (state = initialState, action) => {
     case BOOKMARK_FORM_SUBMITTED:
       return state
         .setIn(
-          [payload.body.controller, 'results'],
-          [...state[payload.body.controller].results, payload.body].sort(sortByName),
+          [payload.data.controller, 'results'],
+          [...state[payload.data.controller].results, payload.data].sort(sortByName),
         )
         .set('showModal', false);
     case BOOKMARKS_MODAL_CLOSED:


### PR DESCRIPTION
jquery is a enormous library, and there is no point to include it only for ajax calls.
Instead, it is better to use dedicated library for async API calls.
Axios is well known library, and well maintained, with easy mocks implementations for testing, and fits to redux async actions.

- [x] Add axios
- [x] Add mocks implementations for testing
- [x] refactor `ajaxRequestAction` to use axios
- [x]  refactor API  `get` function  to use axios
- [x]  add API `post, put and delete` functions 
- [x]  refactor legacy tests