### PR TITLE
Refs #21120 - DHCP update no longer queued twice

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -149,10 +149,10 @@ module Orchestration::DHCP
   def queue_dhcp_update
     return unless dhcp_update_required?
     logger.debug("Detected a changed required for DHCP record")
-    queue.create(:name => _("Remove DHCP Settings for %s") % old, :priority => 5,
-                 :action => [old, :del_dhcp]) if old.dhcp?
-    queue.create(:name   => _("Create DHCP Settings for %s") % self, :priority => 9,
-                 :action => [self, :set_dhcp]) if dhcp?
+    remove_name = _("Remove DHCP Settings for %s") % old
+    create_name = _("Create DHCP Settings for %s") % self
+    queue.create(:name => remove_name, :priority => 5, :action => [old, :del_dhcp]) if old.dhcp? && queue.items.select{|t| t.name == remove_name}.empty?
+    queue.create(:name => create_name, :priority => 9, :action => [self, :set_dhcp]) if dhcp? && queue.items.select{|t| t.name == create_name}.empty?
   end
 
   # do we need to update our dhcp reservations

--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -240,7 +240,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     h.ip = h.ip.succ
     assert h.valid?
     # 1st is creation from factory, 2nd is triggered by h.valid?
-    assert_equal 2, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
+    assert_equal 1, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
     # and also one deletion (of original creation)
     assert_equal 1, h.primary_interface.queue.items.count {|x| x.action.last == :del_dhcp }
   end
@@ -266,7 +266,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     end
     h.mac = next_mac(h.mac)
     assert h.valid?
-    assert_equal 2, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
+    assert_equal 1, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
     assert_equal 1, h.primary_interface.queue.items.count {|x| x.action.last == :del_dhcp }
   end
 
@@ -279,7 +279,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     h.build = true
 
     assert h.valid?, h.errors.messages.to_s
-    assert_equal 2, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
+    assert_equal 1, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
     assert_equal 1, h.primary_interface.queue.items.count {|x| x.action.last == :del_dhcp }
   end
 
@@ -326,7 +326,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     bmc.mac = next_mac(bmc.mac)
     assert h.valid?
     assert bmc.valid?
-    assert_equal 2, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
+    assert_equal 1, h.queue.items.count {|x| x.action == [ h.primary_interface, :set_dhcp ] }
     assert_equal 1, h.queue.items.count {|x| x.action.last == :del_dhcp }
     assert_equal 1, bmc.queue.items.count {|x| x.action == [ bmc,     :set_dhcp ] }
     assert_equal 1, bmc.queue.items.count {|x| x.action == [ bmc.old, :del_dhcp ] }


### PR DESCRIPTION
This is an alternative backport-friendly version of

https://github.com/theforeman/foreman/pull/5079

In short, when PXELoader is edited for existing host, ActiveRecord triggers `valid?` call twice which then enqueues DHCP orchestration twice. Starting from proxy version 1.15 all invalid records are now explicitly not allowed and proxy now errors out with 409 conclits http code. This patch prevents from enqueing the same tasks twice, thus this won't happend and PXELoader can be edited.

This patch is not meant to be merged into `develop` branch as more complex PR is prepared that solves this globally. Once this is reviewed, this can be backported into 1.15 and 1.16 to solve the edit host issue.

When testing this, be aware of bug in `develop` branch of proxy: http://projects.theforeman.org/issues/21975