### PR TITLE
Fixes #23398 - Don't extend ApplicationRecord from Audit initializer

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,9 @@
+require_relative 'concerns/audit_associations'
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  extend AuditAssociations::AssociationsDefinitions
 
   # Rails use Notifications for own sql logging so we can override sql logger for orchestration
   def logger

--- a/config/initializers/audit.rb
+++ b/config/initializers/audit.rb
@@ -5,8 +5,6 @@ require 'audited'
 # Re-opened AuditorInstanceMethods to audit 1-0-* associations
 Audited::Auditor::AuditedInstanceMethods.send(:prepend, AuditAssociations::AssociationsChanges)
 
-ApplicationRecord.send(:extend, AuditAssociations::AssociationsDefinitions)
-
 # Audit includes Taxonomix which already relies on DSL provided by audited gem
 Audit = Audited::Audit
 Audit.send(:include, AuditExtensions)


### PR DESCRIPTION
This fixes an error thrown as a result incorrect extending of ApplicationRecord from the Audit initializer.

As per the description in the commit message:

Any changes to the code locally will kick in rails's auto loading which in turn
will then reload all relevant classes, and in the case of changing a model
inheriting from ApplicationRecord, then ApplicationRecord be reloaded. So since
ApplicationRecord was being extended from within the initializer for audit then
it will load the extend however the module with still be hanging around, causing
rails throw an argument error: 'A copy of
AuditAssociations::AssociationsDefinitions has been removed from the module tree
but is still active!'.

Also note, audit_associations needs to be required because at the time of app
start up during initialization the audit_associations has not yet been loaded.
See the config/application.rb for the loading order and one can see that models
are loaded long before the audit_associations.
