### PR TITLE
Fixes #22036 - Issue with OpenStack Create Host and Security Groups

### DIFF
--- a/app/views/compute_resources_vms/form/openstack/_base.html.erb
+++ b/app/views/compute_resources_vms/form/openstack/_base.html.erb
@@ -12,7 +12,7 @@
 </div>
 <%= select_f f, :tenant_id, compute_resource.tenants, :id, :name, {}, :label => _('Tenant'), :label_size => "col-md-2" %>
 
-<%= select_f f, :security_groups, compute_resource.security_groups, :name, :name, {}, :label => _("Security group"), :label_size => "col-md-2"  %>
+<%= select_f f, :security_group, compute_resource.security_groups, :name, :name, {}, { :label => _("Security group"), :label_size => "col-md-2", :multiple => true} %>
 <%= select_f f, :nics, compute_resource.internal_networks, :id, :name,
              {}, { :label => _('Internal network'), :label_size => "col-md-2", :multiple => true } %>
 <%= selectable_f f, :network, compute_resource.address_pools, { include_blank: 'None' }, { :label => _("Floating IP network"), :label_size => "col-md-2" } %>


### PR DESCRIPTION
When testing against 1.16.0 and OpenStack Ocata
Create Host functionality failed.
this fixes it and makes the security groups a multi select field

before

Go to /hosts/new
Change Deploy On to be OpenStack

![screen shot 2017-12-19 at 4 06 59 pm](https://user-images.githubusercontent.com/683012/34179403-c7b3b3ac-e4d8-11e7-910e-389a64bccce5.png)

after
go to /hosts/new
Change Deploy On to be OpenStack
![screen shot 2017-12-19 at 4 09 40 pm](https://user-images.githubusercontent.com/683012/34179453-ef46074e-e4d8-11e7-8465-01e973fc1422.png)

