### PR TITLE
Fixes #24084 root password hash propagation to authconfig

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -66,7 +66,7 @@ firewall --disable
 <% else -%>
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 <% end -%>
-authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
+authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downcase || 'sha256' %> --kickstart
 timezone --utc <%= host_param('time-zone') || 'UTC' %>
 <% if rhel_compatible -%>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd


### PR DESCRIPTION
If SHA512 is used in host.operatingsystem.password_hash (SHA256 is the default in kickstart_default.erb), authconfig will use SHA256 anyway because it has no value SHA512 (but sha512).
