### PR TITLE
Fixes #22359 - Don't rely on default taxonomy in API for any user

### DIFF
--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -46,14 +46,14 @@ module ApplicationShared
               return false
             end
           end
-        elsif session.has_key?("#{taxonomy}_id") # session with taxonomy explicitly set to id or nil (any contexxt)
+        elsif session.has_key?("#{taxonomy}_id") # session with taxonomy explicitly set to id or nil (any context)
           if session["#{taxonomy}_id"].present?
             determined_taxonomy = find_session_taxonomy(taxonomy, user) # specific id
           else
             determined_taxonomy = nil # explicitly set any context
           end
-        else # user who didn't specify explicit context and does not have anything in session
-          determined_taxonomy = find_default_taxonomy(user, taxonomy)
+        else
+          determined_taxonomy = nil
         end
       else # UI request
         if session["#{taxonomy}_id"].present?

--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -264,7 +264,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     test 'user does not have to specify taxonomy if he is assigned to only one, it is selected automatically' do
       domain = FactoryBot.build(:domain)
       as_user @user do
-        post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :organization_ids => [@org2.id] } }
+        post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :organization_ids => [@org2.id], :location_ids => [@loc1.id] } }
       end
       assert_response :success
       domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -285,7 +285,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     test 'user can create domain in current context thanks to the fact organization_ids defaults to organization_id' do
       domain = FactoryBot.build(:domain)
       as_user @user do
-        post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name } }
+        post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :location_ids => [@loc1.id] } }
       end
       assert_response :success
       domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -296,7 +296,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     test 'user can create domain in different organization than he set as a current organization' do
       domain = FactoryBot.build(:domain)
       as_user @user do
-        post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org1.id, @org2.id] } }
+        post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org1.id, @org2.id], :location_ids => [@loc1.id] } }
       end
       assert_response :success
       domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -307,7 +307,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     test 'user can create domain but current context is always preselected as organization_ids' do
       domain = FactoryBot.build(:domain)
       as_user @user do
-        post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org2.id] } }
+        post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org2.id], :location_ids => [@loc1.id] } }
       end
       assert_response :success
       domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -319,7 +319,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     test 'user can not create resource in any context but they can use it to reset default value of organization_ids' do
       domain = FactoryBot.build(:domain)
       as_user @user do
-        post :create, params: { :organization_id => nil, :domain => { :name => domain.name, :organization_ids => [@org2.id] } }
+        post :create, params: { :organization_id => nil, :domain => { :name => domain.name, :organization_ids => [@org2.id], :location_ids => [@loc1.id] } }
       end
       assert_response :success
       domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -382,7 +382,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
       test 'user can still create domains in specific organization even if it is default one' do
         domain = FactoryBot.build(:domain)
         as_user @user do
-          post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org1.id] } }
+          post :create, params: { :organization_id => @org1.id, :domain => { :name => domain.name, :organization_ids => [@org1.id], :location_ids => [@loc1.id] } }
         end
         assert_response :success
         domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -392,7 +392,7 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
       test 'user can create domain in other than default organization' do
         domain = FactoryBot.build(:domain)
         as_user @user do
-          post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :organization_ids => [@org2.id] } }
+          post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :organization_ids => [@org2.id], :location_ids => [@loc1.id] } }
         end
         assert_response :success
         domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
@@ -403,32 +403,10 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
         # preselected value is the currect context which overrides the default
         domain = FactoryBot.build(:domain)
         as_user @user do
-          post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name } }
+          post :create, params: { :organization_id => @org2.id, :domain => { :name => domain.name, :location_ids => [@loc1.id] } }
         end
         assert_response :success
         domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
-        assert_includes domain.organization_ids, @org2.id
-      end
-
-      test 'user can create domain in default organization without need of specifying any organization' do
-        domain = FactoryBot.build(:domain)
-        as_user @user do
-          post :create, params: { :domain => { :name => domain.name } }
-        end
-        assert_response :success
-        domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
-        assert_includes domain.organization_ids, @org1.id
-      end
-
-      test 'user can create domain in other than default organization without need to specify current context, default becomes preselected value' do
-        # preselected value is the currect context which overrides the default
-        domain = FactoryBot.build(:domain)
-        as_user @user do
-          post :create, params: { :domain => { :name => domain.name, :organization_ids => [@org2.id] } }
-        end
-        assert_response :success
-        domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
-        assert_includes domain.organization_ids, @org1.id
         assert_includes domain.organization_ids, @org2.id
       end
     end

--- a/test/controllers/concerns/application_shared_test.rb
+++ b/test/controllers/concerns/application_shared_test.rb
@@ -56,25 +56,5 @@ class ApplicationSharedTest < ActiveSupport::TestCase
       assert_nil Organization.current
       assert_nil Location.current
     end
-
-    test "set_taxonomy respects user association to orgs and locs, sets nil on unknown organizations and defaults to the only location of user" do
-      Location.stubs(:my_locations => Location.where(:id => taxonomies(:location1).id))
-      Organization.stubs(:my_organizations => Organization.where(:id => nil))
-      as_user :one do
-        @dummy.set_taxonomy
-      end
-      assert_nil Organization.current
-      assert_equal taxonomies(:location1), Location.current
-    end
-
-    test "set_taxonomy respects user association to orgs and locs, sets both if allowed" do
-      Location.stubs(:my_locations => Location.where(:id => taxonomies(:location1).id))
-      Organization.stubs(:my_organizations => Organization.where(:id => taxonomies(:organization1).id))
-      as_user :one do
-        @dummy.set_taxonomy
-      end
-      assert_equal taxonomies(:organization1), Organization.current
-      assert_equal taxonomies(:location1), Location.current
-    end
   end
 end


### PR DESCRIPTION
(cherry picked from commit 8609c702e32d87dcb4b9c1a3a121afeb96af57de)