### PR TITLE
Fixes #20992 - keep selected roles

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -50,7 +50,7 @@ module FormHelper
   def multiple_checkboxes(f, attr, klass, associations, options = {}, html_options = {})
     association_name = attr || ActiveModel::Naming.plural(associations)
     associated_obj = klass.send(association_name)
-    selected_ids = associated_obj.select("#{associations.table_name}.id").map(&:id)
+    selected_ids = options.delete(:selected_ids) || associated_obj.map(&:id)
     multiple_selects(f, attr, associations, selected_ids, options, html_options)
   end
 


### PR DESCRIPTION
To reproduce, just go to new user form, select some roles but don't set name, click submit. You see validation errors and roles selection disappeared. The problem is that the multiple_checkboxes tries to smartly load selected ids with limiting SQL record to only select ids. That does not work on `has_many :through` so I added new option that we can use to pass selected values to the helper. That can be useful elsewhere too.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
