### PR TITLE
Fixes #22403 - every API endpoint can set current context

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -6,6 +6,8 @@ module Api
       resource_description do
         api_version "v2"
         app_info N_("Foreman API v2 is currently the default API version.")
+        param :location_id, Integer, :required => false, :desc => N_("Scope by locations") if SETTINGS[:locations_enabled]
+        param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations") if SETTINGS[:organizations_enabled]
       end
 
       def_param_group :pagination do


### PR DESCRIPTION
@iNecas @mbacovsky this is what we discussed yesterday, this seems as most straightforward way to add this to every request definition. It also adds it to resources which are not taxable, e.g. architectures API, but that is consistent with context switcher on architectures page in UI.