### PR TITLE
Fixes #22272 - don't run CreateRssNotifications in test

### DIFF
--- a/config/initializers/rss_notifications.rb
+++ b/config/initializers/rss_notifications.rb
@@ -8,5 +8,5 @@
   end
 
   # Only create notifications if there isn't a scheduled job
-  CreateRssNotifications.perform_later unless scheduled_job.present?
+  CreateRssNotifications.perform_later if !Rails.env.test? && scheduled_job.blank?
 end


### PR DESCRIPTION
During running tests, we still schedule the CreateRssNotifications job,
which can potentially collide with other tests, as well as seems to run
into some issues related to code reloading.

We should not do this in test environment in the first place.