### PR TITLE
Refs #21871 - Test resource_scope using existing tables

### DIFF
--- a/test/controllers/api/base_controller_subclass_test.rb
+++ b/test/controllers/api/base_controller_subclass_test.rb
@@ -44,23 +44,17 @@ end
 class Testable < ApplicationRecord
   include Authorizable
   belongs_to :domain
-  belongs_to :foo
+  belongs_to :foo, :foreign_key => 'role_id'
+  self.table_name = 'filters'
 end
 
 class Foo < ApplicationRecord
+  self.table_name = 'roles'
   has_many :testables
 end
 
 class Api::TestableControllerTest < ActionController::TestCase
   tests Api::TestableController
-
-  ActiveRecord::Migration.create_table(:testables) { |t| t.integer :foo_id }
-  ActiveRecord::Migration.create_table(:foos)
-
-  Minitest.after_run do
-    ActiveRecord::Migration.drop_table(:testables)
-    ActiveRecord::Migration.drop_table(:foos)
-  end
 
   context "api base headers" do
     test "should contain version in headers" do
@@ -272,7 +266,7 @@ class Api::TestableControllerTest < ActionController::TestCase
     context 'resouce scoping' do
       setup do
         @foo = Foo.create
-        @testable = Testable.create(:foo_id => @foo.id)
+        @testable = Testable.create(:foo => @foo)
       end
 
       it 'should return nested resource' do


### PR DESCRIPTION
This patch is needed in order to run tests with plugins that pass. The
'after_run' method gets called after test rake tasks. In Jenkins,
when plugins are called with 'rake jenkins:unit jenkins:integration'
there's a problem - the 'testables' table gets removed before the
tests run, so these tests fail.

Changes here follow the same strategy we have followed on other
patches - just reuse existing tables to test 'generic' objects.

Example of the failures: 
- tasks http://ci.theforeman.org/job/test_plugin_pull_request/4558/#showFailuresLink
- ansible http://ci.theforeman.org/job/test_plugin_matrix/4613/
Testing foreman-tasks with the patch: http://ci.theforeman.org/job/test_plugin_pull_request/4560 
Testing foreman-ansible with the patch: http://ci.theforeman.org/job/test_plugin_matrix/4626 (seems OK, the error is different - tests passed if you inspect each run)

cc @xprazak2 @iNecas 