### PR TITLE
[WIP] fixes #21964 - speed up host form rendering

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -330,7 +330,7 @@ Metrics/MethodLength:
 # Offense count: 24
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 443
+  Max: 467
 
 # Offense count: 10
 # Configuration parameters: CountKeywordArgs.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -534,11 +534,24 @@ module ApplicationHelper
   end
 
   def accessible_resource(obj, resource, order = :name, association: resource)
-    list = accessible_resource_records(resource, order).to_a
+    klass = resource.to_s.classify.constantize
+
+    list = klass.unscoped.authorized
+
+    list = list.with_taxonomy_scope_override(@location, @organization) if klass.include? Taxonomix
+
     # we need to allow the current value even if it was filtered
-    current = obj.public_send(association) if obj.respond_to?(association)
-    list |= [current] if current.present?
-    list
+    if obj.respond_to?(association)
+      current = obj.public_send(association)
+      # match the unscope and readonly values from the left query
+      list = list.or(klass.unscoped.unscope(list.unscope_values).readonly(list.readonly_value).where(:id => current.id)) if current.present?
+    end
+
+    list.reorder(order)
+  end
+
+  def accessible_resource_for_select(obj, resource, order = :name, association: resource)
+    accessible_resource(obj, resource, order, association: association).pluck(:id, :name)
   end
 
   def accessible_related_resource(obj, relation, order: :name, where: nil)
@@ -546,6 +559,11 @@ module ApplicationHelper
     related = obj.public_send(relation)
     related = related.with_taxonomy_scope_override(@location, @organization) if obj.class.reflect_on_association(relation).klass.include?(Taxonomix)
     related.authorized.where(where).reorder(order)
+  end
+
+  def accessible_related_resource_for_select(obj, relation, order: :name, where: nil)
+    return [] if obj.blank?
+    accessible_related_resource(obj, relation, order: order, where: where).pluck(:id, :name)
   end
 
   def explicit_value?(field)

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -2,19 +2,20 @@ module HostsAndHostgroupsHelper
   include AncestryHelper
 
   def domain_subnets(type)
-    accessible_related_resource(@domain, :subnets, :where => {:type => type})
+    # TODO: fix label
+    accessible_related_resource_for_select(@domain, :subnets, :where => {:type => type})
   end
 
   def arch_oss
-    accessible_related_resource(@architecture, :operatingsystems, order: :title)
+    accessible_related_resource_for_select(@architecture, :operatingsystems, order: :title)
   end
 
   def os_media
-    accessible_related_resource(@operatingsystem, :media)
+    accessible_related_resource_for_select(@operatingsystem, :media)
   end
 
   def os_ptable
-    accessible_related_resource(@operatingsystem, :ptables)
+    accessible_related_resource_for_select(@operatingsystem, :ptables)
   end
 
   def visible_compute_profiles(obj)
@@ -27,11 +28,11 @@ module HostsAndHostgroupsHelper
     # Don't show this if we have no Realms, otherwise always include blank
     # so the user can choose not to use a Realm on this host
     return unless (SETTINGS[:unattended] == true) && @host.managed
-    realms = accessible_resource(f.object, :realm)
+    realms = accessible_resource_for_select(f.object, :realm)
     return unless realms.present?
     select_f(f, :realm_id,
                 realms,
-                :id, :to_label,
+                :first, :last,
                 { :include_blank => true,
                   :disable_button => can_override ? _(INHERIT_TEXT) : nil,
                   :disable_button_enabled => override && !explicit_value?(:realm_id),

--- a/app/helpers/hosts_nic_helper.rb
+++ b/app/helpers/hosts_nic_helper.rb
@@ -6,17 +6,26 @@ module HostsNicHelper
     link_to(_("Suggest new"), '#', :class => link_class)
   end
 
+  def accessible_subnets_for_select(obj, resource)
+    fields = [:id, :name, :vlanid]
+    subnets = accessible_resource(obj, resource).pluck(*fields)
+    subnets.map { |subnet| fields.zip(subnet).to_h }
+  end
+
   def nic_subnet_field(f, attr, klass, html_options = {})
+    # TODO: suggest_new?
+    # TODO: label
+    subnets = accessible_subnets_for_select(f.object, klass)
     html_options.merge!(
-      { :disabled => accessible_resource(f.object, klass).empty? ? true : false,
+      { :disabled => subnets.empty? ? true : false,
         :help_inline => :indicator,
         :'data-url' => freeip_subnets_path,
         :size => "col-md-8", :label_size => "col-md-3" }
     )
-    if accessible_resource(f.object, klass).any?
+    if subnets.any?
       array = options_for_select(
         [[]] +
-        accessible_resource(f.object, klass).map{ |subnet| [subnet.to_label, subnet.id, {'data-suggest_new' => subnet.unused_ip.suggest_new?, 'data-vlan_id' => subnet.vlanid}]}, f.object.public_send(attr)
+        subnets.map{ |subnet| [subnet[:name], subnet[:id], {'data-suggest_new' => false, 'data-vlan_id' => subnet[:vlanid]}]}, f.object.public_send(attr)
       )
     else
       array = [[_("No subnets"), '']]

--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -24,8 +24,8 @@ module LookupKeysHelper
       text_f(f, :puppetclass_id, :label => _('Puppet Class'), :value => f.object.param_class, :disabled => true)
     else # new smart-var with no particular context
          # Give a select for choosing the parent puppetclass
-      puppetclasses = accessible_resource(f.object, :puppetclass)
-      select_f(f, :puppetclass_id, puppetclasses, :id, :to_label, { :include_blank => true }, {:label => _("Puppet class")})
+      puppetclasses = accessible_resource_for_select(f.object, :puppetclass)
+      select_f(f, :puppetclass_id, puppetclasses, :first, :last, { :include_blank => true }, {:label => _("Puppet class")})
     end unless @puppetclass # nested smart-vars form in a tab of puppetclass/_form: no edition allowed, and the puppetclass is already visible as a context
   end
 

--- a/app/helpers/shared_smart_proxies_helper.rb
+++ b/app/helpers/shared_smart_proxies_helper.rb
@@ -16,7 +16,7 @@ module SharedSmartProxiesHelper
     override = options.fetch(:override, false)
     blank = options.fetch(:blank, blank_or_inherit_f(f, resource))
 
-    proxies = accessible_smart_proxies(f.object, resource, options[:feature])
+    proxies = accessible_smart_proxies_for_select(f.object, resource, options[:feature])
     return if !required && proxies.blank?
 
     select_options = {
@@ -26,17 +26,18 @@ module SharedSmartProxiesHelper
     }
     select_options[:include_blank] = blank unless required
 
-    select_f f, :"#{resource}_id", proxies, :id, :name,
+    select_f f, :"#{resource}_id", proxies, :first, :last,
       select_options,
       :label => _(options[:label]),
       :label_help => _(options[:description]),
       :wrapper_class => "form-group #{'hide' if hidden}"
   end
 
-  def accessible_smart_proxies(obj, resource, feature)
-    list = accessible_resource_records(:smart_proxy).with_features(feature).to_a
-    current = obj.public_send(resource) if obj.respond_to?(resource)
-    list |= [current] if current.present?
-    list
+  def accessible_smart_proxies(obj, association, feature)
+    accessible_resource(obj, :smart_proxy, :name, association: association).with_features(feature)
+  end
+
+  def accessible_smart_proxies_for_select(obj, resource, feature)
+    accessible_smart_proxies(obj, resource, feature).pluck(:id, :name)
   end
 end

--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -1,5 +1,5 @@
 <%= fields_for item do |f| %>
-  <%= select_f f, :operatingsystem_id, arch_oss, :id, :to_label,
+  <%= select_f f, :operatingsystem_id, arch_oss, :first, :last,
     {:selected => item.operatingsystem_id, :include_blank => blank_or_inherit_f(f, :operatingsystem)},
     { :label => _("Operating system"),
       :disabled => arch_oss.empty? ? true : false,

--- a/app/views/common/os_selection/_initial.html.erb
+++ b/app/views/common/os_selection/_initial.html.erb
@@ -1,5 +1,5 @@
 <%= fields_for item do |f| %>
-  <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => blank_or_inherit_f(f, :architecture)},
+  <%= select_f f, :architecture_id, accessible_resource_for_select(f.object, :architecture), :first, :last, {:include_blank => blank_or_inherit_f(f, :architecture)},
     {:label => _("Architecture"), :onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' => controller_name.singularize} %>
 
   <span id="host_os">

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -1,11 +1,11 @@
 <%= fields_for item do |f| %>
-  <%= select_f f, :medium_id, os_media, :id, :to_label,
+  <%= select_f f, :medium_id, os_media, :first, :last,
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
     {:label => _("Media"), :disabled => os_media.empty?,
      :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' => method_path('medium_selected'),
      :'data-type' => controller_name.singularize, :required => true }
   %>
-  <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
+  <%= select_f f, :ptable_id, os_ptable, :first, :last,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},
     {:label => _("Partition Table"), :disabled => os_ptable.empty?, :required => true}
   %>

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -40,7 +40,7 @@
 
     <div class="tab-pane" id="network">
       <fieldset>
-        <%= select_f f, :domain_id, accessible_resource(@hostgroup, :domain), :id, :to_label, {:include_blank => blank_or_inherit_f(f, :domain)},
+        <%= select_f f, :domain_id, accessible_resource_for_select(@hostgroup, :domain), :first, :last, {:include_blank => blank_or_inherit_f(f, :domain)},
           {:help_inline => :indicator, :label => _("Domain"),
            :onchange => 'interface_domain_selected(this);', :'data-url' => method_path('domain_selected') } %>
         <%= select_f f, :subnet_id, domain_subnets(:"Subnet::Ipv4"), :id, :to_label,
@@ -55,7 +55,7 @@
                      { :disabled => domain_subnets(:"Subnet::Ipv6").empty?,
                        :label    => _("IPv6 Subnet"),
                        :help_inline => :indicator } %>
-        <%= select_f f, :realm_id, accessible_resource(@hostgroup, :realms), :id, :to_label,
+        <%= select_f f, :realm_id, accessible_resource_for_select(@hostgroup, :realms), :first, :last,
                         {:include_blank => blank_or_inherit_f(f, :realm)}, {:label => _("Realm")} %>
       </fieldset>
     </div>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -42,7 +42,7 @@
           <%= host_taxonomy_select(f, Location) %>
         <% end %>
 
-        <%= select_f f, :hostgroup_id, accessible_resource(@host, :hostgroup, :title), :id, :to_label,
+        <%= select_f f, :hostgroup_id, accessible_resource_for_select(@host, :hostgroup, :title), :first, :last,
           { :include_blank => true},
           { :onchange => 'hostgroup_changed(this);',
             :data => {

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -1,5 +1,5 @@
 
-<%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => true},
+<%= select_f f, :architecture_id, accessible_resource_for_select(f.object, :architecture), :first, :last, {:include_blank => true},
     {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' => controller_name.singularize,
     :help_inline => :indicator, :required => true} %>
 

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -23,9 +23,9 @@
               :class => :interface_name,
               :size => "col-md-8", :label_size => "col-md-3" %>
 <% if SETTINGS[:unattended] %>
-  <%= select_f f, :domain_id, accessible_resource(f.object, :domain), :id, :to_label,
-               { :include_blank => accessible_resource(f.object, :domain).any? ? true : _("No domains")},
-               { :disabled => accessible_resource(f.object, :domain).empty? ? true : false,
+  <%= select_f f, :domain_id, accessible_resource_for_select(f.object, :domain), :first, :last,
+               { :include_blank => accessible_resource_for_select(f.object, :domain).any? ? true : _("No domains")},
+               { :disabled => accessible_resource_for_select(f.object, :domain).empty? ? true : false,
                  :help_inline => :indicator,
                  :class => 'interface_domain', :'data-url' => domain_selected_hosts_path,
                  :size => "col-md-8", :label_size => "col-md-3" } %>


### PR DESCRIPTION
This is an attempt to speed up host form rendering.

* refactor's `accessible_resource` to use sql only as Rails 5 now supports `where.or()`
* uses `pluck` to render select fields content so rails does not allocate unnecessary objects

Unfortunately, this didn't bring any significant speed improvements in my environment. But YMMV.
But the refactoring might be good to do anyway.

Please let me know what you guys think. If you have a chance to actually run this and compare speeds, I'd really love to see the numbers.
The ticket has some more details.

This is just here for discussion and not ready to merge.