### PR TITLE
Fixes #23843 - Exclude requests to local host from proxying

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -19,7 +19,7 @@ class Setting::General < Setting
       self.set('login_text', N_("Text to be shown in the login-page footer"), nil, N_('Login page footer text')),
       self.set('host_power_status', N_("Show power status on host index page. This feature calls to compute resource providers which may lead to decreased performance on host listing page."), true, N_('Show host power status')),
       self.set('http_proxy', N_('Sets a proxy for all outgoing HTTP connections.'), nil, N_('HTTP(S) proxy')),
-      self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied'), [], N_('HTTP(S) proxy except hosts')),
+      self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default.'), [], N_('HTTP(S) proxy except hosts')),
       self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
       self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 5, N_('Out of sync interval'))

--- a/lib/foreman/http_proxy.rb
+++ b/lib/foreman/http_proxy.rb
@@ -8,10 +8,14 @@ module Foreman
       Setting[:http_proxy_except_list]
     end
 
+    # Answers if this request should be proxied
     def proxy_http_request?(current_proxy, request_host, schema)
-      !http_proxy.nil? && current_proxy.nil? && !request_host.nil? &&
+      !http_proxy.nil? &&
+      current_proxy.nil? &&
+      !request_host.nil? &&
       http_request?(schema) &&
-      http_proxy_host?(request_host)
+      http_proxy_host?(request_host) &&
+      !local_request?(request_host)
     end
 
     def http_proxied_rescue(&block)
@@ -21,6 +25,13 @@ module Foreman
     end
 
     private
+
+    def local_request?(request_host)
+      request_host.starts_with?('127.') ||
+      request_host == 'localhost' ||
+      request_host == '::1' ||
+      request_host == SETTINGS[:fqdn]
+    end
 
     def http_request?(schema)
       ['http', 'https'].include?(schema)

--- a/test/unit/foreman/http_proxy_test.rb
+++ b/test/unit/foreman/http_proxy_test.rb
@@ -80,6 +80,23 @@ class HTTPProxyTest < ActiveSupport::TestCase
                          .returns(nil)
         refute adapter.proxy_http_request?(nil, request_host, schema)
       end
+
+      test 'when request_host is localhost' do
+        refute adapter.proxy_http_request?(nil, 'localhost', schema)
+      end
+
+      test 'when request_host is fqdn' do
+        SETTINGS[:fqdn] = 'test.host.com'
+        refute adapter.proxy_http_request?(nil, 'test.host.com', schema)
+      end
+
+      test 'when request_host is a loopback address' do
+        refute adapter.proxy_http_request?(nil, '127.0.0.1', schema)
+      end
+
+      test 'when request_host is a ipv6 local address' do
+        refute adapter.proxy_http_request?(nil, '::1', schema)
+      end
     end
   end
 


### PR DESCRIPTION
Requests to localhost shouldn't go over the proxy, to cause problems with loading resources for example for Katello pages.