### PR TITLE
fixes #23830 - gitignore: add vendor/ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ config/hooks
 *.csv
 .envrc
 node_modules
+vendor/ruby
 public/webpack
 .env*
 package-lock.json


### PR DESCRIPTION
Manual "from source" installation instruction suggests to bundle install with
`--path vendor`. This should not pollute the working copy.

fixes #23830
