### PR TITLE
fixes #23335 - normalize scsi attributes in rails 5

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/host.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/host.rb
@@ -2,6 +2,7 @@ module Foreman::Controller::Parameters::Host
   extend ActiveSupport::Concern
   include Foreman::Controller::Parameters::HostBase
   include Foreman::Controller::Parameters::HostCommon
+  include Foreman::Controller::NormalizeScsiAttributes
 
   class_methods do
     def host_params_filter
@@ -31,6 +32,10 @@ module Foreman::Controller::Parameters::Host
   end
 
   def host_params(top_level_hash = controller_name.singularize)
-    self.class.host_params_filter.filter_params(params, parameter_filter_context, top_level_hash)
+    self.class.host_params_filter.filter_params(params, parameter_filter_context, top_level_hash).tap do |normalized|
+      if parameter_filter_context.ui? && normalized["compute_attributes"] && normalized["compute_attributes"]["scsi_controllers"]
+        normalize_scsi_attributes(normalized["compute_attributes"])
+      end
+    end
   end
 end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -9,7 +9,6 @@ class HostsController < ApplicationController
   include Foreman::Controller::HostFormCommon
   include Foreman::Controller::Puppet::HostsControllerExtensions
   include Foreman::Controller::CsvResponder
-  include Foreman::Controller::NormalizeScsiAttributes
   include Foreman::Controller::ConsoleCommon
 
   SEARCHABLE_ACTIONS= %w[index active errors out_of_sync pending disabled]
@@ -40,7 +39,6 @@ class HostsController < ApplicationController
   before_action :set_host_type, :only => [:update]
   before_action :find_multiple, :only => MULTIPLE_ACTIONS
   before_action :validate_power_action, :only => :update_multiple_power_state
-  before_action :normalize_vm_attributes, :only => [:create, :update, :process_taxonomy]
 
   helper :hosts, :reports, :interfaces
 
@@ -889,12 +887,6 @@ class HostsController < ApplicationController
 
   def csv_columns
     [:name, :operatingsystem, :environment, :compute_resource_or_model, :hostgroup, :last_report]
-  end
-
-  def normalize_vm_attributes
-    if host_params["compute_attributes"] && host_params["compute_attributes"]["scsi_controllers"]
-      normalize_scsi_attributes(host_params["compute_attributes"])
-    end
   end
 
   def origin_intervals_query(compare_with)

--- a/test/controllers/concerns/parameters/host_test.rb
+++ b/test/controllers/concerns/parameters/host_test.rb
@@ -10,7 +10,7 @@ class HostParametersTest < ActiveSupport::TestCase
   test "passes through :compute_attributes hash untouched" do
     inner_params = {:name => 'test.example.com', :compute_attributes => {:foo => 'bar', :memory => 2}}
     expects(:params).at_least_once.returns(ActionController::Parameters.new(:host => inner_params))
-    expects(:parameter_filter_context).returns(context)
+    expects(:parameter_filter_context).at_least_once.returns(context)
     filtered = host_params
 
     assert_equal 'test.example.com', filtered['name']
@@ -20,11 +20,22 @@ class HostParametersTest < ActiveSupport::TestCase
   test "correctly passes through :interfaces_attributes :compute_attributes hash" do
     inner_params = {:name => 'test.example.com', :interfaces_attributes => [{:name => 'abc', :compute_attributes => {:type => 'awesome', :network => 'superawesome'}}]}
     expects(:params).at_least_once.returns(ActionController::Parameters.new(:host => inner_params))
-    expects(:parameter_filter_context).returns(ui_context)
+    expects(:parameter_filter_context).at_least_once.returns(ui_context)
     filtered = host_params
 
     assert_equal 'test.example.com', filtered['name']
     assert_equal 'abc', filtered['interfaces_attributes'][0][:name]
     assert_equal({'type' => 'awesome', 'network' => 'superawesome'}, filtered['interfaces_attributes'][0]['compute_attributes'].to_h)
+  end
+
+  test 'normalizes json scsi attributes' do
+    inner_params = {:name => 'test.example.com', :compute_attributes => {"scsi_controllers"=>"{\"scsiControllers\":[{\"type\":\"VirtualLsiLogicController\",\"key\":1000}],\"volumes\":[{\"thin\":true,\"name\":\"Hard disk\",\"mode\":\"persistent\",\"controllerKey\":1000,\"size\":10485760,\"sizeGb\":10,\"storagePod\":\"Example-Pod\"}]}"}}
+    expects(:params).at_least_once.returns(ActionController::Parameters.new(:host => inner_params))
+    expects(:parameter_filter_context).at_least_once.returns(ui_context)
+    filtered = host_params
+
+    assert_equal 'test.example.com', filtered['name']
+    assert_equal [{"type"=>"VirtualLsiLogicController", "key"=>1000}], filtered['compute_attributes']['scsi_controllers']
+    assert_equal({"0"=>{"thin"=>true, "name"=>"Hard disk", "mode"=>"persistent", "controller_key"=>1000, "size"=>10485760, "size_gb"=>10, "storage_pod"=>"Example-Pod"}}, filtered['compute_attributes']['volumes_attributes'])
   end
 end


### PR DESCRIPTION
(cherry picked from commit 397ea4882382bd15bd271fa772e10e789f1e4952)

This cherry-picks #5475 into `1.18-stable`.