### PR TITLE
Fixes #22880 - Move to Minitest::Retry for integration tests

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -2,7 +2,7 @@ group :test do
   gem 'mocha', '~> 1.1'
   gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1', '< 5.11'
-  gem 'minitest-optional_retry', '~> 0.0', :require => false
+  gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 2.5', :require => false

--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class AboutIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   AboutIntegrationTest.test_0002_about page proxies should have version
-  extend Minitest::OptionalRetry
 
   setup do
     ComputeResource.any_instance.expects(:ping).at_least_once.returns([])

--- a/test/integration/audit_js_test.rb
+++ b/test/integration/audit_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class AuditJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   # AuditJSTest.test_0001_show audit with diff
-  extend Minitest::OptionalRetry
 
   test "show audit with diff" do
     audit = FactoryBot.create(:audit, :with_diff)

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class ComputeProfileJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   ComputeProfileJSTest.test_0001_edit compute attribute page
-  extend MiniTest::OptionalRetry
 
   setup do
     Fog.mock!

--- a/test/integration/compute_resource_js_test.rb
+++ b/test/integration/compute_resource_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class ComputeResourceJSIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   ComputeResourceJSIntegrationTest.test_0002_add new compute attributes two pane
-  extend Minitest::OptionalRetry
 
   setup do
     Fog.mock!

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class DashboardIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   DashboardIntegrationTest.test_0005_dashboard link hosts that had pending changes
-  extend MiniTest::OptionalRetry
 
   def setup
     Dashboard::Manager.reset_user_to_default(users(:admin))

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -12,7 +12,6 @@ class HostJSTest < IntegrationTestWithJavascript
   #   HostJSTest::NIC modal window::adding interfaces.test_0005_selecting domain updates puppetclass parameters
   #   HostJSTest::NIC modal window::adding interfaces.test_0004_selecting domain updates subnet list
   #   HostJSTest::NIC modal window::adding interfaces.test_0001_click on add opens modal
-  extend Minitest::OptionalRetry
 
   include HostFinders
   include HostOrchestrationStubs

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class HostgroupJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   HostgroupJSTest.test_0001_submit updates taxonomy
-  extend Minitest::OptionalRetry
 
   test 'creates a hostgroup with provisioning data' do
     env = FactoryBot.create(:environment)

--- a/test/integration/provisioning_template_js_test.rb
+++ b/test/integration/provisioning_template_js_test.rb
@@ -4,7 +4,6 @@ class ProvisioningTemplateJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   ProvisioningTemplateJSTest.test_0001_edit template page
   #   ProvisioningTemplateJSTest.test_0002_edit snippet page
-  extend Minitest::OptionalRetry
 
   test "edit template page" do
     template = FactoryBot.create(:provisioning_template)

--- a/test/integration/puppetclass_lookup_key_js_test.rb
+++ b/test/integration/puppetclass_lookup_key_js_test.rb
@@ -4,7 +4,6 @@ class PuppetclassLookupKeyJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   PuppetclassLookupKeyJSTest.test_0001_can hide value when overriden
   #   PuppetclassLookupKeyJSTest.test_0002_uncheck override
-  extend Minitest::OptionalRetry
 
   test 'can hide value when overriden' do
     visit puppetclass_lookup_keys_path

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class PuppetclassIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   PuppetclassIntegrationTest.test_0001_edit page
-  extend Minitest::OptionalRetry
 
   test "edit page" do
     visit puppetclasses_path

--- a/test/integration/statistic_test.rb
+++ b/test/integration/statistic_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class StatisticIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   StatisticIntegrationTest.test_0001_statistics page
-  extend Minitest::OptionalRetry
 
   test "statistics page" do
     visit statistics_path

--- a/test/integration/subnet_js_test.rb
+++ b/test/integration/subnet_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class SubnetJSIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   SubnetJSIntegrationTest.test_0001_create new page
-  extend Minitest::OptionalRetry
 
   test "create new page" do
     visit new_subnet_path

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class UserIntegrationTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   UserIntegrationTest.test_0002_edit page
-  extend Minitest::OptionalRetry
 
   test "index page" do
     assert_index_page(users_path,"Users","Create User")

--- a/test/integration/variable_lookup_key_js_test.rb
+++ b/test/integration/variable_lookup_key_js_test.rb
@@ -3,7 +3,6 @@ require 'integration_test_helper'
 class VariableLookupKeyJSTest < IntegrationTestWithJavascript
   # intermittent failures:
   #   VariableLookupKeyJSTest.test_0001_does not turn empty boolean value to false
-  extend Minitest::OptionalRetry
 
   test "does not turn empty boolean value to false" do
     visit variable_lookup_keys_path

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -8,7 +8,12 @@ require 'capybara/poltergeist'
 require 'show_me_the_cookies'
 require 'database_cleaner'
 require 'active_support_test_case_helper'
-require 'minitest-optional_retry'
+require 'minitest/retry'
+Minitest::Retry.use!
+
+Minitest::Retry.on_consistent_failure do |klass, test_name|
+  Rails.logger.error("DO NOT IGNORE - Consistent failure - #{klass} #{test_name}")
+end
 
 Capybara.register_driver :poltergeist do |app|
   opts = {


### PR DESCRIPTION
Since our integration tests are quite flaky, at times because of DNS
problems or similar, I suggest we move away from minitest-optional_retry
(unmaintained) to minitest-retry which seems more maintained and
provides more options. Moreover, we can just specify a limit of 3
retries, and print messages on consistent failures.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
