### PR TITLE
Fixes #23865 - update compression-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.9.0",
-    "compression-webpack-plugin": "~0.3.1",
+    "compression-webpack-plugin": "~1.1.11",
     "coveralls": "^3.0.0",
     "css-loader": "^0.23.1",
     "dotenv": "^5.0.0",


### PR DESCRIPTION
Starting with 1.0, node-zopfli (problematic with NodeJS 10) is not a
dependency anymore.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
