### PR TITLE
Fixes #23679 - Nil error in migrate_template_to_parameters_macros

### DIFF
--- a/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
+++ b/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
@@ -45,6 +45,7 @@ class MigrateTemplateToParametersMacros < ActiveRecord::Migration[4.2]
   end
 
   def convert(content)
+    return nil if content.nil?
     content = content.gsub(/@host\.param_true\?\((.*?)\)/, 'host_param_true?(\1)')
     content = content.gsub(/@host\.param_false\?\((.*?)\)/, 'host_param_false?(\1)')
     content = content.gsub(/@host\.params\[(.*?)\]/, 'host_param(\1)')


### PR DESCRIPTION


I haven't reproduced myself but:

undefined method gsub' for nil:NilClass for 20170112175131_migrate_template_to_parameters_macros.rb:48

https://community.theforeman.org/t/upgrade-1-16-1-to-1-17-a-on-centos-7-4-centos-7-5/9722
