### PR TITLE
Refs #22984 - fix the type for all templates

### DIFF
--- a/db/migrate/20180601102951_fix_all_templates_auditable_type.rb
+++ b/db/migrate/20180601102951_fix_all_templates_auditable_type.rb
@@ -1,0 +1,10 @@
+class FixAllTemplatesAuditableType < ActiveRecord::Migration[5.1]
+  def up
+    Audit.unscoped.where(:auditable_type => 'Template', :auditable_id => ProvisioningTemplate.unscoped.pluck(:id)).update_all(:auditable_type => 'ProvisioningTemplate')
+    Audit.unscoped.where(:auditable_type => 'Template', :auditable_id => Ptable.unscoped.pluck(:id)).update_all(:auditable_type => 'Ptable')
+  end
+
+  def down
+    Audit.unscoped.where(:auditable_type => ['Ptable', 'ProvisioningTemplate']).update_all(:auditable_type => 'Template')
+  end
+end


### PR DESCRIPTION
This is a second migration to fix the issue. The first one, added at https://github.com/theforeman/foreman/pull/5348, didn't fix it for all template audits, because not all Templates where listed. This adds unscoped to Ptable and ProvisioningTemplate models. It needs to be separate migration for users, who already ran the first. Since the problem was originally fixed in 1.18, we should cherry-pick the issue back there. Hence I'm reusing the same ticket.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
