### PR TITLE
Refs #24003 - Extract babel-polyfill from bundle.js

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,6 +15,7 @@
     <%= yield(:stylesheets) %>
 
     <%= csrf_meta_tags %>
+    <%= javascript_include_tag *webpack_asset_paths('babel-polyfill', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag "locale/#{FastGettext.locale}/app", "data-turbolinks-track" => true %>

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = env => {
     process.env.NODE_ENV === 'production';
 
   var bundleEntry = path.join(__dirname, '..', 'webpack/assets/javascripts/bundle.js');
+  var babelPolyfill = path.join(__dirname, '..', 'webpack/assets/javascripts/babel-polyfill.js');
 
   var plugins = pluginUtils.getPluginDirs('pipe');
 
@@ -50,6 +51,7 @@ module.exports = env => {
     {
       bundle: bundleEntry,
       vendor: vendorEntry,
+      'babel-polyfill': babelPolyfill,
     },
     pluginEntries
   );

--- a/webpack/assets/javascripts/babel-polyfill.js
+++ b/webpack/assets/javascripts/babel-polyfill.js
@@ -1,0 +1,1 @@
+import 'babel-polyfill';

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -4,7 +4,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/extensions */
 /* eslint-disable import/first */
-import 'babel-polyfill';
 
 require('expose-loader?$!expose-loader?jQuery!jquery');
 require('jquery-ujs');


### PR DESCRIPTION
We need the polyfill in place before the transpiled vendor.js,
extracting it from bundle to its own file.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
