### PR TITLE
Fixes #23468 - Add a test helper to test reducers with fixtures

### DIFF
--- a/webpack/assets/javascripts/react_app/common/testHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/testHelpers.js
@@ -82,3 +82,14 @@ export const testActionSnapshot = async (runAction) => {
 export const testActionSnapshotWithFixtures = fixtures =>
   Object.entries(fixtures).forEach(([description, runAction]) =>
     it(description, () => testActionSnapshot(runAction)));
+
+/**
+ * Test a reducer with fixtures and snapshots
+ * @param  {Function} reducer  reducer to test
+ * @param  {Object}   fixtures key=fixture description, value=props to apply
+ */
+export const testReducerSnapshotWithFixtures = (reducer, fixtures) => {
+  const reduce = ({ state, action = {} } = {}) => reducer(state, action);
+  Object.entries(fixtures).forEach(([description, action]) =>
+    it(description, () => expect(reduce(action)).toMatchSnapshot()));
+};

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarReducer.test.js
@@ -7,6 +7,7 @@ import {
 } from '../BreadcrumbBarConstants';
 import reducer from '../BreadcrumbBarReducer';
 
+import { testReducerSnapshotWithFixtures } from '../../../common/testHelpers';
 import { resource, resourceList } from '../BreadcrumbBar.fixtures';
 
 const fixtures = {
@@ -55,9 +56,4 @@ const fixtures = {
   },
 };
 
-describe('BreadcrumbBar reducer', () => {
-  const reduce = ({ state, action = {} } = {}) => reducer(state, action);
-
-  Object.entries(fixtures).forEach(([description, action]) =>
-    it(description, () => expect(reduce(action)).toMatchSnapshot()));
-});
+describe('BreadcrumbBar reducer', () => testReducerSnapshotWithFixtures(reducer, fixtures));

--- a/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/PasswordStrengthReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/PasswordStrengthReducer.test.js
@@ -4,25 +4,24 @@ import {
 } from '../PasswordStrengthConstants';
 
 import reducer from '../PasswordStrengthReducer';
+import { testReducerSnapshotWithFixtures } from '../../../common/testHelpers';
 
-describe('PasswordStrength reducer', () => {
-  const reduce = ({ state, action = {} } = {}) => reducer(state, action);
+const fixtures = {
+  'should return the initial state': {},
 
-  it('should return the initial state', () => expect(reduce()).toMatchSnapshot());
+  'should handle PASSWORD_STRENGTH_PASSWORD_CHANGED': {
+    action: {
+      type: PASSWORD_STRENGTH_PASSWORD_CHANGED,
+      payload: 'some-password',
+    },
+  },
 
-  it('should handle PASSWORD_STRENGTH_PASSWORD_CHANGED', () =>
-    expect(reduce({
-      action: {
-        type: PASSWORD_STRENGTH_PASSWORD_CHANGED,
-        payload: 'some-password',
-      },
-    })).toMatchSnapshot());
+  'should handle PASSWORD_STRENGTH_PASSWROD_CONFIRMATION_CHANGED': {
+    action: {
+      type: PASSWORD_STRENGTH_PASSWROD_CONFIRMATION_CHANGED,
+      payload: 'some-password',
+    },
+  },
+};
 
-  it('should handle PASSWORD_STRENGTH_PASSWROD_CONFIRMATION_CHANGED', () =>
-    expect(reduce({
-      action: {
-        type: PASSWORD_STRENGTH_PASSWROD_CONFIRMATION_CHANGED,
-        payload: 'some-password',
-      },
-    })).toMatchSnapshot());
-});
+describe('PasswordStrength reducer', () => testReducerSnapshotWithFixtures(reducer, fixtures));


### PR DESCRIPTION
The idea of testing a reducer using fixtures was introduced in [the BreadcrumBar tests](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarReducer.test.js#L50-L53).

Since, other components are going to be tested using this method, it is moved to [testHelpers.js](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/common/testHelpers.js) to avoid duplication of code.


/cc @sharvit @amirfefer PTAL