### PR TITLE
Fixes 23486 - remove js warnings when a modal opens

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "patternfly-react": "^1.16.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
-    "react-bootstrap": "^0.31.5",
+    "react-bootstrap": "^0.32.1",
     "react-dom": "^16.2.0",
     "react-ellipsis-with-tooltip": "^1.0.7",
     "react-numeric-input": "^2.0.7",

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
@@ -15,7 +15,6 @@ const BreadcrumbSwitcherPopover = ({
   hasError,
   currentPage,
   totalPages,
-  appear, // remove the appear from the ...props
   ...props
 }) => {
   let popoverBody;

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
@@ -42,13 +42,12 @@ class ChartBox extends React.Component {
     const Chart = components[type];
     const dataFiltered = chart.data && chart.data.filter(arr => arr[1] !== 0);
     const hasChartData = dataFiltered && dataFiltered.length > 0;
-    const tooltip = hasChartData
+    const headerProps = hasChartData
       ? {
         onClick: this.onClick,
         title: this.props.tip,
         'data-toggle': 'tooltip',
         'data-placement': 'top',
-        className: 'pointer',
       }
       : {};
     const handleChartClick =
@@ -68,25 +67,32 @@ class ChartBox extends React.Component {
         icontype="error-circle-o"
       />
     );
-    const boxHeader = <h3 {...tooltip}>{this.props.title}</h3>;
+    const boxHeader = (
+      <h3 className="pointer panel-title" {...headerProps}>
+        {this.props.title}
+      </h3>
+    );
 
     return (
       <Panel className="chart-box" header={boxHeader} key={this.props.chart.id}>
-        <Loader status={this.props.status}>{[panelChart, error]}</Loader>
-        {this.state.showModal && (
-          <Modal
-            show={this.state.showModal}
-            enforceFocus
-            onHide={this.closeModal}
-          >
-            <Modal.Header closeButton>
-              <Modal.Title>{this.props.title}</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-              <Chart {...chartProps} config="large" />;
-            </Modal.Body>
-          </Modal>
-        )}
+        <Panel.Heading>{boxHeader}</Panel.Heading>
+        <Panel.Body>
+          <Loader status={this.props.status}>{[panelChart, error]}</Loader>
+          {this.state.showModal && (
+            <Modal
+              show={this.state.showModal}
+              enforceFocus
+              onHide={this.closeModal}
+            >
+              <Modal.Header closeButton>
+                <Modal.Title>{this.props.title}</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <Chart {...chartProps} config="large" />;
+              </Modal.Body>
+            </Modal>
+          )}
+        </Panel.Body>
       </Panel>
     );
   }

--- a/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/statistics/__snapshots__/ChartBox.test.js.snap
@@ -1,72 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartBox error 1`] = `
-<Panel
-  bsClass="panel"
-  bsStyle="default"
+<Uncontrolled(Panel)
   className="chart-box"
-  defaultExpanded={false}
   header={
-    <h3>
+    <h3
+      className="pointer panel-title"
+    >
       some title
     </h3>
   }
   key="2"
 >
-  <Loader
-    status="PENDING"
+  <PanelHeading
+    bsClass="panel"
+    componentClass="div"
   >
-    <DonutChart
-      key="2-chart"
-      onclick={[Function]}
-    />
-    <MessageBox
-      icontype="error-circle-o"
-      key="2-error"
-      msg="some error"
-    />
-  </Loader>
-</Panel>
+    <h3
+      className="pointer panel-title"
+    >
+      some title
+    </h3>
+  </PanelHeading>
+  <PanelBody
+    bsClass="panel"
+    collapsible={false}
+  >
+    <Loader
+      status="PENDING"
+    >
+      <DonutChart
+        key="2-chart"
+        onclick={[Function]}
+      />
+      <MessageBox
+        icontype="error-circle-o"
+        key="2-error"
+        msg="some error"
+      />
+    </Loader>
+  </PanelBody>
+</Uncontrolled(Panel)>
 `;
 
 exports[`ChartBox pending 1`] = `
-<Panel
-  bsClass="panel"
-  bsStyle="default"
+<Uncontrolled(Panel)
   className="chart-box"
-  defaultExpanded={false}
   header={
-    <h3>
+    <h3
+      className="pointer panel-title"
+    >
       some title
     </h3>
   }
   key="2"
 >
-  <Loader
-    status="PENDING"
+  <PanelHeading
+    bsClass="panel"
+    componentClass="div"
   >
-    <DonutChart
-      key="2-chart"
-      onclick={[Function]}
-    />
-    <MessageBox
-      icontype="error-circle-o"
-      key="2-error"
-      msg="some error"
-    />
-  </Loader>
-</Panel>
+    <h3
+      className="pointer panel-title"
+    >
+      some title
+    </h3>
+  </PanelHeading>
+  <PanelBody
+    bsClass="panel"
+    collapsible={false}
+  >
+    <Loader
+      status="PENDING"
+    >
+      <DonutChart
+        key="2-chart"
+        onclick={[Function]}
+      />
+      <MessageBox
+        icontype="error-circle-o"
+        key="2-error"
+        msg="some error"
+      />
+    </Loader>
+  </PanelBody>
+</Uncontrolled(Panel)>
 `;
 
 exports[`ChartBox resolved 1`] = `
-<Panel
-  bsClass="panel"
-  bsStyle="default"
+<Uncontrolled(Panel)
   className="chart-box"
-  defaultExpanded={false}
   header={
     <h3
-      className="pointer"
+      className="pointer panel-title"
       data-placement="top"
       data-toggle="tooltip"
       onClick={[Function]}
@@ -77,26 +102,45 @@ exports[`ChartBox resolved 1`] = `
   }
   key="2"
 >
-  <Loader
-    status="PENDING"
+  <PanelHeading
+    bsClass="panel"
+    componentClass="div"
   >
-    <DonutChart
-      data={
-        Array [
+    <h3
+      className="pointer panel-title"
+      data-placement="top"
+      data-toggle="tooltip"
+      onClick={[Function]}
+      title="sone tooltip"
+    >
+      some title
+    </h3>
+  </PanelHeading>
+  <PanelBody
+    bsClass="panel"
+    collapsible={false}
+  >
+    <Loader
+      status="PENDING"
+    >
+      <DonutChart
+        data={
           Array [
-            1,
-            2,
-          ],
-        ]
-      }
-      key="2-chart"
-      onclick={[Function]}
-    />
-    <MessageBox
-      icontype="error-circle-o"
-      key="2-error"
-      msg="some error"
-    />
-  </Loader>
-</Panel>
+            Array [
+              1,
+              2,
+            ],
+          ]
+        }
+        key="2-chart"
+        onclick={[Function]}
+      />
+      <MessageBox
+        icontype="error-circle-o"
+        key="2-error"
+        msg="some error"
+      />
+    </Loader>
+  </PanelBody>
+</Uncontrolled(Panel)>
 `;


### PR DESCRIPTION
When a react-bootstrap modal opens, there are some js errors:

![screenshot from 2018-05-03 15-57-01](https://user-images.githubusercontent.com/11807069/39581992-855ffe20-4ef5-11e8-8263-1c036600aefe.png)
upgrade `bootstrap-react` solves this.

plus it solves another js warning in the `breadcrumbsBar` that warns about unknown`appear` prop