### PR TITLE
Refs #23414 - Compile webpack bundles with plugin name

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -23,6 +23,7 @@ specs.each do |dep|
   # some plugins share the same base directory (tasks-core and tasks, REX etc)
   # skip the plugin if its path is already included
   next if config[:paths].include?(path)
+  next unless dep.files.include? 'package.json'
   next unless Dir.exist?(path)
   next unless File.exist?("#{dep.to_spec.full_gem_path}/package.json")
   package_json = JSON.parse(File.read("#{dep.to_spec.full_gem_path}/package.json"))


### PR DESCRIPTION
Currently the script is reading '_core' plugins first, such as
'foreman_remote_execution_core'. Since the script does not check the
gemspec at all, it doesn't know whether it's foreman_remote_execution
or foreman_remote_execution_core the plugin that has webpack
dependencies.

I have added a check for 'package.json' inside the plugin deps. That way
the script can be absolutely sure it's creating the bundle with the
right name.

An alternative proposed in the IRC channel by @ehelms would be to move `foreman_remote_execution_core` and `foreman_ansible_core` into a directory so that the gemspec is not in the root of the repo again. Or even to a different repo, thoughts @iNecas @bastilian @adamruzicka ?

** DO NOT MERGE YET ** 