### PR TITLE
Fixes #22285 - Raise error when strong params filters out params

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -44,6 +44,13 @@ module Api
       not_found error.message
     end
 
+    rescue_from ActionController::UnpermittedParameters do |error|
+      logger.info "#{error.message} (#{error.class})"
+      message = n_("Invalid parameter: %s. ", "Invalid parameters: %s. ", error.params.length) % error.params.to_sentence
+      message << _('Please verify that the parameter name is valid and the values are the correct type.')
+      render_error 'param_error', :status => :bad_request, :locals => { :exception => error, :message => message }
+    end
+
     rescue_from Foreman::MaintenanceException, :with => :service_unavailable
 
     def get_resource(message = "Couldn't find resource")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
   rescue_from ActiveRecord::RecordNotFound, :with => :not_found
   rescue_from ProxyAPI::ProxyException, :with => :smart_proxy_exception
+  rescue_from ActionController::UnpermittedParameters, :with => :invalid_parameter
   rescue_from Foreman::MaintenanceException, :with => :service_unavailable
 
   # standard layout to all controllers
@@ -120,6 +121,14 @@ class ApplicationController < ActionController::Base
     else
       process_error(:render => { :plain => exception.message },
                     :error_msg => exception.message)
+    end
+  end
+
+  def invalid_parameter(exception = nil)
+    logger.debug "Strong parameters filtered parameters: #{exception.params}" if exception
+    respond_to do |format|
+      format.html { render "common/400", :status => :bad_request, :locals => { :exception => exception } }
+      format.any { head :bad_request }
     end
   end
 

--- a/app/views/api/v2/errors/param_error.json.rabl
+++ b/app/views/api/v2/errors/param_error.json.rabl
@@ -2,6 +2,9 @@ exception = locals[:exception]
 
 object exception => :error
 
-attributes :message
+node :message do
+  locals[:message] || exception.message
+end
 node(:class) { exception.class.to_s }
 node(:parameter_name) { exception.param } if exception.respond_to? :param
+node(:parameter_names) { exception.params } if exception.respond_to? :params

--- a/app/views/common/400.html.erb
+++ b/app/views/common/400.html.erb
@@ -1,0 +1,7 @@
+<div class='col-md-offset-4 col-md-4'>
+  <%= alert :header => (n_("Invalid parameter: %s", "Invalid parameters: %s", exception.params.length) % exception.params.to_sentence),
+    :text => _('Please verify that the parameter name is valid and the values are the correct type.'),
+    :actions => link_to(_('Back'), main_app.root_path, :class => 'btn btn-default'),
+    :class => 'alert-warning',
+    :close => false %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -136,7 +136,10 @@ module Foreman
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    # Don't raise exception for common parameters
+    # Raise exception on mass assignment of unfiltered parameters
+    config.action_controller.action_on_unpermitted_parameters = :raise
+
+    # Don't raise exception for common parameters (despite the name, they aren't permitted)
     config.action_controller.always_permitted_parameters = %w(
       controller action format locale utf8 _method authenticity_token commit redirect
       page per_page paginate search order sort sort_by sort_order

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,9 +38,6 @@ Foreman::Application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  # Raise exception on mass assignment of unfiltered parameters
-  config.action_controller.action_on_unpermitted_parameters = :strict
-
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,4 @@ Foreman::Application.configure do |app|
   config.active_record.dump_schema_after_migration = false
 
   config.webpack.dev_server.enabled = false
-
-  # Log denied attributes into logger
-  config.action_controller.action_on_unpermitted_parameters = :log
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,9 +54,6 @@ Foreman::Application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raise exception on mass assignment of unfiltered parameters
-  config.action_controller.action_on_unpermitted_parameters = :strict
-
   # Use separate cache stores for parallel_tests
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")
 

--- a/test/controllers/api/v2/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/api/v2/auth_source_ldaps_controller_test.rb
@@ -71,14 +71,20 @@ class Api::V2::AuthSourceLdapsControllerTest < ActionController::TestCase
   end
 
   test 'taxonomies can be set' do
-    put :update, params: { :id => auth_sources(:one).to_param,
-                           :organization_names => [taxonomies(:organization1).name],
-                           :location_ids => [taxonomies(:location1).id] }
+    auth_source = FactoryBot.create(:auth_source_ldap)
+    assert_empty auth_source.organizations
+    assert_empty auth_source.locations
+    org = FactoryBot.create(:organization)
+    loc = FactoryBot.create(:location)
+    put :update, params: { :id => auth_source.to_param,
+                           :organization_names => [org.name],
+                           :location_ids => [loc.id]
+                         }
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert_response :success
-    assert_equal taxonomies(:location1).id,
-      show_response['locations'].first['id']
-    assert_equal taxonomies(:organization1).id,
-      show_response['organizations'].first['id']
+    assert_equal loc.id, show_response['locations'].first['id']
+    assert_equal org.id, show_response['organizations'].first['id']
+    assert_equal [org], auth_source.organizations
+    assert_equal [loc], auth_source.locations
   end
 end

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::V2::UsersControllerTest < ActionController::TestCase
   def valid_attrs
     { :mail => 'john@example.com',
-      :auth_source_id => auth_sources(:internal), :password => '123456' }
+      :password => '123456' }
   end
 
   def min_valid_attrs
@@ -72,7 +72,7 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
 
   test "should update user" do
     user = User.create :login => "foo", :mail => "foo@bar.com", :auth_source => auth_sources(:one)
-    put :update, params: { :id => user.id, :user => valid_attrs }
+    put :update, params: { :id => user.id, :user => valid_attrs.merge(:auth_source_id => auth_sources(:internal).id)}
     assert_response :success
 
     mod_user = User.unscoped.find_by_id(user.id)

--- a/test/controllers/auth_source_ldaps_controller_test.rb
+++ b/test/controllers/auth_source_ldaps_controller_test.rb
@@ -81,6 +81,7 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     as_admin do
       put :update, params: { :commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:name => auth_source_ldap.name} }, session: set_session_user
     end
+    assert_response :redirect
     auth_source_ldap = AuthSourceLdap.unscoped.find(auth_source_ldap.id)
     assert_equal old_pass, auth_source_ldap.account_password
   end
@@ -90,6 +91,7 @@ class AuthSourceLdapsControllerTest < ActionController::TestCase
     as_admin do
       put :update, params: { :commit => "Update", :id => auth_source_ldap.id, :auth_source_ldap => {:account_password => '', :name => auth_source_ldap.name} }, session: set_session_user
     end
+    assert_response :redirect
     auth_source_ldap = AuthSourceLdap.find(auth_source_ldap.id)
     assert_empty auth_source_ldap.account_password
   end

--- a/test/controllers/concerns/parameters/auth_source_ldap_test.rb
+++ b/test/controllers/concerns/parameters/auth_source_ldap_test.rb
@@ -7,6 +7,8 @@ class AuthSourceLdapParametersTest < ActiveSupport::TestCase
 
   test "filters STI :type field" do
     params = ActionController::Parameters.new(:auth_source_ldap => {:type => AuthSourceHidden.name})
-    refute_includes self.class.auth_source_ldap_params_filter.filter_params(params, context), 'type'
+    assert_raises ActionController::UnpermittedParameters do
+      self.class.auth_source_ldap_params_filter.filter_params(params, context)
+    end
   end
 end

--- a/test/controllers/concerns/parameters/user_test.rb
+++ b/test/controllers/concerns/parameters/user_test.rb
@@ -18,7 +18,9 @@ class UserParametersTest < ActiveSupport::TestCase
     test "blocks :admin if current user is not an admin" do
       params = ActionController::Parameters.new(:user => {:admin => true})
       as_user(FactoryBot.create(:user)) do
-        refute_includes self.class.user_params_filter.filter_params(params, context), 'admin'
+        assert_raises ActionController::UnpermittedParameters do
+          self.class.user_params_filter.filter_params(params, context)
+        end
       end
     end
 
@@ -37,7 +39,9 @@ class UserParametersTest < ActiveSupport::TestCase
     test "blocks role attributes" do
       params = ActionController::Parameters.new(:user => {:roles => ['a'], :role_ids => [1], :role_names => ['a']})
       as_user(FactoryBot.create(:user)) do
-        assert_empty self.class.user_params_filter.filter_params(params, context)
+        assert_raises ActionController::UnpermittedParameters do
+          self.class.user_params_filter.filter_params(params, context)
+        end
       end
     end
   end


### PR DESCRIPTION
Currently we silently filter out parameters (or log in production),
causing unexpected results when passing an invalid param (either
incorrect name or incorrect type). This can lead to unexpected results,
since the user, seeing no error, assumes the request was successful when
in fact some of the parameters were filtered out.