### PR TITLE
Fixes #23610,#23417 - audit changes per column

### DIFF
--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -25,3 +25,5 @@ telemetry.add_counter(:importer_facts_count_interfaces, 'Number of changed inter
 telemetry.add_histogram(:ldap_request_duration, 'Total duration of LDAP requests')
 telemetry.add_histogram(:report_importer_create, 'Total duration of report import creation', [:type])
 telemetry.add_histogram(:report_importer_refresh, 'Total duration of report status refresh', [:type])
+telemetry.add_counter(:audit_records_created, 'Number of audit records created in the DB', [:type])
+telemetry.add_counter(:audit_records_logged, 'Number of audit records sent into logger', [:type])

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -34,9 +34,16 @@ module Foreman
     end
 
     def add_logger(logger_name, logger_config)
-      logger          = ::Logging.logger[logger_name]
-      logger.level    = logger_config[:level] if logger_config.key?(:level)
-      logger.additive = logger_config[:enabled] if logger_config.key?(:enabled)
+      logger = ::Logging.logger[logger_name]
+      if logger_config.key?(:enabled)
+        if logger_config[:enabled]
+          logger.additive = true
+          logger.level = logger_config[:level] if logger_config.key?(:level)
+        else
+          # set high level for disabled logger
+          logger.level = :fatal
+        end
+      end
 
       # TODO: Remove once only Logging 2.0 is supported
       if logger.respond_to?(:caller_tracing)


### PR DESCRIPTION
Audit log entries are now search friendly. Also exit fast if audit log
is disabled. This is how audit records looks like now:


```
    SESSION=f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134
    USER_LOGIN=admin
    AUDIT_ACTION=update
    AUDIT_TYPE=Subnet
    FOREMAN_LOGGER=audit
    AUDIT_COLUMN=mtu
    REQUEST=076c25ed-54b7-40f7-84be-761ea32c91eb
    AUDIT_ID=2
    AUDIT_OLD=1500
    AUDIT_NEW=1499
    MESSAGE={"logger":"audit","timestamp":"2018-05-16T14:48:27.974184+02:00","level":"INFO","message":"Subnet (2) update event on mtu","mdc":{"remote_ip":"127.0.0.1","request":"076c25ed-54b7-40f7-84be-761ea32c91eb","session":"f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134","user_login":"admin"},"ndc":[{"audit_action":"update","audit_type":"Subnet","audit_id":2,"audit_column":"mtu","audit_old":1500,"audit_new":1499}]}
--
    REMOTE_IP=127.0.0.1
    SESSION=f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134
    USER_LOGIN=admin
    AUDIT_ACTION=update
    AUDIT_TYPE=Subnet
    AUDIT_COLUMN=vlanid
    FOREMAN_LOGGER=audit
    AUDIT_ID=2
    REQUEST=54953f91-6b60-4c38-a277-cdce866c0e73
    AUDIT_NEW=11
    MESSAGE={"logger":"audit","timestamp":"2018-05-16T14:48:49.043352+02:00","level":"INFO","message":"Subnet (2) update event on vlanid","mdc":{"remote_ip":"127.0.0.1","request":"54953f91-6b60-4c38-a277-cdce866c0e73","session":"f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134","user_login":"admin"},"ndc":[{"audit_action":"update","audit_type":"Subnet","audit_id":2,"audit_column":"vlanid","audit_old":null,"audit_new":11}]}
--
    SESSION=f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134
    USER_LOGIN=admin
    AUDIT_ACTION=update
    AUDIT_TYPE=Subnet
    FOREMAN_LOGGER=audit
    AUDIT_COLUMN=mtu
    AUDIT_NEW=1500
    AUDIT_ID=2
    REQUEST=54953f91-6b60-4c38-a277-cdce866c0e73
    AUDIT_OLD=1499
    MESSAGE={"logger":"audit","timestamp":"2018-05-16T14:48:49.043803+02:00","level":"INFO","message":"Subnet (2) update event on mtu","mdc":{"remote_ip":"127.0.0.1","request":"54953f91-6b60-4c38-a277-cdce866c0e73","session":"f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134","user_login":"admin"},"ndc":[{"audit_action":"update","audit_type":"Subnet","audit_id":2,"audit_column":"mtu","audit_old":1499,"audit_new":1500}]}
--
    SESSION=f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134
    USER_LOGIN=admin
    AUDIT_ACTION=update
    AUDIT_TYPE=Subnet
    AUDIT_ID=1
    AUDIT_COLUMN=vlanid
    FOREMAN_LOGGER=audit
    REQUEST=dddb2c6d-a531-46ac-9d13-bceb83bd80f4
    AUDIT_OLD=222
    MESSAGE={"logger":"audit","timestamp":"2018-05-16T14:49:04.605551+02:00","level":"INFO","message":"Subnet (1) update event on vlanid","mdc":{"remote_ip":"127.0.0.1","request":"dddb2c6d-a531-46ac-9d13-bceb83bd80f4","session":"f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134","user_login":"admin"},"ndc":[{"audit_action":"update","audit_type":"Subnet","audit_id":1,"audit_column":"vlanid","audit_old":222,"audit_new":null}]}
    _SOURCE_REALTIME_TIMESTAMP=1526474944605881
--
    USER_LOGIN=admin
    AUDIT_ACTION=update
    AUDIT_TYPE=Subnet
    AUDIT_ID=1
    FOREMAN_LOGGER=audit
    AUDIT_COLUMN=mtu
    AUDIT_OLD=1500
    AUDIT_NEW=1499
    REQUEST=dddb2c6d-a531-46ac-9d13-bceb83bd80f4
    MESSAGE={"logger":"audit","timestamp":"2018-05-16T14:49:04.606094+02:00","level":"INFO","message":"Subnet (1) update event on mtu","mdc":{"remote_ip":"127.0.0.1","request":"dddb2c6d-a531-46ac-9d13-bceb83bd80f4","session":"f07bce9c-31ba-46a9-a0e6-a4cc5c0e9134","user_login":"admin"},"ndc":[{"audit_action":"update","audit_type":"Subnet","audit_id":1,"audit_column":"mtu","audit_old":1500,"audit_new":1499}]}
    _SOURCE_REALTIME_TIMESTAMP=1526474944606296
```