### PR TITLE
Fixes #23223 - Don't allow Dynflow to initialize in db:drop rake

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -276,7 +276,7 @@ module Foreman
     end
 
     config.after_initialize do
-      init_dynflow
+      init_dynflow unless Foreman.in_rake?('db:drop')
       setup_auditing
     end
 


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
