### PR TITLE
Fixes 22091 - Minor Active Record usage tweak

### DIFF
--- a/app/models/taxable_taxonomy.rb
+++ b/app/models/taxable_taxonomy.rb
@@ -8,7 +8,7 @@ class TaxableTaxonomy < ApplicationRecord
     if types.empty?
       {}
     else
-      where(["taxable_taxonomies.taxable_type NOT IN (?)",types])
+      where.not(taxable_type: types)
     end
   }
 


### PR DESCRIPTION
Using a relation here can be a little faster since Active Record will
use an inequality comparison rather than an IN clause if 'types' has
only one element.