### PR TITLE
Revert "Fixes #22540 - auto-focus search bar"

### DIFF
--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -3,7 +3,7 @@
             id: 'search-form',
             onsubmit: 'return tfm.tools.updateTable(this);' do %>
   <div class="input-group">
-    <%= auto_complete_search(:search, params[:search].try(:squeeze," "), :placeholder => _("Filter") + ' ...', :autofocus => true).html_safe %>
+    <%= auto_complete_search(:search, params[:search].try(:squeeze," "), :placeholder => _("Filter") + ' ...').html_safe %>
     <span class="input-group-btn">
       <button class="btn btn-default" type="submit">
         <%= icon_text("search", content_tag(:span,_("Search"), :class=>"hidden-xs")) %>


### PR DESCRIPTION
This reverts commit 45f16ec8b5106a09a3f935091f879cdd88324b1f.
This has caused issues with mutliple tabs and auto-complete search



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
