### PR TITLE
Fixes #22505 - CoreOS does not work

### DIFF
--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -32,7 +32,7 @@ module OperatingsystemsHelper
                "Junos"
              when /OracleLinux/i
                "OracleLinux"
-             when /CoreOS/i
+             when /CoreOS|ContainerLinux|Container Linux/i
                "CoreOS"
              when /NXOS/i
                "NXOS"


### PR DESCRIPTION
The image is called 'CoreOS.png', however the view is trying to fetch
'Coreos.png'.

To test, just create a Operating System with family "CoreOS", and you will see that the list of OSs does not show the little OS logo.