### PR TITLE
Fixes #23597 - Port robottelo tests - combination template

### DIFF
--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -136,4 +136,24 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     assert_equal 1, imported.locations.count
     assert_equal changed_loc, imported.locations.first
   end
+
+  test_attributes :pid => '392b3782-a3ee-40db-954c-a85d5b452abb'
+  test "should create provisioning template with template_combinations" do
+    name = RFauxFactory.gen_alpha
+    valid_attrs = {
+      :name => name, :template => RFauxFactory.gen_alpha, :template_kind_id => template_kinds(:ipxe).id,
+      :template_combinations_attributes => [
+        { :hostgroup_id => hostgroups(:common).id, :environment_id => environments(:production).id }
+      ]
+    }
+    post :create, params: { :provisioning_template => valid_attrs }
+    assert_response :created
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert response.key?('id')
+    assert response.key?('template_combinations')
+    template_combinations = response['template_combinations']
+    assert_equal 1, template_combinations.length
+    template_combination = TemplateCombination.find(template_combinations[0]['id'])
+    assert_equal response['id'], template_combination.provisioning_template_id
+  end
 end

--- a/test/controllers/api/v2/template_combinations_controller_test.rb
+++ b/test/controllers/api/v2/template_combinations_controller_test.rb
@@ -102,18 +102,22 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
   end
 
   context 'unnested combinations' do
+    test_attributes :pid => '2447674e-c37e-11e6-93cb-68f72889dc7f'
     test "should get template combination directly" do
-      get :show, params: { :id => template_combinations(:two).id }
+      template_combination = template_combinations(:four)
+      get :show, params: { :id => template_combination.id }
       assert_response :success
-      template_combination = ActiveSupport::JSON.decode(@response.body)
-      assert !template_combination.empty?
-      assert_equal template_combination["provisioning_template_id"], template_combinations(:two).provisioning_template_id
+      response = ActiveSupport::JSON.decode(@response.body)
+      refute response.empty?
+      assert_equal template_combination.provisioning_template_id, response["provisioning_template_id"]
     end
 
+    test_attributes :pid => '3a5cb370-c5f6-11e6-bb2f-68f72889dc7f'
     test "should destroy directly" do
-      delete :destroy, params: { :id => template_combinations(:two).id }
-      assert_response :ok
-      refute TemplateCombination.exists?(template_combinations(:two).id)
+      template_combination = template_combinations(:four)
+      delete :destroy, params: { :id => template_combination.id }
+      assert_response :success
+      refute TemplateCombination.exists?(template_combination.id)
     end
   end
 end


### PR DESCRIPTION
Port robottelo tier1 tests for template combination

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5977

part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Modified the currents one to use combination template with hostgroup and  environment
Add a new test "should create provisioning template with template_combinations" to cover robottelo test setup class