### PR TITLE
Fixes #23587 - Verify webpack precompile is needed

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -126,6 +126,7 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
       end
 
       def compile
+        return unless File.exist?("#{@plugin.path}/webpack")
         return unless File.exist?("#{@plugin.path}/package.json")
         ENV["NODE_ENV"] ||= 'production'
         webpack_bin = ::Rails.root.join('node_modules/webpack/bin/webpack.js')


### PR DESCRIPTION
Plugins like bastion do have a package.json but no webpack resources.

Cherry pick of d6828d3bfbf3c74447c5c3c860d51af6e4440e6b / https://github.com/theforeman/foreman/pull/5558