### PR TITLE
Fixes #24200 - Fix ChartBox storybook

### DIFF
--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.js
@@ -104,7 +104,7 @@ ChartBox.propTypes = {
   id: PropTypes.string.isRequired,
   noDataMsg: PropTypes.string,
   errorText: PropTypes.string,
-  type: PropTypes.oneOf(['donut']),
+  type: PropTypes.oneOf(['donut']).isRequired,
   chart: PropTypes.object,
   tip: PropTypes.string,
 };

--- a/webpack/assets/javascripts/react_app/components/statistics/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/statistics/ChartBox.stories.js
@@ -8,7 +8,7 @@ storiesOf('Charts', module)
     <ChartBox chart={{ data: [] }} noDataMsg={'No data here'} title="Title" status="PENDING" />
   ))
   .add('Without Data', () => (
-    <ChartBox chart={{ data: [] }} noDataMsg={'No data here'} title="Title" status="RESOLVED" />
+    <ChartBox type="donut" chart={{ data: [] }} noDataMsg={'No data here'} title="Title" status="RESOLVED" />
   ))
   .add('With Error', () => (
     <ChartBox
@@ -21,6 +21,7 @@ storiesOf('Charts', module)
   ))
   .add('With Data + Modal', () => (
     <ChartBox
+      type="donut"
       chart={{ data: mockStoryData.config.data.columns }}
       noDataMsg={mockStoryData.noDataMsg}
       tip={mockStoryData.tip}


### PR DESCRIPTION
ChartBox storybook failed to load:
 * Without Data
 * With Data + Modal

The error message was:
> Element type is invalid: expected a string (for built-in components)
> or a class/function (for composite components) but got: undefined

Because the `type` prop was missing, the [`Chart`](https://github.com/theforeman/foreman/compare/develop...ripcurld:fixes_24200?expand=1#diff-c613cc11b2f0c91f5121a347d19b7be7R42) component was `undefined` showing this error message.

To fix this, I set the default value of `type` to `donut` as this is the only type right now.
