### PR TITLE
Fixes #24220 - increase recommended pool size for the db

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -3,7 +3,7 @@
 development:
   adapter: sqlite3
   database: db/development.sqlite3
-  pool: 5
+  pool: 10
   timeout: 5000
 
 # Warning: The database defined as "test" will be erased and
@@ -12,11 +12,11 @@ development:
 test:
   adapter: sqlite3
   database: db/test.sqlite3
-  pool: 5
+  pool: 10
   timeout: 5000
 
 production:
   adapter: sqlite3
   database: db/production.sqlite3
-  pool: 5
+  pool: 10
   timeout: 5000


### PR DESCRIPTION
Since Rails 5, it seems the webrick is not limited on single request at
a time, which leads to 500s when loading the dasboards, especially with
plugins.

Suggesting to increse the default pool size in the database.yml
to avoid users running into this.