### PR TITLE
Fixes #23511 - Generate webpack plugins in context of vendor/bundle

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -118,7 +118,7 @@ Foreman::Application.configure do |app|
             Rails.logger.debug { "Loading #{plugin.id} webpack asset manifest from #{manifest_path}" }
             assets = JSON.parse(File.read(manifest_path))
 
-            webpack_manifest['assetsByChunkName'] = webpack_manifest['assetsByChunkName'].merge(assets['assetsByChunkName'])
+            webpack_manifest['assetsByChunkName'][plugin.id.to_s] = assets['assetsByChunkName'][plugin.id.to_s] if assets['assetsByChunkName'].key?(plugin.id.to_s)
           end
         end
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -34,25 +34,25 @@ module.exports = env => {
   if (env && env.pluginName !== undefined) {
     var pluginEntries = {};
     pluginEntries[env.pluginName] = plugins['entries'][env.pluginName];
-    var entry = pluginEntries;
     var outputPath = path.join(plugins['plugins'][env.pluginName]['root'], 'public', 'webpack');
     var jsFilename = production ? env.pluginName + '/[name]-[chunkhash].js' : env.pluginName + '/[name].js';
     var cssFilename = production ? env.pluginName + '/[name]-[chunkhash].css' : env.pluginName + '/[name].css';
     var manifestFilename = env.pluginName + '/manifest.json';
   } else {
     var pluginEntries = plugins['entries'];
-    var entry = Object.assign(
-      {
-        bundle: bundleEntry,
-        vendor: vendorEntry,
-      },
-      pluginEntries
-    )
     var outputPath = path.join(__dirname, '..', 'public', 'webpack');
     var jsFilename = production ? '[name]-[chunkhash].js' : '[name].js';
     var cssFilename = production ? '[name]-[chunkhash].css' : '[name].css';
     var manifestFilename = 'manifest.json';
   }
+
+  var entry = Object.assign(
+    {
+      bundle: bundleEntry,
+      vendor: vendorEntry,
+    },
+    pluginEntries
+  );
 
   var config = {
     entry: entry,
@@ -149,13 +149,10 @@ module.exports = env => {
     ]
   };
 
-  if (!env || !env.pluginName) {
-    config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
-        name: 'vendor',
-        minChunks: Infinity,
-      })
-    )
-  }
+  config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
+    name: 'vendor',
+    minChunks: Infinity,
+  }))
 
   if (production) {
     config.plugins.push(

--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -17,6 +17,7 @@ specs.each do |dep|
   # skip other rails engines that are not plugins
   # TODO: Consider using the plugin registration api?
   next unless dep.name =~ plugin_name_regexp
+  next if dep.name.include?('_core')
   dep = dep.to_spec if gemfile_in
 
   path = "#{dep.to_spec.full_gem_path}/webpack"


### PR DESCRIPTION
Previously, the plugin bundles were being compiled as if the vendor and bundle Javascripts were not present thus bundling in more than was needed. This can lead to out of order, or double up loading of library assets such as jQuery breaking plugin expectations that different from development. This generates the plugin assets in relation to those bundles. The net downside is a bundle-.js and vendor-.js will be generated for each plugin. The code that loads the plugin manifests is updated to ensure only the plugins entry into the manifest is loaded. 