### PR TITLE
Fixes #23577 - Configurable security token path

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -2,9 +2,10 @@ require_dependency 'foreman/util'
 
 namespace :security do
   desc 'Generate new security token'
-  task :generate_token do
+  task :generate_token, [:path] do |t, args|
     include Foreman::Util
-    File.open(Rails.root.join('config', 'initializers', 'local_secret_token.rb'), "w") do |fd|
+    path = args[:path] || Rails.root.join('config', 'initializers', 'local_secret_token.rb')
+    File.open(path, "w") do |fd|
       fd.write("# Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.


### PR DESCRIPTION
In production setups we prefer to store this file in /etc/foreman and a symlink in the rails root.