### PR TITLE
Fixes #21778 - ignore tax scope when displaying filters

### DIFF
--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -55,6 +55,10 @@ module Api
         process_response @filter.destroy
       end
 
+      def resource_scope(*args)
+        resource_class.unscoped
+      end
+
       private
 
       def allowed_nested_id

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -6,7 +6,7 @@ class FiltersController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    @filters = resource_base.includes(:role, :permissions).search_for(params[:search], :order => params[:order])
+    @filters = resource_base.unscoped.includes(:role, :permissions).search_for(params[:search], :order => params[:order])
     @filters = @filters.paginate(:page => params[:page], :per_page => params[:per_page]) unless params[:paginate] == 'client'
     @roles_authorizer = Authorizer.new(User.current, :collection => @filters.map(&:role_id))
   end


### PR DESCRIPTION
---


Steps to Reproduce:
1. Login with admin
2. Navigate to Administer -> Roles 
3. Create role cloning Organization admin role
4. Create user providing location, organization and created role 
5. Login with created user
6. Create test role
7. Edit role to add new filter
8. Click on role to see added filters.

This is caused by the fact, filters are hidden by Taxonomix but in fact these are global resources. They are taxable because of authorization.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
