### PR TITLE
fixes #23909 - Failure finding VMware interface

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -38,8 +38,8 @@ module FogExtensions
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
         all_networks = service.raw_networks(datacenter)
-        vm_network = all_networks.detect { |network| network._ref == nic_attrs['network'] }
-        vm_network ||= all_networks.detect { |network| nic_attrs['network'] && [network.name, network.try(:key)].include?(nic_attrs['network']) }
+        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network.name, network.try(:key)].include?(nic_attrs['network']) }
+        vm_network ||= all_networks.detect { |network| network._ref == nic_attrs['network'] }
         unless vm_network
           Rails.logger.info "Could not find Vsphere network for #{nic_attrs.inspect}"
           return


### PR DESCRIPTION
Creating a new VMware image fails during provisioning with "Could not match network interface".
Searching for distributed virtual switch via key BEFORE searching with the nic_attrs structure
resolves a false positive match when vCenter contains VDS migrated from prior install with ref
attribute that matches a different object's key.

Ref discussion at https://community.theforeman.org/t/vmware-could-not-match-network-interface-related-to-issue-19623/9963/2

And issue at http://projects.theforeman.org/issues/23909