### PR TITLE
Fixes #22816 - Add component for page title/heading

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/layout/PageTitle.js
+++ b/webpack/assets/javascripts/react_app/components/common/layout/PageTitle.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ text }) => {
+  document.title = __(text);
+  return (
+    <div className="row form-group">
+      <h1 className="col-md-8">{ __(text) }</h1>
+    </div>
+  );
+};

--- a/webpack/assets/javascripts/react_app/components/common/layout/PageTitle.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/layout/PageTitle.test.js
@@ -1,0 +1,13 @@
+import toJson from 'enzyme-to-json';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import PageTitle from './PageTitle';
+
+describe('PageTitle', () => {
+  it('should render a page title', () => {
+    const wrapper = shallow(<PageTitle text="Penguins"/>);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/common/layout/__snapshots__/PageTitle.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/layout/__snapshots__/PageTitle.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageTitle should render a page title 1`] = `
+<div
+  className="row form-group"
+>
+  <h1
+    className="col-md-8"
+  >
+    Penguins
+  </h1>
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/common/layout/layout.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/layout/layout.stories.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import PageTitle from './PageTitle';
+
+storiesOf('Layout', module)
+  .add('Page Title', () => <PageTitle text={'Penguins'} />);


### PR DESCRIPTION
This should be a React equivalent of [title helper](https://github.com/theforeman/foreman/blob/develop/app/helpers/layout_helper.rb#L2)