### PR TITLE
Fixes #23679 - Nil error in migrate_template_to_parameters_macros

### DIFF
--- a/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
+++ b/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
@@ -45,6 +45,7 @@ class MigrateTemplateToParametersMacros < ActiveRecord::Migration[4.2]
   end
 
   def convert(content)
+    return nil if content.nil?
     content = content.gsub(/@host\.param_true\?\((.*?)\)/, 'host_param_true?(\1)')
     content = content.gsub(/@host\.param_false\?\((.*?)\)/, 'host_param_false?(\1)')
     content = content.gsub(/@host\.params\[(.*?)\]/, 'host_param(\1)')


### PR DESCRIPTION

(cherry picked from commit 57d90df0cd229a64e9e2afe3e47c0ed12028985c)

---

cc @xprazak2 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
