### PR TITLE
Fixes #24158 - fix cloning of roles

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -220,6 +220,7 @@ class Role < ApplicationRecord
                                :include => [:locations, :organizations, { :filters => :permissions }])
     new_role.attributes = role_params
     new_role.cloned_from_id = self.id
+    new_role.filters = new_role.filters.select {|f| f.filterings.present? }
     new_role
   end
 

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -145,6 +145,18 @@ class RoleTest < ActiveSupport::TestCase
       assert_include Role.cloned, cloned_role
       assert_not_include Role.cloned, role
     end
+
+    context 'role has some empty filters' do
+      before do
+        role.permissions = [ Permission.first ]
+        role.filters.first.filterings = []
+      end
+
+      it 'clones the role ignoring the empty filters' do
+        assert cloned_role.valid?
+        assert_equal cloned_role.filters.size + 1, role.filters.size
+      end
+    end
   end
 
   context "System roles" do


### PR DESCRIPTION
Roles that contains filters without permissions could not be cloned. In
UI, user did not even get any error message, API responded with 422 at
least.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
