### PR TITLE
Fixes #17292 - take otp for freeipa before save @host object in db

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -44,19 +44,19 @@ module Orchestration::Compute
 
   def queue_compute_create
     if find_image.try(:user_data)
-      queue.create(:name   => _("Render user data template for %s") % self, :priority => 1,
+      queue.create(:name   => _("Render user data template for %s") % self, :priority => 2,
                    :action => [self, :setUserData])
     end
-    queue.create(:name   => _("Set up compute instance %s") % self, :priority => 2,
+    queue.create(:name   => _("Set up compute instance %s") % self, :priority => 3,
                  :action => [self, :setCompute])
     if compute_provides?(:ip) || compute_provides?(:ip6)
-      queue.create(:name   => _("Acquire IP addresses for %s") % self, :priority => 3,
+      queue.create(:name   => _("Acquire IP addresses for %s") % self, :priority => 4,
                    :action => [self, :setComputeIP])
     end
-    queue.create(:name   => _("Query instance details for %s") % self, :priority => 4,
+    queue.create(:name   => _("Query instance details for %s") % self, :priority => 5,
                  :action => [self, :setComputeDetails])
     if compute_provides?(:mac) && (mac_based_ipam?(:subnet) || mac_based_ipam?(:subnet6))
-      queue.create(:name   => _("Set IP addresses for %s") % self, :priority => 5,
+      queue.create(:name   => _("Set IP addresses for %s") % self, :priority => 6,
                    :action => [self, :setComputeIPAM])
     end
     if compute_attributes && compute_attributes[:start] == '1'

--- a/app/models/concerns/orchestration/realm.rb
+++ b/app/models/concerns/orchestration/realm.rb
@@ -51,14 +51,14 @@ module Orchestration::Realm
   end
 
   def queue_realm_create
-    queue.create(:name => _("Create realm entry for %s") % self, :priority => 50,
+    queue.create(:name => _("Create realm entry for %s") % self, :priority => 1,
                  :action => [self, :set_realm])
   end
 
   def queue_realm_update
     # Update if the hostgroup is changed or if the realm is changed
     if self.hostgroup_id_changed? || self.realm_id_changed?
-      queue.create(:name => _("Update realm entry for %s") % self, :priority => 50,
+      queue.create(:name => _("Update realm entry for %s") % self, :priority => 1,
                    :action => [self, :update_realm])
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1392620

For render user data with otp for freeipa registrytion, host object should have otp before created job for render userdata.

