### PR TITLE
 Fixes #23654 and Fixes #23655

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -191,6 +191,7 @@ module Host
       # is saved to primary interface so we match it in updating code below
       if !self.managed? && self.primary_interface.mac.blank? && self.primary_interface.identifier.blank?
         identifier, values = parser.suggested_primary_interface(self)
+        logger.debug "Suggested #{identifier} NIC as a primary interface."
         self.primary_interface.mac = Net::Validations.normalize_mac(values[:macaddress]) if values.present?
         self.primary_interface.update_attribute(:identifier, identifier)
         self.primary_interface.save!
@@ -393,7 +394,7 @@ module Host
         # we search bonds based on identifiers, e.g. ubuntu sets random MAC after each reboot se we can't
         # rely on mac
         when 'Nic::Bond', 'Nic::Bridge'
-          base.virtual.where(:identifier => name)
+          base.where(:identifier => name)
         # for other interfaces we distinguish between virtual and physical interfaces
         # for virtual devices we don't check only mac address since it's not unique,
         # if we want to update the device it must have same identifier

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,6 +1,6 @@
 class FactParser
   delegate :logger, :to => :Rails
-  VIRTUAL = /\A([a-z0-9]+)_([a-z0-9]+)\Z/
+  VIRTUAL = /\A([a-z0-9]+)[_\.]+([a-z0-9]+)\Z/
   BRIDGES = /\A(vir)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
@@ -130,11 +130,12 @@ class FactParser
         attributes[:bridge] = true
       else
         attributes[:attached_to] = $1
-
+        tag = $2
         if @facts[:vlans].present?
           vlans = @facts[:vlans].split(',')
-          tag = name.split('_').last
           attributes[:tag] = vlans.include?(tag) ? tag : ''
+        else
+          attributes[:tag] = tag
         end
       end
     else

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1495,6 +1495,15 @@ class HostTest < ActiveSupport::TestCase
       assert_equal '10.10.0.1', host.interfaces.where(:identifier => 'eth0_0').first.ip
     end
 
+    test "#set_interfaces updates existing bridge interface suggested as primary" do
+      host, parser = setup_host_with_nic_parser({:identifier => 'br-ex', :macaddress => '00:00:00:11:22:33', :bridge => true, :virtual => true, :ipaddress => '10.10.0.1'})
+      host.managed = false
+      host.primary_interface.update(:identifier => 'br-ex', :mac => '00:00:00:11:22:33', :ip => '10.10.0.1')
+
+      host.set_interfaces(parser)
+      assert host.interfaces.where(:identifier => 'br-ex').first.virtual
+    end
+
     test "#set_interfaces creates IPMI device if parameters are found" do
       host, parser = setup_host_with_ipmi_parser({:ipaddress => '192.168.0.1', :macaddress => '00:00:00:11:33:55'})
 
@@ -1927,7 +1936,7 @@ class HostTest < ActiveSupport::TestCase
         host.built(true)
         email = ActionMailer::Base.deliveries.detect { |mail| mail.subject =~ /Host #{host} is built/ }
         assert email
-        assert_match /Your host has finished/, email.body.encoded
+        assert_match(/Your host has finished/, email.body.encoded)
       end
 
       test "is not sent when not installed" do


### PR DESCRIPTION
Fixes #23654 - update even virtual interface facts

When getting the scope we shouldn't rely on attributes and check all
the interfaces even virtual. This commit also add some debug logging.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
(cherry picked from commit 01bc926)

Fixes #23655 - fix regexp and interface parsing
This chaneg will fix the issue in case of ansible plugin use.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
(cherry picked from commit 438d100)