### PR TITLE
Fixes #22464 when response has content-length: 0

### DIFF
--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -7,7 +7,7 @@ module ProxyAPI
     def initialize(args)
       raise("Must provide a protocol and host when initialising a smart-proxy connection") unless (url =~ /^http/)
 
-      @connect_params = {:timeout => Setting[:proxy_request_timeout], :open_timeout => 10,
+      @connect_params = {:read_timeout => nil, :open_timeout => 10,
                          :headers => { :accept => :json, :x_request_id => request_id },
                          :user => args[:user], :password => args[:password]}
 


### PR DESCRIPTION
Fixes #22464 in which a valid JSON response without a body causes an exception to be thrown. This is caused by an [upstream bug](https://bugs.ruby-lang.org/issues/14451) in Ruby wherein Net:HTTP (used by the rest-client gem) will attempt to wait for a body even if the web server indicates there is no body, only headers. This option seems sub-optimal, but I fail to see a better solution until 1) this is patched upstream and 2) Foreman runs on this version.