### PR TITLE
fixes #23621 - passwords can be md5 hashed

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -3,6 +3,10 @@ require 'base64'
 class PasswordCrypt
   ALGORITHMS = {'SHA256' => '$5$', 'SHA512' => '$6$', 'Base64' => ''}
 
+  if Foreman::Fips.md5_available?
+    ALGORITHMS['MD5']= '$1$'
+  end
+
   def self.passw_crypt(passwd, hash_alg = 'SHA256')
     raise Foreman::Exception.new(N_("Unsupported password hash function '%s'"), hash_alg) unless ALGORITHMS.has_key?(hash_alg)
     result = (hash_alg == 'Base64') ? Base64.strict_encode64(passwd) : passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")

--- a/lib/foreman/fips.rb
+++ b/lib/foreman/fips.rb
@@ -1,0 +1,12 @@
+module Foreman
+  module Fips
+    def self.md5_available?
+      @md5_available ||= begin
+        OpenSSL::Digest::MD5.digest('')
+        true
+      rescue OpenSSL::Digest::DigestError
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This re-adds the possibility that host's password can be md5-hashes. If fips mode is enabled, this option vanishes from the ui.