### PR TITLE
Fixes #23195 - Audit associations on creation and destruction (#5455)

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -19,7 +19,7 @@ module Taxonomix
     scoped_search :relation => :organizations, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
     dirty_has_many_associations :organizations, :locations
-    audit_associations :organizations, :locations
+    audit_associations :organizations, :locations if self.respond_to? :audit_associations
 
     validate :ensure_taxonomies_not_escalated, :if => Proc.new { User.current.nil? || !User.current.admin? }
   end

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -3,10 +3,9 @@
 require 'audited'
 
 # Re-opened AuditorInstanceMethods to audit 1-0-* associations
-Auditor = Audited::Auditor::AuditedInstanceMethods
-Auditor.send(:include, AuditAssociations)
+Audited::Auditor::AuditedInstanceMethods.send(:prepend, AuditAssociations::AssociationsChanges)
 
-::ActiveRecord::Base.send :include, AuditAssociations::Auditor
+ApplicationRecord.send(:extend, AuditAssociations::AssociationsDefinitions)
 
 # Audit includes Taxonomix which already relies on DSL provided by audited gem
 Audit = Audited::Audit

--- a/test/models/concerns/audit_associations_test.rb
+++ b/test/models/concerns/audit_associations_test.rb
@@ -1,9 +1,48 @@
 require 'test_helper'
 
 class AuditAssociationsTest < ActiveSupport::TestCase
-  test ":find_association_class should be give a class_name" do
-    user_obj = User.new
-    role_class = user_obj.send('find_association_class', 'roles')
+  setup do
+    @user = FactoryBot.build(:user)
+  end
+
+  let (:role) { FactoryBot.create(:role) }
+
+  test "find_association_class should be give a class_name" do
+    role_class = @user.send('find_association_class', 'roles')
     assert_equal Role, role_class
+  end
+
+  test "Should audit associations on creation" do
+    @user.role_ids = [role.id]
+    @user.save!
+
+    audit = @user.audits.last
+    assert_equal role.to_label, audit.audited_changes['roles']
+    assert_equal 'create', audit.action
+  end
+
+  test "Should audit associations on update" do
+    @user.save!
+    assert_empty @user.audits.last.audited_changes['roles']
+
+    @user.role_ids = [role.id]
+    @user.save!
+
+    audit = @user.audits.last
+    assert_equal ["", role.to_label], audit.audited_changes['roles']
+    assert_equal 'update', audit.action
+  end
+
+  test "Should audit associations on destruction" do
+    @user.role_ids = [role.id]
+    @user.save!
+    assert_equal role.to_label, @user.audits.last.audited_changes['roles']
+
+    @user.destroy!
+
+    audit = @user.audits.last
+    # The default role is added in after_save to the user
+    assert_equal [Role.default.to_label, role.to_label].sort.join(', '), audit.audited_changes['roles']
+    assert_equal 'destroy', audit.action
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1216,7 +1216,7 @@ class UserTest < ActiveSupport::TestCase
       audited_changes = recent_audit.audited_changes[:roles]
 
       assert audited_changes, 'No audits found for user-roles'
-      assert_equal [@role.name, Role.default].join(', '), audited_changes.first
+      assert_equal [Role.default.to_label, @role.to_label].sort.join(', '), audited_changes.first
       assert_empty audited_changes.last
     end
 


### PR DESCRIPTION
Also includes a bit of refactoring to the AuditAssociations module.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
