### PR TITLE
Refs #17316 - Ensure the proxy exists before assigning tftp

### DIFF
--- a/db/migrate/20180216094550_add_template_to_subnets.rb
+++ b/db/migrate/20180216094550_add_template_to_subnets.rb
@@ -6,6 +6,7 @@ class AddTemplateToSubnets < ActiveRecord::Migration[5.1]
       dir.up do
         Subnet.unscoped.find_each do |subnet|
           proxy = subnet.tftp
+          next if proxy.blank?
           subnet.template = proxy if proxy.has_feature?("TFTP")
           subnet.save
         end


### PR DESCRIPTION
If the subnet.tftp proxy didn't exist, the migration fails with
> undefined method `has_feature?' for nil:NilClass'
so we rather make sure it exists before trying to set the template
proxy to nil.

cc @lzap