### PR TITLE
fixes #22902 - change suggested memory to 2GB

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -215,7 +215,7 @@ module Foreman::Model
 
     def vm_instance_defaults
       super.merge(
-        :memory     => 768.megabytes,
+        :memory     => 2048.megabytes,
         :nics       => [new_nic],
         :volumes    => [new_volume].compact,
         :display    => { :type     => display_type,

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -640,7 +640,7 @@ module Foreman::Model
 
     def vm_instance_defaults
       super.merge(
-        :memory_mb  => 768,
+        :memory_mb  => 2048,
         :interfaces => [new_interface],
         :volumes    => [new_volume],
         :scsi_controllers => [{ :type => scsi_controller_default_type }],


### PR DESCRIPTION
Outcome of https://community.theforeman.org/t/rfc-minimum-reccomended-memory-for-operating-systems/8553 was to just increase the default to a higher value. Ultimately, users will define their own compute profiles and the amount of memory they want, but this 2GB value will just work for people who accept our default.  

Using network-based provisioning 768mb is not enough for even CentOS 7.  Newer Fedora (and eventually RHEL8) will need even more (at least about 1.5gb in my testing).

