### PR TITLE
Fixes #23220 - Humanized name for RSS notifications

### DIFF
--- a/app/jobs/create_rss_notifications.rb
+++ b/app/jobs/create_rss_notifications.rb
@@ -13,4 +13,8 @@ class CreateRssNotifications < ApplicationJob
       'RSS notification checker: '\
       "Error while creating notifications #{error}: #{error.backtrace}")
   end
+
+  def humanized_name
+    _('Create RSS notifications')
+  end
 end


### PR DESCRIPTION
Redmine is down now, whenever it's back I will create an issue number.

This PR allows to show the notifications in the Tasks page  https://github.com/theforeman/foreman-tasks/pull/238 - without the `humanized_name` method, it'll just display the class name.

![screenshot from 2018-04-11 11-41-14](https://user-images.githubusercontent.com/598891/38609009-440b129a-3d7d-11e8-987f-47d56e59d8cb.png)

Can be merged at any time, it's harmless even if https://github.com/theforeman/foreman-tasks/pull/238 isn't merged yet