### PR TITLE
Fixes #23813 - Allow searching audits by type=auth_source

### DIFF
--- a/app/models/concerns/audit_search.rb
+++ b/app/models/concerns/audit_search.rb
@@ -44,6 +44,7 @@ module AuditSearch
       end
       # Add aliases and STI handling
       complete_values.merge!(
+        :auth_source => 'AuthSource',
         :compute_resource => 'ComputeResource',
         :host => 'Host::Base',
         :interface => 'Nic::Base',


### PR DESCRIPTION
(cherry picked from commit c372e97e1328943fd2976a57a41d98e05fb73f9b)
