### PR TITLE
Fixes #23581 - Don't convert lookup value hashes

### DIFF
--- a/db/migrate/20180403144853_convert_vm_attrs_to_hash.rb
+++ b/db/migrate/20180403144853_convert_vm_attrs_to_hash.rb
@@ -13,9 +13,6 @@ class ConvertVmAttrsToHash < ActiveRecord::Migration[5.1]
     say "Converting Lookup Keys, total: #{FakeLookupKey.unscoped.count}"
     transform_batch_columns(FakeLookupKey, [:default_value])
 
-    say "Converting Lookup Values, total: #{FakeLookupValue.unscoped.count}"
-    transform_batch_columns(FakeLookupValue, [:value])
-
     say "All conversions finished"
   end
 
@@ -44,10 +41,6 @@ class ConvertVmAttrsToHash < ActiveRecord::Migration[5.1]
   class FakeComputeResource < ApplicationRecord
     self.table_name = 'compute_resources'
     self.inheritance_column = nil
-  end
-
-  class FakeLookupValue < ApplicationRecord
-    self.table_name = 'lookup_values'
   end
 
   class FakeLookupKey < ApplicationRecord


### PR DESCRIPTION
Don't convert lookup value YAML hashes to JSON hashes.

Converting of the YAML hashes to JSON hashes doesn't makes sense if one could just add a YAML hash through the UI afterwards. Therefore don't convert lookup_values.
