### PR TITLE
Fixes #23212 - uninitialized constant

### DIFF
--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -32,7 +32,7 @@ module PowerManager
     def default_action(action)
       action_status = vm.send(action)
       # Temporary fix until fog-ovirt is updated
-      if action_status.is_a?(Fog::Compute::Ovirt::Server)
+      if Fog::Compute.const_defined?(:Ovirt) && action_status.is_a?(Fog::Compute::Ovirt::Server)
         return true
       end
       action_status


### PR DESCRIPTION
Seems like the same issue also exists in 1.17, so it would probably have to be cherry-picked/pulled to there as well.