### PR TITLE
Fixes #24279 - Remove leftover handle_ca from ssh provisioning

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -23,8 +23,6 @@ module Orchestration::SSHProvision
                  :action => [self, :setSSHProvisionScript])
     post_queue.create(:name   => _("Wait for %s to come online") % self, :priority => 2001,
                  :action => [self, :setSSHWaitForResponse])
-    post_queue.create(:name   => _("Enable certificate generation for %s") % self, :priority => 2002,
-                 :action => [self, :setSSHCert])
     post_queue.create(:name   => _("Configure instance %s via SSH") % self, :priority => 2003,
                  :action => [self, :setSSHProvision])
   end
@@ -60,24 +58,6 @@ module Orchestration::SSHProvision
   end
 
   def delSSHWaitForResponse
-  end
-
-  def setSSHCert
-    self.handle_ca
-    return false if errors.any?
-    logger.info "Revoked old certificates and enabled autosign"
-    true
-  end
-
-  def delSSHCert
-    # since we enable certificates/autosign via here, we also need to make sure we clean it up in case of an error
-    if puppetca?
-      respond_to?(:initialize_puppetca, true) && initialize_puppetca && delCertificate && delAutosign
-    else
-      true
-    end
-  rescue => e
-    failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
   def setSSHProvision


### PR DESCRIPTION
`handle_ca` wasn't removed [here](https://github.com/theforeman/foreman/pull/5580/files), which is causing ssh provisioning to fail.
Since `handle_ca` was the only substantial piece of logic in `setSSHCert`, I've removed the entire function and its call.