### PR TITLE
Fixes #23417 - telemetry for audit record creation

### DIFF
--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -22,3 +22,4 @@ telemetry.add_histogram(:importer_facts_populate_duration, 'Duration of fields p
 telemetry.add_counter(:importer_facts_count_input, 'Number of facts before imports starts per importer type', [:type])
 telemetry.add_counter(:importer_facts_count_processed, 'Number of facts processed (added, updated, deleted) per importer type', [:type, :action])
 telemetry.add_counter(:importer_facts_count_interfaces, 'Number of changed interfaces per importer type', [:type])
+telemetry.add_counter(:audit_records_created, 'Number of audit records created', [:type])


### PR DESCRIPTION
It's worth monitoring how many audits are being created. We expect
increase in the upcoming version.

Creates:

```
Incrementing counter fm_rails_audit_records_created by 1 {:type=>"Environment"}
```