### PR TITLE
Fixes #13749 - Handle Base64 and binary LDAP avatars

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,7 +247,8 @@ class User < ApplicationRecord
 
         # clean up old avatar if it exists and the image isn't in use by anyone else
         if old_hash.present? && user.avatar_hash != old_hash && !User.unscoped.where(:avatar_hash => old_hash).any?
-          File.delete "#{Rails.public_path}/avatars/#{old_hash}.jpg" if File.exist? old_avatar
+          old_avatar = "#{Rails.public_path}/images/avatars/#{old_hash}.jpg"
+          File.delete(old_avatar) if File.exist?(old_avatar)
         end
       else
         logger.debug "Failed to authenticate #{user.login} against #{user.auth_source} authentication source"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -289,6 +289,15 @@ class UserTest < ActiveSupport::TestCase
         assert user.errors[:firstname].present?
         assert_nil user.reload.firstname
       end
+
+      test 'old avatars can be removed upon login' do
+        attrs = { :firstname => "foo", :mail => "foo@bar.com",
+                  :login => "ldap-user", :avatar_hash => 'testavatar',
+                  :auth_source_id => auth_sources(:one).id }
+        AuthSourceLdap.any_instance.stubs(:authenticate).returns(attrs)
+        User.any_instance.expects(:avatar_hash).returns('oldhash').at_least_once
+        User.try_to_login('foo', 'password')
+      end
     end
   end
 


### PR DESCRIPTION
Before this change, we would always try to Base64.decode absolutely any
avatar. This resulted in broken images, as sometimes the avatars are
automatically turned into binary by net/ldap. In such cases, we want to
save that directly, no decoding needed.

We also had a minor bug - when a user gets its LDAP avatar updated, the
old one could not be deleted. This results in *broken* log in. The bug
was quite minor, the variable where the file was supposed to be was
simply undefined.

@waldirio it'd be very helpful if you could test this one on your systems. Thanks!