### PR TITLE
Refs #22199 - tests fixed for usergroup audits

### DIFF
--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -339,6 +339,7 @@ class UsergroupTest < ActiveSupport::TestCase
       end
 
       test 'should audit when a child-usergroup is assigned to a parent-usergroup' do
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:usergroups]
         assert audited_changes, 'No audits found for usergroups'
@@ -349,6 +350,7 @@ class UsergroupTest < ActiveSupport::TestCase
       test 'should audit when a child-usergroup is removed/de-assigned from a parent-usergroup' do
         @usergroup.usergroup_ids = []
         @usergroup.save
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:usergroups]
         assert audited_changes, 'No audits found for usergroups'
@@ -365,6 +367,7 @@ class UsergroupTest < ActiveSupport::TestCase
       end
 
       test 'should audit when a role is assigned to a usergroup' do
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:roles]
         assert audited_changes, 'No audits found for user-roles'
@@ -375,6 +378,7 @@ class UsergroupTest < ActiveSupport::TestCase
       test 'should audit when a role is removed/de-assigned from a usergroup' do
         @usergroup.role_ids = []
         @usergroup.save
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:roles]
         assert audited_changes, 'No audits found for usergroup-roles'
@@ -391,6 +395,7 @@ class UsergroupTest < ActiveSupport::TestCase
       end
 
       test 'should audit when a user is assigned to a usergroup' do
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:users]
         assert audited_changes, 'No audits found for users'
@@ -401,6 +406,7 @@ class UsergroupTest < ActiveSupport::TestCase
       test 'should audit when a user is removed/de-assigned from a usergroup' do
         @usergroup.user_ids = []
         @usergroup.save
+        refute_empty @usergroup.audits, 'No audits created while expecting at least one'
         recent_audit = @usergroup.audits.last
         audited_changes = recent_audit.audited_changes[:users]
         assert audited_changes, 'No audits found for users'


### PR DESCRIPTION
Hey @swapab and @ares! When I run develop test suite locally, I am
getting this:

```
UsergroupTest::audit usergroup::users#test_0002_should audit when a user is removed/de-assigned from a usergroup:
NoMethodError: undefined method `audited_changes' for nil:NilClass
    test/models/usergroup_test.rb:405:in `block (3 levels) in <class:UsergroupTest>'
```

This fails for all six tests in the test. Now, when I run the test as a
single test via `ruby -Ilib -Itest` it works. Something is wrong.

I noticed that there are errors after each usergroup `save` call:

```
> @usergroup.errors
=> #<ActiveModel::Errors:0x005601c335f9d8
 @base=
  #<Usergroup:0x005601c3353048
   id: 1,
   name: "usergroup9",
   created_at: Fri, 13 Apr 2018 08:34:45 UTC +00:00,
   updated_at: Fri, 13 Apr 2018 08:34:45 UTC +00:00,
   admin: false>,
 @details={},
 @messages={}>
```

But there is no message, weird. This patch is to bring attention, re-run
tests on jenkins and open up discussion.