### PR TITLE
Fixes #22546 - Return power action status for ovirt

### DIFF
--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -30,7 +30,12 @@ module PowerManager
     end
 
     def default_action(action)
-      vm.send(action)
+      action_status = vm.send(action)
+      # Temporary fix until fog-ovirt is updated
+      if action_status.is_a?(Fog::Compute::Ovirt::Server)
+        return true
+      end
+      action_status
     end
 
     def action_map


### PR DESCRIPTION
The right way is fixing this in `fog-ovirt` but until: https://github.com/fog/fog-ovirt/pull/11 is merged and a new gem version released I added a temporary fix.

I can close this and open PRs for 1.17 and 1.16 instead since we will likely have a fixed `fog-ovirt` version for 1.18, or merge this and cherry-pick to both and I'll revert develop when introducing the new gem version. Leaving the decision up to reviewers.
There are also at least 2 other workarounds I can think of instead of this but this was probably the easiest to later revert and the bug is ovirt specific so it makes sense not to change the general behavior. 