### PR TITLE
Fixes #22430 - Plugin permissions are cleared on tests

### DIFF
--- a/test/models/concerns/belongs_to_proxies_test.rb
+++ b/test/models/concerns/belongs_to_proxies_test.rb
@@ -17,13 +17,8 @@ class BelongsToProxiesTest < ActiveSupport::TestCase
     include BelongsToProxies
   end
 
-  setup do
-    Foreman::Plugin.clear
-  end
-
-  teardown do
-    Foreman::Plugin.clear
-  end
+  setup :clear_plugins
+  teardown :restore_plugins
 
   test '#registered_smart_proxies has default value' do
     assert_equal({}, EmptySampleModel.registered_smart_proxies)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -110,3 +110,14 @@ class ActionController::TestCase
     Webpack::Rails::Manifest.stubs(:asset_paths).returns([])
   end
 end
+
+def clear_plugins
+  @klass = Foreman::Plugin
+  @plugins_backup = @klass.registered_plugins
+  @klass.clear
+end
+
+def restore_plugins
+  @klass.clear
+  @klass.instance_variable_set('@registered_plugins', @plugins_backup)
+end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -42,15 +42,8 @@ class PluginTest < ActiveSupport::TestCase
     end
   end
 
-  def setup
-    @klass = Foreman::Plugin
-    # In case some real plugins are installed
-    @klass.clear
-  end
-
-  def teardown
-    @klass.clear
-  end
+  setup :clear_plugins
+  teardown :restore_plugins
 
   def test_register
     @klass.register :foo do

--- a/test/unit/rabl_test.rb
+++ b/test/unit/rabl_test.rb
@@ -25,14 +25,8 @@ class RablTest < ActiveSupport::TestCase
   end
 
   context 'with plugin' do
-    setup do
-      @klass = Foreman::Plugin
-      @klass.clear
-    end
-
-    teardown do
-      @klass.clear
-    end
+    setup :clear_plugins
+    teardown :restore_plugins
 
     test 'render of extended plugin template' do
       Foreman::Plugin.register :test_extend_rabl_template do


### PR DESCRIPTION
- Some tests are removing all plugins (plugin_test, rabl_test,
belongs_to_proxy_test) from the registry. This has, among others,
one important consequence: the plugin permissions are removed.

- Take an example. Foreman Ansible overrides the Host#form with a
list of 'Ansible Roles' to choose.

- When the view for this Host#form is rendered (e.g: a
HostController or HostJSTest), the list of 'Ansible Roles' has
also to be rendered.

- Since a previous test removed the plugin from the
`Foreman::Plugin.all` registry, but the plugin is still installed
as a Rails Engine, the overrides by deface still apply.

- Some tests that render the Host form fail to run as rendering is
impossible without the 'ansible_roles' permission. These
permissions are only loaded in tests if the plugin is registered
in Foreman::Plugin*

I realize this is a tough one to test, you have a reproducer here (make sure plugin_test runs before host_js_test) https://github.com/theforeman/foreman_ansible/pull/114#issuecomment-360697914