### PR TITLE
Refs #11153 - rescue from ldap errors

### DIFF
--- a/app/controllers/external_usergroups_controller.rb
+++ b/app/controllers/external_usergroups_controller.rb
@@ -6,10 +6,12 @@ class ExternalUsergroupsController < ApplicationController
   def refresh
     if @external_usergroup.refresh
       notice _("External user group %{name} refreshed") % { :name => @external_usergroup.name }
+      redirect_to usergroups_path
     else
       message = _("External user group %{name} could not be refreshed.") % { :name => @external_usergroup.name }
       message += ' ' + @external_usergroup.errors.full_messages.join('. ') if @external_usergroup.errors.present?
       warning message
+      process_error :redirect => edit_usergroup_url(@external_usergroup.usergroup)
     end
   rescue => e
     external_usergroups_error(@external_usergroup, e)

--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -22,7 +22,7 @@ class UsergroupsController < ApplicationController
       process_error
     end
   rescue => e
-    external_usergroups_error(e)
+    external_usergroups_error(@usergroup, e)
     process_error
   end
 


### PR DESCRIPTION
There was a PR https://github.com/theforeman/foreman/pull/4686 fixing errors handling for broken ldaps. After another PR https://github.com/theforeman/foreman/pull/4199/ was merged, this one was not properly rebased so it resulted in fixing only one part of the problem. And also the second PR was merged with new regression.

This PR aims to fix the regression about wrong usage of `external_usergroups_error(@usergroup, e)` introduced in #4199 and add missing redirects to external usergroup refresh. In case it succeed or fails it was trying to render non existing `refresh.html.erb` since #4199 removed [the redirection](https://github.com/theforeman/foreman/pull/4199/files#diff-185981937d988bffaed0a8f8a977e70bL10), sadly I missed that when I was rebasing #4686 

I suggest we merge this to 1.17 as this is a new regression.