### PR TITLE
Fixes #23918 - Find correct scope when updating taxonomy [1.18]

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -88,7 +88,7 @@ module Api::V2::TaxonomiesController
 
   # overriding public FindCommon#resource_scope to scope only to user's taxonomies
   def resource_scope(*args)
-    super.send("my_#{taxonomies_plural}")
+    @resource_scope ||= scope_for(resource_class, args).send("my_#{taxonomies_plural}")
   end
 
   private

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -172,4 +172,12 @@ class Api::V2::OrganizationsControllerTest < ActionController::TestCase
     assert_equal organization.name, new_name
     assert_equal organization.description, new_description
   end
+
+  test "should add location to organization" do
+    organization = FactoryBot.create(:organization)
+    location = FactoryBot.create(:location)
+    put :update, params: { :id => organization.id, :organization => { :location_ids => [location.id] } }
+    assert_response :success
+    assert_contains organization.locations, location
+  end
 end


### PR DESCRIPTION
Important issue that I hope can be cherry-picked to 1.18 (see the attached BZ).
