### PR TITLE
Fixes #23536 - No errors when unattended=false

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -507,7 +507,11 @@ class Host::Managed < Host::Base
   end
 
   def self.valid_rebuild_only_values
-    Nic::Managed.rebuild_methods.values + Host::Managed.rebuild_methods.values
+    if Host::Managed.respond_to?(:rebuild_methods)
+      Nic::Managed.rebuild_methods.values + Host::Managed.rebuild_methods.values
+    else
+      Nic::Managed.rebuild_methods.values
+    end
   end
 
   def can_be_built?


### PR DESCRIPTION
Running 'rake apipie:cache:index' is no longer results in NoMethodError when `unattended=false` is set in the settings.yaml file.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
