### PR TITLE
Fixes #23483: edit Foreman license info so that GitHub recognizes it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,41 +1,3 @@
-The Foreman repository/package is licensed under the GNU GPL v3 or newer,
-with some exceptions.
-
-Copyright (c) 2009-2016 to Ohad Levy, Paul Kelly and their respective owners.
-
-All copyright holders for the Foreman project are in the separate file called
-Contributors.
-
-Except where specified below, this program and entire repository is free
-software: you can redistribute it and/or modify it under the terms of the GNU
-General Public License as published by the Free Software Foundation, either
-version 3 of the License, or any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.
-If not, see [GNU licenses](http://www.gnu.org/licenses/).
-
-The following files and directories are exceptions:
-
-* app/views/unattended/ztp/provision.erb is (c) 2013, Juniper Networks under 2-clause BSD license.
-* lib/tasks/convert.rake is (c) 2008, Matson Systems, Inc. under Revised BSD license.
-* extras/noVNC/websockify is (c) 2011, Joel Martin under LGPL v3 license.
-* vendor/assets/fonts/ is (c) 2011-2016, Red Hat Inc. under SIL Open Font License v1.1 or LGPL v2.1 licenses.
-* vendor/assets/javascripts/noVNC/ is (c) 1999 AT&T Laboratories Cambridge, (c) 1996 Widget Workshop, Inc., (c) 1996 Jef Poskanzer <jef@acme.com>, (c) 2011 Joel Martin, (c) Hiroshi Ichikawa <http://gimite.net/en/>, (c) Martijn Pieters <mj@digicool.com>, Samuel Sieb <samuel@sieb.net> under (MPL 1.1 or GPL v2+ or LGPL v2.1+) and LGPL v3 and LGPL v2+ and MIT and Revised BSD licenses.
-* vendor/assets/javascripts/jquery.flot.axislabels.js is (c) 2010 Xuan Luo under MIT license.
-* app/assets/images/RancherOS.png is (c) 2018 Rancher Labs, Inc.
-
-All rights reserved.
-
-All the licenses mentioned above now follows:
-
-------------------------------------------------------------------------
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -655,6 +617,43 @@ reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an “about box”.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <http://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <http://www.gnu.org/philosophy/why-not-lgpl.html>.
 
 -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ We keep a repository of talks, tutorials, articles about everything in the Forem
 The original authors of this project are [Ohad Levy](https://github.com/ohadlevy) and [Paul Kelly](https://github.com/pikelly).
 You can find a more thorough list of people who have contributed to this project at some point in [Contributors](Contributors).
 
-# License
+# Licensing
 
 See [LICENSE](LICENSE) file.
+
+The Foreman repository/package is licensed under the GNU GPL v3 or newer, with some exceptions.
+
+Copyright (c) 2009-2018 to Ohad Levy, Paul Kelly and their respective owners.
+
+All copyright holders for the Foreman project are in the separate file called Contributors.
+
+Except where specified below, this program and entire repository is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program. If not, see [GNU licenses](http://www.gnu.org/licenses/).
+
+The following files and directories are exceptions:
+
+* app/views/unattended/ztp/provision.erb is (c) 2013, Juniper Networks under 2-clause BSD license.
+* lib/tasks/convert.rake is (c) 2008, Matson Systems, Inc. under Revised BSD license.
+* extras/noVNC/websockify is (c) 2011, Joel Martin under LGPL v3 license.
+* vendor/assets/fonts/ is (c) 2011-2016, Red Hat Inc. under SIL Open Font License v1.1 or LGPL v2.1 licenses.
+* vendor/assets/javascripts/noVNC/ is (c) 1999 AT&T Laboratories Cambridge, (c) 1996 Widget Workshop, Inc., (c) 1996 Jef Poskanzer <jef@acme.com>, (c) 2011 Joel Martin, (c) Hiroshi Ichikawa <http://gimite.net/en/>, (c) Martijn Pieters <mj@digicool.com>, Samuel Sieb <samuel@sieb.net> under (MPL 1.1 or GPL v2+ or LGPL v2.1+) and LGPL v3 and LGPL v2+ and MIT and Revised BSD licenses.
+* vendor/assets/javascripts/jquery.flot.axislabels.js is (c) 2010 Xuan Luo under MIT license.
+* app/assets/images/RancherOS.png is (c) 2018 Rancher Labs, Inc.
+
+All rights reserved.
+
+The [LICENSE](LICENSE) file contains the full text of the GNU GPL v3 license, along with the text for all additional licenses referenced above.


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=foreman)

GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit modifies LICENSE so that it begins with the full text of
the GPL 3.0 license. The text that was previously at the beginning of
LICENSE has been moved to the relevant section of the README, which has
been renamed to "Licensing". At the bottom of the "Licensing" section,
there is a note that mentions to the reader that they can reference
LICENSE to see the full text of not only the GPL 3.0 license, but also
all licenses related to Foreman's dependencies.

Collectively, these changes allow Licensee to successfully identify the
license type of Foreman as GPL 3.0.

Here is the output I get when I run Licensee locally on Foreman's remote repo:
```
$ licensee detect https://github.com/theforeman/foreman
License:        Other
Matched files:  LICENSE, README.md, package.json
LICENSE:
  Content hash:  a17b7fcbdc64255d04d0b05e6642373a8ccdf97f
  License:       Other
  Closest licenses:
    GPL-3.0 similarity:   77.68%
    AGPL-3.0 similarity:  74.68%
    LGPL-2.1 similarity:  53.60%
README.md:
  Content hash:  18f341307338ee217d08193931fa550b30ed563b
  License:       Other
  Closest licenses:
    WTFPL similarity:    5.00%
    MS-RL similarity:    2.34%
    BSL-1.0 similarity:  1.75%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     GNU General Public License v3.0
```

And here is the output I get when I run Licensee on my local clone of Foreman (on the `update-license` branch):
```
License:        GNU General Public License v3.0
Matched files:  LICENSE, package.json
LICENSE:
  Content hash:  f9aaff304edbbe732f27b554dcb6abe49e0b4fa0
  Attribution:   Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       GNU General Public License v3.0
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     GNU General Public License v3.0
```