### PR TITLE
Fixes #22908 - add placeholder to datatable search inputs

### DIFF
--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -22,6 +22,9 @@ export function activateDatatables() {
   $('[data-table=inline]')
     .not('.dataTable')
     .DataTable({
+      language: {
+        searchPlaceholder: __('Filter...'),
+      },
       dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>>",
     });
 
@@ -31,6 +34,9 @@ export function activateDatatables() {
       const url = el.getAttribute('data-source');
 
       $(el).DataTable({
+        language: {
+          searchPlaceholder: __('Filter...'),
+        },
         processing: true,
         serverSide: true,
         ordering: false,

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -27,6 +27,9 @@ describe('activateDatatables', () => {
       serverSide: true,
       ordering: false,
       ajax: $('[data-table=server]').data('source'),
+      language: {
+        searchPlaceholder: 'Filter...',
+      },
       dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'><'col-md-6'p>>",
     });
   });


### PR DESCRIPTION
before:
![before_placeholder](https://user-images.githubusercontent.com/11807069/37468003-6c666a1e-286a-11e8-9a75-a1f27d4fb7ba.png)

after:
![after_placeholder](https://user-images.githubusercontent.com/11807069/37468008-7060af62-286a-11e8-9f4f-d82a26b23328.png)

