### PR TITLE
Fixes #23028 - Properly escape params passed to where.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -56,7 +56,7 @@ class DashboardController < ApplicationController
     errors = []
     filter = self.class.widget_params_filter
     params.fetch(:widgets, []).each do |id, values|
-      widget = User.current.widgets.where("id = #{id}").first
+      widget = User.current.widgets.where(:id => id).first
       values = filter.filter_params(values, parameter_filter_context, :none)
       errors << widget.errors unless widget.update_attributes(values)
     end


### PR DESCRIPTION
Properly escape params passed to where.