### PR TITLE
Fixes #22922 - Port robottelo tier1 compute profiles tests

### DIFF
--- a/test/controllers/api/v2/compute_profiles_controller_test.rb
+++ b/test/controllers/api/v2/compute_profiles_controller_test.rb
@@ -17,15 +17,19 @@ class Api::V2::ComputeProfilesControllerTest < ActionController::TestCase
   end
 
   test "should create compute profile" do
+    name = '4-Xlarge'
     assert_difference('ComputeProfile.count') do
-      post :create, params: { :compute_profile => {:name => '4-Xlarge'} }
+      post :create, params: { :compute_profile => {:name => name} }
     end
     assert_response :created
+    assert_equal JSON.parse(@response.body)['name'], name, "Can't create compute profile with valid name #{name}"
   end
 
   test "should update compute_profile" do
-    put :update, params: { :id => compute_profiles(:one).to_param, :compute_profile => {:name => 'new name' } }
+    name = 'new name'
+    put :update, params: { :id => compute_profiles(:one).to_param, :compute_profile => {:name => name } }
     assert_response :success
+    assert_equal JSON.parse(@response.body)['name'], name, "Can't update compute profile with valid name #{name}"
   end
 
   test "should destroy compute profile" do

--- a/test/models/compute_profile_test.rb
+++ b/test/models/compute_profile_test.rb
@@ -7,7 +7,8 @@ class ComputeProfileTest < ActiveSupport::TestCase
 
   should validate_presence_of(:name)
   should validate_uniqueness_of(:name)
-  should_not allow_value('   ').for(:name)
+  should allow_values(*valid_name_list).for(:name)
+  should_not allow_values(*invalid_name_list).for(:name)
 
   test "should not destroy if in use by hostgroup" do
     #hostgroups(:common) uses compute_profiles(:one)
@@ -33,21 +34,6 @@ class ComputeProfileTest < ActiveSupport::TestCase
   test "compute profile with associated attributes can be destroyed" do
     assert_difference('ComputeAttribute.count', -2) do
       assert compute_attributes(:three).compute_profile.destroy
-    end
-  end
-
-  test 'should create with multiple valid names' do
-    valid_name_list.each do |name|
-      compute_profile = FactoryBot.build(:compute_profile, :name => name)
-      assert compute_profile.valid?, "Can't create compute profile with valid name #{name}"
-    end
-  end
-
-  test 'should not create with multiple invalid names' do
-    invalid_name_list.each do |name|
-      compute_profile = FactoryBot.build(:compute_profile, :name => name)
-      refute compute_profile.valid?, "Can create compute profile with invalid name #{name}"
-      assert_includes compute_profile.errors.keys, :name
     end
   end
 

--- a/test/models/compute_profile_test.rb
+++ b/test/models/compute_profile_test.rb
@@ -35,4 +35,36 @@ class ComputeProfileTest < ActiveSupport::TestCase
       assert compute_attributes(:three).compute_profile.destroy
     end
   end
+
+  test 'should create with multiple valid names' do
+    valid_name_list.each do |name|
+      compute_profile = FactoryBot.build(:compute_profile, :name => name)
+      assert compute_profile.valid?, "Can't create compute profile with valid name #{name}"
+    end
+  end
+
+  test 'should not create with multiple invalid names' do
+    invalid_name_list.each do |name|
+      compute_profile = FactoryBot.build(:compute_profile, :name => name)
+      refute compute_profile.valid?, "Can create compute profile with invalid name #{name}"
+      assert_includes compute_profile.errors.keys, :name
+    end
+  end
+
+  test 'should update with multiple valid names' do
+    compute_profile = FactoryBot.create(:compute_profile)
+    valid_name_list.each do |name|
+      compute_profile.name = name
+      assert compute_profile.valid?, "Can't update compute profile with valid name #{name}"
+    end
+  end
+
+  test 'should not update with multiple invalid names' do
+    compute_profile = FactoryBot.create(:compute_profile)
+    invalid_name_list.each do |name|
+      compute_profile.name = name
+      refute compute_profile.valid?, "Can update compute profile with invalid name #{name}"
+      assert_includes compute_profile.errors.keys, :name
+    end
+  end
 end


### PR DESCRIPTION
Redmine issue: http://projects.theforeman.org/issues/22922

Port robottelo tier1 tests for environment part of robottelo minitest port project https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: SatelliteQE/robottelo#5845

Relates on #5295 for rfauxfactory dependency.