### PR TITLE
Fixes #22049 - Add metadata to Audit view

### DIFF
--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -26,6 +26,31 @@
     </div>
     <% end %>
     <div class='tab-pane <%= "active" unless tmplt%>' id="tab1">
+      <div class="row">
+        <h3 class="col-md-12"><%= _("Audit Metadata:") %></h3>
+      </div>
+      <div class="row">
+        <strong class="col-md-2"><%= _("Audit Time:")%></strong>
+        <div class="col-md-10"><%= date_time_absolute(@audit.created_at) %></div>
+      </div>
+      <div class="row">
+        <strong class="col-md-2"><%= _("User Name:")%></strong>
+        <div class="col-md-10"><%= @audit.username %></div>
+      </div>
+      <% if Taxonomy.organizations_enabled %>
+        <div class="row">
+          <strong class="col-md-2"><%= _("Affected Organizations:")%></strong>
+          <div class="col-md-10"><%= @audit.organizations.authorized(:view_organizations).to_sentence %></div>
+        </div>
+      <% end %>
+      <% if Taxonomy.locations_enabled %>
+        <div class="row">
+          <strong class="col-md-2"><%= _("Affected Locations:")%></strong>
+          <div class="col-md-10"><%= @audit.locations.authorized(:view_locations).to_sentence %></div>
+        </div>
+      <% end %>
+      <hr/>
+      <h3><%= _("Changes:") %></h3>
       <table class="<%= table_css_classes %>">
         <% if @audit.audited_changes.key?("template") && @audit.audited_changes.size == 1 %>
           <%= alert :class => 'alert-info', :header => _('There are no changes'), :text => _(' in the provisioning template.') %>


### PR DESCRIPTION
This could use some love on the UI side I think, but at least a first step. @rohoover would love your feedback as to how to make this prettier :smile: 

![image](https://user-images.githubusercontent.com/1540531/37894366-af56f13e-30e6-11e8-9531-8d0cb822de1e.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
