### PR TITLE
Fixes #23654 - update even virtual interface facts 

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -208,6 +208,7 @@ module Host
       if !self.managed? && self.primary_interface.mac.blank? && self.primary_interface.identifier.blank?
         identifier, values = parser.suggested_primary_interface(self)
         if values.present?
+          logger.debug "Suggested #{identifier} NIC as a primary interface."
           self.primary_interface.mac = Net::Validations.normalize_mac(values[:macaddress])
           interface_klass = interface_class(identifier)
           # bridge interfaces are not attached to parent interface so save would not be possible
@@ -479,7 +480,7 @@ module Host
         # we search bonds based on identifiers, e.g. ubuntu sets random MAC after each reboot se we can't
         # rely on mac
         when 'Nic::Bond', 'Nic::Bridge'
-          base.virtual.where(:identifier => name)
+          base.where(:identifier => name)
         # for other interfaces we distinguish between virtual and physical interfaces
         # for virtual devices we don't check only mac address since it's not unique,
         # if we want to update the device it must have same identifier
@@ -528,7 +529,7 @@ module Host
       bond.save!
     rescue StandardError => e
       logger.warn "Saving #{bond.identifier} NIC for host #{self.name} failed, skipping because #{e.message}:"
-      bond.errors.full_messages.each { |e| logger.warn " #{e}" }
+      bond.errors.full_messages.each { |message| logger.warn " #{message}" }
     end
 
     def set_interface(attributes, name, iface)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -937,7 +937,7 @@ class HostTest < ActiveSupport::TestCase
 
       @host.environment = env_with_other_tax
       refute @host.valid?
-      assert_match /is not assigned/, @host.errors[:environment_id].first
+      assert_match(/is not assigned/, @host.errors[:environment_id].first)
     end
   end
 
@@ -1611,6 +1611,15 @@ class HostTest < ActiveSupport::TestCase
     assert host.interfaces.where(:mac => '00:00:00:11:22:33').first.link
   end
 
+  test "#set_interfaces updates existing bridge interface suggested as primary" do
+    host, parser = setup_host_with_nic_parser({:identifier => 'br-ex', :macaddress => '00:00:00:11:22:33', :bridge => true, :virtual => true, :ipaddress => '10.10.0.1'})
+    host.managed = false
+    host.primary_interface.update(:identifier => 'br-ex', :mac => '00:00:00:11:22:33', :ip => '10.10.0.1')
+
+    host.set_interfaces(parser)
+    assert host.interfaces.where(:identifier => 'br-ex').first.virtual
+  end
+
   test "#set_interfaces creates new interface even if primary interface has same MAC" do
     host, parser = setup_host_with_nic_parser({:macaddress => '00:00:00:11:22:33', :virtual => true, :ipaddress => '10.10.0.1', :attached_to => 'eth0', :identifier => 'eth0_0'})
     host.update_attribute :mac, '00:00:00:11:22:33'
@@ -2119,7 +2128,7 @@ class HostTest < ActiveSupport::TestCase
       host.built(true)
       email = ActionMailer::Base.deliveries.detect { |mail| mail.subject =~ /Host #{host} is built/ }
       assert email
-      assert_match /Your host has finished/, email.body.encoded
+      assert_match(/Your host has finished/, email.body.encoded)
     end
 
     test "is not sent when not installed" do
@@ -3164,7 +3173,7 @@ class HostTest < ActiveSupport::TestCase
 
     host.operatingsystem.media = []
     refute host.valid?
-    assert_match /must belong/, host.errors[:medium_id].first
+    assert_match(/must belong/, host.errors[:medium_id].first)
   end
 
   context "lookup value attributes" do
@@ -3797,7 +3806,7 @@ class HostTest < ActiveSupport::TestCase
   test "host have a media provider providing a valid URL" do
     hostgroup = FactoryBot.create(:hostgroup, :with_domain, :with_os)
     host = FactoryBot.create(:host, :managed, :hostgroup => hostgroup)
-    assert_match /^http:/, host.medium_provider.medium_uri.to_s
+    assert_match(/^http:/, host.medium_provider.medium_uri.to_s)
   end
 
   test "should find interface by attached mac" do


### PR DESCRIPTION
When getting the scope we shouldn't rely on attributes and check all
the interfaces even virtual. This commit also add some debug logging.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
