### PR TITLE
Revert " Fixes #23196 - Add default values for cores and socket in VM"

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -94,11 +94,7 @@ module Foreman::Model
 
     #FIXME
     def max_cpu_count
-      16
-    end
-
-    def max_socket_count
-      16
+      8
     end
 
     def max_memory

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -28,9 +28,6 @@
 <% selected_cluster ||= params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
 
 <%= counter_f f, :cores, :disabled => !new_vm, :label => _('Cores'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
-
-<%= counter_f f, :sockets, :disabled => !new_vm, :label => _('Sockets'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_socket_count %>
-
 <%= byte_size_f f, :memory, :disabled => !new_vm, :label => _('Memory'), :label_size => "col-md-2", :'data-soft-max' => compute_resource.max_memory %>
 
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -27,9 +27,9 @@
 
 <% selected_cluster ||= params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:cluster] %>
 
-<%= counter_f f, :cores, :disabled => !new_vm, :label => _('Cores'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count, :value => 1 %>
+<%= counter_f f, :cores, :disabled => !new_vm, :label => _('Cores'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
 
-<%= counter_f f, :sockets, :disabled => !new_vm, :label => _('Sockets'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_socket_count, :value => 1 %>
+<%= counter_f f, :sockets, :disabled => !new_vm, :label => _('Sockets'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_socket_count %>
 
 <%= byte_size_f f, :memory, :disabled => !new_vm, :label => _('Memory'), :label_size => "col-md-2", :'data-soft-max' => compute_resource.max_memory %>
 


### PR DESCRIPTION
Reverts theforeman/foreman#5427

This requires changes in fog that aren't merged yet, and the `value:` parameter overrides the value in the database when reopening the form.