### PR TITLE
Fixes #22114 - Webpack common-chunk vendor.js

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -8,6 +8,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CompressionPlugin = require('compression-webpack-plugin');
 var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var pluginUtils = require('../script/plugin_webpack_directories');
+var vendorEntry = require('./webpack.vendor');
 
 // must match config.webpack.dev_server.port
 var devServerPort = 3808;
@@ -16,6 +17,8 @@ var devServerPort = 3808;
 var production =
   process.env.RAILS_ENV === 'production' ||
   process.env.NODE_ENV === 'production';
+
+var bundleEntry = path.join(__dirname, '..', 'webpack/assets/javascripts/bundle.js');
 
 var plugins = pluginUtils.getPluginDirs();
 
@@ -27,7 +30,8 @@ var resolveModules = [  path.join(__dirname, '..', 'webpack'),
 var config = {
   entry: Object.assign(
     {
-      bundle: './webpack/assets/javascripts/bundle.js'
+      bundle: bundleEntry,
+      vendor: vendorEntry,
     },
     plugins.entries
   ),
@@ -119,9 +123,9 @@ var config = {
       }
     }),
     new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor'
+      name: 'vendor',
+      minChunks: Infinity,
     })
-
   ]
 };
 

--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -1,0 +1,67 @@
+module.exports = [
+  /**
+   * React related
+   */
+  'babel-polyfill',
+  'react',
+  'react-dom',
+  'react-bootstrap',
+  'react-ellipsis-with-tooltip',
+  'react-numeric-input',
+  'react-onclickoutside',
+  'patternfly-react',
+  'react-redux',
+  'redux',
+  'redux-form',
+  'redux-form-validators',
+  'redux-logger',
+  'redux-thunk',
+  'prop-types',
+  'seamless-immutable',
+  'isomorphic-fetch',
+
+  /*
+   * jquery related
+   */
+  'jquery',
+  'jquery.cookie',
+  'select2',
+  'multiselect',
+  'jquery-ujs',
+  'datatables.net-bs',
+  // jquery-flot related
+  'jquery-flot/excanvas',
+  'jquery-flot',
+  'jquery-flot/jquery.flot.pie',
+  'jquery-flot/jquery.flot.selection',
+  'jquery-flot/jquery.flot.stack',
+  'jquery-flot/jquery.flot.time',
+
+  /**
+   * Brace related
+   */
+  'brace',
+  'brace/mode/javascript',
+  'brace/mode/ruby',
+  'brace/mode/html_ruby',
+  'brace/mode/json',
+  'brace/mode/sh',
+  'brace/mode/xml',
+  'brace/mode/yaml',
+  'brace/mode/diff',
+  'brace/theme/twilight',
+  'brace/theme/clouds',
+  'brace/keybinding/vim',
+  'brace/keybinding/emacs',
+  'brace/ext/searchbox',
+
+  /**
+   * Other packages
+   */
+  'c3',
+  'diff',
+  'ipaddr.js',
+  'jstz',
+  'urijs',
+  'uuid',
+];


### PR DESCRIPTION
Use webpack-common-chunk-plugin to include all
required modules from node_modules/ into vendor.js
(cherry picked from commit 3bba4cf188b755663523f86b10b20a2f4e4d7c8a)