### PR TITLE
Fixes #23379 - proxy stubs on API level

### DIFF
--- a/test/controllers/api/v2/config_reports_controller_test.rb
+++ b/test/controllers/api/v2/config_reports_controller_test.rb
@@ -47,8 +47,8 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
       Setting[:restrict_registered_smart_proxies] = true
       Setting[:require_ssl_smart_proxies] = false
 
+      ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
       proxy = smart_proxies(:puppetmaster)
-      proxy.stubs(:associate_features)
       as_admin { proxy.update_attribute(:url, 'http://configreports.foreman') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -586,8 +586,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test 'hosts with a registered smart proxy on should import facts successfully' do
+    ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
     proxy = smart_proxies(:puppetmaster)
-    proxy.stubs(:associate_features)
     proxy.update_attribute(:url, 'https://factsimporter.foreman')
 
     User.current = users(:one) # use an unprivileged user, not apiadmin

--- a/test/controllers/api/v2/reports_controller_test.rb
+++ b/test/controllers/api/v2/reports_controller_test.rb
@@ -52,8 +52,8 @@ class Api::V2::ReportsControllerTest < ActionController::TestCase
       Setting[:restrict_registered_smart_proxies] = true
       Setting[:require_ssl_smart_proxies] = false
 
+      ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
       proxy = smart_proxies(:puppetmaster)
-      proxy.stubs(:associate_features)
       as_admin { proxy.update_attribute(:url, 'http://configreports.foreman') }
       host = URI.parse(proxy.url).host
       Resolv.any_instance.stubs(:getnames).returns([host])

--- a/test/controllers/api/v2/smart_proxies_controller_test.rb
+++ b/test/controllers/api/v2/smart_proxies_controller_test.rb
@@ -179,11 +179,10 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
 
   test "should refresh smart proxy features" do
     proxy = smart_proxies(:one)
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
     post :refresh, params: { :id => proxy }
     assert_response :success
     response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal [{'name' => 'DHCP', 'id' => features(:dhcp).id}], response['features']
+    assert_equal Feature.all.pluck(:name).flatten.sort, response['features'].map{|x| x['name']}.sort
   end
 
   test "should return errors during smart proxy refresh" do
@@ -191,7 +190,6 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
     errors = ActiveModel::Errors.new(Host::Managed.new)
     errors.add :base, "Unable to communicate with the proxy: it's down"
     SmartProxy.any_instance.stubs(:errors).returns(errors)
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
     post :refresh, params: { :id => proxy }, session: set_session_user
     assert_response :unprocessable_entity
   end

--- a/test/controllers/smart_proxies_controller_test.rb
+++ b/test/controllers/smart_proxies_controller_test.rb
@@ -5,7 +5,7 @@ class SmartProxiesControllerTest < ActionController::TestCase
   basic_pagination_per_page_test
 
   setup do
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
+    ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
   end
 
   def test_index
@@ -25,7 +25,6 @@ class SmartProxiesControllerTest < ActionController::TestCase
   end
 
   def test_create_valid
-    ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
     SmartProxy.any_instance.stubs(:valid?).returns(true)
     SmartProxy.any_instance.stubs(:to_s).returns("puppet")
     post :create, params: { :smart_proxy => {:name => "MySmartProxy", :url => "http://nowhere.net:8000"} }, session: set_session_user
@@ -62,7 +61,7 @@ class SmartProxiesControllerTest < ActionController::TestCase
 
   def test_refresh
     proxy = smart_proxies(:one)
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
+    SmartProxy.any_instance.stubs(:features).returns([features(:dns)])
     post :refresh, params: { :id => proxy }, session: set_session_user
     assert_redirected_to smart_proxies_url
     assert_equal "No changes found when refreshing features from DHCP Proxy.", flash[:success]
@@ -70,7 +69,6 @@ class SmartProxiesControllerTest < ActionController::TestCase
 
   def test_refresh_change
     proxy = smart_proxies(:one)
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
     SmartProxy.any_instance.stubs(:features).returns([features(:dns)]).then.returns([features(:dns), features(:tftp)])
     post :refresh, params: { :id => proxy }, session: set_session_user
     assert_redirected_to smart_proxies_url
@@ -82,7 +80,6 @@ class SmartProxiesControllerTest < ActionController::TestCase
     errors = ActiveModel::Errors.new(Host::Managed.new)
     errors.add :base, "Unable to communicate with the proxy: it is down"
     SmartProxy.any_instance.stubs(:errors).returns(errors)
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
     post :refresh, params: { :id => proxy }, session: set_session_user
     assert_redirected_to smart_proxies_url
     assert_equal "Unable to communicate with the proxy: it is down", flash[:error]

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -4,7 +4,7 @@ require 'pagelets_test_helper'
 class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     ProxyStatus::Version.any_instance.stubs(:version).returns({'version' => '1.11', 'modules' => {'dhcp' => '1.11'}})
-    SmartProxy.any_instance.stubs(:associate_features).returns(true)
+    ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
   end
 
   test "index page" do


### PR DESCRIPTION
We see random failures unexpected invocation: statuses() on Jenkins:

http://ci.theforeman.org/job/test_plugin_pull_request/4956/

This does not happen locally for me, anyway I am trying this patch to
move stubs from Proxy model to API which seems to be more clean - method
`associate_features` simply calls refresh which is stubbed in API and it
also works as expected.