### PR TITLE
Fixes #23825 - Allow loading pkg rake task without Rails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,12 @@
-require File.expand_path('../config/application', __FILE__)
-require 'rake'
-require 'rake/testtask'
-include Rake::DSL
+if ENV['BUILD']
+  load File.expand_path('../lib/tasks/pkg.rake', __FILE__)
+else
+  require File.expand_path('../config/application', __FILE__)
+  require 'rake'
+  require 'rake/testtask'
+  include Rake::DSL
 
-require 'single_test/tasks' if defined? SingleTest
+  require 'single_test/tasks' if defined? SingleTest
 
-Foreman::Application.load_tasks
+  Foreman::Application.load_tasks
+end


### PR DESCRIPTION
This allows running:

```
rake pkg:generate_source BUILD=true
```

Without having to configure settings.yaml, or any database information and simplifies requirements to generate tarballs.

BUILD is not my favorite way to specify this but the best I could think of in case anyone has better ideas.

@ekohl @mmoll you may find this interesting