### PR TITLE
Fixes #23559 - fix breadcrumbs switcher in trends page

### DIFF
--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -13,6 +13,10 @@ class Trend < ApplicationRecord
     Parameterizable.parameterize("#{id}-#{to_label}")
   end
 
+  def self.title_name
+    'label'.freeze
+  end
+
   def self.build_trend(trend_params = {})
     (trend_params[:trendable_type] == 'FactName') ? FactTrend.new(trend_params) : ForemanTrend.new(trend_params)
   end

--- a/app/views/api/v2/trends/base.json.rabl
+++ b/app/views/api/v2/trends/base.json.rabl
@@ -1,3 +1,4 @@
 object @trend
 
 attributes :id, :trendable_type, :trendable_id, :fact_name, :type, :name
+attribute to_label: :label


### PR DESCRIPTION
predefined trend types  ( = other than fact trends)  have no name attribute, so it would be better to use `to_label`.