### PR TITLE
Fixes #21007 - new unattended action 'failed'

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -33,7 +33,7 @@ class HostsController < ApplicationController
   before_action :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :puppetrun, :review_before_build,
                                           :setBuild, :cancelBuild, :power, :get_power_state, :overview, :bmc, :vm,
                                           :runtime, :resources, :nics, :ipmi_boot, :console,
-                                          :toggle_manage, :pxe_config, :disassociate]
+                                          :toggle_manage, :pxe_config, :disassociate, :build_errors]
 
   before_action :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_action :set_host_type, :only => [:update]
@@ -253,6 +253,10 @@ class HostsController < ApplicationController
     else
       process_error :redirect => :back, :error_msg => _("Failed to cancel pending build for %{hostname} with the following errors: %{errors}") % {:hostname => @host.name, :errors => @host.errors.full_messages.join(', ')}
     end
+  end
+
+  def build_errors
+    render :plain => @host.build_errors
   end
 
   def power
@@ -647,7 +651,7 @@ class HostsController < ApplicationController
 
   define_action_permission [
     'clone', 'externalNodes', 'overview', 'bmc', 'vm', 'runtime', 'resources', 'templates', 'nics',
-    'pxe_config', 'active', 'errors', 'out_of_sync', 'pending', 'disabled', 'get_power_state', 'preview_host_collection'
+    'pxe_config', 'active', 'errors', 'out_of_sync', 'pending', 'disabled', 'get_power_state', 'preview_host_collection', 'build_errors'
   ], :view
   define_action_permission [
     'setBuild', 'cancelBuild', 'multiple_build', 'submit_multiple_build', 'review_before_build',

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -250,6 +250,15 @@ module HostsHelper
     (SETTINGS[:unattended] && host.managed?) ? host.shortname : host.name
   end
 
+  def build_duration(host)
+    return _("N/A") if host.initiated_at.nil? && host.installed_at.nil?
+    if host.installed_at.nil?
+      time_ago_in_words(host.initiated_at, include_seconds: true) + " (in progress)"
+    else
+      distance_of_time_in_words(host.initiated_at, host.installed_at, include_seconds: true)
+    end
+  end
+
   def overview_fields(host)
     global_status = host.build_global_status
     fields = [
@@ -260,6 +269,9 @@ module HostsHelper
       ]
     ]
     fields += host_detailed_status_list(host)
+    fields += [[_("Build duration"), build_duration(host)]]
+    fields += [[_("Build errors"), link_to("Logs from OS installer", build_errors_host_path(:id => host.id))]] if host.build_errors.present?
+    fields += [[_("Token"), host.token || _("N/A")]] if User.current.admin?
     fields += [[_("Domain"), link_to(host.domain, hosts_path(:search => %{domain = "#{host.domain}"}))]] if host.domain.present?
     fields += [[_("Realm"), link_to(host.realm, hosts_path(:search => %{realm = "#{host.realm}"}))]] if host.realm.present?
     fields += [[_("IP Address"), host.ip]] if host.ip.present?

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -281,6 +281,7 @@ class Host::Managed < Host::Base
     return unless respond_to?(:old) && old && build? && !old.build?
     clear_facts
     clear_reports
+    self.build_errors = nil
   end
 
   # Called from the host build post install process to indicate that the base build has completed
@@ -424,7 +425,8 @@ class Host::Managed < Host::Base
   # Any facts are discarded
   def setBuild
     self.build = true
-    self.save
+    self.initiated_at = Time.now.utc
+    logger.warn("Set build failed: #{errors.inspect}") unless self.save
     errors.empty?
   end
 

--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -2,6 +2,7 @@ module HostStatus
   class BuildStatus < Status
     PENDING = 1
     TOKEN_EXPIRED = 2
+    BUILD_FAILED = 3
     BUILT = 0
 
     def self.status_name
@@ -16,6 +17,8 @@ module HostStatus
           N_("Token expired")
         when BUILT
           N_("Installed")
+        when BUILD_FAILED
+          N_("Installation error")
         else
           N_("Unknown build status")
       end
@@ -23,7 +26,7 @@ module HostStatus
 
     def to_global(options = {})
       case to_status
-        when TOKEN_EXPIRED
+        when TOKEN_EXPIRED, BUILD_FAILED
           HostStatus::Global::ERROR
         else
           HostStatus::Global::OK
@@ -38,7 +41,11 @@ module HostStatus
           PENDING
         end
       else
-        BUILT
+        if build_errors?
+          BUILD_FAILED
+        else
+          BUILT
+        end
       end
     end
 
@@ -52,6 +59,10 @@ module HostStatus
 
     def token_expired?
       host&.token_expired?
+    end
+
+    def build_errors?
+      host && host.build_errors.present?
     end
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -304,7 +304,7 @@ Foreman::AccessControl.map do |permission_set|
     tasks_ajax_actions = [:show]
 
     map.permission :view_hosts,    {:hosts => [:index, :show, :errors, :active, :out_of_sync, :disabled, :pending, :vm,
-                                               :externalNodes, :pxe_config, :auto_complete_search, :bmc,
+                                               :externalNodes, :pxe_config, :auto_complete_search, :bmc, :build_errors,
                                                :runtime, :resources, :templates, :overview, :nics, :get_power_state, :preview_host_collection],
                                     :dashboard => [:OutOfSync, :errors, :active],
                                     :unattended => [:host_template, :hostgroup_template],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Foreman::Application.routes.draw do
         get 'review_before_build'
         put 'setBuild'
         get 'cancelBuild'
+        get 'build_errors'
         get 'puppetrun'
         get 'pxe_config'
         put 'toggle_manage'
@@ -463,8 +464,11 @@ Foreman::Application.routes.draw do
   # get only for alterator unattended scripts
   get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'host_template', :format => 'text',
     :constraints => { :metadata => /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
-  # get for end of build action
+  # built call can be done both via GET (for backward compatibility) and POST
   get 'unattended/built/(:id(:format))', :controller => 'unattended', :action => 'built', :format => 'text'
+  post 'unattended/built/(:id(:format))', :controller => 'unattended', :action => 'built', :format => 'text'
+  # failed call only via POST
+  post 'unattended/failed/(:id(:format))', :controller => 'unattended', :action => 'failed', :format => 'text'
   # get for all unattended scripts
   get 'unattended/(:kind/(:id(:format)))', :controller => 'unattended', :action => 'host_template', :format => 'text'
 

--- a/db/migrate/20180305111232_add_build_errors_to_hosts.rb
+++ b/db/migrate/20180305111232_add_build_errors_to_hosts.rb
@@ -1,0 +1,6 @@
+class AddBuildErrorsToHosts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :hosts, :initiated_at, :datetime
+    add_column :hosts, :build_errors, :text
+  end
+end

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -15,8 +15,8 @@ class AccessPermissionsTest < ActiveSupport::TestCase
   MAY_SKIP_REQUIRE_LOGIN = [
     "users/login", "users/logout", "users/extlogin", "users/extlogout", "home/status", "notices/destroy",
 
-    # unattended built action is not for interactive use
-    "unattended/built",
+    # unattended built and failed action is not for interactive use
+    "unattended/built", "unattended/failed",
 
     # puppetmaster interfaces
     "fact_values/create", "reports/create",

--- a/test/unit/shared/access_permissions_test_base.rb
+++ b/test/unit/shared/access_permissions_test_base.rb
@@ -26,7 +26,7 @@ module AccessPermissionsTestBase
           # Pass if the controller deliberately skips login requirement
           next if controller < ApplicationController && filters.select { |f| f.filter == :require_login }.empty?
 
-          assert_not_empty Foreman::AccessControl.permissions.select { |p| p.actions.include? path }
+          assert_not_empty Foreman::AccessControl.permissions.select { |p| p.actions.include? path }, "permission for #{path} not found, check access_permissions.rb"
         end
       end
     end


### PR DESCRIPTION
Introduces new unattended action "failed" which can be used to exit
build mode with error which is then reported in host status. In addition
to that, both built and failed actions now accepts plain text in the
HTTP GET body which is logged into Rails logger (debug or warn depending
on the action) and also stored in build_errors new field which is used
to identify if build was successful or not.

The patch also adds `initiated_at` colum which stores time and date when
the host entered build mode. This allows reporting of:

1) How long it took to build the host
2) How long the host is already in build mode

This will work even when tokens are disabled.

To take advantage of the new "failed" call, provisioning template must
be changed. I will file a change for kickstart template.