### PR TITLE
fixes #23291 - fixes double appending of /unattended to proxy url

### DIFF
--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -58,7 +58,7 @@ module Foreman
     end
 
     def foreman_url_from_templates_proxy(proxy)
-      url = ProxyAPI::Template.new(:url => proxy.url).template_url
+      url = proxy.template_url
       if url.nil?
         template_logger.warn("unable to obtain template url set by proxy #{proxy.url}. falling back on proxy url.")
         url = proxy.url


### PR DESCRIPTION
Removed the double invocation of the Template class which solves the double appending of "unattended/" to the proxy template URL
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
