### PR TITLE
Fixes #22901 - fix js execution after hitting back/forward

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,9 @@ $(document).on("page:fetch", function() {
 $(document).on("page:change", tfm.tools.hideSpinner)
 
 $(function() {
+  // turbolinks classic cached pages have an issue with react integration
+  // https://github.com/reactjs/react-rails/blob/18a4f5b4c44ab58ad0dd77c5e9315e3cb0edba1f/react_ujs/src/events/turbolinksClassicDeprecated.js#L4
+  Turbolinks.pagesCached(0);
   tfm.nav.init();
   $(document).trigger('ContentLoad');
 });


### PR DESCRIPTION
Turbolinks classic cached pages have an issue with react integration, which breaks react components after hitting back.
A workaround for this is to disable turbolinks internal caching, as [react-rails](https://github.com/reactjs/react-rails/blob/18a4f5b4c44ab58ad0dd77c5e9315e3cb0edba1f/react_ujs/src/events/turbolinksClassicDeprecated.js#L7) does it as well.