### PR TITLE
fixes #22055 - update bookmark loading status.

### DIFF
--- a/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmarks.test.js.snap
@@ -131,21 +131,6 @@ exports[`bookmarks empty state 1`] = `
                         Saved Bookmarks
                       </li>
                     </MenuItem>
-                    <Loader
-                      key=".1"
-                      onKeyDown={[Function]}
-                      onSelect={[Function]}
-                      spinnerSize="xs"
-                      status="PENDING"
-                    >
-                      <div
-                        className="loader-root"
-                      >
-                        <div
-                          className="spinner spinner-xs"
-                        />
-                      </div>
-                    </Loader>
                     <MenuItem
                       bsClass="dropdown"
                       disabled={false}
@@ -308,6 +293,7 @@ exports[`bookmarks should include existing bookmarks for the current controller 
       getBookmarks={[Function]}
       modalClosed={[Function]}
       modalOpened={[Function]}
+      status="RESOLVED"
       url="/api/bookmarks"
     >
       <Uncontrolled(Dropdown)
@@ -646,6 +632,7 @@ exports[`bookmarks should not allow creating a new bookmark for users who dont h
       getBookmarks={[Function]}
       modalClosed={[Function]}
       modalOpened={[Function]}
+      status="RESOLVED"
       url="/api/bookmarks"
     >
       <Uncontrolled(Dropdown)
@@ -821,6 +808,787 @@ exports[`bookmarks should not allow creating a new bookmark for users who dont h
                         </li>
                       </MenuItem>
                     </Bookmark>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={true}
+                      header={false}
+                      key=".4"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="divider"
+                        onKeyDown={[Function]}
+                        role="separator"
+                      />
+                    </MenuItem>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={false}
+                      id="newBookmark"
+                      key=".$newBookmark"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <SafeAnchor
+                          componentClass="a"
+                          id="newBookmark"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          <a
+                            href="#"
+                            id="newBookmark"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            Bookmark this search
+                          </a>
+                        </SafeAnchor>
+                      </li>
+                    </MenuItem>
+                    <Component
+                      id="bookmarkDocumentation"
+                      key=".6"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <MenuItem
+                        bsClass="dropdown"
+                        disabled={false}
+                        divider={false}
+                        header={false}
+                        id="bookmarkDocumentation"
+                        key="documentationUrl"
+                        onClick={[Function]}
+                      >
+                        <li
+                          className=""
+                          role="presentation"
+                        >
+                          <SafeAnchor
+                            componentClass="a"
+                            id="bookmarkDocumentation"
+                            onClick={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            <a
+                              href="#"
+                              id="bookmarkDocumentation"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="menuitem"
+                              tabIndex="-1"
+                            >
+                              <Component
+                                className="icon-black"
+                                type="question-sign"
+                              >
+                                <span
+                                  className="glyphicon glyphicon-question-sign icon-black"
+                                />
+                              </Component>
+                               Documentation
+                            </a>
+                          </SafeAnchor>
+                        </li>
+                      </MenuItem>
+                    </Component>
+                  </ul>
+                </RootCloseWrapper>
+              </DropdownMenu>
+            </div>
+          </ButtonGroup>
+        </Dropdown>
+      </Uncontrolled(Dropdown)>
+    </BookmarkContainer>
+  </Connect(BookmarkContainer)>
+</Provider>
+`;
+
+exports[`bookmarks should show an error message if loading failed 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(BookmarkContainer)
+    data={
+      Object {
+        "canCreate": true,
+        "controller": "hosts",
+        "url": "/api/bookmarks",
+      }
+    }
+  >
+    <BookmarkContainer
+      bookmarks={Array []}
+      canCreate={true}
+      controller="hosts"
+      errors="Oops"
+      getBookmarks={[Function]}
+      modalClosed={[Function]}
+      modalOpened={[Function]}
+      status="ERROR"
+      url="/api/bookmarks"
+    >
+      <Uncontrolled(Dropdown)
+        id="hosts"
+        pullRight={true}
+      >
+        <Dropdown
+          bsClass="dropdown"
+          componentClass={[Function]}
+          id="hosts"
+          onToggle={[Function]}
+          pullRight={true}
+        >
+          <ButtonGroup
+            block={false}
+            bsClass="btn-group"
+            className="dropdown"
+            justified={false}
+            vertical={false}
+          >
+            <div
+              className="dropdown btn-group"
+            >
+              <DropdownToggle
+                bsClass="dropdown-toggle"
+                bsRole="toggle"
+                id="hosts"
+                key=".0"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                useAnchor={false}
+              >
+                <Button
+                  active={false}
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="dropdown-toggle"
+                  disabled={false}
+                  id="hosts"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-default"
+                    disabled={false}
+                    id="hosts"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    type="button"
+                  >
+                     
+                    <span
+                      className="caret"
+                    />
+                  </button>
+                </Button>
+              </DropdownToggle>
+              <DropdownMenu
+                bsClass="dropdown-menu"
+                bsRole="menu"
+                key=".1"
+                labelledBy="hosts"
+                onClose={[Function]}
+                onSelect={[Function]}
+                pullRight={true}
+              >
+                <RootCloseWrapper
+                  disabled={true}
+                  event="click"
+                  onRootClose={[Function]}
+                >
+                  <ul
+                    aria-labelledby="hosts"
+                    className="dropdown-menu dropdown-menu-right"
+                    role="menu"
+                  >
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={true}
+                      key=".0"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="dropdown-header"
+                        onKeyDown={[Function]}
+                        role="heading"
+                      >
+                        Saved Bookmarks
+                      </li>
+                    </MenuItem>
+                    Failed to load bookmarks: %s
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={true}
+                      header={false}
+                      key=".4"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="divider"
+                        onKeyDown={[Function]}
+                        role="separator"
+                      />
+                    </MenuItem>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={false}
+                      id="newBookmark"
+                      key=".$newBookmark"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <SafeAnchor
+                          componentClass="a"
+                          id="newBookmark"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          <a
+                            href="#"
+                            id="newBookmark"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            Bookmark this search
+                          </a>
+                        </SafeAnchor>
+                      </li>
+                    </MenuItem>
+                    <Component
+                      id="bookmarkDocumentation"
+                      key=".6"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <MenuItem
+                        bsClass="dropdown"
+                        disabled={false}
+                        divider={false}
+                        header={false}
+                        id="bookmarkDocumentation"
+                        key="documentationUrl"
+                        onClick={[Function]}
+                      >
+                        <li
+                          className=""
+                          role="presentation"
+                        >
+                          <SafeAnchor
+                            componentClass="a"
+                            id="bookmarkDocumentation"
+                            onClick={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            <a
+                              href="#"
+                              id="bookmarkDocumentation"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="menuitem"
+                              tabIndex="-1"
+                            >
+                              <Component
+                                className="icon-black"
+                                type="question-sign"
+                              >
+                                <span
+                                  className="glyphicon glyphicon-question-sign icon-black"
+                                />
+                              </Component>
+                               Documentation
+                            </a>
+                          </SafeAnchor>
+                        </li>
+                      </MenuItem>
+                    </Component>
+                  </ul>
+                </RootCloseWrapper>
+              </DropdownMenu>
+            </div>
+          </ButtonGroup>
+        </Dropdown>
+      </Uncontrolled(Dropdown)>
+    </BookmarkContainer>
+  </Connect(BookmarkContainer)>
+</Provider>
+`;
+
+exports[`bookmarks should show loading spinner when loading bookmarks 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(BookmarkContainer)
+    data={
+      Object {
+        "canCreate": true,
+        "controller": "hosts",
+        "url": "/api/bookmarks",
+      }
+    }
+  >
+    <BookmarkContainer
+      bookmarks={Array []}
+      canCreate={true}
+      controller="hosts"
+      errors={null}
+      getBookmarks={[Function]}
+      modalClosed={[Function]}
+      modalOpened={[Function]}
+      status="PENDING"
+      url="/api/bookmarks"
+    >
+      <Uncontrolled(Dropdown)
+        id="hosts"
+        pullRight={true}
+      >
+        <Dropdown
+          bsClass="dropdown"
+          componentClass={[Function]}
+          id="hosts"
+          onToggle={[Function]}
+          pullRight={true}
+        >
+          <ButtonGroup
+            block={false}
+            bsClass="btn-group"
+            className="dropdown"
+            justified={false}
+            vertical={false}
+          >
+            <div
+              className="dropdown btn-group"
+            >
+              <DropdownToggle
+                bsClass="dropdown-toggle"
+                bsRole="toggle"
+                id="hosts"
+                key=".0"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                useAnchor={false}
+              >
+                <Button
+                  active={false}
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="dropdown-toggle"
+                  disabled={false}
+                  id="hosts"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-default"
+                    disabled={false}
+                    id="hosts"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    type="button"
+                  >
+                     
+                    <span
+                      className="caret"
+                    />
+                  </button>
+                </Button>
+              </DropdownToggle>
+              <DropdownMenu
+                bsClass="dropdown-menu"
+                bsRole="menu"
+                key=".1"
+                labelledBy="hosts"
+                onClose={[Function]}
+                onSelect={[Function]}
+                pullRight={true}
+              >
+                <RootCloseWrapper
+                  disabled={true}
+                  event="click"
+                  onRootClose={[Function]}
+                >
+                  <ul
+                    aria-labelledby="hosts"
+                    className="dropdown-menu dropdown-menu-right"
+                    role="menu"
+                  >
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={true}
+                      key=".0"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="dropdown-header"
+                        onKeyDown={[Function]}
+                        role="heading"
+                      >
+                        Saved Bookmarks
+                      </li>
+                    </MenuItem>
+                    <li
+                      className="loader-root"
+                      key=".1"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <Spinner
+                        className=""
+                        inline={false}
+                        inverse={false}
+                        loading={true}
+                        size="xs"
+                      >
+                        <div
+                          className="spinner spinner-xs"
+                        />
+                      </Spinner>
+                    </li>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={true}
+                      header={false}
+                      key=".4"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="divider"
+                        onKeyDown={[Function]}
+                        role="separator"
+                      />
+                    </MenuItem>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={false}
+                      id="newBookmark"
+                      key=".$newBookmark"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <SafeAnchor
+                          componentClass="a"
+                          id="newBookmark"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          <a
+                            href="#"
+                            id="newBookmark"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            Bookmark this search
+                          </a>
+                        </SafeAnchor>
+                      </li>
+                    </MenuItem>
+                    <Component
+                      id="bookmarkDocumentation"
+                      key=".6"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <MenuItem
+                        bsClass="dropdown"
+                        disabled={false}
+                        divider={false}
+                        header={false}
+                        id="bookmarkDocumentation"
+                        key="documentationUrl"
+                        onClick={[Function]}
+                      >
+                        <li
+                          className=""
+                          role="presentation"
+                        >
+                          <SafeAnchor
+                            componentClass="a"
+                            id="bookmarkDocumentation"
+                            onClick={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                            <a
+                              href="#"
+                              id="bookmarkDocumentation"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="menuitem"
+                              tabIndex="-1"
+                            >
+                              <Component
+                                className="icon-black"
+                                type="question-sign"
+                              >
+                                <span
+                                  className="glyphicon glyphicon-question-sign icon-black"
+                                />
+                              </Component>
+                               Documentation
+                            </a>
+                          </SafeAnchor>
+                        </li>
+                      </MenuItem>
+                    </Component>
+                  </ul>
+                </RootCloseWrapper>
+              </DropdownMenu>
+            </div>
+          </ButtonGroup>
+        </Dropdown>
+      </Uncontrolled(Dropdown)>
+    </BookmarkContainer>
+  </Connect(BookmarkContainer)>
+</Provider>
+`;
+
+exports[`bookmarks should show no bookmarks if server did not respond with any 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(BookmarkContainer)
+    data={
+      Object {
+        "canCreate": true,
+        "controller": "hosts",
+        "url": "/api/bookmarks",
+      }
+    }
+  >
+    <BookmarkContainer
+      bookmarks={Array []}
+      canCreate={true}
+      controller="hosts"
+      errors={null}
+      getBookmarks={[Function]}
+      modalClosed={[Function]}
+      modalOpened={[Function]}
+      status="RESOLVED"
+      url="/api/bookmarks"
+    >
+      <Uncontrolled(Dropdown)
+        id="hosts"
+        pullRight={true}
+      >
+        <Dropdown
+          bsClass="dropdown"
+          componentClass={[Function]}
+          id="hosts"
+          onToggle={[Function]}
+          pullRight={true}
+        >
+          <ButtonGroup
+            block={false}
+            bsClass="btn-group"
+            className="dropdown"
+            justified={false}
+            vertical={false}
+          >
+            <div
+              className="dropdown btn-group"
+            >
+              <DropdownToggle
+                bsClass="dropdown-toggle"
+                bsRole="toggle"
+                id="hosts"
+                key=".0"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                useAnchor={false}
+              >
+                <Button
+                  active={false}
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="dropdown-toggle"
+                  disabled={false}
+                  id="hosts"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="dropdown-toggle btn btn-default"
+                    disabled={false}
+                    id="hosts"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    type="button"
+                  >
+                     
+                    <span
+                      className="caret"
+                    />
+                  </button>
+                </Button>
+              </DropdownToggle>
+              <DropdownMenu
+                bsClass="dropdown-menu"
+                bsRole="menu"
+                key=".1"
+                labelledBy="hosts"
+                onClose={[Function]}
+                onSelect={[Function]}
+                pullRight={true}
+              >
+                <RootCloseWrapper
+                  disabled={true}
+                  event="click"
+                  onRootClose={[Function]}
+                >
+                  <ul
+                    aria-labelledby="hosts"
+                    className="dropdown-menu dropdown-menu-right"
+                    role="menu"
+                  >
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={false}
+                      divider={false}
+                      header={true}
+                      key=".0"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="dropdown-header"
+                        onKeyDown={[Function]}
+                        role="heading"
+                      >
+                        Saved Bookmarks
+                      </li>
+                    </MenuItem>
+                    <MenuItem
+                      bsClass="dropdown"
+                      disabled={true}
+                      divider={false}
+                      header={false}
+                      key=".2"
+                      onKeyDown={[Function]}
+                      onSelect={[Function]}
+                    >
+                      <li
+                        className="disabled"
+                        role="presentation"
+                      >
+                        <SafeAnchor
+                          componentClass="a"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          <a
+                            href="#"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            role="menuitem"
+                            tabIndex="-1"
+                          >
+                             
+                            None found
+                          </a>
+                        </SafeAnchor>
+                      </li>
+                    </MenuItem>
                     <MenuItem
                       bsClass="dropdown"
                       disabled={false}

--- a/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.fixtures.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import Immutable from 'seamless-immutable';
+import { STATUS } from '../../constants';
 
 export const initialState = Immutable({
   bookmarks: {
@@ -27,9 +28,30 @@ export const bookmarks = [
   },
 ];
 
+export const afterRequest = Immutable({
+  bookmarks: {
+    ...initialState,
+    hosts: { errors: null, results: [], status: STATUS.PENDING },
+  },
+});
+
 export const afterSuccess = Immutable({
   bookmarks: {
     ...initialState,
-    hosts: { errors: null, results: bookmarks },
+    hosts: { errors: null, results: bookmarks, status: STATUS.RESOLVED },
+  },
+});
+
+export const afterSuccessNoResults = Immutable({
+  bookmarks: {
+    ...initialState,
+    hosts: { errors: null, results: [], status: STATUS.RESOLVED },
+  },
+});
+
+export const afterError = Immutable({
+  bookmarks: {
+    ...initialState,
+    hosts: { errors: 'Oops', results: [], status: STATUS.ERROR },
   },
 });

--- a/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/bookmarks.test.js
@@ -5,7 +5,13 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import BookmarksContainer from './';
-import { initialState, afterSuccess } from './bookmarks.fixtures';
+import {
+  initialState,
+  afterSuccess,
+  afterSuccessNoResults,
+  afterRequest,
+  afterError,
+} from './bookmarks.fixtures';
 
 const mockStore = configureMockStore([thunk]);
 
@@ -31,6 +37,30 @@ function setup() {
 describe('bookmarks', () => {
   it('empty state', () => {
     const { wrapper } = setup();
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should show loading spinner when loading bookmarks', () => {
+    const wrapper = mount(<Provider store={mockStore(afterRequest)}>
+        <BookmarksContainer {...setup().props} />
+      </Provider>);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should show an error message if loading failed', () => {
+    const wrapper = mount(<Provider store={mockStore(afterError)}>
+        <BookmarksContainer {...setup().props} />
+      </Provider>);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should show no bookmarks if server did not respond with any', () => {
+    const wrapper = mount(<Provider store={mockStore(afterSuccessNoResults)}>
+        <BookmarksContainer {...setup().props} />
+      </Provider>);
 
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.fixtures.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import Immutable from 'seamless-immutable';
+import { STATUS } from '../../../constants';
 
 export const initialState = Immutable({
   showModal: false,
@@ -7,7 +8,7 @@ export const initialState = Immutable({
 
 export const afterRequest = Immutable({
   ...initialState,
-  hosts: { errors: null, results: [] },
+  hosts: { errors: null, results: [], status: STATUS.PENDING },
 });
 
 export const bookmarks = [
@@ -249,9 +250,13 @@ export const bookmarks = [
 
 export const afterSuccess = Immutable({
   ...initialState,
-  hosts: { errors: null, results: bookmarks },
+  hosts: { errors: null, results: bookmarks, status: STATUS.RESOLVED },
 });
 
+export const afterError = Immutable({
+  ...initialState,
+  hosts: { errors: 'Oops', results: [], status: STATUS.ERROR },
+});
 export const afterModalOpen = Immutable({
   ...afterSuccess,
   showModal: true,

--- a/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/bookmarks.test.js
@@ -4,6 +4,7 @@ import {
   initialState,
   afterRequest,
   afterSuccess,
+  afterError,
   bookmarks,
   afterModalOpen,
 } from './bookmarks.fixtures';
@@ -23,6 +24,12 @@ describe('bookmark reducers', () => {
       type: types.BOOKMARKS_SUCCESS,
       payload: { controller: 'hosts', results: bookmarks },
     })).toEqual(afterSuccess);
+  });
+  it('should set error state on BOOKMARKS_FAILURE action', () => {
+    expect(reducer(afterRequest, {
+      type: types.BOOKMARKS_FAILURE,
+      payload: { item: { controller: 'hosts' }, error: 'Oops' },
+    })).toEqual(afterError);
   });
   it('should set form query on BOOKMARKS_MODAL_OPENED', () => {
     expect(reducer(afterSuccess, {

--- a/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/bookmarks/index.js
@@ -7,6 +7,7 @@ import {
   BOOKMARKS_MODAL_CLOSED,
   BOOKMARK_FORM_SUBMITTED,
 } from '../../consts';
+import { STATUS } from '../../../constants';
 
 const initialState = Immutable({
   showModal: false,
@@ -28,9 +29,11 @@ export default (state = initialState, action) => {
 
   switch (action.type) {
     case BOOKMARKS_REQUEST:
-      return state.set(payload.controller, { results: [], errors: null });
+      return state.set(payload.controller, { results: [], errors: null, status: STATUS.PENDING });
     case BOOKMARKS_SUCCESS:
-      return state.setIn([payload.controller, 'results'], payload.results);
+      return state
+        .setIn([payload.controller, 'results'], payload.results)
+        .setIn([payload.controller, 'status'], STATUS.RESOLVED);
     case BOOKMARKS_MODAL_OPENED:
       return state.set('currentQuery', payload.query).set('showModal', true);
     case BOOKMARK_FORM_SUBMITTED:
@@ -43,7 +46,9 @@ export default (state = initialState, action) => {
     case BOOKMARKS_MODAL_CLOSED:
       return state.set('showModal', false);
     case BOOKMARKS_FAILURE:
-      return state.setIn([payload.controller, 'errors'], payload.error);
+      return state
+        .setIn([payload.item.controller, 'errors'], payload.error)
+        .setIn([payload.item.controller, 'status'], STATUS.ERROR);
     default:
       return state;
   }

--- a/webpack/test_setup.js
+++ b/webpack/test_setup.js
@@ -6,3 +6,4 @@ configure({ adapter: new Adapter() });
 // Mocking translation function
 global.__ = str => str; // eslint-disable-line
 global.n__ = str => str; // eslint-disable-line
+global.Jed = {sprintf: (str) => str}; // eslint-disable-line


### PR DESCRIPTION
This PR both fixes the issue reported by not showing spinner if
there is an empty set of saved bookmarks (it shows None found)

It also adds missing tests cases for spinner, error and empty result sets, and replaces the Loader component with the patternfly-react Spinner component instead.