### PR TITLE
Fixes #17316 - templates feature is subnet association

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -57,6 +57,12 @@ class Subnet < ApplicationRecord
     :api_description => N_('DNS Proxy ID to use within this subnet'),
     :description => N_('DNS Proxy to use within this subnet for managing PTR records, note that A and AAAA records are managed via Domain DNS proxy')
 
+  belongs_to_proxy :template,
+    :feature => N_('Templates'),
+    :label => N_('Template Proxy'),
+    :api_description => N_('Template HTTP(S) Proxy ID to use within this subnet'),
+    :description => N_('Template HTTP(S) Proxy to use within this subnet to allow access templating endpoint from isolated networks')
+
   has_many :hostgroups
   has_many :subnet_domains, :dependent => :destroy, :inverse_of => :subnet
   has_many :domains, :through => :subnet_domains
@@ -165,6 +171,14 @@ class Subnet < ApplicationRecord
 
   def dns_proxy(attrs = {})
     @dns_proxy ||= ProxyAPI::DNS.new({:url => dns.url}.merge(attrs)) if dns?
+  end
+
+  def template?
+    !!(template && template.url)
+  end
+
+  def template_proxy(attrs = {})
+    @template_proxy ||= ProxyAPI::Template.new({:url => template.url}.merge(attrs)) if template?
   end
 
   def ipam?

--- a/db/migrate/20180216094550_add_template_to_subnets.rb
+++ b/db/migrate/20180216094550_add_template_to_subnets.rb
@@ -1,0 +1,15 @@
+class AddTemplateToSubnets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subnets, :template_id, :integer
+
+    reversible do |dir|
+      dir.up do
+        Subnet.unscoped.find_each do |subnet|
+          proxy = subnet.tftp
+          subnet.template = proxy if proxy.has_feature?("TFTP")
+          subnet.save
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -16,12 +16,12 @@ module Foreman
 
       host = @host
       host = self if @host.nil? && self.class < Host::Base
-      proxy = host.try(:provision_interface).try(:subnet).try(:tftp)
+      template_proxy = host.try(:provision_interface).try(:subnet).try(:template_proxy)
 
-      # use template_url from the request if set, but otherwise look for a Template
+      # Use template_url from the request if set, but otherwise look for a Template
       # feature proxy, as PXE templates are written without an incoming request.
       url = @template_url
-      url ||= foreman_url_from_templates_proxy(proxy) if proxy.present? && proxy.has_feature?('Templates')
+      url ||= foreman_url_from_templates_proxy(template_proxy) if template_proxy.present?
 
       url_options = foreman_url_options_from_url(url) if url.present?
 

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -28,7 +28,7 @@ class UnattendedControllerTest < ActionController::TestCase
                                     :organization => @org,
                                     :location => @loc
                                    )
-      @host_with_template_subnet = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :with_tftp_subnet, :build => true,
+      @host_with_template_subnet = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :with_templates_subnet, :build => true,
                                     :operatingsystem => operatingsystems(:ubuntu1010),
                                     :ptable => ptable_ubuntu,
                                     :medium => media(:ubuntu),
@@ -429,7 +429,7 @@ class UnattendedControllerTest < ActionController::TestCase
     @request.env["REMOTE_ADDR"] = '127.0.0.1'
     @host_with_template_subnet.create_token(:value => "aaaaae", :expires => Time.now.utc + 5.minutes)
     get :host_template, params: { :kind => 'provision', 'token' => @host_with_template_subnet.token.value }
-    assert_includes @response.body, "#{@host_with_template_subnet.subnet.tftp.url}/unattended/finish?token=aaaaae"
+    assert_includes @response.body, "#{@host_with_template_subnet.subnet.template.url}/unattended/finish?token=aaaaae"
   end
 
   # Should this test be moved into renderer_test, as it excercises foreman_url() functionality?

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :feature do
-    factory :template_feature do
+    factory :templates do
       name 'Templates'
     end
 

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -368,6 +368,10 @@ FactoryBot.define do
       subnet { FactoryBot.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]) }
     end
 
+    trait :with_templates_subnet do
+      subnet { FactoryBot.build(:subnet_ipv4, :template, locations: [location], organizations: [organization]) }
+    end
+
     trait :with_separate_provision_interface do
       interfaces do
         [FactoryBot.build(:nic_managed,

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     end
 
     factory :template_smart_proxy do
-      features { |sp| [sp.association(:template_feature), sp.association(:tftp_feature) ] }
+      features { |sp| [sp.association(:templates)] }
     end
 
     factory :bmc_smart_proxy do

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
       association :dns, :factory => :dns_smart_proxy
     end
 
+    trait :template do
+      association :template, :factory => :template_smart_proxy
+    end
+
     trait :with_domains do
       transient do
         domains_count 2

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -80,11 +80,10 @@ class RendererTest < ActiveSupport::TestCase
   end
 
   test "foreman_url should respect proxy with Templates feature" do
-    host = FactoryBot.build(:host, :with_separate_provision_interface)
-    template_proxy_url = SmartProxy.with_features("Templates").first.url
-    ProxyAPI::Template.any_instance.stubs(:template_url).returns(template_proxy_url)
+    host = FactoryBot.build(:host, :with_separate_provision_interface, :with_dhcp_orchestration)
+    host.provision_interface.subnet.template = FactoryBot.build(:template_smart_proxy)
     @renderer.host = host
-    assert_match(host.provision_interface.subnet.tftp.url, @renderer.foreman_url)
+    assert_match(host.provision_interface.subnet.template.url, @renderer.foreman_url)
   end
 
   test "foreman_url should run with @host as nil" do

--- a/test/unit/foreman_url_renderer_test.rb
+++ b/test/unit/foreman_url_renderer_test.rb
@@ -39,7 +39,7 @@ class ForemanUrlRendererTest < ActiveSupport::TestCase
       template_server_from_proxy = 'https://someproxy:8443'
       proxy = FactoryBot.build(:template_smart_proxy)
       ProxyAPI::Template.any_instance.stubs(:template_url).returns(template_server_from_proxy)
-      host.subnet.tftp = proxy
+      host.subnet.template = proxy
       renderer.host = host
       assert_equal "#{template_server_from_proxy}/unattended/#{action}?token=#{token}", renderer.foreman_url(action)
     end


### PR DESCRIPTION
Template feature should always have been a proxy association with
Subnet. Currently templating engine searches for TFTP Smart Proxy with
Templates feature and if it's found, then foreman_url is rendered via
Smart Proxy.

This is now changed, Subnet has a "Template Proxy" association that must
be explicitly set in order to have templates proxied. The only open
question is migration - currently it's left unset, which will break
existing installation and users will need to set it. Solution: copy
smart proxy which is set as TFTP if it has Templates feature.