### PR TITLE
fixes #22388 - jwt token auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'dynflow', '>= 1.0.0', '< 2.0.0'
 gem 'daemons'
 gem 'get_process_mem'
 gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
+gem 'jwt', '~> 2.1.0'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -1,0 +1,16 @@
+module JwtAuth
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :jwt_secret, inverse_of: :user, dependent: :destroy
+
+    def jwt_secret!
+      jwt_secret || create_jwt_secret!
+    end
+
+    def jwt_token!
+      jwt_secret = jwt_secret!
+      JwtToken.encode(self, jwt_secret.token).to_s
+    end
+  end
+end

--- a/app/models/jwt_secret.rb
+++ b/app/models/jwt_secret.rb
@@ -1,0 +1,21 @@
+class JwtSecret < ApplicationRecord
+  include Encryptable
+
+  encrypts :token
+
+  belongs_to :user, inverse_of: :jwt_secret
+
+  validates :token, uniqueness: true
+  validates :user, presence: true
+
+  before_save :generate_token, on: :create, prepend: true, :unless => Proc.new {|j| j.token.present?}
+
+  private
+
+  def generate_token
+    loop do
+      self.token = SecureRandom.base64
+      break unless JwtSecret.find_by(token: token)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   include UserUsergroupCommon
   include Exportable
   include TopbarCacheExpiry
+  include JwtAuth
 
   ANONYMOUS_ADMIN = 'foreman_admin'
   ANONYMOUS_API_ADMIN = 'foreman_api_admin'

--- a/app/services/jwt_token.rb
+++ b/app/services/jwt_token.rb
@@ -1,0 +1,51 @@
+require 'jwt'
+require 'base64'
+
+class JwtToken < Struct.new(:token)
+  class << self
+    def encode(user, secret)
+      payload = prepare_payload(user, secret)
+      new JWT.encode(payload, secret)
+    end
+
+    private
+
+    def prepare_payload(user, secret)
+      jti_raw = [secret, iat].join(':')
+      jti = Digest::SHA256.hexdigest(jti_raw)
+      { user_id: user.id, iat: iat, jti: jti }
+    end
+
+    def iat
+      Time.now.to_i
+    end
+  end
+
+  def decode
+    return nil if token.blank?
+    return nil if secret.blank?
+
+    payload = JWT.decode(token, secret.token)
+    payload.first
+  end
+
+  def to_s
+    token
+  end
+
+  private
+
+  def secret
+    return @secret if defined? @secret
+    @secret = JwtSecret.find_by(user: user_id)
+  end
+
+  def user_id
+    @user_id ||= decoded_payload['user_id']
+  end
+
+  # This method does not verify if the token signature is valid
+  def decoded_payload
+    @decoded_payload ||= JWT.decode(token, nil, false).first
+  end
+end

--- a/app/services/sso.rb
+++ b/app/services/sso.rb
@@ -1,5 +1,5 @@
 module SSO
-  METHODS = [Apache, Basic, Oauth]
+  METHODS = [Apache, Basic, Jwt, Oauth]
 
   def self.get_available(controller)
     all_methods = all.map { |method| method.new(controller) }

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -1,0 +1,39 @@
+module SSO
+  class Jwt < Base
+    attr_reader :current_user
+
+    def available?
+      controller.api_request? && bearer_token_set?
+    end
+
+    def authenticate!
+      payload = jwt_token.decode || {}
+      user_id = payload['user_id']
+      user = User.unscoped.except_hidden.find_by(id: user_id) if user_id
+      @current_user = user
+      user&.login
+    rescue JWT::DecodeError
+      Rails.logger.error "JWT SSO: Failed to decode JWT."
+      nil
+    end
+
+    def authenticated?
+      self.user = User.current.presence || authenticate!
+    end
+
+    private
+
+    def jwt_token
+      @jwt_token ||= jwt_token_from_request
+    end
+
+    def jwt_token_from_request
+      token = request.authorization.split(' ')[1]
+      JwtToken.new(token)
+    end
+
+    def bearer_token_set?
+      request.authorization.present? && request.authorization.start_with?('Bearer')
+    end
+  end
+end

--- a/db/migrate/20180129143410_create_jwt_secrets.rb
+++ b/db/migrate/20180129143410_create_jwt_secrets.rb
@@ -1,0 +1,9 @@
+class CreateJwtSecrets < ActiveRecord::Migration[5.1]
+  def change
+    create_table :jwt_secrets do |t|
+      t.string :token, index: { unique: true }, null: false
+      t.references :user, null: false, type: :integer, foreign_key: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/controllers/api/v2/base_controller_subclass_test.rb
+++ b/test/controllers/api/v2/base_controller_subclass_test.rb
@@ -85,6 +85,24 @@ class Api::V2::TestableControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context 'with jwt auth' do
+      let(:sso) { SSO::Jwt.new(@controller) }
+      let(:user) { as_admin { FactoryBot.create(:user, :admin) } }
+      let(:jwt_token) { user.jwt_token! }
+
+      setup do
+        @controller.instance_variable_set(:@available_sso, sso)
+        @controller.stubs(:get_sso_method).returns(sso)
+        @request.headers['Authorization'] = "Bearer #{jwt_token}"
+      end
+
+      test 'it sets the session user' do
+        get :index
+        assert_response :success
+        assert_equal user.id, session[:user]
+      end
+    end
   end
 
   test "should have server error message" do

--- a/test/factories/user_related.rb
+++ b/test/factories/user_related.rb
@@ -116,4 +116,8 @@ FactoryBot.define do
     sequence(:name) {|n| "Status Table #{n}" }
     template { 'status_widget' }
   end
+
+  factory :jwt_secret do
+    token { SecureRandom.base64 }
+  end
 end

--- a/test/models/jwt_secret_test.rb
+++ b/test/models/jwt_secret_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class JwtSecretTest < ActiveSupport::TestCase
+  test 'generate token before creation' do
+    user = FactoryBot.create(:user)
+    jwt_secret = user.build_jwt_secret
+    jwt_secret.save!
+    refute_nil jwt_secret.token
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1051,6 +1051,14 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'creating jwt secret for user' do
+    user = FactoryBot.create(:user)
+    jwt_secret = user.jwt_secret!
+
+    refute_nil jwt_secret
+    assert jwt_secret.persisted?
+  end
+
   context 'Jail' do
     test 'should allow methods' do
       allowed = [:login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail]

--- a/test/unit/jwt_token_test.rb
+++ b/test/unit/jwt_token_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+require 'ostruct'
+
+class JwtTokenTest < ActiveSupport::TestCase
+  # Token created from encoding with 'test_jwt_secret' a following payload:
+  # { 'user_id' => 123, 'iat' => 1514804400, 'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94' }
+  let(:token) { 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjMsImlhdCI6MTUxNDgwNDQwMCwianRpIjoiM2U4Mjg2OTQwZWIxNjJlYzczNWY4YTVhYWM1OTI2MDM3ZmRjN2YwNWU1MjFhNzQyMzFhNjVmMjU1N2E4YWY5NCJ9.TSM2xMnMuMEWwAVoIidyLIwJElJQZVQvcfaxyVA7cDI' }
+
+  test 'encoding' do
+    JwtToken.stubs(:iat).returns(1_514_804_400)
+
+    user = OpenStruct.new(id: 123)
+    jwt_token = JwtToken.encode(user, 'test_jwt_secret')
+
+    assert_equal token, jwt_token.to_s
+  end
+
+  test 'decoding' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
+    JwtSecret.stubs(:find_by).returns(jwt_secret)
+    jwt_token = JwtToken.new(token)
+
+    expected = {'user_id' => 123,
+                'iat' => 1_514_804_400,
+                'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94'}
+
+    assert_equal expected, jwt_token.decode
+  end
+
+  test 'decoding invalid token' do
+    jwt_token = JwtToken.new('inVaLiD.inVaLiD.inVaLiD')
+
+    assert_raises JWT::DecodeError do
+      jwt_token.decode
+    end
+  end
+
+  test 'decoding empty token' do
+    jwt_token = JwtToken.new('')
+
+    assert_nil jwt_token.decode
+  end
+
+  test 'decoding garbage token' do
+    jwt_token = JwtToken.new('fjdfhjjkdsjfdjksn')
+
+    assert_raises JWT::DecodeError do
+      jwt_token.decode
+    end
+  end
+
+  test 'decoding with invalid secret' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'invalid_jwt_secret')
+    JwtSecret.stubs(:find_by).returns(jwt_secret)
+    jwt_token = JwtToken.new(token)
+
+    assert_raises JWT::VerificationError do
+      jwt_token.decode
+    end
+  end
+end

--- a/test/unit/sso/jwt_test.rb
+++ b/test/unit/sso/jwt_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class JwtTest < ActiveSupport::TestCase
+  setup do
+    User.current = nil
+  end
+
+  context 'api request' do
+    let(:token) { 'invalid' }
+    let(:controller) { get_controller(true, token) }
+    let(:sso) { SSO::Jwt.new(controller) }
+
+    test 'jwt is available' do
+      assert sso.available?
+    end
+
+    test 'does not reauthenticate if user.current is set' do
+      as_user(:one) do
+        sso.expects(:authenticate!).never
+        assert_equal users(:one), sso.authenticated?
+      end
+    end
+
+    context 'with valid token' do
+      let(:token) { users(:one).jwt_token! }
+
+      test '#authenticate! authenticates a user' do
+        assert_equal users(:one).login, sso.authenticated?
+        assert_equal users(:one).login, sso.user
+        assert_equal users(:one), sso.current_user
+      end
+    end
+
+    context 'with invalid token' do
+      test '#authenticate! does not set user' do
+        assert_nil sso.authenticated?
+        assert_nil sso.user
+        assert_nil sso.current_user
+      end
+    end
+
+    context "with token signed with another user's secret" do
+      let(:token) { JwtToken.encode(users(:one), users(:two).jwt_secret!.token) }
+
+      test '#authenticate! does not set user' do
+        assert_nil sso.authenticated?
+        assert_nil sso.user
+        assert_nil sso.current_user
+      end
+    end
+  end
+
+  context 'no api request' do
+    let(:controller) { get_controller(false) }
+    let(:sso) { SSO::Jwt.new(controller) }
+
+    test 'jwt is not available' do
+      refute sso.available?
+    end
+  end
+
+  protected
+
+  def get_controller(api_request, jwt_token = 'invalid', headers = {})
+    controller = Struct.new(:request).new(Struct.new(:authorization, :headers).new("Bearer #{jwt_token}", headers))
+    controller.stubs(:api_request?).returns(api_request)
+    controller
+  end
+end


### PR DESCRIPTION
This is part 1 of the graphql series and extracts JWT auth from #5336. It also adds JWT as an SSO method.

Currently there is no API route to return a jwt token for a user. I'd like to add that in a separate PR.

Credits go to @dariuszb-iRonin and @lucasm-iRonin.

---
Other parts:
Part 1 - JWT Auth: #5596
Part 2 - Graphql Scaffolding: #5680
Part 3 - Relay Global ID #5681
Part 4 - Connections with totalCount #5733
Part 5 - Basic mutations for model #5736