### PR TITLE
Bug #23291 - fixes double appending of /unattended to proxy url

### DIFF
--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -58,7 +58,7 @@ module Foreman
     end
 
     def foreman_url_from_templates_proxy(proxy)
-      url = ProxyAPI::Template.new(:url => proxy.url).template_url
+      url = proxy.template_url
       if url.nil?
         template_logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
         url = proxy.url


### PR DESCRIPTION
Removed the double invocation of the Template class which solves the double appending of "unattended/" to the proxy template URL