### PR TITLE
Fixes #23039 - Remove deleted LDAP users

### DIFF
--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -1,15 +1,30 @@
-desc <<-END_DESC
-Refreshes LDAP usergroups. It adds to an LDAP usergroup all the foreman users that belong to it, and removes foreman users
-in that usergroup that do not belong in LDAP anymore.
-END_DESC
-
 namespace :ldap do
   task :refresh_usergroups => :environment do
+    desc <<-END_DESC
+    Refreshes LDAP usergroups. It adds to an LDAP usergroup all the foreman users that belong to it, and removes foreman users
+    in that usergroup that do not belong in LDAP anymore.
+    END_DESC
     ExternalUsergroup.all.each do |eu|
       begin
         eu.refresh
       rescue => error
         puts "User group #{eu} could not be refreshed - LDAP source #{eu.auth_source} not available: #{error}"
+      end
+    end
+  end
+
+  task :remove_deleted_users => :environment do
+    desc <<-END_DESC
+    Deletes all foreman users that authenticate via LDAP, but whose LDAP users do not exist anymore.
+    Also deletes them as the owner of their hosts.
+    END_DESC
+    User.as_anonymous_admin do
+      User.joins(:auth_source).where(:'auth_sources.type' => 'AuthSourceLdap').each do |user|
+        unless user.auth_source.valid_user?(user.login)
+          Host.where(:owner => user).update_all(:owner_type => nil, :owner_id => nil)
+          user.destroy!
+          puts "Deleted user #{user.login}"
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a rake task ldap:remove_deleted_users which checks all users
that authenticate via LDAP whether their users are valid and
deletes invalid ones.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
