### PR TITLE
Fixes #21829: Add association_exists_validator

### DIFF
--- a/app/validators/association_exists_validator.rb
+++ b/app/validators/association_exists_validator.rb
@@ -1,0 +1,7 @@
+class AssociationExistsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if record.send("#{attribute}_id".to_sym).present? && value.nil?
+      record.errors[attribute] << (options[:message] || _("with given ID not found"))
+    end
+  end
+end


### PR DESCRIPTION
This validator ensures that an associated model (fk relation) actually
exists with the ID specified on this model. i.e. Hostgroup.realm_id

This PR is required for Katello to require a ContentFacet on a Host.