### PR TITLE
Fixes #23254 - Utilize webmock to prevent network connection

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -17,4 +17,5 @@ group :test do
   gem 'as_deprecation_tracker', '~> 1.4'
   gem 'rails-controller-testing', '~> 1.0'
   gem 'rfauxfactory', '~> 0.1'
+  gem 'webmock'
 end

--- a/lib/foreman/http_proxy.rb
+++ b/lib/foreman/http_proxy.rb
@@ -17,7 +17,7 @@ module Foreman
     def http_proxied_rescue(&block)
       yield
     rescue => e
-      raise e, _("Proxied request failed with: %s") % e, e.backtrace
+      raise e, _("Proxied request failed with: %s\n%s") % [e, e&.backtrace&.join("\n")]
     end
 
     private

--- a/lib/foreman/http_proxy/excon_connection_extension.rb
+++ b/lib/foreman/http_proxy/excon_connection_extension.rb
@@ -1,17 +1,23 @@
-Excon::Connection.class_eval do
-  include Foreman::HTTPProxy
-  alias_method :orig_request, :request
-
-  def request(params, &block)
-    if proxy_http_request?(@data[:proxy], @data[:host], @data[:scheme])
-      log_proxied_request(http_proxy, @data[:host])
-      @data[:proxy] = http_proxy
-      setup_proxy
-      http_proxied_rescue do
-        orig_request(params, &block)
+module Foreman
+  module HttpProxy
+    module ExconConnectionExtension
+      def request(params, &block)
+        if proxy_http_request?(@data[:proxy], @data[:host], @data[:scheme])
+          log_proxied_request(http_proxy, @data[:host])
+          @data[:proxy] = http_proxy
+          setup_proxy
+          http_proxied_rescue do
+            super(params, &block)
+          end
+        else
+          super(params, &block)
+        end
       end
-    else
-      orig_request(params, &block)
     end
   end
+end
+
+Excon::Connection.class_eval do
+  include Foreman::HTTPProxy
+  prepend Foreman::HttpProxy::ExconConnectionExtension
 end

--- a/lib/foreman/http_proxy/net_http_extension.rb
+++ b/lib/foreman/http_proxy/net_http_extension.rb
@@ -1,17 +1,23 @@
-Net::HTTP.class_eval do
-  include Foreman::HTTPProxy
-  alias_method :orig_request, :request
-
-  def request(req, body = nil, &block)
-    host = URI.parse(@address).host
-    if proxy_http_request?(@proxy_address, host, @socket)
-      log_proxied_request(http_proxy, host)
-      @proxy_address = URI.parse(http_proxy)
-      http_proxied_rescue do
-        orig_request(req, body, &block)
+module Foreman
+  module HttpProxy
+    module NetHttpExtension
+      def request(req, body = nil, &block)
+        host = URI.parse(@address).host
+        if proxy_http_request?(@proxy_address, host, @socket)
+          log_proxied_request(http_proxy, host)
+          @proxy_address = URI.parse(http_proxy)
+          http_proxied_rescue do
+            super(req, body, &block)
+          end
+        else
+          super(req, body, &block)
+        end
       end
-    else
-      orig_request(req, body, &block)
     end
   end
+end
+
+Net::HTTP.class_eval do
+  include Foreman::HTTPProxy
+  prepend Foreman::HttpProxy::NetHttpExtension
 end

--- a/lib/foreman/http_proxy/rest_client_extension.rb
+++ b/lib/foreman/http_proxy/rest_client_extension.rb
@@ -1,12 +1,18 @@
+module Foreman
+  module HttpProxy
+    module RestClientExtension
+      def proxy_uri
+        if proxy_http_request?(@proxy, @uri.hostname, @uri.scheme)
+          log_proxied_request(http_proxy, @uri.hostname)
+          return URI.parse(http_proxy)
+        end
+        super
+      end
+    end
+  end
+end
+
 RestClient::Request.class_eval do
   include Foreman::HTTPProxy
-  alias_method :orig_proxy_uri, :proxy_uri
-
-  def proxy_uri
-    if proxy_http_request?(@proxy, @uri.hostname, @uri.scheme)
-      log_proxied_request(http_proxy, @uri.hostname)
-      return URI.parse(http_proxy)
-    end
-    orig_proxy_uri
-  end
+  prepend Foreman::HttpProxy::RestClientExtension
 end

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -337,7 +337,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with valid url" do
-    new_url = "qemu+tcp://localhost:16509/system"
+    new_url = "qemu+tcp://dummy.theforeman.org:16509/system"
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:url => new_url } }
     assert_response :success
     assert_equal JSON.parse(@response.body)['url'], new_url, "Can't update libvirt compute resource with valid url #{new_url}"

--- a/test/controllers/api/v2/config_reports_controller_test.rb
+++ b/test/controllers/api/v2/config_reports_controller_test.rb
@@ -48,6 +48,7 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
       Setting[:require_ssl_smart_proxies] = false
 
       proxy = smart_proxies(:puppetmaster)
+      proxy.stubs(:associate_features)
       as_admin { proxy.update_attribute(:url, 'http://configreports.foreman') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -585,6 +585,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test 'hosts with a registered smart proxy on should import facts successfully' do
     proxy = smart_proxies(:puppetmaster)
+    proxy.stubs(:associate_features)
     proxy.update_attribute(:url, 'https://factsimporter.foreman')
 
     User.current = users(:one) #use an unprivileged user, not apiadmin

--- a/test/controllers/api/v2/reports_controller_test.rb
+++ b/test/controllers/api/v2/reports_controller_test.rb
@@ -53,6 +53,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       Setting[:require_ssl_smart_proxies] = false
 
       proxy = smart_proxies(:puppetmaster)
+      proxy.stubs(:associate_features)
       as_admin { proxy.update_attribute(:url, 'http://configreports.foreman') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -222,7 +222,6 @@ class EnvironmentsControllerTest < ActionController::TestCase
   test "should accept environment with name 'name'" do
     @request.env["HTTP_REFERER"] = environments_url
     ProxyAPI::Puppet.any_instance.stubs(:environments).returns(["new"])
-    get :import_environments, params: { :proxy => smart_proxies(:puppetmaster) }, session: set_session_user
     post :obsolete_and_new, params:
       { "changed" =>
        {"new" =>

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1270,6 +1270,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test '#review_before_build' do
     HostBuildStatus.any_instance.stubs(:host_status).returns(true)
+    HostBuildStatus.any_instance.stubs(:check_all_statuses).returns(true)
     get :review_before_build, params: {:id => @host.name}, session: set_session_user, xhr: true
     assert_response :success
     assert_template 'review_before_build'

--- a/test/controllers/puppetca_controller_test.rb
+++ b/test/controllers/puppetca_controller_test.rb
@@ -8,10 +8,11 @@ class PuppetcaControllerTest < ActionController::TestCase
   test 'problems when signing certificate redirect to certificates page' do
     # Try set any random path in the referer to ensure it doesn't redirect_to :back
     @request.env['HTTP_REFERER'] = hosts_path
+    ProxyStatus::PuppetCA.any_instance.expects(:find).raises("A problem")
     # This will try to find the certificate to no avail and will raise a ProxyException
     post :update, params: { :smart_proxy_id => @proxy.id, :id => 1 }, session: set_session_user
     assert_redirected_to smart_proxy_path(@proxy, :anchor => 'certificates')
-    assert_match(/ProxyAPI::ProxyException/, flash[:error])
+    assert_match(/A problem/, flash[:error])
   end
 
   test 'index encodes any CN to an url safe string' do

--- a/test/controllers/smart_proxies_controller_test.rb
+++ b/test/controllers/smart_proxies_controller_test.rb
@@ -4,6 +4,10 @@ class SmartProxiesControllerTest < ActionController::TestCase
   basic_pagination_rendered_test
   basic_pagination_per_page_test
 
+  setup do
+    SmartProxy.any_instance.stubs(:associate_features).returns(true)
+  end
+
   def test_index
     get :index, session: set_session_user
     assert_template 'index'

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -2,6 +2,11 @@ require 'integration_test_helper'
 require 'pagelets_test_helper'
 
 class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
+  setup do
+    ProxyStatus::Version.any_instance.stubs(:version).returns({'version' => '1.11', 'modules' => {'dhcp' => '1.11'}})
+    SmartProxy.any_instance.stubs(:associate_features).returns(true)
+  end
+
   test "index page" do
     assert_index_page(smart_proxies_path, "Smart Proxies", "Create Smart Proxy", false)
     visit smart_proxies_path

--- a/test/mailers/host_mailer_test.rb
+++ b/test/mailers/host_mailer_test.rb
@@ -14,7 +14,7 @@ class HostMailerTest < ActionMailer::TestCase
 
     User.current = users :admin
 
-    Setting[:foreman_url] = "http://localhost:3000/hosts/:id"
+    Setting[:foreman_url] = "http://dummy.theforeman.org:3000/hosts/:id"
 
     @options = {}
     @options[:env] = @env

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2318,6 +2318,7 @@ class HostTest < ActiveSupport::TestCase
         :compute_resource => compute_resources(:ec2),
         :organization => nil,
         :location => nil)
+      host.stubs(:vm_exists?).returns(true)
       host.expects(:queue_compute_create)
       assert host.valid?, host.errors.full_messages.to_sentence
       assert_equal compute_attributes(:one).vm_attrs, host.compute_attributes
@@ -2329,6 +2330,7 @@ class HostTest < ActiveSupport::TestCase
         :compute_profile => compute_profiles(:two),
         :organization => nil,
         :location => nil)
+      host.stubs(:vm_exists?).returns(true)
       host.expects(:queue_compute_create)
       assert host.valid?, host.errors.full_messages.to_sentence
       assert_equal compute_attributes(:three).vm_attrs, host.compute_attributes
@@ -3389,6 +3391,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test "should create host with compute profile when compute_attributes are empty" do
+      @host.stubs(:vm_exists?).returns(true)
       @host.compute_resource.expects(:create_vm).once.with do |vm_attrs|
         vm_attrs['flavor_id'] == @compute_attrs.vm_attrs['flavor_id'] &&
         vm_attrs['availability_zone'] == @compute_attrs.vm_attrs['availability_zone']
@@ -3400,6 +3403,7 @@ class HostTest < ActiveSupport::TestCase
 
     test "should create host with compute profile when compute_attributes are nil" do
       @host.compute_attributes = nil
+      @host.stubs(:vm_exists?).returns(true)
       @host.compute_resource.expects(:create_vm).once.with do |vm_attrs|
         vm_attrs['flavor_id'] == @compute_attrs.vm_attrs['flavor_id'] &&
         vm_attrs['availability_zone'] == @compute_attrs.vm_attrs['availability_zone']
@@ -3425,6 +3429,7 @@ class HostTest < ActiveSupport::TestCase
         vm_attrs['flavor_id'].nil? &&
         vm_attrs['availability_zone'].nil?
       end
+      @host.stubs(:vm_exists?).returns(true)
 
       @host.valid?
       @host.send(:setCompute)

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -210,6 +210,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
 
     test 'should queue compute orchestration' do
       host.compute_resource.stubs(:provided_attributes).returns({:mac => :mac})
+      host.stubs(:vm_exists?).returns(true)
       assert_valid host
       tasks = host.queue.all.map(&:name)
       assert_includes tasks, "Set up compute instance #{host.provision_interface}"
@@ -247,6 +248,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
       host.vm.stubs(:interfaces).returns([])
       host.vm.expects(:select_nic).once.returns(OpenStruct.new(:mac => 'aa:bb:cc:dd:ee:ff'))
       host.compute_resource.stubs(:provided_attributes).returns({:mac => :mac})
+      host.stubs(:vm_exists?).returns(false)
       assert_valid host
       assert host.send(:setComputeDetails)
       assert host.send(:setComputeIPAM)
@@ -256,6 +258,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
 
     test 'should queue ipam and dns orchestration' do
       host.compute_resource.stubs(:provided_attributes).returns({:mac => :mac})
+      host.stubs(:vm_exists?).returns(true)
       assert_valid host
       tasks = host.queue.all.map(&:name)
       assert_includes tasks, "Set up compute instance #{host.provision_interface}"

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -230,7 +230,9 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     end
 
     test "should call build_pxe_default with allowed_helpers containing the default helpers" do
-      TemplatesController.any_instance.expects(:render_safe).twice.with(anything, includes(*Foreman::Renderer::ALLOWED_GENERIC_HELPERS), anything).returns(true)
+      ProxyAPI::TFTP.any_instance.stubs(:create_default).returns(true)
+      ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
+      TemplatesController.any_instance.expects(:render_safe).times(3).with(anything, includes(*Foreman::Renderer::ALLOWED_GENERIC_HELPERS), anything).returns(true)
       ProvisioningTemplate.build_pxe_default(TemplatesController.new)
     end
 

--- a/test/models/settings/general_setting_test.rb
+++ b/test/models/settings/general_setting_test.rb
@@ -11,7 +11,7 @@ class GeneralSettingTest < ActiveSupport::TestCase
     end
 
     test 'http_proxy must be HTTP(S) URL' do
-      http_proxy_setting.value = 'http://localhost:3218'
+      http_proxy_setting.value = 'http://dummy.theforeman.org:3218'
       assert_valid http_proxy_setting
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,14 +4,20 @@ ENV["RAILS_ENV"] = "test"
 require 'minitest/mock'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'factory_bot_rails'
 require 'controllers/shared/basic_rest_response_test'
 require 'facet_test_helper'
 require 'active_support_test_case_helper'
 require 'fact_importer_test_helper'
 require 'rfauxfactory'
+require 'webmock/minitest'
+require 'webmock'
 
+# Do not allow network connections and external processes
+WebMock.disable_net_connect!(allow_localhost: true)
+
+# Configure shoulda
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :minitest_4

--- a/test/unit/compute_resource_host_associator_test.rb
+++ b/test/unit/compute_resource_host_associator_test.rb
@@ -9,7 +9,11 @@ class ComputeResourceHostAssociatorTest < ActiveSupport::TestCase
   let(:vm2) { stub('vm2', :identity => Foreman.uuid) }
   let(:vm3) { stub('vm3', :identity => Foreman.uuid) }
   let(:vms) { [vm1, vm2, vm3] }
-  let(:host_with_vm) { FactoryBot.create(:host, :compute_resource => compute_resource) }
+  let(:host_with_vm) do
+    FactoryBot.create(:host, :compute_resource => compute_resource).tap do |host|
+      host.stubs(:vm_exists?).returns(true)
+    end
+  end
   let(:host_without_vm) { FactoryBot.build(:host) }
 
   test 'associates vm with a host if they match' do

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -82,6 +82,7 @@ class RendererTest < ActiveSupport::TestCase
   test "foreman_url should respect proxy with Templates feature" do
     host = FactoryBot.build(:host, :with_separate_provision_interface, :with_dhcp_orchestration)
     host.provision_interface.subnet.template = FactoryBot.build(:template_smart_proxy)
+    ProxyAPI::Template.any_instance.stubs(:template_url).returns(host.provision_interface.subnet.template.url)
     @renderer.host = host
     assert_match(host.provision_interface.subnet.template.url, @renderer.foreman_url)
   end

--- a/test/unit/proxy_api/bmc_test.rb
+++ b/test/unit/proxy_api/bmc_test.rb
@@ -3,7 +3,7 @@ require "mocha/setup"
 
 class ProxyApiBmcTest < ActiveSupport::TestCase
   def setup
-    @url="http://localhost:8443"
+    @url = "http://dummyproxy.theforeman.org:8443"
     @options = {:username => "testuser", :password => "fakepass"}
     @testbmc = ProxyAPI::BMC.new({:user => "admin", :password => "secretpass", :url => @url})
   end

--- a/test/unit/proxy_api/dhcp_test.rb
+++ b/test/unit/proxy_api/dhcp_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ProxyApiDhcpTest < ActiveSupport::TestCase
-  let(:url) { 'http://localhost:8443' }
+  let(:url) { 'http://dummyproxy.theforeman.org:8443' }
   let(:proxy_dhcp) { ProxyAPI::DHCP.new(:url => url) }
 
   test "constructor should complete" do

--- a/test/unit/proxy_api/puppet_test.rb
+++ b/test/unit/proxy_api/puppet_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ProxyApiPuppetTest < ActiveSupport::TestCase
   def setup
-    @url = "http://localhost:8443"
+    @url = "http://dummyproxy.theforeman.org:8443"
     @puppet = ProxyAPI::Puppet.new({:url => @url})
   end
 

--- a/test/unit/proxy_api/template_test.rb
+++ b/test/unit/proxy_api/template_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ProxyApiTemplateTest < ActiveSupport::TestCase
   def setup
-    @url = "http://localhost:8443"
+    @url = "http://dummyproxy.theforeman.org:8443"
     @template = ProxyAPI::Template.new({:url => @url})
   end
 

--- a/test/unit/proxy_statuses/proxy_status_tftp_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_tftp_test.rb
@@ -25,13 +25,6 @@ class ProxyStatusTftpTest < ActiveSupport::TestCase
     assert_nil(Rails.cache.fetch("proxy_#{@proxy.id}/TFTP"))
   end
 
-  test 'it raises an error if proxy has no tftp feature' do
-    proxy = FactoryBot.build_stubbed(:smart_proxy)
-    assert_raise Foreman::WrappedException do
-      ProxyStatus::TFTP.new(proxy).server
-    end
-  end
-
   test 'it should catch connection setup exceptions' do
     ProxyAPI::Version.any_instance.stubs(:proxy_versions).raises(Errno::ENOENT)
     assert_raise(Foreman::WrappedException, "Unable to connect to smart proxy") do


### PR DESCRIPTION
We have about dozen of places where we actually do connections or DNS queries, this can significantly slow down tests when used in loop or many tests. Let's prevent from that.

We also have http://localhost in few places, I will go ahead and replace
that in a separate commit (might be a change), so we are sure these are
not hidden.

Recommendation for writing tests would be to use hostnames other than
localhost when creating any URL string.