### PR TITLE
Fixes #24158 - fix cloning of roles

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -220,6 +220,7 @@ class Role < ApplicationRecord
                                :include => [:locations, :organizations, { :filters => :permissions }])
     new_role.attributes = role_params
     new_role.cloned_from_id = self.id
+    new_role.filters = new_role.filters.select {|f| f.filterings.present? }
     new_role
   end
 

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -145,6 +145,18 @@ class RoleTest < ActiveSupport::TestCase
       assert_include Role.cloned, cloned_role
       assert_not_include Role.cloned, role
     end
+
+    context 'role has some empty filters' do
+      before do
+        role.permissions = [ Permission.first ]
+        role.filters.first.filterings = []
+      end
+
+      it 'clones the role ignoring the empty filters' do
+        assert cloned_role.valid?
+        assert_equal cloned_role.filters.size + 1, role.filters.size
+      end
+    end
   end
 
   context "System roles" do


### PR DESCRIPTION
Roles that contains filters without permissions could not be cloned. In
UI, user did not even get any error message, API responded with 422 at
least.

(cherry picked from commit f968c04292deb37d55fc02b8aae85e6a5072bf5a)

