### PR TITLE
Refs #23215 - 2.3 compat. for webpack in plugins script

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -27,7 +27,7 @@ specs.each do |dep|
   # some plugins share the same base directory (tasks-core and tasks, REX etc)
   # skip the plugin if its path is already included
   next if config[:paths].include?(path)
-  if Dir.exist?(path) && !dep.files.any? { |f| f.match?(/webpack/) }
+  if Dir.exist?(path) && !dep.files.any? { |f| /webpack/ =~ f }
     STDERR.puts "WARNING: webpack was found in #{dep.name}'s source, "\
       "but it's not in the gemspec. Please add it to the gemspec."
   end


### PR DESCRIPTION
.match? was only introduced on 2.4, therefore it's failing to run
on 2.3 and test pipelines for plugins with webpack & Ruby 2.3 fail

This was merged to develop but not to 1.18-stable  



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
