### PR TITLE
Fixes #20347 - remove os in db when removing it from the ui

### DIFF
--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -1,9 +1,9 @@
 <%= fields_for item do |f| %>
   <%= select_f f, :operatingsystem_id, arch_oss, :id, :to_label,
-    {:selected => item.operatingsystem_id, :include_blank => blank_or_inherit_f(f, :operatingsystem)},
+    {:selected => item.operatingsystem_id, :include_blank => blank_or_inherit_f(f, :operatingsystem) },
     { :label => _("Operating system"),
-      :disabled => arch_oss.empty? ? true : false,
       :help_inline => :indicator,
-      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize, :required => true}
+      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize, :required => true,
+      :placeholder => arch_oss.empty? ? _("No options available for selected Architecture") : nil }
   %>
 <% end %>

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -1,13 +1,13 @@
 <%= fields_for item do |f| %>
   <%= select_f f, :medium_id, os_media, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
-    {:label => _("Media"), :disabled => os_media.empty?,
-     :help_inline => :indicator, :onchange => 'medium_selected(this);', :'data-url' => method_path('medium_selected'),
-     :'data-type' => controller_name.singularize, :required => true }
+    {:label => _("Media"), :help_inline => :indicator, :onchange => 'medium_selected(this);',
+     :'data-url' => method_path('medium_selected'), :'data-type' => controller_name.singularize,
+     :required => true, :placeholder => os_media.empty? ? _("No options available for selected Operating System") : nil }
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},
-    {:label => _("Partition Table"), :disabled => os_ptable.empty?, :required => true}
+    {:label => _("Partition Table"), :required => true, :placeholder => os_ptable.empty? ? _("No options available for selected Operating System") : nil }
   %>
 
   <% if @operatingsystem && @operatingsystem.supports_image %>


### PR DESCRIPTION
The os wasn't removed because the field was disabled
changed to read only