### PR TITLE
Fixes #23210 - Handle PuppetCA tokens

### DIFF
--- a/app/models/concerns/hostext/puppetca.rb
+++ b/app/models/concerns/hostext/puppetca.rb
@@ -1,0 +1,9 @@
+module Hostext
+  module Puppetca
+    extend ActiveSupport::Concern
+
+    included do
+      has_one :puppetca_token, :foreign_key => :host_id, :dependent => :destroy, :inverse_of => :host, :class_name => 'Token::Puppetca'
+    end
+  end
+end

--- a/app/models/concerns/hostext/token.rb
+++ b/app/models/concerns/hostext/token.rb
@@ -3,7 +3,7 @@ module Hostext
     extend ActiveSupport::Concern
 
     included do
-      has_one :token, :foreign_key => :host_id, :dependent => :destroy
+      has_one :token, :foreign_key => :host_id, :dependent => :destroy, :inverse_of => :host, :class_name => 'Token::Build'
 
       scope :for_token, ->(token) { joins(:token).where(:tokens => { :value => token }).where("expires >= ?", Time.now.utc.to_s(:db)).select('hosts.*') }
       scope :for_token_when_built, ->(token) { joins(:token).where(:tokens => { :value => token }).select('hosts.*') }

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -11,6 +11,7 @@ class Host::Managed < Host::Base
   include Hostext::SmartProxy
   include Hostext::Token
   include Hostext::OperatingSystem
+  include Hostext::Puppetca
   include SelectiveClone
   include HostInfoExtensions
   include HostParams
@@ -88,7 +89,7 @@ class Host::Managed < Host::Base
       :provision_interface, :interfaces, :bond_interfaces, :bridge_interfaces, :interfaces_with_identifier,
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
-      :ssh_authorized_keys, :pxe_loader, :global_status, :get_status
+      :ssh_authorized_keys, :pxe_loader, :global_status, :get_status, :puppetca_token
   end
 
   scope :recent, lambda { |interval = Setting[:outofsync_interval]|

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -2,10 +2,10 @@ class Token < ApplicationRecord
   validates_lengths_from_database
   belongs_to_host :foreign_key => :host_id
 
-  validates :value, :host_id, :expires, :presence => true
+  validates :value, :host_id, :presence => true
 
   class Jail < ::Safemode::Jail
-    allow :host, :value, :expires, :nil?
+    allow :host, :value, :expires, :nil?, :present?
   end
 
   def to_s

--- a/app/models/token/build.rb
+++ b/app/models/token/build.rb
@@ -1,0 +1,3 @@
+class Token::Build < ::Token
+  validates :expires, presence: true
+end

--- a/app/models/token/puppetca.rb
+++ b/app/models/token/puppetca.rb
@@ -1,0 +1,3 @@
+class Token::Puppetca < ::Token
+  validates :value, uniqueness: true
+end

--- a/db/migrate/20180613100703_add_type_to_token.rb
+++ b/db/migrate/20180613100703_add_type_to_token.rb
@@ -1,0 +1,19 @@
+class AddTypeToToken < ActiveRecord::Migration[5.1]
+  def up
+    remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })
+    remove_index :tokens, :host_id if index_exists? :tokens, :host_id # was unique
+    add_index :tokens, :host_id
+    add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })
+    add_column :tokens, :type, :string, default: 'Token::Build', null: false, index: true
+    change_column :tokens, :value, :string, limit: 900
+  end
+
+  def down
+    change_column :tokens, :value, :string, limit: 255
+    remove_column :tokens, :type
+    remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })
+    remove_index :tokens, :host_id if index_exists? :tokens, :host_id
+    add_index :tokens, :host_id, :unique => true
+    add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })
+  end
+end

--- a/test/models/orchestration/puppetca_test.rb
+++ b/test/models/orchestration/puppetca_test.rb
@@ -23,7 +23,7 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       test 'should queue puppetca autosigning' do
         assert_valid host
-        tasks = host.queue.all.sort.map(&:name)
+        tasks = host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Cleanup PuppetCA certificates for #{host}"
         assert_equal tasks[1], "Enable PuppetCA autosigning for #{host}"
         assert_equal 2, tasks.size
@@ -53,13 +53,13 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       setup do
         @host = host
-        @host.queue.clear
+        @host.post_queue.clear
         @host.build = true
         @host.save!
       end
 
       test 'should queue puppetca autosigning' do
-        tasks = @host.queue.all.sort.map(&:name)
+        tasks = @host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Disable PuppetCA autosigning for #{host}"
         assert_equal tasks[1], "Cleanup PuppetCA certificates for #{host}"
         assert_equal tasks[2], "Enable PuppetCA autosigning for #{host}"
@@ -72,11 +72,11 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       test 'should reset certname when changing from hostname to uuid' do
         assert_valid host
-        host.queue.clear
+        host.post_queue.clear
         Setting[:use_uuid_for_certificates] = true
         host.build = true
         host.save!
-        tasks = host.queue.all.sort.map(&:name)
+        tasks = host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Disable PuppetCA autosigning for #{host}"
         assert_equal tasks[1], "Cleanup PuppetCA certificates for #{host}"
         assert_equal tasks[2], "Enable PuppetCA autosigning for #{host}"
@@ -88,11 +88,11 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
       test 'should reset certname when changing from uuid to hostname' do
         Setting[:use_uuid_for_certificates] = true
         assert_valid host
-        host.queue.clear
+        host.post_queue.clear
         Setting[:use_uuid_for_certificates] = false
         host.build = true
         host.save!
-        tasks = host.queue.all.sort.map(&:name)
+        tasks = host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Reset PuppetCA certname for #{host}"
         assert_equal tasks[1], "Disable PuppetCA autosigning for #{host}"
         assert_equal tasks[2], "Cleanup PuppetCA certificates for #{host}"
@@ -106,13 +106,13 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       setup do
         @host = host
-        @host.queue.clear
+        @host.post_queue.clear
         @host.build = false
         @host.save!
       end
 
       test 'should remove autosign entry for host' do
-        tasks = @host.queue.all.sort.map(&:name)
+        tasks = @host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Disable PuppetCA autosigning for #{host}"
         assert_equal 1, tasks.size
       end
@@ -123,10 +123,10 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       test 'should not queue anything if build mode is not changed' do
         assert_valid host
-        host.queue.clear
+        host.post_queue.clear
         host.comment = "updated"
         host.save!
-        assert_equal 0, host.queue.all.size
+        assert_equal 0, host.post_queue.all.size
       end
     end
 
@@ -135,12 +135,54 @@ class PuppetCaOrchestrationTest < ActiveSupport::TestCase
 
       test 'should queue puppetca destroy' do
         assert_valid host
-        host.queue.clear
+        host.post_queue.clear
         host.send(:queue_puppetca_destroy)
-        tasks = host.queue.all.sort.map(&:name)
+        tasks = host.post_queue.all.sort.map(&:name)
         assert_equal tasks[0], "Disable PuppetCA autosigning for #{host}"
         assert_equal tasks[1], "Delete PuppetCA certificates for #{host}"
         assert_equal 2, tasks.size
+      end
+    end
+
+    context 'handles smart proxy responses correctly' do
+      let(:host) { FactoryBot.create(:host, :managed, :with_puppet_ca, :build => true) }
+
+      setup do
+        @host = host
+        @host.send(:initialize_puppetca)
+      end
+
+      test 'when it uses basic autosigning' do
+        @host.puppetca.stubs(:set_autosign).with(@host.certname).returns(true)
+        assert @host.send(:setAutosign)
+        assert_nil @host.puppetca_token
+      end
+
+      test 'when autosigning fails' do
+        @host.puppetca.stubs(:set_autosign).with(@host.certname).returns(false)
+        refute @host.send(:setAutosign)
+        assert_nil @host.puppetca_token
+      end
+
+      test 'when using token based autosigning' do
+        spresponse = { 'generated_token' => 'foo42' }
+        @host.puppetca.stubs(:set_autosign).with(@host.certname).returns(spresponse)
+        assert @host.send(:setAutosign)
+        assert_valid @host.puppetca_token
+        assert_equal @host.puppetca_token.value, 'foo42'
+      end
+
+      test 'when it gets an invalid hash response' do
+        spresponse = { 'not_a_token' => '' }
+        @host.puppetca.stubs(:set_autosign).with(@host.certname).returns(spresponse)
+        refute @host.send(:setAutosign)
+        assert_nil @host.puppetca_token
+      end
+
+      test 'when it gets an invalid nil response' do
+        @host.puppetca.stubs(:set_autosign).with(@host.certname).returns(nil)
+        refute @host.send(:setAutosign)
+        assert_nil @host.puppetca_token
       end
     end
   end

--- a/test/models/token/build_test.rb
+++ b/test/models/token/build_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class Token::BuildTest < ActiveSupport::TestCase
+  should validate_presence_of(:expires)
+
+  let(:host) { FactoryBot.create(:host) }
+
+  test "a host can create a token" do
+    host.create_token(:value => "aaaaaa", :expires => Time.now.utc)
+    assert_equal Token.first.value, "aaaaaa"
+    assert_equal Token.first.host_id, host.id
+  end
+
+  test "a host can delete its token" do
+    host.create_token(:value => 'aaaaaa', :expires => Time.now.utc + 1.minute)
+    assert_instance_of Token::Build, host.token
+    host.token = nil
+    assert Token.where(:value => 'aaaaaa', :host_id => host.id).empty?
+  end
+
+  test "a host cannot delete tokens for other hosts" do
+    host2 = FactoryBot.create(:host)
+    host.create_token(:value => 'aaaaaa', :expires => Time.now.utc + 1.minute)
+    host2.create_token(:value => 'bbbbbb', :expires => Time.now.utc + 1.minute)
+    assert_equal Token.all.size, 2
+    host.token = nil
+    assert_equal Token.all.size, 1
+  end
+
+  test "not all expired tokens should be removed" do
+    host2 = FactoryBot.create(:host)
+    host.create_token(:value => 'aaaaaa', :expires => Time.now.utc + 1.minute)
+    host2.create_token(:value => 'bbbbbb', :expires => Time.now.utc - 1.minute)
+    assert_equal 2, Token.count
+    host.expire_token
+    assert_equal 1, Token.count
+  end
+end

--- a/test/models/token/puppetca_test.rb
+++ b/test/models/token/puppetca_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class Token::PuppetcaTest < ActiveSupport::TestCase
+  should validate_uniqueness_of(:value)
+
+  let(:host) { FactoryBot.create(:host) }
+
+  test "a host can create a puppetca-token" do
+    host.create_puppetca_token value: 'foo.bar.baz'
+    assert_instance_of Token::Puppetca, host.puppetca_token
+    assert_equal Token::Puppetca.first.host_id, host.id
+    assert_equal 'foo.bar.baz', host.puppetca_token.value
+  end
+
+  test "a host can delete its puppetca-token" do
+    host.create_puppetca_token value: 'aaaa'
+    assert_equal host.puppetca_token.value, 'aaaa'
+    host.puppetca_token = nil
+    assert_nil host.puppetca_token
+    assert_equal Token::Puppetca.all, []
+  end
+end

--- a/test/models/token_test.rb
+++ b/test/models/token_test.rb
@@ -2,43 +2,7 @@ require 'test_helper'
 
 class TokenTest < ActiveSupport::TestCase
   should validate_presence_of(:value)
-  should validate_presence_of(:expires)
   should validate_presence_of(:host_id)
-
-  test "a host can create a token" do
-    h = FactoryBot.create(:host)
-    h.create_token(:value => "aaaaaa", :expires => Time.now.utc)
-    assert_equal Token.first.value, "aaaaaa"
-    assert_equal Token.first.host_id, h.id
-  end
-
-  test "a host can delete its token" do
-    h = FactoryBot.create(:host)
-    h.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minute)
-    assert_instance_of Token, h.token
-    h.token = nil
-    assert Token.where(:value => "aaaaaa", :host_id => h.id).empty?
-  end
-
-  test "a host cannot delete tokens for other hosts" do
-    h1 = FactoryBot.create(:host)
-    h2 = FactoryBot.create(:host)
-    h1.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minute)
-    h2.create_token(:value => "bbbbbb", :expires => Time.now.utc + 1.minute)
-    assert_equal Token.all.size, 2
-    h1.token = nil
-    assert_equal Token.all.size, 1
-  end
-
-  test "not all expired tokens should be removed" do
-    h1 = FactoryBot.create(:host)
-    h2 = FactoryBot.create(:host)
-    h1.create_token(:value => "aaaaaa", :expires => Time.now.utc + 1.minute)
-    h2.create_token(:value => "bbbbbb", :expires => Time.now.utc - 1.minute)
-    assert_equal 2, Token.count
-    h1.expire_token
-    assert_equal 1, Token.count
-  end
 
   test "token jail test" do
     allowed = [:host, :value, :expires, :nil?]


### PR DESCRIPTION
In a new SmartProxy PuppetCA autosigning variant tokens get returned that need to be provisioned on the host.
This adds a Token::PuppetCa model; moves the PuppetCa-orchestration form queue to post-queue (we need the host's id to save the token); and handles the response from the SmartProxy correctly (save the token if we get one, don't do anything if we don't).
This is completely backwards-compatible - old SmartProxy versions and the basic autosigning variant will also work with this.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
