### PR TITLE
Fixes #22556 - Correct host search for parent hostgroup

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -134,8 +134,8 @@ module Hostext
         conditions = sanitize_sql_for_conditions(["hostgroups.title #{operator} ?", value_to_sql(operator, value)])
         # Only one hostgroup (first) is used to determined descendants. Future TODO - alert if result results more than one hostgroup
         hostgroup     = Hostgroup.unscoped.with_taxonomy_scope.where(conditions).first
-        hostgroup_ids = hostgroup.subtree_ids
-        if hostgroup_ids.any?
+        if hostgroup.present?
+          hostgroup_ids = hostgroup.subtree_ids
           opts = "hosts.hostgroup_id IN (#{hostgroup_ids.join(',')})"
         else
           opts = "hosts.id < 0"

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1849,6 +1849,13 @@ class HostTest < ActiveSupport::TestCase
       assert_equal ["Common", "Common/db"].sort, hosts.map { |h| h.hostgroup.title }.sort
     end
 
+    test "search hosts by non-existing parent hostgroup returns no results" do
+      FactoryBot.create(:host, :with_hostgroup)
+      refute_equal Host::Managed.count, 0
+      hosts = Host::Managed.search_for("parent_hostgroup = Nosuchgroup")
+      assert_equal hosts.count, 0
+    end
+
     test "can search hosts by numeric and string facts" do
       host = FactoryBot.create(:host, :hostname => 'num001.example.com')
       host.import_facts({:architecture => "x86_64", :interfaces => 'eth0', :operatingsystem => 'RedHat-test', :operatingsystemrelease => '6.2',:memory_mb => "64498",:custom_fact => "find_me"})


### PR DESCRIPTION
Currently, searching on a non-existant parent fails due to
`hostgroup.subtree_ids` throwing a NoMethodError when no matching
hostgroup is found. This is rescued by scoped search, causing the
search to run with no conditions instead.
(see
https://github.com/wvanbergen/scoped_search/blob/v4.1.2/lib/scoped_search/query_builder.rb#L405
for the scoped_search part)



<!---

Thank you for contributing to The Foreman, please read the following guide
available at https://www.theforeman.org/contribute.html - in short:

* Create an issue at https://projects.theforeman.org/projects/foreman/issues
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see Translating section in the guide
  https://projects.theforeman.org/projects/foreman/wiki/Translating
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
