### PR TITLE
Fixes #22888 - remove code around dynflow db_pool_size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'deacon', '~> 1.0'
 gem 'webpack-rails', '~> 0.9.8'
 gem 'mail', '~> 2.7'
 gem 'sshkey', '~> 1.9'
-gem 'dynflow', '>= 0.8.29', '< 1.0.0'
+gem 'dynflow', '>= 1.0.0', '< 2.0.0'
 gem 'daemons'
 gem 'get_process_mem'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -283,7 +283,6 @@ module Foreman
     config.after_initialize do
       dynflow = Rails.application.dynflow
       dynflow.eager_load_actions!
-      dynflow.config.increase_db_pool_size
 
       unless dynflow.config.lazy_initialization
         if defined?(PhusionPassenger)

--- a/lib/foreman/dynflow/configuration.rb
+++ b/lib/foreman/dynflow/configuration.rb
@@ -5,7 +5,6 @@ module Foreman
         super
         self.pool_size = SETTINGS.fetch(:dynflow, {})
                                  .fetch(:pool_size, pool_size)
-        self.db_pool_size = pool_size + 5
       end
 
       # Action related info such as exceptions raised inside the actions' methods


### PR DESCRIPTION
Remove the code in favor of the Dynfow, where we can handle all the
logic at one place.

Requires https://github.com/Dynflow/dynflow/pull/277