### PR TITLE
fixes #23026 - make changes to compute resource passwords audited

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -1,5 +1,5 @@
 class ComputeResource < ApplicationRecord
-  audited :except => [:password, :attrs]
+  audited :except => [:attrs]
   include Taxonomix
   include Encryptable
   include Authorizable


### PR DESCRIPTION
Removing the :password field from the audit exceptions.
The passwords come out [redacted] in the audit logs, so this is safe.

![audit_image](http://storage7.static.itmages.com/i/18/0327/h_1522152789_2060188_baa3001742.png
)
