### PR TITLE
Fixes #22756 - Allow provisioning based on MAC address

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -173,6 +173,11 @@ class UnattendedController < ApplicationController
         mac_list = []
       end
     end
+
+    if params.key?(:mac)
+      mac_list << params[:mac]
+    end
+
     # we try to match first based on the MAC, falling back to the IP
     # host is readonly because of association so we reload it if we find it
     host = Host.joins(:provision_interface).where(mac_list.empty? ? {:nics => {:ip => ip}} : ["lower(nics.mac) IN (?)", mac_list]).first

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -52,6 +52,11 @@ class UnattendedControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get a kickstart if MAC is provided" do
+    get :host_template, params: { :kind => 'provision', :mac => @rh_host.mac }
+    assert_response :success
+  end
+
   test "should get a kickstart even if we are behind a loadbalancer" do
     @request.env["HTTP_X_FORWARDED_FOR"] = @rh_host.ip
     @request.env["REMOTE_ADDR"] = "127.0.0.1"


### PR DESCRIPTION
This PR allows provisioning based on MAC address also for non-EL systems like Ubuntu or openSUSE. There has already been a PR #1106 several years ago but was sadly never merged.

I don't think the security concerns mentioned in #1106 are really an issue as templates can only be accessed when a host is in build mode even when faking the MAC address. By choosing an appropriate build / token TTL this security risk can be minified.

More details can be found here: https://projects.theforeman.org/issues/22756