### PR TITLE
Fixes #23952 - Include all asset paths when precompiling plugins

### DIFF
--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -11,10 +11,10 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
       def initialize(plugin_id)
         @plugin = Foreman::Plugin.find(plugin_id) or raise("Unable to find registered plugin #{plugin_id}")
 
+        Rails.env = 'production'
         app = Rails.application
         app.config.assets.digest = true
         app.config.assets.precompile = plugin.assets
-        app.config.assets.paths = app.config.assets.paths.select { |path| path.to_s.include?(plugin_id) }
 
         super(Rails.application)
       end


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
