### PR TITLE
Fixes #23977 - add onClick callback to breadcrumbs

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
@@ -1,3 +1,5 @@
+export const mockBreadcrumbItemOnClick = jest.fn();
+
 export const breadcrumbItems = {
   items: [
     {
@@ -5,7 +7,11 @@ export const breadcrumbItems = {
       url: '/some-url',
     },
     {
-      caption: 'child',
+      caption: 'child with onClick',
+      onClick: mockBreadcrumbItemOnClick,
+    },
+    {
+      caption: 'active child',
     },
   ],
 };

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -34,6 +34,7 @@ class BreadcrumbBar extends React.Component {
       searchQuery,
       removeSearchQuery,
       searchDebounceTimeout,
+      onSwitcherItemClick,
     } = this.props;
 
     const isTitle = breadcrumbItems.length === 1;
@@ -41,6 +42,11 @@ class BreadcrumbBar extends React.Component {
       searchQuery,
       page: Number(currentPage) + pageIncrement,
     });
+
+    const handleSwitcherItemClick = (e, url) => {
+      closeSwitcher();
+      onSwitcherItemClick(e, url);
+    };
 
     return (
       <div className="breadcrumb-bar">
@@ -56,7 +62,6 @@ class BreadcrumbBar extends React.Component {
               onTogglerClick={() => toggleSwitcher()}
               onHide={() => closeSwitcher()}
               onOpen={() => this.handleOpen()}
-              onResourceClick={() => closeSwitcher()}
               onSearchChange={event =>
                 loadSwitcherResourcesByResource(resource, { searchQuery: event.target.value })
               }
@@ -69,6 +74,7 @@ class BreadcrumbBar extends React.Component {
               searchValue={searchQuery}
               onSearchClear={() => removeSearchQuery(resource)}
               searchDebounceTimeout={searchDebounceTimeout}
+              onResourceClick={(e, url) => handleSwitcherItemClick(e, url)}
             />
           )}
         </Breadcrumb>
@@ -99,6 +105,7 @@ BreadcrumbBar.propTypes = {
   closeSwitcher: PropTypes.func,
   loadSwitcherResourcesByResource: PropTypes.func,
   onSearchChange: PropTypes.func,
+  onSwitcherItemClick: PropTypes.func,
 };
 
 BreadcrumbBar.defaultProps = {
@@ -118,6 +125,7 @@ BreadcrumbBar.defaultProps = {
   loadSwitcherResourcesByResource: noop,
   onSearchChange: noop,
   searchDebounceTimeout: 300,
+  onSwitcherItemClick: noop,
 };
 
 export default BreadcrumbBar;

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
@@ -4,7 +4,11 @@ import { mount } from 'enzyme';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 
 import BreadcrumbBar from '../BreadcrumbBar';
-import { breadcrumbBar, breadcrumbBarSwithcable } from '../BreadcrumbBar.fixtures';
+import {
+  breadcrumbBar,
+  breadcrumbBarSwithcable,
+  mockBreadcrumbItemOnClick,
+} from '../BreadcrumbBar.fixtures';
 
 const createStubs = () => ({
   toggleSwitcher: jest.fn(),
@@ -47,6 +51,27 @@ describe('BreadcrumbBar', () => {
       expect(props.loadSwitcherResourcesByResource.mock.calls.length).toBe(3);
 
       expect(props.loadSwitcherResourcesByResource.mock.calls).toMatchSnapshot('loadSwitcherResourcesByResource calls');
+    });
+
+    it('onclick callbacks should work', () => {
+      const props = {
+        ...breadcrumbBarSwithcable,
+        ...createStubs(),
+        onSwitcherItemClick: jest.fn(),
+        resourceSwitcherItems: [{ name: 'a', id: '1' }],
+      };
+      const component = mount(<BreadcrumbBar {...props} />);
+
+      // test breadcrumb switcher item click
+      expect(props.onSwitcherItemClick.mock.calls.length).toBe(0);
+      component.setProps({ isSwitcherOpen: true });
+      component.update();
+      component.find('.scrollable-list.list-group button').simulate('click');
+      expect(props.onSwitcherItemClick.mock.calls.length).toBe(1);
+
+      // test breadcrumb item click
+      component.find('.breadcrumbs-pf-title.breadcrumb a').at(1).simulate('click');
+      expect(mockBreadcrumbItemOnClick.mock.calls.length).toBe(1);
     });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
@@ -13,7 +13,11 @@ exports[`BreadcrumbBar rendering renders breadcrumb-bar 1`] = `
           "url": "/some-url",
         },
         Object {
-          "caption": "child",
+          "caption": "child with onClick",
+          "onClick": [Function],
+        },
+        Object {
+          "caption": "active child",
         },
       ]
     }
@@ -38,7 +42,11 @@ exports[`BreadcrumbBar rendering renders switchable breadcrumb-bar 1`] = `
           "url": "/some-url",
         },
         Object {
-          "caption": "child",
+          "caption": "child with onClick",
+          "onClick": [Function],
+        },
+        Object {
+          "caption": "active child",
         },
       ]
     }

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -20,6 +20,7 @@ const Breadcrumb = ({
         <PfBreadcrumb.Item
           key={index}
           active={index === items.length - 1}
+          onClick={item.onClick}
           href={item.url}
           dangerouslySetInnerHTML={{ __html: item.caption }}
         />

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcher.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcher.js
@@ -27,13 +27,13 @@ class BreadcrumbSwitcher extends React.Component {
       resources,
       onTogglerClick,
       onHide,
-      onResourceClick,
       onNextPageClick,
       onPrevPageClick,
       onSearchChange,
       searchValue,
       onSearchClear,
       searchDebounceTimeout,
+      onResourceClick,
     } = this.props;
 
     return (
@@ -60,7 +60,6 @@ class BreadcrumbSwitcher extends React.Component {
             hasError={hasError}
             onSearchChange={onSearchChange}
             resources={resources}
-            onResourceClick={onResourceClick}
             onNextPageClick={onNextPageClick}
             onPrevPageClick={onPrevPageClick}
             currentPage={currentPage}
@@ -68,6 +67,7 @@ class BreadcrumbSwitcher extends React.Component {
             searchValue={searchValue}
             onSearchClear={onSearchClear}
             searchDebounceTimeout={searchDebounceTimeout}
+            onResourceClick={onResourceClick}
           />
         </Overlay>
       </div>
@@ -85,9 +85,9 @@ BreadcrumbSwitcher.propTypes = {
   onTogglerClick: PropTypes.func,
   onHide: PropTypes.func,
   onOpen: PropTypes.func,
-  onResourceClick: PropTypes.func,
   onPrevPageClick: PropTypes.func,
   onNextPageClick: PropTypes.func,
+  onResourceClick: PropTypes.func,
 };
 
 BreadcrumbSwitcher.defaultProps = {

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import { Popover, ListGroup, ListGroupItem, Pager, Icon } from 'patternfly-react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import SearchInput from '../../common/SearchInput';
-import { noop } from '../../../common/helpers';
 import SubstringWrapper from '../../common/SubstringWrapper';
+import { noop } from '../../../common/helpers';
 import './BreadcrumbSwitcherPopover.scss';
 
 const BreadcrumbSwitcherPopover = ({
   resources,
-  onResourceClick,
   onNextPageClick,
   onPrevPageClick,
   loading,
@@ -20,6 +19,7 @@ const BreadcrumbSwitcherPopover = ({
   onSearchClear,
   searchValue,
   searchDebounceTimeout,
+  onResourceClick,
   ...props
 }) => {
   let popoverBody;
@@ -37,11 +37,6 @@ const BreadcrumbSwitcherPopover = ({
       </div>
     );
   } else {
-    const handleItemClick = (item) => {
-      onResourceClick(item);
-      if (item.onClick) item.onClick();
-    };
-
     const createItemProps = (item) => {
       const { id, url, name } = item;
       const key = `${id}-${name}`;
@@ -57,7 +52,7 @@ const BreadcrumbSwitcherPopover = ({
         return { ...itemProps, disabled: true };
       }
 
-      return { ...itemProps, onClick: () => handleItemClick(item), href: url };
+      return { ...itemProps, onClick: e => onResourceClick(e, url), href: url };
     };
 
     popoverBody = (
@@ -104,7 +99,6 @@ BreadcrumbSwitcherPopover.propTypes = {
   hasError: PropTypes.bool,
   currentPage: PropTypes.number,
   totalPages: PropTypes.number,
-  onResourceClick: PropTypes.func,
   resources: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     name: PropTypes.string.isRequired,
@@ -113,6 +107,7 @@ BreadcrumbSwitcherPopover.propTypes = {
   })),
   onSearchChange: PropTypes.func,
   searchValue: PropTypes.string,
+  onResourceClick: PropTypes.func,
 };
 
 BreadcrumbSwitcherPopover.defaultProps = {
@@ -120,8 +115,8 @@ BreadcrumbSwitcherPopover.defaultProps = {
   hasError: false,
   currentPage: 1,
   totalPages: 1,
-  onResourceClick: noop,
   resources: [],
+  onResourceClick: noop,
 };
 
 export default BreadcrumbSwitcherPopover;

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
@@ -15,13 +15,23 @@ exports[`Breadcrumbs renders breadcrumbs menu 1`] = `
     key="0"
   />
   <BreadcrumbItem
-    active={true}
+    active={false}
     dangerouslySetInnerHTML={
       Object {
-        "__html": "child",
+        "__html": "child with onClick",
       }
     }
     key="1"
+    onClick={[Function]}
+  />
+  <BreadcrumbItem
+    active={true}
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "active child",
+      }
+    }
+    key="2"
   />
 </Breadcrumb>
 `;


### PR DESCRIPTION
Katello uses `react-router`, which doesn't support regular href - which means href links won't work in katello. In order to support breadcrumbs in katello, foreman needs to add `onclick` callback support.
