### PR TITLE
fixes #23880 - graphql: relay global id

### DIFF
--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -4,4 +4,24 @@ class ForemanGraphqlSchema < GraphQL::Schema
   use GraphQL::Batch
 
   query(Types::Query)
+
+  def self.id_from_object(object, type_definition, query_ctx)
+    Foreman::GlobalId.encode(type_definition.name, object.id)
+  end
+
+  def self.object_from_id(id, query_ctx)
+    return unless id.present?
+
+    _, type_name, item_id = Foreman::GlobalId.decode(id)
+    model_class = type_name.safe_constantize
+
+    return unless model_class
+
+    Queries::AuthorizedModelQuery.new(model_class: model_class, user: query_ctx[:current_user])
+      .find_by(id: item_id)
+  end
+
+  def self.resolve_type(_, obj, _)
+    types[obj.class.name]
+  end
 end

--- a/app/graphql/types/model.rb
+++ b/app/graphql/types/model.rb
@@ -2,7 +2,10 @@ module Types
   class Model < BaseObject
     description 'A Model'
 
-    field :id, Integer, null: false
+    implements GraphQL::Relay::Node.interface
+
+    global_id_field :id
+
     field :name, String, null: false
     field :info, String, null: true
     field :vendorClass, String, null: true

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -2,6 +2,9 @@ module Types
   class Query < GraphQL::Schema::Object
     graphql_name 'Query'
 
+    field :node, field: GraphQL::Relay::Node.field
+    field :nodes, field: GraphQL::Relay::Node.plural_field
+
     field :model, Types::Model,
       function: Queries::FetchField.new(type: Types::Model, model_class: ::Model), null: true
 

--- a/app/services/foreman/global_id.rb
+++ b/app/services/foreman/global_id.rb
@@ -1,0 +1,25 @@
+module Foreman
+  module GlobalId
+    ID_SEPARATOR = '-'
+    VERSION_SEPARATOR = ':'
+    DEFAULT_VERSION = 1
+
+    def self.encode(type_name, object_value, version: DEFAULT_VERSION)
+      object_value_str = object_value.to_s
+      version_str = "%02d" % version
+
+      if type_name.include?(ID_SEPARATOR)
+        raise "encode(#{type_name}, #{object_value_str}) contains reserved characters `#{ID_SEPARATOR}` in the type name"
+      end
+
+      Base64.strict_encode64([version_str, [type_name, object_value_str].join(ID_SEPARATOR)].join(VERSION_SEPARATOR))
+    end
+
+    def self.decode(node_id)
+      decoded = Base64.decode64(node_id)
+      version, payload = decoded.split(VERSION_SEPARATOR, 2)
+      type_name, object_value = payload.split(ID_SEPARATOR, 2)
+      [version.to_i, type_name, object_value]
+    end
+  end
+end

--- a/test/graphql/queries/model_query_test.rb
+++ b/test/graphql/queries/model_query_test.rb
@@ -23,8 +23,10 @@ class Queries::ModelQueryTest < ActiveSupport::TestCase
 
     result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
 
+    expected_id = Foreman::GlobalId.encode('Model', model.id)
+
     expected_model_attributes = {
-      'id' => model.id,
+      'id' => expected_id,
       'name' => model.name,
       'info' => model.info,
       'vendorClass' => model.vendor_class,

--- a/test/graphql/queries/models_query_test.rb
+++ b/test/graphql/queries/models_query_test.rb
@@ -31,8 +31,10 @@ class Queries::ModelsQueryTest < ActiveSupport::TestCase
 
     result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
 
+    expected_id = Foreman::GlobalId.encode('Model', model.id)
+
     expected_model_attributes = {
-      'id' => model.id,
+      'id' => expected_id,
       'name' => model.name,
       'info' => model.info,
       'vendorClass' => model.vendor_class,

--- a/test/graphql/queries/nodes_query_test.rb
+++ b/test/graphql/queries/nodes_query_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Queries::NodesQueryTest < ActiveSupport::TestCase
+  test 'fetching node by relay global id' do
+    model = FactoryBot.create(:model)
+    global_id = Foreman::GlobalId.encode('Model', model.id)
+
+    query = <<-GRAPHQL
+      query getNode {
+        node(id: #{global_id}) {
+          id
+          ... on Model {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_model_attributes = {
+      'id' => global_id,
+      'name' => model.name
+    }
+
+    assert_empty result['errors']
+    assert_equal expected_model_attributes, result['data']['node']
+  end
+
+  test 'fetching multiple nodes by relay global id' do
+    model = FactoryBot.create(:model)
+    global_id = Foreman::GlobalId.encode('Model', model.id)
+
+    query = <<-GRAPHQL
+      query getNodes {
+        nodes(ids: [#{global_id}]) {
+          id
+          ... on Model {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_model_attributes = {
+      'id' => global_id,
+      'name' => model.name
+    }
+
+    assert_empty result['errors']
+    assert_equal expected_model_attributes, result['data']['nodes'].first
+  end
+end

--- a/test/unit/foreman/global_id_test.rb
+++ b/test/unit/foreman/global_id_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module Foreman
+  class GlobalIdTest < ActiveSupport::TestCase
+    test 'encodes an id' do
+      assert_equal 'MDE6TW9kZWwtMTIz', Foreman::GlobalId.encode('Model', '123')
+    end
+
+    test 'decodes an id' do
+      version, type_name, object_value = Foreman::GlobalId.decode('MDE6TW9kZWwtMTIz')
+      assert_equal 1, version
+      assert_equal 'Model', type_name
+      assert_equal '123', object_value
+    end
+  end
+end


### PR DESCRIPTION
This is part three of the graphql series. 🌸 
It implements the relay global id spec.

https://github.com/rmosolgo/graphql-ruby/blob/master/guides/relay/object_identification.md
http://mgiroux.me/2016/implementing-the-relay-spec-for-a-graphql-server/

This needs GH-5680.

---
Other parts:
Part 1 - JWT Auth: GH-5596
Part 2 - Graphql Scaffolding: GH-5680
Part 3 - Relay Global ID GH-5681
Part 4 - Connections with totalCount GH-5733
Part 5 - Basic mutations for model GH-5736