### PR TITLE
[CP 1.17] Fixes #23782 - restore login disabling

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -9,18 +9,21 @@ module Menu
     def self.load
       Manager.map :header_menu
 
-      Manager.map :side_menu do |menu|
-        menu.sub_menu :user_menu, :caption => N_('User'), :icon => 'fa fa-user' do
-          menu.item :my_account,
-                    :caption => N_('My Account'),
-                    :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
-          menu.divider
-          menu.item :logout,
-                    :caption => N_('Log Out'),
-                    :html => {:method => :post},
-                    :url_hash => {:controller => '/users', :action => 'logout'}
+      if SETTINGS[:login]
+        Manager.map :side_menu do |menu|
+          menu.sub_menu :user_menu, :caption => N_('User'), :icon => 'fa fa-user' do
+            menu.item :my_account,
+                      :caption => N_('My Account'),
+                      :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
+            menu.divider
+            menu.item :logout,
+                      :caption => N_('Log Out'),
+                      :html => {:method => :post},
+                      :url_hash => {:controller => '/users', :action => 'logout'}
+          end
         end
       end
+
       Manager.map :admin_menu do |menu|
         menu.sub_menu :administer_menu,  :caption => N_('Administer'), :icon => 'fa fa-cog' do
           menu.item :locations,          :caption => N_('Locations') if SETTINGS[:locations_enabled]

--- a/app/views/settings/category/_email.html.erb
+++ b/app/views/settings/category/_email.html.erb
@@ -1,3 +1,5 @@
-<%= link_to_function(_("Test email"), "tfm.users.testMail(this, '#{test_mail_user_url(User.current)}')",
-                     :title => _("Send a test message to the current user's email address to confirm the configuration is working."), :id => "test_mail_button", :class =>"btn btn-success") + hidden_spinner('', :id => 'test_indicator').html_safe %>
-<%= content_tag(:br) %>
+<% if Setting[:login] %>
+  <%= link_to_function(_("Test email"), "tfm.users.testMail(this, '#{test_mail_user_url(User.current)}')",
+                       :title => _("Send a test message to the current user's email address to confirm the configuration is working."), :id => "test_mail_button", :class =>"btn btn-success") + hidden_spinner('', :id => 'test_indicator').html_safe %>
+  <%= content_tag(:br) %>
+<% end %>


### PR DESCRIPTION
(cherry picked from commit 7949aadb9fef9edd7147669f791e4912106d4343)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
