### PR TITLE
Fixes #22208, #21920 - Refactor password auditing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '4.5.0'
+gem 'audited', '~> 4.6'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '>= 2.0', '< 4'
 gem 'scoped_search', '>= 4.1.2', '< 5'

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -13,7 +13,7 @@ module AuditsHelper
       when /.*_id$/
         label = name.classify.gsub('Id','').constantize.find(change).to_label
       else
-        label = change.to_s == "[encrypted]" ? _(change.to_s) : change.to_s
+        label = change.to_s == AuditExtensions::REDACTED ? _(change.to_s) : change.to_s
     end
     label = _('[empty]') unless label.present?
     if truncate

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,15 +1,12 @@
 class Image < ApplicationRecord
   include Authorizable
 
-  audited :except => [ :password ]
+  audited
 
   belongs_to :operatingsystem
   belongs_to :compute_resource
   belongs_to :architecture
   has_many_hosts :dependent => :nullify
-  attr_reader :password_changed
-  after_save :unset_password_changed
-  before_validation :set_password_changed, :if => Proc.new { |audit| audit.password_changed? }
 
   validates_lengths_from_database
   validates :username, :operatingsystem_id, :compute_resource_id, :architecture_id, :presence => true
@@ -22,19 +19,6 @@ class Image < ApplicationRecord
   scoped_search :relation => :architecture, :on => :id, :rename => "architecture", :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :relation => :operatingsystem, :on => :id, :rename => "operatingsystem", :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :user_data, :complete_value => {:true => true, :false => false}
-
-  def password_changed_changed?
-    changed.include?('password_changed')
-  end
-
-  def set_password_changed
-    @password_changed = true
-    attribute_will_change!('password_changed')
-  end
-
-  def unset_password_changed
-    @password_changed = false
-  end
 
   private
 

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -33,7 +33,7 @@ class AuditExtensionsTest < ActiveSupport::TestCase
       assert setting.save
     end
     a = Audit.where(auditable_type: 'Setting')
-    assert_equal "[encrypted]", a.last.audited_changes["value"][1]
+    assert_equal "[redacted]", a.last.audited_changes["value"][1]
   end
 
   test "search for type=lookupvalue in audit" do


### PR DESCRIPTION
Recent changes in Rails 5.1 and audited gem cause our method of auditing
passwords to break. This PR refactors password auditing, so that instead
of recording a change to attribute `password_changed`, we will now
record the string `[redacted]` instead of any actual password.
The change is done currently in our audit extensions, which mean that it
will now apply to all resources that have a `password` attribute instead
of just those that have defined the workaround.
The next step will be to move this to the audited gem in a more
generalized method that can be defined in the model when initializing
audited, so that the workaround can be removed.