### PR TITLE
Refs #23215 - 2.3 compat. for webpack in plugins script

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -27,7 +27,7 @@ specs.each do |dep|
   # some plugins share the same base directory (tasks-core and tasks, REX etc)
   # skip the plugin if its path is already included
   next if config[:paths].include?(path)
-  if Dir.exist?(path) && !dep.files.any? { |f| f.match?(/webpack/) }
+  if Dir.exist?(path) && !dep.files.any? { |f| /webpack/ =~ f }
     STDERR.puts "WARNING: webpack was found in #{dep.name}'s source, "\
       "but it's not in the gemspec. Please add it to the gemspec."
   end


### PR DESCRIPTION
.match? was only introduced on 2.4, therefore it's failing to run
on 2.3 and test pipelines for plugins with webpack & Ruby 2.3 fail

As an example: http://ci.theforeman.org/job/test_plugin_pull_request/4899/database=postgresql,label=fast,ruby=2.3/console