### PR TITLE
fixes #23678 - add graphql scaffolding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'daemons'
 gem 'get_process_mem'
 gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
 gem 'jwt', '~> 2.1.0'
+gem 'graphql', '~> 1.8.0'
+gem 'graphql-batch'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -1,0 +1,87 @@
+module Api
+  class GraphqlController < ActionController::Base
+    include Foreman::ThreadSession::Cleaner
+    include Foreman::Controller::Timezone
+    include Foreman::Controller::RequireSsl
+    include Foreman::Controller::Session
+    include Foreman::Controller::Authentication
+
+    rescue_from Exception, :with => :generic_exception if Rails.env.production?
+
+    before_action :authenticate
+    around_action :set_timezone
+
+    def execute
+      result = if params[:_json]
+                 execute_multiplexed_graphql_query
+               else
+                 execute_single_graphql_query
+               end
+
+      render json: result
+    end
+
+    def api_request?
+      true
+    end
+
+    private
+
+    def execute_multiplexed_graphql_query
+      current_user = User.current
+      queries = params[:_json].map do |param|
+        {
+          query: param['query'],
+          operation_name: param['operationName'],
+          variables: ensure_hash(param['variables']),
+          context: {
+            current_user: current_user,
+            request_id: request.uuid
+          }
+        }
+      end
+      ForemanGraphqlSchema.multiplex(queries)
+    end
+
+    def execute_single_graphql_query
+      ForemanGraphqlSchema.execute(
+        params[:query],
+        variables: variables,
+        context: {
+          current_user: User.current,
+          request_id: request.uuid
+        }
+      )
+    end
+
+    def variables
+      ensure_hash(params[:variables])
+    end
+
+    def ensure_hash(ambiguous_param)
+      case ambiguous_param
+      when String
+        if ambiguous_param.present?
+          ensure_hash(JSON.parse(ambiguous_param))
+        else
+          {}
+        end
+      when ActionController::Parameters
+        ambiguous_param.to_unsafe_h
+      when Hash
+        ambiguous_param
+      when nil
+        {}
+      else
+        raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+      end
+    rescue JSON::ParserError
+      raise ArgumentError, "Could not parse JSON data in #{ambiguous_param}"
+    end
+
+    def generic_exception(exception)
+      Foreman::Logging.exception('Action failed', exception)
+      render json: "{ 'error': 500 }", :status => :internal_server_error
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,8 @@ class ApplicationController < ActionController::Base
 
   include Foreman::Controller::Flash
   include Foreman::Controller::Authorize
+  include Foreman::Controller::RequireSsl
 
-  force_ssl :if => :require_ssl?
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
   rescue_from Exception, :with => :generic_exception if Rails.env.production?
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
@@ -73,10 +73,6 @@ class ApplicationController < ActionController::Base
 
   def deny_access
     (User.current.logged? || request.xhr?) ? render_403 : require_login
-  end
-
-  def require_ssl?
-    SETTINGS[:require_ssl]
   end
 
   # This filter is called before FastGettext set_gettext_locale and sets user-defined locale

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -5,21 +5,18 @@ module ApplicationShared
   include Foreman::Controller::Authentication
   include Foreman::Controller::Session
   include Foreman::Controller::TopbarSweeper
+  include Foreman::Controller::Timezone
   include Foreman::ThreadSession::Cleaner
   include FindCommon
 
-  def set_timezone
-    default_timezone = Time.zone
-    client_timezone  = User.current.try(:timezone) || cookies[:timezone]
-    Time.zone        = client_timezone if client_timezone.present?
-    yield
-  ensure
-    # Reset timezone for the next thread
-    Time.zone = default_timezone
-  end
-
   def current_permission
     [action_permission, controller_permission].join('_')
+  end
+
+  def set_current_user(user)
+    super
+    set_taxonomy
+    user.present?
   end
 
   def set_taxonomy

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -85,7 +85,6 @@ module Foreman::Controller::Authentication
       session[:user] = user.id
       update_activity_time
     end
-    set_taxonomy
     user.present?
   end
 end

--- a/app/controllers/concerns/foreman/controller/require_ssl.rb
+++ b/app/controllers/concerns/foreman/controller/require_ssl.rb
@@ -1,0 +1,17 @@
+module Foreman
+  module Controller
+    module RequireSsl
+      extend ActiveSupport::Concern
+
+      included do
+        force_ssl :if => :require_ssl?
+      end
+
+      protected
+
+      def require_ssl?
+        SETTINGS[:require_ssl]
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/foreman/controller/timezone.rb
+++ b/app/controllers/concerns/foreman/controller/timezone.rb
@@ -1,0 +1,17 @@
+module Foreman
+  module Controller
+    module Timezone
+      extend ActiveSupport::Concern
+
+      def set_timezone
+        default_timezone = Time.zone
+        client_timezone  = User.current.try(:timezone) || cookies[:timezone]
+        Time.zone        = client_timezone if client_timezone.present?
+        yield
+      ensure
+        # Reset timezone for the next thread
+        Time.zone = default_timezone
+      end
+    end
+  end
+end

--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -1,0 +1,7 @@
+class ForemanGraphqlSchema < GraphQL::Schema
+  # Set up the graphql-batch gem
+  lazy_resolve(Promise, :sync)
+  use GraphQL::Batch
+
+  query(Types::Query)
+end

--- a/app/graphql/queries/authorized_model_query.rb
+++ b/app/graphql/queries/authorized_model_query.rb
@@ -1,0 +1,44 @@
+module Queries
+  class AuthorizedModelQuery
+    def initialize(model_class:, user:)
+      @model_class = model_class
+      @user = user
+    end
+
+    delegate :find_by, to: :authorized_scope
+
+    def results(params = {})
+      if params[:search].present?
+        authorized_scope.search_for(*search_options(params))
+      elsif params[:orderField].present?
+        ordered_results(order_field: params[:orderField], order_direction: params[:orderDirection])
+      else
+        authorized_scope.all
+      end
+    end
+
+    private
+
+    attr_reader :model_class, :user
+
+    def authorized_scope
+      return model_class unless model_class.respond_to?(:authorized)
+
+      permission = model_class.find_permission_name(:view)
+      model_class.authorized_as(user, permission, model_class)
+    end
+
+    def search_options(params)
+      search_options = [params[:search]]
+      if params[:orderField].present?
+        search_options << { :order => "#{params[:orderField]} #{params[:orderDirection]}".strip }
+      end
+      search_options
+    end
+
+    def ordered_results(order_field:, order_direction:)
+      order_direction = order_direction.presence || :ASC
+      authorized_scope.order(order_field => order_direction).all
+    end
+  end
+end

--- a/app/graphql/queries/fetch_field.rb
+++ b/app/graphql/queries/fetch_field.rb
@@ -1,0 +1,17 @@
+module Queries
+  class FetchField < GraphQL::Function
+    attr_reader :type
+
+    argument(:id, !types.Int, 'ID for Record')
+
+    def initialize(model_class:, type:)
+      @model_class = model_class
+      @type = type
+    end
+
+    def call(_, args, ctx)
+      Queries::AuthorizedModelQuery.new(model_class: @model_class, user: ctx[:current_user])
+                                   .find_by(id: args['id'])
+    end
+  end
+end

--- a/app/graphql/queries/plural_field.rb
+++ b/app/graphql/queries/plural_field.rb
@@ -1,0 +1,20 @@
+module Queries
+  class PluralField < GraphQL::Function
+    attr_reader :type
+
+    argument(:search, types.String, 'Search query')
+    argument(:orderField, types.String, 'Order field')
+    argument(:orderDirection, types.String, 'Order direction')
+
+    def initialize(model_class:, type:)
+      @model_class = model_class
+      @type = type
+    end
+
+    def call(_, args, ctx)
+      params = args.to_h.slice('search', 'orderField', 'orderDirection').symbolize_keys
+      Queries::AuthorizedModelQuery.new(model_class: @model_class, user: ctx[:current_user])
+                                   .results(params)
+    end
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseObject < GraphQL::Types::Relay::BaseObject
+  end
+end

--- a/app/graphql/types/model.rb
+++ b/app/graphql/types/model.rb
@@ -1,0 +1,11 @@
+module Types
+  class Model < BaseObject
+    description 'A Model'
+
+    field :id, Integer, null: false
+    field :name, String, null: false
+    field :info, String, null: true
+    field :vendorClass, String, null: true
+    field :hardwareModel, String, null: true
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -1,0 +1,11 @@
+module Types
+  class Query < GraphQL::Schema::Object
+    graphql_name 'Query'
+
+    field :model, Types::Model,
+      function: Queries::FetchField.new(type: Types::Model, model_class: ::Model), null: true
+
+    field :models, Types::Model.connection_type, connection: true,
+      function: Queries::PluralField.new(type: Types::Model, model_class: ::Model)
+  end
+end

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -33,15 +33,7 @@ module Authorizable
   end
 
   def permission_name(action)
-    type = Permission.resource_name(self.class)
-    permissions = Permission.where(:resource_type => type).where(["#{Permission.table_name}.name LIKE ?", "#{action}_%"])
-
-    # some permissions are grouped for same resource, e.g. edit_comupute_resources and edit_compute_resources_vms, in such case we need to detect the right permission
-    if permissions.size > 1
-      permissions.detect { |p| p.name.end_with?(type.underscore.pluralize) }.try(:name)
-    else
-      permissions.first.try(:name)
-    end
+    self.class.find_permission_name(action)
   end
 
   included do
@@ -114,6 +106,18 @@ module Authorizable
       yield
     ensure
       Thread.current[:ignore_permission_check] = original_value
+    end
+
+    def find_permission_name(action)
+      type = Permission.resource_name(self)
+      permissions = Permission.where(:resource_type => type).where(["#{Permission.table_name}.name LIKE ?", "#{action}_%"])
+
+      # some permissions are grouped for same resource, e.g. edit_comupute_resources and edit_compute_resources_vms, in such case we need to detect the right permission
+      if permissions.size > 1
+        permissions.detect { |p| p.name.end_with?(type.underscore.pluralize) }.try(:name)
+      else
+        permissions.first.try(:name)
+      end
     end
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -278,6 +278,12 @@ class Host::Managed < Host::Base
     ActiveModel::Name.new(Host)
   end
 
+  # Permissions introduced by plugins for this class can cause resource <-> permission
+  # names mapping to fail randomly so as a safety precaution, we specify the name more explicitly.
+  def self.find_permission_name(action)
+    "#{action}_hosts"
+  end
+
   def clear_reports
     # Remove any reports that may be held against this host
     Report.where("host_id = #{id}").delete_all

--- a/config/initializers/graphql.rb
+++ b/config/initializers/graphql.rb
@@ -1,0 +1,2 @@
+require 'graphql'
+require 'graphql/batch'

--- a/config/routes/api/graphql.rb
+++ b/config/routes/api/graphql.rb
@@ -1,0 +1,5 @@
+Foreman::Application.routes.draw do
+  namespace :api, defaults: {format: 'json'} do
+    post '/graphql', to: 'graphql#execute'
+  end
+end

--- a/test/controllers/api/graphql_controller_test.rb
+++ b/test/controllers/api/graphql_controller_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Api::GraphqlControllerTest < ActionController::TestCase
+  test 'empty query' do
+    post :execute, params: {}
+
+    assert_response :success
+    refute_empty json_errors
+    assert_includes json_error_messages, 'No query string was present'
+  end
+end

--- a/test/graphql/queries/authorized_model_query_test.rb
+++ b/test/graphql/queries/authorized_model_query_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+class Queries::AuthorizedModelQueryTest < ActiveSupport::TestCase
+  describe '#find_by' do
+    let(:host) do
+      as_admin { FactoryBot.create(:host) }
+    end
+
+    test 'does not return record for missing user' do
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: nil)
+        .find_by(id: host.id)
+
+      assert_nil result
+    end
+
+    test 'does not return record for not authorized user' do
+      user = as_admin { FactoryBot.create(:user) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .find_by(id: host.id)
+
+      assert_nil result
+    end
+
+    test 'returns record for authorized user' do
+      user = as_admin { setup_user 'view', 'hosts' }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .find_by(id: host.id)
+
+      assert_equal host, result
+    end
+  end
+
+  describe '#results' do
+    test 'does not return records for missing user' do
+      as_admin { FactoryBot.create(:host) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: nil)
+                                            .results
+
+      assert_empty result
+    end
+
+    test 'does not return records for not authorized user' do
+      user = as_admin { FactoryBot.create(:user) }
+      as_admin { FactoryBot.create(:host) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results
+
+      assert_empty result
+    end
+
+    test 'returns records for authorized user' do
+      user = as_admin { setup_user 'view', 'hosts' }
+      host = as_admin { FactoryBot.create(:host) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results
+
+      assert_equal [host], result
+    end
+
+    test 'searches results when search param present' do
+      user = as_admin { setup_user 'view', 'hosts' }
+      excluded_host = as_admin { FactoryBot.create(:host) }
+      included_host = as_admin { FactoryBot.create(:host, hostname: 'sample host 1') }
+
+      result = Queries::AuthorizedModelQuery.new(
+        model_class: Host::Managed, user: user
+      ).results(search: 'name ~ "sample"')
+
+      refute_includes result, excluded_host
+      assert_equal [included_host], result
+    end
+
+    test 'searches and order results when search param present' do
+      user = as_admin { setup_user 'view', 'hosts' }
+      excluded_host = as_admin { FactoryBot.create(:host) }
+      included_hosts = as_admin do
+        [
+          FactoryBot.create(:host, hostname: 'sample host 1'),
+          FactoryBot.create(:host, hostname: 'a sample host 1')
+        ]
+      end
+
+      result = Queries::AuthorizedModelQuery.new(
+        model_class: Host::Managed, user: user
+      ).results(search: 'name ~ "sample"', orderField: 'name', orderDirection: 'DESC')
+
+      refute_includes result, excluded_host
+      assert_equal included_hosts, result
+    end
+
+    test 'returns ordered records for authorized user by given orderField' do
+      user = as_admin { setup_user 'view', 'hosts' }
+      old_host = as_admin { FactoryBot.create(:host, created_at: Time.zone.now - 2.days) }
+      new_host = as_admin { FactoryBot.create(:host, created_at: Time.zone.now) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results(orderField: 'created_at')
+
+      assert_equal [old_host, new_host], result
+    end
+
+    test 'returns ordered records for authorized user by given orderField and orderDirection' do
+      user = as_admin { setup_user 'view', 'hosts' }
+      old_host = as_admin { FactoryBot.create(:host, created_at: Time.zone.now - 2.days) }
+      new_host = as_admin { FactoryBot.create(:host, created_at: Time.zone.now) }
+
+      result = Queries::AuthorizedModelQuery.new(model_class: Host::Managed, user: user)
+                                            .results(orderField: 'created_at', orderDirection: 'desc')
+
+      assert_equal [new_host, old_host], result
+    end
+  end
+end

--- a/test/graphql/queries/model_query_test.rb
+++ b/test/graphql/queries/model_query_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Queries::ModelQueryTest < ActiveSupport::TestCase
+  test 'fetching model attributes' do
+    model = FactoryBot.create(:model)
+
+    query = <<-GRAPHQL
+      query modelQuery (
+        $modelId: Int!
+      ) {
+        model(id: $modelId) {
+          id
+          name
+          info
+          vendorClass
+          hardwareModel
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    variables = { modelId: model.id }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+
+    expected_model_attributes = {
+      'id' => model.id,
+      'name' => model.name,
+      'info' => model.info,
+      'vendorClass' => model.vendor_class,
+      'hardwareModel' => model.hardware_model
+    }
+
+    assert_empty result['errors']
+    assert_equal expected_model_attributes, result['data']['model']
+  end
+end

--- a/test/graphql/queries/models_query_test.rb
+++ b/test/graphql/queries/models_query_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class Queries::ModelsQueryTest < ActiveSupport::TestCase
+  test 'fetching models attributes and relations' do
+    model = FactoryBot.create(:model)
+
+    query = <<-GRAPHQL
+      query modelsQuery {
+        models {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              info
+              vendorClass
+              hardwareModel
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_model_attributes = {
+      'id' => model.id,
+      'name' => model.name,
+      'info' => model.info,
+      'vendorClass' => model.vendor_class,
+      'hardwareModel' => model.hardware_model
+    }
+
+    assert_empty result['errors']
+    assert_includes result['data']['models']['edges'].map { |e| e['node'] }, expected_model_attributes
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,3 +168,20 @@ def with_auditing(klass)
 ensure
   klass.disable_auditing unless auditing_was_enabled
 end
+
+def json_response
+  ActiveSupport::JSON.decode(response.body)
+end
+
+def json_data(key)
+  data = json_response.fetch('data', {})
+  data.fetch(key, {})
+end
+
+def json_errors
+  json_response.fetch('errors', [])
+end
+
+def json_error_messages
+  json_errors.map { |e| e.fetch('message') }
+end

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -50,7 +50,10 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     # https://github.com/rails/rails/issues/31228
     "active_storage/blobs/show", "active_storage/direct_uploads/create", "active_storage/disk/show",
     "active_storage/disk/update", "active_storage/previews/show", "active_storage/representations/show",
-    "active_storage/variants/show"
+    "active_storage/variants/show",
+
+    # graphql
+    "api/graphql/execute"
   ]
 
   MAY_SKIP_AUTHORIZED = [ "about/index" ]


### PR DESCRIPTION
This is part two of the graphql series. 😋 
It just exposes the rails model `Model` via graphql, but adds all the required scaffolding to add more models. Please consider this as a step towards making this perfect. We can iterate on this later.

This PR does _not_ include:
* exception handling
* mutations
* generic taxonomy helpers
* anything that can be added later
* a global id
* plugin support

This is extracted from #5336.

---
Other parts:
Part 1 - JWT Auth: #5596
Part 2 - Graphql Scaffolding: #5680
Part 3 - Relay Global ID #5681
Part 4 - Connections with totalCount #5733
Part 5 - Basic mutations for model #5736