### PR TITLE
Fixes #23768 - keep_subnet flag to prevent subnet override

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -455,8 +455,9 @@ module Host
       iface.ip = attributes.delete(:ipaddress)
       iface.ip6 = attributes.delete(:ipaddress6)
       iface.ip6 = nil if (IPAddr.new('fe80::/10').include?(iface.ip6) rescue false)
+      keep_subnet = attributes.delete(:keep_subnet)
 
-      if Setting[:update_subnets_from_facts]
+      if Setting[:update_subnets_from_facts] && !keep_subnet
         iface.subnet = Subnet.subnet_for(iface.ip) if iface.ip_changed? && !iface.matches_subnet?(:ip, :subnet)
         iface.subnet6 = Subnet.subnet_for(iface.ip6) if iface.ip6_changed? && !iface.matches_subnet?(:ip6, :subnet6)
       end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1755,6 +1755,24 @@ class HostTest < ActiveSupport::TestCase
         assert_equal subnet2, host.primary_interface.subnet
       end
 
+      test "#set_interfaces does not update subnet when keep_subnet attribute is present" do
+        FactoryBot.create(:subnet_ipv4, :dhcp, :network => '10.10.20.0')
+        host = FactoryBot.create(:host,
+                                  :managed,
+                                  :mac => '00:00:00:11:22:33',
+                                  :ip => '10.10.0.1',
+                                  :subnet => subnet
+                                 )
+        hash = { :eth0 => {:macaddress => '00:00:00:11:22:33', :ipaddress => '10.10.20.2', :virtual => false, :keep_subnet => true}
+        }.with_indifferent_access
+        parser = stub(:class_name_humanized => 'TestParser', :interfaces => hash, :ipmi_interface => {}, :suggested_primary_interface => hash.to_a.last)
+        assert_no_difference 'Nic::Base.count' do
+          host.set_interfaces(parser)
+        end
+
+        assert_equal subnet, host.primary_interface.subnet
+      end
+
       test "#set_interfaces updates existing physical interface when subnet6 is set but facts report no ipv6 addr" do
         subnet6 = FactoryBot.create(:subnet_ipv6, :network => '2001:db8::')
         host = FactoryBot.create(:host,


### PR DESCRIPTION
Setting "Update subnets from facts" makes discovery impossible if taxonomy does not match the host leading to "Subnet is not defined for host's organization". Discovery uses standard core Puppet parser to recognize all interfaces, therefore discovery users must have all subnet taxonomy aligned with discovered host taxonomy, even if they don't plan to use all interfaces.

This patch adds flag keep_subnet which is added by discovery, when present subnet is never updated. This prevents the misbehavior when the flag is set.