### PR TITLE
Fixes #23818 - Update fog-openstack to save OpenStack OSP 12

### DIFF
--- a/bundler.d/openstack.rb
+++ b/bundler.d/openstack.rb
@@ -1,3 +1,3 @@
 group :openstack do
-  gem 'fog-openstack', '>= 0.1.11', '< 1.0'
+  gem 'fog-openstack', '>= 0.1.25', '< 1.0'
 end


### PR DESCRIPTION
On fog-openstack 0.1.23, Excon expects a 200 when it creates the first
key-pair on OpenStack. On recent versions, it returns a 201.
There is a fix for it on fog-openstack 0.1.25, so we should update to it
both in Foreman and in packaging.

https://github.com/theforeman/foreman-packaging/pull/2616 

If this can be cherry-picked to 1.18, 1.17 I think it'd be a good idea. The packaging PR should take care of it though, as it's >= 1.11 cc @xprazak2 