### PR TITLE
Fixes #23521 - BreadcrumbBar nested name_field

### DIFF
--- a/webpack/assets/javascripts/react_app/common/testHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/testHelpers.js
@@ -53,6 +53,32 @@ export const shallowRenderComponentWithFixtures = (Component, fixtures) =>
  * @param  {Object}         fixtures  key=fixture description, value=props to apply
  */
 export const testComponentSnapshotsWithFixtures = (Component, fixtures) =>
-  shallowRenderComponentWithFixtures(Component, fixtures)
-    .forEach(({ description, component }) =>
-      it(description, () => expect(toJson(component)).toMatchSnapshot()));
+  shallowRenderComponentWithFixtures(Component, fixtures).forEach(({ description, component }) =>
+    it(description, () => expect(toJson(component)).toMatchSnapshot()));
+
+/**
+ * run an action (sync or async) and except the results to much snapshot
+ * @param  {Function}  runAction  Action runner function
+ * @return {Promise}
+ */
+export const testActionSnapshot = async (runAction) => {
+  const actionResults = runAction();
+
+  // if it's an async action
+  if (typeof actionResults === 'function') {
+    const dispatch = jest.fn();
+    await actionResults(dispatch);
+
+    expect(dispatch.mock.calls).toMatchSnapshot();
+  } else {
+    expect(actionResults).toMatchSnapshot();
+  }
+};
+
+/**
+ * Test actions with fixtures and snapshots
+ * @param  {Object} fixtures key=fixture description, value=action runner function
+ */
+export const testActionSnapshotWithFixtures = fixtures =>
+  Object.entries(fixtures).forEach(([description, runAction]) =>
+    it(description, () => testActionSnapshot(runAction)));

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
@@ -24,6 +24,12 @@ export const resource = {
   switcherItemUrl: 'some/url/:id',
 };
 
+export const resourceWithNestedFields = {
+  resourceUrl: 'some/url',
+  nameField: 'user.name',
+  switcherItemUrl: 'some/url/:id',
+};
+
 export const resourceList = [
   { id: '1', name: 'Host 1', url: '#' },
   { id: '2', name: 'Host 2', url: '#' },
@@ -45,6 +51,19 @@ export const serverResourceListResponse = {
       { id: '1', name: 'name-1' },
       { id: '2', name: 'name-2' },
       { id: '3', name: 'name-3' },
+    ],
+  },
+};
+
+export const serverResourceListWithNestedFieldsResponse = {
+  data: {
+    page: 1,
+    total: 3,
+    per_page: 2,
+    results: [
+      { id: '1', name: 'name-1', user: { name: 'username-1' } },
+      { id: '2', name: 'name-2', user: { name: 'username-2' } },
+      { id: '3', name: 'name-3', user: { name: 'username-3' } },
     ],
   },
 };

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
@@ -1,4 +1,4 @@
-import { flatten } from 'lodash';
+import { flatten, get } from 'lodash';
 import API from '../../API';
 
 import {
@@ -38,7 +38,7 @@ export const loadSwitcherResourcesByResource = (resource, options = {}) => (disp
 
   const formatResults = ({ data }) => {
     const switcherItems = flatten(Object.values(data.results)).map(result => ({
-      name: result[nameField],
+      name: get(result, nameField),
       id: result.id,
       url: switcherItemUrl.replace(':id', result.id),
     }));

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarActions.test.js
@@ -1,39 +1,43 @@
 import API from '../../../API';
+import { testActionSnapshotWithFixtures } from '../../../common/testHelpers';
 import {
   toggleSwitcher,
   closeSwitcher,
   loadSwitcherResourcesByResource,
 } from '../BreadcrumbBarActions';
-import { resource, serverResourceListResponse } from '../BreadcrumbBar.fixtures';
+import {
+  resource,
+  resourceWithNestedFields,
+  serverResourceListResponse,
+  serverResourceListWithNestedFieldsResponse,
+} from '../BreadcrumbBar.fixtures';
 
 jest.mock('../../../API');
 
-describe('BreadcrumbBar actions', () => {
-  it('should toggle-switcher', () => expect(toggleSwitcher()).toMatchSnapshot());
+const runLoadSwitcherResourcesByResourceAction = (resourceMock, serverMock) => {
+  API.get.mockImplementation(serverMock);
 
-  it('should close-switcher', () => expect(closeSwitcher()).toMatchSnapshot());
+  return loadSwitcherResourcesByResource(resourceMock);
+};
 
-  it('should load-switcher-resources-by-resource and success', async () => {
-    API.get.mockImplementation(async () => serverResourceListResponse);
+const fixtures = {
+  'should toggle-switcher': () => toggleSwitcher(),
 
-    const dispatch = jest.fn();
-    const dispatcher = loadSwitcherResourcesByResource(resource);
+  'should close-switcher': () => closeSwitcher(),
 
-    await dispatcher(dispatch);
+  'should load-switcher-resources-by-resource and success': () =>
+    runLoadSwitcherResourcesByResourceAction(resource, async () => serverResourceListResponse),
 
-    expect(dispatch.mock.calls).toMatchSnapshot();
-  });
+  'should load-switcher-resources-by-resource-with-nested-fields and success': () =>
+    runLoadSwitcherResourcesByResourceAction(
+      resourceWithNestedFields,
+      async () => serverResourceListWithNestedFieldsResponse,
+    ),
 
-  it('should load-switcher-resources-by-resource and fail', async () => {
-    API.get.mockImplementation(async () => {
+  'should load-switcher-resources-by-resource and fail': () =>
+    runLoadSwitcherResourcesByResourceAction(resource, async () => {
       throw new Error('some-error');
-    });
+    }),
+};
 
-    const dispatch = jest.fn();
-    const dispatcher = loadSwitcherResourcesByResource(resource);
-
-    await dispatcher(dispatch);
-
-    expect(dispatch.mock.calls).toMatchSnapshot();
-  });
-});
+describe('BreadcrumbBar actions', () => testActionSnapshotWithFixtures(fixtures));

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBarActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBarActions.test.js.snap
@@ -70,6 +70,47 @@ Array [
 ]
 `;
 
+exports[`BreadcrumbBar actions should load-switcher-resources-by-resource-with-nested-fields and success 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "options": Object {},
+        "resourceUrl": "some/url",
+      },
+      "type": "BREADCRUMB_BAR_RESOURCES_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "items": Array [
+          Object {
+            "id": "1",
+            "name": "username-1",
+            "url": "some/url/1",
+          },
+          Object {
+            "id": "2",
+            "name": "username-2",
+            "url": "some/url/2",
+          },
+          Object {
+            "id": "3",
+            "name": "username-3",
+            "url": "some/url/3",
+          },
+        ],
+        "page": 1,
+        "pages": 1.5,
+        "resourceUrl": "some/url",
+      },
+      "type": "BREADCRUMB_BAR_RESOURCES_SUCCESS",
+    },
+  ],
+]
+`;
+
 exports[`BreadcrumbBar actions should toggle-switcher 1`] = `
 Object {
   "type": "BREADCRUMB_BAR_TOGGLE_SWITCHER",


### PR DESCRIPTION
The goal is to allow nested values in the `name_field`. (e.g. `user.name`)
See: https://github.com/theforeman/foreman-tasks/pull/330/files/8f2fff9c930c90c4193e5c945b1a632dd30ae2a3#r184344657