### PR TITLE
Fixes #22165 - Allow disabling HSTS header

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,9 @@
 ::SecureHeaders::Configuration.default do |config|
-  config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
+  if SETTINGS[:hsts_enabled]
+    config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
+  else
+    config.hsts = "max-age=0; includeSubdomains"
+  end
   config.csp = {
     :default_src => ["'self'"],
     :child_src   => ["'self'"],

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -14,6 +14,7 @@ SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
 SETTINGS[:puppetssldir]  ||= "#{SETTINGS[:puppetvardir]}/ssl"
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value
 SETTINGS[:domain] ||= Facter.value(:domain) || Facter.value(:hostname)
+SETTINGS[:hsts_enabled] = true unless SETTINGS.has_key?(:hsts_enabled)
 
 # Load plugin config, if any
 Dir["#{root}/config/settings.plugins.d/*.yaml"].each do |f|

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -26,6 +26,11 @@
 # errors in your browser
 :webpack_dev_server_https: false
 
+# If you wish to allow browsers access to http resources after accessing the
+# server, you will need to disable HSTS headers. This has security implications
+# so only change this if you know what you're doing.
+:hsts_enabled: true
+
 # Ruby on Rails version
 # Defaults to 5.1
 #:rails: 5.1


### PR DESCRIPTION
If a user browses to the Foreman server using HTTPS, HSTS headers will
prevent the browser from connecting to the server again using HTTP. This
adds a setting that allows disabling this header for users requiring
browser access to the server.