### PR TITLE
Fixes #24227 - [Single Page Application] Add permissions to API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -50,6 +50,8 @@ module Api
       instance_variable_get(:"@#{resource_name}") || raise(message)
     end
 
+    helper_method :controller_permission
+
     def controller_permission
       controller_name
     end

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class BaseController < Api::BaseController
       include Api::Version2
+      include Foreman::Controller::Authorize
 
       resource_description do
         api_version "v2"
@@ -49,7 +50,6 @@ module Api
 
       helper_method :root_node_name, :metadata_total, :metadata_subtotal, :metadata_search,
                     :metadata_order, :metadata_by, :metadata_page, :metadata_per_page
-
       def root_node_name
         @root_node_name ||= if Rabl.configuration.use_controller_name_as_json_root
                               controller_name.split('/').last

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include ApplicationShared
 
   include Foreman::Controller::Flash
+  include Foreman::Controller::Authorize
 
   force_ssl :if => :require_ssl?
   protect_from_forgery # See ActionController::RequestForgeryProtection for details
@@ -13,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   # standard layout to all controllers
   helper 'layout'
-  helper_method :authorizer, :resource_path
+  helper_method :resource_path
 
   before_action :require_login
   before_action :set_gettext_locale_db, :set_gettext_locale
@@ -68,10 +69,6 @@ class ApplicationController < ActionController::Base
       return
     end
     authorized ? true : deny_access
-  end
-
-  def authorizer
-    @authorizer ||= Authorizer.new(User.current, :collection => instance_variable_get("@#{controller_name}"))
   end
 
   def deny_access

--- a/app/controllers/concerns/foreman/controller/authorize.rb
+++ b/app/controllers/concerns/foreman/controller/authorize.rb
@@ -1,0 +1,6 @@
+module Foreman::Controller::Authorize
+  extend ActiveSupport::Concern
+  included do
+    delegate :authorized_for, :authorizer, :can_create?, to: :helpers
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,33 +110,6 @@ module ApplicationHelper
         options.merge(:'data-original-title' => _("Click to add %s") % options[:"data-class-name"]))
   end
 
-  # Return true if user is authorized for controller/action, otherwise false
-  # +options+ : Hash containing
-  #             :controller : String or symbol for the controller, defaults to params[:controller]
-  #             :action     : String or symbol for the action
-  #             :id         : Id parameter
-  #             :auth_action: String or symbol for the action, this has higher priority that :action
-  #             :auth_object: Specific object on which we may verify particular permission
-  #             :authorizer : Specific authorizer to perform authorization on (handy to inject authorizer with base collection)
-  #             :permission : Specific permission to check authorization on (handy on custom permission names)
-  def authorized_for(options)
-    action          = options.delete(:auth_action) || options[:action]
-    object          = options.delete(:auth_object)
-    user            = User.current
-    controller      = options[:controller] || params[:controller]
-    controller_name = controller.to_s.gsub(/::/, "_").underscore
-    id              = options[:id]
-    user_id         = options[:user_id].to_param
-    permission      = options.delete(:permission) || [action, controller_name].join('_')
-
-    if object.nil?
-      user.allowed_to?({ :controller => controller_name, :action => action, :id => id, :user_id => user_id }) rescue false
-    else
-      authorizer = options.delete(:authorizer) || Authorizer.new(user)
-      authorizer.can?(permission, object) rescue false
-    end
-  end
-
   # Display a link if user is authorized, otherwise a string
   # +name+    : String to be displayed
   # +options+ : Hash containing options for authorized_for and link_to

--- a/app/helpers/authorize_helper.rb
+++ b/app/helpers/authorize_helper.rb
@@ -1,0 +1,36 @@
+module AuthorizeHelper
+  # Return true if user is authorized for controller/action, otherwise false
+  # +options+ : Hash containing
+  #             :controller : String or symbol for the controller, defaults to params[:controller]
+  #             :action     : String or symbol for the action
+  #             :id         : Id parameter
+  #             :auth_action: String or symbol for the action, this has higher priority that :action
+  #             :auth_object: Specific object on which we may verify particular permission
+  #             :authorizer : Specific authorizer to perform authorization on (handy to inject authorizer with base collection)
+  #             :permission : Specific permission to check authorization on (handy on custom permission names)
+  def authorized_for(options)
+    action          = options.delete(:auth_action) || options[:action]
+    object          = options.delete(:auth_object)
+    user            = User.current
+    controller      = options[:controller] || params[:controller]
+    controller_name = controller.to_s.gsub(/::/, "_").underscore
+    id              = options[:id]
+    user_id         = options[:user_id].to_param
+    permission      = options.delete(:permission) || [action, controller_name].join('_')
+
+    if object.nil?
+      user.allowed_to?({ :controller => controller_name, :action => action, :id => id, :user_id => user_id }) rescue false
+    else
+      authorizer = options.delete(:authorizer) || Authorizer.new(user)
+      authorizer.can?(permission, object) rescue false
+    end
+  end
+
+  def authorizer
+    @authorizer ||= Authorizer.new(User.current, :collection => instance_variable_get("@#{controller_name}"))
+  end
+
+  def can_create?
+    authorized_for(controller: controller_permission, action: 'create', user_id: User.current.id, authorizer: authorizer)
+  end
+end

--- a/app/views/api/v2/layouts/index_layout.json.erb
+++ b/app/views/api/v2/layouts/index_layout.json.erb
@@ -4,6 +4,9 @@
   "page": <%= metadata_page.to_json %>,
   "per_page": <%= metadata_per_page.to_json %>,
   "search": <%= metadata_search.to_json.html_safe %>,
+<% if params.has_key?(:include_permissions) %>
+  "can_create": <%= can_create?.to_json %>,
+<% end %>
   "sort": {
     "by": <%= metadata_by.to_json.html_safe %>,
     "order": <%= metadata_order.to_json.html_safe %>

--- a/app/views/api/v2/layouts/permissions.json.rabl
+++ b/app/views/api/v2/layouts/permissions.json.rabl
@@ -1,0 +1,12 @@
+object @resource
+
+if params.has_key?(:include_permissions)
+  node do |resource|
+    if resource&.class&.try(:include?, Authorizable)
+      # To avoid loading all the records into the cache
+      # authorized_for is used instead of authorizer.can?.
+      node(:can_edit) { authorized_for(:auth_object => resource, :authorizer => authorizer, :permission => "edit_#{controller_permission}") }
+      node(:can_delete) { authorized_for(:auth_object => resource, :authorizer => authorizer, :permission => "destroy_#{controller_permission}") }
+    end
+  end
+end

--- a/app/views/api/v2/models/main.json.rabl
+++ b/app/views/api/v2/models/main.json.rabl
@@ -1,6 +1,7 @@
 object @model
 
 extends "api/v2/models/base"
+extends "api/v2/layouts/permissions"
 
 attributes :info, :created_at, :updated_at, :vendor_class, :hardware_model
 

--- a/test/controllers/api/v2/audits_controller_test.rb
+++ b/test/controllers/api/v2/audits_controller_test.rb
@@ -29,4 +29,11 @@ class Api::V2::AuditsControllerTest < ActionController::TestCase
     audits = ActiveSupport::JSON.decode(@response.body)
     assert_equal expected_audits.count, audits['results'].count
   end
+
+  test "should return permissions passing include_permissions in index" do
+    get :index, params: { :include_permissions => true }
+    assert_response :success
+    resp = ActiveSupport::JSON.decode(@response.body)
+    assert resp["can_create"]
+  end
 end

--- a/test/helpers/host_groups_helper_test.rb
+++ b/test/helpers/host_groups_helper_test.rb
@@ -5,6 +5,7 @@ class HostGroupsHelperTest < ActionView::TestCase
   include HostsAndHostgroupsHelper
   include ApplicationHelper
   include HostsHelper
+  include AuthorizeHelper
   include ::FormHelper
 
   test "should have the full string of the parent class if the child is a substring" do


### PR DESCRIPTION
During the process of moving Hardware Models to a React page the current API was missing significant details that are rendered in the Backend before the page is sent to the user.

For example, whether the user is allowed to edit a model or not

This information should be moved to the API because in the new page, once the page is rendered by Rails any communication is going to be done through the API and by that Rails won't render the page or part of it again.

// @ohadlevy @timogoebel 