### PR TITLE
Fixes #22155 - Allow name of datacenter in API

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -54,6 +54,13 @@ module Api
 
       def create
         @compute_resource = ComputeResource.new_provider(compute_resource_params)
+
+        datacenter = compute_resource_params[:datacenter]
+
+        if @compute_resource.respond_to?(:get_datacenter_uuid) && datacenter.present? && !Foreman.is_uuid?(datacenter)
+          @compute_resource.test_connection
+          @compute_resource.datacenter = @compute_resource.get_datacenter_uuid(datacenter)
+        end
         process_response @compute_resource.save
       end
 

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -193,6 +193,12 @@ module Foreman::Model
       client.datacenters(options).map { |dc| [dc[:name], dc[:id]] }
     end
 
+    def get_datacenter_uuid(name)
+      datacenter_uuid = datacenters.select{|dc| dc[0] == name}
+      raise ::Foreman::Exception.new(N_('Datacenter was not found')) if datacenter_uuid.empty?
+      datacenter_uuid.first[1]
+    end
+
     def editable_network_interfaces?
       # we can't decide whether the networks are available when we
       # don't know the cluster_id, assuming it's possible

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -150,6 +150,28 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     assert !available_storage_domains.empty?
   end
 
+  test "should create with datacenter name" do
+    Foreman::Model::Ovirt.any_instance.stubs(:datacenters).returns([["test", Foreman.uuid]])
+    Foreman::Model::Ovirt.any_instance.stubs(:test_connection).returns(true)
+
+    attrs = { :name => 'Ovirt-create-test', :url => 'https://myovirt/api', :provider => 'ovirt', :datacenter => 'test', :user => 'user@example.com', :password => 'secret' }
+    post :create, params: { :compute_resource => attrs }
+    assert_response :created
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert Foreman.is_uuid?(show_response["datacenter"])
+  end
+
+  test "should create with datacenter uuid" do
+    datacenter_uuid = Foreman.uuid
+    Foreman::Model::Ovirt.any_instance.stubs(:datacenters).returns([["test", datacenter_uuid]])
+
+    attrs = { :name => 'Ovirt-create-test', :url => 'https://myovirt/api', :provider => 'ovirt', :datacenter => datacenter_uuid, :user => 'user@example.com', :password => 'secret' }
+    post :create, params: { :compute_resource => attrs }
+    assert_response :created
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert Foreman.is_uuid?(show_response["datacenter"])
+  end
+
   context 'cache refreshing' do
     test 'should refresh cache if supported' do
       put :refresh_cache, params: { :id => compute_resources(:vmware).to_param }


### PR DESCRIPTION
Background: when using the API to create a compute resource `datacenter` expects any string. When sending a name to an ovirt compute resource any action tries to send that name to ovirt which returns a not found error because ovirt expects to get the datacenter uuid.

I didn't add tests yet because I want to make sure this is the right approach.

From what I understand vmware finds the datacenter by name but ovirt needs the uuid.
There is an option to create an ovirt specific controller or ovirt specific behavior in the api controller that either changes name to uuid or rejects anything that isn't a uuid.

I chose to try and keep something that would work for both ovirt and vmware.
To get the datacenters in ovirt I have to test the connection to get an initialized client with a datacenter list.

There is a problem in case the name in ovirt is not unique which means we'd have to force using uuid but.
  