### PR TITLE
Refs #23364 - Fix JS test regression

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBarActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBarActions.test.js.snap
@@ -81,7 +81,10 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "options": Object {},
+        "options": Object {
+          "page": 1,
+          "searchQuery": "",
+        },
         "resourceUrl": "some/url",
       },
       "type": "BREADCRUMB_BAR_RESOURCES_REQUEST",
@@ -108,7 +111,7 @@ Array [
           },
         ],
         "page": 1,
-        "pages": 1.5,
+        "pages": NaN,
         "resourceUrl": "some/url",
       },
       "type": "BREADCRUMB_BAR_RESOURCES_SUCCESS",


### PR DESCRIPTION
dc86fdd8a92f4aed6eb01313ac436bd01ba54869 was merged in a way that caused the JS tests to fail. Probably because the squashed merge included a rebase and develop had changed by then. The original parent was d88eb390f09419329dc7b854454f94649fa06491 rather than 0572c97e9a453cd7f0b61f0e621a364ee67d6d49.