### PR TITLE
Fixes #23115 - session is used instead session_safe

### DIFF
--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -108,7 +108,7 @@ module ProxyAPI
     end
 
     def request_id
-      ::Logging.mdc['session_safe'] || SecureRandom.hex(32)
+      ::Logging.mdc['session'] || SecureRandom.hex(32)
     end
 
     def ssl_auth_params

--- a/test/unit/proxy_api/resource_test.rb
+++ b/test/unit/proxy_api/resource_test.rb
@@ -11,10 +11,10 @@ class ProxyApiResourceTest < ActiveSupport::TestCase
 
   test "connect_params sets x_request_id to logger safe session ID" do
     begin
-      ::Logging.mdc['session_safe'] = 'test'
+      ::Logging.mdc['session'] = 'test'
       assert_equal 'test', ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id]
     ensure
-      ::Logging.mdc.delete('session_safe')
+      ::Logging.mdc.delete('session')
     end
   end
 


### PR DESCRIPTION
We removed "session_safe" flag, it's now called "session" and it is safe
by default. This passes it into proxy correctly instead generating it's
own id.