### PR TITLE
Fixes #23382 - Hashes in arrays are shown properly on ENC

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -201,7 +201,9 @@ class HostsController < ApplicationController
     begin
       respond_to do |format|
         # don't break lines in yaml to support Ruby < 1.9.3
-        host_info_yaml = @host.info.to_yaml(:line_width => -1)
+        # Remove the HashesWithIndifferentAccess using 'deep_stringify_keys',
+        # then we turn it into YAML
+        host_info_yaml = @host.info.deep_stringify_keys.to_yaml(:line_width => -1)
         format.html { render :html => "<pre>#{ERB::Util.html_escape(host_info_yaml)}</pre>".html_safe }
         format.yml { render :plain => host_info_yaml }
       end


### PR DESCRIPTION
When defining smart class parameter values with type YAML and submitted
in GUI an Ruby error message gets prepended for each array entry.

Defining an YAML-Array like:

---
- name: foo
  mount_point: /bar
- name: john
  mount_point: /doe

is shown on the ENC as:

- !ruby/hash:ActiveSupport::HashWithIndifferentAccess
  name: foo
  mount_point: "/bar"
- !ruby/hash:ActiveSupport::HashWithIndifferentAccess
  name: john
  mount_point: "/doe"

In order to avoid parsing the whole YAML or monkeypatching
HashWithIndifferentAccess the easiest workaround is to convert to
JSON then parse back to YAML

(cherry picked from commit d477552ce73a703fbf9fb93e7b1539ec639607ee)
