### PR TITLE
Fixes #22893 - Specify taxonomies on template import

### DIFF
--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class PtablesController < V2::BaseController
       include Foreman::Controller::Parameters::Ptable
+      include Foreman::Controller::TemplateImport
 
       wrap_parameters :ptable, :include => ptable_params_filter.accessible_attributes(parameter_filter_context)
 
@@ -54,15 +55,12 @@ module Api
       param :ptable, Hash, :required => true, :action_aware => true do
         param :name, String, :required => true, :desc => N_("template name")
         param :template, String, :required => true, :desc => N_("template contents including metadata")
+        param_group :taxonomies, ::Api::V2::BaseController
       end
       param_group :template_import_options, ::Api::V2::BaseController
 
       def import
-        options = params.permit(:options => {}).try(:[], :options) || {}
-        template_params = params.require(:ptable).permit(:name, :template)
-        name = template_params[:name]
-        text = template_params[:template]
-        @ptable = Ptable.import!(name, text, options)
+        @ptable = Ptable.import!(*import_attrs_for(:ptable))
         process_response @ptable
       end
 

--- a/app/controllers/concerns/foreman/controller/parameters/provisioning_template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/provisioning_template.rb
@@ -18,4 +18,12 @@ module Foreman::Controller::Parameters::ProvisioningTemplate
   def provisioning_template_params
     self.class.provisioning_template_params_filter.filter_params(params, parameter_filter_context)
   end
+
+  def organization_params
+    self.class.organization_params_filter(::ProvisioningTemplate).filter_params(params, parameter_filter_context)
+  end
+
+  def location_params
+    self.class.location_params_filter(::ProvisioningTemplate).filter_params(params, parameter_filter_context)
+  end
 end

--- a/app/controllers/concerns/foreman/controller/parameters/ptable.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/ptable.rb
@@ -21,4 +21,12 @@ module Foreman::Controller::Parameters::Ptable
   def ptable_params
     self.class.ptable_params_filter.filter_params(params, parameter_filter_context)
   end
+
+  def organization_params
+    self.class.organization_params_filter(::Ptable).filter_params(params, parameter_filter_context)
+  end
+
+  def location_params
+    self.class.location_params_filter(::Ptable).filter_params(params, parameter_filter_context)
+  end
 end

--- a/app/controllers/concerns/foreman/controller/parameters/taxonomix.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/taxonomix.rb
@@ -3,9 +3,35 @@ module Foreman::Controller::Parameters::Taxonomix
 
   class_methods do
     def add_taxonomix_params_filter(filter)
-      filter.permit :locations => [], :location_ids => [], :location_names => [],
-        :organizations => [], :organization_ids => [], :organization_names => []
+      add_taxonomix_attrs_params_filter(filter).permit :locations => [], :organizations => []
       filter
+    end
+
+    def add_taxonomix_attrs_params_filter(filter)
+      add_organization_attrs_params_filter(filter)
+      add_location_attrs_params_filter(filter)
+      filter
+    end
+
+    def add_organization_attrs_params_filter(filter)
+      filter.permit :organization_ids => [], :organization_names => []
+    end
+
+    def add_location_attrs_params_filter(filter)
+      filter.permit :location_ids => [], :location_names => []
+      filter
+    end
+
+    def organization_params_filter(klass)
+      Foreman::ParameterFilter.new(klass).tap do |filter|
+        add_organization_attrs_params_filter(filter)
+      end
+    end
+
+    def location_params_filter(klass)
+      Foreman::ParameterFilter.new(klass).tap do |filter|
+        add_location_attrs_params_filter(filter)
+      end
     end
   end
 end

--- a/app/controllers/concerns/foreman/controller/template_import.rb
+++ b/app/controllers/concerns/foreman/controller/template_import.rb
@@ -1,0 +1,10 @@
+module Foreman::Controller::TemplateImport
+  extend ActiveSupport::Concern
+  def import_attrs_for(resource_name)
+    options = params.permit(:options => {}).try(:[], :options).try(:to_h) || {}
+    options[:organization_params] = organization_params.to_h
+    options[:location_params] = location_params.to_h
+    template_params = params.require(resource_name).permit(:name, :template)
+    [template_params[:name], template_params[:template], options]
+  end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -82,8 +82,7 @@ class Template < ApplicationRecord
     self.snippet = !!@importing_metadata[:snippet]
     self.locked = options[:lock] unless options[:lock].nil?
 
-    import_locations(options)
-    import_organizations(options)
+    import_taxonomies(options)
     import_custom_data(options)
 
     self
@@ -143,6 +142,20 @@ class Template < ApplicationRecord
         @importing_metadata['oses'].any? {|imported_os| existing_os.to_label =~ /\A#{imported_os}/}
       end
       self.operatingsystem_ids = oses.map(&:id)
+    end
+  end
+
+  def import_taxonomies(options)
+    process_taxonomies options, :organization
+    process_taxonomies options, :location
+  end
+
+  def process_taxonomies(options, taxonomy)
+    tax_options = options["#{taxonomy}_params".to_sym]
+    if tax_options.empty?
+      send("import_#{taxonomy.to_s.pluralize}", options)
+    else
+      self.attributes = tax_options
     end
   end
 

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -187,7 +187,7 @@ EOS
         template = Minitest::Mock.new
         template.expect(:ignore_locking, true)
         Template.expects(:import_without_save => template)
-        Template.import!('test', '', :force => true)
+        Template.import!('test', '',  { :force => true })
         template.verify
       end
     end


### PR DESCRIPTION
If any taxonomy params are passed for template import, they are used instead of what is in metadata.