### PR TITLE
refs #2062 - vmrc: console link is only valid once

### DIFF
--- a/app/views/hosts/console/vmrc.html.erb
+++ b/app/views/hosts/console/vmrc.html.erb
@@ -7,7 +7,7 @@
   <p><%= _('To launch the VMRC console, you need the VMRC software installed.') %></p>
   <p><%= link_to(_('Download VMRC'), 'https://www.vmware.com/go/download-vmrc', :target => '_blank', :rel => 'noopener noreferrer') %></p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to(_('Launch Console'), @console[:console_url], :class => 'btn btn-primary btn-lg') %>
+    <%= link_to(_('Launch Console'), @console[:console_url], :class => 'btn btn-primary btn-lg', :onclick => "$(this).attr('disabled', 'disabled');") %>
     <% if @host %>
       <%= link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _('Back to host'), :class => 'btn btn-default btn-lg') %>
     <% end %>


### PR DESCRIPTION
The vmrc console ticket is only valid once.

This commit adds disabling the console button after the first click.

Before clicking:
![image](https://user-images.githubusercontent.com/4107560/34378884-8af65a7a-eaf8-11e7-81bf-657ada418219.png)

After clicking:
![image](https://user-images.githubusercontent.com/4107560/34378893-95d1a256-eaf8-11e7-8625-f63395867fcc.png)
