### PR TITLE
Fixes #23177 - unattended warning on multiple MACs

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -180,7 +180,9 @@ class UnattendedController < ApplicationController
 
     # we try to match first based on the MAC, falling back to the IP
     # host is readonly because of association so we reload it if we find it
-    host = Host.joins(:provision_interface).where(mac_list.empty? ? {:nics => {:ip => ip}} : ["lower(nics.mac) IN (?)", mac_list]).first
+    candidates = Host.joins(:provision_interface).where(mac_list.empty? ? {:nics => {:ip => ip}} : ["lower(nics.mac) IN (?)", mac_list]).order('created_at DESC, id')
+    logger.warn("Multiple hosts found with #{ip} or #{mac_list}, picking up the oldest") if candidates.count > 1
+    host = candidates.first
     host ? Host.find(host.id) : nil
   end
 

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -25,7 +25,7 @@ mystring2:
 
 myfinish:
   name: MyFinish
-  template: MyFinish
+  template: finish for <%%= @host.name %>
   template_kind: finish
   operatingsystems: centos5_3, redhat, ubuntu1010
   locked: false


### PR DESCRIPTION
In unattended search by MAC or Anaconda. Can be tricky to debug when tokens are turned off.

Optionally, we shall sort the entries by created_at so the last is picked up.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->