### PR TITLE
Fixes #22043 - Allow adding invalid orgs to locs

### DIFF
--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -4,7 +4,7 @@ class Location < Taxonomy
   include Foreman::ThreadSession::LocationModel
   include Parameterizable::ByIdName
 
-  has_and_belongs_to_many :organizations, :join_table => 'locations_organizations'
+  has_and_belongs_to_many :organizations, :join_table => 'locations_organizations', :validate => false
   has_many_hosts :dependent => :nullify
   before_destroy EnsureNotUsedBy.new(:hosts)
 

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -4,7 +4,7 @@ class Organization < Taxonomy
   include Foreman::ThreadSession::OrganizationModel
   include Parameterizable::ByIdName
 
-  has_and_belongs_to_many :locations, :join_table => 'locations_organizations'
+  has_and_belongs_to_many :locations, :join_table => 'locations_organizations', :validate => false
   has_many_hosts :dependent => :nullify
   before_destroy EnsureNotUsedBy.new(:hosts)
 

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -49,6 +49,16 @@ module TaxonomiesBaseTest
       assert taxonomy.valid?
     end
 
+    test 'it should allow assigning invalid opposite_taxonomy' do
+      taxonomy = FactoryBot.build(:"#{taxonomy_name}")
+      domain = FactoryBot.build(:domain)
+      # this makes taxonomy invalid since it has a host in a domain that isn't assigned to it:
+      FactoryBot.create(:host, :domain => domain, :"#{taxonomy_name}" => taxonomy)
+      refute taxonomy.valid?
+      opposite = FactoryBot.build(:"#{opposite_taxonomy}", :"#{taxonomy_name}_ids" => [taxonomy.id])
+      assert opposite.valid?
+    end
+
     test 'it should return array of used ids by hosts' do
       taxonomy = taxonomies(:"#{taxonomy_name}1")
       subnet = FactoryBot.create(:subnet_ipv4,


### PR DESCRIPTION
And vice-versa. Currently when a taxonomy is invalid (e.g. because some
mismatch with hosts and resources), it cannot be assigned to the
opposite taxonomy. This is due to the fact that by default,
`has_and_belongs_to_many` associations validate the associated object as
well.