### PR TITLE
Fixes #23920 - add missing header in some of the welcome pages

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -19,7 +19,7 @@ module LayoutHelper
   def mount_breadcrumbs(options = {}, &block)
     options = BreadcrumbsOptions.new(@page_header, controller, action_name, block_given? ? yield : options)
 
-    mount_react_component("BreadcrumbBar", "#breadcrumb", options.bar_props.to_json)
+    mount_react_component("BreadcrumbBar", "#breadcrumb", options.bar_props.to_json) unless @welcome
   end
 
   def breadcrumbs(options = {}, &block)

--- a/app/views/layouts/_application_content.html.erb
+++ b/app/views/layouts/_application_content.html.erb
@@ -1,22 +1,20 @@
 <div id="main">
   <div id="content">
-    <%= notifications %>
-      <% unless @welcome %>
-        <div id="breadcrumb">
-          <% unless @page_header.blank? %>
-            <div class="row form-group">
-              <h1 class="col-md-8">
-                <%=h @page_header %>
-              </h1>
-            </div>
-          <% end %>
-          <% if content_for?(:breadcrumbs) %>
-            <%= yield(:breadcrumbs) %>
-          <% else %>
-            <%= mount_breadcrumbs %>
-          <% end %>
+    <%= notifications %> 
+    <div id="breadcrumb">
+      <% unless @page_header.blank? %>
+        <div class="row form-group">
+          <h1 class="col-md-8">
+            <%=h @page_header %>
+          </h1>
         </div>
-      <% end %>  
+      <% end %>
+      <% if content_for?(:breadcrumbs) %>
+        <%= yield(:breadcrumbs) %>
+      <% else %>
+        <%= mount_breadcrumbs %>
+      <% end %>
+    </div>
       <div class="row">
         <div class="title_filter <%= searchable? ? " col-md-6 " : "col-md-4 " %>">
           <%= render "common/searchbar" if searchable? %>


### PR DESCRIPTION
before:
![hostsgroup1](https://user-images.githubusercontent.com/11807069/41977523-39a3a564-7a28-11e8-9efb-edda2f920bed.png)

after:
![fixed-header](https://user-images.githubusercontent.com/11807069/41977531-3f464db4-7a28-11e8-918d-2c13472c05a9.png)
