### PR TITLE
Fixes #22354 - Make SilencedLogger thread safe

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -2,8 +2,6 @@ require 'logging'
 require 'fileutils'
 require_dependency File.expand_path('../silenced_logger', __FILE__)
 
-::Logging::Logger.send(:include, ActiveRecord::SessionStore::Extension::LoggerSilencer)
-
 module Foreman
   class LoggingImpl
     private_class_method :new

--- a/lib/foreman/silenced_logger.rb
+++ b/lib/foreman/silenced_logger.rb
@@ -1,16 +1,47 @@
 # Wrap a ::Logging::Logger and implement #silence to temporarily increase the
 # min log level to execute a block of code. Used by sprockets-rails' quiet
-# assets logging feature.
+# assets logging feature. Foreman uses logging gem instead Rails logging stack
+# and it does not provide silencing feature (ships with just a noop method).
+# This implementation only works with Logging gem, not with Ruby/Rails Logger.
+#
+# Inspired by lib/active_record/session_store/extension/logger_silencer.rb
+#
 module Foreman
   class SilencedLogger < SimpleDelegator
-    def silence(new_level = Logger::ERROR, &block)
-      old_level = self.level
-      begin
-        self.level = new_level
-        yield self
-      ensure
-        self.level = old_level
+    def initialize(obj)
+      ::Logging::LEVELS.each do |name, num|
+        instance_eval <<-EOT, __FILE__, __LINE__ + 1
+        def #{name.downcase}?
+          #{num} >= local_level
+        end
+
+        def #{name.downcase}(*args)
+          super(*args) if #{num} >= local_level
+        end
+        EOT
       end
+
+      super(obj)
     end
+
+    def level_key
+      @level_key ||= :"SilencedLogger##{object_id}@level"
+    end
+
+    def local_level
+      Thread.current[level_key] || self.level
+    end
+
+    def local_level=(level)
+      Thread.current[level_key] = level
+    end
+
+    def silence(temporary_level = Logger::ERROR, &block)
+      self.local_level = temporary_level
+      yield self
+    ensure
+      self.local_level = nil
+    end
+    alias :silence_logger :silence
   end
 end


### PR DESCRIPTION
Rails logger silencer code was thread safe for some time:

https://github.com/rails/rails/commit/629efb605728b31ad9644f6f0acaf3760b641a29

But this has been refactored in Rails 5.0 and thread safety is now part of logger instead of silencer:

https://github.com/rails/rails/commit/2518bda97cbbcb33dc9a92e70d5b01c09e64d12d

The patch made assumption that all Rails applications are using Rails logging stack, but that's not the case for Foreman - we rely on much more flexible "logging" gem (https://github.com/TwP/logging) which does not implement this type of thread safety for levels.

Foreman has its own logging delegator called SilencedLogger and the code there was never thread safe, concurrent sprockets requests are now using silence method which is not thread safe at all, with logging gem this leads to level set to ERROR (the default) after few requests in development mode which renders Foreman unusable (no debug logging output). This patch uses the same technique and stores temporary levels into thread-only context, so on concurrent access there are no incorrect readouts.