### PR TITLE
Fixes #24056 - Authorizes perms on associations

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -59,7 +59,16 @@ class Authorizer
       assoc_name = options[:association_name]
       assoc_name ||= options[:joined_on].reflect_on_all_associations.find { |a| a.klass.base_class == resource_class.base_class }.name
 
-      scope = options[:joined_on].joins(assoc_name => scope_components[:includes]).readonly(false)
+      if scope_components[:where].present?
+        # Get a subselect based on the scope search criteria
+        subselect = resource_class.joins(scope_components[:includes])
+        scope_components[:where].each do |where|
+          subselect = subselect.where(where)
+        end
+        scope_components[:where] = [{:id => subselect}]
+      end
+
+      scope = options[:joined_on].joins(assoc_name).readonly(false)
 
       # allow user to add their own further clauses
       scope_components[:where] << options[:where] if options[:where].present?


### PR DESCRIPTION
When one adds a "search" filter to a role on an association the code
prior to this commit would try to "join" the tables belonging to the
columns in the search filter to the main permissions query before
authorizing.
This commit uses subselects to facilitate the same.
Here is an example
Lets say you had a user perms "view_facts", "view_hosts" and filter to
say "content_view_id = 1"
And now you requested the facts via api
Prior code would attempt to do the following,
SELECT  "fact_values".* FROM "fact_values","Hosts", "content_facets"
..... where (...)

The commit uses subselects instead to achieve something similar
select "fact_values".* FROM "fact_values","Hosts" ....
where hosts.id in (select id from hosts ..  katello_content_facets
where katello_content_facets.content_view_id=1 )

The main benefit of  using subselects here is to isolate the selects of
the search filter which is based of scoped search syntax.
The other issue this tries to solve is the case where the scoped search
is using special attributes of the associated object such as "facets".



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
