### PR TITLE
Fixes #22984 - Migrate templates auditable_type

### DIFF
--- a/db/migrate/20180322102951_fix_provision_templates_auditable_type.rb
+++ b/db/migrate/20180322102951_fix_provision_templates_auditable_type.rb
@@ -1,0 +1,10 @@
+class FixProvisionTemplatesAuditableType < ActiveRecord::Migration[5.1]
+  def up
+    Audit.unscoped.where(:auditable_type => 'Template', :auditable_id => ProvisioningTemplate.pluck(:id)).update_all(:auditable_type => 'ProvisioningTemplate')
+    Audit.unscoped.where(:auditable_type => 'Template', :auditable_id => Ptable.pluck(:id)).update_all(:auditable_type => 'Ptable')
+  end
+
+  def down
+    Audit.unscoped.where(:auditable_type => ['Ptable', 'ProvisioningTemplate']).update_all(:auditable_type => 'Template')
+  end
+end


### PR DESCRIPTION
https://github.com/theforeman/foreman/pull/4778 Changed `Ptable` & `ProvisioningTemplate` `auditable_type` this commit adds the missing migration.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
