### PR TITLE
[CP 1.18] Fixes #23965 - Only save ids for association audits (#5753)

### DIFF
--- a/app/models/concerns/audit_associations.rb
+++ b/app/models/concerns/audit_associations.rb
@@ -8,40 +8,34 @@ module AuditAssociations
       super.merge(associated_attributes)
     end
 
-    private
+    protected
 
-    def find_association_class(name)
-      self.class.reflect_on_association(name).class_name.constantize
+    # Prevent associations from being set when looking at revisions since
+    # otherwise they will update the original object rather then the revision
+    def revision_with(attrs)
+      super(attrs.reject{|k, v| k.to_s.ends_with?('_ids')})
     end
+
+    private
 
     def associated_changes
       audited_options[:associations].each_with_object({}) do |association, changes|
-        association_ids = "#{association.to_s.singularize}_ids"
-        if public_send("#{association_ids}_changed?")
-          change = public_send("#{association_ids}_change")
-
-          changes[association] = change.map do |ids|
-            associated_names(association, ids)
-          end
+        if public_send("#{association}_changed?")
+          changes[association] = public_send("#{association}_change")
         end
       end
     end
 
     def associated_attributes
       audited_options[:associations].each_with_object({}) do |association, attributes|
-        ids = public_send("#{association.to_s.singularize}_ids")
-        attributes[association.to_s] = associated_names(association, ids)
+        attributes[association] = public_send(association)
       end
-    end
-
-    def associated_names(association, ids)
-      find_association_class(association).where(id: ids).map(&:to_label).sort.join(', ')
     end
   end
 
   module AssociationsDefinitions
     def audited(options = {})
-      options[:associations] = Array(options[:associations])
+      options[:associations] = normalize_associations(options[:associations])
       if options[:associations].present?
         configure_dirty_associations(options[:associations])
       end
@@ -50,12 +44,18 @@ module AuditAssociations
     end
 
     def audit_associations(*associations)
-      new_associations = Array(associations)
+      new_associations = normalize_associations(associations)
       if self.respond_to?(:audited_options)
         configure_dirty_associations(new_associations)
         self.audited_options[:associations] = self.audited_options[:associations] | new_associations
       else
         logger.warn "ignoring associations #{new_associations.join(', ')} audit definition for #{self}, the resource is not audited"
+      end
+    end
+
+    def normalize_associations(associations)
+      Array(associations).map do |association|
+        "#{association.to_s.singularize}_ids"
       end
     end
 

--- a/app/models/concerns/dirty_associations.rb
+++ b/app/models/concerns/dirty_associations.rb
@@ -21,7 +21,8 @@ module DirtyAssociations
     def dirty_has_many_associations(*args)
       extension = Module.new do
         args.each do |association|
-          association_ids = association.to_s.singularize + '_ids'
+          association_ids = association.to_s
+          association_ids = association_ids.singularize + '_ids' unless association.to_s.end_with?('_ids')
 
           # result for :organizations
           #   def organization_ids_with_change_detection=(organizations)

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -82,7 +82,7 @@
           <% next if name == "template" %>
           <tr>
             <td><%= name.humanize %></td>
-            <% if change.is_a?(Array) %>
+            <% if @audit.action == 'update' %>
               <% change.each do |v| %>
                 <td><%= id_to_label(name,v,false) %></td>
               <% end %>

--- a/test/models/concerns/audit_associations_test.rb
+++ b/test/models/concerns/audit_associations_test.rb
@@ -7,42 +7,37 @@ class AuditAssociationsTest < ActiveSupport::TestCase
 
   let (:role) { FactoryBot.create(:role) }
 
-  test "find_association_class should be give a class_name" do
-    role_class = @user.send('find_association_class', 'roles')
-    assert_equal Role, role_class
-  end
-
   test "Should audit associations on creation" do
     @user.role_ids = [role.id]
     @user.save!
 
     audit = @user.audits.last
-    assert_equal role.to_label, audit.audited_changes['roles']
+    assert_equal [role.id], audit.audited_changes['role_ids']
     assert_equal 'create', audit.action
   end
 
   test "Should audit associations on update" do
     @user.save!
-    assert_empty @user.audits.last.audited_changes['roles']
+    assert_empty @user.audits.last.audited_changes['role_ids']
 
     @user.role_ids = [role.id]
     @user.save!
 
     audit = @user.audits.last
-    assert_equal ["", role.to_label], audit.audited_changes['roles']
+    assert_equal [[], [role.id]], audit.audited_changes['role_ids']
     assert_equal 'update', audit.action
   end
 
   test "Should audit associations on destruction" do
     @user.role_ids = [role.id]
     @user.save!
-    assert_equal role.to_label, @user.audits.last.audited_changes['roles']
+    assert_equal [role.id], @user.audits.last.audited_changes['role_ids']
 
     @user.destroy!
 
     audit = @user.audits.last
     # The default role is added in after_save to the user
-    assert_equal [Role.default.to_label, role.to_label].sort.join(', '), audit.audited_changes['roles']
+    assert_equal [Role.default.id, role.id].sort, audit.audited_changes['role_ids'].sort
     assert_equal 'destroy', audit.action
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1208,11 +1208,11 @@ class UserTest < ActiveSupport::TestCase
       @user.save
 
       recent_audit = @user.audits.last
-      audited_changes = recent_audit.audited_changes[:roles]
+      audited_changes = recent_audit.audited_changes[:role_ids]
 
       assert audited_changes, 'No audits found for user-roles'
       assert_empty audited_changes.first
-      assert_equal @role.name, audited_changes.last
+      assert_equal [@role.id], audited_changes.last
     end
 
     test 'should audit when a role is removed/de-assigned from a user' do
@@ -1222,10 +1222,10 @@ class UserTest < ActiveSupport::TestCase
       @user.save
 
       recent_audit = @user.audits.last
-      audited_changes = recent_audit.audited_changes[:roles]
+      audited_changes = recent_audit.audited_changes[:role_ids]
 
       assert audited_changes, 'No audits found for user-roles'
-      assert_equal [Role.default.to_label, @role.to_label].sort.join(', '), audited_changes.first
+      assert_equal [[@role.id, Role.default.id], []], audited_changes
       assert_empty audited_changes.last
     end
 

--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -323,19 +323,19 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a child-usergroup is assigned to a parent-usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:usergroups]
+        audited_changes = recent_audit.audited_changes[:usergroup_ids]
         assert audited_changes, 'No audits found for usergroups'
         assert_empty audited_changes.first
-        assert_equal @child_usergroup.name, audited_changes.last
+        assert_equal [@child_usergroup.id], audited_changes.last
       end
 
       test 'should audit when a child-usergroup is removed/de-assigned from a parent-usergroup' do
         @usergroup.usergroup_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:usergroups]
+        audited_changes = recent_audit.audited_changes[:usergroup_ids]
         assert audited_changes, 'No audits found for usergroups'
-        assert_equal @child_usergroup.name, audited_changes.first
+        assert_equal [@child_usergroup.id], audited_changes.first
         assert_empty audited_changes.last
       end
     end
@@ -349,19 +349,19 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a role is assigned to a usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:roles]
+        audited_changes = recent_audit.audited_changes[:role_ids]
         assert audited_changes, 'No audits found for user-roles'
         assert_empty audited_changes.first
-        assert_equal @role.name, audited_changes.last
+        assert_equal [@role.id], audited_changes.last
       end
 
       test 'should audit when a role is removed/de-assigned from a usergroup' do
         @usergroup.role_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:roles]
+        audited_changes = recent_audit.audited_changes[:role_ids]
         assert audited_changes, 'No audits found for usergroup-roles'
-        assert_equal @role.name, audited_changes.first
+        assert_equal [@role.id], audited_changes.first
         assert_empty audited_changes.last
       end
     end
@@ -375,19 +375,19 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a user is assigned to a usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:users]
+        audited_changes = recent_audit.audited_changes[:user_ids]
         assert audited_changes, 'No audits found for users'
         assert_empty audited_changes.first
-        assert_equal @user.name, audited_changes.last
+        assert_equal [@user.id], audited_changes.last
       end
 
       test 'should audit when a user is removed/de-assigned from a usergroup' do
         @usergroup.user_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:users]
+        audited_changes = recent_audit.audited_changes[:user_ids]
         assert audited_changes, 'No audits found for users'
-        assert_equal @user.name, audited_changes.first
+        assert_equal [@user.id], audited_changes.first
         assert_empty audited_changes.last
       end
     end


### PR DESCRIPTION
Otherwise, we have issues when trying to check revisions of the audit
since it will fail trying to assign a string to an attribute that
expects an object id.

(cherry picked from commit 38f854cd1aef87adff4e27673d7cae403b7ada10)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
