### PR TITLE
Fixes #24053 - Remove oVirt specific error

### DIFF
--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -36,11 +36,6 @@ class ComputeResourcesController < ApplicationController
       @compute_resource.valid?
       process_error
     end
-  rescue OVIRT::OvirtException => e
-    Foreman::Logging.exception("Error while creating ovirt resource", e)
-    process_error(
-      error_msg: _('Error while trying to create resource: %s') % e.message
-    )
   rescue Fog::Errors::Error => e
     Foreman::Logging.exception("Error while creating a resource", e)
     process_error(
@@ -80,11 +75,6 @@ class ComputeResourcesController < ApplicationController
     else
       process_error
     end
-  rescue OVIRT::OvirtException => e
-    Foreman::Logging.exception("Error while updating ovirt resource", e)
-    process_error(
-      error_msg: _('Error while trying to update resource: %s') % e.message
-    )
   rescue Fog::Errors::Error => e
     Foreman::Logging.exception("Error while updating resource", e)
     process_error(


### PR DESCRIPTION
In 1.18 the `fog-ovirt` version used already wraps OVIRT::OvirtException so this is no longer needed.
Tests are challenging here due to stubbing.