### PR TITLE
Fixes #22997 - increase fact_name name length

### DIFF
--- a/db/migrate/20180322155732_increase_fact_name_length.rb
+++ b/db/migrate/20180322155732_increase_fact_name_length.rb
@@ -1,0 +1,17 @@
+class IncreaseFactNameLength < ActiveRecord::Migration[5.0]
+  def up
+    change_table :fact_names do |t|
+      t.change :name, :string, :limit => 4096
+      t.change :ancestry, :string, :limit => 4096
+      t.change :short_name, :string, :limit => 4096
+    end
+  end
+
+  def down
+    change_table :fact_names do |t|
+      t.change :name, :string, :limit => 255
+      t.change :ancestry, :string, :limit => 255
+      t.change :short_name, :string, :limit => 255
+    end
+  end
+end


### PR DESCRIPTION
Increases field length for fact_name name to accommodate,
for example, container mount point paths since they can be
greater than the default ActiveRecord string field length.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
