### PR TITLE
Fixes #22615 - template rendering is kept inline

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -249,7 +249,7 @@ class UnattendedController < ApplicationController
     end
 
     begin
-      render :plain => unattended_render(@unsafe_template_content, @template_name)
+      render :inline => "<%= unattended_render(@unsafe_template_content, @template_name).html_safe %>"
     rescue => error
       msg = _("There was an error rendering the %s template: ") % (@template_name)
       Foreman::Logging.exception(msg, error)


### PR DESCRIPTION
In recent change, we refactored the line into more readable plain call,
but it actually broke rendering. I guess we want to keep inline
rendering, it was not main purpose of the original PR to change this.

@timogoebel