### PR TITLE
Refs #22049 - improve metadata usability

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -106,6 +106,26 @@ module AuditsHelper
     date_time_absolute(audit.created_at)
   end
 
+  def audit_affected_locations(audit)
+    base = audit.locations.authorized(:view_locations)
+    return _('N/A') if base.empty?
+
+    authorizer = Authorizer.new(User.current, base)
+    base.map do |location|
+      link_to_if_authorized location.name, hash_for_edit_location_path(location).merge(:auth_object => location, :permission => 'edit_locations', :authorizer => authorizer)
+    end.to_sentence.html_safe
+  end
+
+  def audit_affected_organizations(audit)
+    base = audit.organizations.authorized(:view_organizations)
+    return _('N/A') if base.empty?
+
+    authorizer = Authorizer.new(User.current, base)
+    base.map do |organization|
+      link_to_if_authorized organization.name, hash_for_edit_organization_path(organization).merge(:auth_object => organization, :permission => 'edit_organizations', :authorizer => authorizer)
+    end.to_sentence.html_safe
+  end
+
   def audited_icon(audit)
     style = 'label-info'
     style = case audit.action

--- a/app/views/api/v2/audits/show.json.rabl
+++ b/app/views/api/v2/audits/show.json.rabl
@@ -1,3 +1,7 @@
 object @audit
 
 extends "api/v2/audits/main"
+
+node do |audit|
+  partial("api/v2/taxonomies/children_nodes", :object => audit)
+end

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -30,22 +30,22 @@
       </div>
       <div class="row">
         <strong class="col-md-2"><%= _("Audit Time:")%></strong>
-        <div class="col-md-10"><%= date_time_absolute(@audit.created_at) %></div>
+        <div class="col-md-10"><%= audit_time(@audit) %></div>
       </div>
       <div class="row">
         <strong class="col-md-2"><%= _("User Name:")%></strong>
-        <div class="col-md-10"><%= @audit.username %></div>
+        <div class="col-md-10"><%= audit_user(@audit) %></div>
       </div>
       <% if Taxonomy.organizations_enabled %>
         <div class="row">
           <strong class="col-md-2"><%= _("Affected Organizations:")%></strong>
-          <div class="col-md-10"><%= @audit.organizations.authorized(:view_organizations).to_sentence %></div>
+          <div class="col-md-10"><%= audit_affected_organizations(@audit) %></div>
         </div>
       <% end %>
       <% if Taxonomy.locations_enabled %>
         <div class="row">
           <strong class="col-md-2"><%= _("Affected Locations:")%></strong>
-          <div class="col-md-10"><%= @audit.locations.authorized(:view_locations).to_sentence %></div>
+          <div class="col-md-10"><%= audit_affected_locations(@audit) %></div>
         </div>
       <% end %>
       <hr/>


### PR DESCRIPTION
This is a follow up of https://github.com/theforeman/foreman/pull/5359

before
![screenshot_20180329_152522](https://user-images.githubusercontent.com/109773/38091297-6b6aeefe-3365-11e8-9fcb-e7af69da7d39.png)

after
![screenshot_20180329_152049](https://user-images.githubusercontent.com/109773/38091250-44de7c2e-3365-11e8-93b2-e9a4af082ad9.png)
![screenshot_20180329_152040](https://user-images.githubusercontent.com/109773/38091251-44fc9790-3365-11e8-848e-411119fb034e.png)

@tbrisker and @rohoover, your comments would be appreciated, I'd like to get this into 1.18

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
