### PR TITLE
Fixes #23764: Ensure proper plugin asset generation for SCSS

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -4,36 +4,6 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
   # plugin_name/public/assets/<plugin_name>. The generated manifest.yaml found
   # in the assets directory of the plugin is used to add the asset digest paths
   # to the Rails digests list in production.rb.
-  #
-  # The task expects a plugin to define their assets to precompile using SETTINGS.
-  # This can be done via a settings yaml file or if the deinfition requires
-  # complexity through the use of an initializer in the plugins engine.rb.
-  #
-  # Example: Simple Precompile List
-  #
-  #   SETTINGS[:plugin_name] = {
-  #     :assets => {
-  #       :precompile => [
-  #         'plugin_name/plugin.css',
-  #         'plugin_name/plugin.js',
-  #         'plugin_name/another_js_file.js
-  #       ],
-  #     }
-  #   }
-  #
-  # Example: Custom JS Compressor
-  #
-  #   SETTINGS[:plugin_name] = {
-  #     :assets => {
-  #       :precompile => [
-  #         'plugin_name/plugin.css',
-  #         'plugin_name/plugin.js',
-  #         'plugin_name/another_js_file.js
-  #       ],
-  #       :js_compressor => Uglifier.new(:mangle => false)
-  #     }
-  #   }
-
   module Foreman
     class PluginAssetsTask < Sprockets::Rails::Task
       attr_accessor :plugin
@@ -42,65 +12,17 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
         @plugin = Foreman::Plugin.find(plugin_id) or raise("Unable to find registered plugin #{plugin_id}")
 
         app = Rails.application
-        env = app.assets || Sprockets::Environment.new(app.root.to_s)
-
-        config = Rails.application.config
-        config.assets.digest = true
-
-        Rails.application.config.assets.precompile = plugin.assets
-
-        env.register_transformer 'text/scss', 'text/css',
-          Sprockets::ScssProcessor.new(
-            importer: Sass::Rails::SassImporter,
-            sass_config: app.config.sass)
-        env.js_compressor = :uglifier
-        env.css_compressor = :sass
-        env.cache = nil
-
-        env.context_class.class_eval do
-          class_attribute :sass_config
-          self.sass_config = app.config.sass
-        end
+        app.config.assets.digest = true
+        app.config.assets.precompile = plugin.assets
+        app.config.assets.paths = app.config.assets.paths.select { |path| path.to_s.include?(plugin_id) }
 
         super(Rails.application)
       end
 
       def compile
-        environment.context_class.class_eval do
-          def asset_path(path, options = {})
-            ActionController::Base.helpers.asset_path(path, options)
-          end
-        end
-
         with_logger do
           manifest.compile(assets)
         end
-      end
-
-      def environment
-        app    = Rails.application
-        config = app.config
-        env    = app.assets || Sprockets::Environment.new(app.root.to_s)
-
-        Rails.application.config.assets.paths.each do |path|
-          env.append_path path
-        end
-
-        env.context_class.class_eval do
-          def asset_path(path, options = {})
-            ActionController::Base.helpers.asset_path(path, options)
-          end
-        end
-
-        env.version = [
-          'production',
-          config.assets.version,
-          config.action_controller.relative_url_root,
-          (config.action_controller.asset_host unless config.action_controller.asset_host.respond_to?(:call)),
-          Sprockets::Rails::VERSION
-        ].compact.join('-')
-
-        env
       end
 
       def output


### PR DESCRIPTION
If image-url or asset-url are used in SCSS then they are not properly
generated for plugins. This change has the nice side effect of
both simplifying the code and re-using the existing Rails and Sprockets
environments as much as possible.
