### PR TITLE
Fixes #23565 - Port robottelo test for smart variables

### DIFF
--- a/test/controllers/api/v2/override_values_controller_test.rb
+++ b/test/controllers/api/v2/override_values_controller_test.rb
@@ -27,11 +27,254 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     assert k.override
   end
 
+  test_attributes :pid => 'f0b3d51a-cf9a-4b43-9567-eb12cd973299'
   test "should create override values for specific smart variable" do
+    smart_variable = lookup_keys(:four)
+    unless smart_variable.override_values.empty?
+      refute_includes smart_variable.override_values.map { |override_value| override_value['match']}, smart_variable_attrs[:match]
+      refute_includes smart_variable.override_values.map { |override_value| override_value['value']}, smart_variable_attrs[:value]
+    end
     assert_difference('LookupValue.count') do
-      post :create, params: { :smart_variable_id => lookup_keys(:four).to_param, :override_value => smart_variable_attrs }
+      post :create, params: { :smart_variable_id => smart_variable.to_param, :override_value => smart_variable_attrs }
     end
     assert_response :success
+    smart_variable.reload
+    refute smart_variable.override_values.empty?
+    assert_includes smart_variable.override_values.map { |override_value| override_value['match']}, smart_variable_attrs[:match]
+    assert_includes smart_variable.override_values.map { |override_value| override_value['value']}, smart_variable_attrs[:value]
+  end
+
+  test_attributes :pid => '23b16e7f-0626-467e-b53b-35e1634cc30d'
+  test "should not create override values for smart variable with non existing attribute" do
+    match = 'hostgroup=nonexistingHG'
+    smart_variable = lookup_keys(:four)
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => smart_variable.to_param,
+        :override_value => { :match => match, :value => RFauxFactory.gen_alpha }
+      }
+    end
+    assert_response :error
+    assert_includes @response.body, "Validation failed: Match #{match} does not match an existing host group"
+    refute_includes smart_variable.override_values.map { |override_value| override_value['match']}, match
+  end
+
+  test_attributes :pid => 'a90b5bcd-f76c-4663-bf41-2f96e7e15c0f'
+  test "should create override value for smart variable with match and empty value" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :variable_type => 'string',
+      :override_value_order => 'is_virtual'
+    )
+    assert_difference('LookupValue.count') do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => 'is_virtual=true', :value => '' }
+      }
+    end
+    assert_response :success
+    smart_variable.reload
+    assert_equal 1, smart_variable.override_values.length
+    assert_equal 'is_virtual=true', smart_variable.override_values[0]['match']
+    assert_equal '', smart_variable.override_values[0]['value']
+  end
+
+  test_attributes :pid => 'ad24999f-1bed-4abb-a01f-3cb485d67968'
+  test "should not create override value for smart variable with match and empty value" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :variable_type => 'integer',
+      :override_value_order => 'is_virtual',
+      :default_value => RFauxFactory.gen_numeric_string
+    )
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => 'is_virtual=true', :value => '' }
+      }
+    end
+    assert_response :error
+    assert_includes @response.body, 'Validation failed: Value is invalid integer'
+  end
+
+  test_attributes :pid => '625e3221-237d-4440-ab71-6d98cff67713'
+  test "should not create override value for smart variable with invalid match value" do
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => lookup_keys(:four).id,
+        :override_value => { :match => 'invalid_value', :value => RFauxFactory.gen_alpha }
+      }
+    end
+    assert_response :error
+    assert_includes @response.body, 'Validation failed: Match is invalid'
+  end
+
+  test_attributes :pid => '3ad09261-eb55-4758-b915-84006c9e527c'
+  test "should create override value for smart variable with regex validator and matching value" do
+    validator_type = 'regexp'
+    validator_rule = '[0-9]'
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :validator_type => validator_type,
+      :validator_rule => validator_rule,
+      :default_value => RFauxFactory.gen_numeric_string
+    )
+    value = RFauxFactory.gen_numeric_string
+    match = 'domain=example.com'
+    assert_difference('LookupValue.count') do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => match, :value => value }
+      }
+    end
+    assert_response :created
+    smart_variable.reload
+    assert_equal validator_type, smart_variable.validator_type
+    assert_equal validator_rule, smart_variable.validator_rule
+    assert_equal 1, smart_variable.override_values.length
+    assert_equal match, smart_variable.override_values[0]['match']
+    assert_equal value, smart_variable.override_values[0]['value']
+  end
+
+  test_attributes :pid => '8a0f9251-7992-4d1e-bace-7e32637bf56f'
+  test "should not create override value for smart variable with regex validator and non matching value" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :validator_type => 'regexp',
+      :validator_rule => '[0-9]',
+      :default_value => RFauxFactory.gen_numeric_string
+    )
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => 'domain=example.com', :value => RFauxFactory.gen_alpha }
+      }
+    end
+    assert_response :error
+    assert_include @response.body, 'Validation failed: Value is invalid'
+  end
+
+  test_attributes :pid => 'f5eda535-6623-4130-bea0-97faf350a6a6'
+  test "should create override value for smart variable with list validator and matching value" do
+    validator_type = 'list'
+    validator_rule = 'test, example, 30'
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :validator_type => validator_type,
+      :validator_rule => validator_rule,
+      :default_value => 'test'
+    )
+    value = 'example'
+    match = 'domain=example.com'
+    assert_difference('LookupValue.count') do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => match, :value => value }
+      }
+    end
+    assert_response :created
+    smart_variable.reload
+    assert_equal validator_type, smart_variable.validator_type
+    assert_equal validator_rule, smart_variable.validator_rule
+    assert_equal 1, smart_variable.override_values.length
+    assert_equal match, smart_variable.override_values[0]['match']
+    assert_equal value, smart_variable.override_values[0]['value']
+  end
+
+  test_attributes :pid => '0aff0fdf-5a62-49dc-abe1-b727459d030a'
+  test "should not create override value for smart variable with list validator and not matching value" do
+    validator_rule = 'test, example, 30'
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :validator_type => 'list',
+      :validator_rule => validator_rule,
+      :default_value => 'example'
+    )
+    value = 'not_in_list'
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => 'domain=example.com', :value => value }
+      }
+    end
+    assert_response :error
+    assert_include @response.body, "Validation failed: Value #{value} is not one of #{validator_rule}"
+  end
+
+  test_attributes :pid => '99057f05-62cb-4230-b16c-d96ca6a5ae91'
+  test "should create override value for smart variable that match default_value type" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :default_value => true,
+      :variable_type => 'boolean',
+      :override_value_order => 'is_virtual'
+    )
+    match = 'is_virtual=true'
+    assert_difference('LookupValue.count') do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => match, :value => true }
+      }
+    end
+    assert_response :created
+    smart_variable.reload
+    assert_equal 1, smart_variable.override_values.length
+    assert_equal match, smart_variable.override_values[0]['match']
+    assert_equal true, smart_variable.override_values[0]['value']
+  end
+
+  test_attributes :pid => '790c63d7-4e8a-4187-8566-3d85d57f9a4f'
+  test "should not create override value for smart variable that do not match default_value type" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :default_value => true,
+      :variable_type => 'boolean'
+    )
+    assert_difference('LookupValue.count', 0) do
+      post :create, params: {
+        :smart_variable_id => smart_variable.id,
+        :override_value => { :match => 'domain=example.com', :value => 30 }
+      }
+    end
+    assert_response :error
+    assert_include @response.body, 'Validation failed: Value is invalid boolean"'
+    smart_variable.reload
+    assert_equal true, smart_variable.default_value
+  end
+
+  test_attributes :pid => '7a932a99-2bd9-43ee-bcda-2b01a389787c'
+  test "should destroy smart variable override value" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :override_value_order => 'is_virtual'
+    )
+    sv_lookup_value = FactoryBot.create(
+      :lookup_value,
+      :lookup_key_id => smart_variable.id,
+      :match => 'is_virtual=true',
+      :value => 'some_value'
+    )
+    delete :destroy, params: { :smart_variable_id => smart_variable.id, :id => sv_lookup_value.id }
+    assert_response :success
+    assert_raises(ActiveRecord::RecordNotFound) { sv_lookup_value.reload }
   end
 
   test "should create override values for specific smart class parameter" do

--- a/test/controllers/api/v2/smart_variables_controller_test.rb
+++ b/test/controllers/api/v2/smart_variables_controller_test.rb
@@ -35,24 +35,41 @@ class Api::V2::SmartVariablesControllerTest < ActionController::TestCase
     assert_equal "bool_test", results['results'][0]['variable']
   end
 
+  test_attributes :pid => 'cd743329-b354-4ddc-ada0-3ddd774e2701'
   test "should get smart variables for a specific puppetclass" do
     get :index, params: { :puppetclass_id => puppetclasses(:two).id }
     assert_response :success
     assert_not_nil assigns(:smart_variables)
     results = ActiveSupport::JSON.decode(@response.body)
-    assert !results['results'].empty?
+    refute results['results'].empty?
     assert_equal 1, results['results'].count
     assert_equal "special_info", results['results'][0]['variable']
   end
 
+  test_attributes :pid => '4cd20cca-d419-43f5-9734-e9ae1caae4cb'
   test "should create a smart variable" do
+    variable_name = 'test_smart_variable'
+    puppetclass_id  = puppetclasses(:one).id
     assert_difference('LookupKey.count') do
       as_admin do
-        valid_attrs = { :variable => 'test_smart_variable', :puppetclass_id => puppetclasses(:one).id }
+        valid_attrs = { :variable => variable_name, :puppetclass_id => puppetclass_id }
         post :create, params: { :smart_variable => valid_attrs }
       end
     end
     assert_response :created
+    response = JSON.parse(@response.body)
+    assert response.key?('variable')
+    assert_equal response['puppetclass_id'], puppetclass_id
+  end
+
+  test_attributes :pid => 'd92f8bdd-93de-49ba-85a3-685aac9eda0a'
+  test "should not create a smart variable" do
+    assert_difference('LookupKey.count', 0) do
+      as_admin do
+        post :create, params: { :smart_variable => { :variable => '', :puppetclass_id => puppetclasses(:one).id } }
+      end
+    end
+    assert_response :unprocessable_entity
   end
 
   test "should show specific smart variable" do
@@ -62,7 +79,7 @@ class Api::V2::SmartVariablesControllerTest < ActionController::TestCase
     assert !show_response.empty?
   end
 
-  test "should update smart variable" do
+  test "should update smart variable default value" do
     orig_value = lookup_keys(:four).default_value
     put :update, params: { :id => lookup_keys(:four).to_param, :smart_variable => { :default_value => 'newstring' } }
     assert_response :success
@@ -70,6 +87,29 @@ class Api::V2::SmartVariablesControllerTest < ActionController::TestCase
     refute_equal orig_value, new_value
   end
 
+  test_attributes :pid => '2312cb28-c3b0-4fbc-84cf-b66f0c0c64f0'
+  test "should update smart variable puppet class" do
+    smart_variable = lookup_keys(:four)
+    new_puppet_class_id = puppetclasses(:one).id
+    refute_equal smart_variable.puppetclass_id, new_puppet_class_id
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => { :puppetclass_id => new_puppet_class_id } }
+    assert_response :success
+    smart_variable.reload
+    assert_equal new_puppet_class_id, smart_variable.puppetclass_id
+  end
+
+  test_attributes :pid => 'b8214eaa-e276-4fc4-8381-fb0386cda6a5'
+  test "should update smart variable name" do
+    smart_variable = lookup_keys(:four)
+    new_variable_name = 'four_new_variable_name'
+    refute_equal new_variable_name, smart_variable.variable
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => { :variable => new_variable_name } }
+    assert_response :success
+    smart_variable.reload
+    assert_equal new_variable_name, smart_variable.variable
+  end
+
+  test_attributes :pid => '6d8354db-a028-4ae0-bcb6-87aa1cb9ec5d'
   test "should destroy smart variable" do
     assert_difference('LookupKey.count', -1) do
       delete :destroy, params: { :id => lookup_keys(:four).to_param }
@@ -77,7 +117,272 @@ class Api::V2::SmartVariablesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test_attributes :pid => 'c49ad14d-913f-4adc-8ebf-88493556c027'
+  test "should not duplicate smart variable" do
+    assert_difference('LookupKey.count', 0) do
+      as_admin do
+        post :create, params: { :smart_variable => {
+          :variable => lookup_keys(:four).variable,
+          :puppetclass_id => puppetclasses(:two).id
+        }}
+      end
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, 'Key has already been taken'
+  end
+
+  test_attributes :pid => '4c8b4134-33c1-4f7f-83f9-a751c49ae2da'
+  test "should create smart variable with valid type and default_value" do
+    valid_attr = {
+      :variable => 'new_variable_name',
+      :puppetclass_id => puppetclasses(:two).id,
+      :variable_type => 'array',
+      :default_value => '["a string", "123456789", "<test>html</test>"]'
+    }
+    assert_difference('LookupKey.count') do
+      as_admin do
+        post :create, params: { :smart_variable => valid_attr }
+      end
+    end
+    assert_response :created
+    response = JSON.parse(@response.body)
+    assert response.key?('variable_type')
+    assert_equal valid_attr[:variable_type], response['variable_type']
+    assert response.key?('default_value')
+    assert_equal JSON.parse(valid_attr[:default_value]), response['default_value']
+  end
+
+  test_attributes :pid => '9709d67c-682f-4e6c-8b8b-f02f6c2d3b71'
+  test "should not create smart variable with invalid default_value" do
+    invalid_attr = {
+      :variable => 'new_variable_name',
+      :puppetclass_id => puppetclasses(:two).id,
+      :variable_type => 'array',
+      :default_value => 'not a valid array in a string'
+    }
+    assert_difference('LookupKey.count', 0) do
+      as_admin do
+        post :create, params: { :smart_variable => invalid_attr }
+      end
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, 'Default value is invalid'
+  end
+
+  test_attributes :pid => 'aa9803b9-9a45-4ad8-b502-e0e32fc4b7d8'
+  test "should update smart variable with default value that match regexp validator" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :default_value => RFauxFactory.gen_alpha
+    )
+    valid_attr = { :validator_type => 'regexp', :validator_rule => '[0-9]', :default_value => RFauxFactory.gen_numeric_string }
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => valid_attr }
+    assert_response :success
+    smart_variable.reload
+    assert_equal valid_attr[:default_value], smart_variable.default_value
+    assert_equal valid_attr[:validator_type], smart_variable.validator_type
+    assert_equal valid_attr[:validator_rule], smart_variable.validator_rule
+  end
+
+  test_attributes :pid => '0c80bd58-26aa-4c2a-a087-ed3b88b226a7'
+  test "should not update smart variable with default value that do not match regexp validator" do
+    default_value = RFauxFactory.gen_alpha
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :default_value => default_value
+    )
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :validator_type => 'regexp',
+      :validator_rule => '[0-9]',
+      :default_value => RFauxFactory.gen_alpha
+    }}
+    assert_response :error
+    assert_include @response.body, 'Validation failed: Default value is invalid'
+    smart_variable.reload
+    assert_equal default_value, smart_variable.default_value
+  end
+
+  test_attributes :pid => '6bc2caa0-1300-4751-8239-34b96517465b'
+  test "should create smart variable with default value that match list validator rule" do
+    values_list = [
+      RFauxFactory.gen_alpha,
+      RFauxFactory.gen_alphanumeric,
+      rand(100..1000000),
+      %w[true false].sample
+    ]
+    validator_rule = values_list.join(', ')
+    default_value = values_list[1]
+    assert_difference('LookupKey.count') do
+      as_admin do
+        post :create, params: { :smart_variable => {
+          :variable => RFauxFactory.gen_alpha,
+          :puppetclass_id => puppetclasses(:two).id,
+          :validator_type => 'list',
+          :validator_rule => validator_rule,
+          :default_value => default_value
+        }}
+      end
+    end
+    assert_response :created
+    response = JSON.parse(@response.body)
+    assert response.key?('default_value')
+    assert_equal default_value, response['default_value']
+    assert response.key?('validator_type')
+    assert_equal 'list', response['validator_type']
+    assert response.key?('validator_type')
+    assert_equal validator_rule, response['validator_rule']
+  end
+
+  test_attributes :pid => 'cacb83a5-3e50-490b-b94f-a5d27f44ae12'
+  test "should not create smart variable with default value that do not match list validator rule" do
+    validator_rule = '5, test'
+    default_value = 'example'
+    assert_difference('LookupKey.count', 0) do
+      as_admin do
+        post :create, params: { :smart_variable => {
+          :variable => RFauxFactory.gen_alpha,
+          :puppetclass_id => puppetclasses(:two).id,
+          :validator_type => 'list',
+          :validator_rule => validator_rule,
+          :default_value => default_value
+        }}
+      end
+    end
+    assert_response :unprocessable_entity
+    assert_include @response.body, "Default value #{default_value} is not one of #{validator_rule}"
+  end
+
+  test_attributes :pid => 'af2c16e1-9a78-4615-9bc3-34fadca6a179'
+  test "should enable smart variable merge_overrides and merge_default flags" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :variable_type => 'array',
+      :default_value => [rand(1..100000)]
+    )
+    refute smart_variable.merge_overrides
+    refute smart_variable.merge_default
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :merge_overrides => true,
+      :merge_default => true
+    }}
+    assert_response :success
+    smart_variable.reload
+    assert smart_variable.merge_overrides
+    assert smart_variable.merge_default
+  end
+
+  test_attributes :pid => 'f62a7e23-6fb4-469a-8589-4c987ff589ef'
+  test "should not enable smart variable merge_overrides flag" do
+    smart_variable = lookup_keys(:four)
+    refute_includes %w[array hash], smart_variable.variable_type
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :merge_overrides => true
+    }}
+    assert_response :error
+    assert_includes @response.body, 'Validation failed: Merge overrides can only be set for array or hash'
+  end
+
+  test_attributes :pid => 'f5d2d032-2f72-4637-af61-90a556c42425'
+  test "should not enable smart variable merge_default flag" do
+    smart_variable = lookup_keys(:four)
+    refute smart_variable.merge_overrides
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :merge_default => true
+    }}
+    assert_response :error
+    assert_includes @response.body, 'Validation failed: Merge default can only be set when merge overrides is set'
+  end
+
+  test_attributes :pid => '98fb1884-ad2b-45a0-b376-66bbc5ef6f72'
+  test "should enable smart variable avoid_duplicates flag" do
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :variable_type => 'array',
+      :default_value => [rand(1..100000)]
+    )
+    refute smart_variable.merge_overrides
+    refute smart_variable.avoid_duplicates
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :merge_overrides => true,
+      :avoid_duplicates => true
+    }}
+    assert_response :success
+    smart_variable.reload
+    assert smart_variable.merge_overrides
+    assert smart_variable.avoid_duplicates
+  end
+
+  test_attributes :pid => 'c7a2f718-6346-4851-b5f1-ab36c2fa8c6a'
+  test "should not enable smart variable avoid_duplicates flag" do
+    smart_variable = lookup_keys(:four)
+    refute smart_variable.merge_overrides
+    put :update, params: { :id => smart_variable.to_param, :smart_variable => {
+      :avoid_duplicates => true
+    }}
+    assert_response :error
+    assert_includes @response.body, 'Avoid duplicates can only be set for arrays that have merge_overrides set to true'
+  end
+
   context 'hidden' do
+    test_attributes :pid => '04bed7fa8-a5be-4fc0-8e9b-d68da00f8de0'
+    test "should hide smart variable default_value" do
+      assert_difference('LookupKey.count') do
+        as_admin do
+          post :create, params: { :smart_variable => {
+            :variable => RFauxFactory.gen_alpha,
+            :puppetclass_id => puppetclasses(:two).id,
+            :hidden_value => true
+          }}
+        end
+      end
+      assert_response :created
+      response = JSON.parse(@response.body)
+      assert response.key?('hidden_value?')
+      assert response['hidden_value?']
+      assert response.key?('default_value')
+      assert_equal '*****', response['default_value']
+    end
+
+    test_attributes :pid => 'e8b3ec03-1abb-48d8-9409-17178bb887cb'
+    test "should unhide smart variable default_value" do
+      smart_variable = FactoryBot.create(
+        :variable_lookup_key,
+        :variable => RFauxFactory.gen_alpha,
+        :puppetclass_id => puppetclasses(:one).id,
+        :hidden_value => true
+      )
+      assert smart_variable.hidden_value?
+      put :update, params: { :id => smart_variable.to_param, :smart_variable => { :hidden_value => false } }
+      assert_response :success
+      smart_variable.reload
+      refute smart_variable.hidden_value?
+    end
+
+    test_attributes :pid => '21b5586e-9434-45ea-ae85-12e24c549412'
+    test "should update smart variable hidden_value" do
+      smart_variable = FactoryBot.create(
+        :variable_lookup_key,
+        :variable => RFauxFactory.gen_alpha,
+        :puppetclass_id => puppetclasses(:one).id,
+        :hidden_value => true
+      )
+      assert smart_variable.hidden_value?
+      default_value = RFauxFactory.gen_alpha
+      put :update, params: { :id => smart_variable.to_param, :smart_variable => { :default_value => default_value } }
+      assert_response :success
+      smart_variable.reload
+      assert smart_variable.hidden_value?
+      assert_equal default_value, smart_variable.default_value
+    end
+
     test "should show a smart variable as hidden unless show_hidden is true" do
       parameter = FactoryBot.create(:variable_lookup_key, :hidden_value => true, :default_value => 'hidden', :puppetclass => puppetclasses(:one))
       get :show, params: { :id => parameter.id, :puppetclass_id => puppetclasses(:one).id }

--- a/test/models/lookup_keys/variable_lookup_key_test.rb
+++ b/test/models/lookup_keys/variable_lookup_key_test.rb
@@ -1,8 +1,42 @@
 require 'test_helper'
 
+# Returns a list of smart class variable types and valid values
+def valid_sc_variable_data
+  [
+    { sc_type: 'string', value: RFauxFactory.gen_utf8 },
+    { sc_type: 'boolean', value: RFauxFactory.gen_boolean },
+    { sc_type: 'integer', value: rand(1..10000) },
+    # random float in range -1000..1000
+    { sc_type: 'real', value: (rand*2000)-1000 },
+    { sc_type: 'array',
+      value: "[\"#{RFauxFactory.gen_utf8}\",\"#{RFauxFactory.gen_numeric_string}\",\"#{RFauxFactory.gen_html}\"]" },
+    { sc_type: 'hash',
+      value: "{ \"#{RFauxFactory.gen_alpha}\": \"#{RFauxFactory.gen_alpha}\" }" },
+    { sc_type: 'yaml',
+      value: "--- #{RFauxFactory.gen_alpha}=>#{RFauxFactory.gen_alpha} ..." },
+    { sc_type: 'json',
+      value: "{\"#{RFauxFactory.gen_alpha}\":\"#{RFauxFactory.gen_numeric_string}\",\"#{RFauxFactory.gen_alpha}\":\"#{RFauxFactory.gen_alphanumeric}\"}"
+    }
+  ]
+end
+
+# Returns a list of smart class variable type with invalid values
+def invalid_sc_variable_data
+  [
+    { sc_type: 'boolean', value: 'not a boolean' },
+    { sc_type: 'integer', value: 'not an integer' },
+    { sc_type: 'real', value: 'not a float' },
+    { sc_type: 'array', value: 'not a valid array in string' },
+    { sc_type: 'hash', value: 'not a valid hash in string' },
+    { sc_type: 'yaml', value: "{#{RFauxFactory.gen_alpha}:#{RFauxFactory.gen_alpha}}" },
+    { sc_type: 'json', value: "{#{RFauxFactory.gen_alpha}:#{RFauxFactory.gen_numeric_string},#{RFauxFactory.gen_alpha}:#{RFauxFactory.gen_alphanumeric}}"}
+  ]
+end
+
 class VariableLookupKeyTest < ActiveSupport::TestCase
   should validate_uniqueness_of(:key)
   should_not allow_value('with whitespace').for(:key)
+  should allow_values(*valid_name_list).for(:variable)
 
   test "validates presence of puppetclass_id" do
     variable_lk = FactoryBot.build_stubbed(:variable_lookup_key)
@@ -13,5 +47,74 @@ class VariableLookupKeyTest < ActiveSupport::TestCase
   test "should have auditable_type as VariableLookupKey and not LookupKey" do
     VariableLookupKey.create(:key => 'test_audit_variable', :default_value => "test123", :puppetclass => puppetclasses(:one))
     assert_equal 'VariableLookupKey', Audit.unscoped.last.auditable_type
+  end
+
+  test "should not create smart variable with invalid variable" do
+    invalid_name_list.each do |variable|
+      smart_variable = FactoryBot.build(:variable_lookup_key, :variable => variable, :puppetclass_id => puppetclasses(:one).id)
+      refute smart_variable.valid?, "Validation succeeded for create with invalid variable: '#{variable}' length: #{variable.length})"
+      assert_includes smart_variable.errors.keys, :key
+    end
+  end
+
+  test "should create smart variable with valid type and default_value" do
+    valid_sc_variable_data.each do |data|
+      smart_variable = FactoryBot.build(
+        :variable_lookup_key,
+        :variable => RFauxFactory.gen_alpha,
+        :puppetclass_id => puppetclasses(:one).id,
+        :variable_type => data[:sc_type],
+        :default_value => data[:value]
+      )
+      assert smart_variable.valid?
+      if %w[json hash array].include? data[:sc_type]
+        data_value = JSON.parse(data[:value])
+      elsif data[:sc_type] == 'yaml'
+        data_value = YAML.load(data[:value])
+      else
+        data_value = data[:value]
+      end
+      assert_equal data_value, smart_variable.default_value
+    end
+  end
+
+  test "should not create smart variable with invalid default_value" do
+    invalid_sc_variable_data.each do |data|
+      smart_variable = FactoryBot.build(
+        :variable_lookup_key,
+        :variable => RFauxFactory.gen_alpha,
+        :puppetclass_id => puppetclasses(:one).id,
+        :variable_type => data[:sc_type],
+        :default_value => data[:value]
+      )
+      refute smart_variable.valid?, "Validation succeeded for create with invalid default_value: variable_type: #{data[:sc_type]} default_value: #{data[:value]})"
+      assert_includes smart_variable.errors.keys, :default_value
+    end
+  end
+
+  test "should create smart variable with default value that match list validator rule" do
+    values_list = [
+      RFauxFactory.gen_alpha,
+      RFauxFactory.gen_alphanumeric,
+      rand(100..1000000),
+      %w[true false].sample
+    ]
+    validator_rule = values_list.join(', ')
+    valid_attr = {
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:two).id,
+      :validator_type => 'list',
+      :validator_rule => validator_rule
+    }
+    values_list.each do |default_value|
+      smart_variable = FactoryBot.build(
+        :variable_lookup_key,
+        valid_attr.merge(:default_value => default_value)
+      )
+      assert smart_variable.valid?
+      assert_equal valid_attr[:validator_type], smart_variable.validator_type
+      assert_equal validator_rule, smart_variable.validator_rule
+      assert_equal default_value, smart_variable.default_value
+    end
   end
 end

--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -282,4 +282,30 @@ EOF
     value.match = "hostgroup=Common,domain=example.com"
     assert_equal('hostgroup,domain', value.path)
   end
+
+  test "should create override value for smart variable with list validator and matching value" do
+    values_list = [ 'test',  'example', 30 ]
+    validator_type = 'list'
+    validator_rule = values_list.join(', ')
+    smart_variable = FactoryBot.create(
+      :variable_lookup_key,
+      :variable => RFauxFactory.gen_alpha,
+      :puppetclass_id => puppetclasses(:one).id,
+      :validator_type => validator_type,
+      :validator_rule => validator_rule,
+      :default_value => 'example'
+    )
+    match = 'domain=example.com'
+    values_list.each do |value|
+      sv_lookup_value = FactoryBot.build(
+        :lookup_value,
+        :lookup_key_id => smart_variable.id,
+        :match => match,
+        :value => value
+      )
+      assert sv_lookup_value.valid?
+      assert_equal match, sv_lookup_value.match
+      assert_equal value, sv_lookup_value.value
+    end
+  end
 end


### PR DESCRIPTION
Port robottelo tier 1 tests for smart variables

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5965

part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Please note the comments on the issue https://github.com/SatelliteQE/robottelo/issues/5965 about two controller tests that are now implemented for string values, we will need to implement two additional tests for integer values in list. Note also that the related model tests are passing as expected.

Please comment is that an expected behavior, if yes no additional tests will be implemented,
if not we have to create an issue/bug and after resolution create the same tests but with integer values as showed in the issue. 
