### PR TITLE
Fixes #22158 - Add rake task to delete old audits

### DIFF
--- a/lib/tasks/audits.rake
+++ b/lib/tasks/audits.rake
@@ -1,0 +1,24 @@
+# TRANSLATORS: do not translate
+desc <<-END_DESC
+Expire old audits automatically
+
+Available conditions:
+  * days        => number of days to keep audits (defaults to 90)
+
+  Example:
+    rake audits:expire # expires all audits older then 90 days
+    rake audits:expire days=7 # expires all audits older then 7 days
+
+END_DESC
+
+namespace :audits do
+  task :expire => :environment do
+    before = ENV['days'].to_i.days.ago if ENV['days']
+    before ||= 90.days.ago
+    audits = Audited::Audit.up_until(before)
+    puts "Deleting audits older than #{before}. This might take a few minutes..."
+    TaxableTaxonomy.where(taxable_type: "Audited::Audit", taxable: audits).delete_all
+    count = audits.delete_all
+    puts "Successfully deleted #{count} audits!"
+  end
+end


### PR DESCRIPTION
Set the default period to 90 days or older.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
