### PR TITLE
Fixes #22203 - facts traversing supports dot in names

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Foreman::Application.routes.draw do
         resources :facts, :only => :index, :controller => :fact_values
         resources :puppetclasses, :only => :index
 
-        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts'
+        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\w.:_-]+/
       end
     end
 


### PR DESCRIPTION
to reproduce:
1. have a composed fact that contains dot in the name, e.g. puppet facts for vlan interface
2. navigate to it's details
3. you get 404 since the route was not found

after applying the patch, this is possible
![facts](https://user-images.githubusercontent.com/109773/34733035-4c2401d4-f567-11e7-9be8-f0e4c812a3d4.png)
