### PR TITLE
Fixes #23527 - enable breadcrumbs switcher in trends

### DIFF
--- a/app/views/trends/_empty_data.html.erb
+++ b/app/views/trends/_empty_data.html.erb
@@ -1,5 +1,4 @@
 <% title(_("Trends for %s") % trend_title(@trend)) %>
-<% breadcrumbs(switchable: false) %>
 <div class="row">
   <div class="stats-well col-md-12">
     <p><strong><%= _('No data for this trend.') %></strong></p>

--- a/app/views/trends/edit.html.erb
+++ b/app/views/trends/edit.html.erb
@@ -1,5 +1,4 @@
 <% title _("Edit Trend %s") % @trend.to_label %>
-<% breadcrumbs(switchable: false) %>
 <div class="col-md-6">
   <%= form_tag trend_path, :method => :put do %>
     <% if @trend.is_a?(FactTrend) %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,6 +1,5 @@
 <%= javascript 'charts' %>
 <% title(_("Trends for %s") % trend_title(@trend)) %>
-<% breadcrumbs(switchable: false) %>
 <% content_for(:search_bar) { trend_days_filter } %>
 <div class="row">
   <div class="stats-well col-md-12">


### PR DESCRIPTION
Trends API support [PR](https://github.com/theforeman/foreman/pull/4985) was merged, and therefore we can enable breadcrumbs switcher.