### PR TITLE
[WIP] Implement skipable reports

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,6 +5,8 @@ class Report < ApplicationRecord
   include Authorizable
   include ConfigurationStatusScopedSearch
 
+  attr_accessor :skipable
+
   validates_lengths_from_database
   belongs_to_host
   has_many :messages, :through => :logs

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -61,6 +61,7 @@ class Setting::Provisioning < Setting
       self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
       self.set('default_pxe_item_global', N_("Default PXE (PXELinux, PXEGrub, PXEGrub2) menu item in global template - 'local', 'discovery' or custom"), 'local', N_("Default PXE global template entry")),
       self.set('default_pxe_item_local', N_("Default PXE (PXELinux, PXEGrub2) menu item in local template - 'local_chain_hd0', 'local' or custom"), 'local_chain_hd0', N_("Default PXE local template entry")),
+      self.set('import_skipable_reports', N_("Import Reports even when skipable"), true, N_("Import skipable reports")),
       self.set(
         'excluded_facts',
         N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -144,8 +144,10 @@ class ReportImporter
     # Run report scanner
     scan
 
-    @report.save
-    @report
+    unless !!@report.skipable && Setting[:import_skipable_reports]
+      @report.save
+      @report
+    end
   end
 
   def report_scanners


### PR DESCRIPTION
This should allow Reports to be marked as "skipable" and introduces a setting to prevent importing these reports.

Skipable reports are will for example be a Ansible report that is only a command executed via a remote execution job.
