### PR TITLE
Fixes #23808 - monotonic timer to measure durations

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,14 +18,14 @@ class HomeController < ApplicationController
 
   # check for exception - set the result code and duration time
   def exception_watch(&block)
-    start = Time.now.utc
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result = {}
     begin
       yield
       result[:result] = 'ok'
       result[:status] = :ok
       result[:version] = SETTINGS[:version].full
-      result[:db_duration_ms] = ((Time.now.utc - start) * 1000).round.to_s
+      result[:db_duration_ms] = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round.to_s
     rescue => e
       result[:result] = 'fail'
       result[:status] = :internal_server_error

--- a/app/services/foreman/telemetry_helper.rb
+++ b/app/services/foreman/telemetry_helper.rb
@@ -14,7 +14,7 @@ module Foreman::TelemetryHelper
   end
 
   # time spent in a block as histogram, in miliseconds by default
-  def telemetry_duration_histogram(name, scale = 1000, tags = {})
+  def telemetry_duration_histogram(name, scale = 1000, tags = {}, results = nil)
     case scale
     when :ms, :msec, :miliseconds
       scale = 1000
@@ -23,10 +23,12 @@ module Foreman::TelemetryHelper
     when :min, :minutes
       scale = 1 / 60
     end
-    before = Time.now.to_f
+    before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     yield
   ensure
-    after = Time.now.to_f
-    telemetry_observe_histogram(name, (after - before) * scale, tags)
+    after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    duration = (after - before) * scale
+    telemetry_observe_histogram(name, duration, tags)
+    results[name] = duration if results
   end
 end

--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -23,3 +23,5 @@ telemetry.add_counter(:importer_facts_count_input, 'Number of facts before impor
 telemetry.add_counter(:importer_facts_count_processed, 'Number of facts processed (added, updated, deleted) per importer type', [:type, :action])
 telemetry.add_counter(:importer_facts_count_interfaces, 'Number of changed interfaces per importer type', [:type])
 telemetry.add_histogram(:ldap_request_duration, 'Total duration of LDAP requests')
+telemetry.add_histogram(:report_importer_create, 'Total duration of report import creation', [:type])
+telemetry.add_histogram(:report_importer_refresh, 'Total duration of report status refresh', [:type])

--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -81,7 +81,7 @@ namespace :db do
       ActiveRecord::Base.establish_connection(:production)
       skip_tables = ["schema_info", "schema_migrations"]
       (ActiveRecord::Base.connection.tables - skip_tables).each do |table_name|
-        time = Time.now
+        time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         ProductionModelClass.establish_connection(:production)
         ProductionModelClass.table_name = table_name
@@ -150,7 +150,7 @@ namespace :db do
               end
         DevelopmentModelClass.connection.execute(sql) if sql.present?
 
-        print "#{count} records converted in #{Time.now - time} seconds\n"
+        print "#{count} records converted in #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - time} seconds\n"
       end
     end
   end

--- a/lib/tasks/trends.rake
+++ b/lib/tasks/trends.rake
@@ -6,7 +6,7 @@ namespace :trends do
 
   desc 'Reduces amount of points for each trend group'
   task :reduce => :environment do
-    start = Time.now
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     trends = Trend.pluck(:id)
     trends_count = trends.length
@@ -32,6 +32,6 @@ namespace :trends do
 
     TrendCounter.unscoped.where(interval_start: nil).delete_all
 
-    puts "It took #{Time.now - start} seconds to complete" unless Rails.env.test?
+    puts "It took #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - start} seconds to complete" unless Rails.env.test?
   end
 end


### PR DESCRIPTION
Not using monotonic clock may lead to incorrect duration observations. I
fixed hopefully all places, replaced one measurement with telemetry.

https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/