### PR TITLE
Fixes #22096 - Make Audits taxable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '~> 4.6'
+gem 'audited', '~> 4.7'
 gem 'will_paginate', '~> 3.0'
 gem 'ancestry', '>= 2.0', '< 4'
 gem 'scoped_search', '>= 4.1.2', '< 5'

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,7 +4,7 @@ class AuditsController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    Audit.unscoped { @audits = resource_base_search_and_page.includes(:user) }
+    @audits = resource_base_search_and_page.with_taxonomy_scope.preload(:user)
   end
 
   def show

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -73,11 +73,12 @@ module AuditExtensions
     scoped_search :relation => :search_nics, :on => :ip, :complete_value => true, :rename => :interface_ip, :only_explicit => true
     scoped_search :relation => :search_nics, :on => :mac, :complete_value => true, :rename => :interface_mac, :only_explicit => true
 
-    before_save :fix_auditable_type, :ensure_username, :ensure_auditable_and_associated_name
+    before_save :fix_auditable_type, :ensure_username, :ensure_auditable_and_associated_name, :set_taxonomies
     before_save :filter_encrypted, :if => Proc.new {|audit| audit.audited_changes.present?}
     before_save :filter_passwords, :if => Proc.new {|audit| audit.audited_changes.try(:has_key?, 'password')}
 
     include Authorizable
+    include Taxonomix
 
     # audits can be created regardless of permissions
     def check_permissions_after_save
@@ -89,6 +90,11 @@ module AuditExtensions
     end
 
     serialize :audited_changes
+
+    # don't check user's permissions when setting the audit's taxonomies
+    def ensure_taxonomies_not_escalated
+      true
+    end
   end
 
   private
@@ -127,7 +133,29 @@ module AuditExtensions
   end
 
   def ensure_auditable_and_associated_name
-    self.auditable_name  ||= self.auditable.try(:to_label)
+    # If the label changed we want to record the old one, not the new one.
+    # We need to load old version from db since the auditable in memory is the
+    # updated version that hasn't been saved yet.
+    previous_state = auditable.class.where(id: auditable_id).first if auditable
+    previous_state ||= auditable
+    self.auditable_name  ||= previous_state.try(:to_label)
     self.associated_name ||= self.associated.try(:to_label)
+  end
+
+  def set_taxonomies
+    if SETTINGS[:locations_enabled]
+      if auditable.respond_to?(:location_id)
+        self.location_ids = [auditable.location_id, audited_changes['location_id']].flatten.compact.uniq
+      elsif auditable.respond_to?(:location_ids)
+        self.location_ids = auditable.location_ids
+      end
+    end
+    if SETTINGS[:organizations_enabled]
+      if auditable.respond_to?(:organization_id)
+        self.organization_ids = [auditable.organization_id, audited_changes['organization_id']].flatten.compact.uniq
+      elsif auditable.respond_to?(:organization_ids)
+        self.organization_ids = auditable.organization_ids
+      end
+    end
   end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -154,8 +154,8 @@ class Taxonomy < ApplicationRecord
     new
   end
 
-  # overwrite *_ids since need to check if ignored? - don't overwrite location_ids and organizations_ids since these aren't ignored
-  (TaxHost::HASH_KEYS - [:location_ids, :organizations_ids]).each do |key|
+  # overwrite *_ids since need to check if ignored? - don't overwrite location_ids and organization_ids since these aren't ignored
+  (TaxHost::HASH_KEYS - [:location_ids, :organization_ids]).each do |key|
     # def domain_ids
     #  if ignore?("Domain")
     #   Domain.pluck(:id)

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -204,11 +204,12 @@ class SettingTest < ActiveSupport::TestCase
     setting_name = "foo_#{rand(1000000)}"
     Setting.create!(:name => setting_name, :value => "bar", :default => "default", :description => "foo")
 
-    SETTINGS.stubs(:key?).with(setting_name.to_sym).returns(true)
-    SETTINGS.stubs(:[]).with(setting_name.to_sym).returns("no-bar")
+    SETTINGS[setting_name.to_sym] = "no-bar"
 
     persisted = Setting.create!(:name => setting_name, :description => "foo", :default => "default")
     assert_equal "no-bar", persisted.value
+  ensure
+    SETTINGS.delete(setting_name.to_sym)
   end
 
   def test_first_or_create_works


### PR DESCRIPTION
This relies on https://github.com/collectiveidea/audited/pull/413 for taxonomies to be recorded properly on destroy.
Still missing tests as well.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
