### PR TITLE
[WIP] Fixes #23632 - Don't escape non-string parameters multiple times

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -111,7 +111,7 @@ class LookupKey < ApplicationRecord
   end
 
   def value_before_type_cast(val)
-    return val if val.nil? || val.contains_erb?
+    return val if val.nil? || val.contains_erb? || val.is_a?(String)
     case key_type.to_sym
       when :json, :array
         val = JSON.dump(val)


### PR DESCRIPTION
Lookup values are not decoded into an array or hash while retrieving
form data in a POST request.  However that are pushed through a JSON
dumper again while creating the view, leading to JSON in JSON.
