### PR TITLE
Fixes #18675 - telemetry foreman API

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -441,6 +441,18 @@ module Foreman #:nodoc:
       @rabl_template_extensions.fetch(virtual_path, [])
     end
 
+    def add_counter_telemetry(name, description, instance_labels = [])
+      Foreman::Telemetry.instance.add_counter(name, description, instance_labels)
+    end
+
+    def add_gauge_telemetry(name, description, instance_labels = [])
+      Foreman::Telemetry.instance.add_gauge(name, description, instance_labels)
+    end
+
+    def add_histogram_telemetry(name, description, instance_labels = [], buckets = DEFAULT_BUCKETS)
+      Foreman::Telemetry.instance.add_histogram(name, description, instance_labels, buckets)
+    end
+
     private
 
     def permission_table_exists?

--- a/app/services/foreman/telemetry_helper.rb
+++ b/app/services/foreman/telemetry_helper.rb
@@ -1,0 +1,32 @@
+module Foreman::TelemetryHelper
+  extend ActiveSupport::Concern
+
+  def telemetry_increment_counter(name, value = 1, tags = {})
+    Foreman::Telemetry.instance.increment_counter(name, value, tags)
+  end
+
+  def telemetry_set_gauge(name, value, tags = {})
+    Foreman::Telemetry.instance.set_gauge(name, value, tags)
+  end
+
+  def telemetry_observe_histogram(name, value, tags = {})
+    Foreman::Telemetry.instance.observe_histogram(name, value, tags)
+  end
+
+  # time spent in a block as histogram, in miliseconds by default
+  def telemetry_duration_histogram(name, scale = 1000, tags = {})
+    case scale
+    when :ms, :msec, :miliseconds
+      scale = 1000
+    when :sec, :seconds
+      scale = 1
+    when :min, :minutes
+      scale = 1 / 60
+    end
+    before = Time.now.to_f
+    yield
+  ensure
+    after = Time.now.to_f
+    telemetry_observe_histogram(name, (after - before) * scale, tags)
+  end
+end

--- a/bundler.d/telemetry.rb
+++ b/bundler.d/telemetry.rb
@@ -1,0 +1,4 @@
+group :telemetry do
+  gem 'prometheus-client'
+  gem 'statsd-instrument'
+end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,17 @@
 # This file is used by Rack-based servers to start the application.
 
+require 'rack'
+require './lib/foreman/telemetry_rack'
+require 'prometheus/middleware/exporter'
+
+# load Rails environment
 require ::File.expand_path('../config/environment',  __FILE__)
+
+use Foreman::TelemetryRack
+if defined?(Prometheus::Middleware::Exporter) && SETTINGS[:telemetry].try(:fetch, :prometheus).try(:fetch, :enabled)
+  use Prometheus::Middleware::Exporter
+end
+
 # apply a prefix to the application, if one is defined
 # e.g. http://some.server.com/prefix where '/prefix' is defined by env variable
 map ENV['RAILS_RELATIVE_URL_ROOT'] || '/'  do

--- a/config/initializers/5_telemetry.rb
+++ b/config/initializers/5_telemetry.rb
@@ -1,0 +1,11 @@
+# Foreman telemetry global setup.
+telemetry = Foreman::Telemetry.instance
+if SETTINGS[:telemetry] && (Rails.env.production? || Rails.env.development?)
+  telemetry.setup(SETTINGS[:telemetry])
+end
+
+# Register Rails notifications metrics
+telemetry.register_rails
+
+# Register Ruby VM metrics
+telemetry.register_ruby

--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -1,0 +1,19 @@
+# Foreman telemetry metrics registration.
+#
+# There are three types of telemetry measurements: counter, gauge, histogram. Each measurement has unique name
+# represented by a symbol, a description and list of tags which are required and mapped to monitoring frameworks
+# which do not support arbitrary tags.
+#
+# Plugins can add own metrics through add_counter_telemetry, add_gauge_telemetry and add_histogram_telemetry.
+#
+telemetry = Foreman::Telemetry.instance
+telemetry.add_counter(:http_requests, 'A counter of HTTP requests made', [:controller, :action])
+telemetry.add_histogram(:http_request_total_duration, 'Total duration of controller action', [:controller, :action])
+telemetry.add_histogram(:http_request_db_duration, 'Time spent in database for a request', [:controller, :action])
+telemetry.add_histogram(:http_request_view_duration, 'Time spent in view for a request', [:controller, :action])
+telemetry.add_counter(:activerecord_instances, 'Number of instances of ActiveRecord models', [:class])
+telemetry.add_counter(:successful_ui_logins, 'Number of successful logins in total')
+telemetry.add_counter(:failed_ui_logins, 'Number of failed logins in total')
+telemetry.add_counter(:bruteforce_locked_ui_logins, 'Number of blocked logins via bruteforce protection')
+telemetry.add_histogram(:proxy_api_duration, 'Time spent waiting for Proxy (ms)', [:method])
+telemetry.add_counter(:proxy_api_response_code, 'Number of Proxy API responses per HTTP code', [:code])

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -70,6 +70,29 @@
 #    :enabled: true
 #  :dynflow:
 #    :enabled: true
+#  :telemetry:
+#    :enabled: true
+
+# Foreman telemetry has three destinations: prometheus, statsd and rails log.
+:telemetry:
+  # prefix for all metrics
+  :prefix: 'fm_rails'
+  # prometheus endpoint is at /metrics
+  # warning: ruby client library currently does not supprt multi-process web servers
+  :prometheus:
+    :enabled: false
+  # works with statsd_exporter too, use the rake task to generate config
+  :statsd:
+    :enabled: false
+    # IP and port (do not use DNS)
+    :host: '127.0.0.1:8125'
+    # one of 'statsd', 'statsite' or 'datadog'
+    :protocol: 'statsd'
+  # Rails logs end up in logger named 'telemetry' when enabled
+  :logger:
+    :enabled: false
+    # logging level as in Logger::LEVEL
+    :level: 'DEBUG'
 
 #
 # Configure how many workers should dynflow use to handle incoming requests.

--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -1,0 +1,106 @@
+require 'singleton'
+require 'forwardable'
+
+module Foreman
+  class Telemetry
+    include Singleton
+    extend Forwardable
+    attr_accessor :prefix, :sinks
+
+    DEFAULT_BUCKETS = [10, 50, 200, 1000, 15000].freeze
+
+    def initialize
+      @sinks = []
+      @exporter = ::Foreman::TelemetrySinks::MetricExporterSink.new
+    end
+
+    def setup(opts = {})
+      @prefix = opts[:prefix] || ''
+      @sinks << @exporter
+      unless Foreman.in_rake?
+        @sinks << ::Foreman::TelemetrySinks::RailsLoggerSink.new(opts[:logger]) if opts[:logger] && opts[:logger][:enabled]
+        @sinks << ::Foreman::TelemetrySinks::PrometheusSink.new(opts[:prometheus]) if opts[:prometheus] && opts[:prometheus][:enabled]
+        @sinks << ::Foreman::TelemetrySinks::StatsdSink.new(opts[:statsd]) if opts[:statsd] && opts[:statsd][:enabled]
+      end
+      self
+    end
+
+    GC_METRICS = {
+      :count => :ruby_gc_count,
+      :major_gc_count => :ruby_gc_major_count,
+      :minor_gc_count => :ruby_gc_minor_count
+    }
+    def register_rails
+      ActiveSupport::Notifications.subscribe(/process_action.action_controller/) do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        controller = event.payload[:controller].underscore
+        action = event.payload[:action].underscore
+        status = event.payload[:status]
+
+        increment_counter(:http_requests, 1, :controller => controller, :action => action, :status => status)
+        observe_histogram(:http_request_total_duration, event.duration || 0, :controller => controller, :action => action)
+        observe_histogram(:http_request_db_duration, event.payload[:db_runtime] || 0, :controller => controller, :action => action)
+        observe_histogram(:http_request_view_duration, event.payload[:view_runtime] || 0, :controller => controller, :action => action)
+
+        # measure GC stats for each request
+        before = Thread.current[:foreman_telemetry_gcstats]
+        after = GC.stat
+        GC_METRICS.each do |ruby_key, metric_name|
+          increment_counter(metric_name, after[ruby_key] - before[ruby_key], :controller => controller, :action => action) if after.include?(ruby_key)
+        end
+      end if enabled?
+
+      ActiveSupport::Notifications.subscribe(/instantiation.active_record/) do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        class_name = event.payload[:class_name]
+        record_count = event.payload[:record_count]
+        increment_counter(:activerecord_instances, record_count, :class => class_name)
+      end if enabled?
+    end
+
+    def register_ruby
+      begin
+        GC.stat :total_allocated_objects
+      rescue ArgumentError
+        GC_METRICS.update :total_allocated_object => :ruby_gc_allocated_objects, :total_freed_object => :ruby_gc_freed_objects
+      else
+        GC_METRICS.update :total_allocated_objects => :ruby_gc_allocated_objects, :total_freed_objects => :ruby_gc_freed_objects
+      end
+      GC_METRICS.each do |ruby_key, metric_name|
+        add_counter(metric_name, "Ruby GC statistics per request (#{ruby_key})", [:controller, :action])
+      end
+    end
+
+    def metrics
+      @exporter.metrics
+    end
+
+    def enabled?
+      @sinks.count > 0
+    end
+
+    def add_counter(name, description, instance_labels = [])
+      @sinks.each { |x| x.add_counter("#{prefix}_#{name}", description, instance_labels) }
+    end
+
+    def add_gauge(name, description, instance_labels = [])
+      @sinks.each { |x| x.add_gauge("#{prefix}_#{name}", description, instance_labels) }
+    end
+
+    def add_histogram(name, description, instance_labels = [], buckets = DEFAULT_BUCKETS)
+      @sinks.each { |x| x.add_histogram("#{prefix}_#{name}", description, instance_labels, buckets) }
+    end
+
+    def increment_counter(name, value = 1, tags = {})
+      @sinks.each { |x| x.increment_counter("#{prefix}_#{name}", value, tags) }
+    end
+
+    def set_gauge(name, value, tags = {})
+      @sinks.each { |x| x.set_gauge("#{prefix}_#{name}", value, tags) }
+    end
+
+    def observe_histogram(name, value, tags = {})
+      @sinks.each { |x| x.observe_histogram("#{prefix}_#{name}", value, tags) }
+    end
+  end
+end

--- a/lib/foreman/telemetry_rack.rb
+++ b/lib/foreman/telemetry_rack.rb
@@ -1,0 +1,12 @@
+module Foreman
+  class TelemetryRack
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      Thread.current[:foreman_telemetry_gcstats] = GC.stat if Foreman::Telemetry.instance.enabled?
+      @app.call(env)
+    end
+  end
+end

--- a/lib/foreman/telemetry_sinks/metric_exporter_sink.rb
+++ b/lib/foreman/telemetry_sinks/metric_exporter_sink.rb
@@ -1,0 +1,36 @@
+module Foreman::TelemetrySinks
+  class MetricExporterSink
+    attr_reader :counters, :gauges, :histograms
+
+    def initialize
+      @counters = []
+      @gauges = []
+      @histograms = []
+    end
+
+    def add_counter(name, description, instance_labels)
+      @counters << [name, description, instance_labels, :counter]
+    end
+
+    def add_gauge(name, description, instance_labels)
+      @gauges << [name, description, instance_labels, :gauge]
+    end
+
+    def add_histogram(name, description, instance_labels, buckets)
+      @histograms << [name, description, instance_labels, :histogram, buckets]
+    end
+
+    def increment_counter(name, value, tags)
+    end
+
+    def set_gauge(name, value, tags)
+    end
+
+    def observe_histogram(name, value, tags)
+    end
+
+    def metrics
+      counters + gauges + histograms
+    end
+  end
+end

--- a/lib/foreman/telemetry_sinks/prometheus_sink.rb
+++ b/lib/foreman/telemetry_sinks/prometheus_sink.rb
@@ -1,0 +1,33 @@
+require 'prometheus/client'
+
+module Foreman::TelemetrySinks
+  class PrometheusSink
+    def initialize(opts = {})
+      @prom = ::Prometheus::Client.registry
+    end
+
+    def add_counter(name, description, instance_labels)
+      @prom.counter(name.to_sym, description)
+    end
+
+    def add_gauge(name, description, instance_labels)
+      @prom.gauge(name.to_sym, description)
+    end
+
+    def add_histogram(name, description, instance_labels, buckets)
+      @prom.histogram(name.to_sym, description, {}, buckets)
+    end
+
+    def increment_counter(name, value, tags)
+      @prom.get(name.to_sym).increment(tags, value)
+    end
+
+    def set_gauge(name, value, tags)
+      @prom.get(name.to_sym).set(tags, value)
+    end
+
+    def observe_histogram(name, value, tags)
+      @prom.get(name.to_sym).observe(tags, value)
+    end
+  end
+end

--- a/lib/foreman/telemetry_sinks/rails_logger_sink.rb
+++ b/lib/foreman/telemetry_sinks/rails_logger_sink.rb
@@ -1,0 +1,32 @@
+module Foreman::TelemetrySinks
+  class RailsLoggerSink
+    def initialize(opts = {})
+      @logger = Foreman::Logging.logger('telemetry')
+      @level = Logger.const_get(opts[:level].try(:to_sym).try(:upcase) || :debug)
+    end
+
+    def add_counter(name, description, instance_labels)
+      @logger.add(@level, "Registering counter #{name} labels #{instance_labels.inspect}")
+    end
+
+    def add_gauge(name, description, instance_labels)
+      @logger.add(@level, "Registering gauge #{name} labels #{instance_labels.inspect}")
+    end
+
+    def add_histogram(name, description, instance_labels, ignored)
+      @logger.add(@level, "Registering histogram #{name} labels #{instance_labels.inspect}")
+    end
+
+    def increment_counter(name, value, tags)
+      @logger.add(@level, "Incrementing counter #{name} by #{value} #{tags.inspect}")
+    end
+
+    def set_gauge(name, value, tags)
+      @logger.add(@level, "Setting gauge #{name} to #{value} #{tags.inspect}")
+    end
+
+    def observe_histogram(name, value, tags)
+      @logger.add(@level, "Observing histogram #{name} value #{value} #{tags.inspect}")
+    end
+  end
+end

--- a/lib/foreman/telemetry_sinks/statsd_sink.rb
+++ b/lib/foreman/telemetry_sinks/statsd_sink.rb
@@ -1,0 +1,47 @@
+require 'statsd-instrument'
+
+module Foreman::TelemetrySinks
+  class StatsdSink
+    def initialize(opts = {})
+      @instances = {}
+      host = opts[:host] || '127.0.0.1:8125'
+      protocol = opts[:protocol].try(:to_sym) || :statsite
+      StatsD.backend = StatsD::Instrument::Backends::UDPBackend.new(host, protocol)
+    end
+
+    def add_counter(name, description, instance_labels)
+      raise ::Foreman::Exception.new(N_('Metric already registered: %s'), name) if @instances[name]
+      @instances[name] = instance_labels
+    end
+
+    def add_gauge(name, description, instance_labels)
+      raise ::Foreman::Exception.new(N_('Metric already registered: %s'), name) if @instances[name]
+      @instances[name] = instance_labels
+    end
+
+    def add_histogram(name, description, instance_labels, buckets)
+      raise ::Foreman::Exception.new(N_('Metric already registered: %s'), name) if @instances[name]
+      @instances[name] = instance_labels
+    end
+
+    def increment_counter(name, value, tags)
+      StatsD.increment(name_tag_mapping(name, tags), value)
+    end
+
+    def set_gauge(name, value, tags)
+      StatsD.gauge(name_tag_mapping(name, tags), value)
+    end
+
+    def observe_histogram(name, value, tags)
+      StatsD.measure(name_tag_mapping(name, tags), value)
+    end
+
+    private
+
+    def name_tag_mapping(name, tags)
+      insts = @instances[name]
+      return name if insts.blank?
+      (name.to_s + '.' + insts.map {|x| tags[x]}.compact.join('.')).tr(':', '_')
+    end
+  end
+end

--- a/lib/tasks/telemetry.rake
+++ b/lib/tasks/telemetry.rake
@@ -1,0 +1,41 @@
+require "foreman/telemetry"
+require "foreman/telemetry_sinks/metric_exporter_sink"
+
+desc "Telemetry helper tasks"
+namespace :telemetry do
+  desc "List all metrics"
+  task :metrics => :environment do
+    telemetry = Foreman::Telemetry.instance
+    puts "| Metric name | Labels | Type | Description |"
+    puts "| ----------- | ------ | ---- | ----------- |"
+    telemetry.metrics.sort.each do |element|
+      m_name, m_desc, m_labels, m_type, = element
+      puts "| #{m_name} | #{m_labels.join(',')} | #{m_type} | #{m_desc} |"
+    end
+  end
+
+  desc "Generate exporter mapping for statsd_exporter"
+  task :prometheus_statsd, [:output] => [:environment] do |t|
+    telemetry = Foreman::Telemetry.instance
+    File.open(ENV["output"] || "mapping.yaml", "w") do |f|
+      mappings = []
+      telemetry.metrics.sort.each do |element|
+        m_name, m_desc, m_labels, m_type, m_buckets = element
+        metric = {}
+        labels = {}
+        metric["name"] = m_name
+        metric["match"] = m_name + (".*" * m_labels.count)
+        m_labels.each_with_index do |label, i|
+          labels[label.to_s] = "$#{i+1}"
+        end
+        metric["labels"] = labels
+        metric["help"] = m_desc
+        metric["buckets"] = m_buckets.dup if m_buckets
+        metric["timer_type"] = "histogram" if m_type == :histogram
+        mappings << metric if m_labels.count > 0
+      end
+      result = {"mappings" => mappings}
+      f.puts result.to_yaml
+    end
+  end
+end


### PR DESCRIPTION
Foreman telemetry core API. This PR brings a common telemetry API which provides three generic metric types:

* **counter** (monotony increasing counter - for example number of http requests)
* **gauge** (arbitrary float value - for example number of jobs queued)
* **histogram** (arbitrary amount of buckets with observations and float values - for example duration of a request)

Each individual metric must be predefined in config/initializers/5_telemetry_metrics.rb file in this format:

    telemetry.add_counter(:http_requests, 'A counter of HTTP requests made', [:controller, :action])

Optionally buckets can be defined for histograms (a sane default is used if not defined):

    telemetry.add_histogram(:http_request_total_duration, 'Total duration of controller action', [:controller, :action], [5, 10, 50, 200, 1000])

For more about why I picked these, watch my proposal video: https://www.youtube.com/watch?v=gCLSI9-4QpE

There are two implementations for the best possible integration options: Prometheus endpoint and Statsd packets. To configure the former, add this to your settings:

```yaml
:telemetry:
  :type: 'prometheus'
  :prefix: 'fm_rails'
```

Then visit `/metrics` to see aggregated data. Warning - due to limitation of Prometheus Ruby library, this will not work for multi-process web servers (our case) and this will provide you incorrect data. Therefore, until this is fixed upstream, a recommended way is to use Statsd:

```yaml
:telemetry:
  :type: 'statsd'
  :prefix: 'fm_rails'
  :statsd:
    :host: '127.0.0.1:8125'
    :protocol: 'statsd'
```

Then download and run any statsd aggregator on localhost port 8125. I tested with statsite and statsd_exporter for Prometheus, which is super easy to use:

```
./statsd_exporter -statsd.listen-udp :8125
```

This PR provides a rake task that will create useful mapping for statsd_exporter which makes life much more easier and provides label mapping:


```
be rake telemetry:prometheus_statsd output=/tmp/mapping.yaml
./statsd_exporter -statsd.listen-udp :8125 -statsd.mapping-config /tmp/mapping.yaml
```

The last step is to grab the data into some monitoring framework, Prometheus is very easy to use as it's a single binary and configuration is easy:

```
scrape_configs:
  - job_name: 'foreman'
    static_configs:
      - targets: ['localhost:9102']

./prometheus
```

This PR adds bunch of basic telemetry data, we can add more later on via initializer, this could be DSL instead of direct Ruby code (config/initializers/5_telemetry_metrics.rb). The PR currently adds:

| Metric name | Labels | Type | Description |
| ----------- | ------ | ---- | ----------- |
| fm_rails_activerecord_instances | class | counter | Number of instances of ActiveRecord models |
| fm_rails_bruteforce_locked_ui_logins |  | counter | Number of blocked logins via bruteforce protection |
| fm_rails_failed_ui_logins |  | counter | Number of failed logins in total |
| fm_rails_http_request_db_duration | controller,action | histogram | Time spent in database for a request |
| fm_rails_http_request_total_duration | controller,action | histogram | Total duration of controller action |
| fm_rails_http_request_view_duration | controller,action | histogram | Time spent in view for a request |
| fm_rails_http_requests | controller,action | counter | A counter of HTTP requests made |
| fm_rails_proxy_api_duration | method | histogram | Time spent waiting for Proxy (ms) |
| fm_rails_proxy_api_response_code | code | counter | Number of Proxy API responses per HTTP code |
| fm_rails_ruby_gc_allocated_objects | controller,action | counter | Ruby GC statistics per request (total_allocated_objects) |
| fm_rails_ruby_gc_count | controller,action | counter | Ruby GC statistics per request (count) |
| fm_rails_ruby_gc_freed_objects | controller,action | counter | Ruby GC statistics per request (total_freed_objects) |
| fm_rails_ruby_gc_major_count | controller,action | counter | Ruby GC statistics per request (major_gc_count) |
| fm_rails_ruby_gc_minor_count | controller,action | counter | Ruby GC statistics per request (minor_gc_count) |
| fm_rails_successful_ui_logins |  | counter | Number of successful logins in total |

A short demo how to set thigs up:

https://youtu.be/i5iCOLEByZk

TODO:

* [x] Installer
* [x] Documentation
* [x] Packages for new dependencies

