### PR TITLE
Fixes #22140 - upgrade ellipsis-with-tooltip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",
     "react-dom": "^16.2.0",
-    "react-ellipsis-with-tooltip": "^1.0.3",
+    "react-ellipsis-with-tooltip": "^1.0.6",
     "react-numeric-input": "^2.0.7",
     "react-onclickoutside": "^6.6.2",
     "react-redux": "^5.0.2",

--- a/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmark.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmark.test.js.snap
@@ -31,8 +31,16 @@ exports[`bookmark should create a link to a bookmark 1`] = `
         >
           <EllipisWithTooltip>
             <div
-              className="ellipsis"
               onMouseEnter={[Function]}
+              style={
+                Object {
+                  "overflow": "hidden",
+                  "overflowWrap": "break-word",
+                  "textOverflow": "ellipsis",
+                  "whiteSpace": "nowrap",
+                  "wordBreak": "break-all",
+                }
+              }
             >
               label
             </div>

--- a/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/__snapshots__/bookmarks.test.js.snap
@@ -428,8 +428,16 @@ exports[`bookmarks should include existing bookmarks for the current controller 
                             >
                               <EllipisWithTooltip>
                                 <div
-                                  className="ellipsis"
                                   onMouseEnter={[Function]}
+                                  style={
+                                    Object {
+                                      "overflow": "hidden",
+                                      "overflowWrap": "break-word",
+                                      "textOverflow": "ellipsis",
+                                      "whiteSpace": "nowrap",
+                                      "wordBreak": "break-all",
+                                    }
+                                  }
                                 >
                                   1111
                                 </div>
@@ -472,8 +480,16 @@ exports[`bookmarks should include existing bookmarks for the current controller 
                             >
                               <EllipisWithTooltip>
                                 <div
-                                  className="ellipsis"
                                   onMouseEnter={[Function]}
+                                  style={
+                                    Object {
+                                      "overflow": "hidden",
+                                      "overflowWrap": "break-word",
+                                      "textOverflow": "ellipsis",
+                                      "whiteSpace": "nowrap",
+                                      "wordBreak": "break-all",
+                                    }
+                                  }
                                 >
                                   1122
                                 </div>
@@ -781,8 +797,16 @@ exports[`bookmarks should not allow creating a new bookmark for users who dont h
                             >
                               <EllipisWithTooltip>
                                 <div
-                                  className="ellipsis"
                                   onMouseEnter={[Function]}
+                                  style={
+                                    Object {
+                                      "overflow": "hidden",
+                                      "overflowWrap": "break-word",
+                                      "textOverflow": "ellipsis",
+                                      "whiteSpace": "nowrap",
+                                      "wordBreak": "break-all",
+                                    }
+                                  }
                                 >
                                   1111
                                 </div>
@@ -825,8 +849,16 @@ exports[`bookmarks should not allow creating a new bookmark for users who dont h
                             >
                               <EllipisWithTooltip>
                                 <div
-                                  className="ellipsis"
                                   onMouseEnter={[Function]}
+                                  style={
+                                    Object {
+                                      "overflow": "hidden",
+                                      "overflowWrap": "break-word",
+                                      "textOverflow": "ellipsis",
+                                      "whiteSpace": "nowrap",
+                                      "wordBreak": "break-all",
+                                    }
+                                  }
                                 >
                                   1122
                                 </div>
@@ -1108,8 +1140,16 @@ exports[`bookmarks should show an error message if loading failed 1`] = `
                           >
                             <EllipisWithTooltip>
                               <div
-                                className="ellipsis"
                                 onMouseEnter={[Function]}
+                                style={
+                                  Object {
+                                    "overflow": "hidden",
+                                    "overflowWrap": "break-word",
+                                    "textOverflow": "ellipsis",
+                                    "whiteSpace": "nowrap",
+                                    "wordBreak": "break-all",
+                                  }
+                                }
                               >
                                 Failed to load bookmarks: %s
                               </div>


### PR DESCRIPTION
The last version included `react` and `react-dom` in the webpack bundle as a second copy.