### PR TITLE
Fixes #23611 - Provide helper method to run "service" active jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,4 +2,18 @@ class ApplicationJob < ActiveJob::Base
   def humanized_name
     self.class.name
   end
+
+  def self.spawn_if_missing(world)
+    unless Foreman.in_rake? || Rails.env.test?
+      pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
+      scheduled_job = pending_jobs.select do |job|
+        delayed_plan = world.persistence.load_delayed_plan job.id
+        next unless delayed_plan.present?
+        delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == self.to_s
+      end
+
+      # Only create notifications if there isn't a scheduled job
+      self.perform_later if scheduled_job.blank?
+    end
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,16 +4,16 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def self.spawn_if_missing(world)
-    unless Foreman.in_rake? || Rails.env.test?
-      pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
-      scheduled_job = pending_jobs.select do |job|
-        delayed_plan = world.persistence.load_delayed_plan job.id
-        next unless delayed_plan.present?
-        delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == self.to_s
-      end
+    return if Foreman.in_rake? || Rails.env.test?
 
-      # Only create notifications if there isn't a scheduled job
-      self.perform_later if scheduled_job.blank?
+    pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
+    scheduled_job = pending_jobs.select do |job|
+      delayed_plan = world.persistence.load_delayed_plan job.id
+      next unless delayed_plan.present?
+      delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == self.to_s
     end
+
+    # Only create notifications if there isn't a scheduled job
+    self.perform_later if scheduled_job.blank?
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -13,7 +13,7 @@ class ApplicationJob < ActiveJob::Base
       delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == self.to_s
     end
 
-    # Only create notifications if there isn't a scheduled job
+    # Schedule the job only if it doesn't exit yet
     self.perform_later if scheduled_job.blank?
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -10,7 +10,8 @@ class ApplicationJob < ActiveJob::Base
     scheduled_job = pending_jobs.select do |job|
       delayed_plan = world.persistence.load_delayed_plan job.id
       next unless delayed_plan.present?
-      delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == self.to_s
+      arg = delayed_plan.to_hash[:serialized_args].first
+      arg.is_a?(Hash) && arg['job_class'] == self.to_s
     end
 
     # Schedule the job only if it doesn't exit yet

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,7 +4,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def self.spawn_if_missing(world)
-    return if Foreman.in_rake? || Rails.env.test?
+    return if (Foreman.in_rake? && !Foreman.in_rake?('dynflow:executor')) || Rails.env.test?
 
     pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
     scheduled_job = pending_jobs.select do |job|

--- a/config/initializers/rss_notifications.rb
+++ b/config/initializers/rss_notifications.rb
@@ -1,12 +1,4 @@
 # First, we check if there's a job already enqueued for RSS notifications
 ::Foreman::Application.dynflow.config.on_init do |world|
-  pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
-  scheduled_job = pending_jobs.select do |job|
-    delayed_plan = world.persistence.load_delayed_plan job.id
-    next unless delayed_plan.present?
-    delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == 'CreateRssNotifications'
-  end
-
-  # Only create notifications if there isn't a scheduled job
-  CreateRssNotifications.perform_later if !Rails.env.test? && scheduled_job.blank?
+  CreateRssNotifications.spawn_if_missing(world)
 end

--- a/test/unit/application_job_test.rb
+++ b/test/unit/application_job_test.rb
@@ -3,7 +3,6 @@ require 'ostruct'
 
 class ApplicationJobTest < ActiveSupport::TestCase
   describe '.spawn_if_missing' do
-
     # Force world initialization before stubbing,
     #   otherwise CreateRssNotifications would be triggered
     #   on first call to world

--- a/test/unit/application_job_test.rb
+++ b/test/unit/application_job_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+require 'ostruct'
+
+class ApplicationJobTest < ActiveSupport::TestCase
+  describe '.spawn_if_missing' do
+
+    # Force world initialization before stubbing,
+    #   otherwise CreateRssNotifications would be triggered
+    #   on first call to world
+    before { world }
+
+    let(:job_class) { ApplicationJob }
+    let(:world) { Foreman::Application.dynflow.world }
+
+    def stub_delayed_plans_with_serialized_args(*args)
+      execution_plans = args.each_with_index.map { |_, index| OpenStruct.new(:id => index) }
+      world.persistence.expects(:find_execution_plans).returns(execution_plans)
+      args.each_with_index do |arg, index|
+        delayed_plan = OpenStruct.new(:to_hash => { :serialized_args => arg })
+        world.persistence.expects(:load_delayed_plan).with(index).returns(delayed_plan)
+      end
+    end
+
+    describe 'when in rake' do
+      before { Foreman.expects(:in_rake?).returns(true) }
+
+      it 'runs in dynflow:executor rake task' do
+        Foreman.expects(:in_rake?).with('dynflow:executor').returns(true)
+        Rails.env.expects(:test?).returns(false)
+        job_class.expects(:perform_later)
+
+        job_class.spawn_if_missing world
+      end
+
+      it 'does not run in other rake tasks' do
+        Foreman.expects(:in_rake?).with('dynflow:executor').returns(false)
+        Rails.env.expects(:test?).never
+        job_class.expects(:perform_later).never
+
+        job_class.spawn_if_missing world
+      end
+    end
+
+    describe 'when not in rake' do
+      before { Foreman.expects(:in_rake?).returns(false) }
+
+      it 'does not run in test environment' do
+        Rails.env.expects(:test?).returns(true)
+        job_class.expects(:perform_later).never
+
+        job_class.spawn_if_missing world
+      end
+
+      describe 'when not in test environment' do
+        before { Rails.env.expects(:test?).returns(false) }
+
+        it 'runs' do
+          job_class.expects(:perform_later)
+
+          job_class.spawn_if_missing world
+        end
+
+        it 'does not trigger the job if it already exists' do
+          stub_delayed_plans_with_serialized_args [{ 'job_class' => job_class.to_s }]
+          job_class.expects(:perform_later).never
+
+          job_class.spawn_if_missing world
+        end
+
+        it 'ignores other active jobs' do
+          stub_delayed_plans_with_serialized_args [{ 'job_class' => 'NotTheClassWeAreLookingFor' }]
+          job_class.expects(:perform_later)
+
+          job_class.spawn_if_missing world
+        end
+
+        it 'does not crash when delayed jobs have unexpected arguments' do
+          stub_delayed_plans_with_serialized_args [1]
+          job_class.expects(:perform_later)
+
+          job_class.spawn_if_missing world
+        end
+
+        it 'does not crash when delayed jobs have unexpected shape of arguments' do
+          stub_delayed_plans_with_serialized_args [{'something' => 'not important' }]
+          job_class.expects(:perform_later)
+
+          job_class.spawn_if_missing world
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The root cause was we were triggering the active jobs too early,
sometimes even before the db was migrated. This led to all sorts of
errors. The provided helper method does not trigger the jobs when in
any rake or in test environment. This helper should be reused in
Katello as well.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
