### PR TITLE
Fixes #23825 - Add exporting to Rakefile.dist

### DIFF
--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -1,4 +1,5 @@
 require 'rake/clean'
+load File.join(__dir__, 'lib', 'tasks', 'pkg.rake')
 
 BUILDDIR = File.expand_path(ENV['BUILDDIR'] || '_build')
 PREFIX = ENV['PREFIX'] || '/usr/local'

--- a/lib/tasks/pkg.rake
+++ b/lib/tasks/pkg.rake
@@ -22,7 +22,9 @@ namespace :pkg do
     File.exist?('pkg') || FileUtils.mkdir('pkg')
     ref = ENV['ref'] || 'HEAD'
     version = `git show #{ref}:VERSION`.chomp.chomp('-develop')
+    filename = "pkg/foreman-#{version}.tar.bz2"
     raise "can't find VERSION from #{ref}" if version.empty?
-    `git archive --prefix=foreman-#{version}/ #{ref} | bzip2 -9 > pkg/foreman-#{version}.tar.bz2`
+    `git archive --prefix=foreman-#{version}/ #{ref} | bzip2 -9 > #{filename}`
+    puts filename
   end
 end


### PR DESCRIPTION
The benefit is that you no longer need the ful bundle stack installed.
We also output the generated filename for use in scripts.