### PR TITLE
Fixes #22828 - Pin patternfly and regenerate snaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jstz": "~1.0.7",
     "lodash": "~4.15.0",
     "multiselect": "~0.9.12",
-    "patternfly": "^3.31.2",
+    "patternfly": "3.41.6",
     "patternfly-react": "1.11.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",


### PR DESCRIPTION
Some JS tests are currently failing because 3.41.6 changes the props of
some components. Using 3.41.6 our snaps are not up to date, so we can
update to this version, updating the snaps. It makes sense to pin the
dependency to a specific version as we did for patternfly-react, to
avoid future breakages.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
