### PR TITLE
Fixes #22676 - domain checking should ignore scoping

### DIFF
--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -105,7 +105,7 @@ module Nic
       # no hostname was given or a domain was selected, since this is before validation we need to ignore
       # it and let the validations to produce an error
       return if name.empty?
-      if domain.nil? && name.include?('.') && changed_attributes['domain_id'].blank?
+      if domain_id.nil? && name.include?('.') && changed_attributes['domain_id'].blank?
         # try to assign the domain automatically based on our existing domains from the host FQDN
         self.domain = Domain.find_by(:name => name.partition('.')[2])
       elsif persisted? && changed_attributes['domain_id'].present?

--- a/test/models/nics/managed_test.rb
+++ b/test/models/nics/managed_test.rb
@@ -71,6 +71,19 @@ class ManagedTest < ActiveSupport::TestCase
     assert_equal new_domain, nic.domain
   end
 
+  test "#normalize_hostname does not update domain if domain does not match current taxonomies" do
+    domain = FactoryBot.create(:domain)
+    nic = setup_primary_nic_with_name(" Host.#{domain.name}", :domain => domain)
+    nic.save!
+    Location.current = taxonomies(:location2)
+    User.as('one') do
+      nic = Nic::Managed.find(nic.id) #load object to prevent cached association
+      nic.send(:normalize_name)
+      Location.current = nil
+      assert_equal domain.id, nic.domain_id
+    end
+  end
+
   test "#inheriting_mac respects interface mac" do
     h = FactoryBot.build_stubbed(:host, :managed)
     h.primary_interface.mac = '11:22:33:44:55:66'


### PR DESCRIPTION
By using domain_id, the true intent of the logic is held and saving the NIC doesn't require the domain to require the current scope.
