### PR TITLE
Refs #23132 - reuse the cached list of controllers

### DIFF
--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -20,6 +20,7 @@ class BookmarkTest < ActiveSupport::TestCase
     valid_controller_values = (["dashboard", "common_parameters"] +
       ActiveRecord::Base.connection.tables.map(&:to_s) +
       Permission.resources.map(&:tableize)).uniq
+    BookmarkControllerValidator.reset_controllers_list
     valid_controller_values.each do |controller|
       bookmark = FactoryBot.create(:bookmark, :controller => controller, :public => false)
       assert bookmark.valid?, "Can't create bookmark with valid controller #{controller}"


### PR DESCRIPTION
~~~The test implements the same method that we have in the validator. Validator has inline cache which can get out of sync if we later add more tables. The test should reuse the same list as the validator. This should be cherry-picked to 1.18 otherwise we'll see random failures in that branch. The test was introduced in 1.18...~~~

we reset the controllers cache

https://github.com/theforeman/foreman/blob/develop/app/validators/bookmark_controller_validator.rb#L8-L12

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
