### PR TITLE
Fixes #24199 - validate taxonomy of host environment on create

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -954,7 +954,7 @@ class Host::Managed < Host::Base
     raise ArgumentError, "Association #{association_name} not found" unless association
     associated_object_id = public_send(association.foreign_key)
     if Taxonomy.enabled_taxonomies.present? && associated_object_id.present? &&
-      Environment.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
+      association.klass.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
       errors.add(association.foreign_key, _("with id %{object_id} doesn't exist or is not assigned to proper organization and/or location") % { :object_id => associated_object_id })
       false
     else

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -870,6 +870,8 @@ class Host::Managed < Host::Base
       end
     end
 
+    status = validate_association_taxonomy(:environment)
+
     if environment
       puppetclasses.select("puppetclasses.id,puppetclasses.name").distinct.each do |e|
         unless environment.puppetclasses.map(&:id).include?(e.id)
@@ -943,5 +945,20 @@ class Host::Managed < Host::Base
     MailNotification[:host_built].deliver(self, :users => recipients) if recipients.present?
   rescue SocketError, Net::SMTPError => e
     Foreman::Logging.exception("Host has been created. Failed to send email", e)
+  end
+
+  # Ensures that object assigned in the association belongs to the taxonomies of the host.
+  # Returns true if it does, otherwise it adds a validation error and returns false.
+  def validate_association_taxonomy(association_name)
+    association = self.class.reflect_on_association(association_name)
+    raise ArgumentError, "Association #{association_name} not found" unless association
+    associated_object_id = public_send(association.foreign_key)
+    if Taxonomy.enabled_taxonomies.present? && associated_object_id.present? &&
+      Environment.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
+      errors.add(association.foreign_key, _("with id %{object_id} doesn't exist or is not assigned to proper organization and/or location") % { :object_id => associated_object_id })
+      false
+    else
+      true
+    end
   end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -333,6 +333,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   test "should update hostgroup_id of host" do
     host = FactoryBot.create(:host, basic_attrs_with_hg)
     hg = FactoryBot.create(:hostgroup, :with_environment)
+    set_environment_taxonomies(hg)
     put :update, params: { :id => host.to_param, :host => { :hostgroup_id => hg.id }}
     assert_response :success
     host.reload
@@ -1172,6 +1173,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should update with puppet class" do
     environment = environments(:testing)
+    set_environment_taxonomies(@host, environment)
     puppetclass = Puppetclass.find_by_name('git')
     put :update, params: { :id => @host.id, :host => valid_attrs.merge(:environment_id => environment.id, :puppetclass_ids => [puppetclass.id]) }
     assert_response :success

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -12,6 +12,20 @@ def set_nic_attributes(host, attributes, evaluator)
   host
 end
 
+def set_environment_taxonomies(host_or_hostgroup, environment = host_or_hostgroup.environment)
+  if host_or_hostgroup.is_a? Hostgroup
+    organizations = host_or_hostgroup.organizations
+    locations = host_or_hostgroup.locations
+  else
+    organizations = [host_or_hostgroup.organization].compact
+    locations = [host_or_hostgroup.location].compact
+  end
+  return if environment.nil? || (organizations.empty? && locations.empty?)
+  environment.organizations = (environment.organizations + organizations).uniq
+  environment.locations = (environment.locations + locations).uniq
+  environment.save unless environment.new_record?
+end
+
 FactoryBot.define do
   factory :ptable do
     sequence(:name) { |n| "ptable#{n}" }
@@ -127,6 +141,7 @@ FactoryBot.define do
       end
 
       set_nic_attributes(host, deferred_nic_attrs, evaluator)
+      set_environment_taxonomies(host)
     end
 
     trait :with_environment do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -783,6 +783,20 @@ class HostTest < ActiveSupport::TestCase
       assert @host.organization.valid?
       assert @host.location.valid?
     end
+
+    test "assign a host to environment with incorrect taxonomies" do
+      @host = FactoryBot.build(:host, :managed => false)
+      env_with_tax = FactoryBot.create(:environment,
+                                       :organizations => [@host.organization],
+                                       :locations => [@host.location])
+      env_without_tax = FactoryBot.create(:environment)
+      @host.environment = env_with_tax
+      assert @host.valid?
+
+      @host.environment = env_without_tax
+      refute @host.valid?
+      assert_match /is not assigned/, @host.errors[:environment_id].first
+    end
   end
 
   test 'host can be searched in multiple taxonomies' do


### PR DESCRIPTION
Otherwise, we allowed assigning the environment from different
organization/location to host and it was not consistent with the UI
behaviour.

It was also causing strange behavior when it comes to the assignment of
puppet classes.