### PR TITLE
Fixes #22269 - Added ordering for OS template listing by name

### DIFF
--- a/app/views/operatingsystems/_template_defaults.html.erb
+++ b/app/views/operatingsystems/_template_defaults.html.erb
@@ -12,7 +12,7 @@
                           link_to("templates", provisioning_templates_path)).html_safe) %>
     <% end %>
 
-    <%= f.fields_for :os_default_templates do |builder| %>
+    <%= f.fields_for :os_default_templates, f.object.os_default_templates.sort_by{ |t| t.template_kind.to_s.downcase } do |builder| %>
       <%= render 'templates', :f => builder %>
     <% end %>
   <% end %>


### PR DESCRIPTION
This PR fixes inconsistent ordering of Operatingsystem templates listed on the templates tab. Templates would be listed alphabetically (downcase).