### PR TITLE
Fixes #21833 - added bootsnap development dependency

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -15,4 +15,5 @@ group :development do
   gem 'spring', '>= 1.0', '< 3'
   gem 'benchmark-ips'
   gem 'foreman'
+  gem('bootsnap', :require => false)
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,5 +2,8 @@ require 'rubygems'
 
 unless File.exist?(File.expand_path('../Gemfile.in', __dir__))
   ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-  require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+  # Set up boootsnap on Ruby 2.3+ in development env with Bundler enabled and development group
+  early_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+  require 'active_support/dependencies'
+  require('bootsnap/setup') if early_env == "development" && File.exist?(ENV['BUNDLE_GEMFILE']) && !Gem::Specification.stubs_for("bootsnap").empty?
 end


### PR DESCRIPTION
This is another try to enable Bootsnap, which is not turned on for new Rails applications in version 5. Now it works, but all plugins must have this change which was breaking Bootsnap:

https://github.com/theforeman/foreman_bootdisk/pull/66/files

I am only aware of Bootdisk plugin doing this.

With Spring preloader disabled here are times to boot Rails console of my Foreman (Discovery, Bootdisk, Templates plugins):

* without bootsnap: 11.9 sec
* with bootsnap: 8 sec (2nd run)

Bootsnap works well with Spring, I just disabled it to see the difference. It should be much bigger once Katello and other plugins are installed.

For tests, I don't see much of an improvement tho, we might be cleaning cache before tests.

* without bootsnap: 32m29,838s
* with bootsnap: 28m0,364s (2nd run)