### PR TITLE
Fixes #23574 - add selector to facts charts using reselect

### DIFF
--- a/webpack/assets/javascripts/react_app/components/factCharts/FactChartSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/FactChartSelectors.js
@@ -1,0 +1,18 @@
+import { createSelector } from 'reselect';
+
+export const selectFactChartData = state => selectFactChart(state).chartData;
+
+const hostCounter = (accumulator, currentValue) =>
+  accumulator + currentValue;
+
+export const selectHostCount = createSelector(
+  selectFactChartData,
+  chartData =>
+    (chartData.length
+      ? chartData.map(item => item[1]).reduce(hostCounter)
+      : 0),
+);
+
+export const selectFactChart = state => state.factChart;
+
+export const selectDisplayModal = (state, id) => state.factChart.modalToDisplay[id] || false;

--- a/webpack/assets/javascripts/react_app/components/factCharts/FactChartSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/FactChartSelectors.test.js
@@ -1,0 +1,29 @@
+import { selectHostCount, selectFactChart, selectDisplayModal, selectFactChartData } from './FactChartSelectors';
+import { chartDataValues } from './factChart.fixtures';
+
+describe('Fact Chart Selector', () => {
+  const factChartState = { factChart: { chartData: chartDataValues, modalToDisplay: { 1: true } } };
+
+  it('should count hosts', () => {
+    const selected = selectHostCount(factChartState);
+    expect(selected).toEqual(13);
+  });
+
+  it('should return factChart object', () => {
+    const chart = selectFactChart(factChartState);
+
+    expect(chart).toMatchSnapshot();
+  });
+
+  it('should return true for rendering modal', () => {
+    const chart = selectDisplayModal(factChartState, 1);
+
+    expect(chart).toMatchSnapshot();
+  });
+
+  it('should return factChart data', () => {
+    const data = selectFactChartData(factChartState);
+
+    expect(data).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/factCharts/__snapshots__/FactChartSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/factCharts/__snapshots__/FactChartSelectors.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fact Chart Selector should return factChart data 1`] = `
+Array [
+  Array [
+    "Fedora 21 extra extra extra extra extra extra extra extra extra extra long label",
+    3,
+  ],
+  Array [
+    "Ubuntu 14.04",
+    4,
+  ],
+  Array [
+    "Centos 7 extra extra long label",
+    2,
+  ],
+  Array [
+    "Debian 8",
+    1,
+  ],
+  Array [
+    "Fedora 27",
+    2,
+  ],
+  Array [
+    "Fedora 26",
+    1,
+  ],
+]
+`;
+
+exports[`Fact Chart Selector should return factChart object 1`] = `
+Object {
+  "chartData": Array [
+    Array [
+      "Fedora 21 extra extra extra extra extra extra extra extra extra extra long label",
+      3,
+    ],
+    Array [
+      "Ubuntu 14.04",
+      4,
+    ],
+    Array [
+      "Centos 7 extra extra long label",
+      2,
+    ],
+    Array [
+      "Debian 8",
+      1,
+    ],
+    Array [
+      "Fedora 27",
+      2,
+    ],
+    Array [
+      "Fedora 26",
+      1,
+    ],
+  ],
+  "modalToDisplay": Object {
+    "1": true,
+  },
+}
+`;
+
+exports[`Fact Chart Selector should return true for rendering modal 1`] = `true`;

--- a/webpack/assets/javascripts/react_app/components/factCharts/__snapshots__/factChart.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/factCharts/__snapshots__/factChart.test.js.snap
@@ -12,12 +12,12 @@ exports[`factCharts should render closed 1`] = `
   factChart={
     Object {
       "chartData": Array [],
-      "hostsCount": null,
       "loaderStatus": "",
       "modalToDisplay": Object {},
     }
   }
   getChartData={[Function]}
+  hostsCount={0}
   modalToDisplay={false}
   showModal={[Function]}
   store={
@@ -64,12 +64,12 @@ exports[`factCharts should render open 1`] = `
   factChart={
     Object {
       "chartData": Array [],
-      "hostsCount": null,
       "loaderStatus": "",
       "modalToDisplay": Object {},
     }
   }
   getChartData={[Function]}
+  hostsCount={0}
   modalToDisplay={false}
   showModal={[Function]}
   store={

--- a/webpack/assets/javascripts/react_app/components/factCharts/factChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/factChart.fixtures.js
@@ -8,7 +8,6 @@ const state = {
   modalToDisplay: {},
   chartData: [],
   loaderStatus: '',
-  hostsCount: null,
 };
 
 export const initialState = Immutable(state);
@@ -22,7 +21,6 @@ export const modalSuccessState = Immutable(Object.assign(
     modalToDisplay: { 1: true },
     chartData: chartDataValues,
     loaderStatus: STATUS.RESOLVED,
-    hostsCount: 13,
   },
 ));
 

--- a/webpack/assets/javascripts/react_app/components/factCharts/index.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/index.js
@@ -10,6 +10,7 @@ import { STATUS } from '../../constants';
 import * as FactChartActions from '../../redux/actions/factCharts/';
 import { sprintf, ngettext as n__, translate as __ } from '../../../react_app/common/I18n';
 import { navigateToSearch } from '../../../services/charts/DonutChartService';
+import { selectHostCount, selectFactChart, selectDisplayModal } from './FactChartSelectors';
 
 class FactChart extends React.Component {
   constructor(props) {
@@ -35,6 +36,7 @@ class FactChart extends React.Component {
   render() {
     const {
       factChart,
+      hostsCount,
       data: { id, title, search },
       modalToDisplay,
     } = this.props;
@@ -75,8 +77,8 @@ class FactChart extends React.Component {
                 <b>
                   {sprintf(__('Fact distribution chart - %s '), title)}
                 </b>
-                {factChart.hostsCount && (<small>
-                  {sprintf(n__('(%s host)', '(%s hosts)', factChart.hostsCount), factChart.hostsCount)}
+                {hostsCount && (<small>
+                  {sprintf(n__('(%s host)', '(%s hosts)', hostsCount), hostsCount)}
                 </small>)}
               </Modal.Title>
             </Modal.Header>
@@ -99,8 +101,9 @@ FactChart.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  factChart: state.factChart,
-  modalToDisplay: state.factChart.modalToDisplay[ownProps.data.id] || false,
+  factChart: selectFactChart(state),
+  hostsCount: selectHostCount(state),
+  modalToDisplay: selectDisplayModal(state, ownProps.data.id),
 });
 
 export default connect(

--- a/webpack/assets/javascripts/react_app/redux/reducers/factCharts/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/factCharts/index.js
@@ -11,20 +11,15 @@ const initialState = Immutable({
   modalToDisplay: {},
   chartData: [],
   loaderStatus: '',
-  hostsCount: null,
 });
-
-let hostsCount = 0;
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case FACT_CHART_DATA_REQUEST:
       return state.set('loaderStatus', 'PENDING');
     case FACT_CHART_DATA_SUCCESS:
-      action.payload.values.forEach((val) => { (hostsCount += val[1]); });
       return state
         .set('chartData', action.payload.values)
-        .set('hostsCount', hostsCount)
         .set('loaderStatus', 'RESOLVED');
     case FACT_CHART_DATA_FAILURE:
       return state.set('loaderStatus', 'ERROR');
@@ -33,11 +28,9 @@ export default (state = initialState, action) => {
         .set('title', action.payload.title)
         .set('modalToDisplay', { [action.payload.id]: true });
     case CLOSE_FACT_CHART_MODAL:
-      hostsCount = 0;
       return state
         .set('modalToDisplay', {})
         .set('loaderStatus', '')
-        .set('hostsCount', null)
         .set('chartData', []);
     default:
       return state;


### PR DESCRIPTION
Reslect memorize derived data from the store, allowing redux to store the minimal possible state and improves performance.