### PR TITLE
Fixes #22455 - Provide a fallback humanized_name

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  def humanized_name
+    self.class.name
+  end
 end


### PR DESCRIPTION
Jobs defined in Foreman should have a humanized_name in order to show up
in the Tasks list. However, in case they don't (plugins, or just
something that slipped under the radar during review), an empty line
is displayed on this page. Instead, at least the class name should be
displayed so that it makes more sense.