### PR TITLE
Fixes #22954 - only deserialize safe objects when parsing metadata

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -101,7 +101,7 @@ class Template < ApplicationRecord
   # Pull out the first erb comment only - /m is for a multiline regex
   def self.parse_metadata(text)
     extracted = text.match(/<%\#[\t a-z0-9=:]*(.+?).-?%>/m)
-    extracted.nil? ? {} : YAML.load(extracted[1]).with_indifferent_access
+    extracted.nil? ? {} : YAML.safe_load(extracted[1]).with_indifferent_access
   rescue RuntimeError => e
     Foreman::Logging.exception('invalid metadata', e)
     {}


### PR DESCRIPTION
see https://ruby-doc.org/stdlib-2.1.3/libdoc/psych/rdoc/Psych.html#method-c-safe_load for list of safe objects

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
