### PR TITLE
Refs #18675 - Optionally load prometheus exporter

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,16 +1,8 @@
 # This file is used by Rack-based servers to start the application.
-
 require 'rack'
-require './lib/foreman/telemetry_rack'
-require 'prometheus/middleware/exporter'
 
 # load Rails environment
 require ::File.expand_path('../config/environment',  __FILE__)
-
-use Foreman::TelemetryRack
-if defined?(Prometheus::Middleware::Exporter) && SETTINGS[:telemetry].try(:fetch, :prometheus).try(:fetch, :enabled)
-  use Prometheus::Middleware::Exporter
-end
 
 # apply a prefix to the application, if one is defined
 # e.g. http://some.server.com/prefix where '/prefix' is defined by env variable

--- a/lib/middleware/telemetry.rb
+++ b/lib/middleware/telemetry.rb
@@ -1,5 +1,5 @@
-module Foreman
-  class TelemetryRack
+module Middleware
+  class Telemetry
     def initialize(app)
       @app = app
     end


### PR DESCRIPTION
In case the bundler group telemetry is not installed, we should handle that.