### PR TITLE
fixes #24046 - return id as str for name as last resort

### DIFF
--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -7,13 +7,14 @@ module HasManyCommon
 
   # calls method :name or whatever is defined in attr_name :title
   def name_method
-    send(self.class.attribute_name)
+    send(self.class.attribute_name).to_s
   end
 
   module ClassMethods
     # default attribute used by *_names and *_name is :name
-    # if :name doesn't exist, :id is used, so it doesn't error out if attr_name :field is not defined
-    # most likely model will have attr_name :field to overwrite attribute_name
+    # if :name doesn't exist, :id as a string is used, so it doesn't error out
+    # if attr_name :field is not defined most likely model will have attr_name
+    # :field to overwrite attribute_name
     def attribute_name
       if has_name?
         :name


### PR DESCRIPTION
Foreman HasManyCommon concern uses 'id' as a value of last resort for
the name of an attribute. But Rails expects this value to a return a
string. This causes a problem for Katello. Take a look at the output
here in Katello:

```
irb(main):001:0> Host.first
Hirb Error: undefined method `gsub' for 2:Integer
```

Where's that coming from? Hirb is formatting columns, and rightly expects `:name` of an association to be a string.

```
<pre>
irb(main):006:0> Host.first.content_facet_attributes.to_s
=> 2
irb(main):007:0> Host.first.content_facet_attributes.to_s.is_a?(String)
=> false
</pre>
```

Foreman should use a method that returns string as a last resort.  Open to other ideas, and I'm not sure if changing this to a string is going to break something that was relying on this behavior...


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
