### PR TITLE
Fixes #22358 - add templates importing

### DIFF
--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -8,6 +8,7 @@ class Ptable < Template
   friendly_id :name
   include Parameterizable::ByIdName
   include ValidateOsFamily
+  include DirtyAssociations
 
   class << self
     # we have to override the base_class because polymorphic associations does not detect it correctly, more details at
@@ -44,6 +45,8 @@ class Ptable < Template
 
   attr_exportable :os_family
 
+  dirty_has_many_associations :operatingsystems
+
   # with proc support, default_scope can no longer be chained
   # include all default scoping here
   default_scope lambda {
@@ -62,5 +65,13 @@ class Ptable < Template
 
   def taxonomy_foreign_conditions
     { :ptable_id => id }
+  end
+
+  private
+
+  def import_custom_data(options)
+    import_oses(options)
+
+    self.os_family = self.operatingsystems.first.family if self.operatingsystem_ids.present?
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -106,12 +106,12 @@ Foreman::AccessControl.map do |permission_set|
                                       }
     map.permission :create_provisioning_templates,  {:provisioning_templates => [:new, :create, :clone_template],
                                         :"api/v2/config_templates" => [:create, :clone],
-                                        :"api/v2/provisioning_templates" => [:create, :clone],
+                                        :"api/v2/provisioning_templates" => [:create, :clone, :import],
                                         :"api/v2/template_combinations" => [:create]
                                       }
     map.permission :edit_provisioning_templates,    {:provisioning_templates => [:edit, :update],
                                         :"api/v2/config_templates" => [:update],
-                                        :"api/v2/provisioning_templates" => [:update],
+                                        :"api/v2/provisioning_templates" => [:update, :import],
                                         :"api/v2/template_combinations" => [:update]
                                       }
     map.permission :destroy_provisioning_templates, {:provisioning_templates => [:destroy],
@@ -482,10 +482,10 @@ Foreman::AccessControl.map do |permission_set|
                                       :"api/v2/ptables" => [:index, :show, :revision, :export]
     }
     map.permission :create_ptables, {:ptables => [:new, :create, :clone_template],
-                                      :"api/v2/ptables" => [:create, :clone]
+                                      :"api/v2/ptables" => [:create, :clone, :import]
     }
     map.permission :edit_ptables, {:ptables => [:edit, :update],
-                                      :"api/v2/ptables" => [:update]
+                                      :"api/v2/ptables" => [:update, :import]
     }
     map.permission :destroy_ptables, {:ptables => [:destroy],
                                       :"api/v2/ptables" => [:destroy]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -46,6 +46,7 @@ Foreman::Application.routes.draw do
         collection do
           post 'build_pxe_default'
           get 'revision'
+          post :import
         end
         resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]
@@ -156,6 +157,7 @@ Foreman::Application.routes.draw do
         end
         collection do
           get 'revision'
+          post :import
         end
 
         resources :operatingsystems, :except => [:new, :edit]

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -128,7 +128,7 @@ class ActiveSupport::TestCase
 
   # if a method receieves a block it will be yielded just before user save
   def setup_user(operation, type = "", search = nil, user = :one)
-    @one = users(user)
+    @one = user.is_a?(User) ? user : users(user)
     as_admin do
       permission = Permission.find_by_name("#{operation}_#{type}") ||
         FactoryBot.build(:permission, :name => "#{operation}_#{type}")

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -108,4 +108,11 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     get :index, params: { :operatingsystem_id => operatingsystems(:centos5_3).fullname }
     assert_response :success
   end
+
+  test "should import provisioning template" do
+    snippet = FactoryBot.create(:provisioning_template, :snippet)
+    post :import, params: { :provisioning_template => { :name => snippet.name, :template => "<%#\nsnippet: true\n-%>\nbbbb"} }
+    assert_response :success
+    assert_match 'bbbb', ProvisioningTemplate.unscoped.find_by_name(snippet.name).template
+  end
 end

--- a/test/controllers/api/v2/ptables_controller_test.rb
+++ b/test/controllers/api/v2/ptables_controller_test.rb
@@ -98,4 +98,11 @@ class Api::V2::PtablesControllerTest < ActionController::TestCase
                            :ptable => {:name => ''} }
     assert_response :unprocessable_entity
   end
+
+  test "should import partition table" do
+    ptable = FactoryBot.create(:ptable, :template => 'a')
+    post :import, params: { :ptable => { :name => ptable.name, :template => 'b'} }
+    assert_response :success
+    assert_equal 'b', Ptable.unscoped.find_by_name(ptable.name).template
+  end
 end

--- a/test/models/ptable_test.rb
+++ b/test/models/ptable_test.rb
@@ -85,4 +85,18 @@ class PtableTest < ActiveSupport::TestCase
     assert_includes lines, "os_family: #{ptable.os_family}"
     assert_includes lines, "name: #{ptable.name}"
   end
+
+  context 'importing' do
+    describe '#import_custom_data' do
+      test 'it sets the family based on assigned oses' do
+        template = Ptable.new
+        os1 = FactoryBot.create(:debian7_0)
+        os2 = FactoryBot.create(:suse)
+        template.operatingsystem_ids = [os1.id, os2.id]
+        template.stubs :import_oses => true
+        template.send(:import_custom_data, {})
+        assert_equal 'Debian', template.os_family
+      end
+    end
+  end
 end

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -67,7 +67,7 @@ below"
 
     test "metadata are detected by name attribute on any comment line" do
       lines = @template.template.lines
-      @template.template = [ lines[0], 'another: comment', lines[1..-1] ].flatten.join("\n")
+      @template.template = [lines[0], 'another: comment', lines[1..-1]].flatten.join("\n")
       without = @template.template_without_metadata
       refute_includes without, 'name: basic'
     end
@@ -113,6 +113,262 @@ data"
       @template.template = "<?xml ...>\n" + @template.template
       @template.stub(:metadata, "METADATA") do
         assert_equal "<?xml ...>\nMETADATA\ndata", @template.to_erb
+      end
+    end
+  end
+
+  context "importing" do
+    setup do
+      @snippet_text = <<EOS
+<%#
+kind: snippet
+name: epel
+model: ProvisioningTemplate
+snippet: true
+-%>
+rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+EOS
+      @template = Template.new
+    end
+
+    describe '.import_without_save' do
+      test 'it does match existing template by name' do
+        existing = FactoryBot.create(:ptable)
+        assert_equal existing.id, Template.import_without_save(existing.name, @snippet_text).id
+      end
+
+      test 'it builds a new object if there is no template with such name and it initializes the name attribute' do
+        template = Template.import_without_save('absolutely_new_template_snippet', @snippet_text)
+        assert template.new_record?
+        assert_equal 'absolutely_new_template_snippet', template.name
+        assert_kind_of Template, template
+        assert template.snippet
+      end
+
+      test 'it searches templates regardless of current scope, validations prevent permission exceeding' do
+        existing = FactoryBot.create(:ptable, :name => 'epel', :organization_ids => [taxonomies(:organization2).id])
+        in_taxonomy(taxonomies(:organization1)) do
+          assert_equal existing.id, Template.import_without_save(existing.name, @snippet_text).id
+        end
+      end
+    end
+
+    describe '.parse_metadata' do
+      test 'parses yaml from first comment' do
+        result = Template.parse_metadata(@snippet_text)
+        assert_equal 'snippet', result[:kind]
+        assert_equal 'snippet', result['kind']
+        assert_equal true, result['snippet']
+      end
+
+      test 'it ignores other erb tags' do
+        assert_nothing_raised do
+          assert_equal({}, Template.parse_metadata('<% puts 1 %>'))
+        end
+      end
+
+      test 'it does not fail on invalid metadata, it just silently ignores them' do
+        assert_nothing_raised do
+          assert_equal({}, Template.parse_metadata("<%#\n: %>"))
+        end
+      end
+    end
+
+    describe '.import!' do
+      test 'by default it does not ignore locking' do
+        template = Minitest::Mock.new
+        template.expect(:save!, true)
+        Template.expects(:import_without_save => template)
+        Template.import!('test', '')
+        template.verify
+      end
+
+      test 'locking can be overriden by force option' do
+        template = Minitest::Mock.new
+        template.expect(:ignore_locking, true)
+        Template.expects(:import_without_save => template)
+        Template.import!('test', '', :force => true)
+        template.verify
+      end
+    end
+
+    describe "#import_without_save" do
+      setup do
+        @template.import_without_save(@snippet_text)
+      end
+
+      test 'it parses metadata' do
+        metadata = @template.instance_variable_get('@importing_metadata')
+        metadata_keys = metadata.keys
+        assert_includes metadata_keys, 'kind'
+        assert_includes metadata_keys, 'name'
+        assert_includes metadata_keys, 'model'
+        assert_includes metadata_keys, 'snippet'
+        assert_not_includes metadata_keys, 'description'
+      end
+
+      test 'it sets the snippet flag' do
+        assert @template.snippet, 'template was not marked as a snippet'
+      end
+
+      test 'snippet flag defaults to false' do
+        text = @template.template.sub /snippet: true\n/, ''
+        @template = Template.new
+        @template.expects :import_locations
+        @template.expects :import_organizations
+        @template.expects :import_custom_data
+        assert_kind_of @template.class, @template.import_without_save(text)
+        refute @template.snippet, 'template was not marked as a snippet'
+      end
+
+      test 'does not save the template' do
+        assert @template.new_record?
+      end
+    end
+
+    describe '#associate_metadata_on_import?' do
+      setup do
+        @new_template = Template.new
+        @existing = FactoryBot.create(:provisioning_template)
+      end
+
+      test 'it return true for when associate options is always' do
+        assert @new_template.send(:associate_metadata_on_import?, :associate => 'always')
+        assert @existing.send(:associate_metadata_on_import?, :associate => 'always')
+      end
+
+      test 'it returns true when associate options is new and object is new record' do
+        assert @new_template.send(:associate_metadata_on_import?, :associate => 'new')
+        refute @existing.send(:associate_metadata_on_import?, :associate => 'new')
+      end
+
+      test 'it returns true when associate options is new and object is never or not specified' do
+        refute @new_template.send(:associate_metadata_on_import?, :associate => 'never')
+        refute @existing.send(:associate_metadata_on_import?, :associate => 'never')
+        refute @new_template.send(:associate_metadata_on_import?, {})
+        refute @existing.send(:associate_metadata_on_import?, {})
+      end
+    end
+
+    describe '#import_organizations' do
+      setup do
+        @template = ProvisioningTemplate.new
+        @org1 = FactoryBot.create(:organization)
+        @org2 = FactoryBot.create(:organization)
+        @org3 = FactoryBot.create(:organization)
+      end
+
+      test 'it ignores organizations if none was set in metadata and sets current organization' do
+        @template.instance_variable_set '@importing_metadata', {}
+        in_taxonomy(@org1) do
+          @template.send(:import_organizations, :associate => 'always')
+        end
+        assert_equal [@org1.id], @template.organization_ids
+      end
+
+      test 'it associates organizations with matching prefix' do
+        @template.instance_variable_set '@importing_metadata', { 'organizations' => [@org1.name, @org2.name] }
+        @template.send(:import_organizations, :associate => 'always')
+        assert_includes @template.organization_ids, @org1.id
+        assert_includes @template.organization_ids, @org2.id
+        refute_includes @template.organization_ids, @org3.id
+      end
+
+      test 'unknown organizations are ignored' do
+        @template.instance_variable_set '@importing_metadata', { 'organizations' => ['not_available'] }
+        assert_nothing_raised { @template.send(:import_oses, :associate => 'always') }
+      end
+
+      test 'associated organizations are authorized for current user' do
+        @template.instance_variable_set '@importing_metadata', { 'organizations' => [@org1.name, @org2.name, @org3.name] }
+        user = FactoryBot.create(:user, :organization_ids => [@org2.id], :location_ids => [taxonomies(:location1).id])
+        setup_user 'view', 'organizations', "name = #{@org2}", user
+        as_user user do
+          @template.send(:import_organizations, :associate => 'always')
+        end
+        refute_includes @template.organization_ids, @org1.id
+        assert_includes @template.organization_ids, @org2.id
+        refute_includes @template.organization_ids, @org3.id
+      end
+    end
+
+    describe '#import_locations' do
+      setup do
+        @template = ProvisioningTemplate.new
+        @loc1 = FactoryBot.create(:location)
+        @loc2 = FactoryBot.create(:location)
+        @loc3 = FactoryBot.create(:location)
+      end
+
+      test 'it ignores locations if none was set in metadata and sets current location' do
+        @template.instance_variable_set '@importing_metadata', {}
+        in_taxonomy(@loc1) do
+          @template.send(:import_locations, :associate => 'always')
+        end
+        assert_equal [@loc1.id], @template.location_ids
+      end
+
+      test 'it associates locations with matching prefix' do
+        @template.instance_variable_set '@importing_metadata', { 'locations' => [@loc1.name, @loc2.name] }
+        @template.send(:import_locations, :associate => 'always')
+        assert_includes @template.location_ids, @loc1.id
+        assert_includes @template.location_ids, @loc2.id
+        refute_includes @template.location_ids, @loc3.id
+      end
+
+      test 'unknown locations are ignored' do
+        @template.instance_variable_set '@importing_metadata', { 'locations' => ['not_available'] }
+        assert_nothing_raised { @template.send(:import_oses, :associate => 'always') }
+      end
+
+      test 'associated locations are authorized for current user' do
+        @template.instance_variable_set '@importing_metadata', { 'locations' => [@loc1.name, @loc2.name, @loc3.name] }
+        user = FactoryBot.create(:user, :location_ids => [@loc2.id], :organization_ids => [taxonomies(:organization1).id])
+        setup_user 'view', 'locations', "name = #{@loc2}", user
+        as_user user do
+          @template.send(:import_locations, :associate => 'always')
+        end
+        refute_includes @template.location_ids, @loc1.id
+        assert_includes @template.location_ids, @loc2.id
+        refute_includes @template.location_ids, @loc3.id
+      end
+    end
+
+    describe '#import_oses' do
+      setup do
+        @template = ProvisioningTemplate.new
+        @os1 = FactoryBot.create(:operatingsystem, :name => 'my_new_os_1')
+        @os2 = FactoryBot.create(:operatingsystem, :name => 'my_new_os_2')
+        @os3 = FactoryBot.create(:operatingsystem, :name => 'net_new_os')
+      end
+
+      test 'it ignores oses if none was set in metadata' do
+        @template.instance_variable_set '@importing_metadata', {}
+        assert_nil @template.send(:import_oses, :associate => 'always')
+      end
+
+      test 'it associates operating systems with matching prefix' do
+        @template.instance_variable_set '@importing_metadata', { 'oses' => ['my_new_os'] }
+        @template.send(:import_oses, :associate => 'always')
+        assert_includes @template.operatingsystem_ids, @os1.id
+        assert_includes @template.operatingsystem_ids, @os2.id
+        refute_includes @template.operatingsystem_ids, @os3.id
+      end
+
+      test 'unknown oses are ignored' do
+        @template.instance_variable_set '@importing_metadata', { 'oses' => ['not_available'] }
+        assert_nothing_raised { @template.send(:import_oses, :associate => 'always') }
+      end
+
+      test 'associated operating systems are authorized for viewing' do
+        @template.instance_variable_set '@importing_metadata', { 'oses' => ['my_new_os'] }
+        user = FactoryBot.create(:user, :organization_ids => [taxonomies(:organization1).id], :location_ids => [taxonomies(:location1).id])
+        setup_user 'view', 'operatingsystems', "name = #{@os1}", user
+        as_user user do
+          @template.send(:import_oses, :associate => 'always')
+        end
+        assert_includes @template.operatingsystem_ids, @os1.id
+        refute_includes @template.operatingsystem_ids, @os2.id
       end
     end
   end


### PR DESCRIPTION
The importing is easily extendable for other template types. It's based on the logic in foreman_templates but refactored so each subtype can add its own metadata parsing logic.