### PR TITLE
Fixes #23147 - Allow plugins to compile production webpack assets

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -11,156 +11,180 @@ var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var pluginUtils = require('../script/plugin_webpack_directories');
 var vendorEntry = require('./webpack.vendor');
 
-// must match config.webpack.dev_server.port
-var devServerPort = 3808;
 
-// set TARGETNODE_ENV=production on the environment to add asset fingerprints
-var production =
-  process.env.RAILS_ENV === 'production' ||
-  process.env.NODE_ENV === 'production';
 
-var bundleEntry = path.join(__dirname, '..', 'webpack/assets/javascripts/bundle.js');
+module.exports = env => {
+  // must match config.webpack.dev_server.port
+  var devServerPort = 3808;
 
-var plugins = pluginUtils.getPluginDirs('pipe');
+  // set TARGETNODE_ENV=production on the environment to add asset fingerprints
+  var production =
+    process.env.RAILS_ENV === 'production' ||
+    process.env.NODE_ENV === 'production';
 
-var resolveModules = [  path.join(__dirname, '..', 'webpack'),
-                        path.join(__dirname, '..', 'node_modules'),
-                        'node_modules/',
-                     ].concat(pluginUtils.pluginNodeModules(plugins));
+  var bundleEntry = path.join(__dirname, '..', 'webpack/assets/javascripts/bundle.js');
 
-var config = {
-  entry: Object.assign(
-    {
-      bundle: bundleEntry,
-      vendor: vendorEntry,
-    },
-    plugins.entries
-  ),
-  output: {
-    // Build assets directly in to public/webpack/, let webpack know
-    // that all webpacked assets start with webpack/
+  var plugins = pluginUtils.getPluginDirs('pipe');
 
-    // must match config.webpack.output_dir
-    path: path.join(__dirname, '..', 'public', 'webpack'),
-    publicPath: '/webpack/',
+  var resolveModules = [  path.join(__dirname, '..', 'webpack'),
+                          path.join(__dirname, '..', 'node_modules'),
+                          'node_modules/',
+                       ].concat(pluginUtils.pluginNodeModules(plugins));
 
-    filename: production ? '[name]-[chunkhash].js' : '[name].js'
-  },
-
-  resolve: {
-    modules: resolveModules,
-    alias: Object.assign({
-      foremanReact:
-        path.join(__dirname,
-           '../webpack/assets/javascripts/react_app'),
+  if (env && env.pluginName !== undefined) {
+    var pluginEntries = {};
+    pluginEntries[env.pluginName] = plugins['entries'][env.pluginName];
+    var entry = pluginEntries;
+    var outputPath = path.join(plugins['plugins'][env.pluginName]['root'], 'public', 'webpack');
+    var jsFilename = production ? env.pluginName + '/[name]-[chunkhash].js' : env.pluginName + '/[name].js';
+    var cssFilename = production ? env.pluginName + '/[name]-[chunkhash].css' : env.pluginName + '/[name].css';
+    var manifestFilename = env.pluginName + '/manifest.json';
+  } else {
+    var pluginEntries = plugins['entries'];
+    var entry = Object.assign(
+      {
+        bundle: bundleEntry,
+        vendor: vendorEntry,
       },
-      pluginUtils.aliasPlugins(plugins['entries'])
+      pluginEntries
     )
-  },
+    var outputPath = path.join(__dirname, '..', 'public', 'webpack');
+    var jsFilename = production ? '[name]-[chunkhash].js' : '[name].js';
+    var cssFilename = production ? '[name]-[chunkhash].css' : '[name].css';
+    var manifestFilename = 'manifest.json';
+  }
 
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loader: 'babel-loader',
-        options: {
-          'presets': [
-            path.join(__dirname, '..', 'node_modules/babel-preset-react'),
-            path.join(__dirname, '..', 'node_modules/babel-preset-env')
-          ],
-          'plugins': [
-            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-class-properties'),
-            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),
-            path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-assign'),
-            path.join(__dirname, '..', 'node_modules/babel-plugin-lodash')
-          ]
+  var config = {
+    entry: entry,
+    output: {
+      // Build assets directly in to public/webpack/, let webpack know
+      // that all webpacked assets start with webpack/
+
+      // must match config.webpack.output_dir
+      path: outputPath,
+      publicPath: '/webpack/',
+      filename: jsFilename
+    },
+
+    resolve: {
+      modules: resolveModules,
+      alias: Object.assign({
+        foremanReact:
+          path.join(__dirname,
+             '../webpack/assets/javascripts/react_app'),
+        },
+        pluginUtils.aliasPlugins(pluginEntries)
+      )
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader',
+          options: {
+            'presets': [
+              path.join(__dirname, '..', 'node_modules/babel-preset-react'),
+              path.join(__dirname, '..', 'node_modules/babel-preset-env')
+            ],
+            'plugins': [
+              path.join(__dirname, '..', 'node_modules/babel-plugin-transform-class-properties'),
+              path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-rest-spread'),
+              path.join(__dirname, '..', 'node_modules/babel-plugin-transform-object-assign'),
+              path.join(__dirname, '..', 'node_modules/babel-plugin-lodash')
+            ]
+          }
+        },
+        {
+          test: /\.css$/,
+          use: ExtractTextPlugin.extract({
+            fallback: 'style-loader',
+            use: 'css-loader'
+          })
+        },
+        {
+          test: /(\.png|\.gif)$/,
+          use: 'url-loader?limit=32767'
+        },
+        {
+          test: /\.scss$/,
+          use: ExtractTextPlugin.extract({
+            fallback: 'style-loader', // The backup style loader
+            use: production ? 'css-loader!sass-loader' : 'css-loader?sourceMap!sass-loader?sourceMap'
+          })
         }
-      },
-      {
-        test: /\.css$/,
-        use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: 'css-loader'
-        })
-      },
-      {
-        test: /(\.png|\.gif)$/,
-        use: 'url-loader?limit=32767'
-      },
-      {
-        test: /\.scss$/,
-        use: ExtractTextPlugin.extract({
-          fallback: 'style-loader', // The backup style loader
-          use: production ? 'css-loader!sass-loader' : 'css-loader?sourceMap!sass-loader?sourceMap'
-        })
-      }
+      ]
+    },
+
+    plugins: [
+      new LodashModuleReplacementPlugin({
+        paths: true,
+        collections: true,
+        flattening: true,
+      }),
+      // must match config.webpack.manifest_filename
+      new StatsWriterPlugin({
+        filename: manifestFilename,
+        fields: null,
+        transform: function (data, opts) {
+          return JSON.stringify(
+            {
+              assetsByChunkName: data.assetsByChunkName,
+              errors: data.errors,
+              warnings: data.warnings
+            }, null, 2 );
+        }
+      }),
+      new ExtractTextPlugin({
+        filename: cssFilename,
+        allChunks: true
+      }),
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(production ? 'production' : 'development'),
+          NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING
+        }
+      }),
     ]
-  },
-
-  plugins: [
-    new LodashModuleReplacementPlugin({
-      paths: true,
-      collections: true,
-      flattening: true,
-    }),
-    // must match config.webpack.manifest_filename
-    new StatsWriterPlugin({
-      filename: 'manifest.json',
-      fields: null,
-      transform: function (data, opts) {
-        return JSON.stringify(
-          {
-            assetsByChunkName: data.assetsByChunkName,
-            errors: data.errors,
-            warnings: data.warnings
-          }, null, 2 );
-      }
-    }),
-    new ExtractTextPlugin({
-      filename: production ? '[name]-[chunkhash].css' : '[name].css',
-      allChunks: true
-    }),
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(production ? 'production' : 'development'),
-        NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING
-      }
-    }),
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      minChunks: Infinity,
-    })
-  ]
-};
-
-if (production) {
-  config.plugins.push(
-    new webpack.NoEmitOnErrorsPlugin(),
-    new UglifyJsPlugin({
-      uglifyOptions: {
-        compress: { warnings: false },
-      },
-      sourceMap: false
-    }),
-    new webpack.optimize.ModuleConcatenationPlugin(),
-    new webpack.optimize.OccurrenceOrderPlugin(),
-    new CompressionPlugin()
-  );
-} else {
-  config.plugins.push(
-    new webpack.HotModuleReplacementPlugin() // Enable HMR
-  );
-  require('dotenv').config();
-
-  config.devServer = {
-    host: process.env.BIND || 'localhost',
-    port: devServerPort,
-    headers: { 'Access-Control-Allow-Origin': '*' },
-    hot: true
   };
-  // Source maps
-  config.devtool = 'inline-source-map';
-}
 
-module.exports = config;
+  if (!env || !env.pluginName) {
+    config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
+        name: 'vendor',
+        minChunks: Infinity,
+      })
+    )
+  }
+
+  if (production) {
+    config.plugins.push(
+      new webpack.NoEmitOnErrorsPlugin(),
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          compress: { warnings: false },
+        },
+        sourceMap: false
+      }),
+      new webpack.optimize.ModuleConcatenationPlugin(),
+      new webpack.optimize.OccurrenceOrderPlugin(),
+      new CompressionPlugin()
+    );
+  } else {
+    config.plugins.push(
+      new webpack.HotModuleReplacementPlugin() // Enable HMR
+    );
+    require('dotenv').config();
+
+    config.devServer = {
+      host: process.env.BIND || 'localhost',
+      port: devServerPort,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      hot: true
+    };
+    // Source maps
+    config.devtool = 'inline-source-map';
+  }
+
+  return config;
+}

--- a/script/plugin_webpack_directories.js
+++ b/script/plugin_webpack_directories.js
@@ -47,6 +47,17 @@ var webpackedDirs = (stderr) => {
   });
 };
 
+var pluginEntry = (pluginEntries, pluginName) => {
+  var entry = {};
+
+  Object.keys(pluginEntries).forEach((key) => {
+    if (key === pluginName) {
+        entry[key] = path.dirname(pluginEntries[key]);
+    }
+  });
+  return entry;
+}
+
 var getPluginDirs = stderr => JSON.parse(sanitizeWebpackDirs(webpackedDirs(stderr)));
 
 var packageJsonDirs = stderr => pluginPath('package.json')(getPluginDirs(stderr)).map(path.dirname);


### PR DESCRIPTION
The intent of this change is to allow plugins to individually compile their webpack assets for use in production. This follows a similar model to existing sprockets asset compilation. 

The requirements for plugins:

 1) Ability to generate webpack assets for plugin only
 2) Need to deliver the webpack assets in a plugins individual package (RPM/Deb)
 3) Need for those assets to be accessible in production and references to those assets to be in the final manifest.json

The intended workflow for build and deployment:

 1) A plugin calls `rake plugin:assets:precompile[plugin_name]`
 2) Webpack assets are generated inside `<plugin>/public/webpack/<plugin>/`
 3) In production build, such as RPM, these assets would need to be copied to `/usr/share/foreman/public/webpack` and laid down during install
 4) This puts plugin assets inside their own directories inside the `public/webpack` directory
 
How production server works:

 1) During startup, asset initialization code finds all plugin manifests and adds their entries to the main Foreman `manifest.json`
 2) A new version of `manifest.json` is written to disk
 3) All plugin assets are presumed present in `public/webpack`

Example "new" manifest on disk during server startup:

```
{
    "assetsByChunkName": {
        "ansible": [
            "ansible/ansible-d3598e423c33e9cbe088.js",
            "ansible/ansible-d3598e423c33e9cbe088.css"
        ],
        "bundle": [
            "bundle-511ea80f9d5431e940d7.js",
            "bundle-511ea80f9d5431e940d7.css"
        ],
        "vendor": "vendor-a3efca51ed683d599828.js",
        "katello": [
            "katello/katello-3b2f236fa6305d516a6d.js",
            "katello/katello-3b2f236fa6305d516a6d.css"
        ]
    },
    "errors": [

    ],
    "warnings": [

    ]
}
```

There are bound to be some nuances and edge cases I am not aware of when trying to apply this pattern to webpack. One question I was unclear about is the `vendor` JS that I think differs from how it was being done in development. If I understand correctly, plugins will potentially have overlapping dependencies given the vendor JS is generated separately from individual plugin JS. Are there any gotchas here that this does not account for?

I'd be happy to simplify this code if possible, and simplify the workflow if possible. However, given the stated requirements, and the workflows we've seen with Sprockets based assets and independence of plugins I am not sure there is a different workflow we can take. Note that some limitations are based on how webpack-rails is designed today (and with no real time to make changes to it to adapt to our architecture).