### PR TITLE
Fixes #23703 - Remove "Create Puppet Environment" buttons

### DIFF
--- a/app/helpers/environments_helper.rb
+++ b/app/helpers/environments_helper.rb
@@ -3,7 +3,6 @@ module EnvironmentsHelper
 
   def environments_title_actions
     title_actions import_proxy_select(hash_for_import_environments_environments_path),
-                  button_group(new_link(_('Create Puppet Environment'))),
                   button_group(help_button)
   end
 end

--- a/app/views/environments/welcome.html.erb
+++ b/app/views/environments/welcome.html.erb
@@ -9,9 +9,6 @@
   </p>
   <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url("4.2.1Environments")) %></p>
   <div class="blank-slate-pf-main-action">
-      <%= new_link(_('Create Puppet Environment'), {}, { :class => "btn-lg" }) %>
-  </div>
-  <div class="blank-slate-pf-secondary-action">
-    <%= import_proxy_select(hash_for_import_environments_environments_path) %>
+      <%= import_proxy_select(hash_for_import_environments_environments_path) %>
   </div>
 </div>


### PR DESCRIPTION
It should probably be OK to remove the "Delete" buttons from the list of
actions too. There should only be one way to get new environments/puppet
classes, and that's by clicking on the import button and selecting them.
It's less error-prone as that way we have only one path, and we can
ensure it's well tested.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
