### PR TITLE
fixes #23499 - port robottelo tests for filters

### DIFF
--- a/test/controllers/api/v2/filters_controller_test.rb
+++ b/test/controllers/api/v2/filters_controller_test.rb
@@ -22,6 +22,8 @@ class Api::V2::FiltersControllerTest < ActionController::TestCase
       post :create, params: { :filter => valid_attrs }
     end
     assert_response :created
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal show_response["permissions"].first["name"], "view_architectures"
   end
 
   test "should update filter" do

--- a/test/controllers/api/v2/roles_controller_test.rb
+++ b/test/controllers/api/v2/roles_controller_test.rb
@@ -48,6 +48,17 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
     assert_equal perm_count, r.permissions.count
   end
 
+  test "should remove role with associated filters" do
+    role = FactoryBot.create(:role, :name => "New Role")
+    FactoryBot.create(:filter, :role_id => role.id, :permission_ids => [permissions(:view_domains).id])
+    assert_difference('Role.count', -1) do
+      assert_difference('Filter.count', -1) do
+        delete :destroy, params: { :id => role.id }
+      end
+    end
+    assert_response :success
+  end
+
   test "should clone role and its taxonomies" do
     new_name = "New Role"
     loc = Location.first


### PR DESCRIPTION
port robottelo tier1 tests for filters

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5876

```
ruby -I test test/controllers/api/v2/filters_controller_test.rb 

Api::V2::FiltersControllerTest#test_0003_should create filter = 0.08 s = .
Api::V2::FiltersControllerTest#test_0005_should destroy filters = 0.48 s = .
...

ruby -I test test/controllers/api/v2/roles_controller_test.rb -vvvv

Api::V2::RolesControllerTest#test_0010_should remove role with associated filters = 0.32 s = .
```