### PR TITLE
Refs #22493 - Avoid loading logging-journald

### DIFF
--- a/bundler.d/journald.rb
+++ b/bundler.d/journald.rb
@@ -1,4 +1,4 @@
 # disable to avoid journald native gem in development setup
 group :journald do
-  gem 'logging-journald', '~> 1.0'
+  gem 'logging-journald', '~> 1.0', require: false
 end


### PR DESCRIPTION
Without this bundler_ext would always load the gem. This fails because logging-journald doesn't place a ruby file in the correct place. That's not a problem in most operations because the logging framework can automatically load the plugin if needed.