### PR TITLE
Fixes #23487 - support namespaced controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 
   # standard layout to all controllers
   helper 'layout'
-  helper_method :authorizer
+  helper_method :authorizer, :resource_path
 
   before_action :require_login
   before_action :set_gettext_locale_db, :set_gettext_locale
@@ -43,6 +43,21 @@ class ApplicationController < ActionController::Base
   # this method is returns the active user which gets used to populate the audits table
   def current_user
     User.current
+  end
+
+  def resource_path(type)
+    return '' if type.nil?
+
+    path = type.pluralize.underscore + "_path"
+    prefix, suffix = path.split('/', 2)
+    if path.include?("/") && Rails.application.routes.mounted_helpers.method_defined?(prefix)
+      # handle mounted engines
+      engine = send(prefix)
+      engine.send(suffix) if engine.respond_to?(suffix)
+    else
+      path = path.tr("/", "_")
+      send(path) if respond_to?(path)
+    end
   end
 
   protected

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -71,14 +71,14 @@ class DashboardController < ApplicationController
     process_ajax_error exception, 'save positions'
   end
 
+  def resource_name
+    "widget"
+  end
+
   private
 
   def init_widget_data
     find_resource unless @widget
     @data = Dashboard::Data.new(params[:search], @widget.data[:settings])
-  end
-
-  def resource_name
-    "widget"
   end
 end

--- a/app/helpers/filters_helper.rb
+++ b/app/helpers/filters_helper.rb
@@ -11,27 +11,12 @@ module FiltersHelper
         else
           return FiltersHelperOverrides.search_path(type) if FiltersHelperOverrides.can_override?(type)
           resource_path = resource_path(type)
-          resource_path.nil? ? "" : resource_path + auto_complete_search_path
+          resource_path.blank? ? "" : (resource_path + auto_complete_search_path)
       end
     end
   end
 
   def auto_complete_search_path
     '/auto_complete_search'
-  end
-
-  def resource_path(type)
-    return '' if type.nil?
-
-    path = type.pluralize.underscore + "_path"
-    prefix, suffix = path.split('/', 2)
-    if path.include?("/") && Rails.application.routes.mounted_helpers.method_defined?(prefix)
-      # handle mounted engines
-      engine = send(prefix)
-      engine.send(suffix) if engine.respond_to?(suffix)
-    else
-      path = path.tr("/", "_")
-      send(path) if respond_to?(path)
-    end
   end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -17,7 +17,7 @@ module LayoutHelper
   end
 
   def mount_breadcrumbs(options = {}, &block)
-    options = BreadcrumbsOptions.new(@page_header, controller_name, action_name, block_given? ? yield : options)
+    options = BreadcrumbsOptions.new(@page_header, controller, action_name, block_given? ? yield : options)
 
     mount_react_component("BreadcrumbBar", "#breadcrumb", options.bar_props.to_json)
   end

--- a/app/services/breadcrumbs_options.rb
+++ b/app/services/breadcrumbs_options.rb
@@ -2,9 +2,9 @@ class BreadcrumbsOptions
   # TODO: extract URL handing from menu/item and use it here too
   include Rails.application.routes.url_helpers
 
-  def initialize(page_header, controller_name, action_name, options = {})
+  def initialize(page_header, controller, action_name, options = {})
     @page_header = page_header
-    @controller_name = controller_name
+    @controller = controller
     @action_name = action_name
     @options = options
   end
@@ -20,11 +20,18 @@ class BreadcrumbsOptions
   private
 
   delegate :logger, :to => :Rails
-  attr_reader :controller_name, :action_name, :page_header, :options
+  delegate :resource_name, :resource_class, :controller_path, :resource_path, :to => :controller
+  attr_reader :controller, :action_name, :page_header, :options
   def index_item
+    begin
+      class_name = resource_class.to_s
+    rescue
+      class_name = ''
+    end
+
     {
-      caption: _(controller_name.humanize),
-      url: try("#{controller_name}_path")
+      caption: _(resource_name.pluralize.humanize),
+      url: resource_path(class_name)
     }
   end
 
@@ -48,14 +55,20 @@ class BreadcrumbsOptions
 
   def switcher_url_template
     actual_action_name = (action_name == 'show') ? '' : action_name
-    "/#{controller_name}/:id/#{actual_action_name}"
+    if respond_to?(resource_name + '_path')
+      resource_path = try(resource_name + '_path', :id => ':id')
+    else
+      resource_path = "/#{controller_path}/:id"
+    end
+
+    "#{resource_path}/#{actual_action_name}"
   end
 
   def model_name_field
-    controller_name.camelize.singularize.try(:constantize).try(:title_name)
+    resource_class.try(:title_name)
   rescue => err
     # TODO: better handling for plugin detection
-    logger.warn("unable to detect breadcrumb title name in for #{controller_name}, defaulting to name")
+    logger.warn("unable to detect breadcrumb title name in for #{controller_path}, defaulting to name")
     logger.debug(err)
     "name"
   end
@@ -64,7 +77,7 @@ class BreadcrumbsOptions
     return unless switchable?
     {
       switcherItemUrl: options[:switcher_item_url] || switcher_url_template,
-      resourceUrl: options[:resource_url] || "/api/v2/#{controller_name}",
+      resourceUrl: options[:resource_url] || "/api/v2/#{controller_path}",
       nameField: options[:name_field] || model_name_field || 'name'
     }
   end

--- a/test/helpers/filters_helper_test.rb
+++ b/test/helpers/filters_helper_test.rb
@@ -17,7 +17,6 @@ class FiltersHelperTest < ActionView::TestCase
   end
 
   def test_search_path_for_foreman_model
-    expects(:resource_path).with('Host').returns('hosts_path')
     assert_equal 'hosts_path/auto_complete_search', search_path('Host')
   end
 
@@ -36,6 +35,10 @@ class FiltersHelperTest < ActionView::TestCase
   end
 
   private
+
+  def resource_path(klass)
+    (klass == 'Host') ? 'hosts_path' : nil
+  end
 
   def with_search_overrides(search_overrides)
     plugin = mock('ExamplePlugin')

--- a/test/unit/breadcrumbs_options_test.rb
+++ b/test/unit/breadcrumbs_options_test.rb
@@ -1,21 +1,39 @@
 require "test_helper"
 
 class BreadcrumbsOptionsTest < ActiveSupport::TestCase
+  class FakeController
+    def resource_class
+      String
+    end
+
+    def resource_name
+      'string'
+    end
+
+    def controller_path
+      'strings'
+    end
+
+    def resource_path(_resource)
+      'strings'
+    end
+  end
+
   def setup
     @page_header = "a page"
-    @controller_name = "SomePage"
+    @controller = FakeController.new
     @action_name = "show"
   end
 
   test "it should provide default breadcrumb options" do
-    options = BreadcrumbsOptions.new(@page_header, @controller_name, @action_name, {})
+    options = BreadcrumbsOptions.new(@page_header, @controller, @action_name, {})
 
     assert_equal options.bar_props, {
       isSwitchable: true,
       breadcrumbItems: [
         {
-          caption: "Somepage",
-          url: nil
+          caption: "Strings",
+          url: 'strings'
         },
         {
           caption: "a page"
@@ -23,8 +41,8 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
       ],
       resource:
       {
-        switcherItemUrl: "/SomePage/:id/",
-        resourceUrl: "/api/v2/SomePage",
+        switcherItemUrl: "/strings/:id/",
+        resourceUrl: "/api/v2/strings",
         nameField: "name"
       }
     }
@@ -43,7 +61,7 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
     custom_resource_url = "/api/v2/custom_page"
     custom_switcher_item_url = '/customPage/:id'
 
-    options = BreadcrumbsOptions.new(@page_header, @controller_name, @action_name,
+    options = BreadcrumbsOptions.new(@page_header, @controller, @action_name,
                                    { items: custom_items, switcher_item_url: custom_switcher_item_url,
                                      resource_url: custom_resource_url })
 
@@ -60,15 +78,15 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
   end
 
   test "it should be switchable" do
-    options = BreadcrumbsOptions.new(@page_header, @controller_name, 'show', {})
-    custom_options = BreadcrumbsOptions.new(@page_header, @controller_name, 'index', { switchable: true})
+    options = BreadcrumbsOptions.new(@page_header, @controller, 'show', {})
+    custom_options = BreadcrumbsOptions.new(@page_header, @controller, 'index', { switchable: true})
 
     assert_equal options.bar_props[:isSwitchable], true
     assert_equal custom_options.bar_props[:isSwitchable], true
   end
 
   test "it shouldn't be switchable" do
-    options = BreadcrumbsOptions.new(@page_header, @controller_name, 'index', {})
+    options = BreadcrumbsOptions.new(@page_header, @controller, 'index', {})
 
     assert_equal options.bar_props[:isSwitchable], false
   end


### PR DESCRIPTION
```
controller_name #=> foreman_virt_who_configure_configs
controller_path #=> foreman_virt_who_configure/configs
```

also it's better to use controller `resource_name` and `resource_class` that are used elsewhere for mapping resource name

ping @sharvit @amirfefer, I marked this as 1.18 cherry-pick since this was introduced in this version, otherwise we'd need to disable resource switcher in namespaced plugins

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
