### PR TITLE
Fixes #24017 - Add scrollbar in org/loc dropdown

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -321,8 +321,8 @@ a.btn-info span {
   }
 }
 
-.dropdown-submenu > .dropdown-menu {
-  max-height: 80vh;
+.org-switcher > .dropdown-menu {
+  max-height: 24vh;
   overflow-y: auto;
 }
 // Color origin: pf-orange-400

--- a/app/views/home/_location_dropdown.html.erb
+++ b/app/views/home/_location_dropdown.html.erb
@@ -1,11 +1,9 @@
 <li class="dropdown-header"><%= _('Location') %></li>
-<li class="dropdown-submenu loc-menu">
-  <li><%= link_to(_('Any Location'), main_app.clear_locations_path) %></li>
-  <% if User.current.allowed_to?(:view_locations) %>
-    <li><%= link_to _("Manage Locations"), main_app.locations_path, :class=> "manage-menu" %></li>
-  <% end %>
-  <%= content_tag(:li, "", :class=>"divider") %>
-  <% Location.my_locations.each do |location| %>
-    <li><%= link_to(trunc_with_tooltip(location.title), main_app.select_location_path(location)) %></li>
-  <% end %>
-</li>
+<li><%= link_to(_('Any Location'), main_app.clear_locations_path) %></li>
+<% if User.current.allowed_to?(:view_locations) %>
+  <li><%= link_to _("Manage Locations"), main_app.locations_path, :class=> "manage-menu" %></li>
+<% end %>
+<%= content_tag(:li, "", :class=>"divider") %>
+<% Location.my_locations.each do |location| %>
+  <li><%= link_to(trunc_with_tooltip(location.title), main_app.select_location_path(location)) %></li>
+<% end %>

--- a/app/views/home/_org_switcher.html.erb
+++ b/app/views/home/_org_switcher.html.erb
@@ -3,7 +3,7 @@
       <a href="#" class ="dropdown-toggle nav-item-iconic" data-toggle="dropdown" >
        <%= tax_title("organization") %><span class="caret"></span>
       </a>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu" id='org-dropdown-menu'>
         <%= render 'home/organization_dropdown' if SETTINGS[:organizations_enabled] %>
       </ul>
     </li>
@@ -13,7 +13,7 @@
       <a href="#" class="dropdown-toggle nav-item-iconic" data-toggle="dropdown" >
         <%= tax_title("location") %><span class="caret"></span>
       </a>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu" id='loc-dropdown-menu'>
         <%= render 'home/location_dropdown' if SETTINGS[:locations_enabled] %>
       </ul>
     </li>

--- a/app/views/home/_organization_dropdown.html.erb
+++ b/app/views/home/_organization_dropdown.html.erb
@@ -1,11 +1,9 @@
 <li class="dropdown-header"><%= _('Organization') %></li>
-<li class="dropdown-submenu org-menu">
-  <li><%= link_to(_('Any Organization'), main_app.clear_organizations_path) %></li>
-  <% if User.current.allowed_to?(:view_organizations) %>
-    <li><%= link_to _("Manage Organizations"), main_app.organizations_path, :class => "manage-menu" %></li>
-  <% end %>
-  <%= content_tag(:li, "", :class => "divider") %>
-  <% Organization.my_organizations.each do |organization| %>
-    <li><%= link_to(trunc_with_tooltip(organization.title), main_app.select_organization_path(organization)) %></li>
-  <% end %>
-</li>
+<li><%= link_to(_('Any Organization'), main_app.clear_organizations_path) %></li>
+<% if User.current.allowed_to?(:view_organizations) %>
+  <li><%= link_to _("Manage Organizations"), main_app.organizations_path, :class => "manage-menu" %></li>
+<% end %>
+<%= content_tag(:li, "", :class => "divider") %>
+<% Organization.my_organizations.each do |organization| %>
+  <li><%= link_to(trunc_with_tooltip(organization.title), main_app.select_organization_path(organization)) %></li>
+<% end %>


### PR DESCRIPTION
before:
![no-scrollbar](https://user-images.githubusercontent.com/11807069/41654093-fa67cc96-7490-11e8-954f-b1899ddd5220.png)


after:
![scroll-bar](https://user-images.githubusercontent.com/11807069/41654101-009aafd4-7491-11e8-8b83-32e3853ee00b.png)

This caused due to a regression from vertical navigation change. the taxonomies items were  in a new submenu:
![screenshot from 2018-06-20 13-54-10](https://user-images.githubusercontent.com/11807069/41654273-97bf7a48-7491-11e8-8292-4869a2f0b663.png)
 