### PR TITLE
Fixes #23373 - Fix host dissociation when updating host

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -156,6 +156,7 @@ module Api
         @all_parameters = true
 
         @host.attributes = host_attributes(host_params, @host)
+        @host.attributes.delete(:compute_profile_id)
         apply_compute_profile(@host) if (params[:host] && params[:host][:compute_attributes].present?) || @host.compute_profile_id_changed?
 
         process_response @host.save

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -118,7 +118,7 @@ class HostsController < ApplicationController
     forward_url_options
     Taxonomy.no_taxonomy_scope do
       attributes = @host.apply_inherited_attributes(host_params)
-
+      attributes.delete(:compute_resource_id)
       if @host.update(attributes)
         process_success :success_redirect => host_path(@host)
       else

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -583,6 +583,15 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal hostgroup.root_pass, Host.find_by(:name => hostname).root_pass
   end
 
+  test 'host update shouldnt diassociate from VM' do
+    hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_os, :with_compute_resource)
+    host = FactoryBot.create(:host, :hostgroup => hostgroup)
+    put :update, params: { :commit => "Update", :id => host.id, :params => {:compute_resource_id => ""}}, session: set_session_user
+    assert_response :success
+    host.reload
+    assert_not_nil host.compute_resource_id
+  end
+
   test 'when ":restrict_registered_smart_proxies" is false, HTTP requests should be able to import facts' do
     User.current = users(:one) # use an unprivileged user, not apiadmin
     Setting[:restrict_registered_smart_proxies] = false

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1260,6 +1260,15 @@ class HostsControllerTest < ActionController::TestCase
     refute host.compute_resource_id
   end
 
+  test "#host update shouldn't diassociate from VM" do
+    hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_os, :with_compute_resource)
+    host = FactoryBot.create(:host, :hostgroup => hostgroup)
+    put :update, params: { :commit => "Update", :id => host.id, :params => {:compute_resource_id => ""}}, session: set_session_user
+    assert_response :redirect
+    host.reload
+    assert_not_nil host.compute_resource_id
+  end
+
   test '#update_multiple_disassociate' do
     host = FactoryBot.create(:host, :on_compute_resource)
     post :update_multiple_disassociate, params: { :host_ids => [host.id], :host_names => [host.name] }, session: set_session_user


### PR DESCRIPTION
Host gets disassociate from the VM when the following happens:
1. Creating the host with a certain "hostgroup" and  changing the "Deploy on" from the inherited value to something else.
2. After the host created -> Edit the host 

This happens because in Update, the "Deploy on" is disabled (it shouldnt be possible to edit the compute resource), and this means that the form doesn't send the value of "Deploy on", but it does send the values of selected hostgroup. So the the "Deploy on" gets overriten by the "hostgroup".

The solution is to simply delete the "compute_resource_id"  parameter when updating the host,  there is no problem to do so because it's not possible to edit the compute resource after the host created.