### PR TITLE
Fixes #23991 - rephrase RSS setting description

### DIFF
--- a/app/models/setting/notification.rb
+++ b/app/models/setting/notification.rb
@@ -1,7 +1,7 @@
 class Setting::Notification < Setting
   def self.default_settings
     [
-      self.set('rss_enable', N_('Whether to get RSS notifications or not'), true, N_('RSS enable')),
+      self.set('rss_enable', N_('Whether to pull RSS notifications or not'), true, N_('RSS enable')),
       self.set('rss_url', N_('URL to fetch RSS notifications from'), 'https://theforeman.org/feed.xml', N_('RSS URL'))
     ]
   end


### PR DESCRIPTION
This description may be confusing, which can be interpreted as "Whether the RSS notifications will be displayed or not" as well. a user may think that after this setting is disabled, existing RSS will be deleted.
