### PR TITLE
Fixes #23689 - Use host name for hosts_breadcrumb

### DIFF
--- a/app/views/api/v2/hosts/thin.json.rabl
+++ b/app/views/api/v2/hosts/thin.json.rabl
@@ -1,5 +1,5 @@
 collection @hosts
 
 node do |host|
-  {id: host[0], name: host[1]}
+  { id: host[1], name: host[1] }
 end


### PR DESCRIPTION
As per the issue this changes the host breadcrumb to use the host's name when navigating to a different host with it. Now the URL is more consistent and has the host's name after navigation. 

Needs to be checked to make sure this change doesn't break anything else since it does change the thin api for V2 Hosts