### PR TITLE
Fixes #23601 - switch org/loc button ordering in vertical nav

### DIFF
--- a/app/views/home/_navbar.html.erb
+++ b/app/views/home/_navbar.html.erb
@@ -10,8 +10,9 @@
 
     <%= render_vertical_menu :admin_menu %>
 
-    <%= render "home/vertical_taxonomies", :taxonomy_type => "location", :icon_name => "fa fa-globe" if SETTINGS[:locations_enabled]  %>
     <%= render "home/vertical_taxonomies", :taxonomy_type => "organization", :icon_name => "fa fa-building" if SETTINGS[:organizations_enabled]  %>
+    <%= render "home/vertical_taxonomies", :taxonomy_type => "location", :icon_name => "fa fa-globe" if SETTINGS[:locations_enabled]  %>
+
     <%= render_vertical_menu :side_menu, true %>
   </ul>
 </div>

--- a/test/integration/top_bar_test.rb
+++ b/test/integration/top_bar_test.rb
@@ -94,7 +94,7 @@ class TopBarIntegrationTest < ActionDispatch::IntegrationTest
 
   test "hamburger menu should have some mobile submenu " do
     visit root_path
-    mobile_menu = ["Location", "Organization", "User"]
+    mobile_menu = ["Organization", "Location", "User"]
     all(".visible-xs-block").each_with_index do |el, index|
       assert el.has_content?(mobile_menu[index])
     end


### PR DESCRIPTION
Org/Loc Button ordering is not the same when moved after window resize