### PR TITLE
Fixes #23775 - exposed random name generator

### DIFF
--- a/app/services/name_generator.rb
+++ b/app/services/name_generator.rb
@@ -20,21 +20,33 @@ class NameGenerator
     @random_generator = Deacon::RandomGenerator.new
   end
 
+  # does respect global setting
   def next_mac_name(mac)
     if mac_based? && mac
-      @mac_generator.generate(mac).join('-').downcase
+      generate_next_mac_name(mac)
     else
       ''
     end
   end
 
+  # does not respect global setting
+  def generate_next_mac_name(mac)
+    @mac_generator.generate(mac).join('-').downcase
+  end
+
+  # does respect global setting
   def next_random_name
     if random_based?
-      self.register, firstname, lastname = @random_generator.generate(self.register)
-      [firstname, lastname].join('-').downcase
+      generate_next_random_name
     else
       ''
     end
+  end
+
+  # does not respect global setting
+  def generate_next_random_name
+    self.register, firstname, lastname = @random_generator.generate(self.register)
+    [firstname, lastname].join('-').downcase
   end
 
   def register


### PR DESCRIPTION
Current implementation of NameGenerator relies on Administer - Setting. Plugins cannot use NameGenerator for other things. This patch adds methods which can be used in plugins to generate random names regardless of global setting.