### PR TITLE
Fixes #19980 - Merge hashes or arrays with ERB

### DIFF
--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -70,7 +70,7 @@ class LookupValue < ApplicationRecord
   end
 
   def validate_and_cast_value
-    return if !self.value.is_a?(String) || value.contains_erb?
+    return if !self.value.is_a?(String) || value.contains_erb? == 0 || (value.contains_erb? && !lookup_key.merge_overrides)
     Foreman::Parameters::Caster.new(self, :attribute_name => :value, :to => lookup_key.key_type).cast!
   rescue StandardError, SyntaxError => e
     Foreman::Logging.exception("Error while parsing #{lookup_key}", e)

--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -153,6 +153,36 @@ class LookupValueTest < ActiveSupport::TestCase
     assert_equal lv.value, "<%= [4,5,6] %>"
   end
 
+  test "should cast and uncast hashes with not only erb" do
+    key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'hash', :merge_overrides => true, :avoid_duplicates => false,
+                            :default_value => "{}", :puppetclass => puppetclasses(:one))
+    lk1 = LookupValue.new(:value => "---\n foo: <%= bar %>", :match => "hostgroup=Common", :lookup_key => key)
+    assert lk1.save!
+    assert lk1.value.is_a? Hash
+    assert_equal lk1.value, {"foo" => "<%= bar %>"}
+  end
+
+  test "should cast and uncast hashes with not only erb even when erb is in first place" do
+    key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'hash', :merge_overrides => true, :avoid_duplicates => false,
+                            :default_value => "{}", :puppetclass => puppetclasses(:one))
+    lk1 = LookupValue.new(:value => "---\n <%= foo %>: <%= bar %>", :match => "hostgroup=Common", :lookup_key => key)
+    assert lk1.save!
+    assert lk1.value.is_a? Hash
+    assert_equal lk1.value, {"<%= foo %>" => "<%= bar %>"}
+  end
+
+  test "should cast and uncast arrays with not only erb" do
+    key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'array', :merge_overrides => true, :avoid_duplicates => false,
+                            :default_value => "[]", :puppetclass => puppetclasses(:one))
+    lk1 = LookupValue.new(:value => "[\"foo\", \"<%= bar %>\"]", :match => "hostgroup=Common", :lookup_key => key)
+    assert lk1.save!
+    assert lk1.value.is_a? Array
+    assert_equal lk1.value, ["foo", "<%= bar %>"]
+  end
+
   test "boolean lookup value should allow for false value" do
     # boolean key
     key = lookup_keys(:three)


### PR DESCRIPTION
Cast the value to the right type if it does not exclusively contains ERB and merge is enabled.
This way it is possible to merge hashes or arrays with ERB in it which resulted in an error before.

