### PR TITLE
Fixes #23225 - fix vm tab js error in host page

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -297,7 +297,7 @@ class HostsController < ApplicationController
     @vm = @host.compute_resource.find_vm_by_uuid(@host.uuid)
     @compute_resource = @host.compute_resource
     render :partial => "compute_resources_vms/details"
-  rescue ActionView::Template::Error => exception
+  rescue ActiveRecord::RecordNotFound, ActionView::Template::Error => exception
     process_ajax_error exception, 'fetch vm information'
   end
 


### PR DESCRIPTION
the host vm tab only catches `ActionView::Template::Error`, which works if the error is in the template rendering, but if `find_vm_by_uuid` fails it throws a `ActiveRecord::RecordNotFound` exception which isn't caught by the controller, leading to the generic controller reply which includes the entire layout - including JS which is executed and breaks all the JS on the page.