### PR TITLE
Refs #23511 - make the webpack generated bundle reusable by plugins

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -163,6 +163,11 @@ module.exports = env => {
         },
         sourceMap: false
       }),
+      new webpack.HashedModuleIdsPlugin({
+        hashFunction: 'sha256',
+        hashDigest: 'hex',
+        hashDigestLength: 20
+      }),
       new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.optimize.OccurrenceOrderPlugin(),
       new CompressionPlugin()


### PR DESCRIPTION
use stable (hashed) module references instead of numbers 