### PR TITLE
Fixes #21328 - Correct link to HTTP proxy documentation

### DIFF
--- a/app/views/http_proxies/welcome.html.erb
+++ b/app/views/http_proxies/welcome.html.erb
@@ -6,7 +6,7 @@
   <p>
     <%= _("Defining HTTP Proxies that exist on your network allows you to perform various actions through those proxies.") %></br>
   </p>
-  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4Provisioning")%></p>
+  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("5.9HTTP(S)Proxy")%></p>
   <div class="blank-slate-pf-main-action">
       <%= new_link(_("New HTTP Proxy"), {}, { :class => "btn-lg" }) %>
   </div>


### PR DESCRIPTION
(cherry picked from commit c422c3147af6a2229465d8d1fab5666365034b79)