### PR TITLE
Refs #22354 - Don't instance_eval at every instance creation

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -1,6 +1,5 @@
 require 'logging'
 require 'fileutils'
-require_dependency File.expand_path('../silenced_logger', __FILE__)
 
 module Foreman
   class LoggingImpl
@@ -21,6 +20,9 @@ module Foreman
       configure_root_logger(options)
 
       build_console_appender
+      # we need to postpone loading of the silenced logger
+      # to the time the Logging::LEVELS is initialized
+      require_dependency File.expand_path('../silenced_logger', __FILE__)
     end
 
     def add_loggers(loggers = {})

--- a/lib/foreman/silenced_logger.rb
+++ b/lib/foreman/silenced_logger.rb
@@ -8,9 +8,8 @@
 #
 module Foreman
   class SilencedLogger < SimpleDelegator
-    def initialize(obj)
-      ::Logging::LEVELS.each do |name, num|
-        instance_eval <<-EOT, __FILE__, __LINE__ + 1
+    ::Logging::LEVELS.each do |name, num|
+      class_eval <<-EOT, __FILE__, __LINE__ + 1
         def #{name.downcase}?
           #{num} >= local_level
         end
@@ -18,10 +17,7 @@ module Foreman
         def #{name.downcase}(*args)
           super(*args) if #{num} >= local_level
         end
-        EOT
-      end
-
-      super(obj)
+      EOT
     end
 
     def level_key


### PR DESCRIPTION
Before this patch, we were defining the methods at every instance
creation. This means potential performance issues, as defining new
methods causes the method lookup cache to get dropped.

I needed to move the time for loading the silencer a bit later so that
the `Logging::LEVELS` are already initialized (as they are empty at the
beginning).