### PR TITLE
fixes #21520 - vsphere: valid vm cloning request

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 1.13.0'
+  gem 'fog-vsphere', '>= 2.1.0'
 end


### PR DESCRIPTION
This PR fixes cloning with VMWare. `fog-vsphere` contained a bug that broke cloning of VMWare VMs completely.

Affected fog-vsphere-Versions:

1.13.0
1.13.1 (currently in Foreman 1.17)
2.0.0
2.0.1

Unaffected:
2.1.0

@mmoll: Do Debian packages use other versions? Bug reports indicate, this also affects Foreman 1.15 and 1.16 on Debian.

cc: @chris1984, @xprazak2