### PR TITLE
Fixes #23918 - Find correct scope when updating taxonomy

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -88,7 +88,7 @@ module Api::V2::TaxonomiesController
 
   # overriding public FindCommon#resource_scope to scope only to user's taxonomies
   def resource_scope(*args)
-    super.send("my_#{taxonomies_plural}")
+    @resource_scope ||= scope_for(resource_class, args).send("my_#{taxonomies_plural}")
   end
 
   private

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -182,4 +182,12 @@ class Api::V2::OrganizationsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
     assert_equal "Missing one of the required permissions: create_organizations", response['error']['details']
   end
+
+  test "should add location to organization" do
+    organization = FactoryBot.create(:organization)
+    location = FactoryBot.create(:location)
+    put :update, params: { :id => organization.id, :organization => { :location_ids => [location.id] } }
+    assert_response :success
+    assert_contains organization.locations, location
+  end
 end


### PR DESCRIPTION
[resource_scope](https://github.com/theforeman/foreman/blob/develop/app/controllers/concerns/find_common.rb#L36) caches the scope, on update the `@resource_scope` is `[]` (no idea how that happens), but `scope_for` fetches the correct scope.