### PR TITLE
Fixes #22425 - generate selinux interfaces once in debug

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -290,7 +290,8 @@ if [ $NOGENERIC -eq 0 ]; then
   add_cmd "ausearch -m AVC -m USER_AVC -m SELINUX_ERR | head -n 100" "selinux_first_denials.log"
   add_cmd "ausearch -m AVC -m USER_AVC -m SELINUX_ERR || grep AVC /var/log/audit/audit.log" "selinux_denials.log"
   if [ -f /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
-    add_cmd "sepolgen-ifgen &>/dev/null && audit2allow -Ra || audit2allow -a" "selinux_audit2allow"
+    [[ -f /var/lib/sepolgen/interface_info ]] || sepolgen-ifgen &>/dev/null
+    add_cmd "audit2allow -Ra || audit2allow -a" "selinux_audit2allow"
     add_cmd "semodule -l" "selinux_modules"
     add_cmd "semanage boolean -l" "selinux_booleans"
     add_cmd "semanage fcontext -l" "selinux_fcontext"


### PR DESCRIPTION
This is speedup patch, saves about 13 seconds on my system.