### PR TITLE
Fixes #23932 - Fixes failing application job tests for some plugins

### DIFF
--- a/test/unit/application_job_test.rb
+++ b/test/unit/application_job_test.rb
@@ -3,13 +3,15 @@ require 'ostruct'
 
 class ApplicationJobTest < ActiveSupport::TestCase
   describe '.spawn_if_missing' do
-    # Force world initialization before stubbing,
-    #   otherwise CreateRssNotifications would be triggered
-    #   on first call to world
-    before { world }
-
     let(:job_class) { ApplicationJob }
-    let(:world) { Foreman::Application.dynflow.world }
+
+    # Using real world led to various issues, let's stub it out
+    let(:world) do
+      persistence = mock()
+      persistence.stubs(:find_execution_plans).returns([])
+      persistence.stubs(:load_delayed_plan)
+      OpenStruct.new(:persistence => persistence)
+    end
 
     def stub_delayed_plans_with_serialized_args(*args)
       execution_plans = args.each_with_index.map { |_, index| OpenStruct.new(:id => index) }


### PR DESCRIPTION
The tests were failing with:
Sequel::DatabaseError: PG::DuplicateTable:
ERROR:  relation "dynflow_execution_plans" already exists

This failure was probably caused by forcing initialization of the
Dynflow world in a before test block.

REX tests are running on [jenkins here](http://ci.theforeman.org/job/test_plugin_matrix/5472/)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
