### PR TITLE
Fixes #24211 - Allow a newer version of patternfly-sass

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,7 +1,7 @@
 group :assets do
   gem 'jquery-turbolinks', '~> 2.1'
   gem 'jquery-ui-rails', '< 5.0.0'
-  gem 'patternfly-sass', '~> 3.32.1'
+  gem 'patternfly-sass', '>= 3.32.1', '< 3.38.0'
   gem 'gridster-rails', '~> 0.5'
   gem 'gettext_i18n_rails_js', '~> 1.0'
   gem 'execjs', '>= 1.4.0', '< 3.0'


### PR DESCRIPTION
The current dependency on patternfly-sass is `~> 3.32.1` but in RPM packaging we already use 3.37.0. We should at least let the gem dependency and RPM packaging match but I'm not sure what's the best solution here.