### PR TITLE
 Fixes #22918 - Audit all taxonomies assignments

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -1,4 +1,5 @@
 class Architecture < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -12,7 +13,6 @@ class Architecture < ApplicationRecord
   has_many :images, :dependent => :destroy
   has_and_belongs_to_many :operatingsystems
   validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
-  audited
 
   scoped_search :on => :name, :complete_value => :true
 

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 class AuthSource < ApplicationRecord
+  audited
   include Authorizable
   scoped_search :on => :name, :complete_value => :true
 
@@ -34,7 +35,9 @@ class AuthSource < ApplicationRecord
 
   scoped_search :on => :name, :complete_value => :true
 
-  audited
+  # audited gem uses class variable for audied_options so once child class define auditing of these associations
+  # other auth sources definitions start failing, since organization_ids_changed? method is undefined there
+  audit_associations :organizations, :locations
 
   validates_lengths_from_database :except => [:name, :account_password, :host, :attr_login, :attr_firstname, :attr_lastname, :attr_mail]
   before_destroy EnsureNotUsedBy.new(:users)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,5 @@
 class Bookmark < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -7,7 +8,6 @@ class Bookmark < ApplicationRecord
   validates_lengths_from_database
 
   belongs_to :owner, :polymorphic => true
-  audited
 
   validates :name, :uniqueness => {:scope => :controller}, :unless => Proc.new{|b| Bookmark.my_bookmarks.where(:name => b.name).empty?}
   validates :name, :query, :presence => true

--- a/app/models/compute_profile.rb
+++ b/app/models/compute_profile.rb
@@ -1,4 +1,5 @@
 class ComputeProfile < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -6,7 +7,6 @@ class ComputeProfile < ApplicationRecord
 
   validates_lengths_from_database
 
-  audited
   has_associated_audits
 
   before_destroy EnsureNotUsedBy.new(:hostgroups)

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -1,4 +1,5 @@
 class ComputeResource < ApplicationRecord
+  audited :except => [:password, :attrs]
   include Taxonomix
   include Encryptable
   include Authorizable
@@ -7,7 +8,6 @@ class ComputeResource < ApplicationRecord
 
   validates_lengths_from_database
 
-  audited :except => [:password, :attrs]
   serialize :attrs, Hash
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
   belongs_to :http_proxy

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -19,6 +19,7 @@ module Taxonomix
     scoped_search :relation => :organizations, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
     dirty_has_many_associations :organizations, :locations
+    audit_associations :organizations, :locations
 
     validate :ensure_taxonomies_not_escalated, :if => Proc.new { User.current.nil? || !User.current.admin? }
   end

--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -1,7 +1,7 @@
 class ConfigGroupClass < ApplicationRecord
-  include Authorizable
-
   audited :associated_with => :config_group
+
+  include Authorizable
 
   belongs_to :puppetclass
   belongs_to :config_group

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,6 +1,7 @@
 require "resolv"
 # This models a DNS domain and so represents a site.
 class Domain < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -10,7 +11,6 @@ class Domain < ApplicationRecord
   include BelongsToProxies
   include ParameterAttributes
 
-  audited
   validates_lengths_from_database
   has_many :hostgroups
   #order matters! see https://github.com/rails/rails/issues/670

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,11 +1,11 @@
 class Environment < ApplicationRecord
+  audited
   extend FriendlyId
   friendly_id :name, :reserved_words => []
   include Taxonomix
   include Authorizable
   include Parameterizable::ByName
 
-  audited
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,4 +1,6 @@
 class Filter < ApplicationRecord
+  audited :associated_with => :role
+
   include Taxonomix
   include Authorizable
   include TopbarCacheExpiry
@@ -36,7 +38,6 @@ class Filter < ApplicationRecord
     end
   end
 
-  audited :associated_with => :role
   belongs_to :role
   has_many :filterings, :autosave => true, :dependent => :destroy
   has_many :permissions, :through => :filterings

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -1,4 +1,11 @@
 class Host::Managed < Host::Base
+  # audit the changes to this model
+  audited :except => [:last_report, :last_compile, :lookup_value_matcher]
+  has_associated_audits
+  #redefine audits relation because of the type change (by default the relation will look for auditable_type = 'Host::Managed')
+  has_many :audits, -> { where(:auditable_type => 'Host::Base') }, :foreign_key => :auditable_id,
+           :class_name => 'Audited::Audit'
+
   include Hostext::PowerInterface
   include Hostext::Search
   include Hostext::SmartProxy
@@ -181,13 +188,6 @@ class Host::Managed < Host::Base
   scope :for_vm, ->(cr,vm) { where(:compute_resource_id => cr.id, :uuid => Array.wrap(vm).compact.map(&:identity).map(&:to_s)) }
 
   scope :with_compute_resource, -> { where.not(:compute_resource_id => nil, :uuid => nil) }
-
-  # audit the changes to this model
-  audited :except => [:last_report, :last_compile, :lookup_value_matcher]
-  has_associated_audits
-  #redefine audits relation because of the type change (by default the relation will look for auditable_type = 'Host::Managed')
-  has_many :audits, -> { where(:auditable_type => 'Host::Base') }, :foreign_key => :auditable_id,
-    :class_name => 'Audited::Audit'
 
   # some shortcuts
   alias_attribute :arch, :architecture

--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -1,8 +1,8 @@
 class HostClass < ApplicationRecord
+  audited :associated_with => :host
   include Authorizable
 
   validates_lengths_from_database
-  audited :associated_with => :host
   belongs_to_host
   belongs_to :puppetclass
 

--- a/app/models/host_config_group.rb
+++ b/app/models/host_config_group.rb
@@ -1,7 +1,6 @@
 class HostConfigGroup < ApplicationRecord
   include Authorizable
   audited :associated_with => :host
-  audited :associated_with => :hostgroup
   belongs_to :host, :polymorphic => true
   belongs_to :config_group
 

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -1,4 +1,5 @@
 class Hostgroup < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :title

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -1,7 +1,7 @@
 class HostgroupClass < ApplicationRecord
+  audited :associated_with => :hostgroup
   include Authorizable
 
-  audited :associated_with => :hostgroup
   belongs_to :hostgroup
   belongs_to :puppetclass
 

--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -1,9 +1,9 @@
 class HttpProxy < ApplicationRecord
+  audited
   include Authorizable
   include Taxonomix
   include Encryptable
 
-  audited
 
   extend FriendlyId
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,7 @@
 class Image < ApplicationRecord
+  audited
   include Authorizable
 
-  audited
 
   belongs_to :operatingsystem
   belongs_to :compute_resource

--- a/app/models/key_pair.rb
+++ b/app/models/key_pair.rb
@@ -1,9 +1,9 @@
 class KeyPair < ApplicationRecord
+  audited :except => :secret, :associated_with => :compute_resource
   belongs_to :compute_resource
   validates_lengths_from_database
   validates :name, :secret, :presence => true
   validates :compute_resource_id, :presence => true, :uniqueness => true
-  audited :except => :secret, :associated_with => :compute_resource
 
   def skip_strip_attrs
     ['secret']

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -1,4 +1,5 @@
 class LookupKey < ApplicationRecord
+  audited :associated_with => :audit_class
   include Authorizable
   include HiddenValue
   include Classification
@@ -10,7 +11,6 @@ class LookupKey < ApplicationRecord
   EQ_DELM  = "="
   VALUE_REGEX =/\A[^#{KEY_DELM}]+#{EQ_DELM}[^#{KEY_DELM}]+(#{KEY_DELM}[^#{KEY_DELM}]+#{EQ_DELM}[^#{KEY_DELM}]+)*\Z/
 
-  audited :associated_with => :audit_class
   validates_lengths_from_database
 
   serialize :default_value

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -1,10 +1,10 @@
 class LookupValue < ApplicationRecord
+  audited :associated_with => :lookup_key
   include Authorizable
   include PuppetLookupValueExtensions
   include HiddenValue
 
   validates_lengths_from_database
-  audited :associated_with => :lookup_key
   delegate :hidden_value?, :editable_by_user?, :to => :lookup_key, :allow_nil => true
 
   belongs_to :lookup_key

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,11 +1,11 @@
 class Medium < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
   include Taxonomix
   include ValidateOsFamily
   include Parameterizable::ByIdName
-  audited
 
   validates_lengths_from_database
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -1,10 +1,10 @@
 class Model < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName
 
-  audited
 
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many_hosts

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -2,6 +2,7 @@
 # This class is the both parent
 module Nic
   class Base < ApplicationRecord
+    audited associated_with: :host
     prepend Foreman::STI
     include Encryptable
     encrypts :password
@@ -61,8 +62,6 @@ module Nic
     belongs_to :domain
 
     belongs_to_host :inverse_of => :interfaces, :class_name => "Host::Base"
-
-    audited associated_with: :host
 
     # keep extra attributes needed for sub classes.
     serialize :attrs, Hash

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -2,6 +2,7 @@ require 'ostruct'
 require 'uri'
 
 class Operatingsystem < ApplicationRecord
+  audited
   include Authorizable
   include ValidateOsFamily
   include PxeLoaderSupport
@@ -40,7 +41,6 @@ class Operatingsystem < ApplicationRecord
 
   before_save :set_family
 
-  audited
   default_scope -> { order(:title) }
 
   scoped_search :on => :name,        :complete_value => :true

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -1,10 +1,9 @@
 class PersonalAccessToken < ApplicationRecord
+  audited :except => [:token], :associated_with => :user
   include Authorizable
   include Expirable
 
   belongs_to :user
-
-  audited :except => [:token], :associated_with => :user
 
   scoped_search :on => :name
   scoped_search :on => :user_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -1,4 +1,7 @@
 class ProvisioningTemplate < Template
+  audited
+  has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
+
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -13,9 +16,6 @@ class ProvisioningTemplate < Template
     end
   end
   self.table_name = 'templates'
-
-  audited
-  has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
 
   validates :name, :uniqueness => true
   validates :template_kind_id, :presence => true, :unless => Proc.new {|t| t.snippet }

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -3,6 +3,9 @@
 # A host object may contain a reference to one of these ptables or, alternatively, it may contain a
 # modified version of one of these in textual form
 class Ptable < Template
+  audited
+  has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
+
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -18,9 +21,6 @@ class Ptable < Template
     end
   end
   self.table_name = 'templates'
-
-  audited
-  has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
 
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   has_many_hosts

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -1,4 +1,5 @@
 class Puppetclass < ApplicationRecord
+  audited
   include Authorizable
   include ScopedSearchExtensions
   extend FriendlyId
@@ -24,7 +25,6 @@ class Puppetclass < ApplicationRecord
   accepts_nested_attributes_for :class_params, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
 
   validates :name, :uniqueness => true, :presence => true, :no_whitespace => true
-  audited
 
   alias_attribute :smart_variables, :lookup_keys
   alias_attribute :smart_variable_ids, :lookup_key_ids

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -1,4 +1,5 @@
 class Realm < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -8,7 +9,6 @@ class Realm < ApplicationRecord
   TYPES = ["FreeIPA", "Active Directory"]
 
   validates_lengths_from_database
-  audited
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
 
   belongs_to_proxy :realm_proxy,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 class Role < ApplicationRecord
+  audited
   include Authorizable
   include ScopedSearchExtensions
   extend FriendlyId
@@ -28,7 +29,6 @@ class Role < ApplicationRecord
   ORG_ADMIN = 'Organization admin'
   VIEWER = 'Viewer'
 
-  audited
   has_associated_audits
   scope :givable, -> { where(:builtin => 0).order(:name) }
   scope :for_current_user, -> { User.current.admin? ? where('0 = 0') : where(:id => User.current.role_ids) }

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,7 @@
 require 'resolv'
 
 class Setting < ApplicationRecord
+  audited :except => [:name, :description, :category, :settings_type, :full_name, :encrypted], :on => [:update]
   extend FriendlyId
   friendly_id :name
   include ActiveModel::Validations
@@ -28,7 +29,6 @@ class Setting < ApplicationRecord
 
   validates_lengths_from_database
   # audit the changes to this model
-  audited :except => [:name, :description, :category, :settings_type, :full_name, :encrypted], :on => [:update]
 
   validates :name, :presence => true, :uniqueness => true
   validates :description, :presence => true

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -1,10 +1,10 @@
 class SmartProxy < ApplicationRecord
+  audited
   include Authorizable
   extend FriendlyId
   friendly_id :name
   include Taxonomix
   include Parameterizable::ByIdName
-  audited
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups, :subnets, :domains, [:puppet_ca_hosts, :hosts], [:puppet_ca_hostgroups, :hostgroups], :realms)

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -1,4 +1,5 @@
 class SshKey < ApplicationRecord
+  audited :associated_with => :user
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -8,7 +9,6 @@ class SshKey < ApplicationRecord
   before_validation :generate_fingerprint
   before_validation :calculate_length
 
-  audited :associated_with => :user
 
   scoped_search :on => :name
   scoped_search :on => :user_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,6 +1,7 @@
 require 'ipaddr'
 
 class Subnet < ApplicationRecord
+  audited
   IP_FIELDS = [:network, :mask, :gateway, :dns_primary, :dns_secondary, :from, :to]
   REQUIRED_IP_FIELDS = [:network, :mask]
   SUBNET_TYPES = {:'Subnet::Ipv4' => N_('IPv4'), :'Subnet::Ipv6' => N_('IPv6')}
@@ -33,7 +34,6 @@ class Subnet < ApplicationRecord
     super
   end
 
-  audited
 
   validates_lengths_from_database :except => [:gateway]
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups, :interfaces, :domains)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 require 'digest/sha1'
 
 class User < ApplicationRecord
+  audited :except => [:last_login_on, :password_hash, :password_salt, :password_confirmation],
+          :associations => :roles
   include Authorizable
   extend FriendlyId
   friendly_id :login
@@ -121,8 +123,6 @@ class User < ApplicationRecord
 
   dirty_has_many_associations :roles
 
-  audited :except => [:last_login_on, :password_hash, :password_salt, :password_confirmation],
-          :associations => :roles
 
   attr_exportable :firstname, :lastname, :mail, :description, :fullname, :name => ->(user) { user.login }, :ssh_authorized_keys => ->(user) { user.ssh_keys.map(&:to_export_hash) }
 

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -1,4 +1,5 @@
 class Usergroup < ApplicationRecord
+  audited :associations => [:usergroups, :roles, :users]
   include Authorizable
   extend FriendlyId
   friendly_id :name
@@ -39,7 +40,6 @@ class Usergroup < ApplicationRecord
 
   accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
 
-  audited :associations => [:usergroups, :roles, :users]
 
   class Jail < ::Safemode::Jail
     allow :ssh_keys, :all_users, :ssh_authorized_keys

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -2,11 +2,12 @@
 # we reopen here to add search functionality
 require 'audited'
 
-Audit = Audited::Audit
-Audit.send(:include, AuditExtensions)
-
 # Re-opened AuditorInstanceMethods to audit 1-0-* associations
 Auditor = Audited::Auditor::AuditedInstanceMethods
 Auditor.send(:include, AuditAssociations)
 
 ::ActiveRecord::Base.send :include, AuditAssociations::Auditor
+
+# Audit includes Taxonomix which already relies on DSL provided by audited gem
+Audit = Audited::Audit
+Audit.send(:include, AuditExtensions)


### PR DESCRIPTION
We need to move all audited definitions to top of models because all
concerns can use audit_associations call which relies on audit being
already activated.

---

based on top of #5322