### PR TITLE
Fixes #22205 - restore blueprint actions for notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -66,10 +66,10 @@ class Notification < ApplicationRecord
 
   def set_custom_attributes
     return unless notification_blueprint # let validation catch this.
-    self.actions ||= UINotifications::URLResolver.new(
+    self.actions = UINotifications::URLResolver.new(
       subject,
       notification_blueprint.actions
-    ).actions if notification_blueprint.actions.any?
+    ).actions if notification_blueprint.actions.any? && self.actions.blank?
     # copy notification message in case we didn't create a custom one.
     self.message ||= UINotifications::StringParser.new(
       notification_blueprint.message,


### PR DESCRIPTION
self.actions defaults to `{}`, the logic with conditional overiding is correct but the condition is wrong