### PR TITLE
Fixes #24192 - Clean up auth_source_selected action leftovers

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -628,16 +628,14 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :users do |map|
-    ajax_actions = [:auth_source_selected]
-
     map.permission :view_users,
                    :users => [:index, :show, :auto_complete_search, :test_mail],
                    :"api/v2/users" => [:index, :show]
     map.permission :create_users,
-                   :users => [:new, :create].push(*ajax_actions),
+                   :users => [:new, :create],
                    :"api/v2/users" => [:create]
     map.permission :edit_users,
-                   :users => [:edit, :update].push(*ajax_actions),
+                   :users => [:edit, :update],
                    :"api/v2/users" => [:update]
     map.permission :destroy_users,
                    :users => [:destroy],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,7 +284,6 @@ Foreman::Application.routes.draw do
         post 'logout'
         get 'extlogin'
         get 'extlogout'
-        get 'auth_source_selected'
         get 'auto_complete_search'
       end
       resources :ssh_keys, :only => [:new, :create, :destroy]


### PR DESCRIPTION
The `UsersController#auth_source_selected` action was removed in commit
feacea35f07f362d9e2c694a83516bbc902321a0 but a few leftovers remain in
the code. This commit removes them.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
