### PR TITLE
Refs #22575 - Replace only_path by ignore_query

### DIFF
--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -16,7 +16,7 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
     within "li[data-name='Host Configuration Status']" do
       click_link(text)
     end
-    assert_current_path hosts_path
+    assert_current_path hosts_path, :ignore_query => true
     assert_match(/search=/, current_url)
   end
 


### PR DESCRIPTION
The original commit meant to remove deprecation notices, and I believe
its intent was to change :only_path to :ignore_query to remove the
deprecation from the test output. In the end by mistake it was merged
just removing the :only_path option, which broke dashboard tests.
:ignore_query is the new equivalent of the :only_path option, which
makes tests pass again and does not produce any deprecation warnings



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
