### PR TITLE
Fixes #23462 - bump patternfly-react to ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.15.0",
     "multiselect": "~0.9.12",
     "patternfly": "3.41.6",
-    "patternfly-react": "^1.16.0",
+    "patternfly-react": "^2.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",


### PR DESCRIPTION
patternfly-react 2.1.0 introduced inline editing for tables (see https://github.com/patternfly/patternfly-react/releases).