### PR TITLE
Fixes #22876 - message/source digests are bigint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'sshkey', '~> 1.9'
 gem 'dynflow', '>= 0.8.29', '< 1.0.0'
 gem 'daemons'
 gem 'get_process_mem'
+gem 'xxhash'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,8 +8,17 @@ class Message < ApplicationRecord
     value
   end
 
+  def self.make_digest(val)
+    # convert from unsinged to signed int64
+    XXhash.xxh64(val) - 9_223_372_036_854_775_808
+  end
+
+  def self.make_digest_legacy(val)
+    Digest::SHA1.hexdigest(val)
+  end
+
   def self.find_or_create(val)
-    digest = Digest::SHA1.hexdigest(val)
+    digest = make_digest(val)
     Message.where(:digest => digest).first || Message.create(:value => val, :digest => digest)
   end
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -8,8 +8,17 @@ class Source < ApplicationRecord
     value
   end
 
+  def self.make_digest(val)
+    # convert from unsinged to signed int64
+    XXhash.xxh64(val) - 9_223_372_036_854_775_808
+  end
+
+  def self.make_digest_legacy(val)
+    Digest::SHA1.hexdigest(val)
+  end
+
   def self.find_or_create(val)
-    digest = Digest::SHA1.hexdigest(val)
+    digest = make_digest(val)
     Source.where(:digest => digest).first || Source.create(:value => val, :digest => digest)
   end
 end

--- a/db/migrate/20180313113654_change_digests_to_bigint.rb
+++ b/db/migrate/20180313113654_change_digests_to_bigint.rb
@@ -1,0 +1,33 @@
+class ChangeDigestsToBigint < ActiveRecord::Migration[5.1]
+  def up
+    # messages digest
+    remove_index :messages, :digest
+    remove_column :messages, :digest
+    add_column :messages, :digest, :bigint, :limit => 8
+    Message.unscoped.all.find_each {|rec| rec.update_attribute :digest, Message.make_digest(rec.value)}
+    add_index :messages, :digest
+
+    # sources digest
+    remove_index :sources, :digest
+    remove_column :sources, :digest
+    add_column :sources, :digest, :bigint, :limit => 8
+    Source.unscoped.all.find_each {|rec| rec.update_attribute :digest, Source.make_digest(rec.value)}
+    add_index :sources, :digest
+  end
+
+  def down
+    # messages digest
+    remove_index :messages, :digest
+    remove_column :messages, :digest
+    add_column :messages, :digest, :string, :limit => 40
+    Message.unscoped.all.find_each {|rec| rec.update_attribute :digest, Message.make_digest_legacy(rec.value)}
+    add_index :messages, :digest
+
+    # sources digest
+    remove_index :sources, :digest
+    remove_column :sources, :digest
+    add_column :sources, :digest, :string, :limit => 40
+    Source.unscoped.all.find_each {|rec| rec.update_attribute :digest, Source.make_digest_legacy(rec.value)}
+    add_index :sources, :digest
+  end
+end

--- a/test/benchmark/benchmark_helper.rb
+++ b/test/benchmark/benchmark_helper.rb
@@ -3,8 +3,8 @@ require 'benchmark/ips'
 require File.expand_path('../../../config/environment', __FILE__)
 
 unless Rails.env.production? && !Rails.configuration.database_configuration["production"]["migrate"]
-  puts "Rais must be in production and database must have migrations turned off!"
-  puts "Please add similar configuration to your config/database.yaml:"
+  puts "Rails must be in production (set RAILS_ENV) and database must have migrations turned off!"
+  puts "Please add similar configuration to your config/database.yml:"
   puts <<EOS
 production:
   adapter: sqlite3

--- a/test/benchmark/report_importer_logs.rb
+++ b/test/benchmark/report_importer_logs.rb
@@ -1,0 +1,46 @@
+require "benchmark/benchmark_helper"
+require "deacon"
+
+Rails.logger.level = Logger::ERROR
+reg_one = 1
+reg_two = 1
+generator = Deacon::RandomGenerator.new
+
+foreman_benchmark do
+  Benchmark.ips do |x|
+    x.config(:time => 10, :warmup => 2)
+
+    x.report("raw performance") do
+      Message.make_digest("Raw performance test string")
+    end
+
+    x.report("raw legacy") do
+      Message.make_digest_legacy("Raw performance test string")
+    end
+
+    x.report("create message") do
+      reg_one, firstname, lastname = generator.generate(reg_one)
+      Message.find_or_create('A test test test test message: ' + firstname + ' ' + lastname)
+    end
+
+    x.report("create source") do
+      reg_one, firstname, lastname = generator.generate(reg_one)
+      Source.find_or_create('A test test test source message: ' + firstname + ' ' + lastname)
+    end
+
+    x.report("find message") do
+      reg_two, firstname, lastname = generator.generate(reg_two)
+      Message.find_or_create('A test test test test message: ' + firstname + ' ' + lastname)
+    end
+
+    x.report("find source") do
+      reg_two, firstname, lastname = generator.generate(reg_two)
+      Source.find_or_create('A test test test source message: ' + firstname + ' ' + lastname)
+    end
+  end
+end
+
+puts "No. of messages in db after test: #{Message.all.count}"
+puts "Example message digest: #{Message.first.digest}"
+puts "No. of sources in db after test: #{Source.all.count}"
+puts "Example source digest: #{Source.first.digest}"


### PR DESCRIPTION
This patch converts digest columns from SHA1 HEX (40 characters) to
BIGINT (8 bytes). Instead using secure SHA1 hash, it now uses very fast
XXHash which aims for speed and delivers high quality entropy.

Although the benchmark included in the patch shows small performance
improvement on sqlite3, the main reason for this page is saved storage
on PostgreSQL server - instead storing 40 characters we only need 8
bytes (64 bits). Searching BIGINT via indexes is faster than VARCHAR in
every aspect, so there will be performance boost seen on deployments
with millions of records in those tables.

Please do not merge until this performance boost is confirmed. To test
this patch, please try it on production instance (PostgreSQL/MySQL) with
tens of millions of records in message and/or source tables. The
benchmark test can be used to compare before/after.