### PR TITLE
Fixes #23756 - improved wait_for_ajax

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -96,7 +96,7 @@ class ActionDispatch::IntegrationTest
 
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do
-      loop until page.evaluate_script('jQuery.active').zero? && page.evaluate_script('window.axiosActive').zero?
+      sleep 0.15 until ([page.evaluate_script('jQuery.active'), page.evaluate_script('window.axiosActive')] - [0, nil]).empty?
     end
   end
 


### PR DESCRIPTION
We have two issues with wait_for_ajax.

1) Statement page.evaluate_script sometimes evaluates to nil leading to NoMethodError: undefined method `zero?' for nil:NilClass (e.g. in discovery integration tests)

2) Doing endless loop for nothing burns CPU time, adding a small delay will actually improve performance of JS tests because other processes can be served by the same CPU core while waiting.