### PR TITLE
Fixes #23248 - disable breadcrumb switcher in compute attributes page

### DIFF
--- a/app/views/compute_attributes/edit.html.erb
+++ b/app/views/compute_attributes/edit.html.erb
@@ -16,8 +16,7 @@
         caption: _('Edit %s' % @set.compute_profile.to_label)
       }
     ],
-    resource_url: api_compute_resource_compute_profiles_path(@set.compute_resource),
-    switcher_item_url: edit_compute_profile_compute_attribute_path(@set.compute_profile.to_param, ':id')
+    switchable: false,
   )
 %>
 


### PR DESCRIPTION
The breadcrumb switcher doesn't function as intended, and may link to wrong pages.
therefore it would be better to turn the switcher off until a fix.
a RM [issue](http://projects.theforeman.org/issues/23525) has been opened