### PR TITLE
Fixes #24072 - freeip with compute resource via hostgroup

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -29,11 +29,13 @@ function update_nics(success_callback) {
 }
 
 var nic_update_handler = function() {
-  update_nics(function() {
-    interface_subnet_selected(primary_nic_form().find('select.interface_subnet'), 'ip');
-    interface_subnet_selected(primary_nic_form().find('select.interface_subnet6'), 'ip6');
-  });
+  update_nics(updatePrimarySubnetIPs);
 };
+
+function updatePrimarySubnetIPs() {
+  interface_subnet_selected(primary_nic_form().find('select.interface_subnet'), 'ip');
+  interface_subnet_selected(primary_nic_form().find('select.interface_subnet6'), 'ip6');
+}
 
 function computeResourceSelected(item){
   providerSpecificNICInfo = null;
@@ -316,6 +318,10 @@ function update_form(element, options) {
         // to handle case if def process_taxonomy changed compute_resource_id to nil
         if (!host_compute_resource_id.val()) {
           host_compute_resource_id.change();
+        } else {
+          // in case the compute resource was selected, we still want to check for
+          // free ip if applicable
+          updatePrimarySubnetIPs();
         }
         update_capabilities(host_compute_resource_id.val() ? $('#capabilities').val() : $('#bare_metal_capabilities').val());
       }

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -146,10 +146,13 @@ class HostsController < ApplicationController
   end
 
   def compute_resource_selected
-    return not_found unless (params[:host] && (id = params[:host][:compute_resource_id]))
+    return not_found unless params[:host]
     Taxonomy.as_taxonomy @organization, @location do
-      compute_profile_id = params[:host][:compute_profile_id] || Hostgroup.find_by_id(params[:host][:hostgroup_id]).try(:inherited_compute_profile_id)
-      compute_resource = ComputeResource.authorized(:view_compute_resources).find_by_id(id)
+      hostgroup = Hostgroup.find_by_id(params[:host][:hostgroup_id])
+      compute_resource_id = params[:host][:compute_resource_id] || hostgroup.try(:inherited_compute_resource_id)
+      return not_found if compute_resource_id.blank?
+      compute_profile_id = params[:host][:compute_profile_id] || hostgroup.try(:inherited_compute_profile_id)
+      compute_resource = ComputeResource.authorized(:view_compute_resources).find_by_id(compute_resource_id)
       render :partial => "compute", :locals => { :compute_resource => compute_resource,
                                                  :vm_attrs         => compute_resource.compute_profile_attributes_for(compute_profile_id) }
     end
@@ -606,6 +609,7 @@ class HostsController < ApplicationController
 
     @host.set_hostgroup_defaults true
     @host.set_compute_attributes unless params[:host][:compute_profile_id]
+    @host.apply_compute_profile(InterfaceMerge.new) if @host.compute_profile_id
     set_class_variables(@host)
     render :partial => "form"
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -559,8 +559,11 @@ class Host::Managed < Host::Base
   end
 
   def set_compute_attributes
-    return unless compute_profile_present?
-    self.compute_attributes = compute_resource.compute_profile_attributes_for(compute_profile_id)
+    if compute_profile_present?
+      self.compute_attributes = compute_resource.compute_profile_attributes_for(compute_profile_id)
+    elsif compute_resource
+      self.compute_attributes ||= {}
+    end
   end
 
   def set_ip_address

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -467,6 +467,10 @@ FactoryBot.define do
       puppetclasses { [ FactoryBot.create(:puppetclass, :environments => [environment]) ] }
     end
 
+    trait :with_compute_resource do
+      compute_resource { FactoryBot.create(:compute_resource, :libvirt) }
+    end
+
     trait :with_config_group do
       environment
       config_groups { [ FactoryBot.create(:config_group, :with_puppetclass, :class_environments => [environment]) ] }

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -181,7 +181,8 @@ class HostJSTest < IntegrationTestWithJavascript
     end
 
     test 'choosing a hostgroup with compute resource works' do
-      hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_compute_resource)
+      hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_compute_resource)
+      hostgroup.subnet.update!(ipam: IPAM::MODES[:db])
       compute_profile = FactoryBot.create(:compute_profile, :with_compute_attribute, :compute_resource => hostgroup.compute_resource)
       compute_attributes = compute_profile.compute_attributes.where(:compute_resource_id => hostgroup.compute_resource.id).first
       compute_attributes.vm_attrs['nics_attributes'] = {'0' => {'type' => 'bridge', 'bridge' => 'test'}}
@@ -198,7 +199,13 @@ class HostJSTest < IntegrationTestWithJavascript
       cpus_field = page.find_field('host_compute_attributes_cpus')
       assert_equal '1', cpus_field.value
 
-      click_link('Host')
+      click_link('Interfaces')
+      click_button('Edit')
+      ipv4_field = page.find_field('host_interfaces_attributes_0_ip')
+      refute_empty ipv4_field.value
+      close_interfaces_modal
+
+      find(:css, '#host_tab').click
       click_on_inherit('compute_profile')
       select2(compute_profile.name, :from => 'host_compute_profile_id')
       wait_for_ajax
@@ -239,11 +246,7 @@ class HostJSTest < IntegrationTestWithJavascript
       fill_in 'host_interfaces_attributes_0_mac', :with => '00:11:11:11:11:11'
       wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
-      click_button 'Ok' # close interfaces
-      # wait for the dialog to close
-      Timeout.timeout(Capybara.default_max_wait_time) do
-        loop while find(:css, '#interfaceModal', :visible => false).visible?
-      end
+      close_interfaces_modal
       click_on_submit
       find('#host-show') # wait for host details page
 
@@ -283,12 +286,7 @@ class HostJSTest < IntegrationTestWithJavascript
       wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '2.3.4.44'
       wait_for_ajax
-      click_button 'Ok'
-
-      # wait for the dialog to close
-      Timeout.timeout(Capybara.default_max_wait_time) do
-        loop while find(:css, '#interfaceModal', :visible => false).visible?
-      end
+      close_interfaces_modal
 
       wait_for_ajax
       click_on_submit

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -100,6 +100,14 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def close_interfaces_modal
+    click_button 'Ok' # close interfaces
+    # wait for the dialog to close
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop while find(:css, '#interfaceModal', :visible => false).visible?
+    end
+  end
+
   def login_user(username, password)
     logout_admin
     visit "/"


### PR DESCRIPTION
In #5790, we added an option to set the compute resource via hostgroup.
There was one thing missed though: the freeip not getting assigned
automagically, when the compute resource was selected this way.

After this change, we make sure to check for the ip addresses (and other
potential subnet related refreshes) after the hostgroup is selected, in
case the interfaces were populated during the hostgroup change.