### PR TITLE
Fixes #23875 - removed old session tests

### DIFF
--- a/test/controllers/application_controller_subclass_test.rb
+++ b/test/controllers/application_controller_subclass_test.rb
@@ -119,13 +119,6 @@ class TestableResourcesControllerTest < ActionController::TestCase
         get :index
       end
 
-      it "doesn't escalate privileges in the old session" do
-        old_session = session
-        get :index
-        refute old_session.keys.include?(:user), "old session contains user"
-        assert session[:user], "new session doesn't contain user"
-      end
-
       it "retains taxonomy session attributes in new session" do
         get :index, session: {:location_id => taxonomies(:location1).id,
                               :organization_id => taxonomies(:organization1).id,

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -321,13 +321,6 @@ class UsersControllerTest < ActionController::TestCase
     post :login, params: { :login => {'login' => users(:admin).login, 'password' => 'secret'} }
   end
 
-  test "#login doesn't escalate privileges in the old session" do
-    old_session = session
-    post :login, params: { :login => {'login' => users(:admin).login, 'password' => 'secret'} }
-    refute old_session.keys.include?(:user), "old session contains user"
-    assert session[:user], "new session doesn't contain user"
-  end
-
   test "#login refuses logins when User.try_to_login fails" do
     u = FactoryBot.create(:user)
     User.expects(:try_to_login).with(u.login, 'password').returns(nil)


### PR DESCRIPTION
In #4457 we introduced a change and two tests to verify the session does not leak session id via old session hash reference. Starting from Rails 4.0 the implementation used in tests (TestSession) was given a `destroy` method (https://github.com/rails/rails/commit/7d624e0e8cfa3adffd8f475e3588d83f3b367c24#diff-600d5368b55e46ed961abb4295977ac3R254) which enables the session stack to use it instead creation of new hash instance (https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L349-L355). This should lead to regression in tests, but due to oversight in test assertion, it was never failing:

    refute old_session.keys.include?(:user)

Method keys always return entries as strings, therefore this line never fired. The purpose of this ticket is to refactor this - simply by removing the two tests, because we already test presence of user session key in "sets the session user" test and call of `reset_session` (which calls `destroy` method) in "changes the session ID to prevent fixation" test.