### PR TITLE
Fixes #21997 - make http_proxy extension excon >0.59 compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,6 @@ gem 'rails-i18n', '~> 5.0'
 gem 'turbolinks', '>= 2.5.4', '< 3'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '1.45.0'
-# lib/foreman/http_proxy/excon_connection_extension.rb is not compatible
-# with excon 0.60, see https://projects.theforeman.org/issues/21997
-gem 'excon', '>= 0.58', '< 0.60'
 gem 'net-scp'
 gem 'net-ssh'
 gem 'net-ldap', '>= 0.8.0'

--- a/lib/foreman/http_proxy.rb
+++ b/lib/foreman/http_proxy.rb
@@ -31,12 +31,12 @@ module Foreman
       !http_host_excepted_by_wildcard?(request_host)
     end
 
-    def logger
+    def foreman_logger
       Foreman::Logging.logger('app')
     end
 
     def log_proxied_request(current_proxy, requested_host)
-      logger.info "Proxying request to #{requested_host} via #{current_proxy}"
+      foreman_logger.info "Proxying request to #{requested_host} via #{current_proxy}"
     end
 
     def http_host_excepted_by_wildcard?(host)


### PR DESCRIPTION
excon 0.60 defines it's own "logger", which conflicts here.