### PR TITLE
Fixes #19244 - added clean interfaces rake task

### DIFF
--- a/app/services/interface_cleaner.rb
+++ b/app/services/interface_cleaner.rb
@@ -1,0 +1,50 @@
+class InterfaceCleaner
+  include ActiveRecord::Sanitization
+
+  ESCAPE_CHAR = '\\'
+
+  def self.nic_pattern_to_like(nic)
+    sanitize_sql_like(nic, ESCAPE_CHAR).tr('*', '%')
+  end
+
+  def self.ignored_interface_like_patterns
+    Setting[:ignored_interface_identifiers].map { |pattern| nic_pattern_to_like(pattern) }
+  end
+
+  delegate :logger, :to => :Rails
+
+  attr_reader :primary_nics, :provision_nics, :primary_hosts, :provision_hosts
+
+  def clean!
+    @deleted_count = delete_excluded_nics
+
+    @primary_nics, @primary_hosts = excluded_nics.where(primary: true).pluck(:id, :host_id).transpose
+    @provision_nics, @provision_hosts = excluded_nics.where(provision: true).pluck(:id, :host_id).transpose
+    self
+  end
+
+  def deleted_count
+    raise 'cleaner has not cleaned anything yet, run #clean! first' if @deleted_count.nil?
+    @deleted_count
+  end
+
+  private
+
+  def excluded_nics
+    ignored_nic_patterns = InterfaceCleaner.ignored_interface_like_patterns
+
+    arel = Nic::Base.arel_table
+    chained_or = arel[:identifier].matches_any(ignored_nic_patterns, ESCAPE_CHAR, true)
+
+    Nic::Base.where(chained_or)
+  end
+
+  def delete_excluded_nics
+    nics = excluded_nics.where(primary: false, provision: false)
+
+    logger.debug "Removing excluded nics..."
+    deleted_nics = nics.delete_all
+    logger.debug "Removed #{deleted_nics} nic records."
+    deleted_nics
+  end
+end

--- a/lib/tasks/interfaces.rake
+++ b/lib/tasks/interfaces.rake
@@ -1,0 +1,39 @@
+namespace :interfaces do
+  desc <<-END_DESC
+Removes old interfaces that match ignored interfaces pattern setting.
+
+This is useful when you change the ignored pattern setting.
+
+Examples:
+  # foreman-rake interfaces:clean
+END_DESC
+
+  task :clean => :environment do
+    puts 'Starting ingnored interfaces clean up...'
+    cleaner = InterfaceCleaner.new.clean!
+    puts "Finished, cleaned #{cleaner.deleted_count} interfaces"
+    unless cleaner.primary_hosts.empty?
+      puts "Following hosts have ignored interface set as primary, please set other interface as primary and rerun the task:"
+      print_host_queries(cleaner.primary_hosts)
+    end
+    unless cleaner.provision_hosts.empty?
+      puts "Following hosts have ignored interface set as provision, please set other interface as provisioning and rerun the task:"
+      print_host_queries(cleaner.provision_hosts)
+    end
+  end
+
+  def print_host_queries(hosts)
+    Host.unscoped.where(id: hosts.uniq).pluck(:name).in_groups_of(hosts_group_count, false) do |names|
+      query = "name ^ (#{names.join(',')})"
+      puts "#{Setting[:foreman_url]}#{helper.hosts_url(only_path: true, search: query)}"
+    end
+  end
+
+  def hosts_group_count
+    @hosts_group_count ||= (ENV['MAX_HOSTS'] || '50').to_i
+  end
+
+  def helper
+    @helper ||= Rails.application.routes.url_helpers
+  end
+end

--- a/test/unit/interface_cleaner_test.rb
+++ b/test/unit/interface_cleaner_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class InterfaceCleanerTest < ActiveSupport::TestCase
+  let(:null_store) { ActiveSupport::Cache.lookup_store(:null_store) }
+  let(:cleaner) do
+    InterfaceCleaner.new
+  end
+
+  test "it cleans excluded interfaces" do
+    Setting.stubs(:cache).returns(null_store)
+    Setting[:ignored_interface_identifiers] = ['ignored*']
+
+    host = FactoryBot.create(:host, :managed)
+    additional_interface = FactoryBot.build(:nic_managed, ip: '0.0.0.2')
+    additional_interface.identifier = 'ignored01'
+    host.interfaces << additional_interface
+    host.save!
+
+    assert_difference 'Nic::Base.unscoped.count', -1 do
+      cleaner.clean!
+    end
+
+    assert_equal 1, cleaner.deleted_count
+  end
+
+  test "it warns about primary and provision interfaces" do
+    Setting.stubs(:cache).returns(null_store)
+    Setting[:ignored_interface_identifiers] = ['ignored*']
+
+    host = FactoryBot.create(:host, :managed)
+    host.primary_interface.identifier = 'ignored01'
+    host.save!
+
+    assert_difference 'Nic::Base.unscoped.count', 0 do
+      cleaner.clean!
+    end
+
+    assert_equal 0, cleaner.deleted_count
+    assert_equal host.primary_interface.id, cleaner.primary_nics.first
+    assert_equal host.provision_interface.id, cleaner.provision_nics.first
+    assert_equal host.id, cleaner.primary_hosts.first
+    assert_equal host.id, cleaner.provision_hosts.first
+  end
+
+  test "it handles underscores" do
+    Setting.stubs(:cache).returns(null_store)
+    Setting[:ignored_interface_identifiers] = ['test_underscore*']
+
+    host = FactoryBot.create(:host, :managed)
+    additional_interface = FactoryBot.build(:nic_managed, ip: '0.0.0.3')
+    additional_interface.identifier = 'test_underscore_ignored'
+    host.interfaces << additional_interface
+    additional_interface = FactoryBot.build(:nic_managed, ip: '0.0.0.4')
+    additional_interface.identifier = 'testXunderscore_ignored'
+    host.interfaces << additional_interface
+    host.save!
+
+    assert_difference 'Nic::Base.unscoped.count', -1 do
+      cleaner.clean!
+    end
+
+    assert_equal 1, cleaner.deleted_count
+  end
+end

--- a/test/unit/tasks/interfaces_test.rb
+++ b/test/unit/tasks/interfaces_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require 'rake'
+
+class InterfacesTest < ActiveSupport::TestCase
+  let(:null_store) { ActiveSupport::Cache.lookup_store(:null_store) }
+
+  setup do
+    Rake.application.rake_require 'tasks/interfaces'
+    Rake::Task.define_task(:environment)
+    Rake::Task['interfaces:clean'].reenable
+
+    @cleaner = InterfaceCleaner.new
+
+    InterfaceCleaner.stubs(:new).returns(@cleaner)
+  end
+
+  test 'interface:clean prints deleted count' do
+    @cleaner.stubs(:deleted_count).returns(10)
+
+    stdout, _stderr = capture_io do
+      Rake.application.invoke_task 'interfaces:clean'
+    end
+
+    assert_match /cleaned 10 interfaces/, stdout
+  end
+
+  test 'interface:clean warns about primary interface' do
+    Setting.stubs(:cache).returns(null_store)
+    Setting[:ignored_interface_identifiers] = ['ignored*']
+    host = FactoryBot.create(:host, interfaces: [FactoryBot.build(:nic_managed, identifier: 'ignored01', primary: true, provision: false)])
+
+    stdout, _stderr = capture_io do
+      Rake.application.invoke_task 'interfaces:clean'
+    end
+
+    assert_match /cleaned 0 interfaces/, stdout
+    encoded_hostname = URI.encode("(#{host.name})")
+    assert_match /#{encoded_hostname}/, stdout
+    assert_match /ignored interface set as primary/, stdout
+  end
+
+  test 'interface:clean warns about provision interface' do
+    Setting.stubs(:cache).returns(null_store)
+    Setting[:ignored_interface_identifiers] = ['ignored*']
+    host = FactoryBot.create(:host, interfaces: [FactoryBot.build(:nic_managed, identifier: 'ignored01', primary: false, provision: true)])
+
+    stdout, _stderr = capture_io do
+      Rake.application.invoke_task 'interfaces:clean'
+    end
+
+    assert_match /cleaned 0 interfaces/, stdout
+    encoded_hostname = URI.encode("(#{host.name})")
+    assert_match /#{encoded_hostname}/, stdout
+    query = URI.decode(stdout.match(/^.*search=(.*?%29)/)[1]).tr('+', ' ')
+    assert_equal host.id, Host.search_for(query).first.id
+    assert_match /ignored interface set as provision/, stdout
+  end
+end


### PR DESCRIPTION
Added rake task that cleans up interfaces that match `ignored_interface_identifiers` setting.

@ares, do you think it would be enough for the users?