### PR TITLE
Fixes #14833 - Allow changing disk attrs on oVirt

### DIFF
--- a/webpack/assets/javascripts/compute_resource/ovirt.js
+++ b/webpack/assets/javascripts/compute_resource/ovirt.js
@@ -97,11 +97,11 @@ function addVolume({
   // eslint-disable-next-line no-undef
   const newId = add_child_node($('#storage_volumes .add_nested_fields'));
 
-  disableElement($(`[id$=${newId}_size_gb]`).val(size_gb));
-  disableElement($(`[id$=${newId}_storage_domain]`).val(storage_domain));
-  disableElement($(`[id$=${newId}_wipe_after_delete]`).val(wipe_after_delete));
-  disableElement($(`[id$=${newId}_interface]`).val(disk_interface));
-  disableElement($(`[id$=${newId}_bootable_true]`).attr('checked', bootable));
+  $(`[id$=${newId}_wipe_after_delete]`).val(wipe_after_delete);
+  $(`[id$=${newId}_storage_domain]`).val(storage_domain);
+  $(`[id$=${newId}_interface]`).val(disk_interface);
+  $(`[id$=${newId}_bootable_true]`).attr('checked', bootable);
+  $(`[id$=${newId}_size_gb]`).val(size_gb);
   if (id) {
     $(`[id$=${newId}_id]`).val(id);
   }


### PR DESCRIPTION
Currently, there is a method 'preallocate_disks' which allows us to
create new disks even when a template is selected. By passing the option
':clone => true' to the API, we can change the volume attributes.

Here you can see the attributes that are changeable in an oVirt instance:
![screenshot from 2018-06-06 10-10-17](https://user-images.githubusercontent.com/598891/41030444-a6960bea-697e-11e8-9cef-e8d6b49f6836.png)


And here how can we change them now in the UI (before, the attributes were disabled):
![screenshot from 2018-06-06 11-37-50](https://user-images.githubusercontent.com/598891/41030435-a1e14c72-697e-11e8-8e84-6b0ec2c55470.png)

The only issue I see is that the original volume "provided by the template" is never deleted. https://github.com/theforeman/foreman/blob/develop/app/models/compute_resources/foreman/model/ovirt.rb#L542 simply adds new volumes, and `create_vm` creates the VM with the template volume first, not with the storage we define - https://github.com/theforeman/foreman/blob/develop/app/models/compute_resources/foreman/model/ovirt.rb#L542

cc @shiramax @orrabin 