### PR TITLE
Fixes #2828 - Report an error when trying to create/update ovirt resource

### DIFF
--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -36,6 +36,16 @@ class ComputeResourcesController < ApplicationController
       @compute_resource.valid?
       process_error
     end
+  rescue OVIRT::OvirtException => e
+    Foreman::Logging.exception("Error while creating ovirt resource", e)
+    process_error(
+      error_msg: _('Error while trying to create resource: %s') % e.message
+    )
+  rescue Fog::Errors::Error => e
+    Foreman::Logging.exception("Error while creating a resource", e)
+    process_error(
+      error_msg: _('Error while trying to create resource: %s') % e.message
+    )
   end
 
   def edit
@@ -70,6 +80,16 @@ class ComputeResourcesController < ApplicationController
     else
       process_error
     end
+  rescue OVIRT::OvirtException => e
+    Foreman::Logging.exception("Error while updating ovirt resource", e)
+    process_error(
+      error_msg: _('Error while trying to update resource: %s') % e.message
+    )
+  rescue Fog::Errors::Error => e
+    Foreman::Logging.exception("Error while updating resource", e)
+    process_error(
+      error_msg: _('Error while trying to update resource: %s') % e.message
+    )
   end
 
   def destroy

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -157,7 +157,7 @@ module Foreman::Model
         when /404/
           errors[:url] << e.message
         when /302/
-          errors[:url] << 'HTTPS URL is required for API access'
+          errors[:url] << _('HTTPS URL is required for API access')
         when /401/
           errors[:user] << e.message
         else


### PR DESCRIPTION
On both create and update, there was no exception handler to captured
given exception. That resulted in having an exception screen instead of
an error message.
The fix capture all of the given exceptions, and report them as an error.