### PR TITLE
Fixes #23924 - Use consistent IDs for modules in webpack

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 app/**
 vendor/**
 config/webpack.config.js
+webpack/simple_named_modules.js

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -10,8 +10,7 @@ var CompressionPlugin = require('compression-webpack-plugin');
 var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var pluginUtils = require('../script/plugin_webpack_directories');
 var vendorEntry = require('./webpack.vendor');
-
-
+var SimpleNamedModulesPlugin = require('../webpack/simple_named_modules');
 
 module.exports = env => {
   // must match config.webpack.dev_server.port
@@ -163,7 +162,7 @@ module.exports = env => {
         },
         sourceMap: false
       }),
-      new webpack.NamedModulesPlugin(),
+      new SimpleNamedModulesPlugin(),
       new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.optimize.OccurrenceOrderPlugin(),
       new CompressionPlugin()

--- a/webpack/simple_named_modules.js
+++ b/webpack/simple_named_modules.js
@@ -1,0 +1,35 @@
+/*
+  Simple Named Modules Plugin
+  Strips relative path up to node_modules/ from the module ID.
+  This allows for consistent module IDs when building webpack bundles from
+  differing base paths relative to the node_modules directory.
+
+  Based on NamedModulesPlugin by Tobias Koppers @sokra, originally licensed under
+  MIT License: http://www.opensource.org/licenses/mit-license.php
+*/
+"use strict";
+
+class SimpleNamedModulesPlugin {
+  constructor(options) {
+    this.options = options || {};
+  }
+
+  apply(compiler) {
+    compiler.plugin("compilation", (compilation) => {
+      compilation.plugin("before-module-ids", (modules) => {
+        modules.forEach((module) => {
+          if(module.id === null && module.libIdent) {
+            module.id = module.libIdent({
+              context: this.options.context || compiler.options.context
+            });
+            if (module.id.includes('node_modules')) {
+              module.id = module.id.slice(module.id.indexOf('node_modules'))
+            }
+          }
+        });
+      });
+    });
+  }
+}
+
+module.exports = SimpleNamedModulesPlugin;


### PR DESCRIPTION
This replaces the NamedModulesPlugin with a simplified version, that
strips the relative path part of the module ID up to and including the
node_modules/ part. This allows using consistent naming for modules,
even when running the packaging from different directories relative to
the node_modules folder (as is the case, for example, with katello and
foreman).



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
