### PR TITLE
Fixes #23599 - fix subtotal value in hosts API call with thin=true

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -45,6 +45,7 @@ module Api
         @hosts = action_scope_for(:index, resource_scope_for_index)
 
         if params[:thin]
+          @subtotal = @hosts.total_entries
           @hosts = @hosts.reorder(:name).distinct.pluck(:id, :name)
           render 'thin'
           return

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -108,6 +108,17 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal Host.all.pluck(:id, :name), hosts['results'].map(&:values)
   end
 
+  test "subtotal should be the same as the search count with thin" do
+    FactoryBot.create_list(:host, 2)
+    Host.last.update_attribute(:name, 'test')
+
+    get :index, params: { thin: true, per_page: 1, search: 'host' }
+    assert_response :success
+    assert_not_nil assigns(:hosts)
+    hosts = ActiveSupport::JSON.decode(@response.body)
+    assert_equal hosts['subtotal'], Host.search_for('host').size
+  end
+
   test "should include registered scope on index" do
     # remember the previous state
     old_scopes = Api::V2::HostsController.scopes_for(:index).dup


### PR DESCRIPTION
When querying about hosts via API and using this=true the API returns wrong subtotal count. This happens when the query matches more records than what is the current per_page setting.

Example:

Search for "*" on 30 hosts in total with per page being 5 will result in:
```ruby
results: [5 hosts...]
per_page: 5
total: 30
subtotal: 5
```
In this example the expected result is subtotal being 30.