### PR TITLE
Fixes #24109 - common kernelcmd param for all OSes

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -269,6 +269,12 @@ class Operatingsystem < ApplicationRecord
     end
   end
 
+  def pxe_kernel_options(params)
+    options = []
+    options << params['kernelcmd'] if params['kernelcmd']
+    options
+  end
+
   private
 
   def set_family
@@ -295,10 +301,5 @@ class Operatingsystem < ApplicationRecord
     provisioning_template_id_empty = attributes[:provisioning_template_id].blank?
     attributes[:_destroy] = 1 if template_exists && provisioning_template_id_empty
     (!template_exists && provisioning_template_id_empty)
-  end
-
-  # overriden by operating systems
-  def pxe_kernel_options(params)
-    []
   end
 end

--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -103,6 +103,15 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal 'modprobe.blacklist=dirty_driver,badbad_driver', @renderer.pxe_kernel_options
   end
 
+  ["Redhat", "Ubuntu", "OpenSuse", "Solaris"].each do |osname|
+    test "pxe_kernel_options returns kernelcmd option for #{osname}" do
+      host = FactoryBot.build_stubbed(:host, :operatingsystem => Operatingsystem.find_by_name(osname))
+      host.params['kernelcmd'] = 'one two'
+      @renderer.host = host
+      assert_equal 'one two', @renderer.pxe_kernel_options
+    end
+  end
+
   [:normal_renderer, :safemode_renderer].each do |renderer_name|
     test "#{renderer_name} is properly configured" do
       send "setup_#{renderer_name}"


### PR DESCRIPTION
This is global `kernelcmd` option which will be present for all OSes so
adding a kernel command line option is no longer: find template, clone
it, edit it, associate with os, select as default process.