### PR TITLE
fixes #24050 - graphql: add connections with totalCount

### DIFF
--- a/app/graphql/collection_loader.rb
+++ b/app/graphql/collection_loader.rb
@@ -1,0 +1,43 @@
+class CollectionLoader < GraphQL::Batch::Loader
+  def initialize(model, association_name)
+    @model = model
+    @association_name = association_name
+    validate
+  end
+
+  def load(record)
+    raise TypeError, "#{@model} loader can't load association for #{record.class}" unless record.is_a?(@model)
+    return Promise.resolve(read_association(record)) if association_loaded?(record)
+    super
+  end
+
+  # We want to load the associations on all records, even if they have the same id
+  def cache_key(record)
+    record.object_id
+  end
+
+  def perform(records)
+    preload_association(records)
+    records.each { |record| fulfill(record, read_association(record)) }
+  end
+
+  private
+
+  def validate
+    unless @model.reflect_on_association(@association_name)
+      raise ArgumentError, "No association #{@association_name} on #{@model}"
+    end
+  end
+
+  def preload_association(records)
+    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+  end
+
+  def read_association(record)
+    record.public_send(@association_name)
+  end
+
+  def association_loaded?(record)
+    record.association(@association_name).loaded?
+  end
+end

--- a/app/graphql/connections/base_connection.rb
+++ b/app/graphql/connections/base_connection.rb
@@ -1,0 +1,9 @@
+module Connections
+  class BaseConnection < GraphQL::Types::Relay::BaseConnection
+    field :total_count, Integer, null: false
+
+    def total_count
+      object.nodes.size
+    end
+  end
+end

--- a/app/graphql/record_loader.rb
+++ b/app/graphql/record_loader.rb
@@ -1,0 +1,10 @@
+class RecordLoader < GraphQL::Batch::Loader
+  def initialize(model)
+    @model = model
+  end
+
+  def perform(ids)
+    @model.where(id: ids).each { |record| fulfill(record.id, record) }
+    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+  end
+end

--- a/app/graphql/resolvers/host.rb
+++ b/app/graphql/resolvers/host.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Host < BaseResolver
+    MODEL_CLASS = ::Host
+
+    include Concerns::Record
+  end
+end

--- a/app/graphql/resolvers/hosts.rb
+++ b/app/graphql/resolvers/hosts.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Hosts < BaseResolver
+    MODEL_CLASS = ::Host
+
+    include Concerns::Collection
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -2,6 +2,8 @@ module Types
   class BaseObject < GraphQL::Types::Relay::BaseObject
     implements GraphQL::Relay::Node.interface
 
+    connection_type_class Connections::BaseConnection
+
     def self.timestamps
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/graphql/types/host.rb
+++ b/app/graphql/types/host.rb
@@ -1,0 +1,11 @@
+module Types
+  class Host < BaseObject
+    description 'A Host'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: false
+    field :model, Types::Model, null: true,
+      resolve: proc { |object| RecordLoader.for(::Model).load(object.model_id) }
+  end
+end

--- a/app/graphql/types/model.rb
+++ b/app/graphql/types/model.rb
@@ -8,5 +8,8 @@ module Types
     field :info, String, null: true
     field :vendorClass, String, null: true
     field :hardwareModel, String, null: true
+
+    field :hosts, Types::Host.connection_type, null: false,
+      resolve: proc { |object| CollectionLoader.for(object.class, :hosts).load(object) }
   end
 end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -22,5 +22,8 @@ module Types
 
     field :architecture, Types::Architecture, resolver: Resolvers::Architecture
     field :architectures, Types::Architecture.connection_type, resolver: Resolvers::Architectures
+
+    field :host, Types::Host, resolver: Resolvers::Host
+    field :hosts, Types::Host.connection_type, resolver: Resolvers::Hosts
   end
 end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -144,6 +144,10 @@ FactoryBot.define do
       set_environment_taxonomies(host)
     end
 
+    trait :with_model do
+      model
+    end
+
     trait :with_environment do
       environment
     end

--- a/test/graphql/queries/host_query_test.rb
+++ b/test/graphql/queries/host_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Queries::HostQueryTest < ActiveSupport::TestCase
+  test 'fetching host attributes' do
+    host = FactoryBot.create(:host, :managed, :with_model)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        host(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          model {
+            id
+          }
+        }
+      }
+    GRAPHQL
+
+    host_global_id = Foreman::GlobalId.encode('Host', host.id)
+    variables = { id: host_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'host' => {
+        'id' => host_global_id,
+        'createdAt' => host.created_at.utc.iso8601,
+        'updatedAt' => host.updated_at.utc.iso8601,
+        'name' => host.name,
+        'model' => {
+          'id' => Foreman::GlobalId.for(host.model)
+        }
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/hosts_query_test.rb
+++ b/test/graphql/queries/hosts_query_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
-class Queries::ModelsQueryTest < ActiveSupport::TestCase
-  test 'fetching models attributes' do
-    FactoryBot.create_list(:model, 2)
+class Queries::HostsQueryTest < ActiveSupport::TestCase
+  test 'fetching hosts attributes' do
+    FactoryBot.create_list(:host, 2, :managed)
 
     query = <<-GRAPHQL
       query {
-        models {
+        hosts {
           totalCount
           pageInfo {
             startCursor
@@ -27,10 +27,10 @@ class Queries::ModelsQueryTest < ActiveSupport::TestCase
     context = { current_user: FactoryBot.create(:user, :admin) }
     result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
 
-    expected_count = Model.count
+    expected_count = Host.count
 
     assert_empty result['errors']
-    assert_equal expected_count, result['data']['models']['totalCount']
-    assert_equal expected_count, result['data']['models']['edges'].count
+    assert_equal expected_count, result['data']['hosts']['totalCount']
+    assert_equal expected_count, result['data']['hosts']['edges'].count
   end
 end

--- a/test/graphql/queries/locations_query_test.rb
+++ b/test/graphql/queries/locations_query_test.rb
@@ -7,6 +7,7 @@ class Queries::LocationsQueryTest < ActiveSupport::TestCase
     query = <<-GRAPHQL
       query {
         locations {
+          totalCount
           pageInfo {
             startCursor
             endCursor
@@ -26,7 +27,10 @@ class Queries::LocationsQueryTest < ActiveSupport::TestCase
     context = { current_user: FactoryBot.create(:user, :admin) }
     result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
 
+    expected_count = Location.count
+
     assert_empty result['errors']
-    assert_equal Location.count, result['data']['locations']['edges'].count
+    assert_equal expected_count, result['data']['locations']['totalCount']
+    assert_equal expected_count, result['data']['locations']['edges'].count
   end
 end

--- a/test/graphql/queries/operatingsystems_query_test.rb
+++ b/test/graphql/queries/operatingsystems_query_test.rb
@@ -7,6 +7,7 @@ class Queries::OperatingsystemsQueryTest < ActiveSupport::TestCase
     query = <<-GRAPHQL
       query {
         operatingsystems {
+          totalCount
           pageInfo {
             startCursor
             endCursor
@@ -26,7 +27,10 @@ class Queries::OperatingsystemsQueryTest < ActiveSupport::TestCase
     context = { current_user: FactoryBot.create(:user, :admin) }
     result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
 
+    expected_count = Operatingsystem.count
+
     assert_empty result['errors']
-    assert_equal Operatingsystem.count, result['data']['operatingsystems']['edges'].count
+    assert_equal expected_count, result['data']['operatingsystems']['totalCount']
+    assert_equal expected_count, result['data']['operatingsystems']['edges'].count
   end
 end


### PR DESCRIPTION
This is part four of the graphql series.
This adds support for connections (associations) to the models. It adds a basic host type that just has name, id and model attributes.

---
Other parts:
Part 1 - JWT Auth: #5596
Part 2 - Graphql Scaffolding: #5680
Part 3 - Relay Global ID #5681
Part 4 - Connections with totalCount #5733
Part 5 - Basic mutations for model #5736