### PR TITLE
Fixes #22310 - Implement report scanner to identify origin

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -44,4 +44,20 @@ module ReportsHelper
              {}, {:class=>"col-md-1 form-control", :onchange =>"filter_by_level(this);"})
     end
   end
+
+  def report_origin_icon(origin)
+    return 'N/A' if origin.blank?
+    origin_icon = self.try("#{origin.downcase}_report_origin_icon".to_sym)
+    image_tag(origin_icon || origin + ".png", :title => _("Reported by %s") % origin)
+  end
+
+  def report_origin_output_partial(origin)
+    return report_default_partial if origin.blank?
+    origin_partial = self.try("#{origin.downcase}_report_origin_partial".to_sym)
+    origin_partial || report_default_partial
+  end
+
+  def report_default_partial
+    'output'.freeze
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -28,6 +28,7 @@ class Report < ApplicationRecord
 
       scoped_search :on => :reported_at, :complete_value => true, :default_order => :desc, :rename => :reported, :only_explicit => true
       scoped_search :on => :host_id,     :complete_value => false, :only_explicit => true
+      scoped_search :on => :origin
     end
     super
   end

--- a/app/registries/foreman/plugin/report_scanner_registry.rb
+++ b/app/registries/foreman/plugin/report_scanner_registry.rb
@@ -1,0 +1,38 @@
+require_dependency File.expand_path('../../../../services/report_scanner/puppet_report_scanner', __FILE__)
+
+module Foreman
+  class Plugin
+    class ReportScannerRegistry
+      DEFAULT_REPORT_SCANNERS = [
+        ::Foreman::PuppetReportScanner
+      ].freeze
+
+      attr_accessor :report_scanners
+
+      def initialize
+        @report_scanners = []
+        register_default_scanner
+      end
+
+      def report_scanners
+        @report_scanners ||= []
+      end
+
+      def register_report_scanner(scanner)
+        @report_scanners = (report_scanners << scanner).uniq
+      end
+
+      def unregister_report_scanner(scanner)
+        @report_scanners -= [scanner]
+      end
+
+      private
+
+      def register_default_scanner
+        DEFAULT_REPORT_SCANNERS.each do |default_scanner|
+          register_report_scanner default_scanner
+        end
+      end
+    end
+  end
+end

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -1,6 +1,6 @@
 class ReportImporter
   delegate :logger, :to => :Rails
-  attr_reader :report
+  attr_reader :report, :report_scanners
 
   # When writing your own Report importer, provide feature(s) of authorized Smart Proxies
   def self.authorized_smart_proxy_features
@@ -42,6 +42,15 @@ class ReportImporter
       refreshed_time = Time.now
       logger.info("Imported report for #{name} in #{(imported_time - start_time).round(2)} seconds, status refreshed in #{(refreshed_time - imported_time).round(2)} seconds")
     end
+  end
+
+  def scan
+    logger.info "Scanning report with: #{report_scanners.join(', ')}"
+    logger.info logs.inspect
+    report_scanners.each do |scanner|
+      break if scanner.scan(report, logs)
+    end
+    logger.debug "Changes after scanning: #{report.changes.inspect}"
   end
 
   private
@@ -130,10 +139,17 @@ class ReportImporter
     host.save(:validate => false)
 
     status = report_status
-
     # and save our report
     @report = report_name_class.new(:host => host, :reported_at => time, :status => status, :metrics => raw['metrics'])
+
+    # Run report scanner
+    scan
+
     @report.save
     @report
+  end
+
+  def report_scanners
+    Foreman::Plugin.report_scanner_registry.report_scanners
   end
 end

--- a/app/services/report_scanner/puppet_report_scanner.rb
+++ b/app/services/report_scanner/puppet_report_scanner.rb
@@ -1,0 +1,17 @@
+module Foreman
+  class PuppetReportScanner
+    class << self
+      def scan(report, logs)
+        if is_puppet = puppet_report?(logs)
+          report.origin = 'Puppet'
+        end
+        is_puppet
+      end
+
+      def puppet_report?(logs)
+        first_log = logs.first
+        first_log && first_log['log'].fetch('sources', {}).fetch('source', '') =~ /Puppet/
+      end
+    end
+  end
+end

--- a/app/views/config_reports/_list.html.erb
+++ b/app/views/config_reports/_list.html.erb
@@ -5,6 +5,7 @@
       <th><%= sort :host, :as => _("Host") %></th>
       <% end %>
       <th><%= sort :reported, :as => _("Last report") %></th>
+      <th class="col-md-1 fact-origin"><%= sort :origin, :as => _('Origin') %></th>
       <th class="col-md-1"><%= sort :applied, :as => _("Applied") %></th>
       <th class="col-md-1"><%= sort :restarted, :as => _("Restarted") %></th>
       <th class="col-md-1"><%= sort :failed, :as => _("Failed") %></th>
@@ -25,6 +26,7 @@
           <% end %>
         <% end %>
         <td><%= reported_at_column(report) %></td>
+        <td class="fact-origin"><%= report_origin_icon(report.origin) %></td>
         <td><%= report_event_column(report.applied, "label-info") %></td>
         <td><%= report_event_column(report.restarted, "label-info") %></td>
         <td><%= report_event_column(report.failed, "label-danger") %></td>

--- a/app/views/config_reports/show.html.erb
+++ b/app/views/config_reports/show.html.erb
@@ -12,7 +12,7 @@
 
 <% content_for(:search_bar) {logs_show} %>
 
-<%= render 'output', :logs => @config_report.logs%>
+<%= render report_origin_output_partial(@config_report.origin), :logs => @config_report.logs %>
 <%= render 'metrics', :status => @config_report.status, :metrics => @config_report.metrics["time"] if @config_report.metrics["time"] %>
 
 <%= title_actions link_to(_('Back'), :back, :class => 'btn btn-default'),

--- a/db/migrate/20180111130853_add_config_reports_origin.rb
+++ b/db/migrate/20180111130853_add_config_reports_origin.rb
@@ -1,0 +1,5 @@
+class AddConfigReportsOrigin < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reports, :origin, :string
+  end
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -567,4 +567,29 @@ class PluginTest < ActiveSupport::TestCase
       assert_equal "My Tab", ::Pagelets::Manager.pagelets_at("tests/show", :main_tabs).first.name
     end
   end
+
+  describe 'Report scanner' do
+    subject { Foreman::Plugin.register('test') {} }
+    let(:report_scanner) { stub_everything('Object') }
+
+    describe '.register_report_scanner' do
+      it 'adds a class to report_scanner' do
+        refute subject.class.registered_report_scanners.include? report_scanner
+        subject.register_report_scanner report_scanner
+        assert subject.class.registered_report_scanners.include? report_scanner
+      end
+    end
+
+    describe '.unregister_report_scanner' do
+      before do
+        subject.register_report_scanner report_scanner
+      end
+
+      it 'removes a class to report_scanner' do
+        assert subject.class.registered_report_scanners.include? report_scanner
+        subject.unregister_report_scanner report_scanner
+        refute subject.class.registered_report_scanners.include? report_scanner
+      end
+    end
+  end
 end

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -132,6 +132,24 @@ class ReportImporterTest < ActiveSupport::TestCase
     reporter.send(:host).expects(:refresh_statuses).with([])
     reporter.import
   end
+
+  describe 'Report scanning' do
+    let(:report_scanner) { stub_everything('TestReportScanner') }
+    let(:report) { read_json_fixture('reports/empty.json') }
+
+    describe '.scan' do
+      let(:importer) { TestReportImporter.new(report) }
+      setup do
+        importer.stubs(:report_scanners).returns([report_scanner])
+        importer.send(:create_report_and_logs)
+      end
+
+      it 'calls scan with the report on scanner' do
+        report_scanner.expects(:scan)
+        importer.send(:scan)
+      end
+    end
+  end
 end
 
 class TestReportImporter < ReportImporter

--- a/test/unit/report_scanner/puppet_report_scanner_test.rb
+++ b/test/unit/report_scanner/puppet_report_scanner_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class PuppetReportScannerTest < ActiveSupport::TestCase
+  subject { Foreman::PuppetReportScanner }
+
+  describe '.scan' do
+    let(:report) { stub_everything('ConfigReport') }
+
+    it 'sets the report origin to Puppet when puppet_report? returns true' do
+      assert_nil report.origin
+      subject.expects(:puppet_report?).returns(true)
+      report.expects(:"origin=").with('Puppet')
+      assert subject.scan(report, [])
+    end
+
+    it 'sets the report NO origin when puppet_report? returns false' do
+      assert_nil report.origin
+      subject.expects(:puppet_report?).returns(false)
+      report.expects(:"origin=").never
+      refute subject.scan(report, [])
+    end
+  end
+
+  describe '.puppet_report' do
+    let(:example_puppet_logs) do
+      [
+        {
+          "log" => {
+            "sources" => {
+              "source" => "//scapclient.example.tst/Puppet"
+            }
+          }
+        }
+      ]
+    end
+
+    it 'returns true if the source of the first log is puppet' do
+      assert subject.puppet_report?(example_puppet_logs)
+    end
+
+    it 'returns false if "Puppet" is not found in the source' do
+      example_puppet_logs.first['log']['sources']['source'] = 'AnotherReporting'
+      refute subject.puppet_report?(example_puppet_logs)
+    end
+  end
+end


### PR DESCRIPTION
Report scanner provide an interface for plugins to add callbacks and process them after they have been saved.

The first use is to set an origin for reports submitted by Puppet. 
The origin set is also shown in the report overview.

An implementation for Ansible is also implemented in [foreman-ansible](https://github.com/theforeman/foreman_ansible/pull/116).