### PR TITLE
Fixes #24125 - Show error when libvirt not reachable

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -128,7 +128,7 @@ module Foreman::Model
 
     def new_vm(attr = { })
       test_connection
-      return unless errors.empty?
+      libvirt_connection_error unless errors.empty?
       opts = vm_instance_defaults.merge(attr.to_h).deep_symbolize_keys
 
       # convert rails nested_attributes into a plain hash
@@ -198,6 +198,11 @@ module Foreman::Model
     end
 
     protected
+
+    def libvirt_connection_error
+      msg = N_('Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions.')
+      raise Foreman::Exception.new(msg, errors.full_messages.join(', '))
+    end
 
     def client
       # WARNING potential connection leak

--- a/app/views/common/_ajax_error.html.erb
+++ b/app/views/common/_ajax_error.html.erb
@@ -1,1 +1,1 @@
-<%= alert(:text => trunc_with_tooltip(_("Failure: %s") % message, 90), :class => 'alert-danger', :header => '', :close => false) %>
+<%= alert(:text => trunc_with_tooltip(_("Failure: %s") % message, 90, "", false), :class => 'alert-danger', :header => '', :close => false) %>

--- a/test/controllers/api/v2/compute_attributes_controller_test.rb
+++ b/test/controllers/api/v2/compute_attributes_controller_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class Api::V2::ComputeAttributesControllerTest < ActionController::TestCase
   test "should create compute attribute" do
     assert_difference('ComputeAttribute.count') do
-      valid_attrs = {:vm_attrs => {"cpus"=>"2", "memory"=>"2147483648"}}
+      ComputeAttribute.any_instance.stubs(:new_vm).returns(nil)
+      valid_attrs = {:vm_attrs => {"cpus" => "2", "memory" => "2147483648"}}
       post :create, params: { :compute_attribute => valid_attrs,
                               :compute_profile_id => compute_profiles(:three).id,
                               :compute_resource_id => compute_resources(:one).id }
@@ -12,7 +13,8 @@ class Api::V2::ComputeAttributesControllerTest < ActionController::TestCase
   end
 
   test "should update compute attribute" do
-    valid_attrs = {:vm_attrs => {"cpus"=>"4"}}
+    valid_attrs = {:vm_attrs => {"cpus" => "4"}}
+    ComputeAttribute.any_instance.stubs(:new_vm).returns(nil)
     put :update, params: { :id => compute_attributes(:two).id,
                            :compute_profile_id => compute_profiles(:one).id,
                            :compute_resource_id =>compute_resources(:one).id,

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -12,6 +12,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       @host = FactoryBot.create(:host)
       @ptable = FactoryBot.create(:ptable)
       @ptable.operatingsystems = [ Operatingsystem.find_by_name('Redhat') ]
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(true)
     end
   end
 
@@ -89,6 +90,10 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     modifier = mock(modifier_class.name)
     modifier_class.expects(:new).with(*args).returns(modifier)
     Host.any_instance.expects(:apply_compute_profile).with(modifier)
+  end
+
+  def last_record
+    Host.unscoped.order(:id).last
   end
 
   test "should get index" do
@@ -962,11 +967,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     end
   end
 
-  private
-
-  def last_record
-    Host.unscoped.order(:id).last
-  end
 
   test "host with two interfaces should get ips assigned on both interfaces" do
     disable_orchestration

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -269,8 +269,11 @@ class HostsControllerTest < ActionController::TestCase
       ComputeResource.any_instance.stubs(:find_vm_by_uuid).raises(ActiveRecord::RecordNotFound)
       host = FactoryBot.create(:host, :with_hostgroup, :with_environment, :on_compute_resource)
       get :vm, params: { :id => host.id }, session: set_session_user
-      expected_body = "<div class=\"alert alert-danger \"><span class=\"pficon pficon-error-circle-o \"></span> <span class=\"text\"><span>Failure: ActiveRecord::RecordNotFound</span></span></div>\n"
-      assert_equal response.body, expected_body
+      expected_body = "<div class=\"alert alert-danger \">"\
+                      "<span class=\"pficon pficon-error-circle-o \"></span>"\
+                      " <span class=\"text\"><span data-original-title=\"Failure: ActiveRecord::RecordNotFound\" rel=\"twipsy\">"\
+                      "Failure: ActiveRecord::RecordNotFound</span></span></div>\n"
+      assert_equal expected_body, response.body
       assert_response :internal_server_error
     end
 

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -181,6 +181,8 @@ class HostJSTest < IntegrationTestWithJavascript
     end
 
     test 'choosing a hostgroup with compute resource works' do
+      require 'fog/libvirt/models/compute/node'
+      Foreman::Model::Libvirt.any_instance.stubs(:hypervisor).returns(Fog::Compute::Libvirt::Node.new(:cpus => 4))
       hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_compute_resource)
       hostgroup.subnet.update!(ipam: IPAM::MODES[:db])
       compute_profile = FactoryBot.create(:compute_profile, :with_compute_attribute, :compute_resource => hostgroup.compute_resource)
@@ -189,8 +191,6 @@ class HostJSTest < IntegrationTestWithJavascript
       compute_attributes.vm_attrs['cpus'] = '2'
       compute_attributes.save
 
-      require 'fog/libvirt/models/compute/node'
-      Foreman::Model::Libvirt.any_instance.stubs(:hypervisor).returns(Fog::Compute::Libvirt::Node.new(:cpus => 4))
 
       visit new_host_path
       select2(hostgroup.name, :from => 'host_hostgroup_id')

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3324,6 +3324,8 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'set_hostgroup_defaults doesnt touch compute attributes' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(true)
+      Host::Managed.any_instance.stubs(:compute_update_required?).returns(false)
       host = FactoryBot.create(:host, :managed, :compute_resource => compute_resources(:one), :hostgroup => @group1)
       assert_not_equal 4, host.compute_attributes['cpus']
 
@@ -3333,6 +3335,8 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'set_compute_attributes changes the compute attributes' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(true)
+      Host::Managed.any_instance.stubs(:compute_update_required?).returns(false)
       host = FactoryBot.create(:host, :managed, :compute_resource => compute_resources(:one), :hostgroup => @group1)
       assert_not_equal 4, host.compute_attributes['cpus']
       host.attributes = host.apply_inherited_attributes('hostgroup_id' => @group2.id)

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -184,6 +184,8 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
       test "it checks the image belongs to the compute resource" do
         @host.provision_method = 'image'
         @host.compute_attributes = { :image_id => @image.uuid }
+        @host.stubs(:vm_exists?).returns(true)
+        @host.stubs(:compute_update_required?).returns(false)
         assert @host.valid?
 
         @host.compute_attributes = { :image_id => 'not-existing-image' }


### PR DESCRIPTION
(cherry picked from commit 91b8eed6b2b2869e760183a629a50bf0046448aa)
