### PR TITLE
Fixes #23059 - journald plugin is not required

### DIFF
--- a/bundler.d/journald.rb
+++ b/bundler.d/journald.rb
@@ -1,4 +1,4 @@
 # disable to avoid journald native gem in development setup
 group :journald do
-  gem 'logging-journald', '~> 1.0'
+  gem 'logging-journald', '~> 1.0', :require => false
 end


### PR DESCRIPTION
This is a non-required gem, it's a plugin. It works with bundler but
with bundler_ext it fails and Rails won't boot.