### PR TITLE
Fixes #23587 - Verify webpack precompile is needed

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -126,6 +126,7 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
       end
 
       def compile
+        return unless File.exist?("#{@plugin.path}/webpack")
         return unless File.exist?("#{@plugin.path}/package.json")
         ENV["NODE_ENV"] ||= 'production'
         webpack_bin = ::Rails.root.join('node_modules/webpack/bin/webpack.js')


### PR DESCRIPTION
Plugins like bastion do have a package.json but no webpack resources.

Should fix http://koji.katello.org/koji/watchlogs?taskID=98491:
```
/builddir/build/BUILD/bastion-6.1.10/usr/share/foreman/node_modules/webpack/bin/webpack.js --config /builddir/build/BUILD/bastion-6.1.10/usr/share/foreman/config/webpack.config.js --bail --env.pluginName=bastion
/builddir/build/BUILD/bastion-6.1.10/usr/share/foreman/config/webpack.config.js:37
    var outputPath = path.join(plugins['plugins'][env.pluginName]['root'], 'public', 'webpack');
                                                                 ^
TypeError: Cannot read property 'root' of undefined
    at module.exports.env (/builddir/build/BUILD/bastion-6.1.10/usr/share/foreman/config/webpack.config.js:37:66)
    at handleFunction (/usr/lib/node_modules/webpack/lib/prepareOptions.js:26:13)
    at prepareOptions (/usr/lib/node_modules/webpack/lib/prepareOptions.js:11:13)
    at requireConfig (/usr/lib/node_modules/webpack/bin/convert-argv.js:98:14)
    at /usr/lib/node_modules/webpack/bin/convert-argv.js:104:17
    at Array.forEach (native)
    at module.exports (/usr/lib/node_modules/webpack/bin/convert-argv.js:102:15)
    at Object.<anonymous> (/usr/lib/node_modules/webpack/bin/webpack.js:155:40)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
    at startup (bootstrap_node.js:149:9)
rake aborted!
```