### PR TITLE
Fixes #22349 - Travis CI should run with npm v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
   - '6.10' # current EPEL 7
-  - '6' # current LTS
-  - '8' # current stable
+  - '6' # previous LTS
+  - '8' # current LTS
 before_install:
   - cp config/settings.yaml.example config/settings.yaml
   - bundle install --without console development ec2 fog gce jsonp libvirt mysql2 openid openstack ovirt postgresql rackspace sqlite test vmware
-  - npm install -g npm@'>=3.0.0, <5.0.0'
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
Currently, Travis configured to run with npm < 5
https://github.com/theforeman/foreman/blob/develop/.travis.yml#L9

We should let nvm to fetch node together with a compatible npm version.