### PR TITLE
Fixes #21938 - add plugable upgrade rake task

### DIFF
--- a/app/models/upgrade_task.rb
+++ b/app/models/upgrade_task.rb
@@ -1,0 +1,36 @@
+class UpgradeTask < ApplicationRecord
+  validates :name, :presence => true, :uniqueness => true
+  validates :task_name, :presence => true
+
+  before_validation :ensure_name, on: :create
+
+  scope :needing_run, lambda {
+    where(:last_run_time => nil).or(where(:always_run => true)).order(ordering: :asc, created_at: :asc)
+  }
+
+  def mark_as_ran!
+    update!(:last_run_time => Time.now)
+  end
+
+  def self.define_tasks(subject)
+    existing = UpgradeTask.where(:subject => subject)
+    seeded_tasks = yield
+
+    # delete unknown tasks
+    existing_names = seeded_tasks.pluck(:name)
+    existing.where.not(:name => existing_names).destroy_all
+
+    seeded_tasks.each do |seed_task|
+      if (existing_task = existing.find_by(:name => seed_task[:name]))
+        existing_task.update!(seed_task)
+      else
+        seed_task[:subject] = subject
+        self.create!(seed_task)
+      end
+    end
+  end
+
+  def ensure_name
+    self.task_name ||= name
+  end
+end

--- a/db/migrate/20180705191153_add_upgrade_task.rb
+++ b/db/migrate/20180705191153_add_upgrade_task.rb
@@ -1,0 +1,17 @@
+class AddUpgradeTask < ActiveRecord::Migration[5.1]
+  def change
+    create_table :upgrade_tasks do |t|
+      t.column :name, :string, :null => false
+      t.column :task_name, :string, :null => false
+      t.column :long_running, :boolean, :default => false, :null => false
+      t.column :always_run, :boolean, :default => false, :null => false
+      t.column :skip_failure, :boolean, :default => false, :null => false
+      t.column :last_run_time, :datetime, :null => true
+      t.column :ordering, :integer, :null => false, :default => 100
+      t.column :subject, :string, :null => false
+      t.timestamps
+    end
+
+    add_index :upgrade_tasks, :name, :unique => true
+  end
+end

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -1,0 +1,43 @@
+# TRANSLATORS: do not translate
+desc <<-END_DESC
+  This task runs predefined upgrade steps.
+
+  Examples:
+    rake upgrade:run
+    rake upgrade:mark_as_ran TASK_NAME=some_rake_task,another_rake_task
+
+END_DESC
+
+namespace :upgrade do
+  task :run => :environment do
+    ENV['FOREMAN_UPGRADE'] = '1'
+
+    raise "DB migration has not run" if Setting['db_pending_migration']
+    raise "DB seed has not run" if Setting['db_pending_seed']
+
+    total = UpgradeTask.needing_run.count
+    UpgradeTask.needing_run.each_with_index do |task, index|
+      count = "#{index + 1}/#{total}"
+
+      message = "Upgrade Step #{count}: #{task.name}. "
+      message += "This may take a long while." if task.long_running?
+
+      puts '============================================='
+      puts message
+      task.mark_as_ran! if run_task(task)
+    end
+  end
+
+  def run_task(task)
+    Rake::Task[task.task_name].execute
+  rescue => e
+    puts "Failed upgrade task: #{task.name}, see logs for more information."
+
+    if task.skip_failure?
+      Foreman::Logging.exception("Failed upgrade task: #{task.name}", e)
+      false
+    end
+
+    true
+  end
+end

--- a/test/models/upgrade_task_test.rb
+++ b/test/models/upgrade_task_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class UpgradeTaskTest < ActiveSupport::TestCase
+  test "needing run should return results" do
+    task1 = UpgradeTask.create!(:name => 'task1', :subject => 'foreman')
+    task2 = UpgradeTask.create!(:name => 'task2', :always_run => true, :last_run_time => Time.now, :subject => 'foreman')
+    task3 = UpgradeTask.create!(:name => 'task3', :last_run_time => Time.now, :subject => 'foreman')
+
+    assert_includes UpgradeTask.needing_run, task1
+    assert_includes UpgradeTask.needing_run, task2
+    refute_includes UpgradeTask.needing_run, task3
+  end
+
+  test "mark as ran causes task to not need run" do
+    task1 = UpgradeTask.create!(:name => 'task1', :subject => 'foreman')
+    assert_includes UpgradeTask.needing_run, task1
+
+    task1.mark_as_ran!
+    refute_includes UpgradeTask.needing_run, task1
+  end
+
+  test "defining tasks should update tasks" do
+    UpgradeTask.define_tasks(:test_tasks) do
+      [
+        {:name => 'testTask1', :always_run => true}
+      ]
+    end
+
+    assert UpgradeTask.find_by(:name => :testTask1).always_run?
+
+    UpgradeTask.define_tasks(:test_tasks) do
+      [
+        {:name => 'testTask1', :always_run => false}
+      ]
+    end
+
+    refute UpgradeTask.find_by(:name => :testTask1).always_run?
+  end
+
+  test "defining tasks should delete old tasks" do
+    UpgradeTask.define_tasks(:test_tasks) do
+      [
+        {:name => 'testTask1'},
+        {:name => 'testTask2'}
+      ]
+    end
+
+    assert UpgradeTask.find_by(:name => 'testTask2')
+
+    UpgradeTask.define_tasks(:test_tasks) do
+      [
+        {:name => 'testTask1'}
+      ]
+    end
+
+    assert UpgradeTask.find_by(:name => 'testTask1')
+    refute UpgradeTask.find_by(:name => 'testTask2')
+  end
+
+  test "task name should be pulled from name" do
+    task1 = UpgradeTask.create!(:name => 'task1', :subject => 'foreman')
+
+    assert_equal task1.name, task1.task_name
+  end
+end


### PR DESCRIPTION
This commit adds the ability for plugins to define upgrade
rake tasks within the plugin api.  The installer can then run
the upgrade:run rake task to run them.  Tasks can be defined
to run once or to always run when the upgrade:run master task is
run.
