### PR TITLE
Fixes #22402 - Adds a config for docker and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.4.3-alpine3.7
+RUN apk update && \
+    apk add --virtual build_deps \
+    build-base ruby-dev libc-dev linux-headers \
+    postgresql-dev libxml2-dev \
+    libvirt-dev mariadb-dev sqlite-dev && \
+    apk add nodejs yarn libxslt-dev python tzdata && \
+    gem install nokogiri -- --use-system-libraries
+
+# foreman minimum config for gems and node modules
+RUN mkdir -p /app/config/
+RUN mkdir -p /app/script/
+RUN mkdir -p /app/app/registries/foreman/
+RUN mkdir -p /app/bundler.d/
+COPY Gemfile package.json /app/
+COPY config/boot_settings.rb config/settings.yaml config/settings.yaml.dist /app/config/
+COPY script/npm_install_plugins.js script/plugin_webpack_directories.js script/plugin_webpack_directories.rb /app/script/
+COPY app/registries/foreman/webpack_assets.rb /app/app/registries/foreman/
+COPY bundler.d/* /app/bundler.d/
+
+# set home dir
+ENV APP_HOME /app
+ENV BUNDLE_PATH /bundle
+WORKDIR $APP_HOME
+
+# install all gems and node modules
+RUN bundle install && yarn install && npm rebuild node-sass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  web:
+    build: .
+    image: foreman
+    working_dir: /app
+    # Repeat the bundle install, it's faster though we have them already fetched. 
+    # This is because we lost the Gemfile.lock through mounting the app volume.
+    command: 'sh -c  "bundle install && yarn install && npm rebuild node-sass && rm -f /app/tmp/pids/server.pid && bin/rails db:migrate && ./script/foreman-start-dev"'
+    ports:
+     - "3000:3000"
+    # see https://stackoverflow.com/questions/30043872/
+    volumes:
+      - ./:/app
+      - /app/node_modules


### PR DESCRIPTION
It mounts the local working directory into the docker
container. So updating code should automatically reload
the app inside.

Brief Introduction:
Bootup with "docker-compose up -d"
DB Seed with "docker-compose exec web rake db:seed"
Logs with "docker-compose logs -f"