### PR TITLE
Fixes #23346 - memory cache store is used for tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,8 +57,8 @@ Foreman::Application.configure do
   # Raise exception on mass assignment of unfiltered parameters
   config.action_controller.action_on_unpermitted_parameters = :strict
 
-  # Use separate cache stores for parallel_tests
-  config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")
+  # Use default memory cache (32 MB top)
+  config.cache_store = :memory_store
 
   # Enable automatic creation/migration of the test DB when running tests
   config.active_record.maintain_test_schema = true

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -56,9 +56,6 @@ class ActiveSupport::TestCase
 
   def reset_rails_cache
     Rails.cache.clear
-  rescue Errno::ENOENT
-    # Clear on a file cache fails on a clean checkout when the cache hasn't been written to.
-    # This rescue may be removed on Rails 5 (16d7cfb fixes it).
   end
 
   # for backwards compatibility to between Minitest syntax


### PR DESCRIPTION
The only difference is that this will be a little faster, I haven't
measured myself but it can be a difference on Jenkins where I/O is
limited.