### PR TITLE
Fixes - #23440 Removing pclasses with API can't use friendly

### DIFF
--- a/app/controllers/api/v2/host_classes_controller.rb
+++ b/app/controllers/api/v2/host_classes_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
 
       before_action :find_host, :only => [:index, :create, :destroy]
-      before_action :find_puppetclass, :only => [:create]
+      before_action :find_puppetclass, :only => [:create, :destroy]
 
       api :GET, "/hosts/:host_id/puppetclass_ids/", N_("List all Puppet class IDs for host")
 
@@ -26,7 +26,7 @@ module Api
       param :id, String, :required => true, :desc => N_("ID of Puppet class")
 
       def destroy
-        @host_class = HostClass.authorized(:edit_classes).where(:host_id => @host.id, :puppetclass_id => params[:id])
+        @host_class = HostClass.authorized(:edit_classes).where(:host_id => @host.id, :puppetclass_id => @puppetclass.id)
         process_response @host_class.destroy_all
       end
 
@@ -45,7 +45,12 @@ module Api
       end
 
       def find_puppetclass
-        @puppetclass = resource_finder(Puppetclass.authorized(:view_puppetclasses), params[:puppetclass_id])
+        if params[:action] == 'create'
+          puppetclass_id = params[:puppetclass_id]
+        else
+          puppetclass_id = params[:id]
+        end
+        @puppetclass = resource_finder(Puppetclass.authorized(:view_puppetclasses), puppetclass_id)
       end
     end
   end

--- a/test/controllers/api/v2/host_classes_controller_test.rb
+++ b/test/controllers/api/v2/host_classes_controller_test.rb
@@ -31,4 +31,9 @@ class Api::V2::HostClassesControllerTest < ActionController::TestCase
     post :create, params: { :host_id => @host.to_param, :puppetclass_id => "invalid_id" }
     assert_response :not_found
   end
+
+  test "should not delete a puppetclass that does not exist from a host" do
+    post :destroy, params: { :host_id => @host.to_param, :id => "invalid_id" }
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
This PR is to address - Bug #23440. Friendly can't be utlised when deleting a puppetclass from a host using the API. This will also mean that validation occurs when an API call is attempted that the puppetclass does indeed exist.