### PR TITLE
Fixes #22624 - User selectable columns model + api

### DIFF
--- a/app/controllers/api/v2/table_preferences_controller.rb
+++ b/app/controllers/api/v2/table_preferences_controller.rb
@@ -1,0 +1,59 @@
+module Api
+  module V2
+    class TablePreferencesController < V2::BaseController
+      include Api::Version2
+      include Foreman::Controller::UserAware
+      before_action :check_user
+      before_action :find_resource, :only => [:destroy, :update, :show]
+
+      api :GET, "/users/:user_id/table_preferences", N_("List of table preferences for a user")
+      def index
+        @table_preferences = @user.table_preferences
+      end
+
+      api :GET, "/users/:user_id/table_preferences/:name", N_("Table preference details of a given table")
+      param :name, String, :required => true
+      def show
+        if @table_preference.blank?
+          @table_preference = TablePreference.new(:user => @user, :name => params[:name])
+        end
+      end
+
+      def_param_group :table_preference do
+        param :table_preferences, Hash, :required => true do
+          param :name, String, :required => true, :desc => N_("Name of the table")
+          param :columns, Array, :desc => N_("List of user selected columns")
+        end
+      end
+
+      api :POST, "/users/:user_id/table_preferences/", N_("Creates a table preference for a given table")
+      param_group :table_preference
+      def create
+        @table_preference = @user.table_preferences.build(:name => params[:name], :columns => params[:columns])
+        process_response @table_preference.save
+      end
+
+      api :PUT, "/users/:user_id/table_preferences/:name", N_("Updates a table preference for a given table")
+      param_group :table_preference
+      def update
+        process_response @table_preference.update_attributes(:columns => params[:columns])
+      end
+
+      api :DELETE, "/users/:user_id/table_preferences/:name/", N_("Delete a table preference for a given table")
+      param :name, String, :required => true, :desc => N_("name of the table")
+      def destroy
+        process_response @table_preference.destroy
+      end
+
+      private
+
+      def check_user
+        deny_access N_("You are trying access the preferences of a different user") if @user != User.current
+      end
+
+      def resource_class
+        TablePreference
+      end
+    end
+  end
+end

--- a/app/models/table_preference.rb
+++ b/app/models/table_preference.rb
@@ -1,0 +1,10 @@
+class TablePreference < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name
+  include Parameterizable::ByIdName
+
+  belongs_to :user
+  validates :user_id, :name, :presence => true
+  serialize :columns
+  validates_lengths_from_database
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
   has_many :widgets, :dependent => :destroy
   has_many :ssh_keys, :dependent => :destroy
   has_many :personal_access_tokens, :dependent => :destroy
-
+  has_many :table_preferences, :dependent => :destroy, :inverse_of => :user
   has_many :user_mail_notifications, :dependent => :destroy, :inverse_of => :user
   has_many :mail_notifications, :through => :user_mail_notifications
   has_many :notification_recipients, :dependent => :delete_all

--- a/app/views/api/v2/table_preferences/create.json.rabl
+++ b/app/views/api/v2/table_preferences/create.json.rabl
@@ -1,0 +1,2 @@
+object @table_preference
+extends "api/v2/table_preferences/main"

--- a/app/views/api/v2/table_preferences/destroy.json.rabl
+++ b/app/views/api/v2/table_preferences/destroy.json.rabl
@@ -1,0 +1,2 @@
+object @table_preference
+extends "api/v2/table_preferences/main"

--- a/app/views/api/v2/table_preferences/index.json.rabl
+++ b/app/views/api/v2/table_preferences/index.json.rabl
@@ -1,0 +1,3 @@
+collection @table_preferences
+
+extends "api/v2/table_preferences/main"

--- a/app/views/api/v2/table_preferences/main.json.rabl
+++ b/app/views/api/v2/table_preferences/main.json.rabl
@@ -1,0 +1,2 @@
+object @table_preference
+attributes :id, :name, :columns, :created_at, :updated_at

--- a/app/views/api/v2/table_preferences/show.json.rabl
+++ b/app/views/api/v2/table_preferences/show.json.rabl
@@ -1,0 +1,2 @@
+object @table_preference
+extends "api/v2/table_preferences/main"

--- a/app/views/api/v2/table_preferences/update.json.rabl
+++ b/app/views/api/v2/table_preferences/update.json.rabl
@@ -1,0 +1,2 @@
+object @table_preference
+extends "api/v2/table_preferences/main"

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -264,6 +264,7 @@ Foreman::Application.routes.draw do
           resources :usergroups, :except => [:new, :edit]
           resources :ssh_keys, :only => [:index, :show, :create, :destroy]
           resources :personal_access_tokens, :only => [:index, :show, :create, :destroy]
+          resources :table_preferences, :only => [:index, :create, :destroy, :show, :update]
         end
       end
 

--- a/db/migrate/20180208053256_create_table_preferences.rb
+++ b/db/migrate/20180208053256_create_table_preferences.rb
@@ -1,0 +1,12 @@
+class CreateTablePreferences < ActiveRecord::Migration[5.1]
+  def change
+    create_table :table_preferences do |t|
+      t.string :name, :limit => 255, :null => false
+      t.text :columns
+      t.timestamps :null => false
+      t.integer :user_id, :null => false
+    end
+    add_foreign_key :table_preferences, :users, :name => "table_preferences_user_id_fk"
+    add_index :table_preferences, [:user_id, :name], :unique => true
+  end
+end

--- a/test/controllers/api/v2/table_preferences_controller_test.rb
+++ b/test/controllers/api/v2/table_preferences_controller_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class Api::V2::TablePreferencesControllerTest < ActionController::TestCase
+  def resources
+    ["test_subscriptions_resource", "test_organizations_resource"]
+  end
+
+  def expected_columns
+    ["1", "2", "3"]
+  end
+
+  def setup
+    setup_users
+  end
+
+  def test_should_NOT_get_index_with_json_result
+    other_user = FactoryBot.create(:user, :with_widget)
+    get :index, params: {user_id: other_user.id}
+    assert_response :forbidden
+  end
+
+  def test_should_get_index_with_json_result
+    get :index, params: {user_id: User.current.id}
+    assert_response :success
+    columns = ActiveSupport::JSON.decode(@response.body)["results"]
+    assert_equal(columns.length, 0)
+  end
+
+  def test_should_show_columns_correctly
+    resource = resources.first
+    TablePreference.create!(user: User.current,
+                       name: resource, columns: expected_columns)
+    get :show, params: {user_id: User.current.id, id: resource}
+    assert_response :success
+    actual_columns = ActiveSupport::JSON.decode(@response.body)["columns"]
+    assert_equal(expected_columns, actual_columns)
+  end
+
+  def test_should_create_correctly
+    resource = resources.first
+    current_user = User.current
+    post :create, params: {user_id: User.current.id, name: resource, columns: expected_columns}
+    assert_response :success
+    columns = current_user.reload.table_preferences.first
+    assert_equal(expected_columns, columns.columns)
+  end
+
+  def test_should_update_correctly
+    resource = resources.first
+    current_user = User.current
+    TablePreference.create!(user: User.current,
+                       name: resource, columns: expected_columns)
+
+    put :update, params: {user_id: User.current.id, id: resource, columns: expected_columns}
+    assert_response :success
+    columns = current_user.reload.table_preferences.first
+    assert_equal(expected_columns, columns.columns)
+  end
+
+  def test_should_destroy_correctly
+    resource1 = resources[0]
+    resource2 = resources[1]
+    current_user = User.current
+    TablePreference.create!(user: User.current,
+                       name: resource1, columns: expected_columns)
+    TablePreference.create!(user: User.current,
+                       name: resource2, columns: expected_columns)
+
+    delete :destroy, params: { user_id: User.current.id, id: resource1}
+    assert_response :success
+
+    columns = current_user.reload.table_preferences
+    assert_equal(1, columns.size)
+    assert_equal(resource2, columns.first.name)
+  end
+end

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -40,7 +40,11 @@ class AccessPermissionsTest < ActiveSupport::TestCase
 
     # Content Security Policy report forwarding endpoint - noop if not configured.
     # See https://github.com/twitter/secureheaders/issues/113
-    "content_security_policy/scribe"
+    "content_security_policy/scribe",
+
+    #table preferences. No special permissions comes with user
+    "api/v2/table_preferences/index", "api/v2/table_preferences/show", "api/v2/table_preferences/create",
+    "api/v2/table_preferences/update", "api/v2/table_preferences/destroy",
   ]
 
   MAY_SKIP_AUTHORIZED = [ "about/index" ]


### PR DESCRIPTION
Adding initial bindings to user selectable columns. This model + api is
going to be used in work related Katello plugin's subscription pages.
The main intent of this PR is to provide a basic model where a user can
store "desirable or interested columns for a resource"
When the user for example says "I want to only see name column in
subscriptions" , we need model that would store that information
(similar to widgets or preferences.)
This commit facilitates that.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
