### PR TITLE
Fixes #23953 - Port robottelo tests for settings

### DIFF
--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -45,4 +45,19 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
     assert_no_match /location_fact/, @response.body
     SETTINGS[:locations_enabled] = true
   end
+
+  test_attributes :pid => 'fb8b0bf1-b475-435a-926b-861aa18d31f1'
+  test "should update login page footer text with long value" do
+    value = RFauxFactory.gen_alpha 1000
+    setting = Setting.find_by_name("login_text")
+    put :update, params: { :id => setting.id, :setting => { :value => value } }
+    assert_equal JSON.parse(@response.body)['value'], value, "Can't update login_text setting with valid value #{value}"
+  end
+
+  test_attributes :pid => '7a56f194-8bde-4dbf-9993-62eb6ab10733'
+  test "should update login page footer text with empty value" do
+    setting = Setting.find_by_name("login_text")
+    put :update, params: { :id => setting.id, :setting => { :value => "" } }
+    assert_equal JSON.parse(@response.body)['value'], "", "Can't update login_text setting with empty value"
+  end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -384,3 +384,8 @@ attribute80:
   category: Setting::Auth
   default: 30
   description: "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+attribute81:
+  name: login_text
+  category: Setting::General
+  default: "--- \n"
+  description: 'Text to be shown in the login-page footer'

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -632,4 +632,12 @@ class SettingTest < ActiveSupport::TestCase
     settings = Setting.live_descendants.map(&:full_name).compact
     assert_equal settings.sort, settings
   end
+
+  test "should update login page footer text with multiple valid long values" do
+    setting = Setting.find_by_name("login_text")
+    RFauxFactory.gen_strings(1000).values.each do |value|
+      setting.value = value
+      assert setting.valid?, "Can't update discovery_prefix setting with valid value #{value}"
+    end
+  end
 end


### PR DESCRIPTION
Redmine issue: http://projects.theforeman.org/issues/23953

Port robottelo tier1 tests for settings part of robottelo minitest port project https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: SatelliteQE/robottelo#5978