### PR TITLE
Fixes #23550 - add to_hash method to Menu::Manager

### DIFF
--- a/app/registries/menu/divider.rb
+++ b/app/registries/menu/divider.rb
@@ -6,6 +6,10 @@ module Menu
       super name
     end
 
+    def to_hash
+      {type: :divider, name: @caption}
+    end
+
     def authorized?
       true
     end

--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -22,6 +22,10 @@ module Menu
       super @name.to_sym
     end
 
+    def to_hash
+      {type: :item, name: @caption || @name, url: url}
+    end
+
     def url
       add_relative_path(@url || @context.routes.url_for(url_hash.merge(:only_path=>true).except(:use_route)))
     end

--- a/app/registries/menu/manager.rb
+++ b/app/registries/menu/manager.rb
@@ -32,6 +32,10 @@ module Menu
         @items || Menu::Loader.load
         @items[menu_name.to_sym] || Node.new(:root)
       end
+
+      def to_hash(menu_name)
+        items(menu_name).children.map(&:to_hash)
+      end
     end
 
     class Mapper

--- a/app/registries/menu/toggle.rb
+++ b/app/registries/menu/toggle.rb
@@ -7,6 +7,10 @@ module Menu
       super name.to_sym
     end
 
+    def to_hash
+      {type: :sub_menu, name: @caption, icon: @icon, children: children.map(&:to_hash)}
+    end
+
     def authorized?
       true
     end

--- a/test/unit/menu_manager_test.rb
+++ b/test/unit/menu_manager_test.rb
@@ -31,4 +31,45 @@ class MenuManagerTest < ActiveSupport::TestCase
     items = Menu::Manager.items(:test_menu)
     assert_kind_of Menu::Node, items.first
   end
+
+  def test_hashed_menu
+    create_nested_menu
+    items = Menu::Manager.to_hash(:nested_menu)
+    assert_equal menu_hash, items
+  end
+
+  private
+
+  def menu_hash
+    [{:type => :sub_menu,
+      :name => "User",
+      :icon => "fa-icon",
+      :children =>
+        [{:type => :item, :name=>"Item", :url=>"some url"},
+         {:type => :divider, :name=>nil},
+         {:type => :item, :name=>"Item 2", :url=>"some url"}]},
+     {:type => :sub_menu,
+      :name => "User",
+      :icon => "fa-icon",
+      :children => [{:type=>:item, :name=>"Item 3", :url=>"some url"}]}]
+  end
+
+  def create_nested_menu
+    Menu::Manager.map :nested_menu do |menu|
+      menu.sub_menu :sub_menu_one, :caption => 'User', :icon => 'fa-icon' do
+        menu.item :item_one,
+                  caption: 'Item',
+                  url: 'some url'
+        menu.divider
+        menu.item :item_two,
+                  caption: 'Item 2',
+                  url: 'some url'
+      end
+      menu.sub_menu :sub_menu_two, :caption => 'User', :icon => 'fa-icon' do
+        menu.item :item_three,
+                  caption: 'Item 3',
+                  url: 'some url'
+      end
+    end
+  end
 end


### PR DESCRIPTION
In order to move navbar (include vertical nav) to react, menu items should render as json

#### E.g

```ruby
Menu::Manager.to_hash(:admin_menu)
```
returns: 
```ruby
[{:type=>:sub_menu, :name=>"Administer", :icon=>"fa fa-cog", :children=>[{:type=>:item, 
:name=>"Locations", :url=>"/locations"}, {:type=>:item, :name=>"Organizations", :url=>"/organizations"},
 {:type=>:divider, :name=>nil}, {:type=>:item, :name=>"LDAP Authentication", 
:url=>"/auth_source_ldaps"}, {:type=>:item, :name=>"Users", :url=>"/users"}, {:type=>:item, 
:name=>"User Groups", :url=>"/usergroups"}, {:type=>:item, :name=>"Roles", :url=>"/roles"}, 
{:type=>:divider, :name=>nil}, {:type=>:item, :name=>"Bookmarks", :url=>"/bookmarks"}, {:type=>:item,
 :name=>"Settings", :url=>"/settings"}, {:type=>:item, :name=>"About", :url=>"/about"}]}]
```