### PR TITLE
fixes #24100 - add /etc/default/pulp_workers to foreman_debug

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -380,6 +380,7 @@ add_files /etc/{sysconfig,default}/foreman
 add_files /etc/{sysconfig,default}/libvirt*
 add_files /etc/sysconfig/pgsql
 add_files /var/lib/pgsql/data/pg_log/*
+add_files /etc/default/pulp_workers
 add_cmd "passenger-status --show=pool" "passenger_status_pool"
 add_cmd "passenger-status --show=requests" "passenger_status_requests"
 add_cmd "passenger-status --show=backtraces" "passenger_status_backtraces"


### PR DESCRIPTION
Add /etc/default/pulp_workers to foreman_debug to easily verify PULP_CONCURRENCY and 
PULP_MAX_TASKS_PER_CHILD


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
