### PR TITLE
Fixes #23634 - Drop puppet related settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -12,7 +12,7 @@ class Setting < ApplicationRecord
   FROZEN_ATTRS = %w{name category full_name}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page max_trend outofsync_interval}
   BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text
-                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list}
+                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list ssl_certificate ssl_ca_file ssl_priv_key }
   ARRAY_HOSTNAMES = %w{trusted_hosts}
   URI_ATTRS = %w{foreman_url unattended_url}
   URI_BLANK_ATTRS = %w{login_delegation_logout_url}

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -1,11 +1,5 @@
 class Setting::Auth < Setting
   def self.default_settings
-    fqdn = SETTINGS[:fqdn]
-    lower_fqdn = fqdn.downcase
-    ssl_cert     = "#{SETTINGS[:puppetssldir]}/certs/#{lower_fqdn}.pem"
-    ssl_ca_file  = "#{SETTINGS[:puppetssldir]}/certs/ca.pem"
-    ssl_priv_key = "#{SETTINGS[:puppetssldir]}/private_keys/#{lower_fqdn}.pem"
-
     [
       self.set('oauth_active', N_("Foreman will use OAuth for API authorization"), false, N_('OAuth active')),
       self.set('oauth_consumer_key', N_("OAuth consumer key"), '', N_('OAuth consumer key'), nil, {:encrypted => true}),
@@ -15,9 +9,9 @@ class Setting::Auth < Setting
       self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
       self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
       self.set('trusted_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted hosts')),
-      self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), ssl_cert, N_('SSL certificate')),
-      self.set('ssl_ca_file', N_("SSL CA file that Foreman will use to communicate with its proxies"), ssl_ca_file, N_('SSL CA file')),
-      self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), ssl_priv_key, N_('SSL private key')),
+      self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), nil, N_('SSL certificate')),
+      self.set('ssl_ca_file', N_("SSL CA file that Foreman will use to communicate with its proxies"), nil, N_('SSL CA file')),
+      self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), nil, N_('SSL private key')),
       self.set('ssl_client_dn_env', N_('Environment variable containing the subject DN from a client SSL certificate'), 'SSL_CLIENT_S_DN', N_('SSL client DN env')),
       self.set('ssl_client_verify_env', N_('Environment variable containing the verification status of a client SSL certificate'), 'SSL_CLIENT_VERIFY', N_('SSL client verify env')),
       self.set('ssl_client_cert_env', N_("Environment variable containing a client's SSL certificate"), 'SSL_CLIENT_CERT', N_('SSL client cert env')),

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -8,9 +8,6 @@ SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result)
 SETTINGS[:version] = Foreman::Version.new
 SETTINGS[:unattended] = SETTINGS[:unattended].nil? || SETTINGS[:unattended]
 SETTINGS[:login]    ||= SETTINGS[:login].nil? || SETTINGS[:ldap]
-SETTINGS[:puppetconfdir] ||= '/etc/puppet'
-SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
-SETTINGS[:puppetssldir]  ||= "#{SETTINGS[:puppetvardir]}/ssl"
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value
 SETTINGS[:hsts_enabled] = true unless SETTINGS.has_key?(:hsts_enabled)
 

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -10,9 +10,6 @@
 #JSONP or "JSON with padding" is a complement to the base JSON data format.
 #It provides a method to request JSON data from a server in a different domain.
 :support_jsonp: false
-#:puppetconfdir: /etc/puppet
-#:puppetvardir: /var/lib/puppet
-#:puppetssldir: /var/lib/puppet/ssl
 
 # Mark translated strings with X characters (for developers)
 :mark_translated: false

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -8,8 +8,8 @@ require 'yaml'
 namespace :puppet do
   namespace :import do
     desc "Imports hosts and facts from existings YAML files, use dir= to override default directory"
-    task :hosts_and_facts => :environment do
-      dir = ENV['dir'] || "#{SETTINGS[:puppetvardir]}/yaml/facts"
+    task :hosts_and_facts, [:dir] => :environment do |t, args|
+      dir = args[:dir] || ENV['dir'] || '/opt/puppetlabs/server/data/puppetserver/yaml/facts'
       puts "Importing from #{dir}"
       Dir["#{dir}/*.yaml"].each do |yaml|
         name = yaml.match(/.*\/(.*).yaml/)[1]


### PR DESCRIPTION
This is a breaking change since we no longer provide defaults for SSL
communication with proxies. This should be manageable because the
installer explicitly sets these values.

Another breaking change is the importing of facts which no is no longer
configurable through the settings. It now defaults to the hardcoded
Puppet 4 path but does accept an explicit parameter in case this is
incorrect. It also still accepts the DIR env var to override it.