### PR TITLE
Fixes #24298 - Some audits show 'Missing ID' instead of name

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -3,7 +3,7 @@ module AuditsHelper
                     Location Organization Domain Subnet SmartProxy AuthSource Image Role Usergroup Bookmark ConfigGroup Ptable)
 
   # lookup the Model representing the numerical id and return its label
-  def id_to_label(name, change, truncate = true)
+  def id_to_label(name, change, audit: @audit, truncate: true)
     return _("N/A") if change.nil?
     case name
       when "ancestry"
@@ -12,13 +12,13 @@ module AuditsHelper
         label = change.to_s(:short)
       when /.*_id$/
         begin
-          label = key_to_class(name)&.find(change)&.to_label
+          label = key_to_class(name, audit)&.find(change)&.to_label
         rescue NameError
           # fallback to the value only instead of N/A that is in generic rescue below
           return _("Missing(ID: %s)") % change
         end
       when /.*_ids$/
-        existing = key_to_class(name)&.where(id: change)&.index_by(&:id)
+        existing = key_to_class(name, audit)&.where(id: change)&.index_by(&:id)
         label = change.map do |id|
           if existing&.has_key?(id)
             existing[id].to_label
@@ -77,7 +77,10 @@ module AuditsHelper
           to = HostStatus::Global.new(base[1]).to_label
           _("Global status changed from %{from} to %{to}") % { :from => from, :to => to }
         else
-          _("%{name} changed from %{label1} to %{label2}") % { :name => name.humanize, :label1 => id_to_label(name, change[0]), :label2 => id_to_label(name, change[1]) }
+          _("%{name} changed from %{label1} to %{label2}") % {
+            :name => name.humanize,
+            :label1 => id_to_label(name, change[0], audit: audit),
+            :label2 => id_to_label(name, change[1], audit: audit) }
         end
       end
     elsif !main_object? audit
@@ -237,7 +240,8 @@ module AuditsHelper
     MAIN_OBJECTS.include?(type)
   end
 
-  def key_to_class(key)
-    @audit.auditable_type.constantize.reflect_on_association(key.sub(/_id(s?)$/, '\1'))&.klass
+  def key_to_class(key, audit)
+    auditable_type = (audit.auditable_type == 'Host::Base') ? 'Host::Managed' : audit.auditable_type
+    auditable_type.constantize.reflect_on_association(key.sub(/_id(s?)$/, '\1'))&.klass
   end
 end

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -84,10 +84,10 @@
             <td><%= name.humanize %></td>
             <% if @audit.action == 'update' %>
               <% change.each do |v| %>
-                <td><%= id_to_label(name,v,false) %></td>
+                <td><%= id_to_label(name, v, truncate: false) %></td>
               <% end %>
             <% else %>
-              <td><%= id_to_label(name,change,false) %></td>
+              <td><%= id_to_label(name, change, truncate: false) %></td>
             <% end %>
           </tr>
         <% end %>


### PR DESCRIPTION
This happens when you're visiting the index page. The helper relies on
'@audit' to generate some of the audits. This does not work, since
@audit is only set when you view the details page of an audit.

For this reason, as an example changing fields of a host with
associations, like the puppet proxy, does not show the proper value in
the index, but it does show the proper value on the details page.

See the issue in Redmine for a reproduced with Katello sync plans. It's easily reproducible with any host attribute in plain Foreman too.

Before
![screenshot from 2018-07-19 12-34-53](https://user-images.githubusercontent.com/598891/42937890-b51d6cbe-8b50-11e8-91ff-a940cfd756b8.png)
After:
![screenshot from 2018-07-19 12-36-15](https://user-images.githubusercontent.com/598891/42937889-b4f0cd08-8b50-11e8-920b-f82931a0ae38.png)

Actually I think there's an issue with the fix still - please hold off from merging for the time being.