### PR TITLE
Fixes #22199 - Audit has_many associations

### DIFF
--- a/app/models/concerns/audit_associations.rb
+++ b/app/models/concerns/audit_associations.rb
@@ -1,0 +1,62 @@
+module AuditAssociations
+  def self.included(base)
+    base.send :include, InstanceMethods
+  end
+
+  module InstanceMethods
+    def changes_to_save
+      if audited_options[:associations].present?
+        super.merge(associated_changes)
+      else
+        super
+      end
+    end
+
+    private
+
+    def associated_changes
+      associations = Array.wrap(audited_options[:associations])
+      associations.inject({}) do |changes_hash, association_name|
+        association_ids = "#{association_name.to_s.singularize}_ids"
+
+        if send("#{association_ids}_changed?")
+          association_class = self.class.reflect_on_association(association_name).class_name.constantize
+          change = send("#{association_ids}_change")
+          change_ids = change.flatten.uniq
+
+          id_name_map = association_class.where(id: change_ids).inject({}) { |r,p| r.merge(p.id => p.to_label) }
+
+          changes_hash[association_name] = change.inject([]) do |humaized_associations, ids|
+            humaized_associations << ids.inject([]) do |humanized_ids, id|
+              humanized_ids << id_name_map[id]
+              humanized_ids
+            end.join(', ')
+            humaized_associations
+          end
+        end
+
+        changes_hash
+      end
+    end
+  end
+
+  module Auditor
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      include Audited::Auditor::ClassMethods
+
+      def audited(options = {})
+        if options[:associations].present?
+          include DirtyAssociations
+
+          dirty_has_many_associations(*(Array(options[:associations])))
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/app/models/concerns/dirty_associations.rb
+++ b/app/models/concerns/dirty_associations.rb
@@ -57,6 +57,10 @@ module DirtyAssociations
               value
             end
           end
+
+          define_method "#{association_ids}_change" do
+            [self.send("#{association_ids}_was"), self.send(association_ids)]
+          end
         end
       end
       self.prepend(extension)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,6 @@ class User < ApplicationRecord
   include UserUsergroupCommon
   include Exportable
   include TopbarCacheExpiry
-  audited :except => [:last_login_on, :password_hash, :password_salt, :password_confirmation]
 
   ANONYMOUS_ADMIN = 'foreman_admin'
   ANONYMOUS_API_ADMIN = 'foreman_api_admin'
@@ -121,6 +120,9 @@ class User < ApplicationRecord
   }
 
   dirty_has_many_associations :roles
+
+  audited :except => [:last_login_on, :password_hash, :password_salt, :password_confirmation],
+          :associations => :roles
 
   attr_exportable :firstname, :lastname, :mail, :description, :fullname, :name => ->(user) { user.login }, :ssh_authorized_keys => ->(user) { user.ssh_keys.map(&:to_export_hash) }
 

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -1,5 +1,4 @@
 class Usergroup < ApplicationRecord
-  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -22,7 +21,7 @@ class Usergroup < ApplicationRecord
   has_many :cached_usergroups, :through => :cached_usergroup_members, :source => :usergroup
   has_many :cached_usergroup_members, :foreign_key => 'usergroup_id'
   has_many :usergroup_parents, -> { where("member_type = 'Usergroup'") }, :dependent => :destroy,
-    :foreign_key => 'member_id', :class_name => 'UsergroupMember'
+           :foreign_key => 'member_id', :class_name => 'UsergroupMember'
   has_many :parents,    :through => :usergroup_parents, :source => :usergroup, :dependent => :destroy
 
   has_many_hosts :as => :owner
@@ -39,6 +38,8 @@ class Usergroup < ApplicationRecord
   validate :ensure_uniq_name, :ensure_last_admin_remains_admin
 
   accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
+
+  audited :associations => [:usergroups, :roles, :users]
 
   class Jail < ::Safemode::Jail
     allow :ssh_keys, :all_users, :ssh_authorized_keys

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -4,3 +4,9 @@ require 'audited'
 
 Audit = Audited::Audit
 Audit.send(:include, AuditExtensions)
+
+# Re-opened AuditorInstanceMethods to audit 1-0-* associations
+Auditor = Audited::Auditor::AuditedInstanceMethods
+Auditor.send(:include, AuditAssociations)
+
+::ActiveRecord::Base.send :include, AuditAssociations::Auditor


### PR DESCRIPTION
@ares 
This is how associational audits will look like(Stored in a single parent object). It's the first iteration, we can customize it further to have links to resources(once non-existent resources are thought of) and audit comments like:
```
Role "my viewer" has a new permission :view_hosts" 
User "someone" roles changed, new roles are "my viewer", "manager"
```

![associational-audits](https://user-images.githubusercontent.com/1291980/35089138-09892cd6-fc5c-11e7-994d-85345a629a09.png)

---
This PR is WIP because it's a POC implementation of associational audits and needs review/feedback.