### PR TITLE
Fixes #22779 - Calculate out of sync host via origin specific interval setting

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -74,7 +74,8 @@ class DashboardController < ApplicationController
   private
 
   def init_widget_data
-    @data = Dashboard::Data.new(params[:search])
+    find_resource unless @widget
+    @data = Dashboard::Data.new(params[:search], @widget.data[:settings])
   end
 
   def resource_name

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -17,6 +17,8 @@ module Hostext
       scoped_search :on => :owner_type,    :complete_value => true, :only_explicit => true
       scoped_search :on => :owner_id,      :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
+      scoped_search :relation => :last_report_object, :on => :origin
+
       scoped_search :relation => :configuration_status_object, :on => :status, :offset => 0, :word_size => ConfigReport::BIT_NUM*4, :rename => :'status.interesting', :complete_value => {:true => true, :false => false}, :only_explicit => true
       scoped_search_status "applied",         :relation => :configuration_status_object, :on => :status, :rename => :'status.applied'
       scoped_search_status "restarted",       :relation => :configuration_status_object, :on => :status, :rename => :'status.restarted'

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -17,7 +17,20 @@ module HostStatus
       if (host && !host.enabled?) || no_reports?
         false
       else
-        !reported_at.nil? && reported_at < (Time.now.utc - (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes)
+        !reported_at.nil? && reported_at < (Time.now.utc - expected_report_interval)
+      end
+    end
+
+    def expected_report_interval
+      (reported_origin_interval + default_report_interval).minutes
+    end
+
+    def reported_origin_interval
+      if last_report.origin &&
+         (interval = Setting[:"#{last_report.origin.downcase}_interval"])
+        interval.to_i
+      else
+        default_report_interval
       end
     end
 
@@ -110,6 +123,10 @@ module HostStatus
 
     def calculator
       ConfigReportStatusCalculator.new(:bit_field => status)
+    end
+
+    def default_report_interval
+      Setting[:outofsync_interval]
     end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -86,4 +86,8 @@ class Report < ApplicationRecord
   def no_report
     false
   end
+
+  def self.origins
+    Foreman::Plugin.report_origin_registry.all_origins
+  end
 end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -23,6 +23,7 @@ class Setting::General < Setting
       self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied'), [], N_('HTTP(S) proxy except hosts')),
       self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
+      self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 5, N_('Out of sync interval'))
     ]
   end
 

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -2,7 +2,6 @@ class Setting::Puppet < Setting
   def self.default_settings
     [
       self.set('puppet_interval', N_("Puppet interval in minutes"), 30, N_('Puppet interval')),
-      self.set('outofsync_interval', N_("Duration in minutes after the Puppet interval for servers to be classed as out of sync."), 5, N_('Out of sync interval')),
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map{|env| [env[:name], env[:name]]}]} }),
       self.set('modulepath',N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
       self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -19,6 +19,7 @@ require_dependency 'foreman/plugin/logging'
 require_dependency 'foreman/plugin/rbac_registry'
 require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
+require_dependency 'foreman/plugin/report_origin_registry'
 
 module Foreman #:nodoc:
   class PluginNotFound < Foreman::Exception; end
@@ -38,10 +39,12 @@ module Foreman #:nodoc:
     @registered_plugins = {}
     @tests_to_skip = {}
     @report_scanner_registry = Plugin::ReportScannerRegistry.new
+    @report_origin_registry = Plugin::ReportOriginRegistry.new
 
     class << self
       attr_reader   :registered_plugins
-      attr_accessor :tests_to_skip, :report_scanner_registry
+      attr_accessor :tests_to_skip, :report_scanner_registry,
+                    :report_origin_registry
       private :new
       include Foreman::WebpackAssets
 
@@ -112,6 +115,7 @@ module Foreman #:nodoc:
     # Foreman::Plugin.find('my_plugin').registered_roles
     delegate :registered_roles, :registered_permissions, :default_roles, :permissions, :permission_names, :to => :rbac_registry
     delegate :register_report_scanner, :unregister_report_scanner, :to => :report_scanner_registry
+    delegate :register_report_origin, :to => :report_origin_registry
 
     def initialize(id)
       @id = id.to_sym
@@ -130,6 +134,10 @@ module Foreman #:nodoc:
 
     def report_scanner_registry
       self.class.report_scanner_registry
+    end
+
+    def report_origin_registry
+      self.class.report_origin_registry
     end
 
     def after_initialize

--- a/app/registries/foreman/plugin/report_origin_registry.rb
+++ b/app/registries/foreman/plugin/report_origin_registry.rb
@@ -1,0 +1,43 @@
+module Foreman
+  class Plugin
+    class ReportOriginRegistry
+      DEFAULT_ORIGIN_REPORT_CLASS = 'Report'.freeze
+      DEFAULT_REPORT_ORIGINS = {
+        'ConfigReport' => ['Puppet']
+      }.freeze
+
+      attr_accessor :report_origins
+
+      def initialize
+        @report_origins = DEFAULT_REPORT_ORIGINS.dup
+      end
+
+      def register(origin, report_class = DEFAULT_ORIGIN_REPORT_CLASS)
+        @report_origins[report_class] ||= []
+        @report_origins[report_class] << origin
+      end
+      alias register_report_origin register
+
+      def origins_for(report_class = DEFAULT_ORIGIN_REPORT_CLASS)
+        @report_origins[report_class.to_s]
+      end
+
+      def all_origins
+        @report_origins.map { |_, origins| origins }.inject(:+)
+      end
+
+      def origins_with_interval_setting
+        Hash[all_origins.map do |origin|
+          interval_setting = Setting[:"#{origin.downcase}_interval"]
+          [origin, (interval_setting || default_interval).to_i]
+        end]
+      end
+
+      private
+
+      def default_interval
+        Setting[:outofsync_interval]
+      end
+    end
+  end
+end

--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -1,17 +1,21 @@
 class Dashboard::Data
-  attr_reader :filter
+  attr_reader :filter, :settings
+
   # returns a status hash
   def self.status(filter = "")
     new(filter).report
   end
 
-  def initialize(filter = "")
+  def initialize(filter = "", settings = nil)
     @filter = filter
     @report = {}
+    @settings = settings || {}
   end
 
   def hosts
     @hosts ||= Host.authorized(:view_hosts, Host).search_for(filter).reorder('')
+    @hosts = @hosts.with_last_report_origin(settings[:origin]) if settings[:origin] && settings[:origin] != 'All'
+    @hosts
   end
 
   def report
@@ -39,23 +43,39 @@ class Dashboard::Data
   def fetch_data
     @report.update(
       {  :total_hosts               => hosts.size,
-         :bad_hosts                 => hosts.recent.with_error.count,
-         :bad_hosts_enabled         => hosts.recent.with_error.alerts_enabled.count,
-         :active_hosts              => hosts.recent.with_changes.count,
-         :active_hosts_ok           => hosts.recent.with_changes.without_error.count,
-         :active_hosts_ok_enabled   => hosts.recent.with_changes.without_error.alerts_enabled.count,
-         :ok_hosts                  => hosts.recent.successful.count,
-         :ok_hosts_enabled          => hosts.recent.successful.alerts_enabled.count,
-         :out_of_sync_hosts         => hosts.out_of_sync.count,
-         :out_of_sync_hosts_enabled => hosts.out_of_sync.alerts_enabled.count,
+         :bad_hosts                 => recent_hosts.with_error.count,
+         :bad_hosts_enabled         => recent_hosts.with_error.alerts_enabled.count,
+         :active_hosts              => recent_hosts.with_changes.count,
+         :active_hosts_ok           => recent_hosts.with_changes.without_error.count,
+         :active_hosts_ok_enabled   => recent_hosts.with_changes.without_error.alerts_enabled.count,
+         :ok_hosts                  => recent_hosts.successful.count,
+         :ok_hosts_enabled          => recent_hosts.successful.alerts_enabled.count,
+         :out_of_sync_hosts         => out_of_sync_hosts.count,
+         :out_of_sync_hosts_enabled => out_of_sync_hosts.alerts_enabled.count,
          :disabled_hosts            => hosts.alerts_disabled.count,
-         :pending_hosts             => hosts.recent.with_pending_changes.count,
-         :pending_hosts_enabled     => hosts.recent.with_pending_changes.alerts_enabled.count
+         :pending_hosts             => recent_hosts.with_pending_changes.count,
+         :pending_hosts_enabled     => recent_hosts.with_pending_changes.alerts_enabled.count
       })
     @report[:good_hosts]         = @report[:ok_hosts]         + @report[:active_hosts_ok]
     @report[:good_hosts_enabled] = @report[:ok_hosts_enabled] + @report[:active_hosts_ok_enabled]
     @report[:percentage]         = percentage
     @report[:reports_missing]    = reports_missing
+  end
+
+  def out_of_sync_hosts
+    if settings[:origin] && settings[:origin] != 'All'
+      hosts.out_of_sync_for(settings[:origin])
+    else
+      hosts.out_of_sync
+    end
+  end
+
+  def recent_hosts
+    if settings[:origin] && settings[:origin] != 'All'
+      hosts.recent(Setting[:"#{settings[:origin].downcase}_interval"])
+    else
+      hosts.recent
+    end
   end
 
   def percentage

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -46,7 +46,6 @@ class ReportImporter
 
   def scan
     logger.info "Scanning report with: #{report_scanners.join(', ')}"
-    logger.info logs.inspect
     report_scanners.each do |scanner|
       break if scanner.scan(report, logs)
     end

--- a/app/views/dashboard/_distribution_widget.html.erb
+++ b/app/views/dashboard/_distribution_widget.html.erb
@@ -1,4 +1,9 @@
+<% origin = @data.settings[:origin] %>
 <h4 class="header">
-  <%= n_("Run Distribution (last %s minute)", "Run Distribution (last %s minutes)", Setting[:puppet_interval]) % Setting[:puppet_interval] %>
+  <% if origin %>
+    <%= N_('Run Distribution Chart for %s') % origin %>
+  <% else %>
+    <%= N_('Run Distribution Chart') %>
+  <% end %>
 </h4>
-<%= render_run_distribution(@data.hosts, :class => 'statistics-bar') %>
+<%= render_run_distribution(@data.hosts, :class => 'statistics-bar', :origin => origin) %>

--- a/app/views/dashboard/_status_chart_widget.html.erb
+++ b/app/views/dashboard/_status_chart_widget.html.erb
@@ -1,9 +1,18 @@
+<%
+  origin = @data.settings[:origin]
+  widget_chart_id = "host_configuration_chart"
+  widget_chart_id += "_#{origin.downcase}" if origin
+%>
 <h4 class="header">
-  <%= title = _('Host Configuration Chart') %>
+  <% if origin %>
+    <%= title = _('Host Configuration Chart for %s') % origin %>
+  <% else %>
+    <%= title = _('Host Configuration Chart') %>
+  <% end %>
 </h4>
-<div id="host_configuration_chart">
+<div id="<%= widget_chart_id %>">
 </div>
-<%= mount_react_component('DonutChart', '#host_configuration_chart', get_overview_json(@data.report))%>
+<%= mount_react_component('DonutChart', "##{widget_chart_id}", get_overview_json(@data.report))%>
 <ul class="ui-helper-hidden">
   <%= render "dashboard/status_links" %>
 </ul>

--- a/app/views/dashboard/_status_links.html.erb
+++ b/app/views/dashboard/_status_links.html.erb
@@ -1,28 +1,55 @@
+<%
+  origin = @data.settings[:origin] || nil
+  origin = nil if origin == 'All'
+  interval_setting = report_origin_interval_setting(origin)
+%>
+
 <%= searchable_links _('Hosts that had performed modifications without error'),
-                     "last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
+                     search_filter_with_origin(
+                       "last_report > \"#{interval_setting} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
+                       origin
+                     ),
                      :active_hosts_ok_enabled
 %>
 <%= searchable_links _('Hosts in error state'),
-                     "last_report > \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
+                     search_filter_with_origin(
+                       "last_report > \"#{interval_setting} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
+                       origin
+                     ),
                      :bad_hosts_enabled
 %>
-<%= searchable_links _("Good host reports in the last %s") % time_ago_in_words((Setting[:puppet_interval]+Setting[:outofsync_interval]).minutes.ago),
-                    "last_report > \"#{Setting[:puppet_interval]+Setting[:outofsync_interval]} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
+<%= searchable_links _("Good host reports in the last %s") % time_ago_in_words((interval_setting.to_i || 0).minutes.ago),
+                     search_filter_with_origin(
+                       "last_report > \"#{interval_setting} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
+                       origin
+                     ),
                     :ok_hosts_enabled
 %>
 <%= searchable_links _('Hosts that had pending changes'),
-                     'status.pending > 0 and status.enabled = true',
+                     search_filter_with_origin(
+                       "status.pending > 0 and status.enabled = true",
+                       origin
+                     ),
                      :pending_hosts_enabled
 %>
 <%= searchable_links _('Out of sync hosts'),
-                     "last_report < \"#{Setting[:puppet_interval] + Setting[:outofsync_interval]} minutes ago\" and status.enabled = true",
+                     search_filter_with_origin(
+                       "last_report < \"#{interval_setting} minutes ago\" and status.enabled = true",
+                       origin
+                     ),
                      :out_of_sync_hosts_enabled
 %>
 <%= searchable_links _('Hosts with no reports'),
-                     "not has last_report and status.enabled = true",
+                     search_filter_with_origin(
+                       "not has last_report and status.enabled = true",
+                       origin
+                     ),
                      :reports_missing
 %>
 <%= searchable_links _('Hosts with alerts disabled'),
-                     "status.enabled = false",
+                     search_filter_with_origin(
+                       "status.enabled = false",
+                       origin
+                     ),
                      :disabled_hosts
 %>

--- a/app/views/dashboard/_status_widget.html.erb
+++ b/app/views/dashboard/_status_widget.html.erb
@@ -1,5 +1,9 @@
 <h4 class="header">
-  <%= _('Host Configuration Status') %>
+  <% if @data.settings[:origin] %>
+    <%= _('Host Configuration Status for %s') % @data.settings[:origin] %>
+  <% else %>
+    <%= _('Host Configuration Status') %>
+  <% end %>
 </h4>
 <ul>
   <%= render "dashboard/status_links" %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,7 +15,7 @@
             <div class='widget_control'>
               <a class='remove' data-url='<%= widget_path(widget) %>'>&times;</a>
             </div>
-            <div class="widget <%= widget.name.parameterize %>">
+            <div class="widget <%= widget_class_name(widget).parameterize %>">
               <div data-ajax-url="<%= widget_path(widget, search: params[:search]) %>" data-on-complete="widgetLoaded">
                 <%= spinner(_("%s widget loading...") % widget.name) %>
               </div>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -2,15 +2,14 @@
 <% title _("Trends") %>
 <% title_actions new_link(_("Add Trend Counter")),
                  documentation_button('4.1.3Trends') %>
-
 <% if @trends.empty? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter defined"),
-            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' every Puppet Interval (%s minutes).") % Setting[:puppet_interval]).html_safe %>
+            :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' at least every %s minutes.") % Setting[:outofsync_interval]).html_safe %>
 <% end %>
 
 <% if @trends.any? and TrendCounter.unconfigured? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter found"),
-            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> every Puppet Interval (%s minutes)") % Setting[:puppet_interval]).html_safe %>
+            :text => (_("To start collecting trend data, set a cron job to execute <span class='black'>foreman-rake trends:counter</span> at least every %s minutes.") % Setting[:outofsync_interval]).html_safe %>
 <% end %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">

--- a/lib/tasks/hosts.rake
+++ b/lib/tasks/hosts.rake
@@ -38,7 +38,7 @@ namespace :hosts do
 
     def out_of_sync_interval
       return ENV['OUTOFSYNC_INTERVAL'] if ENV['OUTOFSYNC_INTERVAL'].present?
-      2 * (Setting[:puppet_interval] + Setting[:outofsync_interval])
+      2 * (Setting[:outofsync_interval])
     end
 
     pingable = []

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class DashboardControllerTest < ActionController::TestCase
+  let(:any_default_widget) { Dashboard::Manager.default_widgets.sample }
+
   test 'should get index' do
     get :index, session: set_session_user
     assert_response :success
@@ -13,7 +15,8 @@ class DashboardControllerTest < ActionController::TestCase
 
   test 'create adds widget to user if widget is valid' do
     assert_difference('users(:admin).widgets.count', 1) do
-      post :create, params: { :name => 'Host Configuration Status' }, session: set_session_user
+      post :create, params: { :name => any_default_widget[:name] },
+                    session: set_session_user
     end
     assert_response :success
   end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -7,13 +7,14 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
 
   def setup
     Dashboard::Manager.reset_user_to_default(users(:admin))
+    Setting[:outofsync_interval] = 35
   end
 
   def assert_dashboard_link(text)
     visit dashboard_path
     wait_for_ajax
     assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
-    within "li[data-name='Host Configuration Status']" do
+    within "li[data-name='Host Configuration Status for All']" do
       click_link(text)
     end
     assert_current_path hosts_path, :only_path => true
@@ -35,7 +36,7 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
   end
 
   test "dashboard link good host reports" do
-    assert_dashboard_link 'Good host reports in the last 35 minutes'
+    assert_dashboard_link "Good host reports in the last 35 minutes"
   end
 
   test "dashboard link hosts that had pending changes" do

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -8,5 +8,72 @@ module Host
       end
       should validate_uniqueness_of(:uuid)
     end
+
+    describe 'Scopes' do
+      subject { Host::Managed }
+      let(:host) { FactoryBot.create(:host, :with_reports, :managed) }
+      let(:past_time) { Time.now - (Setting[:outofsync_interval] * 2).minutes }
+      let(:out_of_sync_host) do
+        FactoryBot.create(:host, :with_reports, :managed)
+      end
+
+      setup do
+        host.save
+        out_of_sync_host.update_attribute(:last_report, past_time)
+      end
+
+      describe '.recent' do
+        test 'returns hosts recently reported' do
+          assert subject.recent.include?(host)
+          refute subject.recent.include?(out_of_sync_host)
+        end
+      end
+
+      describe '.out_of_sync' do
+        test 'returns hosts not recently reported' do
+          refute subject.out_of_sync.include?(host)
+          assert subject.out_of_sync.include?(out_of_sync_host)
+        end
+      end
+
+      context 'with hosts reporting an origin' do
+        let(:fake_origin) { 'fake_origin' }
+        let(:host_with_origin) do
+          new_host = FactoryBot.create(:host, :with_reports, :managed)
+          new_host.reports.each do |report|
+            report.update_attribute(:origin, fake_origin)
+          end
+          new_host
+        end
+
+        setup do
+          Foreman::Plugin.report_origin_registry
+                         .stubs(:all_origins)
+                         .returns([fake_origin])
+          host_with_origin.update_attribute(:last_report, past_time)
+          out_of_sync_host.update_attribute(:last_report, past_time)
+        end
+
+        describe '.out_of_sync' do
+          test 'returns all hosts even with an origin' do
+            assert subject.out_of_sync
+                          .include?(host_with_origin)
+            assert subject.out_of_sync
+                          .include?(out_of_sync_host)
+            refute subject.out_of_sync
+                          .include?(host)
+          end
+        end
+
+        describe '.out_of_sync_for' do
+          test 'returns only hosts out of sync with in an origin' do
+            assert subject.out_of_sync_for(fake_origin)
+                          .include?(host_with_origin)
+            refute subject.out_of_sync_for(fake_origin)
+                          .include?(out_of_sync_host)
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/dashboard_manager_test.rb
+++ b/test/unit/dashboard_manager_test.rb
@@ -31,8 +31,9 @@ class DashboardManagerTest < ActiveSupport::TestCase
   end
 
   test '.default_widgets returns built-in widgets' do
+    Dashboard::Manager.stubs(:registered_report_orgins).returns(['Puppet'])
     Foreman::Plugin.expects(:all).returns([])
-    assert_equal 5, Dashboard::Manager.default_widgets.count
+    assert_equal 7, Dashboard::Manager.default_widgets.count
   end
 
   test '.default_widgets adds plugin widgets' do
@@ -46,7 +47,7 @@ class DashboardManagerTest < ActiveSupport::TestCase
   end
 
   test '.find_default_widget_by_name returns built-in widget' do
-    assert_equal ['status_chart_widget'], Dashboard::Manager.find_default_widget_by_name('Host Configuration Chart').map { |w| w[:template] }
+    assert_equal ['status_chart_widget'], Dashboard::Manager.find_default_widget_by_name('Host Configuration Chart for All').map { |w| w[:template] }
   end
 
   test '.find_default_widget_by_name returns plugin widget' do
@@ -63,9 +64,9 @@ class DashboardManagerTest < ActiveSupport::TestCase
     user.widgets = [user.widgets.first]
 
     Foreman::Plugin.expects(:all).at_least_once.returns([])
-    assert_difference('user.widgets.size', 4) do
-      Dashboard::Manager.reset_user_to_default(user)
-      user.widgets.reload
-    end
+    Dashboard::Manager.reset_user_to_default(user)
+    user.widgets.reload
+    assert_equal Dashboard::Manager.default_widgets.count,
+                 user.widgets.count
   end
 end


### PR DESCRIPTION
This is based on #5186 and uses the report origin to look for a interval setting.
The origin specific interval setting allows adjusting the time until hosts are considered "out of sync".

For Puppet we already have `Setting[:puppet_interval]` and https://github.com/theforeman/foreman_ansible/pull/123 introduce `Setting[:ansible_interval]` for Ansible.