### PR TITLE
fixes #22090 - friendlyid for lookupvalue plus override api

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -88,6 +88,9 @@ module Api
 
       def find_override_value
         @override_value = LookupValue.find_by_id(params[:id])
+        if @smart
+          @override_value ||= @smart.lookup_values.friendly.find(params[:id])
+        end
       end
 
       def return_if_override_mismatch

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -1,5 +1,7 @@
 class LookupValue < ApplicationRecord
   audited :associated_with => :lookup_key
+  extend FriendlyId
+  friendly_id :match
   include Authorizable
   include PuppetLookupValueExtensions
   include HiddenValue

--- a/test/controllers/api/v2/override_values_controller_test.rb
+++ b/test/controllers/api/v2/override_values_controller_test.rb
@@ -42,14 +42,21 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
   end
 
   test "should show specific override values for specific smart variable" do
-    get :show, params: { :smart_variable_id => lookup_keys(:two).to_param, :id => lookup_values(:four).to_param }
+    get :show, params: { :smart_variable_id => lookup_keys(:two).to_param, :id => lookup_values(:four).id }
     assert_response :success
     results = ActiveSupport::JSON.decode(@response.body)
     assert_not_empty results
     assert_equal "hostgroup=Common", results['match']
   end
   test "should show specific override values for specific smart class parameter" do
-    get :show, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).to_param }
+    get :show, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).id }
+    results = ActiveSupport::JSON.decode(@response.body)
+    assert_not_empty results
+    assert_equal "hostgroup=Common", results['match']
+    assert_response :success
+  end
+  test "should show specific override values using match" do
+    get :show, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).match }
     results = ActiveSupport::JSON.decode(@response.body)
     assert_not_empty results
     assert_equal "hostgroup=Common", results['match']
@@ -57,13 +64,23 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
   end
 
   test "should update specific override value" do
-    put :update, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).to_param, :override_value => { :match => 'os=abc' } }
+    put :update, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).id, :override_value => { :match => 'os=abc' } }
+    assert_response :success
+  end
+  test "should update specific override value using match" do
+    put :update, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).match, :override_value => { :match => 'os=abc' } }
     assert_response :success
   end
 
   test "should destroy specific override value" do
     assert_difference('LookupValue.count', -1) do
-      delete :destroy, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).to_param, :override_value => { :match => 'host=abc.com' } }
+      delete :destroy, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).id }
+    end
+    assert_response :success
+  end
+  test "should destroy specific override value using match" do
+    assert_difference('LookupValue.count', -1) do
+      delete :destroy, params: { :smart_class_parameter_id => lookup_keys(:complex).to_param, :id => lookup_values(:hostgroupcommon).match }
     end
     assert_response :success
   end


### PR DESCRIPTION
Allow use of match instead of ids in API call for overrides.
Present tests default to using the match name due to 
to_param hence the tests in place should already apply.