### PR TITLE
Refs #22711 - add uglifyjs-webpack-plugin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "style-loader": "^0.13.1",
     "stylelint": "^7.13.0",
     "stylelint-config-standard": "^16.0.0",
+    "uglifyjs-webpack-plugin": "^1.2.2",
     "url-loader": "^0.5.7",
     "webpack": "^3.4.1",
     "webpack-dev-server": "^2.5.1",


### PR DESCRIPTION
As the building process does *require* uglifyjs-webpack-plugin to be installed, it should get added to package.json.