### PR TITLE
Fixes #23344 - stubs instead expects in setup blocks

### DIFF
--- a/test/controllers/api/v2/config_templates_controller_test.rb
+++ b/test/controllers/api/v2/config_templates_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Api::V2::ConfigTemplatesControllerTest < ActionController::TestCase
   setup do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/config_templates were moved to /provisioning_templates}))
+    Foreman::Deprecation.stubs(:api_deprecation_warning).with(regexp_matches(%r{/config_templates were moved to /provisioning_templates}))
   end
 
   test "should get index" do

--- a/test/controllers/api/v2/reports_controller_test.rb
+++ b/test/controllers/api/v2/reports_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
   include ::ReportHostPermissionsTest
 
   setup do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/reports were moved to /config_reports}))
+    Foreman::Deprecation.stubs(:api_deprecation_warning).with(regexp_matches(%r{/reports were moved to /config_reports}))
   end
 
   describe "Non Admin User" do

--- a/test/controllers/api/v2/template_combinations_controller_test.rb
+++ b/test/controllers/api/v2/template_combinations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
   context 'with provisioning_template_id' do
     setup do
-      Foreman::Deprecation.expects(:api_deprecation_warning).never
+      Foreman::Deprecation.stubs(:api_deprecation_warning).never
     end
 
     test "should get index" do

--- a/test/integration/about_test.rb
+++ b/test/integration/about_test.rb
@@ -5,10 +5,10 @@ class AboutIntegrationTest < IntegrationTestWithJavascript
   #   AboutIntegrationTest.test_0002_about page proxies should have version
 
   setup do
-    ComputeResource.any_instance.expects(:ping).at_least_once.returns([])
+    ComputeResource.any_instance.stubs(:ping).returns([])
     proxy_status = mock('ProxyStatus::Version')
-    proxy_status.expects(:version).at_least_once.returns('version' => '1.13.0')
-    SmartProxy.any_instance.expects(:statuses).at_least_once.returns(:version => proxy_status)
+    proxy_status.stubs(:version).returns('version' => '1.13.0')
+    SmartProxy.any_instance.stubs(:statuses).returns(:version => proxy_status)
   end
 
   test "about page" do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3282,7 +3282,7 @@ class HostTest < ActiveSupport::TestCase
       @nic.expects(:rebuild_tftp).returns(true)
       @nic.expects(:rebuild_dns).never
       @nic.expects(:rebuild_dhcp).never
-      Nic::Managed.expects(:rebuild_methods_for).returns(:rebuild_tftp => "TFTP")
+      Nic::Managed.stubs(:rebuild_methods_for).returns(:rebuild_tftp => "TFTP")
     end
 
     test "recreate TFTP config with success" do

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -90,7 +90,7 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
 
   context 'locked templates outside of rake' do
     setup do
-      Foreman.expects(:in_rake?).returns(false).at_least_once
+      Foreman.stubs(:in_rake?).returns(false)
       @template = templates(:locked)
     end
 

--- a/test/unit/concerns/api_hosts_controller_extension_test.rb
+++ b/test/unit/concerns/api_hosts_controller_extension_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ApiHostsControllerExtensionTest < ActiveSupport::TestCase
   setup do
     @klass = Class.new
-    @klass.expects(:before_action).with(:find_resource)
+    @klass.stubs(:before_action).with(:find_resource)
     @klass.send :include, Api::V2::HostsControllerExtension
   end
 
@@ -19,12 +19,12 @@ class ApiHostsControllerExtensionTest < ActiveSupport::TestCase
       @instance = @klass.new
 
       params = { :action => 'permissions_check_test' }
-      @instance.expects(:params).returns(params)
+      @instance.stubs(:params).returns(params)
       @host = mock('mock_host')
       @host.stubs(:id).returns(1000)
       @instance.instance_variable_set '@host', @host
 
-      Host.expects(:authorized).with(:permissions_check_test_hosts, Host).returns(@result)
+      Host.stubs(:authorized).with(:permissions_check_test_hosts, Host).returns(@result)
     end
 
     teardown do

--- a/test/unit/concerns/scopes_per_action_test.rb
+++ b/test/unit/concerns/scopes_per_action_test.rb
@@ -9,7 +9,7 @@ class ScopesPerActionTest < ActiveSupport::TestCase
     self.class.add_scope_for(:test_action) { |base_scope| base_scope.includes(:my_table1) }
 
     @scope = mock('scope')
-    @scope_expectation = @scope.expects(:includes).with(:my_table1)
+    @scope_expectation = @scope.stubs(:includes).with(:my_table1)
   end
 
   test 'returns the same scope if callback returns nil' do

--- a/test/unit/proxy_api/dhcp_test.rb
+++ b/test/unit/proxy_api/dhcp_test.rb
@@ -28,7 +28,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
 
     describe '#record' do
       setup do
-        proxy_dhcp.expects(:get).with('192.168.0.0/mac/192.168.0.10').returns(fake_rest_client_response(fake_response))
+        proxy_dhcp.stubs(:get).with('192.168.0.0/mac/192.168.0.10').returns(fake_rest_client_response(fake_response))
       end
 
       test 'retrieves an array with a single dhcp record' do
@@ -47,7 +47,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
 
     describe '#records_by_ip' do
       setup do
-        proxy_dhcp.expects(:get).with('192.168.0.0/ip/192.168.0.10').returns(fake_rest_client_response([fake_response]))
+        proxy_dhcp.stubs(:get).with('192.168.0.0/ip/192.168.0.10').returns(fake_rest_client_response([fake_response]))
       end
 
       test 'retrieves an array with a single dhcp record' do

--- a/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_puppetca_test.rb
@@ -15,7 +15,7 @@ class ProxyStatusPuppetcaTest < ActiveSupport::TestCase
                        "proxy.host.with_no_dates" => {"state" => "valid", "fingerprint" => "SHA256", "serial" => 5, "not_before" => nil, "not_after" => nil},
                        "refuted.host" => {"state" => "refuted", "fingerprint" => "SHA256", "serial" => 4, "not_before" => "2015-12-22T14:33:10UTC", "not_after" => "2020-12-22T14:33:10UTC"},
                        "pending.host" => {"state" => "pending", "fingerprint" => "SHA256", "serial" => 6}}
-      ProxyAPI::Puppetca.any_instance.expects(:all).returns(certificates)
+      ProxyAPI::Puppetca.any_instance.stubs(:all).returns(certificates)
     end
 
     test 'it returns all certificates' do
@@ -42,7 +42,7 @@ class ProxyStatusPuppetcaTest < ActiveSupport::TestCase
 
   context 'CA has no certificates' do
     setup do
-      ProxyAPI::Puppetca.any_instance.expects(:all).returns({})
+      ProxyAPI::Puppetca.any_instance.stubs(:all).returns({})
     end
 
     test 'it returns no certificates' do


### PR DESCRIPTION
I know this might bring some controversy, but I believe that *all* test
expectations belong to tests themselves. This is all about style,
nothing should improve or make things faster of course.