### PR TITLE
 Fixes #23334 - Order temeplates audits correctly

### DIFF
--- a/db/migrate/201805145603_fix_template_audit_versions.rb
+++ b/db/migrate/201805145603_fix_template_audit_versions.rb
@@ -1,0 +1,15 @@
+class FixTemplateAuditVersions < ActiveRecord::Migration[5.1]
+  def up
+    [ ProvisioningTemplate, Ptable].each do |model|
+      model.unscoped.each do |object|
+        object.audits.order(created_at: :asc).first.update(:version => 1) if object.audits.any?
+        object.audits.order(created_at: :asc).each_cons(2) do |prev_audit, curr_audit|
+          curr_audit.update(:version => prev_audit.version + 1)
+        end
+      end
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
As you can see, `descending` doesn't really work.

```
irb(main):041:0* Audit.descending.where(:auditable_id => 111, :auditable_type => 'ProvisioningTemplate', :action => 'update').second.created_at
=> Fri, 16 Mar 2018 15:46:56 UTC +00:00
irb(main):042:0> Audit.descending.where(:auditable_id => 111, :auditable_type => 'ProvisioningTemplate', :action => 'update').last.created_at
=> Wed, 21 Mar 2018 16:27:10 UTC +00:00
irb(main):043:0> 
irb(main):044:0* Audit.order(created_at: :desc).where(:auditable_id => 111, :auditable_type => 'ProvisioningTemplate', :action => 'update').second.created_at
=> Thu, 05 Apr 2018 10:30:17 UTC +00:00
irb(main):045:0> Audit.order(created_at: :desc).where(:auditable_id => 111, :auditable_type => 'ProvisioningTemplate', :action => 'update').last.created_at
=> Mon, 12 Sep 2016 12:11:02 UTC +00:00
```

Without this my history is like 

![screenshot-1](https://user-images.githubusercontent.com/13135483/38988108-e858e6cc-43c9-11e8-88d4-0469b4b080b7.png)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
