### PR TITLE
fixes #23178 - seeded location should be in seeded org

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -2,7 +2,7 @@
 if SETTINGS[:organizations_enabled] && ENV['SEED_ORGANIZATION'] && !Organization.any?
   Organization.without_auditing do
     original_user, User.current = User.current, User.anonymous_admin
-    Organization.where(:name => ENV['SEED_ORGANIZATION']).first_or_create
+    @organization = Organization.where(:name => ENV['SEED_ORGANIZATION']).first_or_create
     User.current = original_user
   end
 end
@@ -11,7 +11,13 @@ end
 if SETTINGS[:locations_enabled] && ENV['SEED_LOCATION'] && !Location.any?
   Location.without_auditing do
     original_user, User.current = User.current, User.anonymous_admin
-    Location.where(:name => ENV['SEED_LOCATION']).first_or_create!
+    @location = Location.where(:name => ENV['SEED_LOCATION']).first_or_create!
     User.current = original_user
   end
+end
+
+# Add the initial location to the initial organization to prevent mismatches
+# when a host is created that uses them
+if @organization && @location && @organization.locations.exclude?(@location)
+  @organization.locations << @location
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -748,6 +748,8 @@ class HostTest < ActiveSupport::TestCase
       @host = FactoryBot.create(:host, :managed => false)
       @location = Location.create :name => "New York"
       @organization = Organization.create :name => "Hosting client 1"
+
+      @organization.locations << @location
     end
 
     test "assign a host to a location" do
@@ -778,6 +780,8 @@ class HostTest < ActiveSupport::TestCase
       @host.organization_id = @organization.id
 
       assert @host.save!
+      assert @host.organization.valid?
+      assert @host.location.valid?
     end
   end
 

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -161,6 +161,23 @@ class SeedsTest < ActiveSupport::TestCase
     refute Location.unscoped.find_by_name('seed_test')
   end
 
+  test "seeded organization contains seeded location" do
+    Location.stubs(:any?).returns(false)
+    Organization.stubs(:any?).returns(false)
+
+    org_name = 'seed_org'
+    loc_name = 'seed_loc'
+
+    with_env('SEED_ORGANIZATION' => org_name, 'SEED_LOCATION' => loc_name) do
+      seed
+    end
+
+    org = Organization.unscoped.find_by_name(org_name)
+    loc = Location.unscoped.find_by_name(loc_name)
+
+    assert org.locations.include?(loc)
+  end
+
   test "all access permissions are created by permissions seed" do
     seed
     access_permissions = Foreman::AccessControl.permissions.reject(&:public?).reject(&:plugin?).map(&:name).map(&:to_s)


### PR DESCRIPTION
When creating a host in the seeded org and seeded loc, host saves and
then organization becomes invalid: "Locations expecting locations used
by hosts or inherited (check mismatches report)."



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
