### PR TITLE
Fixes #23376 - subnet.vlanid size is 4 bytes

### DIFF
--- a/db/migrate/20180424080702_change_subnet_vlanid_size.rb
+++ b/db/migrate/20180424080702_change_subnet_vlanid_size.rb
@@ -1,0 +1,12 @@
+class ChangeSubnetVlanidSize < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :subnets, :vlanid, :integer, limit: 4
+      end
+      dir.down do
+        change_column :subnets, :vlanid, :string, limit: 10
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves "ActiveRecord::ActiveRecordError: No integer type has byte size
10. Use a decimal with scale 0 instead." for MySQL users. It is worth
backporting into 1.17 as this is a blocker issue for all MySQL users I
guess.

It used to be string with 10 chars, we converted it to integer with 10
bytes limit which only PostgreSQL handles correctly.