### PR TITLE
Fixes #24217 - accept shell script for cloud-init in oVirt

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -220,7 +220,7 @@ module Foreman::Model
 
     def start_vm(uuid)
       vm = find_vm_by_uuid(uuid)
-      if vm.comment.include? "cloud-config"
+      if vm.comment.to_s =~ %r{cloud-config|^#!/}
         vm.start_with_cloudinit(:blocking => true, :user_data => vm.comment, :use_custom_script => true)
         vm.comment = ''
         vm.save


### PR DESCRIPTION
Our default user_data template uses shell format for cloud-init: we
should be able to use it for oVirt as well, especially after #24217
has been fixed.