### PR TITLE
fixes #22062 - support vmware vmrc console

### DIFF
--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -2,6 +2,7 @@ class ComputeResourcesVmsController < ApplicationController
   include Foreman::Controller::ComputeResourcesCommon
   include ::Foreman::Controller::ActionPermissionDsl
   include ::Foreman::Controller::HostFormCommon
+  include Foreman::Controller::ConsoleCommon
 
   before_action :find_compute_resource
   before_action :find_vm, :only => [:import, :associate, :show, :console, :pause, :power]
@@ -84,15 +85,7 @@ class ComputeResourcesVmsController < ApplicationController
 
   def console
     @console = @compute_resource.console @vm.identity
-    @encrypt = Setting[:websockets_encrypt]
-    render case @console[:type]
-           when 'spice'
-             "hosts/console/spice"
-           when 'vnc'
-             "hosts/console/vnc"
-           else
-             "hosts/console/log"
-           end
+    super
   rescue => e
     process_error :redirect => compute_resource_vm_path(@compute_resource, @vm.identity), :error_msg => (_("Failed to set console: %s") % e), :object => @vm
   end

--- a/app/controllers/concerns/foreman/controller/console_common.rb
+++ b/app/controllers/concerns/foreman/controller/console_common.rb
@@ -1,0 +1,15 @@
+module Foreman::Controller::ConsoleCommon
+  def console
+    @encrypt = Setting[:websockets_encrypt]
+    render case @console[:type]
+             when 'spice'
+               'hosts/console/spice'
+             when 'vnc'
+               'hosts/console/vnc'
+             when 'vmrc'
+               'hosts/console/vmrc'
+             else
+               'hosts/console/log'
+           end
+  end
+end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -10,6 +10,7 @@ class HostsController < ApplicationController
   include Foreman::Controller::Puppet::HostsControllerExtensions
   include Foreman::Controller::CsvResponder
   include Foreman::Controller::NormalizeScsiAttributes
+  include Foreman::Controller::ConsoleCommon
 
   SEARCHABLE_ACTIONS= %w[index active errors out_of_sync pending disabled ]
   AJAX_REQUESTS=%w{compute_resource_selected current_parameters process_hostgroup process_taxonomy review_before_build scheduler_hint_selected}
@@ -342,15 +343,7 @@ class HostsController < ApplicationController
   def console
     return unless @host.compute_resource
     @console = @host.compute_resource.console @host.uuid
-    @encrypt = Setting[:websockets_encrypt]
-    render case @console[:type]
-             when 'spice'
-               "hosts/console/spice"
-             when 'vnc'
-               "hosts/console/vnc"
-             else
-               "hosts/console/log"
-           end
+    super
   rescue => e
     Foreman::Logging.exception("Failed to set console", e)
     process_error :redirect => :back, :error_msg => _("Failed to set console: %s") % (e)

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -314,11 +314,11 @@ class ComputeResource < ApplicationRecord
     self.attrs[:setpw] = nil
   end
 
-  # this method is overwritten for Libvirt
+  # this method is overwritten for Libvirt & VMWare
   def display_type=(_)
   end
 
-  # this method is overwritten for Libvirt
+  # this method is overwritten for Libvirt & VMWare
   def display_type
     nil
   end

--- a/app/views/api/v2/compute_resources/vmware.json.rabl
+++ b/app/views/api/v2/compute_resources/vmware.json.rabl
@@ -1,1 +1,1 @@
-attributes :user, :datacenter, :server, :set_console_password, :caching_enabled
+attributes :user, :datacenter, :server, :set_console_password, :caching_enabled, :display_type

--- a/app/views/compute_resources/form/_vmware.html.erb
+++ b/app/views/compute_resources/form/_vmware.html.erb
@@ -4,9 +4,14 @@
 <% datacenters = list_datacenters f.object%>
 <%= selectable_f(f, :datacenter, datacenters, {}, {:label => _('Datacenter'), :help_inline_permanent => load_datacenters_button_f(f, !datacenters.empty?) })%>
 <%= text_f f, :pubkey_hash, :disabled => true, :label => _("Fingerprint"), :size => "col-md-8" %>
+<%= select_f f, :display_type, f.object.class.supported_display_types,
+  :first, :last, {}, {
+  :label => _('Display Type'),
+  :help_inline => _('VNC consoles are unsupported on VMware ESXi 6.5 and later.')
+} %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
-                  :label => _("Console Passwords"),
-                  :help_inline => _("Set a randomly generated password on the display connection") %>
+                  :label => _("VNC Console Passwords"),
+                  :help_inline => _("Set a randomly generated password on the VNC display connection") %>
 <%= checkbox_f f, :caching_enabled, :label => _("Enable Caching"),
                   :help_inline => _("Cache slow calls to VMWare to speed up page rendering") %>
 <%= f.hidden_field(:pubkey_hash) if f.object.uuid.present? %>

--- a/app/views/compute_resources/show/_vmware.html.erb
+++ b/app/views/compute_resources/show/_vmware.html.erb
@@ -3,9 +3,15 @@
   <td><%= @compute_resource.url %></td>
 </tr>
 <tr>
+  <td><%= _("Display Type") %></td>
+  <td><%= @compute_resource.humanized_display_type %></td>
+</tr>
+<% if @compute_resource.display_type == 'vnc' %>
+<tr>
   <td><%= _("Console passwords") %></td>
   <td><%= @compute_resource.set_console_password? ? _("Enabled") : _("Disabled") %></td>
 </tr>
+<% end %>
 <tr>
   <td><%= _("Caching") %></td>
   <td><%= @compute_resource.caching_enabled ? _("Enabled") : _("Disabled") %></td>

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -20,7 +20,7 @@
       </td>
       <td>
         <%= action_buttons(vm_power_action(vm, authorizer),
-                         (display_link_if_authorized("Console", hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer)) if vm.ready?),
+                         (display_link_if_authorized(_('Console'), hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer)) if vm.ready?),
                          vm_import_action(vm),
                          display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer))) %>
       </td>

--- a/app/views/hosts/console/vmrc.html.erb
+++ b/app/views/hosts/console/vmrc.html.erb
@@ -1,0 +1,15 @@
+<% title "#{@console[:name]}" %>
+<div class="blank-slate-pf">
+  <div class="blank-slate-pf-icon">
+    <%= icon_text('screen', '', :kind => 'pficon') %>
+  </div>
+  <h1><%= _('VMRC Console') %></h1>
+  <p><%= _('To launch the VMRC console, you need the VMRC software installed.') %></p>
+  <p><%= link_to(_('Download VMRC'), 'https://www.vmware.com/go/download-vmrc', :target => '_blank') %></p>
+  <div class="blank-slate-pf-main-action">
+    <%= link_to(_('Launch Console'), @console[:console_url], :class => 'btn btn-primary btn-lg') %>
+    <% if @host %>
+      <%= link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _('Back to host'), :class => 'btn btn-default btn-lg') %>
+    <% end %>
+  </div>
+</div>

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -349,4 +349,26 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
       assert_equal expected_attrs, attrs
     end
   end
+
+  describe '#display_type' do
+    let(:cr) { FactoryBot.build(:vmware_cr) }
+
+    test "default display type is 'vmrc'" do
+      assert_nil cr.attrs[:display]
+      assert_equal 'vmrc', cr.display_type
+    end
+
+    test "display type can be set" do
+      expected = 'vnc'
+      cr.display_type = 'VNC'
+      assert_equal expected, cr.attrs[:display]
+      assert_equal expected, cr.display_type
+      assert cr.valid?
+    end
+
+    test "don't allow wrong display type to be set" do
+      cr.display_type = 'spice'
+      refute cr.valid?
+    end
+  end
 end


### PR DESCRIPTION
As vSphere >= 6.5 dropped support for the VNC consoles, this is a second attempt (#4755) to provide an alternative.
This uses the VMRC type console, which is basically a standalone program (or something like VMWare Fusion) that provides the console, i.e. the console is not displayed in the browser.
This is actually quite nice (feature wise) because you can easily attach .iso images etc.

![image](https://user-images.githubusercontent.com/4107560/34299396-e708bc60-e722-11e7-8f4f-7be20c39a51a.png)

![image](https://user-images.githubusercontent.com/4107560/34299478-7619f090-e723-11e7-9240-4b413e32c701.png)
"Open Link in VMWare Fusion?"

![image](https://user-images.githubusercontent.com/4107560/34299503-9b6ba686-e723-11e7-9ca1-fabefa1461de.png)

