### PR TITLE
Fixes #23852 - Properly escape html in template preview errors

### DIFF
--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -271,7 +271,7 @@ export function getRenderedTemplate() {
     $('div#preview_error span.text').html('');
     session.setValue(response);
   }).fail((response) => {
-    $('div#preview_error span.text').html(response.responseText);
+    $('div#preview_error span.text').text(response.responseText);
     $('div#preview_error').show();
     session.setValue(__('There was an error during rendering, return to the Code tab to edit the template.'));
   });


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
