### PR TITLE
Fixes #22698 - clear the search filter

### DIFF
--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -103,43 +103,22 @@ export function initTypeAheadSelect(input) {
 // handle table updates via turoblinks
 export function updateTable(element) {
   const uri = new URI(window.location.href);
-  let searchTerm;
-  let perPage;
-  let isSearchForm;
-  let pageNum;
 
-  if (element !== undefined) {
-    isSearchForm = element.id === 'search-form';
+  const values = { };
 
-    pageNum = $('#cur_page_num').val();
-    if (pageNum !== undefined) {
-      uri.setSearch('page', pageNum);
-    }
 
-    if (isSearchForm || element.id === 'per_page') {
-      uri.setSearch('page', 1);
-    }
-
-    if (isSearchForm) {
-      searchTerm = $(element)
-        .find('.autocomplete-input')
-        .val();
-      if (searchTerm) {
-        uri.setSearch('search', searchTerm.trim());
-      }
-    }
-
-    perPage = $('#per_page').val();
-    if (
-      perPage !== undefined &&
-      $('#search-form')
-        .find('.autocomplete-input')
-        .val() === undefined
-    ) {
-      uri.removeSearch('search');
-    }
-    uri.setSearch('per_page', perPage);
+  if (['per_page', 'search-form'].includes(element.id)) {
+    values.page = '1';
+  } else {
+    values.page = $('#cur_page_num').val();
   }
+
+  const searchTerm = $(element).find('.autocomplete-input').val();
+  if (searchTerm !== undefined) {
+    values.search = searchTerm.trim();
+  }
+  values.per_page = $('#per_page').val();
+  uri.setSearch(values);
 
   /* eslint-disable no-undef */
   Turbolinks.visit(uri.toString());

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -143,11 +143,6 @@ describe('updateTableTest', () => {
     `;
   });
 
-  it('should use turoblinks', () => {
-    tools.updateTable();
-    expect(global.Turbolinks.visit).toBeCalled();
-  });
-
   it('should use selected per page value and add it to the url considering search term and pagination', () => {
     const PerPage = $('#per_page').val();
 
@@ -177,5 +172,21 @@ describe('updateTableTest', () => {
     $('.autocomplete-input').val('test');
     $('#search-form').submit();
     expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=1&search=test&per_page=${PerPage}`);
+  });
+
+  it('should not reset search when set the per_page param', () => {
+    window.location.href = 'http://localhost/?search=blue';
+    $('#per_page').val('20');
+    $('#pagination').submit();
+    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith('http://localhost/?search=blue&page=1&per_page=20');
+  });
+
+  it('should remove search param if search is empty', () => {
+    ['', ' '].map((searchValue) => {
+      const PerPage = $('#per_page').val();
+      $('.autocomplete-input').val(searchValue);
+      $('#search-form').submit();
+      return expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=1&search=&per_page=${PerPage}`);
+    });
   });
 });


### PR DESCRIPTION
clearing the search filter does not take place when submitting

Signed-off-by: Boaz Shuster <boaz.shuster.github@gmail.com>
(cherry picked from commit 2ce888d2b98697dbfec964ea9ff03905607aa237)

cc @xprazak2 - this is a CP of GH-5434 to 1.18 stable

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
