### PR TITLE
[WIP] Fixes #22109, #22388 - add graphql as API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,3 +77,7 @@ Layout/FirstParameterIndentation:
 
 Bundler/OrderedGems:
   Enabled: false
+
+Style/Attr:
+  Exclude:
+    - 'app/graphql/types/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,11 @@ gem 'sshkey', '~> 1.9'
 gem 'dynflow', '>= 0.8.29', '< 1.0.0'
 gem 'daemons'
 gem 'get_process_mem'
+gem 'graphql', '~> 1.7.8'
+gem 'graphql-activerecord'
+gem 'graphql-batch'
+gem 'jwt', '~> 2.1.0'
+gem 'rack-cors', '~> 1.0.2'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -1,0 +1,78 @@
+module Api
+  class GraphqlController < ActionController::Base
+    force_ssl :if => :require_ssl?
+    rescue_from Exception, :with => :generic_exception if Rails.env.production?
+
+    before_action :set_current_user
+    around_action :set_timezone
+
+    def execute
+      result = ForemanGraphqlSchema.execute(params[:query],
+                                            variables: variables,
+                                            context: {
+                                              current_user: User.current
+                                            })
+      render json: result
+    end
+
+    private
+
+    def set_current_user
+      @current_user = begin
+        payload = jwt_token.decode || {}
+        user_id = payload['user_id']
+        User.unscoped.find_by(id: user_id) if user_id
+      rescue JWT::DecodeError
+        nil
+      end
+      User.current = @current_user
+    end
+
+    def jwt_token
+      @jwt_token ||= begin
+        token = request.headers.fetch('Authorization', '')
+        JwtToken.new(token)
+      end
+    end
+
+    def variables
+      ensure_hash(params[:variables])
+    end
+
+    def ensure_hash(ambiguous_param)
+      case ambiguous_param
+      when String
+        if ambiguous_param.present?
+          ensure_hash(JSON.parse(ambiguous_param))
+        else
+          {}
+        end
+      when Hash, ActionController::Parameters
+        ambiguous_param
+      when nil
+        {}
+      else
+        raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+      end
+    end
+
+    def generic_exception(exception)
+      Foreman::Logging.exception("Action failed", exception)
+      render json: "{ 'error': 500 }", :status => :internal_server_error
+    end
+
+    def set_timezone
+      default_timezone = Time.zone
+      client_timezone  = User.current.try(:timezone)
+      Time.zone = client_timezone if client_timezone.present?
+      yield
+    ensure
+      # Reset timezone for the next thread
+      Time.zone = default_timezone
+    end
+
+    def require_ssl?
+      SETTINGS[:require_ssl]
+    end
+  end
+end

--- a/app/graphql/association_loader.rb
+++ b/app/graphql/association_loader.rb
@@ -1,0 +1,43 @@
+class AssociationLoader < GraphQL::Batch::Loader
+  def initialize(model, association_name)
+    @model = model
+    @association_name = association_name
+    validate
+  end
+
+  def load(record)
+    raise TypeError, "#{@model} loader can't load association for #{record.class}" unless record.is_a?(@model)
+    return Promise.resolve(read_association(record)) if association_loaded?(record)
+    super
+  end
+
+  # We want to load the associations on all records, even if they have the same id
+  def cache_key(record)
+    record.object_id
+  end
+
+  def perform(records)
+    preload_association(records)
+    records.each { |record| fulfill(record, read_association(record)) }
+  end
+
+  private
+
+  def validate
+    unless @model.reflect_on_association(@association_name)
+      raise ArgumentError, "No association #{@association_name} on #{@model}"
+    end
+  end
+
+  def preload_association(records)
+    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+  end
+
+  def read_association(record)
+    record.public_send(@association_name)
+  end
+
+  def association_loaded?(record)
+    record.association(@association_name).loaded?
+  end
+end

--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -1,0 +1,11 @@
+ForemanGraphqlSchema = GraphQL::Schema.define do
+  # Set up the graphql-batch gem
+  lazy_resolve(Promise, :sync)
+  use GraphQL::Batch
+
+  # Set up the graphql-activerecord gem
+  instrument(:field, GraphQL::Models::Instrumentation.new)
+
+  mutation(Types::Mutation)
+  query(Types::Query)
+end

--- a/app/graphql/mutations/sign_in_user.rb
+++ b/app/graphql/mutations/sign_in_user.rb
@@ -1,0 +1,22 @@
+class Mutations::SignInUser < GraphQL::Function
+  argument :login, Types::AuthProviderLoginInput
+
+  type do
+    name 'SIGN_IN_USER_PAYLOAD'
+
+    field :user_id, types.ID
+    field :token, types.String
+  end
+
+  def call(obj, args, ctx)
+    login = args[:login] || {}
+    username = login[:username]
+    password = login[:password]
+    return unless username && password
+
+    user = User.try_to_login(username, password)
+    return unless user
+
+    OpenStruct.new(user_id: user.id, token: user.jwt_token!)
+  end
+end

--- a/app/graphql/queries/authorized_model_query.rb
+++ b/app/graphql/queries/authorized_model_query.rb
@@ -1,0 +1,31 @@
+module Queries
+  class AuthorizedModelQuery
+    def initialize(model_class:, user:)
+      @model_class = model_class
+      @user = user
+    end
+
+    def find_by(params)
+      authorized_scope.find_by(id: params[:id])
+    end
+
+    def results(params = {})
+      if params[:search]
+        authorized_scope.search_for(params[:search], :order => params[:order])
+      else
+        authorized_scope.all
+      end
+    end
+
+    private
+
+    attr_reader :model_class, :user
+
+    def authorized_scope
+      return model_class unless model_class.respond_to?(:authorized)
+
+      permission = model_class.find_permission_name(:view)
+      model_class.authorized_as(user, permission, model_class)
+    end
+  end
+end

--- a/app/graphql/queries/current_user.rb
+++ b/app/graphql/queries/current_user.rb
@@ -1,0 +1,14 @@
+class Queries::CurrentUser < GraphQL::Function
+  type do
+    name 'CURRENT_USER_PAYLOAD'
+
+    field :user_id, types.ID
+  end
+
+  def call(obj, args, ctx)
+    current_user = ctx[:current_user]
+    return unless current_user
+
+    OpenStruct.new(user_id: current_user.id)
+  end
+end

--- a/app/graphql/queries/fetch_field.rb
+++ b/app/graphql/queries/fetch_field.rb
@@ -1,0 +1,17 @@
+module Queries
+  class FetchField < GraphQL::Function
+    attr_reader :type
+
+    argument(:id, !types.Int, 'ID for Record')
+
+    def initialize(model_class:, type:)
+      @model_class = model_class
+      @type = type
+    end
+
+    def call(_, args, ctx)
+      Queries::AuthorizedModelQuery.new(model_class: @model_class, user: ctx[:current_user])
+                                   .find_by(id: args['id'])
+    end
+  end
+end

--- a/app/graphql/queries/plural_field.rb
+++ b/app/graphql/queries/plural_field.rb
@@ -1,0 +1,19 @@
+module Queries
+  class PluralField < GraphQL::Function
+    attr_reader :type
+
+    argument(:search, types.String, 'Search query')
+    argument(:order, types.String, 'Search query')
+
+    def initialize(model_class:, type:)
+      @model_class = model_class
+      @type = type
+    end
+
+    def call(_, args, ctx)
+      params = args.to_h.slice('search', 'order').symbolize_keys
+      Queries::AuthorizedModelQuery.new(model_class: @model_class, user: ctx[:current_user])
+                                   .results(params)
+    end
+  end
+end

--- a/app/graphql/record_loader.rb
+++ b/app/graphql/record_loader.rb
@@ -1,0 +1,10 @@
+class RecordLoader < GraphQL::Batch::Loader
+  def initialize(model)
+    @model = model
+  end
+
+  def perform(ids)
+    @model.where(id: ids).each { |record| fulfill(record.id, record) }
+    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+  end
+end

--- a/app/graphql/types/architecture_type.rb
+++ b/app/graphql/types/architecture_type.rb
@@ -1,0 +1,9 @@
+Types::ArchitectureType = GraphQL::ObjectType.define do
+  name 'Architecture'
+  description 'An Architecture'
+
+  backed_by_model :architecture do
+    attr :id
+    attr :name
+  end
+end

--- a/app/graphql/types/auth_provider_login_input.rb
+++ b/app/graphql/types/auth_provider_login_input.rb
@@ -1,0 +1,6 @@
+Types::AuthProviderLoginInput = GraphQL::InputObjectType.define do
+  name 'AUTH_PROVIDER_LOGIN'
+
+  argument :username, !types.String
+  argument :password, !types.String
+end

--- a/app/graphql/types/bookmark_type.rb
+++ b/app/graphql/types/bookmark_type.rb
@@ -1,0 +1,11 @@
+Types::BookmarkType = GraphQL::ObjectType.define do
+  name 'Bookmark'
+  description 'A Bookmark'
+
+  backed_by_model :bookmark do
+    attr :id
+    attr :name
+    attr :controller
+    attr :public
+  end
+end

--- a/app/graphql/types/compute_attribute_type.rb
+++ b/app/graphql/types/compute_attribute_type.rb
@@ -1,0 +1,15 @@
+Types::ComputeAttributeType = GraphQL::ObjectType.define do
+  name 'ComputeAttribute'
+  description 'A ComputeAttribute'
+
+  backed_by_model :compute_attribute do
+    attr :id
+    attr :name
+  end
+
+  field :vmAttrs, Types::VmAttrsType, resolve: (proc do |obj|
+    obj.vm_attrs.map do |k, v|
+      [k.to_s, v.is_a?(Hash) ? v : v.to_s]
+    end.to_h
+  end)
+end

--- a/app/graphql/types/compute_resource_type.rb
+++ b/app/graphql/types/compute_resource_type.rb
@@ -1,0 +1,13 @@
+Types::ComputeResourceType = GraphQL::ObjectType.define do
+  name 'ComputeResource'
+  description 'A ComputeResource'
+
+  backed_by_model :compute_resource do
+    attr :id
+    attr :name
+  end
+
+  field :computeAttributes, types[Types::ComputeAttributeType], resolve: (proc do |obj|
+    AssociationLoader.for(ComputeResource, :compute_attributes).load(obj)
+  end)
+end

--- a/app/graphql/types/date_time_type.rb
+++ b/app/graphql/types/date_time_type.rb
@@ -1,0 +1,6 @@
+Types::DateTimeType = GraphQL::ScalarType.define do
+  name 'DateTime'
+
+  coerce_input ->(value, _ctx) { Time.zone.parse(value) }
+  coerce_result ->(value, _ctx) { value.utc.iso8601 }
+end

--- a/app/graphql/types/domain_type.rb
+++ b/app/graphql/types/domain_type.rb
@@ -1,0 +1,24 @@
+Types::DomainType = GraphQL::ObjectType.define do
+  name 'Domain'
+  description 'A Domain'
+
+  backed_by_model :domain do
+    attr :id
+    attr :name
+    attr :fullname
+  end
+
+  connection :subnets, Types::SubnetType.connection_type do
+    argument :type, types.String
+
+    resolve(proc do |obj, args|
+      AssociationLoader.for(obj.class, :subnets).load(obj).then do |subnets|
+        if args[:type].present?
+          subnets.select { |s| s.type == args[:type] }
+        else
+          subnets
+        end
+      end
+    end)
+  end
+end

--- a/app/graphql/types/environment_type.rb
+++ b/app/graphql/types/environment_type.rb
@@ -1,0 +1,13 @@
+Types::EnvironmentType = GraphQL::ObjectType.define do
+  name 'Environment'
+  description 'An Environment'
+
+  backed_by_model :environment do
+    attr :id
+    attr :name
+  end
+
+  connection :puppetclasses, Types::PuppetclassType.connection_type do
+    resolve(proc { |obj| AssociationLoader.for(obj.class, :puppetclasses).load(obj) })
+  end
+end

--- a/app/graphql/types/host_type.rb
+++ b/app/graphql/types/host_type.rb
@@ -1,0 +1,43 @@
+Types::HostType = GraphQL::ObjectType.define do
+  name 'Host'
+  description 'A Host'
+
+  backed_by_model :host do
+    attr :id
+    attr :name
+    attr :build
+    attr :created_at
+  end
+
+  field :location, Types::LocationType, resolve: (proc do |obj|
+    RecordLoader.for(Location).load(obj.location_id)
+  end)
+
+  field :operatingsystem, Types::OperatingsystemType, resolve: (proc do |obj|
+    RecordLoader.for(Operatingsystem).load(obj.operatingsystem_id)
+  end)
+
+  field :architecture, Types::ArchitectureType, resolve: (proc do |obj|
+    RecordLoader.for(Architecture).load(obj.architecture_id)
+  end)
+
+  field :computeResource, Types::ComputeResourceType, resolve: (proc do |obj|
+    RecordLoader.for(ComputeResource).load(obj.compute_resource_id)
+  end)
+
+  field :environment, Types::EnvironmentType, resolve: (proc do |obj|
+    RecordLoader.for(Environment).load(obj.environment_id)
+  end)
+
+  field :puppetProxy, Types::SmartProxyType, resolve: (proc do |obj|
+    RecordLoader.for(SmartProxy).load(obj.puppet_proxy_id)
+  end)
+
+  field :puppetCaProxy, Types::SmartProxyType, resolve: (proc do |obj|
+    RecordLoader.for(SmartProxy).load(obj.puppet_ca_proxy_id)
+  end)
+
+  field :puppetclasses, types[Types::PuppetclassType], resolve: (proc do |obj|
+    AssociationLoader.for(obj.class, :puppetclasses).load(obj)
+  end)
+end

--- a/app/graphql/types/json_type.rb
+++ b/app/graphql/types/json_type.rb
@@ -1,0 +1,6 @@
+Types::JsonType = GraphQL::ScalarType.define do
+  name 'JSON'
+
+  coerce_input ->(value, _ctx) { value }
+  coerce_result ->(value, _ctx) { value }
+end

--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -1,0 +1,10 @@
+Types::LocationType = GraphQL::ObjectType.define do
+  name 'Location'
+  description 'A Location'
+
+  backed_by_model :location do
+    attr :id
+    attr :name
+    attr :title
+  end
+end

--- a/app/graphql/types/model_type.rb
+++ b/app/graphql/types/model_type.rb
@@ -1,0 +1,12 @@
+Types::ModelType = GraphQL::ObjectType.define do
+  name 'Model'
+  description 'A Model'
+
+  backed_by_model :model do
+    attr :id
+    attr :name
+    attr :info
+    attr :vendor_class
+    attr :hardware_model
+  end
+end

--- a/app/graphql/types/mutation.rb
+++ b/app/graphql/types/mutation.rb
@@ -1,0 +1,5 @@
+Types::Mutation = GraphQL::ObjectType.define do
+  name 'Mutation'
+
+  field :signInUser, function: Mutations::SignInUser.new
+end

--- a/app/graphql/types/operatingsystem_type.rb
+++ b/app/graphql/types/operatingsystem_type.rb
@@ -1,0 +1,11 @@
+Types::OperatingsystemType = GraphQL::ObjectType.define do
+  name 'Operatingsystem'
+  description 'An Operatingsystem'
+
+  backed_by_model :operatingsystem do
+    attr :id
+    attr :name
+    attr :title
+    attr :type
+  end
+end

--- a/app/graphql/types/puppetclass_type.rb
+++ b/app/graphql/types/puppetclass_type.rb
@@ -1,0 +1,9 @@
+Types::PuppetclassType = GraphQL::ObjectType.define do
+  name 'Puppetclass'
+  description 'A Puppetclass'
+
+  backed_by_model :puppetclass do
+    attr :id
+    attr :name
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -1,0 +1,39 @@
+Types::Query = GraphQL::ObjectType.define do
+  name 'Query'
+
+  field :currentUser, function: Queries::CurrentUser.new
+
+  field :model, Types::ModelType,
+        function: Queries::FetchField.new(type: Types::ModelType, model_class: Model)
+  field :bookmark, Types::BookmarkType,
+        function: Queries::FetchField.new(type: Types::BookmarkType, model_class: Bookmark)
+  field :subnet, Types::SubnetType,
+        function: Queries::FetchField.new(type: Types::SubnetType, model_class: Subnet)
+  field :host, Types::HostType,
+        function: Queries::FetchField.new(type: Types::HostType, model_class: Host::Managed)
+  field :smartProxy, Types::SmartProxyType,
+        function: Queries::FetchField.new(type: Types::SmartProxyType, model_class: SmartProxy)
+  field :environment, Types::EnvironmentType,
+        function: Queries::FetchField.new(type: Types::EnvironmentType, model_class: Environment)
+  field :puppetclass, Types::PuppetclassType,
+        function: Queries::FetchField.new(type: Types::PuppetclassType, model_class: Puppetclass)
+  field :domain, Types::DomainType,
+        function: Queries::FetchField.new(type: Types::DomainType, model_class: Domain)
+
+  connection :models, Types::ModelType.connection_type,
+             function: Queries::PluralField.new(type: Types::ModelType, model_class: Model)
+  connection :bookmarks, Types::BookmarkType.connection_type,
+             function: Queries::PluralField.new(type: Types::BookmarkType, model_class: Bookmark)
+  connection :subnets, Types::SubnetType.connection_type,
+             function: Queries::PluralField.new(type: Types::SubnetType, model_class: Subnet)
+  connection :hosts, Types::HostType.connection_type,
+             function: Queries::PluralField.new(type: Types::HostType, model_class: Host::Managed)
+  connection :smartProxies, Types::SmartProxyType.connection_type,
+             function: Queries::PluralField.new(type: Types::SmartProxyType, model_class: SmartProxy)
+  connection :environments, Types::EnvironmentType.connection_type,
+             function: Queries::PluralField.new(type: Types::EnvironmentType, model_class: Environment)
+  connection :puppetclasses, Types::PuppetclassType.connection_type,
+             function: Queries::PluralField.new(type: Types::PuppetclassType, model_class: Puppetclass)
+  connection :domains, Types::DomainType.connection_type,
+             function: Queries::PluralField.new(type: Types::DomainType, model_class: Domain)
+end

--- a/app/graphql/types/smart_proxy_type.rb
+++ b/app/graphql/types/smart_proxy_type.rb
@@ -1,0 +1,10 @@
+Types::SmartProxyType = GraphQL::ObjectType.define do
+  name 'SmartProxy'
+  description 'A SmartProxy'
+
+  backed_by_model :smart_proxy do
+    attr :id
+    attr :name
+    attr :url
+  end
+end

--- a/app/graphql/types/subnet_type.rb
+++ b/app/graphql/types/subnet_type.rb
@@ -1,0 +1,27 @@
+Types::SubnetType = GraphQL::ObjectType.define do
+  name 'Subnet'
+  description 'A Subnet'
+
+  backed_by_model :subnet do
+    attr :id
+    attr :name
+    attr :type
+    attr :network
+    attr :mask
+    attr :priority
+    attr :vlanid
+    attr :gateway
+    attr :dns_primary
+    attr :dns_secondary
+    attr :from
+    attr :to
+    attr :ipam
+    attr :boot_mode
+    attr :created_at
+    attr :updated_at
+  end
+
+  field :networkAddress, types.String, resolve: proc { |obj| obj.network_address }
+  field :networkType, types.String, resolve: proc { |obj| obj.network_type }
+  field :cidr, types.String, resolve: proc { |obj| obj.cidr }
+end

--- a/app/graphql/types/vm_attrs_type.rb
+++ b/app/graphql/types/vm_attrs_type.rb
@@ -1,0 +1,10 @@
+Types::VmAttrsType = GraphQL::ObjectType.define do
+  name 'VmAttr'
+  description 'A VmAttr'
+
+  field :cpus, types.String, hash_key: 'cpus'
+  field :memory, types.String, hash_key: 'memory'
+  field :volumesAttributes, Types::JsonType, resolve: (proc do |obj|
+    obj['volumes_attributes']
+  end)
+end

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -34,15 +34,7 @@ module Authorizable
   end
 
   def permission_name(action)
-    type = Permission.resource_name(self.class)
-    permissions = Permission.where(:resource_type => type).where(["#{Permission.table_name}.name LIKE ?", "#{action}_%"])
-
-    # some permissions are grouped for same resource, e.g. edit_comupute_resources and edit_compute_resources_vms, in such case we need to detect the right permission
-    if permissions.size > 1
-      permissions.detect { |p| p.name.end_with?(type.underscore.pluralize) }.try(:name)
-    else
-      permissions.first.try(:name)
-    end
+    self.class.find_permission_name(action)
   end
 
   included do
@@ -115,6 +107,18 @@ module Authorizable
       yield
     ensure
       Thread.current[:ignore_permission_check] = original_value
+    end
+
+    def find_permission_name(action)
+      type = Permission.resource_name(self)
+      permissions = Permission.where(:resource_type => type).where(["#{Permission.table_name}.name LIKE ?", "#{action}_%"])
+
+      # some permissions are grouped for same resource, e.g. edit_comupute_resources and edit_compute_resources_vms, in such case we need to detect the right permission
+      if permissions.size > 1
+        permissions.detect { |p| p.name.end_with?(type.underscore.pluralize) }.try(:name)
+      else
+        permissions.first.try(:name)
+      end
     end
   end
 end

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -1,0 +1,16 @@
+module JwtAuth
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :jwt_secret, inverse_of: :user, dependent: :destroy
+
+    def jwt_secret!
+      jwt_secret || create_jwt_secret!
+    end
+
+    def jwt_token!
+      jwt_secret = jwt_secret!
+      JwtToken.encode(self, jwt_secret.token).to_s
+    end
+  end
+end

--- a/app/models/jwt_secret.rb
+++ b/app/models/jwt_secret.rb
@@ -1,0 +1,25 @@
+class JwtSecret < ActiveRecord::Base
+  include Encryptable
+
+  encrypts :token
+
+  belongs_to :user, inverse_of: :jwt_secret
+
+  validates :token, uniqueness: true
+  validates :user, presence: true
+
+  before_save :generate_token, on: :create, prepend: true, :unless => Proc.new{|j| j.token.present?}
+
+  def self.for_user(user_or_user_id)
+    find_by(user: user_or_user_id)
+  end
+
+  private
+
+  def generate_token
+    loop do
+      self.token = SecureRandom.base64
+      break unless JwtSecret.find_by(token: token)
+    end
+  end
+end

--- a/app/models/jwt_token.rb
+++ b/app/models/jwt_token.rb
@@ -1,0 +1,60 @@
+require 'jwt'
+require 'base64'
+
+class JwtToken < Struct.new(:token)
+  class << self
+    def encode(user, secret)
+      payload = prepare_payload(user, secret)
+      new JWT.encode(payload, secret)
+    end
+
+    private
+
+    def prepare_payload(user, secret)
+      iat = Time.now.to_i
+      jti_raw = [secret, iat].join(':').to_s
+      jti = Digest::MD5.hexdigest(jti_raw)
+      { user_id: user.id, iat: iat, jti: jti }
+    end
+  end
+
+  def decode
+    return nil if token.blank?
+    return nil if secret.blank?
+
+    payload = JWT.decode(token, secret.token)
+    payload.first
+  end
+
+  def to_s
+    token
+  end
+
+  private
+
+  def secret
+    return @secret if defined? @secret
+    @secret = JwtSecret.for_user(user_id) if user_id
+  end
+
+  def user_id
+    return @user_id if defined? @user_id
+    @user_id = decoded_payload['user_id']
+  end
+
+  def decoded_payload
+    @decoded_payload ||= begin
+      payload = token.split('.')
+      if payload.size > 1
+        payload = payload[1]
+        payload += '=' * (4 - payload.length.modulo(4))
+        payload = Base64.decode64(payload.tr('-_', '+/'))
+        JSON.parse(payload)
+      else
+        {}
+      end
+    rescue JSON::ParserError
+      {}
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   include UserUsergroupCommon
   include Exportable
   include TopbarCacheExpiry
+  include JwtAuth
 
   ANONYMOUS_ADMIN = 'foreman_admin'
   ANONYMOUS_API_ADMIN = 'foreman_api_admin'

--- a/bundler.d/graphiql.rb
+++ b/bundler.d/graphiql.rb
@@ -1,0 +1,3 @@
+group :development, :test do
+  gem 'graphiql-rails', '~> 1.4.8'
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -89,6 +89,7 @@ module Foreman
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/services"]
     config.autoload_paths += Dir["#{config.root}/app/mailers"]
+    config.autoload_paths += Dir[ Rails.root.join('app', 'graphql') ]
 
     config.autoload_paths += %W(#{config.root}/app/models/auth_sources)
     config.autoload_paths += %W(#{config.root}/app/models/compute_resources)

--- a/config/initializers/graphql.rb
+++ b/config/initializers/graphql.rb
@@ -1,0 +1,30 @@
+require 'rack'
+require 'rack/cors'
+require 'graphql'
+require 'graphql/batch'
+require 'graphql/activerecord'
+
+Foreman::Application.configure do |app|
+  initializer 'configure_cors', :before=> :build_middleware_stack do |app|
+    app.config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins ENV['FOREMAN_GRAPHQL_CORS_DOMAINS'].to_s.split(',')
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
+  end
+
+  if Rails.env.development?
+    GraphiQL::Rails::EditorsController.send(:include, GraphiqlExt::JwtAuth)
+  end
+
+  GraphQL::Models::DatabaseTypes.register(:text, 'GraphQL::STRING_TYPE')
+  GraphQL::Models::DatabaseTypes.register(:datetime, 'Types::DateTimeType')
+
+  # The `graphql/activerecord` gem assumes that if your model is called `MyModel`,
+  # the corresponding type is `MyModelType`.
+  # This line supports our types structure: `Types::MyModelType`
+  GraphQL::Models.model_to_graphql_type = (lambda do |model_class|
+    "Types::#{model_class.name}Type".safe_constantize
+  end)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,4 +530,8 @@ Foreman::Application.routes.draw do
       put 'group/:group' => 'notification_recipients#update_group_as_read'
     end
   end
+
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/graphql'
+  end
 end

--- a/config/routes/api/graphql.rb
+++ b/config/routes/api/graphql.rb
@@ -1,0 +1,5 @@
+Foreman::Application.routes.draw do
+  namespace :api, :defaults => {:format => 'json'} do
+    post '/graphql', to: 'graphql#execute'
+  end
+end

--- a/db/migrate/20180315093821_create_jwt_secrets.rb
+++ b/db/migrate/20180315093821_create_jwt_secrets.rb
@@ -1,0 +1,9 @@
+class CreateJwtSecrets < ActiveRecord::Migration[5.1]
+  def change
+    create_table :jwt_secrets do |t|
+      t.string :token, index: { unique: true }, null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps :null => false
+    end
+  end
+end

--- a/lib/graphiql_ext/jwt_auth.rb
+++ b/lib/graphiql_ext/jwt_auth.rb
@@ -1,0 +1,22 @@
+module GraphiqlExt
+  module JwtAuth
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :set_auth_headers, only: :show
+
+      private
+
+      def set_auth_headers
+        user_id = params[:user_id]
+
+        if user_id.present? && (user = User.unscoped.find(user_id))
+          GraphiQL::Rails.config.headers['Authorization'] = ->(_context) { user.jwt_token! }
+        elsif GraphiQL::Rails.config.headers.key? 'Authorization'
+          # Reset Authorization if previously set
+          GraphiQL::Rails.config.headers.delete 'Authorization'
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/graphql_controller_test.rb
+++ b/test/controllers/api/graphql_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Api::GraphqlControllerTest < ActionController::TestCase
+  test 'empty query' do
+    post :execute, {}
+
+    assert_response :success
+    refute_empty json_errors
+    assert_includes json_error_messages, 'No query string was present'
+  end
+
+  test 'siging user in' do
+    user = FactoryBot.create(:user, :with_jwt_secret)
+    query = <<-GRAPHQL
+      mutation {
+        signInUser(login: { username: "#{user.login}", password: "#{user.password}" }) {
+          user_id
+          token
+        }
+      }
+    GRAPHQL
+    post :execute, params: { query: query }
+
+    assert_response :success
+    assert json_data('signInUser')['token']
+    assert_equal user.id.to_s, json_data('signInUser')['user_id']
+  end
+
+  test 'fetching current user' do
+    user = setup_jwt_authorized_user
+    query = <<-GRAPHQL
+      query {
+        currentUser() {
+          user_id
+        }
+      }
+    GRAPHQL
+    post :execute, params: { query: query }
+
+    assert_response :success
+    assert_equal user.id.to_s, json_data('currentUser')['user_id']
+  end
+end

--- a/test/factories/user_related.rb
+++ b/test/factories/user_related.rb
@@ -40,6 +40,10 @@ FactoryBot.define do
     trait :with_usergroup do
       usergroups { [FactoryBot.create(:usergroup)] }
     end
+
+    trait :with_jwt_secret do
+      after(:create) { |user| FactoryBot.create(:jwt_secret, user: user) }
+    end
   end
 
   factory :permission do
@@ -115,5 +119,9 @@ FactoryBot.define do
   factory :widget do
     sequence(:name) {|n| "Status Table #{n}" }
     template 'status_widget'
+  end
+
+  factory :jwt_secret do
+    token { SecureRandom.base64 }
   end
 end

--- a/test/graphql/queries/authorized_model_query_test.rb
+++ b/test/graphql/queries/authorized_model_query_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class Queries::AuthorizedModelQueryTest < ActiveSupport::TestCase
+  describe '#find_by' do
+    test 'does not return record for missing user' do
+      host = FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: nil)
+                                            .find_by(id: host.id)
+
+      assert_nil result
+    end
+
+    test 'does not return record for not authorized user' do
+      user = FactoryBot.create(:user)
+      host = FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .find_by(id: host.id)
+
+      assert_nil result
+    end
+
+    test 'returns record for authorized user' do
+      user = setup_user 'view', 'hosts'
+      host = FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .find_by(id: host.id)
+
+      assert_equal result, host
+    end
+  end
+
+  describe '#results' do
+    test 'does not return records for missing user' do
+      FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: nil)
+                                            .results
+
+      assert_empty result
+    end
+
+    test 'does not return records for not authorized user' do
+      user = FactoryBot.create(:user)
+      FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results
+
+      assert_empty result
+    end
+
+    test 'returns records for authorized user' do
+      user = setup_user 'view', 'hosts'
+      host = FactoryBot.create(:host)
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results
+
+      assert_equal result, [host]
+    end
+
+    test 'searches and order results when search param present' do
+      user = setup_user 'view', 'hosts'
+      excluded_host = FactoryBot.create(:host)
+      included_hosts = [
+        FactoryBot.create(:host, hostname: 'sample host 1'),
+        FactoryBot.create(:host, hostname: 'a sample host 1')
+      ]
+
+      result = Queries::AuthorizedModelQuery.new(
+        model_class: Host::Managed, user: user
+      ).results(search: 'name ~ "sample"', order: 'name DESC')
+
+      refute_includes result, excluded_host
+      assert_equal result, included_hosts
+    end
+  end
+end

--- a/test/graphql/queries/bookmark_query_test.rb
+++ b/test/graphql/queries/bookmark_query_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class Queries::BookmarkQueryTest < ActiveSupport::TestCase
+  test 'fetching bookmark attributes' do
+    bookmark = FactoryBot.create(:bookmark, controller: 'users')
+
+    query = <<-GRAPHQL
+      query {
+        bookmark(id: #{bookmark.id}) {
+          id
+          name
+          controller
+          public
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_bookmark_attributes = {
+      'id' => bookmark.id,
+      'name' => bookmark.name,
+      'controller' => bookmark.controller,
+      'public' => bookmark.public
+    }
+
+    assert_equal expected_bookmark_attributes, result['data']['bookmark']
+  end
+end

--- a/test/graphql/queries/bookmarks_query_test.rb
+++ b/test/graphql/queries/bookmarks_query_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class Queries::BookmarksQueryTest < ActiveSupport::TestCase
+  test 'fetching bookmarks attributes' do
+    bookmark = FactoryBot.create(:bookmark, controller: 'users')
+
+    query = <<-GRAPHQL
+      query {
+        bookmarks {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              controller
+              public
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_bookmark_attributes = {
+      'id' => bookmark.id,
+      'name' => bookmark.name,
+      'controller' => bookmark.controller,
+      'public' => bookmark.public
+    }
+
+    assert_includes result['data']['bookmarks']['edges'].map { |e| e['node'] }, expected_bookmark_attributes
+  end
+end

--- a/test/graphql/queries/domain_query_test.rb
+++ b/test/graphql/queries/domain_query_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Queries::DomainQueryTest < ActiveSupport::TestCase
+  test 'fetching domain attributes' do
+    subnet = FactoryBot.create(:subnet_ipv4)
+    domain = FactoryBot.create(:domain, subnets: [subnet])
+
+    query = <<-GRAPHQL
+      query {
+        domain(id: #{domain.id}) {
+          id
+          name
+          fullname
+          subnets(type: "#{subnet.type}") {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_domain_attributes = {
+      'id' => domain.id,
+      'name' => domain.name,
+      'fullname' => domain.fullname,
+      'subnets' => {
+        'edges' => [
+          'node' => {
+            'id' => subnet.id,
+            'name' => subnet.name
+          }
+        ]
+      }
+    }
+
+    assert_equal expected_domain_attributes, result['data']['domain']
+  end
+end

--- a/test/graphql/queries/domains_query_test.rb
+++ b/test/graphql/queries/domains_query_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class Queries::DomainQueryTest < ActiveSupport::TestCase
+  test 'fetching domain attributes' do
+    domain = FactoryBot.create(:domain)
+
+    query = <<-GRAPHQL
+      query {
+        domains(search: "name=#{domain.name}") {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              fullname
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_domain_attributes = {
+      'id' => domain.id,
+      'name' => domain.name,
+      'fullname' => domain.fullname
+    }
+
+    assert_includes result['data']['domains']['edges'].map { |e| e['node'] }, expected_domain_attributes
+  end
+end

--- a/test/graphql/queries/environment_query_test.rb
+++ b/test/graphql/queries/environment_query_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class Queries::EnvironmentQueryTest < ActiveSupport::TestCase
+  test 'fetching environment attributes' do
+    environment = environments(:testing)
+
+    query = <<-GRAPHQL
+      query {
+        environment(id: #{environment.id}) {
+          id
+          name
+          puppetclasses {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_environment_attributes = {
+      'id' => environment.id,
+      'name' => environment.name,
+      'puppetclasses' => {
+        'edges' => environment.puppetclasses.map do |pc|
+          {
+            'node' => {
+              'id' => pc.id,
+              'name' => pc.name
+            }
+          }
+        end
+      }
+    }
+
+    assert_equal expected_environment_attributes, result['data']['environment']
+  end
+end

--- a/test/graphql/queries/environments_query_test.rb
+++ b/test/graphql/queries/environments_query_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Queries::EnvironmentsQueryTest < ActiveSupport::TestCase
+  test 'fetching environment attributes' do
+    environment = FactoryBot.create(:environment)
+
+    query = <<-GRAPHQL
+      query {
+        environments {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_environment_attributes = {
+      'id' => environment.id,
+      'name' => environment.name
+    }
+
+    assert_includes(
+      result['data']['environments']['edges'].map { |e| e['node'] },
+      expected_environment_attributes
+    )
+  end
+end

--- a/test/graphql/queries/host_query_test.rb
+++ b/test/graphql/queries/host_query_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+
+class Queries::HostQueryTest < ActiveSupport::TestCase
+  test 'fetching host attributes and relations' do
+    host = FactoryBot.create(
+      :host,
+      :managed, :on_compute_resource, :with_environment, :with_puppet,
+      :with_puppet_ca, :with_puppetclass
+    )
+    compute_attribute = FactoryBot.create(
+      :compute_attribute,
+      compute_profile: FactoryBot.create(:compute_profile),
+      compute_resource: host.compute_resource,
+      vm_attrs: {
+        cpus: 4,
+        memory: 536_870_912,
+        volumes_attributes: {
+          '0' => { 'vol' => 1 },
+          '1' => { 'vol' => 2 }
+        }
+      }
+    )
+
+    query = <<-GRAPHQL
+      query {
+        host(id: #{host.id}) {
+          id
+          name
+          build
+          createdAt
+          architecture {
+            id
+            name
+          }
+          operatingsystem {
+            id
+            name
+          }
+          location {
+            id
+            name
+          }
+          environment {
+            id
+            name
+          }
+          puppetProxy {
+            id
+            name
+          }
+          puppetCaProxy {
+            id
+            name
+          }
+          puppetclasses {
+            id
+          }
+          computeResource {
+            id
+            computeAttributes {
+              id
+              vmAttrs {
+                cpus
+                memory
+                volumesAttributes
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_host_attributes = {
+      'id' => host.id,
+      'name' => host.name,
+      'build' => host.build,
+      'createdAt' => host.created_at.utc.iso8601,
+      'architecture' => { 'id' => host.architecture_id, 'name' => host.architecture.name },
+      'operatingsystem' => { 'id' => host.operatingsystem_id, 'name' => host.operatingsystem.name },
+      'location' => { 'id' => host.location_id, 'name' => host.location.name },
+      'environment' => { 'id' => host.environment_id, 'name' => host.environment.name },
+      'puppetProxy' => { 'id' => host.puppet_proxy_id, 'name' => host.puppet_proxy.name },
+      'puppetCaProxy' => { 'id' => host.puppet_ca_proxy_id, 'name' => host.puppet_ca_proxy.name },
+      'puppetclasses' => [{ 'id' => host.puppetclasses.first.id }],
+      'computeResource' => {
+        'id' => host.compute_resource.id,
+        'computeAttributes' => [
+          'id' => compute_attribute.id,
+          'vmAttrs' => {
+            'cpus' => compute_attribute.vm_attrs[:cpus].to_s,
+            'memory' => compute_attribute.vm_attrs[:memory].to_s,
+            'volumesAttributes' => compute_attribute.vm_attrs[:volumes_attributes]
+          }
+        ]
+      }
+    }
+
+    assert_equal expected_host_attributes, result['data']['host']
+  end
+end

--- a/test/graphql/queries/hosts_query_test.rb
+++ b/test/graphql/queries/hosts_query_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class Queries::HostsQueryTest < ActiveSupport::TestCase
+  test 'fetching hosts attributes and relations' do
+    host = FactoryBot.create(
+      :host,
+      :managed, :on_compute_resource, :with_environment, :with_puppet,
+      :with_puppet_ca, :with_puppetclass
+    )
+    compute_attribute = FactoryBot.create(
+      :compute_attribute,
+      compute_profile: FactoryBot.create(:compute_profile),
+      compute_resource: host.compute_resource,
+      vm_attrs: {
+        cpus: 4,
+        memory: 536_870_912,
+        volumes_attributes: { '0' => { 'vol' => 1 }, '1' => { 'vol' => 2 } }
+      }
+    )
+
+    query = <<-GRAPHQL
+      query {
+        hosts {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              build
+              id
+              name
+              build
+              createdAt
+              architecture {
+                id
+                name
+              }
+              operatingsystem {
+                id
+                name
+              }
+              environment {
+                id
+                name
+              }
+              puppetProxy {
+                id
+                name
+              }
+              puppetCaProxy {
+                id
+                name
+              }
+              puppetclasses {
+                id
+              }
+              computeResource {
+                id
+                computeAttributes {
+                  id
+                  vmAttrs {
+                    cpus
+                    memory
+                    volumesAttributes
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_host_attributes = {
+      'id' => host.id,
+      'name' => host.name,
+      'build' => host.build,
+      'createdAt' => host.created_at.utc.iso8601,
+      'architecture' => { 'id' => host.architecture_id, 'name' => host.architecture.name },
+      'operatingsystem' => { 'id' => host.operatingsystem_id, 'name' => host.operatingsystem.name },
+      'environment' => { 'id' => host.environment_id, 'name' => host.environment.name },
+      'puppetProxy' => { 'id' => host.puppet_proxy_id, 'name' => host.puppet_proxy.name },
+      'puppetCaProxy' => { 'id' => host.puppet_ca_proxy_id, 'name' => host.puppet_ca_proxy.name },
+      'puppetclasses' => [{ 'id' => host.puppetclasses.first.id }],
+      'computeResource' => {
+        'id' => host.compute_resource.id,
+        'computeAttributes' => [
+          'id' => compute_attribute.id,
+          'vmAttrs' => {
+            'cpus' => compute_attribute.vm_attrs[:cpus].to_s,
+            'memory' => compute_attribute.vm_attrs[:memory].to_s,
+            'volumesAttributes' => compute_attribute.vm_attrs[:volumes_attributes]
+          }
+        ]
+      }
+    }
+
+    assert_includes result['data']['hosts']['edges'].map { |e| e['node'] }, expected_host_attributes
+  end
+end

--- a/test/graphql/queries/model_query_test.rb
+++ b/test/graphql/queries/model_query_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class Queries::ModelQueryTest < ActiveSupport::TestCase
+  test 'fetching model attributes' do
+    model = FactoryBot.create(:model)
+
+    query = <<-GRAPHQL
+      query {
+        model(id: #{model.id}) {
+          id
+          name
+          info
+          vendorClass
+          hardwareModel
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_model_attributes = {
+      'id' => model.id,
+      'name' => model.name,
+      'info' => model.info,
+      'vendorClass' => model.vendor_class,
+      'hardwareModel' => model.hardware_model
+    }
+
+    assert_equal expected_model_attributes, result['data']['model']
+  end
+end

--- a/test/graphql/queries/models_query_test.rb
+++ b/test/graphql/queries/models_query_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class Queries::ModelsQueryTest < ActiveSupport::TestCase
+  test 'fetching models attributes' do
+    model = FactoryBot.create(:model)
+
+    query = <<-GRAPHQL
+      query {
+        models {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              info
+              vendorClass
+              hardwareModel
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_model_attributes = {
+      'id' => model.id,
+      'name' => model.name,
+      'info' => model.info,
+      'vendorClass' => model.vendor_class,
+      'hardwareModel' => model.hardware_model
+    }
+
+    assert_includes result['data']['models']['edges'].map { |e| e['node'] }, expected_model_attributes
+  end
+end

--- a/test/graphql/queries/puppetclass_query_test.rb
+++ b/test/graphql/queries/puppetclass_query_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Queries::PuppetclassQueryTest < ActiveSupport::TestCase
+  test 'fetching puppetclass attributes' do
+    puppetclass = FactoryBot.create(:puppetclass)
+
+    query = <<-GRAPHQL
+      query {
+        puppetclass(id: #{puppetclass.id}) {
+          id
+          name
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_puppetclass_attributes = {
+      'id' => puppetclass.id,
+      'name' => puppetclass.name
+    }
+
+    assert_equal expected_puppetclass_attributes, result['data']['puppetclass']
+  end
+end

--- a/test/graphql/queries/puppetclasses_query_test.rb
+++ b/test/graphql/queries/puppetclasses_query_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Queries::PuppetclassQueryTest < ActiveSupport::TestCase
+  test 'fetching puppetclass attributes' do
+    puppetclass = FactoryBot.create(:puppetclass)
+
+    query = <<-GRAPHQL
+      query {
+        puppetclasses {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_puppetclass_attributes = {
+      'id' => puppetclass.id,
+      'name' => puppetclass.name
+    }
+
+    assert_includes(
+      result['data']['puppetclasses']['edges'].map { |e| e['node'] },
+      expected_puppetclass_attributes
+    )
+  end
+end

--- a/test/graphql/queries/smart_proxies_query_test.rb
+++ b/test/graphql/queries/smart_proxies_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Queries::SmartProxiesQueryTest < ActiveSupport::TestCase
+  test 'fetching smartProxies attributes' do
+    smart_proxy = FactoryBot.create(:smart_proxy)
+
+    query = <<-GRAPHQL
+      query {
+        smartProxies {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              url
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_smart_proxy_attributes = {
+      'id' => smart_proxy.id,
+      'name' => smart_proxy.name,
+      'url' => smart_proxy.url
+    }
+
+    assert_includes(
+      result['data']['smartProxies']['edges'].map { |e| e['node'] },
+      expected_smart_proxy_attributes
+    )
+  end
+end

--- a/test/graphql/queries/smart_proxy_query_test.rb
+++ b/test/graphql/queries/smart_proxy_query_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Queries::SmartProxyQueryTest < ActiveSupport::TestCase
+  test 'fetching smartProxy attributes' do
+    smart_proxy = FactoryBot.create(:smart_proxy)
+
+    query = <<-GRAPHQL
+      query {
+        smartProxy(id: #{smart_proxy.id}) {
+          id
+          name
+          url
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_smart_proxy_attributes = {
+      'id' => smart_proxy.id,
+      'name' => smart_proxy.name,
+      'url' => smart_proxy.url
+    }
+
+    assert_equal expected_smart_proxy_attributes, result['data']['smartProxy']
+  end
+end

--- a/test/graphql/queries/subnet_query_test.rb
+++ b/test/graphql/queries/subnet_query_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Queries::SubnetQueryTest < ActiveSupport::TestCase
+  test 'fetching subnet attributes' do
+    subnet = FactoryBot.create(:subnet_ipv4)
+
+    query = <<-GRAPHQL
+      query {
+        subnet(id: #{subnet.id}) {
+          id
+          name
+          network
+          mask
+          priority
+          vlanid
+          gateway
+          dnsPrimary
+          dnsSecondary
+          from
+          to
+          ipam
+          bootMode
+          createdAt
+          updatedAt
+          networkAddress
+          networkType
+          cidr
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_subnet_attributes = {
+      'id' => subnet.id,
+      'name' => subnet.name,
+      'network' => subnet.network,
+      'mask' => subnet.mask,
+      'priority' => subnet.priority,
+      'vlanid' => subnet.vlanid,
+      'gateway' => subnet.gateway,
+      'dnsPrimary' => subnet.dns_primary,
+      'dnsSecondary' => subnet.dns_secondary,
+      'from' => subnet.from,
+      'to' => subnet.to,
+      'ipam' => subnet.ipam,
+      'bootMode' => subnet.boot_mode,
+      'createdAt' => subnet.created_at.utc.iso8601,
+      'updatedAt' => subnet.updated_at.utc.iso8601,
+      'networkAddress' => subnet.network_address,
+      'networkType' => subnet.network_type,
+      'cidr' => subnet.cidr.to_s
+    }
+
+    assert_equal expected_subnet_attributes, result['data']['subnet']
+  end
+end

--- a/test/graphql/queries/subnets_query_test.rb
+++ b/test/graphql/queries/subnets_query_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class Queries::SubnetsQueryTest < ActiveSupport::TestCase
+  test 'fetching subnets attributes' do
+    subnet = FactoryBot.create(:subnet_ipv4)
+
+    query = <<-GRAPHQL
+      query {
+        subnets {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              network
+              mask
+              priority
+              vlanid
+              gateway
+              dnsPrimary
+              dnsSecondary
+              from
+              to
+              ipam
+              bootMode
+              createdAt
+              updatedAt
+              networkAddress
+              networkType
+              cidr
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_subnet_attributes = {
+      'id' => subnet.id,
+      'name' => subnet.name,
+      'network' => subnet.network,
+      'mask' => subnet.mask,
+      'priority' => subnet.priority,
+      'vlanid' => subnet.vlanid,
+      'gateway' => subnet.gateway,
+      'dnsPrimary' => subnet.dns_primary,
+      'dnsSecondary' => subnet.dns_secondary,
+      'from' => subnet.from,
+      'to' => subnet.to,
+      'ipam' => subnet.ipam,
+      'bootMode' => subnet.boot_mode,
+      'createdAt' => subnet.created_at.utc.iso8601,
+      'updatedAt' => subnet.updated_at.utc.iso8601,
+      'networkAddress' => subnet.network_address,
+      'networkType' => subnet.network_type,
+      'cidr' => subnet.cidr.to_s
+    }
+
+    assert_includes result['data']['subnets']['edges'].map { |e| e['node'] }, expected_subnet_attributes
+  end
+end

--- a/test/models/jwt_secret_test.rb
+++ b/test/models/jwt_secret_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class JwtSecretTest < ActiveSupport::TestCase
+  test 'generate token before creation' do
+    user = FactoryBot.create(:user)
+    jwt_secret = user.build_jwt_secret
+    jwt_secret.save!
+    refute_nil jwt_secret.token
+  end
+end

--- a/test/models/jwt_token_test.rb
+++ b/test/models/jwt_token_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'ostruct'
+
+class JwtTokenTest < ActiveSupport::TestCase
+  test 'encoding' do
+    Time.zone = 'Europe/Berlin'
+    time = Time.local(2018, 1, 1, 12, 0, 0)
+    Time.stubs(:now).returns(time)
+
+    user = OpenStruct.new(id: 123)
+    jwt_token = JwtToken.encode(user, 'test_jwt_secret')
+
+    assert_equal token, jwt_token.to_s
+  end
+
+  test 'decoding' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
+    JwtSecret.stubs(:for_user).returns(jwt_secret)
+    jwt_token = JwtToken.new(token)
+
+    expected = {'user_id' => 123,
+                'iat' => 1_514_804_400,
+                'jti' => 'b4e196b3dd77f9e2116ba086a1a9b435'}
+
+    assert_equal expected, jwt_token.decode
+  end
+
+  test 'decoding invalid token' do
+    jwt_token = JwtToken.new('inVaLiD.inVaLiD.inVaLiD')
+
+    assert_nil jwt_token.decode
+  end
+
+  test 'decoding empty token' do
+    jwt_token = JwtToken.new('')
+
+    assert_nil jwt_token.decode
+  end
+
+  test 'decoding with invalid secret' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'invalid_jwt_secret')
+    JwtSecret.stubs(:for_user).returns(jwt_secret)
+    jwt_token = JwtToken.new(token)
+
+    assert_raises JWT::VerificationError do
+      jwt_token.decode
+    end
+  end
+
+  # Token created from encoding with 'test_jwt_secret' a following payload:
+  #
+  # { 'user_id' => 123, 'iat' => 1514804400, 'jti' => 'b4e196b3dd77f9e2116ba086a1a9b435' }
+  def token
+    'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjMsImlhdCI6MTUxNDgwNDQwMCwianRpIjoiYjRlMTk2YjNkZDc3ZjllMjExNmJhMDg2YTFhOWI0MzUifQ.GkZWjmsRP1v9KrcJGBaH2PJlSoPKALWtYMkJy6OaZhA'
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -937,6 +937,14 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'creating jwt secret for user' do
+    user = FactoryBot.create(:user)
+    jwt_secret = user.jwt_secret!
+
+    refute_nil jwt_secret
+    assert jwt_secret.persisted?
+  end
+
   context 'Jail' do
     test 'should allow methods' do
       allowed = [:login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,6 +131,30 @@ class ActionController::TestCase
   def disable_webpack
     Webpack::Rails::Manifest.stubs(:asset_paths).returns([])
   end
+
+  def json_response
+    ActiveSupport::JSON.decode(response.body)
+  end
+
+  def json_data(key)
+    data = json_response.fetch('data', {})
+    data.fetch(key, {})
+  end
+
+  def json_errors
+    json_response.fetch('errors', [])
+  end
+
+  def json_error_messages
+    json_errors.map { |e| e.fetch('message') }
+  end
+
+  def setup_jwt_authorized_user
+    user = FactoryBot.create(:user, :admin, :with_jwt_secret)
+    jwt_token = JwtToken.encode(user, user.jwt_secret.token)
+    request.headers['Authorization'] = jwt_token.to_s
+    user
+  end
 end
 
 def clear_plugins

--- a/test/unit/graphql/queries/fetch_field_test.rb
+++ b/test/unit/graphql/queries/fetch_field_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Queries::FetchFieldTest < ActiveSupport::TestCase
+  test 'finds single record' do
+    klass = 'SampleModelClass'
+    type = 'SampleModelTypeClass'
+    user = Object.new
+    expected_record = Object.new
+    ctx = { current_user: user }
+    record_id = 1234
+    model_query = stub('Queries::AuthorizedModelQuery')
+
+    Queries::AuthorizedModelQuery.expects(:new)
+                                 .with(model_class: klass, user: user)
+                                 .returns(model_query)
+    model_query.expects(:find_by).with(id: record_id).returns(expected_record)
+
+    result = Queries::FetchField.new(type: type, model_class: klass)
+                                .call(nil, { 'id' => record_id }, ctx)
+
+    assert_equal expected_record, result
+  end
+end

--- a/test/unit/graphql/queries/plural_field_test.rb
+++ b/test/unit/graphql/queries/plural_field_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class Queries::PluralFieldTest < ActiveSupport::TestCase
+  test 'fetch results' do
+    klass = 'SampleModelClass'
+    type = 'SampleModelTypeClass'
+    user = Object.new
+    expected_results = Object.new
+    args = {
+      'search' => 'search_argument',
+      'order' => 'desc',
+      'name' => 'sample_name'
+    }
+    expected_args = args.slice('search', 'order').symbolize_keys
+    ctx = { current_user: user }
+    model_query = stub('Queries::AuthorizedModelQuery')
+
+    Queries::AuthorizedModelQuery.expects(:new)
+                                 .with(model_class: klass, user: user)
+                                 .returns(model_query)
+    model_query.expects(:results).with(expected_args).returns(expected_results)
+
+    result = Queries::PluralField.new(type: type, model_class: klass)
+                                 .call(nil, args, ctx)
+
+    assert_equal expected_results, result
+  end
+end

--- a/test/unit/graphql/types/compute_attribute_type_test.rb
+++ b/test/unit/graphql/types/compute_attribute_type_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Types::ComputeAttributeTypeTest < ActiveSupport::TestCase
+  test 'vmAttrs resolve function' do
+    vm_attrs_hash = {
+      cpus: 4,
+      memory: 536_870_912,
+      volumes_attributes: {
+        '0' => { :vol => 1 },
+        '1' => { :vol => 2 }
+      }
+    }
+    compute_attribute = ComputeAttribute.new(vm_attrs: vm_attrs_hash)
+
+    vm_attrs_field = ForemanGraphqlSchema.types['ComputeAttribute'].fields['vmAttrs']
+
+    resolved_vm_attrs = vm_attrs_field.resolve(compute_attribute, nil, nil)
+
+    expected_vm_attrs = {
+      'cpus' => '4',
+      'memory' => '536870912',
+      'volumes_attributes' => vm_attrs_hash[:volumes_attributes]
+    }
+
+    assert_equal resolved_vm_attrs, expected_vm_attrs
+  end
+end


### PR DESCRIPTION
I'm working with @timogoebel on graphql API and finally we are able to show our progress. It's still WIP, but it's fully workable :)


**Instructions:**

To play with this, you need a graphql client.
Fortunately, this PR ships one in develop. Just browse to `http://localhost:3000/graphiql`.
On OSX, you can install an electron based client: `brew cask install graphiql`

The API is mounted at `http://localhost:3000/api/graphql`

To test this, you need a JWT token. Use below mutation to sign in and get token:

```
mutation {
  signInUser(login: {username: "admin", password: "test"}) {
    token
    user_id
  }
}
```

This token needs to be set as an `Authorization` header.
This is not possible with the integrated graphiql client, but you can specify the user via a query parameter: `http://localhost:3000/graphiql?user_id=1`. FYI: In mention electron based client you are able to set headers.

Then you can e.g. list subnet names:

```
query {
  subnets {
    edges {
      node {
        name
      }
    }
  }
}
```

or show the name of a specific subnet:

```
query {
  subnet(id: 1) {
    name
  }
}
```

There is implemented pagination(cursor based pagination - http://graphql-ruby.org/relay/connections.html). You can read more about eg in this article: https://dev-blog.apollodata.com/understanding-pagination-rest-graphql-and-relay-b10f835549e7

To test it you need to pass `first`/`last` and `after`/`before` parameters to given query.
Also there is need to pass additional `pageInfo` parameters to get some informations about pagination.

```
query {
  subnets(first: 10, after: #{cursor}) {
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPreviousPage
    }
    edges {
      node {
        id
      }
    }
  }
}
```


You can use it also like simple `page` `per_page` pagination. For example to get 6th page with 10 elements per page you need to pass:

```
query {
  subnets(first: 60, last: 10) {
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPreviousPage
    }
    edges {
      node {
        id
      }
    }
  }
}
```

We also added  `rack-cors`.
To allow CORS set `FOREMAN_GRAPHQL_CORS_DOMAINS` env variable.
To support multiple domains separate them with comma(`,`).

```
export FOREMAN_GRAPHQL_CORS_DOMAINS="http://localhost:3001,http://localhost:3002"
```

We can consider moving that configuration to `settings.yml`

