### PR TITLE
Fixes #23331 - grouped permissions for host disabled

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -833,6 +833,12 @@ class Host::Managed < Host::Base
 
   private
 
+  # Permissions introduced by plugins for this class can cause resource <-> permission
+  # names mapping to fail randomly so as a safety precaution, we specify the name more explicitly.
+  def permission_name(action)
+    "#{action}_hosts"
+  end
+
   def compute_profile_present?
     !(compute_profile_id.nil? || compute_resource_id.nil?)
   end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1897,6 +1897,11 @@ class HostTest < ActiveSupport::TestCase
       assert_equal [host], Host::Managed.search_for(query)
     end
 
+    test "host edit permision must be always edit_hosts" do
+      h = FactoryBot.build(:host, :managed)
+      assert_equal "edit_hosts", h.send(:permission_name, :edit)
+    end
+
     test "non-admin user with edit_hosts permission can update interface" do
       @one = users(:one)
       # add permission for user :one


### PR DESCRIPTION
Authorizable#permission_name generic implementation allows grouping of
permissions in one resource, this is used in couple of them, for example
in SmartProxy or ComputeResource: `edit_comupute_resources and edit_compute_resources_vms`. The way the implementation searches those is using LIKE SQL command:

```ruby
  def permission_name(action)
    type = Permission.resource_name(self.class)
    permissions = Permission.where(:resource_type => type).where(["#{Permission.table_name}.name LIKE ?", "#{action}_%"])

    # some permissions are grouped for same resource, e.g. edit_comupute_resources and edit_compute_resources_vms, in such case we need to detect the right permission
    if permissions.size > 1
      permissions.detect { |p| p.name.end_with?(type.underscore.pluralize) }.try(:name)
    else
      permissions.first.try(:name)
    end
  end
```

This is a problem for discovery host which uses STI and permission name
`edit_discovered_hosts` which matches `edit_hosts` permission and the
LIKE SQL query *sometimes* match - it depends on record order returned
by database server.

This patch explicitly disallows this beahior for STI model "Host".