### PR TITLE
fixes #22983 - add HostgroupClass in permissions list

### DIFF
--- a/db/seeds.d/020-permissions_list.rb
+++ b/db/seeds.d/020-permissions_list.rb
@@ -61,6 +61,7 @@ class PermissionsList
         ['Hostgroup', 'create_hostgroups'],
         ['Hostgroup', 'edit_hostgroups'],
         ['Hostgroup', 'destroy_hostgroups'],
+        ['HostgroupClass', 'create_hostgroup_classes'],
         ['Host', 'view_hosts'],
         ['Host', 'create_hosts'],
         ['Host', 'edit_hosts'],


### PR DESCRIPTION
Add missing permissions ['HostgroupClass', 'create_hostgroup_classes']
required for adding classes to hostgroups.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
