### PR TITLE
Fixes #23896 - Update taxonomies when refreshing metadata

### DIFF
--- a/app/models/concerns/template_tax.rb
+++ b/app/models/concerns/template_tax.rb
@@ -1,0 +1,20 @@
+module TemplateTax
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def taxonomy_exportable
+      {
+        :organizations => method(:assigned_organization_titles),
+        :locations => method(:assigned_location_titles)
+      }
+    end
+
+    def assigned_organization_titles(template, user = User.current)
+      template.organizations.select { |org| user.my_organizations.include?(org) }.map(&:title)
+    end
+
+    def assigned_location_titles(template, user = User.current)
+      template.locations.select { |loc| user.my_locations.include?(loc) }.map(&:title)
+    end
+  end
+end

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -35,6 +35,7 @@ class ProvisioningTemplate < Template
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
   include Taxonomix
+  include TemplateTax
   scoped_search :on => :name,    :complete_value => true, :default_order => true
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
@@ -47,8 +48,10 @@ class ProvisioningTemplate < Template
   scoped_search :relation => :hostgroups,       :on => :name, :rename => :hostgroup,       :complete_value => true
   scoped_search :relation => :template_kind,    :on => :name, :rename => :kind,            :complete_value => true
 
-  attr_exportable :kind => Proc.new { |template| template.template_kind.try(:name) },
-                  :oses => Proc.new { |template| template.operatingsystems.map(&:name).uniq }
+  attr_exportable({
+    :kind => Proc.new { |template| template.template_kind.try(:name) },
+    :oses => Proc.new { |template| template.operatingsystems.map(&:name).uniq }
+  }.merge(taxonomy_exportable))
 
   dirty_has_many_associations :template_combinations, :os_default_templates, :operatingsystems
 

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -34,6 +34,7 @@ class Ptable < Template
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
   include Taxonomix
+  include TemplateTax
   scoped_search :on => :name,    :complete_value => true, :default_order => true
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
@@ -46,7 +47,7 @@ class Ptable < Template
 
   alias_attribute :layout, :template
 
-  attr_exportable :os_family
+  attr_exportable :os_family, taxonomy_exportable
 
   dirty_has_many_associations :operatingsystems
 

--- a/test/controllers/api/v2/ptables_controller_test.rb
+++ b/test/controllers/api/v2/ptables_controller_test.rb
@@ -216,6 +216,7 @@ class Api::V2::PtablesControllerTest < ActionController::TestCase
     get :export, params: { :id => ptable.to_param }
     assert_response :success
     assert_equal 'text/plain', response.content_type
+    User.current = users(:admin)
     assert_equal ptable.to_erb, response.body
   end
 

--- a/test/controllers/ptables_controller_test.rb
+++ b/test/controllers/ptables_controller_test.rb
@@ -60,6 +60,7 @@ class PtablesControllerTest < ActionController::TestCase
     get :export, params: { :id => @ptable.to_param }, session: set_session_user
     assert_response :success
     assert_equal 'text/plain', response.content_type
+    User.current = users(:admin)
     assert_equal @ptable.to_erb, response.body
   end
 

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -436,5 +436,18 @@ EOS
         assert_equal "cannot be used, please choose another", template.errors.messages[:name].first
       end
     end
+
+    describe 'taxonomies in metadata' do
+      test 'should add taxonomies to metadata' do
+        org = FactoryBot.create(:organization, :name => 'TemplateOrg')
+        loc = FactoryBot.create(:location, :name => 'TemplateLoc')
+        provisioning_template = FactoryBot.create(:provisioning_template,
+                                                  :name => 'exported_template',
+                                                  :organizations => [org],
+                                                  :locations => [loc])
+        assert_equal org.title, provisioning_template.to_export["organizations"].first
+        assert_equal loc.title, provisioning_template.to_export["locations"].first
+      end
+    end
   end
 end


### PR DESCRIPTION
(cherry picked from commit 2d5e52d9b6631541ad7ff510720836cfd82e0060)


