### PR TITLE
Refs #22208 - pin audited to 4.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.8'
 gem 'rest-client', '>= 1.8.0', '< 3', :require => 'rest_client'
-gem 'audited', '~> 4.3'
+gem 'audited', '~> 4.3', '< 4.6.0'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '~> 2.0'
 gem 'scoped_search', '>= 4.1.2', '< 5'


### PR DESCRIPTION
4.6.0 versions causes test failures on models trying to prevent saved
passwords from being saved in the audit log. This is due to hacks we
added to core along with changes in rails 5.1 change tracking.
This should be fixed to work correctly in the code, but pinning for now
to prevent CI breakage.