### PR TITLE
Fixes #23654 and Fixes #23655

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -196,6 +196,7 @@ module Host
       # is saved to primary interface so we match it in updating code below
       if !self.managed? && self.primary_interface.mac.blank? && self.primary_interface.identifier.blank?
         identifier, values = parser.suggested_primary_interface(self)
+        logger.debug "Suggested #{identifier} NIC as a primary interface."
         self.primary_interface.mac = Net::Validations.normalize_mac(values[:macaddress]) if values.present?
         self.primary_interface.update_attribute(:identifier, identifier)
         self.primary_interface.save!
@@ -400,7 +401,7 @@ module Host
         # we search bonds based on identifiers, e.g. ubuntu sets random MAC after each reboot se we can't
         # rely on mac
         when 'Nic::Bond', 'Nic::Bridge'
-          base.virtual.where(:identifier => name)
+          base.where(:identifier => name)
         # for other interfaces we distinguish between virtual and physical interfaces
         # for virtual devices we don't check only mac address since it's not unique,
         # if we want to update the device it must have same identifier
@@ -444,7 +445,7 @@ module Host
       bond.save!
     rescue StandardError => e
       logger.warn "Saving #{bond.identifier} NIC for host #{self.name} failed, skipping because #{e.message}:"
-      bond.errors.full_messages.each { |e| logger.warn " #{e}" }
+      bond.errors.full_messages.each { |message| logger.warn " #{message}" }
     end
 
     def set_interface(attributes, name, iface)

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,6 +1,6 @@
 class FactParser
   delegate :logger, :to => :Rails
-  VIRTUAL = /\A([a-z0-9]+)_([a-z0-9]+)\Z/
+  VIRTUAL = /\A([a-z0-9]+)[_\.]+([a-z0-9]+)\Z/
   BRIDGES = /\A(vir)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
@@ -134,11 +134,12 @@ class FactParser
         attributes[:bridge] = true
       else
         attributes[:attached_to] = Regexp.last_match(1)
-
+        tag = Regexp.last_match(2)
         if @facts[:vlans].present?
           vlans = @facts[:vlans].split(',')
-          tag = name.split('_').last
           attributes[:tag] = vlans.include?(tag) ? tag : ''
+        else
+          attributes[:tag] = tag
         end
       end
     else


### PR DESCRIPTION
Fixes #23654 - update even virtual interface facts

When getting the scope we shouldn't rely on attributes and check all
the interfaces even virtual. This commit also add some debug logging.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
(cherry picked from commit 01bc926)

Fixes #23655 - fix regexp and interface parsing
This chaneg will fix the issue in case of ansible plugin use.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
(cherry picked from commit 438d100)