### PR TITLE
Fixes #19389 - Added medium hash to TFTP files

### DIFF
--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -93,9 +93,14 @@ module Api
       param :architecture, String
 
       def bootfiles
+        Foreman::Deprecation.deprecation_warning("1.20", "Bootfiles should be calculated per host")
+
         medium = Medium.authorized(:view_media).find(params[:medium])
         arch   = Architecture.authorized(:view_architectures).find(params[:architecture])
-        render :json => @operatingsystem.pxe_files(medium, arch)
+        host_mock = Openstruct.new(operatingsystem: @operatingsystem, medium: medium, architecture: arch)
+        medium_provider = MediumProviders::Default.new(host_mock)
+
+        render :json => @operatingsystem.pxe_files(medium_provider)
       rescue => e
         render_message(e.to_s, :status => :unprocessable_entity)
       end

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -74,9 +74,13 @@ module HostCommon
     end
   end
 
+  def host_medium_provider
+    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self)
+  end
+
   # Returns a url pointing to boot file
   def url_for_boot(file)
-    "#{os.medium_uri(self)}/#{os.url_for_boot(file)}"
+    os.url_for_boot(medium_provider, file)
   end
 
   def puppetca?
@@ -112,7 +116,7 @@ module HostCommon
       # We encode the hw_model into the image file name as not all Sparc flashes can contain all possible hw_models. The user can always
       # edit it if required or use symlinks if they prefer.
       hw_model = model.try :hardware_model if defined?(model_id)
-      operatingsystem.interpolate_medium_vars(nfs_path, architecture.name, operatingsystem) + \
+      host_medium_provider.interpolate_vars(nfs_path) + \
         "#{operatingsystem.file_prefix}.#{architecture}#{hw_model.empty? ? '' : '.' + hw_model.downcase}.#{operatingsystem.image_extension}"
     else
       ""

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -15,11 +15,11 @@ module HostTemplateHelpers
   end
 
   def multiboot
-    operatingsystem.pxe_prefix(architecture) + "-multiboot"
+    operatingsystem.pxe_prefix(architecture, @host) + "-multiboot"
   end
 
   def miniroot
-    operatingsystem.initrd(architecture)
+    operatingsystem.initrd(architecture, @host)
   end
 
   attr_writer(:url_options)

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -4,6 +4,8 @@ module HostTemplateHelpers
   extend ActiveSupport::Concern
   include ::Foreman::ForemanUrlRenderer
 
+  delegate :medium_uri, to: :medium_provider
+
   # Calculates the media's path in relation to the domain and convert host to an IP
   def install_path
     operatingsystem.interpolate_medium_vars(operatingsystem.media_path(medium, domain), architecture.name, operatingsystem)
@@ -15,11 +17,11 @@ module HostTemplateHelpers
   end
 
   def multiboot
-    operatingsystem.pxe_prefix(architecture, @host) + "-multiboot"
+    operatingsystem.pxe_prefix(medium_provider) + "-multiboot"
   end
 
   def miniroot
-    operatingsystem.initrd(architecture, @host)
+    operatingsystem.initrd(medium_provider)
   end
 
   attr_writer(:url_options)
@@ -30,5 +32,9 @@ module HostTemplateHelpers
     url_options[:protocol] = "http://"
     url_options[:host] = Setting[:foreman_url] if Setting[:foreman_url]
     url_options
+  end
+
+  def medium_provider
+    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(@host)
   end
 end

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -56,15 +56,15 @@ module Orchestration::TFTP
   def generate_pxe_template(kind)
     # this is the only place we generate a template not via a web request
     # therefore some workaround is required to "render" the template.
-    @kernel = host.operatingsystem.kernel(host.arch)
-    @initrd = host.operatingsystem.initrd(host.arch)
+    @kernel = host.operatingsystem.kernel(host.arch, host)
+    @initrd = host.operatingsystem.initrd(host.arch, host)
     if host.operatingsystem.respond_to?(:mediumpath)
       @mediapath = host.operatingsystem.mediumpath(host)
     end
 
     # Xen requires additional boot files.
     if host.operatingsystem.respond_to?(:xen)
-      @xen = host.operatingsystem.xen(host.arch)
+      @xen = host.operatingsystem.xen(host.arch, host)
     end
 
     # work around for ensuring that people can use @host as well, as tftp templates were usually confusing.

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -129,7 +129,8 @@ class Operatingsystem < ApplicationRecord
   end
 
   def medium_uri(host, url = nil)
-    url ||= host.medium.path
+    url ||= host.medium.path unless host.medium.nil?
+    url ||= ''
     medium_vars_to_uri(url, host.architecture.name, host.operatingsystem)
   end
 
@@ -191,8 +192,12 @@ class Operatingsystem < ApplicationRecord
   end
 
   # sets the prefix for the tfp files based on the os / arch combination
-  def pxe_prefix(arch)
-    "boot/#{self}-#{arch}".tr(" ", "-")
+  def pxe_prefix(arch, host)
+    "boot/#{self}-#{arch}-#{medium_digest(host)}".tr(" ","-")
+  end
+
+  def medium_digest(host)
+    host.nil? ? '' : Digest::SHA1.hexdigest(medium_uri(host).to_s)
   end
 
   def pxe_files(medium, arch, host = nil)
@@ -201,16 +206,16 @@ class Operatingsystem < ApplicationRecord
     end
   end
 
-  def kernel(arch)
-    bootfile(arch, :kernel)
+  def kernel(arch, host)
+    bootfile(arch,:kernel, host)
   end
 
-  def initrd(arch)
-    bootfile(arch, :initrd)
+  def initrd(arch, host)
+    bootfile(arch,:initrd, host)
   end
 
-  def bootfile(arch, type)
-    pxe_prefix(arch) + "-" + self.family.constantize::PXEFILES[type.to_sym]
+  def bootfile(arch, type, host)
+    pxe_prefix(arch, host) + "-" + self.family.constantize::PXEFILES[type.to_sym]
   end
 
   # Does this OS family support a build variant that is constructed from a prebuilt archive

--- a/app/models/operatingsystems/aix.rb
+++ b/app/models/operatingsystems/aix.rb
@@ -9,10 +9,6 @@ class AIX < Operatingsystem
     "boot/$arch/loader"
   end
 
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
-  end
-
   def display_family
     "AIX"
   end

--- a/app/models/operatingsystems/altlinux.rb
+++ b/app/models/operatingsystems/altlinux.rb
@@ -1,12 +1,9 @@
 class Altlinux < Operatingsystem
   PXEFILES = {:kernel => "vmlinuz", :initrd => "full.cz" }
 
-  def boot_files_uri(medium, architecture)
-    raise ::Foreman::Exception.new(N_("invalid medium for %s"), to_s) unless media.include?(medium)
-    raise ::Foreman::Exception.new(N_("invalid architecture for %s"), to_s) unless architectures.include?(architecture)
-
+  def boot_files_uri(medium_provider)
     PXEFILES.values.collect do |img|
-      URI.parse("#{medium_vars_to_uri(medium.path, architecture.name, self)}/syslinux/alt0/#{img}").normalize
+      URI.parse("#{medium_provider.medium_uri}/syslinux/alt0/#{img}").normalize
     end
   end
 
@@ -16,10 +13,6 @@ class Altlinux < Operatingsystem
 
   def pxedir
     "boot"
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
   end
 
   def display_family

--- a/app/models/operatingsystems/archlinux.rb
+++ b/app/models/operatingsystems/archlinux.rb
@@ -2,8 +2,8 @@ class Archlinux < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
   # Simple output of the media url
-  def mediumpath(host)
-    medium_uri(host).to_s
+  def mediumpath(medium_provider)
+    medium_provider.medium_uri.to_s
   end
 
   def pxe_type
@@ -12,10 +12,6 @@ class Archlinux < Operatingsystem
 
   def pxedir
     "boot/$arch/loader"
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
   end
 
   def display_family

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -23,11 +23,11 @@ class Freebsd < Operatingsystem
     pxedir + "/" + PXEFILES[file]
   end
 
-  def kernel(arch)
+  def kernel(arch, _host)
     "memdisk"
   end
 
-  def initrd(arch)
+  def initrd(arch, _host)
     "boot/FreeBSD-#{arch}-#{release}-mfs.img"
   end
 

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -7,8 +7,10 @@ class Freebsd < Operatingsystem
   PXEFILES = {}
 
   # Simple output of the media url
-  def mediumpath(host)
-    medium_uri(host).to_s.gsub("x86_64", "amd64")
+  def mediumpath(medium_provider)
+    medium_provider.to_s do |vars|
+      transform_vars(vars)
+    end
   end
 
   def pxe_type
@@ -19,19 +21,23 @@ class Freebsd < Operatingsystem
     "boot/$arch/images"
   end
 
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
-  end
-
-  def kernel(arch, _host)
+  def kernel(_medium_provider)
     "memdisk"
   end
 
-  def initrd(arch, _host)
-    "boot/FreeBSD-#{arch}-#{release}-mfs.img"
+  def initrd(medium_provider)
+    medium_provider.interpolate_vars("boot/FreeBSD-$arch-$release-mfs.img") do |vars|
+      transform_vars(vars)
+    end
   end
 
   def display_family
     "FreeBSD"
+  end
+
+  private
+
+  def transform_vars(vars)
+    vars[:arch] = vars[:arch].gsub('x86_64', 'amd64')
   end
 end

--- a/app/models/operatingsystems/gentoo.rb
+++ b/app/models/operatingsystems/gentoo.rb
@@ -1,10 +1,10 @@
 class Gentoo < Operatingsystem
   PXEFILES = {}
 
-  def mediumpath(host)
+  def mediumpath(_medium_provider)
   end
 
-  def url_for_boot(file)
+  def url_for_boot(_medium_provider, file)
   end
 
   def display_family

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -3,8 +3,8 @@ class Junos < Operatingsystem
   PXEFILES = {}
 
   # Simple output of the media url
-  def mediumpath(host)
-    medium_uri(host).to_s
+  def mediumpath(medium_provider)
+    medium_provider.medium_uri.to_s
   end
 
   # The PXE type to use when generating actions and evaluating attributes. jumpstart, kickstart and preseed are currently supported.
@@ -24,19 +24,15 @@ class Junos < Operatingsystem
     "boot/$arch/images"
   end
 
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
-  end
-
   def boot_filename(host = nil)
     "ztp.cfg/" + host.mac.delete(':').upcase
   end
 
-  def kernel(arch, _host)
+  def kernel(_medium_provider)
     "memdisk"
   end
 
-  def initrd(arch, _host)
+  def initrd(_medium_provider)
     "none"
   end
 

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -32,11 +32,11 @@ class Junos < Operatingsystem
     "ztp.cfg/" + host.mac.delete(':').upcase
   end
 
-  def kernel(arch)
+  def kernel(arch, _host)
     "memdisk"
   end
 
-  def initrd(arch)
+  def initrd(arch, _host)
     "none"
   end
 

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -3,8 +3,8 @@ class NXOS < Operatingsystem
   PXEFILES = {}
 
   # Simple output of the media url
-  def mediumpath(host)
-    medium_uri(host).to_s
+  def mediumpath(medium_provider)
+    medium_provider.medium_uri.to_s
   end
 
   def template_kinds
@@ -27,11 +27,11 @@ class NXOS < Operatingsystem
     "poap.cfg/" + host.mac.delete(':').upcase
   end
 
-  def kernel(arch, _host)
+  def kernel(_medium_provider)
     "none"
   end
 
-  def initrd(arch, _host)
+  def initrd(_medium_provider)
     "none"
   end
 

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -27,11 +27,11 @@ class NXOS < Operatingsystem
     "poap.cfg/" + host.mac.delete(':').upcase
   end
 
-  def kernel(arch)
+  def kernel(arch, _host)
     "none"
   end
 
-  def initrd(arch)
+  def initrd(arch, _host)
     "none"
   end
 

--- a/app/models/operatingsystems/rancheros.rb
+++ b/app/models/operatingsystems/rancheros.rb
@@ -5,7 +5,7 @@ class Rancheros < Operatingsystem
     'rancheros'
   end
 
-  def mediumpath(host)
+  def mediumpath(medium_provider)
     ''
   end
 

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -3,8 +3,8 @@ class Redhat < Operatingsystem
 
   # outputs kickstart installation medium based on the medium type (NFS or URL)
   # it also convert the $arch string to the current host architecture
-  def mediumpath(host)
-    uri = medium_uri(host)
+  def mediumpath(medium_provider)
+    uri = medium_provider.medium_uri
 
     case uri.scheme
       when 'http', 'https', 'ftp'
@@ -27,10 +27,6 @@ class Redhat < Operatingsystem
 
   def pxedir
     "images/pxeboot"
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
   end
 
   def display_family

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -6,7 +6,7 @@ class Solaris < Operatingsystem
   end
 
   # sets the prefix for the tftp files based on the OS
-  def pxe_prefix(architecture = nil)
+  def pxe_prefix(_architecture, _host)
     "boot/#{file_prefix}"
   end
 

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -6,7 +6,7 @@ class Solaris < Operatingsystem
   end
 
   # sets the prefix for the tftp files based on the OS
-  def pxe_prefix(_architecture, _host)
+  def pxe_prefix(_medium_provider)
     "boot/#{file_prefix}"
   end
 
@@ -28,11 +28,7 @@ class Solaris < Operatingsystem
   end
 
   def pxedir
-    "Solaris_#{minor}/Tools/Boot"
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
+    "Solaris_$minor/Tools/Boot"
   end
 
   def boot_filename(host)
@@ -77,11 +73,12 @@ class Solaris < Operatingsystem
   end
 
   def jumpstart_params(host, vendor)
+    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
     # root server and install server are always the same under Foreman
     server_name = host.medium.media_host
     server_ip   = host.domain.resolver.getaddress(server_name).to_s
     jpath       = jumpstart_path host.medium, host.domain
-    ipath       = interpolate_medium_vars(host.medium.media_dir, host.architecture.name, self)
+    ipath       = medium_provider.interpolate_vars(host.medium.media_dir).to_s
 
     {
       :vendor => "<#{vendor}>",

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -2,8 +2,8 @@ class Suse < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd"}
 
   # Simple output of the media url
-  def mediumpath(host)
-    medium_uri(host).to_s
+  def mediumpath(medium_provider)
+    medium_provider.medium_uri.to_s
   end
 
   def pxe_type
@@ -16,10 +16,6 @@ class Suse < Operatingsystem
 
   def available_loaders
     self.class.all_loaders
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
   end
 
   def display_family

--- a/app/models/operatingsystems/windows.rb
+++ b/app/models/operatingsystems/windows.rb
@@ -9,8 +9,8 @@ class Windows < Operatingsystem
     "waik"
   end
 
-  def pxe_prefix(arch)
-    "boot/windows-#{arch}/".tr(" ", "-")
+  def pxe_prefix(arch, host)
+    "boot/windows-#{arch}-#{medium_digest(host)}/".tr(" ","-")
   end
 
   def bootfile(arch, type)

--- a/app/models/operatingsystems/windows.rb
+++ b/app/models/operatingsystems/windows.rb
@@ -9,17 +9,15 @@ class Windows < Operatingsystem
     "waik"
   end
 
-  def pxe_prefix(arch, host)
-    "boot/windows-#{arch}-#{medium_digest(host)}/".tr(" ","-")
+  def pxe_prefix(medium_provider)
+    medium_provider.interpolate_vars("boot/windows-$arch-#{medium_provider.unique_id}/").tr(" ", "-")
   end
 
-  def bootfile(arch, type)
-    pxe_prefix(arch) + PXEFILES[type.to_sym]
+  def bootfile(medium_provider, type)
+    pxe_prefix(medium_provider) + PXEFILES[type.to_sym]
   end
 
-  def boot_files_uri(medium, architecture, host = nil)
-    raise ::Foreman::Exception.new(N_("invalid medium for %s"), to_s) unless media.include?(medium)
-
+  def boot_files_uri(medium_provider)
     pxe_dir = ""
 
     PXEFILES.values.collect do |img|
@@ -31,7 +29,7 @@ class Windows < Operatingsystem
         pxe_dir = ""
       end
 
-      URI.parse("#{medium_vars_to_uri(medium.path, architecture.name, self)}/#{pxe_dir}/#{img}").normalize
+      medium_provider.medium_uri("/#{pxe_dir}/#{img}").normalize
     end
   end
 

--- a/app/models/operatingsystems/xenserver.rb
+++ b/app/models/operatingsystems/xenserver.rb
@@ -2,8 +2,8 @@ class Xenserver < Operatingsystem
   PXEFILES = {:kernel => "boot/vmlinuz", :initrd => "install.img", :xen => "boot/xen.gz"}
   MBOOT = "boot/pxelinux/mboot.c32"
 
-  def mediumpath(host)
-    medium_uri(host).to_s
+  def mediumpath(medium_provider)
+    medium_provider.medium_uri.to_s
   end
 
   def pxe_type
@@ -14,27 +14,21 @@ class Xenserver < Operatingsystem
     ""
   end
 
-  def xen(arch, host)
-    bootfile(arch,:xen, host)
-  end
-
-  def url_for_boot(file)
-    pxedir + "/" + PXEFILES[file]
+  def xen(medium_provider)
+    bootfile(medium_provider, :xen)
   end
 
   def display_family
     "XenServer"
   end
 
-  def bootfile(arch, type, host)
-    pxe_prefix(arch, host) + "-" + PXEFILES[type.to_sym].split("/")[-1]
+  def bootfile(medium_provider, type)
+    pxe_prefix(medium_provider) + "-" + PXEFILES[type.to_sym].split("/")[-1]
   end
 
-  def boot_files_uri(medium, architecture, host = nil)
-    raise ::Foreman::Exception.new(N_("Invalid medium for %s"), self) unless media.include?(medium)
-    raise ::Foreman::Exception.new(N_("Invalid architecture for %s"), self) unless architectures.include?(architecture)
+  def boot_files_uri(medium_provider)
     PXEFILES.values.push(MBOOT).map do |img|
-      medium_vars_to_uri("#{medium.path}/#{img}", architecture.name, self)
+      medium_provider.medium_uri(img)
     end
   end
 end

--- a/app/models/operatingsystems/xenserver.rb
+++ b/app/models/operatingsystems/xenserver.rb
@@ -14,8 +14,8 @@ class Xenserver < Operatingsystem
     ""
   end
 
-  def xen(arch)
-    bootfile(arch, :xen)
+  def xen(arch, host)
+    bootfile(arch,:xen, host)
   end
 
   def url_for_boot(file)
@@ -26,8 +26,8 @@ class Xenserver < Operatingsystem
     "XenServer"
   end
 
-  def bootfile(arch, type)
-    pxe_prefix(arch) + "-" + PXEFILES[type.to_sym].split("/")[-1]
+  def bootfile(arch, type, host)
+    pxe_prefix(arch, host) + "-" + PXEFILES[type.to_sym].split("/")[-1]
   end
 
   def boot_files_uri(medium, architecture, host = nil)

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -183,7 +183,8 @@ class ProvisioningTemplate < Template
 
   def self.fetch_boot_files_combo(tftp)
     @profiles.each do |combo|
-      combo[:hostgroup].operatingsystem.pxe_files(combo[:hostgroup].medium, combo[:hostgroup].architecture).each do |bootfile_info|
+      medium_provider = Foreman::Plugin.medium_providers.find_provider(combo[:hostgroup])
+      combo[:hostgroup].operatingsystem.pxe_files(medium_provider).each do |bootfile_info|
         for prefix, path in bootfile_info do
           tftp.fetch_boot_file(:prefix => prefix.to_s, :path => path)
         end
@@ -203,11 +204,12 @@ class ProvisioningTemplate < Template
       template.template_combinations.each do |combination|
         hostgroup = combination.hostgroup
         if hostgroup&.operatingsystem && hostgroup.architecture && hostgroup.medium
+          medium_provider = Foreman::Plugin.medium_providers.find_provider(hostgroup)
           combos << {
             :hostgroup => hostgroup,
             :template => template,
-            :kernel => hostgroup.operatingsystem.kernel(hostgroup.architecture, nil),
-            :initrd => hostgroup.operatingsystem.initrd(hostgroup.architecture, nil),
+            :kernel => hostgroup.operatingsystem.kernel(medium_provider),
+            :initrd => hostgroup.operatingsystem.initrd(medium_provider),
             :pxe_type => hostgroup.operatingsystem.pxe_type
           }
         end

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -206,8 +206,8 @@ class ProvisioningTemplate < Template
           combos << {
             :hostgroup => hostgroup,
             :template => template,
-            :kernel => hostgroup.operatingsystem.kernel(hostgroup.architecture),
-            :initrd => hostgroup.operatingsystem.initrd(hostgroup.architecture),
+            :kernel => hostgroup.operatingsystem.kernel(hostgroup.architecture, nil),
+            :initrd => hostgroup.operatingsystem.initrd(hostgroup.architecture, nil),
             :pxe_type => hostgroup.operatingsystem.pxe_type
           }
         end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -20,6 +20,7 @@ require_dependency 'foreman/plugin/rbac_registry'
 require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
 require_dependency 'foreman/plugin/report_origin_registry'
+require_dependency 'foreman/plugin/medium_providers_registry'
 
 module Foreman #:nodoc:
   class PluginNotFound < Foreman::Exception; end
@@ -40,11 +41,12 @@ module Foreman #:nodoc:
     @tests_to_skip = {}
     @report_scanner_registry = Plugin::ReportScannerRegistry.new
     @report_origin_registry = Plugin::ReportOriginRegistry.new
+    @medium_providers = Plugin::MediumProvidersRegistry.new
 
     class << self
       attr_reader   :registered_plugins
       attr_accessor :tests_to_skip, :report_scanner_registry,
-                    :report_origin_registry
+                    :report_origin_registry, :medium_providers
       private :new
 
       def def_field(*names)
@@ -486,6 +488,10 @@ module Foreman #:nodoc:
 
     def add_histogram_telemetry(name, description, instance_labels = [], buckets = DEFAULT_BUCKETS)
       Foreman::Telemetry.instance.add_histogram(name, description, instance_labels, buckets)
+    end
+
+    def medium_providers
+      self.class.medium_providers
     end
 
     def smart_proxy_reference(hash)

--- a/app/registries/foreman/plugin/medium_providers_registry.rb
+++ b/app/registries/foreman/plugin/medium_providers_registry.rb
@@ -1,0 +1,59 @@
+module Foreman
+  class Plugin
+    # This class is used to store list of medium uri providers that are responsible to supply
+    # locations of installation medium in form of URI.
+    # This is used by provisioning framework to supply download location for various files
+    # used during the provisioning.
+    class MediumProvidersRegistry
+      attr_reader :providers
+
+      def initialize
+        @providers = []
+      end
+
+      # Register a new medium_uri provider.
+      def register(provider)
+        provider = provider.to_s
+        @providers.unshift(provider)
+        provider
+      end
+
+      # Find a provider that can provide a URI for a given entity.
+      def find_provider(entity)
+        raise Foreman::Exception.new('Must supply an entity to find a medium provider') unless entity
+
+        provider_instances = providers.map { |provider| provider.constantize.new(entity) }
+        valid_providers = provider_instances.select { |provider| provider.valid? }
+        if valid_providers.count > 1
+          raise Foreman::Exception.new(
+            'Found more than one provider for %{entity}. Valid providers: %{providers}',
+            {
+              entity: entity,
+              providers: providers.map { |provider| provider.class.friendly_name }
+            })
+        end
+
+        unless valid_providers.present?
+          raise Foreman::Exception.new(
+            'Could not find a provider for %{entity}. Providers returned %{errors}',
+            {
+              entity: entity,
+              errors: provider_instances.map { |provider| [provider.class.friendly_name, provider.errors] }.to_h
+            })
+        end
+
+        valid_providers.first
+      end
+
+      private
+
+      def ensure_provider(selected_provider, entity)
+        return if selected_provider.present?
+
+        self.class.providers.reduce({}) do |errors_hash, provider|
+          errors_hash[provider.friendly_name] = provider.errors(entity)
+        end
+      end
+    end
+  end
+end

--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -1,0 +1,66 @@
+module MediumProviders
+  class Default < Provider
+    def validate
+      errors = []
+      os = entity.operatingsystem
+      medium = entity.medium
+      arch = entity.architecture
+
+      errors << N_("%{os} medium was not set for host '%{host}'") % { :host => entity, :os => os } if medium.nil?
+      errors << N_("Invalid medium '%{medium}' for '%{os}'") % { :medium => medium, :os => os } unless os.media.include?(medium)
+      errors << N_("Invalid architecture '%{arch}' for '%{os}'") % { :arch => arch, :os => os } unless os.architectures.include?(arch)
+      errors
+    end
+
+    def medium_uri(path = "", &block)
+      url ||= entity.medium.path if entity.medium.present?
+      url ||= ''
+      url += '/' + path unless path.empty?
+      medium_vars_to_uri(url, entity.architecture.name, entity.operatingsystem, &block)
+    end
+
+    def interpolate_vars(pattern)
+      medium_vars_to_uri(pattern, entity.architecture.name, entity.operatingsystem)
+    end
+
+    def unique_id
+      @unique_id ||= begin
+        full_uniq = super
+        "#{entity.medium.name.parameterize}-#{full_uniq[1..10]}"
+      end
+    end
+
+    private
+
+    def medium_vars_to_uri(url, arch, os, &block)
+      URI.parse(interpolate_medium_vars(url, arch, os, &block)).normalize
+    end
+
+    def interpolate_medium_vars(path, arch, os)
+      return "" if path.empty?
+
+      path = path.gsub('$arch', '%{arch}').
+                  gsub('$major',  '%{major}').
+                  gsub('$minor',  '%{minor}').
+                  gsub('$version', '%{version}').
+                  gsub('$release', '%{release}')
+
+      vars = medium_vars(arch, os)
+      if block_given?
+        yield(vars)
+      end
+
+      path % vars
+    end
+
+    def medium_vars(arch, os)
+      {
+        arch: arch,
+        major: os.major,
+        minor: os.minor,
+        version: os.minor.blank? ? os.major : [os.major, os.minor].compact.join('.'),
+        release: os.release_name.presence || ''
+      }
+    end
+  end
+end

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -1,0 +1,54 @@
+module MediumProviders
+  # This is a base class for medium providers.
+  # Medium provider is responsible to provide location of installation medium for a given entity
+  # Example:
+  # provider = MyMediumProvider.new(centos_host)
+  # provider.medium_uri
+  # => #<URI::HTTP http://mirror.centos.org/centos/7/os/x86_64>
+  class Provider
+    # Provides a friendly name of the provider in case of provider error.
+    def self.friendly_name
+      self.name
+    end
+
+    class Jail < Safemode::Jail
+      allow :medium_uri, :unique_id, :errors
+    end
+
+    def initialize(entity)
+      @entity = entity
+    end
+
+    # Returns URI of the installation medium for the current host.
+    def medium_uri
+      throw "medium_uri is not implemented for #{self.class.name}"
+    end
+
+    # Returns unique string representing current installation medium.
+    def unique_id
+      @unique_id ||= Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri.to_s), padding: false)
+    end
+
+    def valid?
+      errors.empty?
+    end
+
+    def errors
+      @errors ||= validate
+    end
+
+    # This method is used to determine whether this provider can handle the entity or not.
+    # This method uses rails pattern for validation - it adds errors to #errors property
+    # Example:
+    # def validate
+    #   errors << "Can't handle entity without medium" unless entity.respond_to?(:medium)
+    # end
+    def validate
+      raise "validate is not implemented for #{self.class.name}"
+    end
+
+    private
+
+    attr_reader :entity
+  end
+end

--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -50,7 +50,7 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
 
   if host_param('blacklist')

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -50,7 +50,7 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
 
   if host_param('blacklist')

--- a/app/views/unattended/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/alterator_default_pxelinux.erb
@@ -13,11 +13,10 @@ oses:
 <%
     metadata    = @host.token.nil? ? '?metadata=' : '&metadata='
     os          = @host.operatingsystem
-    mediumpath  = os.mediumpath @host
+    mediumpath  = os.mediumpath(medium_provider)
 -%>
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
     APPEND initrd=<%= @initrd %> stagename=altunat showopts ramdisk_size=150000 automatic=<%= mediumpath %>,directory:/altlinux/p<%= @host.operatingsystem.major %>/<%= @host.architecture %> ai curl=<%= foreman_url('provision')%><%= metadata %>
-

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -50,9 +50,9 @@ oses:
 
   # optional repository for Atomic
   if @host.operatingsystem.name.match(/Atomic/i)
-    options.push("inst.repo=#{@host.operatingsystem.medium_uri(@host)}")
+    options.push("inst.repo=#{medium_uri}")
   end
-  
+
   if host_param('blacklist')
     options.push("modprobe.blacklist=" + host_param('blacklist').gsub(' ', ''))
   end

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_ovirt_pxelinux.erb
@@ -10,5 +10,5 @@ DEFAULT rhvh
 
 LABEL rhvh
 KERNEL <%= @kernel %>
-APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url("provision") %> inst.stage2=<%= @host.operatingsystem.medium_uri(@host) %> local_boot_trigger=<%= foreman_url("built") %> intel_iommu=on
+APPEND initrd=<%= @initrd %> inst.ks=<%= foreman_url("provision") %> inst.stage2=<%= medium_uri %> local_boot_trigger=<%= foreman_url("built") %> intel_iommu=on
 IPAPPEND 2

--- a/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -8,10 +8,10 @@ oses:
 - OpenSUSE
 %>
 
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
+<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> splash=silent install=<%=@host.os.medium_uri(@host)%> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
+kernel <%= kernel %> splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1
 initrd <%= initrd %>
 boot

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -12,7 +12,7 @@ oses:
 <% else -%>
 <% keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(@host.medium,@host.architecture) -%>
+<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 <% static = @host.token.nil? ? '?static=yes' : '&static=yes' -%>

--- a/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -28,12 +28,12 @@ bootloader --timeout=3
 text
 
 <% if @host.os.name.match /.*fedora.*/i -%>
-# Use @host.operatingsystem.medium_uri(@host)}/content/repo/ as the URL if you
+# Use medium_uri/content/repo/ as the URL if you
 # have set up a local installation media for Fedora
 <% fedora_atomic_url = host_param('atomic_refs_url') || "https://dl.fedoraproject.org/pub/fedora/linux/atomic/#{@host.os.major}/" %>
 ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=<%= fedora_atomic_url %> --ref=fedora-atomic/f<%= @host.os.major %>/<%= @host.architecture %>/docker-host
 <% elsif @host.os.name.match /.*centos.*/i -%>
-ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= host_param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : @host.operatingsystem.medium_uri(@host) %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
+ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= host_param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : medium_uri %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
 <% else -%>
 ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host --url=file:///install/ostree --ref=rhel-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
 <% end -%>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -42,7 +42,7 @@ liveimg_name = host_param('liveimg_name') || 'squashfs.img'
 if host_param('kt_activation_keys')
   liveimg_url = repository_url(liveimg_name, 'isos')
 else
-  liveimg_url = "#{@host.operatingsystem.medium_uri(@host)}/#{liveimg_name}"
+  liveimg_url = "#{medium_uri}/#{liveimg_name}"
 end
 %>
 

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -36,3 +36,5 @@ Menu::Loader.load
 # clear our users topbar cache
 # The users table may not be exist during initial migration of the database
 TopbarSweeper.expire_cache_all_users if (User.table_exists? rescue false)
+
+Foreman::Plugin.medium_providers.register MediumProviders::Default

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -24,7 +24,9 @@ module Foreman
       :pxe_kernel_options,
       :save_to_file,
       :subnet_param, :subnet_has_param?,
-      :global_setting
+      :global_setting,
+      :medium_provider,
+      :medium_uri
     ]
     ALLOWED_HOST_HELPERS ||= [
       :grub_pass,
@@ -265,6 +267,10 @@ module Foreman
       file
     end
 
+    def medium_provider
+      @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(@host)
+    end
+
     # can be used to load additional variable relevant for give pxe type, requires @host to be present
     def load_template_vars
       # load the os family default variables
@@ -310,7 +316,7 @@ module Foreman
     end
 
     def alterator_attributes
-      @mediapath   = @host.operatingsystem.mediumpath @host
+      @mediapath   = @host.operatingsystem.mediumpath medium_provider
       @mediaserver = URI(@mediapath).host
       @metadata    = params[:metadata].to_s
     end
@@ -334,24 +340,24 @@ module Foreman
       @dynamic   = @host.diskLayout =~ /^#Dynamic/ if (@host.respond_to?(:disk) && @host.disk.present?) || @host.ptable.present?
       @arch      = @host.architecture.name
       @osver     = @host.operatingsystem.major.to_i
-      @mediapath = @host.operatingsystem.mediumpath @host if @host.medium
+      @mediapath = @host.operatingsystem.mediumpath medium_provider if @host.medium
       @repos     = @host.operatingsystem.repos @host
     end
 
     def preseed_attributes
       if @host.operatingsystem && @host.medium && @host.architecture
-        @preseed_path   = @host.operatingsystem.preseed_path   @host
-        @preseed_server = @host.operatingsystem.preseed_server @host
+        @preseed_path   = @host.operatingsystem.preseed_path   medium_provider
+        @preseed_server = @host.operatingsystem.preseed_server medium_provider
       end
     end
 
     def yast_attributes
       @dynamic   = @host.diskLayout =~ /^#Dynamic/ if (@host.respond_to?(:disk) && @host.disk.present?) || @host.ptable.present?
-      @mediapath = @host.operatingsystem.mediumpath @host if @host.medium
+      @mediapath = @host.operatingsystem.mediumpath medium_provider if @host.medium
     end
 
     def coreos_attributes
-      @mediapath = @host.operatingsystem.mediumpath @host
+      @mediapath = @host.operatingsystem.mediumpath medium_provider
     end
 
     def rancheros_attributes
@@ -359,28 +365,28 @@ module Foreman
     end
 
     def aif_attributes
-      @mediapath = @host.operatingsystem.mediumpath @host
+      @mediapath = @host.operatingsystem.mediumpath medium_provider
     end
 
     def memdisk_attributes
-      @mediapath = @host.operatingsystem.mediumpath @host
+      @mediapath = @host.operatingsystem.mediumpath medium_provider
     end
 
     def ZTP_attributes
-      @mediapath = @host.operatingsystem.mediumpath @host
+      @mediapath = @host.operatingsystem.mediumpath medium_provider
     end
 
     def waik_attributes
     end
 
     def xenserver_attributes
-      @mediapath = @host.operatingsystem.mediumpath @host
-      @xen = @host.operatingsystem.xen(@host.arch, @host)
+      @mediapath = @host.operatingsystem.mediumpath medium_provider
+      @xen = @host.operatingsystem.xen(medium_provider)
     end
 
     def pxe_config
-      @kernel = @host.operatingsystem.kernel(@host.arch, @host)
-      @initrd = @host.operatingsystem.initrd(@host.arch, @host)
+      @kernel = @host.operatingsystem.kernel(medium_provider)
+      @initrd = @host.operatingsystem.initrd(medium_provider)
     end
 
     def validate_subnet(subnet)

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -375,12 +375,12 @@ module Foreman
 
     def xenserver_attributes
       @mediapath = @host.operatingsystem.mediumpath @host
-      @xen = @host.operatingsystem.xen @host.arch
+      @xen = @host.operatingsystem.xen(@host.arch, @host)
     end
 
     def pxe_config
-      @kernel = @host.operatingsystem.kernel @host.arch
-      @initrd = @host.operatingsystem.initrd @host.arch
+      @kernel = @host.operatingsystem.kernel(@host.arch, @host)
+      @initrd = @host.operatingsystem.initrd(@host.arch, @host)
     end
 
     def validate_subnet(subnet)

--- a/lib/tasks/exports.rake
+++ b/lib/tasks/exports.rake
@@ -45,7 +45,7 @@ end
 exporter_template(:enabled, :managed_hosts_bootfiles) do |header, data|
   header << ["Host", "Boot files"]
   Host::Managed.all.find_each do |host|
-    bootfiles = host.operatingsystem.send(:boot_files_uri, host.medium, host.architecture, host) rescue []
+    bootfiles = host.operatingsystem.send(:boot_files_uri, host.host_medium_provider) rescue []
     data << [
       host.name,
       bootfiles.join(' + ')

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -14,6 +14,10 @@ class UnattendedControllerTest < ActionController::TestCase
     setup do
       ptable = FactoryBot.create(:ptable, :name => 'default',
                                   :operatingsystem_ids => [operatingsystems(:redhat).id])
+      media(:one).organizations << @org
+      media(:one).locations << @loc
+      media(:ubuntu).organizations << @org
+      media(:ubuntu).locations << @loc
       @rh_host = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :build => true,
                                     :operatingsystem => operatingsystems(:redhat),
                                     :ptable => ptable,

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -308,13 +308,6 @@ class OperatingsystemTest < ActiveSupport::TestCase
     assert_equal("#{operatingsystem.id}-applet-מערכתההפעלהשלי 4", operatingsystem.to_param)
   end
 
-  test 'interpolated $version does not include dots if only major is specified' do
-    operatingsystem = FactoryBot.build_stubbed(:operatingsystem, :name => 'foo', :major => '4')
-    result_path = operatingsystem.interpolate_medium_vars('http://foo.org/$version',
-                                                          'x64', operatingsystem)
-    assert result_path, 'http://foo.org/4'
-  end
-
   context 'name should be unique in scope of major and minor' do
     setup do
       @os = FactoryBot.create(:operatingsystem, :name => 'centos', :major => 8, :minor => 3)

--- a/test/models/operatingsystems/operatingsystems_test.rb
+++ b/test/models/operatingsystems/operatingsystems_test.rb
@@ -30,10 +30,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :coreos, 'expected' => 'boot/CoreOS-494.5.0-x86_64-coreos_production_pxe.vmlinuz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-linux' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-linux' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :suse,   'expected' => 'boot/OpenSuse-11.4-x86_64-linux' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-coreos_production_pxe.vmlinuz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-linux' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8-linux' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89-linux' } }.
   each do |os, config|
     test "kernel location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -41,16 +41,17 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                :operatingsystem => FactoryBot.build_stubbed(config['os'],
                                                                      :architectures => [arch],
                                                                      :ptables => [FactoryBot.create(:ptable)],
-                                                                     :media => [FactoryBot.build_stubbed(:medium)]),
-                               :architecture => arch)
-      assert_equal(config['expected'], host.operatingsystem.kernel(host.arch))
+                                                                     :media => [media(config['medium'])]),
+                               :architecture => arch,
+                               :medium => media(config['medium']))
+      assert_equal(config['expected'], host.operatingsystem.kernel(host.arch, host))
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :coreos, 'expected' => 'boot/CoreOS-494.5.0-x86_64-coreos_production_pxe_image.cpio.gz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-initrd.gz' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-initrd.gz' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :suse,   'expected' => 'boot/OpenSuse-11.4-x86_64-initrd' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-coreos_production_pxe_image.cpio.gz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-initrd.gz' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8-initrd.gz' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89-initrd' } }.
   each do |os, config|
     test "initrd location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -58,16 +59,17 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                :operatingsystem => FactoryBot.build_stubbed(config['os'],
                                                                      :architectures => [arch],
                                                                      :ptables => [FactoryBot.create(:ptable)],
-                                                                     :media => [FactoryBot.build_stubbed(:medium)]),
-                               :architecture => arch)
-      assert_equal(config['expected'], host.operatingsystem.initrd(host.arch))
+                                                                     :media => [media(config['medium'])]),
+                               :architecture => arch,
+                               :medium => media(config['medium']))
+      assert_equal(config['expected'], host.operatingsystem.initrd(host.arch, host))
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :coreos, 'expected' => 'boot/CoreOS-494.5.0-x86_64'},
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64'},
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64'},
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :suse,   'expected' => 'boot/OpenSuse-11.4-x86_64' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62'},
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62'},
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8'},
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89' } }.
   each do |os, config|
     test "pxe prefix for #{os}" do
       arch = architectures(config['arch'])
@@ -75,9 +77,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                :operatingsystem => FactoryBot.build_stubbed(config['os'],
                                                                      :architectures => [arch],
                                                                      :ptables => [FactoryBot.create(:ptable)],
-                                                                     :media => [FactoryBot.build_stubbed(:medium)]),
-                               :architecture => arch)
-      assert_equal(config['expected'], host.operatingsystem.pxe_prefix(host.arch))
+                                                                     :media => [media(config['medium'])]),
+                               :architecture => arch,
+                               :medium => media(config['medium']))
+      assert_equal(config['expected'], host.operatingsystem.pxe_prefix(host.arch, host))
     end
   end
 
@@ -110,8 +113,8 @@ class OperatingsystemsTest < ActiveSupport::TestCase
       host.medium.operatingsystems << host.operatingsystem
       host.arch.operatingsystems << host.operatingsystem
 
-      prefix = host.operatingsystem.pxe_prefix(host.arch).to_sym
-      pxe_files = host.operatingsystem.pxe_files(host.medium, host.arch)
+      prefix = host.operatingsystem.pxe_prefix(host.arch, host).to_sym
+      pxe_files = host.operatingsystem.pxe_files(host.medium, host.arch, host)
 
       assert pxe_files.include?({ prefix => config['kernel'] })
       assert pxe_files.include?({ prefix => config['initrd'] })

--- a/test/models/operatingsystems/operatingsystems_test.rb
+++ b/test/models/operatingsystems/operatingsystems_test.rb
@@ -15,7 +15,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'expected' => '$arch/$version' },
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'expected' => '$arch-usr/$version' },
     :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/debian-installer/$arch' },
     :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/ubuntu-installer/$arch' },
     :suse        => { 'os' => :suse,        'arch' => :x86_64, 'expected' => 'boot/$arch/loader' } }.
@@ -30,10 +30,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-coreos_production_pxe.vmlinuz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-linux' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8-linux' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89-linux' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-coreos_production_pxe.vmlinuz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-linux' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw-linux' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y-linux' } }.
   each do |os, config|
     test "kernel location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -44,14 +44,16 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :media => [media(config['medium'])]),
                                :architecture => arch,
                                :medium => media(config['medium']))
-      assert_equal(config['expected'], host.operatingsystem.kernel(host.arch, host))
+      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+
+      assert_equal(config['expected'], host.operatingsystem.kernel(medium_provider))
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-coreos_production_pxe_image.cpio.gz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62-initrd.gz' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8-initrd.gz' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89-initrd' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-coreos_production_pxe_image.cpio.gz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-initrd.gz' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw-initrd.gz' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y-initrd' } }.
   each do |os, config|
     test "initrd location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -62,14 +64,16 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :media => [media(config['medium'])]),
                                :architecture => arch,
                                :medium => media(config['medium']))
-      assert_equal(config['expected'], host.operatingsystem.initrd(host.arch, host))
+
+      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      assert_equal(config['expected'], host.operatingsystem.initrd(medium_provider))
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/CoreOS-494.5.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62'},
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/Debian-7.0-x86_64-c440a52e0119b57fc9109aeb7c4a19f5e8e75c62'},
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/Ubuntu-14.10-x86_64-d7fdf2554cca70ac1a710b4a75127bf7fcb9dad8'},
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse,   'expected' => 'boot/OpenSuse-11.4-x86_64-a60c87650b8a37ecb9e71348c355c5032abdac89' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_'},
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_'},
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw'},
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y' } }.
   each do |os, config|
     test "pxe prefix for #{os}" do
       arch = architectures(config['arch'])
@@ -80,7 +84,8 @@ class OperatingsystemsTest < ActiveSupport::TestCase
                                                                      :media => [media(config['medium'])]),
                                :architecture => arch,
                                :medium => media(config['medium']))
-      assert_equal(config['expected'], host.operatingsystem.pxe_prefix(host.arch, host))
+      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      assert_equal(config['expected'], host.operatingsystem.pxe_prefix(medium_provider))
     end
   end
 
@@ -112,10 +117,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
 
       host.medium.operatingsystems << host.operatingsystem
       host.arch.operatingsystems << host.operatingsystem
+      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
 
-      prefix = host.operatingsystem.pxe_prefix(host.arch, host).to_sym
-      pxe_files = host.operatingsystem.pxe_files(host.medium, host.arch, host)
-
+      prefix = host.operatingsystem.pxe_prefix(medium_provider).to_sym
+      pxe_files = host.operatingsystem.pxe_files(medium_provider)
       assert pxe_files.include?({ prefix => config['kernel'] })
       assert pxe_files.include?({ prefix => config['initrd'] })
     end

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -198,10 +198,10 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     expected = <<-EXPECTED
 default linux
 label linux
-kernel boot/Redhat-6.1-x86_64-vmlinuz
-append initrd=boot/Redhat-6.1-x86_64-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
+kernel boot/Redhat-6.1-x86_64-7a166fa29c0319903fb4a3d40be16c3785f27a96-vmlinuz
+append initrd=boot/Redhat-6.1-x86_64-7a166fa29c0319903fb4a3d40be16c3785f27a96-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
 EXPECTED
-    assert_equal template, expected.strip
+    assert_equal expected.strip, template
     assert h.build
   end
 
@@ -341,10 +341,10 @@ EXPECTED
     expected = <<-EXPECTED
 DEFAULT linux
 LABEL linux
-KERNEL boot/OpenSuse-12.3-x86_64-linux
-APPEND initrd=boot/OpenSuse-12.3-x86_64-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
+KERNEL boot/OpenSuse-12.3-x86_64-eaf117e51697908ee13fe86912fa81ad16c21a6b-linux
+APPEND initrd=boot/OpenSuse-12.3-x86_64-eaf117e51697908ee13fe86912fa81ad16c21a6b-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
 EXPECTED
-    assert_equal template, expected.strip
+    assert_equal expected.strip, template
     assert h.build
   end
 end

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -198,8 +198,8 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     expected = <<-EXPECTED
 default linux
 label linux
-kernel boot/Redhat-6.1-x86_64-7a166fa29c0319903fb4a3d40be16c3785f27a96-vmlinuz
-append initrd=boot/Redhat-6.1-x86_64-7a166fa29c0319903fb4a3d40be16c3785f27a96-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
+kernel boot/centos-5-4-hZvopwDGZA-vmlinuz
+append initrd=boot/centos-5-4-hZvopwDGZA-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
 EXPECTED
     assert_equal expected.strip, template
     assert h.build
@@ -208,7 +208,12 @@ EXPECTED
   test "generate_pxe_template_for_pxelinux_localboot" do
     return unless unattended?
     h = FactoryBot.create(:host, :managed)
-    as_admin { h.update_attribute :operatingsystem, operatingsystems(:centos5_3) }
+    as_admin do
+      os = operatingsystems(:centos5_3)
+      os.media << h.medium
+      os.architectures << h.architecture
+      h.update_attribute :operatingsystem, os
+    end
     assert !h.build
 
     template = h.send(:generate_pxe_template, :PXELinux).to_s.tr! '~', "\n"
@@ -235,7 +240,12 @@ EXPECTED
                                                           :template_kind => template_kinds(:pxelinux))
     Setting['local_boot_PXELinux'] = template.name
     h = FactoryBot.create(:host, :managed)
-    as_admin { h.update_attribute :operatingsystem, operatingsystems(:centos5_3) }
+    as_admin do
+      os = operatingsystems(:centos5_3)
+      os.media << h.medium
+      os.architectures << h.architecture
+      h.update_attribute :operatingsystem, os
+    end
     assert !h.build
 
     result = h.send(:generate_pxe_template, :PXELinux)
@@ -249,7 +259,12 @@ EXPECTED
                                                           :template_kind => template_kinds(:pxelinux))
     h = FactoryBot.create(:host, :managed)
     FactoryBot.create(:host_parameter, :name => 'local_boot_PXELinux', :value => template.name, :reference_id => h.id)
-    as_admin { h.update_attribute :operatingsystem, operatingsystems(:centos5_3) }
+    as_admin do
+      os = operatingsystems(:centos5_3)
+      os.media << h.medium
+      os.architectures << h.architecture
+      h.update_attribute :operatingsystem, os
+    end
     assert !h.build
 
     result = h.send(:generate_pxe_template, :PXELinux)
@@ -341,8 +356,8 @@ EXPECTED
     expected = <<-EXPECTED
 DEFAULT linux
 LABEL linux
-KERNEL boot/OpenSuse-12.3-x86_64-eaf117e51697908ee13fe86912fa81ad16c21a6b-linux
-APPEND initrd=boot/OpenSuse-12.3-x86_64-eaf117e51697908ee13fe86912fa81ad16c21a6b-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
+KERNEL boot/opensuse-vEX5RaXkI7-linux
+APPEND initrd=boot/opensuse-vEX5RaXkI7-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
 EXPECTED
     assert_equal expected.strip, template
     assert h.build

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -40,7 +40,7 @@ class RendererTest < ActiveSupport::TestCase
       host = FactoryBot.build_stubbed(:host, :managed)
       architecture = FactoryBot.build_stubbed(:architecture)
       medium = FactoryBot.build_stubbed(:medium, :path => 'http://my-example.com/my_path')
-      os = FactoryBot.build_stubbed(:debian7_0, :media => [ medium ])
+      os = FactoryBot.build_stubbed(:debian7_0, :media => [ medium ], :architectures => [architecture])
       host.architecture = architecture
       host.operatingsystem = os
       host.medium = medium

--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class DefaultMediumProviderTest < ActiveSupport::TestCase
+  test 'interpolated $version does not include dots if only major is specified' do
+    operatingsystem = FactoryBot.build_stubbed(:operatingsystem, :name => 'foo', :major => '4')
+    architecture = FactoryBot.build_stubbed(:architecture, :name => 'x64')
+    mock_entity = OpenStruct.new(operatingsystem: operatingsystem, architecture: architecture)
+
+    provider = MediumProviders::Default.new(mock_entity)
+
+    result_path = provider.interpolate_vars('http://foo.org/$version')
+    assert result_path, 'http://foo.org/4'
+  end
+end


### PR DESCRIPTION
After this change, boot file names will contain a hash of the medium they were created from. Example:
```
# old:
boot/Redhat-6.1-x86_64-vmlinuz
boot/Redhat-6.1-x86_64-initrd.img
# new:
boot/CentOS_mirror-aBsbsZ_lDn-vmlinuz
boot/CentOS_mirror-aBsbsZ_lDn-initrd.img
```

This will add the ability to distinguish between multiple "flavors" of the same operating system. For example, if a user wants to have both Fedora 27 server and Fedora 27 workstation. Best way to do it, would be defining multiple installation media for the same OS.

Before this change, foreman would overwrite the same file from different source each time the user deployed a host with different medium selected. After the change, both files would coexist in the TFTP directory.

Technically, the hash is the digest of medium URI. This should work even with katello, since they are overloading the same methods.

Edit by lzap: Corrected according to final naming conventions we agreed on.