### PR TITLE
Fixes #23142,#23503 - telemetry improvements

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -165,13 +165,13 @@ module Foreman
       nil
     end
 
-    if SETTINGS[:telemetry].try(:fetch, :prometheus).try(:fetch, :enabled)
-      begin
+    begin
+      if SETTINGS[:telemetry].try(:fetch, :prometheus).try(:fetch, :enabled)
         require 'prometheus/middleware/exporter'
         config.middleware.use Prometheus::Middleware::Exporter
-      rescue LoadError
-        # bundler group 'telemetry' was disabled
       end
+    rescue LoadError, KeyError
+      # not configured or bundler group 'telemetry' was disabled
     end
 
     # Enable the asset pipeline

--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -22,3 +22,4 @@ telemetry.add_histogram(:importer_facts_populate_duration, 'Duration of fields p
 telemetry.add_counter(:importer_facts_count_input, 'Number of facts before imports starts per importer type', [:type])
 telemetry.add_counter(:importer_facts_count_processed, 'Number of facts processed (added, updated, deleted) per importer type', [:type, :action])
 telemetry.add_counter(:importer_facts_count_interfaces, 'Number of changed interfaces per importer type', [:type])
+telemetry.add_histogram(:ldap_request_duration, 'Total duration of LDAP requests')

--- a/config/initializers/ldap_instrumentation.rb
+++ b/config/initializers/ldap_instrumentation.rb
@@ -1,12 +1,15 @@
 # Debug logging from net-ldap and ldap_fluff events sent via ActiveSupport::Notifications
 module Foreman
   class LdapSubscriber < ActiveSupport::LogSubscriber
+    include Foreman::TelemetryHelper
+
     def logger
       ::Foreman::Logging.logger('ldap')
     end
 
     def self.define_log(action, log_name, color)
       define_method(action) do |event|
+        telemetry_duration_histogram(:ldap_request_duration, event.duration)
         return unless logger.debug?
         name = '%s (%.1fms)' % [log_name, event.duration]
         debug "  #{color(name, color, true)}  [ #{yield(event.payload)} ]"

--- a/lib/foreman/telemetry_sinks/rails_logger_sink.rb
+++ b/lib/foreman/telemetry_sinks/rails_logger_sink.rb
@@ -18,15 +18,15 @@ module Foreman::TelemetrySinks
     end
 
     def increment_counter(name, value, tags)
-      @logger.add(@level, "Incrementing counter #{name} by #{value} #{tags.inspect}")
+      @logger.add(@level, "Incrementing counter #{name} by #{sprintf('%0.02f', value)} #{tags.inspect}")
     end
 
     def set_gauge(name, value, tags)
-      @logger.add(@level, "Setting gauge #{name} to #{value} #{tags.inspect}")
+      @logger.add(@level, "Setting gauge #{name} to #{sprintf('%0.02f', value)} #{tags.inspect}")
     end
 
     def observe_histogram(name, value, tags)
-      @logger.add(@level, "Observing histogram #{name} value #{value} #{tags.inspect}")
+      @logger.add(@level, "Observing histogram #{name} value #{sprintf('%0.02f', value)} #{tags.inspect}")
     end
   end
 end

--- a/lib/foreman/telemetry_sinks/statsd_sink.rb
+++ b/lib/foreman/telemetry_sinks/statsd_sink.rb
@@ -40,7 +40,7 @@ module Foreman::TelemetrySinks
     def name_tag_mapping(name, tags)
       insts = @instances[name]
       return name if insts.blank?
-      (name.to_s + '.' + insts.map {|x| tags[x]}.compact.join('.')).tr(':', '_')
+      (name.to_s + '.' + insts.map {|x| tags[x]}.compact.join('.')).tr('-:/ ', '____')
     end
   end
 end

--- a/lib/tasks/telemetry.rake
+++ b/lib/tasks/telemetry.rake
@@ -1,6 +1,3 @@
-require "foreman/telemetry"
-require "foreman/telemetry_sinks/metric_exporter_sink"
-
 desc "Telemetry helper tasks"
 namespace :telemetry do
   desc "List all metrics"


### PR DESCRIPTION
Two bugs are fixed by this patch and few other improvements for telemetry.

Bugs:
* Rails won't error out on missing configuration keys (RM#23503)
* Rails will boot if statsd/prometheus gem is missing (RM#23142)

Improvements:
* histogram (duration) for LDAP external requests
* GC metrics are not reported when zero
* AR record counts are not reported when zero
* Rails logger sink is nicely formatted
* Telemetry stack was always enabled
* dash, slash and space are also converted to underscore
* removed unwanted require statements from rake task