### PR TITLE
Fixes #23415 - nullify taxonomy associations for audits

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -218,6 +218,14 @@ class Taxonomy < ApplicationRecord
     self.subtree.flat_map(&:users).map(&:id).uniq
   end
 
+  # note - this method used by before_destroy callbacks in extension files from plugins
+  # audits for 'destroy' action on resources lead to taxable_taxonomies records.
+  # This will check if any taxable_taxonomies records present and apply destroy_all
+  # so that it nullifies all associated audit records
+  def destroy_taxable_taxonomies
+    TaxableTaxonomy.where(taxonomy_id: self.id).destroy_all
+  end
+
   private
 
   delegate :need_to_be_selected_ids, :selected_ids, :used_and_selected_ids, :mismatches, :missing_ids, :check_for_orphans,


### PR DESCRIPTION
On taxonomy destroy, nullify taxonomy associations for audit
records that are created by 'destroy' action on dependent
resources.

---

cherry pick of https://github.com/theforeman/foreman/pull/5502 cc @xprazak2 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
