### PR TITLE
Fixes #21875 - added support for sha512 grub passwords

### DIFF
--- a/app/helpers/unattended_helper.rb
+++ b/app/helpers/unattended_helper.rb
@@ -6,7 +6,11 @@ module UnattendedHelper
   end
 
   def grub_pass
-    @grub ? "--md5pass=#{@host.grub_pass}": ""
+    if @grub
+      @host.grub_pass.start_with?('$1$') ? "--md5pass=#{@host.grub_pass}" : "--iscrypted --password=#{@host.grub_pass}"
+    else
+      ""
+    end
   end
 
   def root_pass

--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -1,7 +1,7 @@
 require 'base64'
 
 class PasswordCrypt
-  ALGORITHMS = {'SHA256' => '$5$', 'SHA512' => '$6$', 'MD5' => '$1$', 'Base64' => ''}
+  ALGORITHMS = {'SHA256' => '$5$', 'SHA512' => '$6$', 'Base64' => ''}
 
   def self.passw_crypt(passwd, hash_alg = 'SHA256')
     raise Foreman::Exception.new(N_("Unsupported password hash function '%s'"), hash_alg) unless ALGORITHMS.has_key?(hash_alg)
@@ -11,7 +11,7 @@ class PasswordCrypt
   end
 
   def self.grub2_passw_crypt(passw)
-    self.passw_crypt(passw, 'MD5')
+    self.passw_crypt(passw, 'SHA512')
   end
 
   def self.crypt_gnu_compatible?


### PR DESCRIPTION
	All new hosts provisioned using default and rhel
	kickstarts will use sha512 grub passwords from
	now on.