### PR TITLE
Fixes #23683 - Fix importing os fact

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -413,6 +413,8 @@ class Host::Managed < Host::Base
   def populate_fields_from_facts(parser, type, source_proxy)
     super
     operatingsystem.architectures << architecture if operatingsystem && architecture && !operatingsystem.architectures.include?(architecture)
+    operatingsystem.media << medium if operatingsystem && medium && !operatingsystem.media.include?(medium)
+    operatingsystem.ptables << ptable if operatingsystem && ptable && !operatingsystem.ptables.include?(ptable)
 
     populate_facet_fields(parser, type, source_proxy)
   end


### PR DESCRIPTION
When a host is assigned to a new operating system by the fact importer, make
sure, that medium and ptabel is available to the new OS.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
