### PR TITLE
fixes #23232 - fix error when domain not in taxonomy

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -116,7 +116,15 @@ module Nic
     end
 
     def shortname
-      domain.nil? ? name : name.to_s.chomp("." + domain.name)
+      if domain
+        name.to_s.chomp("." + domain.name)
+      elsif domain_id && (unscoped_domain = Domain.unscoped.find_by(id: domain_id))
+        # If domain is nil, but domain_id is set, domain could be
+        # in another taxonomy.  Don't fail to create a correct shortname.
+        name.to_s.chomp("." + unscoped_domain.name)
+      else
+        name
+      end
     end
 
     def validated?

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -78,7 +78,7 @@ module Nic
     end
 
     def fqdn_before_last_save
-      domain_before_last_save = Domain.find(domain_id_before_last_save) if domain_id_before_last_save.present?
+      domain_before_last_save = Domain.unscoped.find(domain_id_before_last_save) if domain_id_before_last_save.present?
       return name_before_last_save if name_before_last_save.blank? || domain_before_last_save.blank?
       name_before_last_save.include?('.') ? name_before_last_save : "#{name_before_last_save}.#{domain_before_last_save}"
     end
@@ -124,10 +124,10 @@ module Nic
       return if name.empty?
       if domain_id.nil? && name.include?('.') && changed_attributes['domain_id'].blank?
         # try to assign the domain automatically based on our existing domains from the host FQDN
-        self.domain = Domain.find_by(:name => name.partition('.')[2])
+        self.domain = Domain.unscoped.find_by(:name => name.partition('.')[2])
       elsif persisted? && changed_attributes['domain_id'].present?
         # if we've just updated the domain name, strip off the old one
-        old_domain = Domain.find(changed_attributes["domain_id"])
+        old_domain = Domain.unscoped.find(changed_attributes["domain_id"])
         # Remove the old domain, until fqdn will be set as the full name
         self.name = self.name.chomp('.' + old_domain.to_s)
       end

--- a/test/models/hosts/base_test.rb
+++ b/test/models/hosts/base_test.rb
@@ -75,5 +75,17 @@ module Host
       assert host.primary_interface
       assert_equal 1, host.interfaces.size
     end
+
+    test 'shortname periods check considers domain outside taxonomy scope' do
+      host_org = FactoryBot.create(:organization)
+      other_org = FactoryBot.create(:organization)
+
+      domain = FactoryBot.create(:domain, organizations: [other_org])
+      refute domain.organizations.include?(host_org)
+
+      host = FactoryBot.create(:host, organization: host_org, domain_id: domain.id)
+      host = Host.find(host.id)
+      assert host.valid?
+    end
   end
 end

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -465,7 +465,6 @@ class NicTest < ActiveSupport::TestCase
     nic_name = 'hostname.sub.bigdomain'
     interface = FactoryBot.build_stubbed(:nic_managed, :name => nic_name)
     subdomain = FactoryBot.create(:domain, :name => 'sub.bigdomain')
-    Domain.expects(:find_by).with(:name => subdomain.name).returns(subdomain)
     interface.send(:normalize_name)
     assert_equal subdomain, interface.domain
   end
@@ -474,9 +473,6 @@ class NicTest < ActiveSupport::TestCase
     nic_name = 'hostname.undefined-subdomain.bigdomain'
     FactoryBot.create(:domain, :name => 'bigdomain')
     interface = FactoryBot.build_stubbed(:nic_managed, :name => nic_name)
-    Domain.expects(:find_by).
-      with(:name => 'undefined-subdomain.bigdomain').
-      returns(nil)
     interface.send(:normalize_name)
     refute interface.domain
   end


### PR DESCRIPTION
In Foreman, you can set a host’s associations to ones that are not in
the host’s own org. That results in some weird behaviour, especially
once Organization.current is set. In Katello, Organization.current is
always set, so you end up with things like Foreman thinking a host has
no domain and not validating the FQDN because it thinks it has periods
that aren’t part of the domain name.

~~This PR adds a setting to automatically fix mismatches when a new host
is created. This can reduce the friction when creating a host from
"Any Context," or via the API.  It also changes the host shortname check
to consider the Domain from an unscoped perspective, in case, for
example, the domain is not part of the host org.  Otherwise, the
shortname check fails with "Host name must not include periods."~~



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
