### PR TITLE
Fixes #22138 - fix tooltip triggering

### DIFF
--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -52,7 +52,7 @@ export function activateTooltips(elParam = 'body') {
   el
     .find('*[title]')
     .not('*[rel]')
-    .tooltip({ container: 'body' });
+    .tooltip({ container: 'body', trigger: 'hover' });
   $(document).on('page:restore', () => {
     $('.tooltip.in').remove();
   });


### PR DESCRIPTION
Tooltip is not removed after click and requires antoher click in order to remove it.
This may be annoying especially on dropdown / buttons etc...
![hosts - edited](https://user-images.githubusercontent.com/11807069/34526548-761dfb18-f0ab-11e7-96c5-907e10e58c30.gif)
