### PR TITLE
Fixes #24269 - clean all reports

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -922,9 +922,9 @@ class Host::Managed < Host::Base
   # For performance reasons logs and reports are deleted in batch
   # see http://projects.theforeman.org/issues/8316 for details
   def remove_reports
-    return if reports.empty?
-    Log.where("report_id IN (#{reports.pluck(:id).join(',')})").delete_all
-    Report.where("host_id = #{id}").delete_all
+    host_reports = Report.where(host_id: id)
+    Log.where(report_id: host_reports.pluck(:id)).delete_all
+    host_reports.delete_all
   end
 
   def clear_puppetinfo


### PR DESCRIPTION
The problem with the method was that it uses `.reports` which operates only on ConfigReport models (reports are STIed). Later it cleared all reports, e.g. arf_reports. In fact, it should clean all report types so should always work with Report parent class.

@snagoor mind to try applying the patch on your reproducer and let us know if it works? cc @xprazak2 for review as you're already familiar with the issue.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
