### PR TITLE
Fixes #24185 - logging env override config fixed

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -109,7 +109,7 @@ module Foreman
     def load_config(environment, overrides = {})
       fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?('config/logging.yaml')
       overrides ||= {}
-      overrides = overrides[environment.to_sym] if overrides.has_key?(environment.to_sym)
+      overrides.deep_merge!(overrides[environment.to_sym]) if overrides.has_key?(environment.to_sym)
       @config = YAML.load_file('config/logging.yaml')
       @config = @config[:default].deep_merge(@config[environment.to_sym]).deep_merge(overrides)
     end


### PR DESCRIPTION
This does not work due to bad implementation in https://github.com/theforeman/foreman/pull/3755/files

```
:logging:
  :level: debug
  :production:
    :type: file
    :layout: pattern
```

Environment-level sub-hash overrides the root values, so level is unset
(set to default = info). This works:

```
:logging:
  :production:
    :level: debug
    :type: file
    :layout: pattern
```

And this works too:

```
:logging:
  :level: debug
  :type: file
  :layout: pattern
```

This patch fixes the very first case so it works for everyone.