### PR TITLE
Fixes #22685 - improve statistics page  loading time

### DIFF
--- a/webpack/assets/javascripts/react_app/common/testHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/testHelpers.js
@@ -21,3 +21,12 @@ export default {
     };
   },
 };
+
+// a helper method for invoking a class method (for unit tests)
+// obj = a class
+// func = a tested function
+// objThis = an object's this
+// arg = function args
+
+export const classFunctionUnitTest = (obj, func, objThis, args) =>
+  obj.prototype[func].apply(objThis, args);

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
 import { Modal } from 'patternfly-react';
+import { isEqual } from 'lodash';
 import helpers from '../../common/helpers';
 import DonutChart from '../common/charts/DonutChart';
-import {
-  navigateToSearch,
-} from '../../../services/ChartService';
+import { navigateToSearch } from '../../../services/ChartService';
 import Loader from '../common/Loader';
 import MessageBox from '../common/MessageBox';
 
@@ -15,6 +14,12 @@ class ChartBox extends React.Component {
     super(props);
     this.state = { showModal: false };
     helpers.bindMethods(this, ['onClick', 'closeModal', 'openModal']);
+  }
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      !isEqual(this.props.chart, nextProps.chart) ||
+      !isEqual(this.state, nextState)
+    );
   }
 
   onClick() {
@@ -37,13 +42,15 @@ class ChartBox extends React.Component {
     const Chart = components[type];
     const dataFiltered = chart.data && chart.data.filter(arr => arr[1] !== 0);
     const hasChartData = dataFiltered && dataFiltered.length > 0;
-    const tooltip = hasChartData ? {
-      onClick: this.onClick,
-      title: this.props.tip,
-      'data-toggle': 'tooltip',
-      'data-placement': 'top',
-      className: 'pointer',
-    } : {};
+    const tooltip = hasChartData
+      ? {
+        onClick: this.onClick,
+        title: this.props.tip,
+        'data-toggle': 'tooltip',
+        'data-placement': 'top',
+        className: 'pointer',
+      }
+      : {};
     const handleChartClick =
       chart.search && chart.search.match(/=$/)
         ? null
@@ -63,20 +70,25 @@ class ChartBox extends React.Component {
     );
     const boxHeader = <h3 {...tooltip}>{this.props.title}</h3>;
 
-    return <Panel className="chart-box" header={boxHeader} key={this.props.chart.id}>
-        <Loader status={this.props.status}>
-          {[panelChart, error]}
-        </Loader>
-        {this.state.showModal &&
-        <Modal show={this.state.showModal} enforceFocus onHide={this.closeModal}>
-          <Modal.Header closeButton>
-            <Modal.Title>{this.props.title}</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <Chart {...chartProps} config="large" />;
-          </Modal.Body>
-        </Modal>}
-      </Panel>;
+    return (
+      <Panel className="chart-box" header={boxHeader} key={this.props.chart.id}>
+        <Loader status={this.props.status}>{[panelChart, error]}</Loader>
+        {this.state.showModal && (
+          <Modal
+            show={this.state.showModal}
+            enforceFocus
+            onHide={this.closeModal}
+          >
+            <Modal.Header closeButton>
+              <Modal.Title>{this.props.title}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <Chart {...chartProps} config="large" />;
+            </Modal.Body>
+          </Modal>
+        )}
+      </Panel>
+    );
   }
 }
 

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.test.js
@@ -2,6 +2,7 @@ import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';
 import React from 'react';
 import ChartBox from './ChartBox';
+import { classFunctionUnitTest } from '../../common/testHelpers';
 
 jest.unmock('../../../services/ChartService');
 jest.unmock('./ChartBox');
@@ -47,5 +48,35 @@ describe('ChartBox', () => {
     expect(box.find('Modal').length).toBe(0);
     box.setState({ showModal: true });
     expect(box.find('Modal').length).toBe(1);
+  });
+  it('shouldComponentUpdate should be called', () => {
+    const shouldUpdateSpy = jest.spyOn(ChartBox.prototype, 'shouldComponentUpdate');
+    const box = shallow(<ChartBox
+      id='4'
+      type="donut"
+      chart={{ id: '4', data: undefined }}
+      status="PENDING"
+    />);
+    box.setProps({ status: 'PENDING' });
+    expect(shouldUpdateSpy).toHaveBeenCalled();
+  });
+  it('shouldComponentUpdate', () => {
+    const objThis = {
+      state: { showModal: false },
+      props: { chart: { data: [1, 2] } },
+    };
+
+    expect(classFunctionUnitTest(ChartBox, 'shouldComponentUpdate', objThis, [
+      { chart: { data: [1, 2] } },
+      { showModal: false },
+    ])).toBe(false);
+    expect(classFunctionUnitTest(ChartBox, 'shouldComponentUpdate', objThis, [
+      { chart: { data: [1, 1] } },
+      { showModal: false },
+    ])).toBe(true);
+    expect(classFunctionUnitTest(ChartBox, 'shouldComponentUpdate', objThis, [
+      { chart: { data: [1, 2] } },
+      { showModal: true },
+    ])).toBe(true);
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/index.js
@@ -14,4 +14,3 @@ export const getStatisticsData = charts => dispatch =>
     url: chart.url,
     item: chart,
   })));
-


### PR DESCRIPTION
all ajax calls for each chart occurs in `StatisticsChartsList.js`, so with each and every store update, this entire component is re-rendered, and causes a performance issue.

 performance before change:
![statistics-too-slow](https://user-images.githubusercontent.com/11807069/36642956-8e7baa80-1a4e-11e8-81bc-3844adfa77f0.png)

after change:
![statistics-ok](https://user-images.githubusercontent.com/11807069/36642974-974300d2-1a4e-11e8-9a98-dcc3ae8f710c.png)


