### PR TITLE
Fixes #23361 - Write the webpack manifest to a tmp file

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -17,7 +17,7 @@ specs.each do |dep|
   # skip other rails engines that are not plugins
   # TODO: Consider using the plugin registration api?
   if gemfile_in
-    next unless dep =~ plugin_name_regexp
+    next unless dep.name =~ plugin_name_regexp
     dep = dep.to_spec
   else
     next unless dep.name =~ plugin_name_regexp


### PR DESCRIPTION
In a production setup Foreman can't write to the manifest.json location so it needs a temporary location. Here we copy the pattern from the above sprockets initialization and change the webpack-rails setting to read it.