### PR TITLE
Fixes #23930 - PXELinux loader is now preferred

### DIFF
--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -7,9 +7,10 @@ module PxeLoaderSupport
     :PXEGrub2 => /^(grub2|Grub2).*/
   }.with_indifferent_access.freeze
 
+  # preference order is defined in Operatingsystem#template_kinds
   PREFERRED_KINDS = {
-    :PXEGrub2 => "Grub2 UEFI",
     :PXELinux => "PXELinux BIOS",
+    :PXEGrub2 => "Grub2 UEFI",
     :PXEGrub => "Grub UEFI"
   }.with_indifferent_access.freeze
 

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -220,7 +220,7 @@ class Operatingsystem < ApplicationRecord
 
   # Compatible kinds for this OS sorted by preferrence
   def template_kinds
-    ["PXEGrub2", "PXELinux", "PXEGrub"]
+    ["PXELinux", "PXEGrub2", "PXEGrub"]
   end
 
   def boot_filename(host = nil)

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -87,17 +87,22 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
       assert_nil @subject.preferred_loader
     end
 
-    test "is PXEGrub2 for associated templates" do
+    test "is PXELinux for all associated template kinds" do
       @subject.expects(:os_default_templates).returns([@template_pxelinux, @template_pxegrub, @template_pxegrub2])
-      assert_equal "Grub2 UEFI", @subject.preferred_loader
+      assert_equal "PXELinux BIOS", @subject.preferred_loader
     end
 
-    test "is PXELinux for associated templates" do
+    test "is PXELinux for associated PXELinux and PXEGrub" do
       @subject.expects(:os_default_templates).returns([@template_pxelinux, @template_pxegrub])
       assert_equal "PXELinux BIOS", @subject.preferred_loader
     end
 
-    test "is PXEGrub for associated templates" do
+    test "is PXEGrub2 for associated template PXEGrub2" do
+      @subject.expects(:os_default_templates).returns([@template_pxegrub2])
+      assert_equal "Grub2 UEFI", @subject.preferred_loader
+    end
+
+    test "is PXEGrub for associated template PXEGrub" do
       @subject.expects(:os_default_templates).returns([@template_pxegrub])
       assert_equal "Grub UEFI", @subject.preferred_loader
     end


### PR DESCRIPTION
When new bare-metal host is created and all PXE template kinds are associated and set for selected OS, Foreman sets PXE loader in this order:

* PXEGrub2 UEFI
* PXELinux BIOS
* PXEGrub UEFI

We should still prefer BIOS as the primary options because this can end up with hosts not booting for users with BIOS-PXE workflow which is still the most used one.