### PR TITLE
Fixes #23336 - env variables for test retry and logs

### DIFF
--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -5,10 +5,10 @@ class AboutIntegrationTest < IntegrationTestWithJavascript
   #   AboutIntegrationTest.test_0002_about page proxies should have version
 
   setup do
-    ComputeResource.any_instance.expects(:ping).at_least_once.returns([])
+    ComputeResource.any_instance.stubs(:ping).returns([])
     proxy_status = mock('ProxyStatus::Version')
-    proxy_status.expects(:version).at_least_once.returns('version' => '1.13.0')
-    SmartProxy.any_instance.expects(:statuses).at_least_once.returns(:version => proxy_status)
+    proxy_status.stubs(:version).returns('version' => '1.13.0')
+    SmartProxy.any_instance.stubs(:statuses).returns(:version => proxy_status)
   end
 
   test "about page" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -10,7 +10,8 @@ require 'show_me_the_cookies'
 require 'database_cleaner'
 require 'active_support_test_case_helper'
 require 'minitest/retry'
-Minitest::Retry.use!
+retry_count = (ENV['MINITEST_RETRY_COUNT'] || 3).to_i rescue 1
+Minitest::Retry.use!(retry_count: retry_count) if retry_count > 1
 
 Minitest::Retry.on_consistent_failure do |klass, test_name|
   Rails.logger.error("DO NOT IGNORE - Consistent failure - #{klass} #{test_name}")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,13 +68,13 @@ module TestCaseRailsLoggerExtensions
     @_ext_old_logger = Rails.logger
     @_ext_old_ar_logger = ActiveRecord::Base.logger
     Rails.logger = Foreman::SilencedLogger.new(ActiveSupport::TaggedLogging.new(Logger.new(@_ext_current_buffer)))
-    ActiveRecord::Base.logger = Rails.logger
+    ActiveRecord::Base.logger = Rails.logger if ENV['PRINT_TEST_LOGS_SQL']
   end
 
   def after_teardown
     Rails.logger = @_ext_old_logger if @_ext_old_logger
     ActiveRecord::Base.logger = @_ext_old_ar_logger if @_ext_old_ar_logger
-    if error?
+    if (ENV['PRINT_TEST_LOGS_ON_ERROR'] && error?) || (ENV['PRINT_TEST_LOGS_ON_FAILURE'] && !self.passed?)
       @_ext_current_buffer.close_write
       STDOUT << "\n\nRails logs for #{self.name} FAILURE:\n"
       STDOUT << @_ext_current_buffer.string

--- a/test/unit/foreman/util_test.rb
+++ b/test/unit/foreman/util_test.rb
@@ -4,6 +4,13 @@ require 'foreman/util'
 class UtilTest < ActiveSupport::TestCase
   include Foreman::Util
 
+  setup do
+    ENV.stubs(:[]).with('PRINT_TEST_LOGS_ON_ERROR').returns(false)
+    ENV.stubs(:[]).with('PRINT_TEST_LOGS_ON_FAILURE').returns(false)
+    ENV.stubs(:[]).with('PRINT_TEST_LOGS_SQL').returns(false)
+    ENV.stubs(:[]).with('MINITEST_RETRY_COUNT').returns(1)
+  end
+
   test "should support which" do
     assert :which
   end


### PR DESCRIPTION
Our tests keeps logs for each individual test in a buffer and when it errors/fails we print them including SQL logs. This is quite heavy and can flood stdout, I want to turn this off and have this opt-in.

* PRINT_TEST_LOGS_ON_FAILURE - print Rails logs on failure
* PRINT_TEST_LOGS_ON_ERROR - print Rails logs on test error
* PRINT_TEST_LOGS_SQL - print ActiveRecord (SQL) logs (very verbose)
* MINITEST_RETRY_COUNT - Minitest::Retry count (set to 1 to disable)