### PR TITLE
Refs #23177 - datetime precision fixed for unattended test

### DIFF
--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -201,8 +201,10 @@ class UnattendedControllerTest < ActionController::TestCase
       ptable_ubuntu = FactoryBot.create(:ptable, :ubuntu, :name => 'ubuntu default',
         :layout => 'd-i partman-auto/disk string /dev/sda\nd-i partman-auto/method string regular...',
                                          :operatingsystem_ids => [operatingsystems(:ubuntu1010).id])
+      # MySQL datetime precision is seconds - explicitly create host1 with tomorrow's created_at
       host1 = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :build => true,
         :name => "host2_same_mac",
+        :created_at => Time.now.tomorrow,
         :mac => @rh_host.mac,
         :operatingsystem => operatingsystems(:ubuntu1010),
         :ptable => ptable_ubuntu,
@@ -215,7 +217,6 @@ class UnattendedControllerTest < ActionController::TestCase
       assert @rh_host.created_at
       assert host1.created_at
       assert @rh_host.created_at <= host1.created_at, "host created at #{@rh_host.created_at} must be older than host created at #{host1.created_at}"
-      skip "Randomly fails on MySQL - investigating: http://projects.theforeman.org/issues/23177"
       assert_equal "finish for #{host1.name}", response.body
       assert_response :success
     end


### PR DESCRIPTION
It looks like PostgreSQL has milisecond precision for datetime columns but MySQL has only seconds. I created a test which relied on `created_at` column but on MySQL this was obviously failing.

Rails 5+ and MySQL 5.6.4+ is now able to handle datetime columns in miliseconds:

https://blog.bigbinary.com/2016/02/23/rails-5-handles-datetime-with-better-precision.html

This needs a migration for our app, not sure if it is worth it but would be nice to have the consistent behavior on both main database platforms. The migration must be executed on MySQL 5.6.4+ version tho, otherwise it won't be effective:

https://gist.github.com/MarkMurphy/93adca601b05acffb8b5601df09f66df

For now, I will only fix the test which was failing.

Discussion at:

https://community.theforeman.org/t/heads-up-mysql-datetime-precision-is-seconds-by-default/8888