### PR TITLE
Fixes #23113 - Allow disabling of out of sync status

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -14,7 +14,7 @@ module HostStatus
     end
 
     def out_of_sync?
-      if (host && !host.enabled?) || no_reports?
+      if (host && !host.enabled?) || no_reports? || out_of_sync_disabled?
         false
       else
         !reported_at.nil? && reported_at < (Time.now.utc - expected_report_interval)
@@ -127,6 +127,14 @@ module HostStatus
 
     def default_report_interval
       Setting[:outofsync_interval]
+    end
+
+    def out_of_sync_disabled?
+      if last_report.origin
+        Setting[:"#{last_report.origin.downcase}_out_of_sync_disabled"]
+      else
+        false
+      end
     end
   end
 end

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -2,6 +2,7 @@ class Setting::Puppet < Setting
   def self.default_settings
     [
       self.set('puppet_interval', N_("Puppet interval in minutes"), 30, N_('Puppet interval')),
+      self.set('puppet_out_of_sync_disabled', N_("Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval") % 'Puppet', false, N_('%s out of sync disabled') % 'Puppet'),
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map{|env| [env[:name], env[:name]]}]} }),
       self.set('modulepath',N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
       self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),

--- a/app/views/dashboard/_status_links.html.erb
+++ b/app/views/dashboard/_status_links.html.erb
@@ -1,30 +1,31 @@
 <%
   origin = @data.settings[:origin] || nil
   origin = nil if origin == 'All'
-  interval_setting = report_origin_interval_setting(origin)
 %>
 
 <%= searchable_links _('Hosts that had performed modifications without error'),
                      search_filter_with_origin(
-                       "last_report > \"#{interval_setting} minutes ago\" and (status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
+                       "(status.applied > 0 or status.restarted > 0) and (status.failed = 0)",
                        origin
                      ),
                      :active_hosts_ok_enabled
 %>
 <%= searchable_links _('Hosts in error state'),
                      search_filter_with_origin(
-                       "last_report > \"#{interval_setting} minutes ago\" and (status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
+                       "(status.failed > 0 or status.failed_restarts > 0) and status.enabled = true",
                        origin
                      ),
                      :bad_hosts_enabled
 %>
-<%= searchable_links _("Good host reports in the last %s") % time_ago_in_words((interval_setting.to_i || 0).minutes.ago),
+
+<%= searchable_links (out_of_sync_enabled?(origin) ? _("Good host reports in the last %s") % time_ago_in_words((report_origin_interval_setting(origin).to_i || 0).minutes.ago) : _("Good host with reports")),
                      search_filter_with_origin(
-                       "last_report > \"#{interval_setting} minutes ago\" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
+                       "status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0",
                        origin
                      ),
                     :ok_hosts_enabled
 %>
+
 <%= searchable_links _('Hosts that had pending changes'),
                      search_filter_with_origin(
                        "status.pending > 0 and status.enabled = true",
@@ -32,13 +33,18 @@
                      ),
                      :pending_hosts_enabled
 %>
-<%= searchable_links _('Out of sync hosts'),
-                     search_filter_with_origin(
-                       "last_report < \"#{interval_setting} minutes ago\" and status.enabled = true",
-                       origin
-                     ),
-                     :out_of_sync_hosts_enabled
-%>
+
+<% if out_of_sync_enabled?(origin) %>
+  <%= searchable_links _('Out of sync hosts'),
+                       search_filter_with_origin(
+                         "status.enabled = true",
+                         origin,
+                         true
+                       ),
+                       :out_of_sync_hosts_enabled
+  %>
+<% end %>
+
 <%= searchable_links _('Hosts with no reports'),
                      search_filter_with_origin(
                        "not has last_report and status.enabled = true",

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -70,6 +70,42 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
     Setting[:outofsync_interval] = original
   end
 
+  describe '#out_of_sync?' do
+    let(:host) { FactoryBot.create(:host, :with_reports) }
+    let(:status) do
+      HostStatus::ConfigurationStatus.new(:host => host)
+    end
+
+    test '#out_of_sync? is false when out of sync is disabled' do
+      status.stubs(:out_of_sync_disabled?).returns(true)
+      refute @status.out_of_sync?
+    end
+
+    context 'with last report origin' do
+      setup do
+        status.last_report.stubs(:origin).returns('TestOrigin')
+      end
+
+      test 'is false when origins out of sync is disabled' do
+        stub_outofsync_setting(true)
+        refute status.out_of_sync?
+      end
+
+      test "is true when origins out of sync isn't disbled and it is ouf of sync" do
+        stub_outofsync_setting(false)
+        status.reported_at = '2015-01-01 00:00:00'
+        status.save
+        assert status.out_of_sync?
+      end
+
+      def stub_outofsync_setting(value)
+        Setting.create(name: :testorigin_out_of_sync_disabled,
+                       description: 'description', default: false)
+        Setting[:testorigin_out_of_sync_disabled] = value
+      end
+    end
+  end
+
   test '#refresh! refreshes the date and persists the record' do
     @status.expects(:refresh)
     @status.refresh!


### PR DESCRIPTION
This allows plugins that make use of an origin to add a setting to disable out of sync status for their origin. This is useful for environments that do not regulraly run configurations, as it is with most Ansible environments.
The changes are to widgets and the out of sync status of a host itself.

Here is a screenshot of the Ansible dashboard Widgets out of sync still enabled:

![screenshot_2018-04-04_12-27-26](https://user-images.githubusercontent.com/7757/38302965-db3234c4-3804-11e8-9953-42eb3807c106.png)

With the `ansible_out_of_sync_disabled` enabled out of sync hosts become ok hosts:

![screenshot_2018-04-04_12-35-10](https://user-images.githubusercontent.com/7757/38303010-01dfaaca-3805-11e8-8a01-b2e0c00de65a.png)

Settings for Puppet are implemented as well and the PR introducing the Ansible setting can be found here: https://github.com/theforeman/foreman_ansible/pull/158