### PR TITLE
Fixes #22869 - support template locking on import

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -31,6 +31,14 @@ module Api
         param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations") if SETTINGS[:organizations_enabled]
       end
 
+      def_param_group :template_import_options do
+        param :options, Hash, :required => false do
+          param :force, :bool, :allow_nil => true, :desc => N_('use if you want update locked templates')
+          param :associate, ['new', 'always', 'never'], :allow_nil => true, :desc => N_('determines when the template should associate objects based on metadata, new means only when new template is being created, always means both for new and existing template which is only being updated, never ignores metadata')
+          param :lock, :bool, :allow_nil => true, :desc => N_('lock imported templates (false by default)')
+        end
+      end
+
       before_action :setup_has_many_params, :only => [:create, :update]
       before_action :check_content_type
       # ensure include_root_in_json = false for V2 only

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -60,10 +60,7 @@ module Api
         param :name, String, :required => true, :desc => N_("template name")
         param :template, String, :required => true, :desc => N_("template contents including metadata")
       end
-      param :options, Hash, :required => false do
-        param :force, :bool, :allow_nil => true, :desc => N_('use if you want update locked templates')
-        param :associate, ['new', 'always', 'never'], :allow_nil => true, :desc => N_('determines when the template should associate objects based on metadata, new means only when new template is being created, always means both for new and existing template which is only being updated, never ignores metadata')
-      end
+      param_group :template_import_options, ::Api::V2::BaseController
 
       def import
         options = params.permit(:options => {}).try(:[], :options) || {}

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -55,10 +55,7 @@ module Api
         param :name, String, :required => true, :desc => N_("template name")
         param :template, String, :required => true, :desc => N_("template contents including metadata")
       end
-      param :options, Hash, :required => false do
-        param :force, :bool, :allow_nil => true, :desc => N_('use if you want update locked templates')
-        param :associate, ['new', 'always', 'never'], :allow_nil => true, :desc => N_('determines when the template should associate objects based on metadata, new means only when new template is being created, always means both for new and existing template which is only being updated, never ignores metadata')
-      end
+      param_group :template_import_options, ::Api::V2::BaseController
 
       def import
         options = params.permit(:options => {}).try(:[], :options) || {}

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -118,6 +118,20 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     refute clone.locked
   end
 
+  test "locked template can be modified if it's being unlocked at the same time" do
+    tmplt = templates(:locked)
+    tmplt.template = 'new_content'
+    tmplt.locked = false
+    assert tmplt.valid?
+  end
+
+  test "unlocked template can be modified if it's being locked at the same time" do
+    tmplt = templates(:mystring)
+    tmplt.template = 'new_content'
+    tmplt.locked = true
+    assert tmplt.valid?
+  end
+
   test "should change a locked template while in rake" do
     Foreman.stubs(:in_rake?).returns(true)
     tmplt = templates(:locked)

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -221,6 +221,36 @@ EOS
         refute @template.snippet, 'template was not marked as a snippet'
       end
 
+      test 'keeps locked unchanged if lock option was not set' do
+        text = @template.template
+        @template = Template.new :locked => true
+        @template.expects :import_locations
+        @template.expects :import_organizations
+        @template.expects :import_custom_data
+        @template.import_without_save(text)
+        assert @template.locked
+      end
+
+      test 'keeps locks the template if lock is set to true' do
+        text = @template.template
+        @template = Template.new
+        @template.expects :import_locations
+        @template.expects :import_organizations
+        @template.expects :import_custom_data
+        @template.import_without_save(text, :lock => true)
+        assert @template.locked
+      end
+
+      test 'unlocks the template if lock is set to false' do
+        text = @template.template
+        @template = Template.new :locked => true
+        @template.expects :import_locations
+        @template.expects :import_organizations
+        @template.expects :import_custom_data
+        @template.import_without_save(text, :lock => false)
+        refute @template.locked
+      end
+
       test 'does not save the template' do
         assert @template.new_record?
       end


### PR DESCRIPTION
Can be tested with following

```
curl -u admin:changeme -v --insecure -XPOST -H "Content-type: application/json" --data @- 'https://foreman.example.tst/api/v2/provisioning_templates/import' <<'EODATA'
  {
    "provisioning_template": {
      "name": "An Import Test",
      "template": "<%#\nkind: script\nname: A Grubby default2\nmodel: ProvisioningTemplate\n%>\ntest3"
    }, "options": {
      "associate": "always",
      "lock": true
    }
  }
EODATA


curl -u admin:changeme -v --insecure -XPOST -H "Content-type: application/json" --data @- 'https://foreman.example.tst/api/v2/provisioning_templates/import' <<'EODATA'
  {
    "provisioning_template": {
      "name": "An Import Test",
      "template": "<%#\nkind: script\nname: A Grubby default2\nmodel: ProvisioningTemplate\n%>\ntest3"
    }, "options": {
      "associate": "always",
      "force": true,
      "lock": false
    }
  }
EODATA
```

@xprazak2 and/or @jyejare mind to take a look?
