### PR TITLE
Fixes #23645 - Make loading settings.yaml optional

### DIFF
--- a/config/boot_settings.rb
+++ b/config/boot_settings.rb
@@ -5,7 +5,9 @@ dist_settings_file = File.expand_path('../settings.yaml.dist', __FILE__)
 SETTINGS = File.exist?(dist_settings_file) ? YAML.load(ERB.new(File.read(dist_settings_file)).result) || {} : {}
 
 settings_file = File.expand_path('../settings.yaml', __FILE__)
-settings = YAML.load(ERB.new(File.read(settings_file)).result)
-SETTINGS[:rails] = settings[:rails] if settings[:rails]
+if File.exist?(settings_file)
+  settings = YAML.load(ERB.new(File.read(settings_file)).result)
+  SETTINGS[:rails] = settings[:rails] if settings[:rails]
+end
 SETTINGS[:rails] ||= '5.1'
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -5,10 +5,10 @@ require 'facter'
 root = File.expand_path(File.dirname(__FILE__) + "/..")
 settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
 
-SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result)
+SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result) if File.exist?(settings_file)
 SETTINGS[:version] = Foreman::Version.new
 SETTINGS[:unattended] = SETTINGS[:unattended].nil? || SETTINGS[:unattended]
-SETTINGS[:login]    ||= SETTINGS[:ldap]
+SETTINGS[:login]    ||= SETTINGS[:login].nil? || SETTINGS[:ldap]
 SETTINGS[:puppetconfdir] ||= '/etc/puppet'
 SETTINGS[:puppetvardir]  ||= '/var/lib/puppet'
 SETTINGS[:puppetssldir]  ||= "#{SETTINGS[:puppetvardir]}/ssl"


### PR DESCRIPTION
This makes the loading of config/settings.yaml optional. We do change the hardcoded default to default logins to true.