### PR TITLE
Fixes #22339 - normalize empty values for User.timezone

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,7 @@ class User < ApplicationRecord
                     :unless => Proc.new {|user| user.password.empty?}
   before_validation :prepare_password, :normalize_mail
   before_save       :set_lower_login
+  before_save       :normalize_timezone
 
   after_create :welcome_mail
   after_create :set_default_widgets
@@ -552,6 +553,10 @@ class User < ApplicationRecord
 
   def normalize_locale
     self.locale = nil if self.respond_to?(:locale) && locale.empty?
+  end
+
+  def normalize_timezone
+    self.timezone = nil if timezone.blank?
   end
 
   def normalize_mail

--- a/db/migrate/20180119205740_change_user_timezone_empty_to_nil.rb
+++ b/db/migrate/20180119205740_change_user_timezone_empty_to_nil.rb
@@ -1,0 +1,13 @@
+class ChangeUserTimezoneEmptyToNil < ActiveRecord::Migration[4.2]
+  class FakeUser < ApplicationRecord
+    self.table_name = 'users'
+  end
+
+  def up
+    FakeUser.where(:timezone => '').update_all(:timezone => nil)
+  end
+
+  def down
+    # no action: we don't know which data should be '' and which nil
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -902,10 +902,12 @@ class UserTest < ActiveSupport::TestCase
     refute user.valid?
   end
 
-  test 'timezone can be blank' do
+  test 'empty timezone is normalized to nil' do
     user = users(:one)
     user.timezone = ''
     assert user.valid?
+    user.save
+    user.timezone.must_be_nil
   end
 
   test "changing user password as admin without setting current password" do


### PR DESCRIPTION
Otherwise, we would need to deal with two values for the browser's
timezone. Less variants is better in this case.