### PR TITLE
Fixes #22798 Include the vmFolder in the list_vms filter spec

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -26,7 +26,7 @@ module FogExtensions
             [key, vm[value]]
           end.to_h
 
-          attrs['path'] = folder_inventory[vm['parent']._ref][:path]
+          attrs[:path] = folder_inventory[vm['parent']._ref][:path]
 
           MiniServer.new(attrs)
         end
@@ -36,7 +36,7 @@ module FogExtensions
 
       def generate_folder_inventory(folders)
         folder_inventory = folders.each_with_object({}) do |folder, inventory|
-          parent = if folder['parent'] == dc.vmFolder
+          parent = if folder['parent'] == dc
                      nil
                    else
                      folder['parent']._ref
@@ -65,7 +65,7 @@ module FogExtensions
         RbVmomi::VIM.PropertyFilterSpec(
           :objectSet => [
             :obj => dc.vmFolder,
-            :skip => true,
+            :skip => false,
             :selectSet => [
               RbVmomi::VIM.TraversalSpec(
                 :name => 'tsFolder',


### PR DESCRIPTION
If a VM is in the root of the datacenter its parent is the vmFolder.
This folder was being skipped by the PropertyFilterSpec causing an
undefined method error '[]' for nil:NilClass when accessing the
vm['parent'] key.

git bisect points to e7e9821aa028957575a2aa0d79e696439f393e72 as introducing this issue.

Backtrace:
```
2018-03-06T11:11:34 fd0ae69d [app] [W] Error has occurred while listing VMs on dev-vc65 (VMware) | NoMethodError: undefined method `[]' for nil:NilClass
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:61:in `lookup_parent_folders'
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:62:in `lookup_parent_folders'
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:56:in `block in set_folder_paths'
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:55:in `each'
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:55:in `set_folder_paths'\
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:50:in `generate_folder_inventory'
/home/agrare/src/foreman/app/services/fog_extensions/vsphere/mini_servers.rb:21:in `all'
```

Which is failing on this line `attrs['path'] = folder_inventory[vm['parent']._ref][:path]` [[ref]](https://github.com/theforeman/foreman/blob/develop/app/services/fog_extensions/vsphere/mini_servers.rb#L29) because `folder_inventory` doesn't include the `datacenter.vmFolder`.

Before fix:
![screenshot from 2018-03-06 11-32-32](https://user-images.githubusercontent.com/12851112/37044696-25336f82-2132-11e8-8eaf-ab92395a2487.png)

After fix:
![screenshot from 2018-03-06 11-55-55](https://user-images.githubusercontent.com/12851112/37046075-6fa39738-2135-11e8-9fb4-ddc2f38aab40.png)

Fixes #22798 - VMware: Exception listing VMs in the root of the datacenter