### PR TITLE
Fixes #23558 - fix npm warning about ellipsis-with-tooltip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react": "^16.2.0",
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.2.0",
-    "react-ellipsis-with-tooltip": "^1.0.7",
+    "react-ellipsis-with-tooltip": "^1.0.8",
     "react-numeric-input": "^2.0.7",
     "react-onclickoutside": "^6.6.2",
     "react-password-strength": "^2.1.0",


### PR DESCRIPTION
after npm install a warning appears:
```
npm WARN react-ellipsis-with-tooltip@1.0.7 requires a peer of react-bootstrap@^0.31.0 but none is installed. You must install peer dependencies yourself.
```