### PR TITLE
Fixes #21926 - Ensure uniqueness on image names and uuids

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,7 +12,8 @@ class Image < ApplicationRecord
   before_validation :set_password_changed, :if => Proc.new { |audit| audit.password_changed? }
 
   validates_lengths_from_database
-  validates :username, :name, :operatingsystem_id, :compute_resource_id, :architecture_id, :presence => true
+  validates :username, :operatingsystem_id, :compute_resource_id, :architecture_id, :presence => true
+  validates :name, :presence => true, :uniqueness => {:scope => [:compute_resource_id, :operatingsystem_id]}
   validates :uuid, :presence => true, :uniqueness => {:scope => :compute_resource_id}
   validate :uuid_exists?
 

--- a/db/migrate/20171213161035_add_indexes_on_images.rb
+++ b/db/migrate/20171213161035_add_indexes_on_images.rb
@@ -1,0 +1,25 @@
+class AddIndexesOnImages < ActiveRecord::Migration[5.0]
+  def up
+    deduped = Image.group(:name, :compute_resource_id, :operatingsystem_id).pluck('min(id)')
+    Image.where.not(id: deduped).each_with_index do |image, i|
+      say "Found images with duplicate name #{image.name} on Compute Resource #{ComputeResource.unscoped.find(image.compute_resource_id)}!"
+      say "Duplicates have been renamed, please check your setup to resolve the duplication."
+      image.update_column(:name, "#{image.name}(Duplicate #{i})")
+    end
+
+    deduped = Image.group(:uuid, :compute_resource_id).pluck('min(id)')
+    Image.where.not(id: deduped).each_with_index do |image, i|
+      say "Found images with duplicate uuid #{image.uuid} on Compute Resource #{ComputeResource.unscoped.find(image.compute_resource_id)}!"
+      say "Duplicates' uuids have been modified, please check your setup to resolve the duplication."
+      image.update_column(:uuid, "#{image.uuid}(Duplicate #{i})")
+    end
+
+    add_index :images, [:name, :compute_resource_id, :operatingsystem_id], name: 'image_name_index', unique: true
+    add_index :images, [:uuid, :compute_resource_id], name: 'image_uuid_index', unique: true
+  end
+
+  def down
+    remove_index :images, name: 'image_name_index'
+    remove_index :images, name: 'image_uuid_index'
+  end
+end

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -65,9 +65,9 @@ FactoryBot.define do
 
   factory :image do
     sequence(:name) { |n| "image#{n}" }
-    uuid Foreman.uuid
+    uuid { Foreman.uuid }
     username 'root'
-    compute_resource
+    association :compute_resource, factory: :libvirt_cr
     operatingsystem
     architecture
   end


### PR DESCRIPTION
Image names should be unique per CR and OS. UUID uniqueness is already
enforced by ActiveRecord but not in the DB, which could cause conflicts
in multi-proccess environments. Also cleaned up a bit of the image tests
and made them all use FactoryBot instead of fixtures.