### PR TITLE
Fixes #23256 - Check if the delayed plans have expected interface

### DIFF
--- a/config/initializers/rss_notifications.rb
+++ b/config/initializers/rss_notifications.rb
@@ -4,7 +4,7 @@
   scheduled_job = pending_jobs.select do |job|
     delayed_plan = world.persistence.load_delayed_plan job.id
     next unless delayed_plan.present?
-    delayed_plan.to_hash[:serialized_args].first["job_class"] == 'CreateRssNotifications'
+    delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == 'CreateRssNotifications'
   end
 
   # Only create notifications if there isn't a scheduled job


### PR DESCRIPTION
Not all delayed plan records have 'job_class' key in first element in serialized_args.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
