### PR TITLE
Fixes #23623 - expiration rake task in batches

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -6,6 +6,8 @@ Available conditions:
   * days        => number of days to keep reports (defaults to 7)
   * status      => status of the report (if not set defaults to any status)
   * report_type => report type (defaults to config_report), accepts either underscore / class name styles
+  * batch_size  => number of records deleted in single SQL transaction (defaults to 1k)
+  * sleep_time  => delay in seconds between batches (defaults to 0.2)
 
   Example:
     rake reports:expire days=7 RAILS_ENV="production" # expires all reports regardless of their status
@@ -30,8 +32,10 @@ namespace :reports do
     conditions = {}
     conditions[:timerange] = ENV['days'].to_i.days if ENV['days']
     conditions[:status] = ENV['status'].to_i if ENV['status']
+    batch_size = ENV['batch_size'].to_i if ENV['batch_size']
+    sleep_time = ENV['sleep_time'].to_f if ENV['sleep_time']
 
-    report_type.expire(conditions)
+    report_type.expire(conditions, batch_size, sleep_time)
   end
 end
 # TRANSLATORS: do not translate


### PR DESCRIPTION
Foreman reports have long-standing problem that has something to do with concurrency of reports creation and deletion. Managed hosts uploads lots of reports and due to how reports are being stored in our RDBM, this operation is slow, but scaleable. The problem starts when there is a rake task which is regularly called (weekly or daily I think) which tries to delete those records. If the rate of creation is fast enough, the rake task is unable to delete the records because for deletion whole table needs to be locked which slows down or even kills new report creation. We've seen this misbehavior on both MySQL and PostgreSQL.

I created a patch which aims to solve this by breaking the (rake) deletion into batches (by default by 500 reports - configurable). There is a small sleep between batches (100ms by default) so the locked transactions have a chance to start. We need to find the right balance of deletion of records so you actually keep up with incoming records.

I hereby ask users with some decent amount of reports (ideally live instance so new reports are incoming) to test this small patch. It should be any Foreman version compatible. Measure how reports are being deleted before and after the patch. I am interested in time spent deleting those records and performance of report upload calls. If you want, change the batch size or delay time and share results.

Without enough testing, we can't be confident enough this won't make things even worse. Please test both on MySQL and/or PostgreSQL - the patch should work on both.