### PR TITLE
Fixes #23635 - Centralize use of facter

### DIFF
--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -1,7 +1,6 @@
-require 'facter'
 class Setting::Auth < Setting
   def self.default_settings
-    fqdn = Facter.value(:fqdn) || SETTINGS[:fqdn]
+    fqdn = SETTINGS[:fqdn]
     lower_fqdn = fqdn.downcase
     ssl_cert     = "#{SETTINGS[:puppetssldir]}/certs/#{lower_fqdn}.pem"
     ssl_ca_file  = "#{SETTINGS[:puppetssldir]}/certs/ca.pem"

--- a/app/models/setting/email.rb
+++ b/app/models/setting/email.rb
@@ -1,5 +1,3 @@
-require 'facter'
-
 class Setting::Email < Setting
   NON_EMAIL_YAML_SETTINGS = %w(send_welcome_email email_reply_address email_subject_prefix)
 

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -1,4 +1,3 @@
-require 'facter'
 class Setting::General < Setting
   include UrlValidator
 
@@ -6,7 +5,7 @@ class Setting::General < Setting
     protocol = SETTINGS[:require_ssl] ? 'https' : 'http'
     domain = SETTINGS[:domain]
     administrator = "root@#{domain}"
-    foreman_url = "#{protocol}://#{Facter.value(:fqdn) || SETTINGS[:fqdn]}"
+    foreman_url = "#{protocol}://#{SETTINGS[:fqdn]}"
 
     [
       self.set('administrator', N_("The default administrator email address"), administrator, N_('Administrator email address')),

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -1,4 +1,3 @@
-require 'facter'
 class Setting::Provisioning < Setting
   def self.default_global_labels
     TemplateKind::PXE.map do |pxe_kind|
@@ -33,7 +32,7 @@ class Setting::Provisioning < Setting
     'vovsbr*'
   ]
   def self.default_settings
-    fqdn = Facter.value(:fqdn) || SETTINGS[:fqdn]
+    fqdn = SETTINGS[:fqdn]
     unattended_url = "http://#{fqdn}"
     select = [{:name => _("Users"), :class => 'user', :scope => 'visible', :value_method => 'id_and_type', :text_method => 'login'},
               {:name => _("Usergroup"), :class => 'usergroup', :scope => 'visible', :value_method => 'id_and_type', :text_method => 'name'}]

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -1,6 +1,5 @@
 require_relative 'boot_settings'
 require_relative '../app/services/foreman/version'
-require 'facter'
 
 root = File.expand_path(File.dirname(__FILE__) + "/..")
 settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
@@ -13,8 +12,13 @@ SETTINGS[:puppetconfdir] ||= '/etc/puppet'
 SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
 SETTINGS[:puppetssldir]  ||= "#{SETTINGS[:puppetvardir]}/ssl"
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value
-SETTINGS[:domain] ||= Facter.value(:domain) || Facter.value(:hostname)
 SETTINGS[:hsts_enabled] = true unless SETTINGS.has_key?(:hsts_enabled)
+
+unless SETTINGS[:domain] && SETTINGS[:fqdn]
+  require 'facter'
+  SETTINGS[:domain] ||= Facter.value(:domain) || Facter.value(:hostname)
+  SETTINGS[:fqdn] ||= Facter.value(:fqdn)
+end
 
 # Load plugin config, if any
 Dir["#{root}/config/settings.plugins.d/*.yaml"].each do |f|

--- a/db/migrate/20100419151910_add_owner_to_hosts.rb
+++ b/db/migrate/20100419151910_add_owner_to_hosts.rb
@@ -1,4 +1,3 @@
-require 'facter'
 class AddOwnerToHosts < ActiveRecord::Migration[4.2]
   class User < ApplicationRecord; end
   class Host < ApplicationRecord; end
@@ -9,7 +8,7 @@ class AddOwnerToHosts < ActiveRecord::Migration[4.2]
 
     Host.reset_column_information
 
-    email = SETTINGS[:administrator] || "root@#{Facter.value(:domain)}"
+    email = SETTINGS[:administrator] || "root@#{SETTINGS[:domain]}"
     owner = User.find_by_mail email
     owner ||= User.where(:admin => true).first
     unless owner.nil? || owner.id.nil?

--- a/db/migrate/20100628123400_add_internal_auth.rb
+++ b/db/migrate/20100628123400_add_internal_auth.rb
@@ -1,4 +1,3 @@
-require 'facter'
 class AddInternalAuth < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :password_hash, :string, :limit => 128

--- a/lib/tasks/reset_permissions.rake
+++ b/lib/tasks/reset_permissions.rake
@@ -1,4 +1,3 @@
-require 'facter'
 namespace :permissions do
   desc <<-END_DESC
 Create or reset "admin" user permissions to defaults.  Alternatively, you may


### PR DESCRIPTION
We have a bundler group for facter. That implies it's optional but
before this change it wasn't With this change it's only required if no
domain and fqdn are set. This is still the default so in most cases it's
no difference, but at least we have centralized all use of facter to one
place.