### PR TITLE
Fixes #23598 - move report metrics chart to c3

### DIFF
--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -63,7 +63,7 @@
 .statistics-bar {
   width: 260px;
   height: 305px;
-  margin: 0 auto 27;
+  margin: 0 auto 27px;
 }
 
 .statistics-pie,
@@ -141,6 +141,12 @@
   width: 100%;
   margin-bottom: 20px;
   font-size: 14px;
+}
+
+.metrics-chart {
+  width: 240px;
+  margin: 50px auto 12px;
+  padding-bottom: 40px;
 }
 
 #host-show {

--- a/app/views/config_reports/_metrics.html.erb
+++ b/app/views/config_reports/_metrics.html.erb
@@ -4,9 +4,8 @@
   <div class="col-md-4">
     <div class="stats-well">
       <h4 class="ca" ><%= _('Report Metrics') %></h4>
-      <div style="margin-top:50px;padding-bottom: 40px;">
-        <%= flot_pie_chart("metrics" ,_("Report Metrics"), metrics, :class => "statistics-pie small")%>
-      </div>
+      <div id="metrics_chart" class='metrics-chart'></div>
+      <%= mount_react_component('DonutChart', '#metrics_chart', metrics.to_a.to_json) %>
     </div>
   </div>
   <div class="col-md-4">
@@ -16,7 +15,7 @@
     </div>
   </div>
   <div class="col-md-4">
-    <table class="<%= table_css_classes %>" style="height: 398px;">
+    <table class="<%= table_css_classes %>" style="height: 400px;">
       <tbody>
         <% metrics.sort.each do |title, value|%>
           <tr>

--- a/test/integration/config_report_js_test.rb
+++ b/test/integration/config_report_js_test.rb
@@ -1,0 +1,9 @@
+require 'integration_test_helper'
+
+class ConfigReportJSTest < IntegrationTestWithJavascript
+  test "should display report metrics chart" do
+    report = ConfigReport.import(read_json_fixture('reports/applied.json'))
+    visit config_report_path(report)
+    assert page.find('.donut-chart-pf')
+  end
+end

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.fixtures.js
@@ -8,7 +8,7 @@ export const mockStoryData = {
     },
   },
   data: {
-    columns: [['Fedora 21 extra extra extra extra extra extra extra extra extra extra long label', 3], ['Ubuntu 14.04', 4], ['Centos 7 extra extra long label', 2], ['Debian 8', 1]],
+    columns: [['Fedora 21 extra extra extra extra extra extra extra extra extra extra long label', 3], ['Ubuntu 14.04', 4], ['Centos 7 extra extra long label', 2], ['Debian 8', 1], ['Fedora 27', 2], ['Fedora 26', 1]],
   },
   tooltip: {
     show: true,

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/__snapshots__/DonutChart.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/__snapshots__/DonutChart.test.js.snap
@@ -30,6 +30,14 @@ exports[`renders DonutChart render donut chart 1`] = `
           "Debian 8",
           1,
         ],
+        Array [
+          "Fedora 27",
+          2,
+        ],
+        Array [
+          "Fedora 26",
+          1,
+        ],
       ],
     }
   }

--- a/webpack/assets/javascripts/react_app/components/factCharts/factChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/factChart.fixtures.js
@@ -22,7 +22,7 @@ export const modalSuccessState = Immutable(Object.assign(
     modalToDisplay: { 1: true },
     chartData: chartDataValues,
     loaderStatus: STATUS.RESOLVED,
-    hostsCount: 10,
+    hostsCount: 13,
   },
 ));
 

--- a/webpack/assets/javascripts/services/ChartService.consts.js
+++ b/webpack/assets/javascripts/services/ChartService.consts.js
@@ -18,7 +18,7 @@ export const donutChartConfig = {
     columns: [],
   },
   color: {
-    pattern: ['#0088ce', '#cc0000', '#ec7a08', '#3f9c35', '#005c66', 'f9d67a'],
+    pattern: ['#0088ce', '#ec7a08', '#3f9c35', '#005c66', 'f9d67a', '#703fec'],
   },
   tooltip: {
     show: true,


### PR DESCRIPTION
Using pf-react donut chart instead of flot

![image](https://user-images.githubusercontent.com/15361156/40061034-abe97250-5860-11e8-9187-8a6099e9113d.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
