### PR TITLE
Refs #21580 - require rbvmomi

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -1,6 +1,12 @@
 require 'fog_extensions/vsphere/mini_servers'
 require 'foreman/exception'
 
+begin
+  require 'rbvmomi'
+rescue LoadError
+  # rbvmomi might not be installed
+end
+
 module Foreman::Model
   class Vmware < ComputeResource
     include ComputeResourceConsoleCommon

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,4 @@
 group :vmware do
   gem 'fog-vsphere', '>= 2.1.1'
+  gem 'rbvmomi', '>= 1.9.0'
 end


### PR DESCRIPTION
The compute resource for VMware was using `rbvmomi` classes wihout explicitly requiring `rbvmomi`. That can cause "NameError: uninitialized constant RbVmomi" errors in tests (https://ci.theforeman.org/job/puppetdb_foreman-pull-request/11/database=mysql,label=fast,ruby=2.4/testReport/junit/(root)/Foreman__Model__VmwareTest___normalize_vm_attrs/).

`rbvmomi` is dependency of `fog-vsphere` that we require when foreman is installed with WMware support. We have that already packaged.