### PR TITLE
[CP] Fixes #23365 - Silence the ENOENT error for .env

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -176,7 +176,10 @@ module.exports = env => {
     config.plugins.push(
       new webpack.HotModuleReplacementPlugin() // Enable HMR
     );
-    require('dotenv').config();
+    var result = require('dotenv').config();
+    if (result.error && result.error.code !== 'ENOENT') {
+      throw result.error;
+    }
 
     config.devServer = {
       host: process.env.BIND || 'localhost',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "compression-webpack-plugin": "~0.3.1",
     "coveralls": "^3.0.0",
     "css-loader": "^0.23.1",
-    "dotenv": "^2.0.0",
+    "dotenv": "^5.0.0",
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.0.4",
     "enzyme-to-json": "^3.2.1",


### PR DESCRIPTION
If .env doesn't exist, it can be safely ignored. This updates the
library to the newest version to simplify error handling. The 2.0.0 also
had a silent option, but that didn't allow for only hiding the ENOENT
error.

(cherry picked from commit 3505d7370ce00ae673c6c5b6f9323c8fcc17c35a)