### PR TITLE
Fixes #22764 - gc stat metric works on rails reload

### DIFF
--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -47,7 +47,7 @@ module Foreman
         after = GC.stat
         GC_METRICS.each do |ruby_key, metric_name|
           increment_counter(metric_name, after[ruby_key] - before[ruby_key], :controller => controller, :action => action) if after.include?(ruby_key)
-        end
+        end if before
       end if enabled?
 
       ActiveSupport::Notifications.subscribe(/instantiation.active_record/) do |*args|


### PR DESCRIPTION
Reproducer: change a file and let Rails to reload, then there is nil
exception because `before` is nil (thread context gets cleaned or
something during Rails reload). This fixes this.