### PR TITLE
Fixes #23468 - Add a test helper to test reducers with fixtures

### DIFF
--- a/webpack/assets/javascripts/react_app/common/testHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/testHelpers.js
@@ -82,3 +82,14 @@ export const testActionSnapshot = async (runAction) => {
 export const testActionSnapshotWithFixtures = fixtures =>
   Object.entries(fixtures).forEach(([description, runAction]) =>
     it(description, () => testActionSnapshot(runAction)));
+
+/**
+ * Test a reducer with fixtures and snapshots
+ * @param  {Function} reducer  reducer to test
+ * @param  {Object}   fixtures key=fixture description, value=props to apply
+ */
+export const testReducerSnapshotWithFixtures = (reducer, fixtures) => {
+  const reduce = ({ state, action = {} } = {}) => reducer(state, action);
+  Object.entries(fixtures).forEach(([description, action]) =>
+    it(description, () => expect(reduce(action)).toMatchSnapshot()));
+};

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBarReducer.test.js
@@ -7,6 +7,7 @@ import {
 } from '../BreadcrumbBarConstants';
 import reducer from '../BreadcrumbBarReducer';
 
+import { testReducerSnapshotWithFixtures } from '../../../common/testHelpers';
 import { resource, resourceList } from '../BreadcrumbBar.fixtures';
 
 const fixtures = {
@@ -55,9 +56,4 @@ const fixtures = {
   },
 };
 
-describe('BreadcrumbBar reducer', () => {
-  const reduce = ({ state, action = {} } = {}) => reducer(state, action);
-
-  Object.entries(fixtures).forEach(([description, action]) =>
-    it(description, () => expect(reduce(action)).toMatchSnapshot()));
-});
+describe('BreadcrumbBar reducer', () => testReducerSnapshotWithFixtures(reducer, fixtures));


### PR DESCRIPTION
The idea of testing a reducer using fixtures was introduced
in the BreadcrumBar tests.

Since, other components are going to be tested using this method,
it is moved to testHelpers.js to avoid duplication of code.

Signed-off-by: Boaz Shuster <boaz.shuster.github@gmail.com>
(cherry picked from commit c28d51eb132cc079dd7a5ad7fbef63aba3cca2ab)


js tests are now red for 1.18-stable because https://github.com/theforeman/foreman/commit/8983441e9f2de6369ed011c3d05d7b07cbbf174f depends on code in this commit