### PR TITLE
Do not use string interpolation when composing SQL queries.

### DIFF
--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -74,7 +74,7 @@ module NestedAncestryCommon
   end
 
   def nested(attr)
-    self.class.sort_by_ancestry(ancestors.where("#{attr} is not NULL")).last.try(attr) if ancestry.present?
+    self.class.sort_by_ancestry(ancestors.where.not(attr => nil)).last.try(attr) if ancestry.present?
   end
 
   private

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -139,7 +139,7 @@ module Taxonomix
         # We need to generate the WHERE part of the SQL query as a string,
         # otherwise the default scope would set id on each new instance
         # and the same taxable_id on taxable_taxonomy objects
-        scope.where("#{self.table_name}.id IN (#{cached_ids.join(',')})")
+        scope.where("#{self.table_name}.id" => cached_ids)
       end
     end
   end

--- a/app/models/environment_class.rb
+++ b/app/models/environment_class.rb
@@ -18,7 +18,7 @@ class EnvironmentClass < ApplicationRecord
 
   scope :used_by_other_environment_classes, lambda{|puppetclass_lookup_key_id, this_environment_class_id|
     where(:puppetclass_lookup_key_id => puppetclass_lookup_key_id).
-      where("id != #{this_environment_class_id}")
+      where.not(:id => this_environment_class_id)
   }
 
   #TODO move these into scopes?

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -81,7 +81,7 @@ class Host::Managed < Host::Base
   scope :out_of_sync, ->(*args) { where(["#{Host.table_name}.last_report < ? and hosts.enabled != ?", (args.first || (Setting[:puppet_interval] + Setting[:outofsync_interval]).minutes.ago), false]) }
 
   scope :with_status, lambda { |status_type|
-    eager_load(:host_statuses).where("host_status.type = '#{status_type}'")
+    eager_load(:host_statuses).where('host_status.type' => status_type)
   }
 
   scope :with_config_status, lambda {

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -70,8 +70,8 @@ class Report < ApplicationRecord
   def self.expire(conditions = {})
     timerange = conditions[:timerange] || 1.week
     status = conditions[:status]
-    cond = "reports.created_at < \'#{(Time.now.utc - timerange).to_formatted_s(:db)}\'"
-    cond += " and reports.status = #{status}" unless status.nil?
+    cond = [["reports.created_at < '?'", Time.now.utc - timerange]]
+    cond << ["reports.status = ?", status] if status.present?
 
     Log.where(:report_id => where(cond)).reorder('').delete_all
     Message.where("id not IN (#{Log.unscoped.select('DISTINCT message_id').to_sql})").delete_all


### PR DESCRIPTION
Do not use string interpolation when composing SQL queries.

Fix some places that seem simple enough.

Work in progress.

Issues: https://projects.theforeman.org/issues/23300
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
