### PR TITLE
Fixes #22351 - update react-ellipsis-with-tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",
     "react-dom": "^16.2.0",
-    "react-ellipsis-with-tooltip": "^1.0.6",
+    "react-ellipsis-with-tooltip": "^1.0.7",
     "react-numeric-input": "^2.0.7",
     "react-onclickoutside": "^6.6.2",
     "react-redux": "^5.0.2",


### PR DESCRIPTION
This release adds description and license type into `package.json`, which is required.