### PR TITLE
Fixes #22927 - method in audit_associations to get class

### DIFF
--- a/app/models/concerns/audit_associations.rb
+++ b/app/models/concerns/audit_associations.rb
@@ -14,13 +14,16 @@ module AuditAssociations
 
     private
 
+    def find_association_class(name)
+      self.class.reflect_on_association(name).class_name.constantize
+    end
+
     def associated_changes
       associations = Array.wrap(audited_options[:associations])
       associations.inject({}) do |changes_hash, association_name|
         association_ids = "#{association_name.to_s.singularize}_ids"
-
         if send("#{association_ids}_changed?")
-          association_class = self.class.reflect_on_association(association_name).class_name.constantize
+          association_class = find_association_class(association_name)
           change = send("#{association_ids}_change")
           change_ids = change.flatten.uniq
 

--- a/test/models/concerns/audit_associations_test.rb
+++ b/test/models/concerns/audit_associations_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AuditAssociationsTest < ActiveSupport::TestCase
+  test ":find_association_class should be give a class_name" do
+    user_obj = User.new
+    role_class = user_obj.send('find_association_class', 'roles')
+    assert_equal Role, role_class
+  end
+end


### PR DESCRIPTION
With this commit, we can override association_class method in other plugins like Katello.