### PR TITLE
[CP 1.17] Fixes #23818 - Update fog-openstack to save OpenStack OSP 12

### DIFF
--- a/bundler.d/openstack.rb
+++ b/bundler.d/openstack.rb
@@ -1,3 +1,3 @@
 group :openstack do
-  gem 'fog-openstack', '~> 0.1', '>= 0.1.11'
+  gem 'fog-openstack', '>= 0.1.25', '< 1.0'
 end


### PR DESCRIPTION
On fog-openstack 0.1.23, Excon expects a 200 when it creates the first
key-pair on OpenStack. On recent versions, it returns a 201.
There is a fix for it on fog-openstack 0.1.25, so we should update to it
both in Foreman and in packaging.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
