### PR TITLE
Fixes #22983, #22010 - ignore persistence authz for relations

### DIFF
--- a/app/models/config_group_class.rb
+++ b/app/models/config_group_class.rb
@@ -9,4 +9,8 @@ class ConfigGroupClass < ApplicationRecord
   validates :puppetclass, :presence => true
   validates :config_group, :presence => true,
     :uniqueness => { :scope => :puppetclass_id }
+
+  def check_permissions_after_save
+    true
+  end
 end

--- a/app/models/host_class.rb
+++ b/app/models/host_class.rb
@@ -11,4 +11,8 @@ class HostClass < ApplicationRecord
   def name
     "#{host} - #{puppetclass}"
   end
+
+  def check_permissions_after_save
+    true
+  end
 end

--- a/app/models/host_config_group.rb
+++ b/app/models/host_config_group.rb
@@ -5,4 +5,8 @@ class HostConfigGroup < ApplicationRecord
   belongs_to :config_group
 
   validates :host_id, :uniqueness => { :scope => [:config_group_id, :host_type] }
+
+  def check_permissions_after_save
+    true
+  end
 end

--- a/app/models/hostgroup_class.rb
+++ b/app/models/hostgroup_class.rb
@@ -11,4 +11,8 @@ class HostgroupClass < ApplicationRecord
   def name
     "#{hostgroup} - #{puppetclass}"
   end
+
+  def check_permissions_after_save
+    true
+  end
 end


### PR DESCRIPTION
To reproduce the original issue, as non-admin user, try assigning puppet class to hostgroup or config group or try assigning config group to hostgroup. Neither of this work. With the patch, all works as previously. This is a regression introduced in 1.16 and most likely should be cherry-picked down to 1.16-stable.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
