### PR TITLE
Fixes #23576 - Fix the 'webpacked_plugins_js_for' helper

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -27,7 +27,7 @@ module ReactjsHelper
 
   def js_tags_for(requested_plugins)
     requested_plugins.map do |plugin|
-      javascript_include_tag(*webpack_asset_paths(plugin, :extension => 'js'), "data-turbolinks-track" => true)
+      javascript_include_tag(*webpack_asset_paths(plugin.to_s, :extension => 'js'), "data-turbolinks-track" => true)
     end
   end
 end


### PR DESCRIPTION
For some reason, using symbol does not work any more. Turning it into a string seems to fix it.