### PR TITLE
Fixes #23643 - Stop bundle install in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,4 @@ node_js:
   - '6.10' # current EPEL 7
   - '6' # previous LTS
   - '8' # current LTS
-before_install:
-  - sudo apt-get install -y libsystemd-journal-dev
-  - cp config/settings.yaml.example config/settings.yaml
-  - bundle install --without console development ec2 fog gce jsonp libvirt mysql2 openid openstack ovirt postgresql rackspace sqlite test vmware
 script: ./script/travis_run_js_tests.sh

--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -8,7 +8,12 @@ if File.exist?(File.expand_path(File.join(%w[.. .. Gemfile.in]), __FILE__))
   specs = BundlerExt::Gemfile.parse(gemfile_in, :all).map { |spec, value| value[:dep] }
 else
   require 'bundler'
-  specs = Bundler.load.specs
+  begin
+    specs = Bundler.load.specs
+  rescue Bundler::GemNotFound
+    raise if File.exist?(File.expand_path(File.join(%w[.. Gemfile.lock]), __dir__))
+    specs = []
+  end
 end
 
 config = { entries: {}, paths: [], plugins: {} }


### PR DESCRIPTION
Since 90db5e364ff209f093c64849e21d3362644367f8 we no longer require core Foreman in script/plugin_webpack_directories.rb which means we no longer need all dependencies installed. Just Ruby with JSON support. This should greatly reduce the setup time on Travis.