### PR TITLE
Fixes #22416 - Taxonomy buttons visible for right taxonomies

### DIFF
--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -26,10 +26,10 @@
         <td><%= link_to hosts_count.fetch(taxonomy.id, 0), hosts_path(:search => "#{controller_name.singularize} = \"#{taxonomy}\"") %></td>
         <td>
           <%= action_buttons(
-            display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
-            display_link_if_authorized(_("Nest"), hash_for_nest_taxonomy_path(taxonomy) ),
-            display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy) ),
-            display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :data => { :confirm => taxonomy.hosts.count.zero? ? _("Delete %s?") % taxonomy.name : n_("%{taxonomy_type} %{taxonomy_name} has %{count} host that will need to be reassociated after deletion. Delete %{taxonomy_name2}?", "%{taxonomy_type} %{taxonomy_name} has %{count} hosts that will need to be reassociated after deletion. Delete %{taxonomy_name2}?", taxonomy.hosts.count) % {:taxonomy_type => taxonomy_title, :taxonomy_name => taxonomy.name, :count => taxonomy.hosts.count, :taxonomy_name2 => taxonomy.name}}, :action => :destroy),
+            display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy).merge(:auth_object => taxonomy) ),
+            display_link_if_authorized(_("Nest"), hash_for_nest_taxonomy_path(taxonomy).merge(:auth_object => taxonomy) ),
+            display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy).merge(:auth_object => taxonomy) ),
+            display_delete_if_authorized(hash_for_taxonomy_path(taxonomy).merge(:auth_object => taxonomy), :data => { :confirm => taxonomy.hosts.count.zero? ? _("Delete %s?") % taxonomy.name : n_("%{taxonomy_type} %{taxonomy_name} has %{count} host that will need to be reassociated after deletion. Delete %{taxonomy_name2}?", "%{taxonomy_type} %{taxonomy_name} has %{count} hosts that will need to be reassociated after deletion. Delete %{taxonomy_name2}?", taxonomy.hosts.count) % {:taxonomy_type => taxonomy_title, :taxonomy_name => taxonomy.name, :count => taxonomy.hosts.count, :taxonomy_name2 => taxonomy.name}}, :action => :destroy),
             (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
             (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,
                 assign_all_hosts_taxonomy_path(taxonomy),


### PR DESCRIPTION

User that can edit a specific location (using the name = foo filter), can now do actions only for location or organizations which can really edit.