### PR TITLE
refs #23378 - vsphere: filter volume key parameter

### DIFF
--- a/app/controllers/concerns/foreman/controller/normalize_scsi_attributes.rb
+++ b/app/controllers/concerns/foreman/controller/normalize_scsi_attributes.rb
@@ -9,7 +9,7 @@ module Foreman::Controller::NormalizeScsiAttributes
       deep_symbolize_keys
     volumes = {}
     scsi_and_vol[:volumes].each_with_index do |vol, index|
-      volumes[index.to_s] = vol
+      volumes[index.to_s] = vol.except(:key)
     end
 
     attrs["scsi_controllers"] = scsi_and_vol[:scsi_controllers]


### PR DESCRIPTION
This is an alternative, but well tested (by the community) solution for #5492. My suggestion is to cherry-pick this (because we know it fixes the issue and is less intrusive) for 1.17.1.

cc: @tbrisker