### PR TITLE
Fixes #22348 - pin redux-form to v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-onclickoutside": "^6.6.2",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
-    "redux-form": "^7.2.0",
+    "redux-form": "7.2.0",
     "redux-form-validators": "^2.1.2",
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",


### PR DESCRIPTION
Currently, all Travis tests are failing because redux-form released a new version (7.2.1).

This is a temporary fix until we resolve this issue.

**Test result:**
https://travis-ci.org/theforeman/foreman/jobs/330761776#L4877

**Test code:**
https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/bookmarks/form/form.test.js#L35

**Foreman issue:**
http://projects.theforeman.org/issues/22348

**ReduxForm issue:**
https://github.com/erikras/redux-form/issues/3771
