### PR TITLE
Fixes #22713 - fix donut chart re-rendering

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.fixtures.js
@@ -9,12 +9,6 @@ export const mockStoryData = {
   },
   data: {
     columns: [['Fedora 21', 3], ['Ubuntu 14.04', 4], ['Centos 7', 2], ['Debian 8', 1]],
-    names: {
-      'Fedora 21': 'Fedora 21',
-      'Ubuntu 14.04': 'Ubuntu 14.04',
-      'Centos 7': 'Centos 7',
-      'Debian 8': 'Debian 8',
-    },
   },
   tooltip: {
     show: true,
@@ -45,3 +39,17 @@ export const emptyData = {
   },
   noDataMsg: 'No data available',
 };
+
+export const zeroedData = [
+  ['Fedora 21', 0],
+  ['Ubuntu 14.04', 0],
+  ['Centos 7', 0],
+  ['Debian 8', 0],
+];
+
+export const mixedData = [
+  ['Fedora 21', 3],
+  ['Ubuntu 14.04', 2],
+  ['Centos 7', 0],
+  ['Debian 8', 0],
+];

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/__snapshots__/DonutChart.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/__snapshots__/DonutChart.test.js.snap
@@ -31,12 +31,6 @@ exports[`renders DonutChart render donut chart 1`] = `
           1,
         ],
       ],
-      "names": Object {
-        "Centos 7": "Centos 7",
-        "Debian 8": "Debian 8",
-        "Fedora 21": "Fedora 21",
-        "Ubuntu 14.04": "Ubuntu 14.04",
-      },
     }
   }
   donut={
@@ -81,6 +75,7 @@ exports[`renders DonutChart render donut chart 1`] = `
     }
   }
   type="donut"
+  unloadBeforeLoad={false}
 />
 `;
 

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/index.js
@@ -9,6 +9,7 @@ const DonutChart = ({
   config = 'regular',
   noDataMsg = __('No data available'),
   title = { type: 'percent' },
+  unloadData = false,
 
 }) => {
   const chartConfig = getDonutChartConfig({ data, config, onclick });
@@ -18,6 +19,7 @@ const DonutChart = ({
       <PfDonutChart
        {...chartConfig}
        title={title}
+       unloadBeforeLoad = {unloadData}
       />
     );
   }

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Panel } from 'react-bootstrap';
-import Immutable from 'seamless-immutable';
 import { Modal } from 'patternfly-react';
 import helpers from '../../common/helpers';
 import DonutChart from '../common/charts/DonutChart';
@@ -50,7 +49,7 @@ class ChartBox extends React.Component {
         ? null
         : navigateToSearch.bind(null, chart.search);
     const chartProps = {
-      data: chart.data ? Immutable.asMutable(chart.data) : null,
+      data: chart.data ? chart.data : undefined,
       key: `${this.props.chart.id}-chart`,
       onclick: handleChartClick,
     };

--- a/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
@@ -17,7 +17,6 @@ exports[`ChartBox error 1`] = `
     status="PENDING"
   >
     <DonutChart
-      data={null}
       key="2-chart"
       onclick={[Function]}
     />
@@ -47,7 +46,6 @@ exports[`ChartBox pending 1`] = `
     status="PENDING"
   >
     <DonutChart
-      data={null}
       key="2-chart"
       onclick={[Function]}
     />

--- a/webpack/assets/javascripts/services/ChartService.js
+++ b/webpack/assets/javascripts/services/ChartService.js
@@ -6,59 +6,41 @@ const sizeConfig = {
   large: donutLargeChartConfig,
 };
 
-function getChartConfig({
-  data, config, onclick, id = uuidV1(),
-}) {
-  if (!data) {
-    return {};
+const doDataExist = (data) => {
+  if (!data || data.length === 0) {
+    return false;
   }
+  return data.reduce((curr, next) => {
+    const value = next[1];
+
+    return value !== 0 ? true : curr;
+  }, false);
+};
+const getColors = data =>
+  data.reduce((curr, next) => {
+    const key = next[0];
+    const color = next[2];
+
+    return color ? { ...curr, [key]: color } : curr;
+  }, {});
+
+const getChartConfig = ({
+  data, config, onclick, id = uuidV1(),
+}) => {
   const chartConfigForType = sizeConfig[config];
-  const nonEmptyData = data.filter((d) => {
-    const amount = d[1];
-
-    return amount !== 0;
-  });
-
-  const chartData = nonEmptyData.reduce(
-    (curr, next) => {
-      const key = next[0];
-      const color = next[2];
-
-      const names = {
-        ...curr.names,
-        [key]: key,
-      };
-
-      const retVal = {
-        ...curr,
-        names,
-      };
-
-      if (color) {
-        return Object.assign({}, retVal, {
-          colors: {
-            ...(retVal.colors || {}),
-            [key]: color,
-          },
-        });
-      }
-
-      return retVal;
-    },
-    {
-      ...chartConfigForType.data,
-      columns: nonEmptyData,
-      names: {},
-      onclick,
-    },
-  );
+  const colors = getColors(data);
+  const colorsSize = Object.keys(colors).length;
 
   return {
     ...chartConfigForType,
-    data: chartData,
     id,
+    data: {
+      columns: doDataExist(data) ? data : [],
+      onclick,
+      ...(colorsSize > 0 ? { colors } : {}),
+    },
   };
-}
+};
 
 export const getDonutChartConfig = ({
   data, config, onclick, id = uuidV1(),
@@ -69,7 +51,6 @@ export const getDonutChartConfig = ({
     onclick,
     id,
   });
-
 
 export const navigateToSearch = (url, data) => {
   let val = data.id;

--- a/webpack/assets/javascripts/services/ChartServices.test.js
+++ b/webpack/assets/javascripts/services/ChartServices.test.js
@@ -1,0 +1,30 @@
+import { getDonutChartConfig } from './ChartService';
+import { zeroedData, mixedData } from '../react_app/components/common/charts/DonutChart/DonutChart.fixtures';
+
+jest.unmock('./ChartService');
+describe('getDonutChartConfig', () => {
+  it('data should be filtered', () => {
+    expect(getDonutChartConfig({
+      data: zeroedData,
+      onclick: jest.fn(),
+      config: 'regular',
+      id: 'some-id',
+    })).toMatchSnapshot();
+  });
+  it('data should not be filtered with regular size donut ', () => {
+    expect(getDonutChartConfig({
+      data: mixedData,
+      onclick: jest.fn(),
+      config: 'regular',
+      id: 'some-id',
+    })).toMatchSnapshot();
+  });
+  it('data should not be filtered with large size donut', () => {
+    expect(getDonutChartConfig({
+      data: mixedData,
+      onclick: jest.fn(),
+      config: 'large',
+      id: 'some-id',
+    })).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/services/__snapshots__/ChartServices.test.js.snap
+++ b/webpack/assets/javascripts/services/__snapshots__/ChartServices.test.js.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getDonutChartConfig data should be filtered 1`] = `
+Object {
+  "color": Object {
+    "pattern": Array [],
+  },
+  "data": Object {
+    "columns": Array [],
+    "onclick": [Function],
+  },
+  "donut": Object {
+    "label": Object {
+      "show": false,
+    },
+    "width": 15,
+  },
+  "id": "some-id",
+  "legend": Object {
+    "show": false,
+  },
+  "padding": Object {
+    "bottom": 0,
+    "left": 0,
+    "right": 0,
+    "top": 0,
+  },
+  "size": Object {
+    "height": 240,
+    "width": 240,
+  },
+  "tooltip": Object {
+    "show": true,
+  },
+}
+`;
+
+exports[`getDonutChartConfig data should not be filtered with large size donut 1`] = `
+Object {
+  "color": Object {
+    "pattern": Array [],
+  },
+  "data": Object {
+    "columns": Array [
+      Array [
+        "Fedora 21",
+        3,
+      ],
+      Array [
+        "Ubuntu 14.04",
+        2,
+      ],
+      Array [
+        "Centos 7",
+        0,
+      ],
+      Array [
+        "Debian 8",
+        0,
+      ],
+    ],
+    "onclick": [Function],
+  },
+  "donut": Object {
+    "label": Object {
+      "show": false,
+    },
+    "width": 25,
+  },
+  "id": "some-id",
+  "legend": Object {
+    "position": "bottom",
+    "show": true,
+  },
+  "padding": Object {
+    "bottom": 0,
+    "left": 0,
+    "right": 0,
+    "top": 0,
+  },
+  "size": Object {
+    "height": 500,
+  },
+  "tooltip": Object {
+    "show": true,
+  },
+}
+`;
+
+exports[`getDonutChartConfig data should not be filtered with regular size donut  1`] = `
+Object {
+  "color": Object {
+    "pattern": Array [],
+  },
+  "data": Object {
+    "columns": Array [
+      Array [
+        "Fedora 21",
+        3,
+      ],
+      Array [
+        "Ubuntu 14.04",
+        2,
+      ],
+      Array [
+        "Centos 7",
+        0,
+      ],
+      Array [
+        "Debian 8",
+        0,
+      ],
+    ],
+    "onclick": [Function],
+  },
+  "donut": Object {
+    "label": Object {
+      "show": false,
+    },
+    "width": 15,
+  },
+  "id": "some-id",
+  "legend": Object {
+    "show": false,
+  },
+  "padding": Object {
+    "bottom": 0,
+    "left": 0,
+    "right": 0,
+    "top": 0,
+  },
+  "size": Object {
+    "height": 240,
+    "width": 240,
+  },
+  "tooltip": Object {
+    "show": true,
+  },
+}
+`;


### PR DESCRIPTION
When some data is deleted from a donut chart, it doesn't unload before , which means it remains the same.
In order to make it dynamic, just add `dynamic` prop to it.

![statistics - edited](https://user-images.githubusercontent.com/11807069/36779175-d1b6c84a-1c77-11e8-9c7f-b0f742a41478.gif)

In addition, with this change, it possible to pass the chart data as is, no `mutable` function is needed,
because I removed the redundant `names` prop. `c3js` documentation mentions  that the `names` prop uses for mutating the existing names. 