### PR TITLE
Fixes #23951 - fix searching by config group

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -171,7 +171,7 @@ module Hostext
 
       def search_by_config_group(key, operator, value)
         conditions = sanitize_sql_for_conditions(["config_groups.name #{operator} ?", value_to_sql(operator, value)])
-        host_ids      = Host::Managed.authorized(:view_hosts, Host).where(conditions).joins(:config_groups).distinct.pluck('hosts.id')
+        host_ids      = Host::Managed.where(conditions).joins(:config_groups).distinct.pluck('hosts.id')
         hostgroup_ids = Hostgroup.unscoped.with_taxonomy_scope.where(conditions).joins(:config_groups).distinct.map(&:subtree_ids).flatten.uniq
 
         opts = ''

--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Hostext
+  class SearchTest < ActiveSupport::TestCase
+    context 'host exists' do
+      setup do
+        @host = FactoryBot.create(:host)
+      end
+
+      test "can be found by config group" do
+        config_group = FactoryBot.create(:config_group)
+        @host.config_groups = [ config_group ]
+        result = Host.search_for("config_group = #{config_group.name}")
+        assert_includes result, @host
+      end
+
+      test "search by config group returns only host within that config group" do
+        config_group = FactoryBot.create(:config_group)
+        result = Host.search_for("config_group = #{config_group.name}")
+        assert_not_includes result, @host
+      end
+    end
+  end
+end


### PR DESCRIPTION
the problem is that when you under non-admin user search for hosts using config_group = x, the search_by_config_group ext method uses Host.authorized which again calls search_by_config_group. The authorization of host in this case is redundant, as this is a search method of host and we don't know, whether the query should be authorized or nor (e.g. system call like this). Authorized can be safely removed since host_ids are joined with the rest of conditions so if this was authorized query already, result will be authorized anyway.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
