### PR TITLE
[WIP] handle webpacked plugins without sources

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -20,8 +20,8 @@ module ReactjsHelper
   end
 
   def all_webpacked_plugins
-    Foreman::Plugin.registered_plugins.values.select do |plugin|
-      File.exist? File.join(plugin.path, 'webpack/index.js')
+    Foreman::Plugin.all.select do |plugin|
+      File.exist?(File.join(plugin.path, 'webpack/index.js')) || plugin.webpack_manifest_path
     end
   end
 

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -164,6 +164,11 @@ module Foreman #:nodoc:
       "Foreman plugin: #{id}, #{version}, #{author}, #{description}"
     end
 
+    def webpack_manifest_path
+      manifest_path = File.join(self.path, 'public', 'webpack', self.id.to_s, 'manifest.json')
+      File.file?(manifest_path) ? manifest_path : nil
+    end
+
     # Sets a requirement on Foreman version
     # Raises a PluginRequirementError exception if the requirement is not met
     # matcher format is gem dependency format

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -111,9 +111,9 @@ Foreman::Application.configure do |app|
         webpack_manifest = JSON.parse(File.read(webpack_manifest_file))
 
         Foreman::Plugin.all.each do |plugin|
-          manifest_path = File.join(plugin.path, 'public', 'webpack', plugin.id.to_s, 'manifest.json')
+          manifest_path = plugin.webpack_manifest_path
 
-          if File.file?(manifest_path)
+          if manifest_path
             Rails.logger.debug { "Loading #{plugin.id} webpack asset manifest from #{manifest_path}" }
             assets = JSON.parse(File.read(manifest_path))
 


### PR DESCRIPTION
In a production setup the webpack sources might not be present. In that
case there is a manifest which we can test for.