### PR TITLE
Fixes #20873 - simplify text in disassociate hosts screen

### DIFF
--- a/app/views/hosts/_selected_hosts.html.erb
+++ b/app/views/hosts/_selected_hosts.html.erb
@@ -39,8 +39,8 @@
           <% end %>
         </tbody>
       </table>
-      <%= check_box_tag "keep_selected", "", false, :title => _("Keep selected hosts for a future action") %>
-      <%= _('Keep selected hosts for a future action') %><br/><br/>
+      <%= check_box_tag "keep_selected", "", false, :title => _("Remember hosts selection for the next bulk action") %>
+      <%= _('Remember hosts selection for the next bulk action') %><br/><br/>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
before - "Keep selected hosts for a future action" -

![before](https://user-images.githubusercontent.com/15361156/35043256-9be0e470-fb94-11e7-8f28-a4ea6dcd3461.png)

after - "Remember hosts selection for the next bulk action" -

![image](https://user-images.githubusercontent.com/15361156/35043321-d62a79ac-fb94-11e7-87a3-f81e626e0cb5.png)

