### PR TITLE
Revert "Fixes #24003 - remove babel-polyfill from vendor.js"

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -2,6 +2,7 @@ module.exports = [
   /**
    * React related
    */
+  'babel-polyfill',
   'react',
   'react-dom',
   'react-bootstrap',


### PR DESCRIPTION
This reverts commit bff82b8918b68b0127e4ea32a7d3b958f1a55a91.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
