### PR TITLE
Refs #3763 - fix indentation in rabl_test.rb

### DIFF
--- a/test/unit/rabl_test.rb
+++ b/test/unit/rabl_test.rb
@@ -25,29 +25,29 @@ class RablTest < ActiveSupport::TestCase
   end
 
   context 'with plugin' do
-   setup do
-    @klass = Foreman::Plugin
-    @klass.clear
-   end
+    setup do
+      @klass = Foreman::Plugin
+      @klass.clear
+    end
 
-   teardown do
-     @klass.clear
-   end
+    teardown do
+      @klass.clear
+    end
 
-   test 'render of extended plugin template' do
-     Foreman::Plugin.register :test_extend_rabl_template do
-       extend_rabl_template 'api/v2/test/one', 'api/v2/test/two'
-     end
-     @media = FactoryBot.build(:medium)
-     rendered = Rabl.render(@media,
-                            'api/v2/test/one',
-                            :format => :json,
-                            :view_path => File.expand_path('../../../test/static_fixtures/views', __FILE__))
-     loaded = JSON.load(rendered)
-     assert_equal Hash, loaded.class
-     assert_equal @media.name, loaded['name']
-     assert_equal '1', loaded['one']
-     assert_equal '2', loaded['two']
-   end
+    test 'render of extended plugin template' do
+      Foreman::Plugin.register :test_extend_rabl_template do
+        extend_rabl_template 'api/v2/test/one', 'api/v2/test/two'
+      end
+      @media = FactoryBot.build(:medium)
+      rendered = Rabl.render(@media,
+                             'api/v2/test/one',
+                             :format => :json,
+                             :view_path => File.expand_path('../../../test/static_fixtures/views', __FILE__))
+      loaded = JSON.load(rendered)
+      assert_equal Hash, loaded.class
+      assert_equal @media.name, loaded['name']
+      assert_equal '1', loaded['one']
+      assert_equal '2', loaded['two']
+    end
   end
 end


### PR DESCRIPTION
Looks like hound didn't bark because the branch this was merged from didn't include the activation of the indentation cop.