### PR TITLE
fixes #23378 - vsphere: filter volume key parameter in react ui

### DIFF
--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import { omit } from 'lodash';
 
 import Controller from './controller/';
 import * as VmWareActions from '../../../../redux/actions/hosts/storage/vmware';
 import { MaxDisksPerController } from './StorageContainer.consts';
 import './StorageContainer.scss';
 
-const controllersToJsonString = (controllers, volumes) =>
+const filterKeyFromVolume = (volume) => {
+  // eslint-disable-next-line no-unused-vars
+  const { key, ...volumeWithoutKey } = volume;
+  return volumeWithoutKey;
+};
+
+export const controllersToJsonString = (controllers, volumes) =>
   JSON.stringify({
     scsiControllers: controllers,
-    volumes: volumes.map(v => omit(v, 'key')),
+    volumes: volumes.map(v => filterKeyFromVolume(v)),
   });
 
 class StorageContainer extends React.Component {

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.test.js
@@ -1,0 +1,28 @@
+import { controllersToJsonString } from './index';
+
+describe('controllersToJsonString', () => {
+  it('removes the key parameter from volumes', () => {
+    const volumes = [
+      {
+        thin: true,
+        name: 'Hard disk',
+        mode: 'persistent',
+        controllerKey: 1000,
+        size: 10485760,
+        sizeGb: 10,
+        key: 'bd3ebb40-4862-11e8-9aaf-adeef3f61848',
+      },
+    ];
+
+    const controllers = [
+      {
+        type: 'VirtualLsiLogicController',
+        key: 1000,
+      },
+    ];
+
+    const expectedJson = '{"scsiControllers":[{"type":"VirtualLsiLogicController","key":1000}],"volumes":[{"thin":true,"name":"Hard disk","mode":"persistent","controllerKey":1000,"size":10485760,"sizeGb":10}]}';
+
+    expect(controllersToJsonString(controllers, volumes)).toEqual(expectedJson);
+  });
+});


### PR DESCRIPTION
This is one of the bugs that question your faith in computers being deterministic individuals...

The vSphere UI generates JSON and stores that in a hidden field.
On `1.18-stable` the JSON looks like this:
```json
{"scsiControllers":[{"type":"VirtualLsiLogicController","key":1000}],"volumes":[{"thin":true,"name":"Hard disk","mode":"persistent","controllerKey":1000,"size":10485760,"sizeGb":10}]}
```

On `1.17-stable` the JSON looks like this:
```json
{"scsiControllers":[{"type":"VirtualLsiLogicController","key":1000}],"volumes":[{"thin":true,"name":"Hard disk","mode":"persistent","controllerKey":1000,"size":10485760,"sizeGb":10,"key":"bd3ebb40-4862-11e8-9aaf-adeef3f61848"}]}
```
The extra hash key named `key` causes an error.
On `1.16-stable` we haven't received any bug reports that I know of.

I have solved this by replacing the lodash `omit` with a custom implementation, but haven't had time to investigate the actual root cause. I'm opening this PR to show my progress.