### PR TITLE
fixes #22258 - vmware: speed up vm listing

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -3,16 +3,14 @@ module FogExtensions
     class MiniServer
       attr_reader :name, :identity, :cpus, :corespersocket, :memory, :state, :path
 
-      def initialize(raw, path = nil, uuid = nil)
-        hardware  = raw.config.hardware
-        @raw      = raw
-        @name     = raw.name
-        @identity = uuid
-        @cpus     = hardware.numCPU
-        @corespersocket = hardware.numCoresPerSocket
-        @memory   = hardware.memoryMB.megabytes
-        @state    = raw.runtime.powerState
-        @path     = path
+      def initialize(attrs = {})
+        @name     = attrs[:name]
+        @identity = attrs[:identity]
+        @cpus     = attrs[:cpus]
+        @corespersocket = attrs[:corespersocket]
+        @memory   = attrs[:memory].megabytes
+        @state    = attrs[:state]
+        @path     = attrs[:path]
       end
 
       def ready?
@@ -22,10 +20,6 @@ module FogExtensions
       def to_s
         name
       end
-
-      private
-
-      attr_reader :raw
     end
   end
 end

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -4,37 +4,99 @@ module FogExtensions
   module Vsphere
     class MiniServers
       def initialize(client, dc)
-        @client = client
-        @dc     = client.send(:find_datacenters, dc)[0]
+        @client     = client
+        @dc         = client.send(:find_datacenters, dc).first
+        @connection = client.send(:connection)
       end
 
       def all(filters = { })
-        allvmsbyfolder(dc.vmFolder, nil).map do |entry|
-          MiniServer.new(entry[:vm], entry[:path], entry[:uuid])
-        end
-      end
+        property_collector = connection.serviceContent.propertyCollector
 
-      def allvmsbyfolder(folder, path = nil)
-        ret = []
-        unless folder == @dc.vmFolder
-          path = path.nil? ? folder.name : path + '/' + folder.name
+        results = property_collector.RetrieveProperties(:specSet => [filter_spec])
+
+        folders = results.select { |result| result.obj.is_a?(RbVmomi::VIM::Folder) }
+
+        folder_inventory = generate_folder_inventory(folders)
+
+        vms = results.select { |result| result.obj.is_a?(RbVmomi::VIM::VirtualMachine) && !result['config.template'] }
+
+        vms.map do |vm|
+          attrs = attribute_mapping.map do |key, value|
+            [key, vm[value]]
+          end.to_h
+
+          attrs['path'] = folder_inventory[vm['parent']._ref][:path]
+
+          MiniServer.new(attrs)
         end
-        folder.childEntity.each do |entity|
-          if entity.is_a?(RbVmomi::VIM::Folder)
-            ret.push(*allvmsbyfolder(entity, path))
-          elsif entity.is_a?(RbVmomi::VIM::VirtualMachine)
-            config = entity.config
-            if (config && !config.template && (uuid = config.instanceUuid))
-              ret.push({ :vm => entity, :path => path, :uuid => uuid})
-            end
-          end
-        end
-        ret
       end
 
       private
 
-      attr_reader :client, :dc
+      def generate_folder_inventory(folders)
+        folder_inventory = folders.each_with_object({}) do |folder, inventory|
+          parent = if folder['parent'] == dc.vmFolder
+                     nil
+                   else
+                     folder['parent']._ref
+                   end
+          inventory[folder.obj._ref] = {
+            :name => folder['name'],
+            :parent => parent
+          }
+        end
+        set_folder_paths(folder_inventory)
+        folder_inventory
+      end
+
+      def set_folder_paths(folder_inventory)
+        folder_inventory.each do |ref, props|
+          props[:path] = lookup_parent_folders(folder_inventory, ref).reverse.join('/')
+        end
+      end
+
+      def lookup_parent_folders(folder_inventory, ref)
+        return [] if folder_inventory[ref][:parent].nil?
+        [folder_inventory[ref][:name], lookup_parent_folders(folder_inventory, folder_inventory[ref][:parent])].flatten
+      end
+
+      def filter_spec
+        RbVmomi::VIM.PropertyFilterSpec(
+          :objectSet => [
+            :obj => dc.vmFolder,
+            :skip => true,
+            :selectSet => [
+              RbVmomi::VIM.TraversalSpec(
+                :name => 'tsFolder',
+                :type => 'Folder',
+                :path => 'childEntity',
+                :skip => false,
+                :selectSet => [
+                  RbVmomi::VIM.SelectionSpec(:name => 'tsFolder'),
+                ]
+              )
+            ]
+          ],
+          :propSet => [
+            { :type => 'Folder', :pathSet => ['name', 'parent'] },
+            { :type => 'VirtualMachine', :pathSet => attribute_mapping.values + ['parent'] }
+          ]
+        )
+      end
+
+      def attribute_mapping
+        {
+          :name => 'name',
+          :template => 'config.template',
+          :identity => 'config.instanceUuid',
+          :cpus => 'config.hardware.numCPU',
+          :corespersocket => 'config.hardware.numCoresPerSocket',
+          :memory => 'config.hardware.memoryMB',
+          :state => 'runtime.powerState'
+        }
+      end
+
+      attr_reader :client, :connection, :dc
     end
   end
 end


### PR DESCRIPTION
This uses a single API call to vSphere to get the VM listing.

I timed the code that retrieves the data from vSphere and got an improvement from approx. 50 seconds to 1.5 seconds (❤️ ).