### PR TITLE
 Fixes #23386 - Exit fullscreen when pressing ESC 

### DIFF
--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -335,7 +335,7 @@ export function enterFullscreen(element, relativeTo) {
   $(document).on('keyup', (e) => {
     if (e.keyCode === 27) {
       // esc
-      exit_fullscreen_editor();
+      exitFullscreen();
     }
   });
   Editor.resize(true);


### PR DESCRIPTION
Pressing the escape key should make the editor exit
the fullscreen mode.  Nonetheless, when this key is pressed
the "exit_fullscreen_editor" function is called but
it was renamed to "exitFullscreen" which ends up with an error
message in the console.

In this patch, I updated the called function to be "exitFullscreen"
so it will be possible to exit fullscreen when escape key is pressed.