### PR TITLE
refs #22107 - subnet host count: permissions and n+1

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -257,7 +257,7 @@ Metrics/MethodLength:
 # Offense count: 25
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 434
+  Max: 437
 
 # Offense count: 10
 # Configuration parameters: CountKeywordArgs.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -491,13 +491,16 @@ module ApplicationHelper
   end
 
   def hosts_count(resource_name = controller.resource_name)
-    # If we are on /organizations or /locations, this allows to display the
-    # count for hosts not in the current organization & location.
     hosts_scope = Host::Managed.reorder('')
-    if ['organization', 'location'].include? resource_name
+    case resource_name
+    when 'organization', 'location'
+      # If we are on /organizations or /locations, this allows to display the
+      # count for hosts not in the current organization & location.
       hosts_scope = hosts_scope.unscoped
+    when 'subnet'
+      hosts_scope = hosts_scope.joins(:primary_interface)
     end
-    @hosts_count ||= hosts_scope.authorized.group("#{resource_name}_id").count
+    @hosts_count ||= hosts_scope.authorized.group(:"#{resource_name}_id").count
   end
 
   def webpack_dev_server

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -213,10 +213,6 @@ class Subnet < ApplicationRecord
     super({:methods => [:to_label, :type]}.merge(options))
   end
 
-  def hosts_count
-    hosts.authorized(:view_hosts).size
-  end
-
   private
 
   def validate_ranges

--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -20,10 +20,10 @@
       <tr>
         <td class="display-two-pane ellipsis"><%=link_to_if_authorized subnet.name, hash_for_edit_subnet_path(:id => subnet).merge(:auth_object => subnet, :authorizer => authorizer) %></td>
         <td><%=subnet.network_address %></td>
-        <td class="ellipsis"><%=subnet.domains.map(&:name).to_sentence %></td>
-        <td><%=subnet.vlanid %></td>
-        <td class="ellipsis"><%=subnet.dhcp %></td>
-        <td><%= link_to subnet.hosts_count, hosts_path(:search => "subnet.name=\"#{subnet}\"") %>
+        <td class="ellipsis"><%= subnet.domains.map(&:name).to_sentence %></td>
+        <td><%= subnet.vlanid %></td>
+        <td class="ellipsis"><%= subnet.dhcp %></td>
+        <td><%= link_to_if_authorized(hosts_count.fetch(subnet.id, 0), hash_for_hosts_path(:search => "subnet.name=\"#{subnet}\"")) %>
         <td class="col-md-1">
           <%= action_buttons(display_delete_if_authorized(
             hash_for_subnet_path(:id => subnet).


### PR DESCRIPTION
Only displays the link to the host count if a user has the "view_hosts" permission and counts the number of hosts without a "n+1" query as we do on similar pages.
I'm still not sure if the query counts correct, but could you (@dLobatog + @tbrisker) please take a look? Thanks.