### PR TITLE
Fixes #23549 - add axios support for wait_for_ajax

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -96,7 +96,7 @@ class ActionDispatch::IntegrationTest
 
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do
-      loop until page.evaluate_script('jQuery.active').zero?
+      loop until page.evaluate_script('jQuery.active').zero? && page.evaluate_script('window.axiosActive').zero?
     end
   end
 

--- a/webpack/assets/javascripts/react_app/API.js
+++ b/webpack/assets/javascripts/react_app/API.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import './APITestSetup';
 
 const getcsrfToken = () => {
   const token = document.querySelector('meta[name="csrf-token"]');

--- a/webpack/assets/javascripts/react_app/APITestSetup.js
+++ b/webpack/assets/javascripts/react_app/APITestSetup.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+// a counter for active requests, like jQuery.active
+window.axiosActive = 0;
+
+axios.interceptors.request.use((config) => {
+  window.axiosActive += 1;
+  return config;
+});
+
+axios.interceptors.response.use((response) => {
+  window.axiosActive -= 1;
+  return response;
+});


### PR DESCRIPTION
wait_for_ajax helper method works only with jQuery.ajax thanks to jQuery.active counter.
We added axios to handle ajax requests, so wait_for_ajax should work with axios as well.