### PR TITLE
Fixes #22721 - Rename setting to trusted_hosts

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -104,14 +104,14 @@ module Foreman::Controller::SmartProxyAuth
     return false unless request_hosts
 
     hosts = Hash[proxies.map { |p| [URI.parse(p.url).host, p] }]
-    allowed_hosts = hosts.keys.push(*Setting[:trusted_puppetmaster_hosts])
+    allowed_hosts = hosts.keys.push(*Setting[:trusted_hosts])
     logger.debug { ("Verifying request from #{request_hosts.inspect} against #{allowed_hosts.inspect}") }
 
     if (host = detect_matching_host(allowed_hosts, request_hosts))
       @detected_proxy = hosts[host] if host
       true
     else
-      logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_puppetmaster_hosts"
+      logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_hosts"
       false
     end
   end

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -14,7 +14,7 @@ class Setting::Auth < Setting
       self.set('oauth_map_users', N_("Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."), true, N_('OAuth map users')),
       self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
       self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
-      self.set('trusted_puppetmaster_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted puppetmaster hosts')),
+      self.set('trusted_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted hosts')),
       self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert, N_('SSL certificate')),
       self.set('ssl_ca_file', N_("SSL CA file that Foreman will use to communicate with its proxies"), ssl_ca_file, N_('SSL CA file')),
       self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ssl_priv_key, N_('SSL private key')),

--- a/db/migrate/20180228132500_rename_trusted_hosts.rb
+++ b/db/migrate/20180228132500_rename_trusted_hosts.rb
@@ -1,0 +1,23 @@
+class RenameTrustedHosts < ActiveRecord::Migration[5.1]
+  def up
+    trusted_puppetmaster_hosts = Setting.find_by_name('trusted_puppetmaster_hosts')
+    trusted_hosts = Setting.find_by_name('trusted_hosts')
+    return unless trusted_hosts.present? && trusted_puppetmaster_hosts.present?
+    trusted_hosts.update_attribute(
+      :value,
+      trusted_puppetmaster_hosts.value
+    )
+    trusted_puppetmaster_hosts.destroy
+  end
+
+  def down
+    trusted_puppetmaster_hosts = Setting.find_by_name('trusted_puppetmaster_hosts')
+    trusted_hosts = Setting.find_by_name('trusted_hosts')
+    return unless trusted_hosts.present? && trusted_puppetmaster_hosts.present?
+    trusted_puppetmaster_hosts.update_attributes(
+      :name => 'trusted_hosts',
+      :value => trusted_hosts.value
+    )
+    trusted_hosts.destroy
+  end
+end

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -891,7 +891,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['else.where']
+    Setting[:trusted_hosts] = ['else.where']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = 'CN=else.where'
@@ -905,7 +905,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['foreman.example']
+    Setting[:trusted_hosts] = ['foreman.example']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = 'CN=foreman.example,OU=PUPPET,O=FOREMAN,ST=North Carolina,C=US'
@@ -919,7 +919,7 @@ class HostsControllerTest < ActionController::TestCase
     User.current = nil
     Setting[:restrict_registered_smart_proxies] = true
     Setting[:require_ssl_smart_proxies] = true
-    Setting[:trusted_puppetmaster_hosts] = ['foreman.linux.lab.local']
+    Setting[:trusted_hosts] = ['foreman.linux.lab.local']
 
     @request.env['HTTPS'] = 'on'
     @request.env['SSL_CLIENT_S_DN'] = '/C=US/ST=NC/L=City/O=Example/OU=IT/CN=foreman.linux.lab.local/emailAddress=user@example.com'

--- a/test/controllers/smart_proxy_auth_test.rb
+++ b/test/controllers/smart_proxy_auth_test.rb
@@ -142,7 +142,7 @@ class SmartProxyAuthApiTest < ActionController::TestCase
 
   def test_trusted_puppet_master_hosts_by_ip_match
     @request.env['REMOTE_ADDR'] = '127.0.0.2'
-    Setting[:trusted_puppetmaster_hosts] = ['127.0.0.2']
+    Setting[:trusted_hosts] = ['127.0.0.2']
     assert @controller.send(:auth_smart_proxy)
   end
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -152,7 +152,7 @@ attribute31:
   default: "SSL_CLIENT_CERT"
   description: "Environment variable containing a client SSL certificate"
 attribute32:
-  name: trusted_puppetmaster_hosts
+  name: trusted_hosts
   category: Setting::Auth
   default: []
   description: "Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -301,14 +301,14 @@ class SettingTest < ActiveSupport::TestCase
     check_zero_value_not_allowed_for 'puppet_interval'
   end
 
-  test "trusted_puppetmaster_hosts can be empty array" do
-    check_empty_array_allowed_for "trusted_puppetmaster_hosts"
+  test "trusted_hosts can be empty array" do
+    check_empty_array_allowed_for "trusted_hosts"
   end
 
-  test "trusted_puppetmaster_hosts must have comma separated values" do
-    attrs = { :name => "trusted_puppetmaster_hosts", :default => [], :description => "desc" }
+  test "trusted_hosts must have comma separated values" do
+    attrs = { :name => "trusted_hosts", :default => [], :description => "desc" }
     assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
-    setting = Setting.find_by_name("trusted_puppetmaster_hosts")
+    setting = Setting.find_by_name("trusted_hosts")
     setting.value = ["localhost", "remotehost"]
     assert setting.save
     setting.value = ["localhost remotehost"]


### PR DESCRIPTION
#The setting trusted_puppetmaster_hosts is used to allow hosts to submit
stuff to the facts/reports API endpoint.
The name made sense a long time ago, but these days other plugins and
any user can submit stuff to this API to generate
their own reports, send facts from ohai, etc..

It should be renamed to 'trusted_hosts' - for example in the foreman_ansible docs, I'm telling people to modify a setting `trusted_puppetmaster_hosts`, which doesn't make much sense in that context...



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
