### PR TITLE
Extract updated translations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "$": true,
     "_": true,
     "__": true,
+    "n__": true,
     "d3": true
   },
   "parser": "babel-eslint",

--- a/locale/ca/foreman.po
+++ b/locale/ca/foreman.po
@@ -26,7 +26,10 @@ msgstr "Suprimeix"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -85,6 +88,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr ""
 
@@ -111,6 +117,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "fa %s mes"
 msgstr[1] "fa %s mesos"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s amfitrions seleccionats"
@@ -270,6 +279,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr ""
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Miscel·lani)"
@@ -450,9 +464,6 @@ msgstr "Afegeix un paràmetre"
 msgid "Add SSH Key"
 msgstr "Afegeix un clau SSH"
 
-msgid "Add SSH Key for %s"
-msgstr "Afegeix un clau SSH per %s"
-
 msgid "Add SSH key"
 msgstr "Afegeix un clau SSH"
 
@@ -528,6 +539,12 @@ msgstr "Adreça de correu electrònic de l'administrador"
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alerta"
 
@@ -542,9 +559,6 @@ msgstr "Tot"
 
 msgid "All Hosts"
 msgstr "Tots els amfitrions"
-
-msgid "All Puppet Classes for %s"
-msgstr "Totes les classes de Puppet per %s"
 
 msgid "All Reports"
 msgstr "Tots els informes"
@@ -803,6 +817,12 @@ msgstr ""
 
 msgid "Audit Comment"
 msgstr "Comentari d'auditoria"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Resum de l'auditoria"
@@ -1114,14 +1134,26 @@ msgstr "Franja horària del navegador"
 msgid "Build"
 msgstr "Construeix"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Construeix els amfitrions"
 
 msgid "Build PXE Default"
 msgstr ""
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Construeix des de la imatge del SO"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1252,6 +1284,9 @@ msgstr ""
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Xassís"
 
@@ -1297,6 +1332,12 @@ msgstr "Classes"
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr ""
 
@@ -1305,9 +1346,6 @@ msgstr "Feu clic per afegir %s"
 
 msgid "Click to log in again."
 msgstr "Feu clic per tornar a iniciar la sessió."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Feu clic per suprimir %s"
@@ -1428,6 +1466,10 @@ msgstr "Descripció"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1677,6 +1719,9 @@ msgstr "Crea un servidor intermediari"
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "Crea un reialme"
 
@@ -1800,6 +1845,9 @@ msgstr "Crea una variable intel·ligent"
 msgid "Create a subnet"
 msgstr "Crea una subxarxa"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Crea un usuari"
 
@@ -1839,6 +1887,9 @@ msgstr ""
 msgid "Create autosign entry"
 msgstr "Crea una entrada autosign"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Crea un volum d'arrencada nou a partir de la imatge"
 
@@ -1852,6 +1903,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2028,9 +2082,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Suprimeix els amfitrions"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr ""
 
@@ -2124,8 +2175,14 @@ msgstr "Suprimeix una variable intel·ligent"
 msgid "Delete a subnet"
 msgstr "Suprimeix una subxarxa"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Suprimeix una combinació de plantilles"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Suprimeix un usuari"
@@ -2265,10 +2322,16 @@ msgstr "Visualitza les diferències"
 msgid "Disable Notifications"
 msgstr "inhabilita les notificacions"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Inhabilita les alertes per als amfitrions seleccionats"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2399,47 +2462,11 @@ msgstr "Edita"
 msgid "Edit %s"
 msgstr "Edita %s"
 
-msgid "Edit Architecture"
-msgstr "Edita l'arquitectura"
-
-msgid "Edit Bookmark"
-msgstr "Edita l'adreça d'interès"
-
 msgid "Edit Compute profile"
 msgstr "Edita el perfil computacional"
 
-msgid "Edit Compute profile: %s"
-msgstr "Edita el perfil computacional: %s"
-
-msgid "Edit Config group"
-msgstr "Edita el grup de configuracions"
-
-msgid "Edit Domain"
-msgstr "Edita el domini"
-
-msgid "Edit Environment"
-msgstr "Edita l'entorn"
-
-msgid "Edit Filter"
-msgstr "Edita el filtre"
-
-msgid "Edit Global Parameter"
-msgstr "Edita els paràmetres globals"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "Edita l'amfitrió"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Edita l'origen d'autenticació LDAP"
-
-msgid "Edit Medium"
-msgstr "Edita el mitjà"
-
-msgid "Edit Model"
-msgstr "Edita el model"
 
 msgid "Edit Operating System"
 msgstr "Edita el sistema operatiu"
@@ -2447,23 +2474,11 @@ msgstr "Edita el sistema operatiu"
 msgid "Edit Parameters"
 msgstr "Edita els paràmetres"
 
-msgid "Edit Partition Table"
-msgstr "Edita la taula de particions"
-
 msgid "Edit Properties"
 msgstr "Edita les propietats"
 
-msgid "Edit Proxy"
-msgstr "Edita el servidor intermediari"
-
 msgid "Edit Puppet Class %s"
 msgstr "Edita la classe de Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Edita el reialme"
-
-msgid "Edit Role"
-msgstr "Edita el rol"
 
 msgid "Edit Smart Variable"
 msgstr "Edita la variable intel·ligent"
@@ -2471,23 +2486,8 @@ msgstr "Edita la variable intel·ligent"
 msgid "Edit Smart class parameters"
 msgstr "Edita els paràmetres de la classe intel·ligent"
 
-msgid "Edit Subnet"
-msgstr "Edita la subxarxa"
-
-msgid "Edit Template"
-msgstr "Edita la plantilla"
-
 msgid "Edit Trend %s"
 msgstr "Edita la tendència %s"
-
-msgid "Edit User"
-msgstr "Edita l'usuari"
-
-msgid "Edit User group"
-msgstr "Edita el grup d'usuaris"
-
-msgid "Edit compute profile on %s"
-msgstr "Edita el perfil computacional en %s"
 
 msgid "Edit this host"
 msgstr "Editeu aquest amfitrió"
@@ -2518,6 +2518,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Habilita les notificacions"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Habilita les alertes per als amfitrions seleccionats"
@@ -2639,6 +2642,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2763,11 +2775,11 @@ msgstr "Nom de l'objecte d'interès"
 msgid "Fact Values"
 msgstr "Valors dels objectes d'interès"
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "Gràfica de distribució de l'objecte d'interès"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2827,6 +2839,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr ""
 
@@ -2837,9 +2852,6 @@ msgid "Failed to acquire IP addresses from compute resource for %s"
 msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
-msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
 msgstr ""
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
@@ -3021,11 +3033,11 @@ msgstr "Filtra les classes"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtres"
-
-msgid "Filters for role %s"
-msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3138,6 +3150,9 @@ msgstr "Foreman pot utilitzar serveis que estiguin basats en LDAP per a l'autent
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3180,6 +3195,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman crearà l'amfitrió quan es rebi un informe"
 
@@ -3217,9 +3235,6 @@ msgid "Foreman will query the locally configured resolver instead of the SOA/NS 
 msgstr ""
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
-msgstr ""
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
 msgstr ""
 
 msgid "Foreman will update a host's environment from its facts"
@@ -3345,6 +3360,9 @@ msgstr "Variables globals"
 msgid "Good host reports in the last %s"
 msgstr "Amfitrions amb bons informes en els últims %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "ID de projecte de Google"
 
@@ -3370,6 +3388,9 @@ msgid "HTTP(S) proxy"
 msgstr "Servidor intermediari HTTP(S)"
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3403,6 +3424,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3514,6 +3538,10 @@ msgid "Host::Base|Build"
 msgstr "Construcció"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr ""
 
@@ -3540,6 +3568,10 @@ msgstr "Contrasenya de grub"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Fitxer de la imatge"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3675,6 +3707,12 @@ msgid "Hosts created after a puppet run will be placed in the location this fact
 msgstr ""
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
+msgstr ""
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
 msgstr ""
 
 msgid "Hosts in error state"
@@ -4161,6 +4199,9 @@ msgstr "Entrada"
 msgid "Installation Media"
 msgstr "Mitjans d'instal·lació"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configuració del mitjà d'instal·lació"
 
@@ -4345,9 +4386,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "Obteniu més informació sobre això a la documentació."
 
-msgid "Legacy Puppet hostname"
-msgstr "Nom d'amfitrió del llegat de Puppet"
-
 msgid "Length"
 msgstr ""
 
@@ -4410,6 +4448,15 @@ msgstr "Llista totes les auditories"
 
 msgid "List all audits for a given host"
 msgstr "Llista totes les auditories per a un amfitrió donat"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Llista totes les entrades autosign"
@@ -4576,6 +4623,9 @@ msgstr "Llista tots els usuaris"
 msgid "List all users for LDAP authentication source"
 msgstr "Llista tots els usuaris per origen d'autenticació LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Llista tots els usuaris per ubicació"
 
@@ -4636,6 +4686,15 @@ msgstr "Llista tots els entorns per ubicació"
 msgid "List environments per organization"
 msgstr "Llista tots els entorns per organització"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Llista els entorns per entorn"
 
@@ -4647,6 +4706,9 @@ msgstr "Llista els amfitrions per organització"
 
 msgid "List installed plugins"
 msgstr "Llista els connectors instal·lats"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "Llista dels servidors intermediaris HTTP"
@@ -4722,6 +4784,15 @@ msgstr "Llista de les subxarxes per ubicació"
 
 msgid "List of subnets per organization"
 msgstr "Llista de les subxarxes per organització"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Llista els sistemes operatius on estigui establerta aquesta plantilla com a predeterminada"
@@ -4961,6 +5032,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Tipus de màquina"
 
@@ -5159,6 +5242,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Model"
@@ -5239,6 +5325,9 @@ msgstr "Nom del grup d'amfitrions"
 msgid "Name of the parameter"
 msgstr "Nom del paràmetre"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Nom de la variable"
 
@@ -5281,14 +5370,11 @@ msgstr "Tipus de xarxa"
 msgid "New"
 msgstr "Nou"
 
-msgid "New Autosign Entry"
+msgid "New %s"
 msgstr ""
 
-msgid "New Event"
-msgstr "Esdeveniment nou"
-
-msgid "New Events"
-msgstr "Esdeveniments nous"
+msgid "New Autosign Entry"
+msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr "Servidor intermediari HTTP nou"
@@ -5310,9 +5396,6 @@ msgstr "Màquina virtual nova"
 
 msgid "New boot volume size (GB)"
 msgstr "Mida del volum d'arrencada nou (GB)"
-
-msgid "New compute profile on %s"
-msgstr "Nou perfil computacional a %s"
 
 msgid "New filter"
 msgstr "Filtre nou"
@@ -5338,6 +5421,10 @@ msgstr "Opcions de vinculació"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5412,10 +5499,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "No s'han seleccionat subxarxes IPv4"
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6139,9 +6229,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contrasenya"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Contrasenya per a oVirt, EC2, VMware i OpenStack. Clau secreta per a EC2."
 
@@ -6165,6 +6252,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "Contrasenya:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Camí"
@@ -6437,13 +6527,18 @@ msgstr "Nom"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "Fragment"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Servidors intermediaris"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6748,6 +6843,9 @@ msgstr ""
 msgid "Report|Status"
 msgstr "Estat"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "Requereix SSL per als servidors intermediaris intel·ligents"
 
@@ -6755,6 +6853,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7019,9 +7120,6 @@ msgstr "DNS secundari per aquesta subxarxa"
 msgid "Secret Key"
 msgstr "Clau secreta"
 
-msgid "Security group"
-msgstr "Grup de seguretat"
-
 msgid "Security groups"
 msgstr "Grups de seguretat"
 
@@ -7180,7 +7278,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr ""
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7369,6 +7467,9 @@ msgstr "Mostra una variable intel·ligent"
 msgid "Show a subnet"
 msgstr "Mostra una subxarxa"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Mostra un usuari"
 
@@ -7402,6 +7503,9 @@ msgstr "Mostra una notificació de correu electrònic"
 msgid "Show an environment"
 msgstr "Mostra un entorn"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Mostra un grup d'usuaris externs per a l'origen d'autenticació LDAP"
 
@@ -7413,6 +7517,9 @@ msgstr "Mostra una imatge"
 
 msgid "Show an interface for host"
 msgstr "Mostra una interfície per a l'amfitrió"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Mostra un sistema operatiu"
@@ -7495,9 +7602,6 @@ msgstr "Servidors intermediaris intel·ligents"
 msgid "Smart Proxy"
 msgstr "Servidor intermediari intel·ligent"
 
-msgid "Smart Proxy: %s"
-msgstr "Servidor intermediari intel·ligent: %s"
-
 msgid "Smart Variables"
 msgstr "Variables intel·ligents"
 
@@ -7511,6 +7615,9 @@ msgstr "Servidor intermediari intel·ligent"
 msgid "Smart proxy IDs"
 msgstr "Els ID dels servidors intermediaris intel·ligents"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7523,11 +7630,18 @@ msgid "SmartProxy|Name"
 msgstr "Nom"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "Fragment"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7560,6 +7674,9 @@ msgid "Sorry but no templates were configured."
 msgstr "Ho sento, però no s'ha configurat cap plantilla."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
+msgstr ""
+
+msgid "Sort field and order, eg. ‘id DESC’"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7667,6 +7784,9 @@ msgstr "Els ID de les subxarxes"
 msgid "Subnet description"
 msgstr "Descripció de la subxarxa"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nom de la subxarxa"
 
@@ -7710,6 +7830,10 @@ msgstr "IPAM"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Màscara"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7831,6 +7955,21 @@ msgid "TFTP server"
 msgstr "Servidor TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr ""
 
@@ -7933,6 +8072,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7942,6 +8093,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8378,6 +8533,9 @@ msgstr ""
 msgid "Token"
 msgstr "Testimoni"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Duració del testimoni"
 
@@ -8441,7 +8599,7 @@ msgstr "Tendències"
 msgid "Trends for %s"
 msgstr "Tendències per %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8539,6 +8697,9 @@ msgid "Unable to connect"
 msgstr ""
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8751,6 +8912,12 @@ msgstr ""
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8880,6 +9047,9 @@ msgstr "Actualitza una arquitectura"
 msgid "Update an environment"
 msgstr "Actualitza un entorn"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Actualitza una imatge"
 
@@ -8931,8 +9101,14 @@ msgstr ""
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Puja els objectes d'interès per a un amfitrió, creant el nou amfitrió si fos necessari"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "Utilitza els grups de xarxa NIS en comptes dels grups posix."
@@ -8942,6 +9118,9 @@ msgstr "Utilitza UUID per als certificats"
 
 msgid "Use short name for VMs"
 msgstr "Utilitza el nom curt per a les MV"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Utilitza aquest compte per autenticar, <i>opcional</i>"
@@ -8967,6 +9146,9 @@ msgstr "Grups d'usuaris"
 
 msgid "User IDs"
 msgstr "ID d'usuaris"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr ""
@@ -9118,6 +9300,9 @@ msgstr ""
 
 msgid "VLAN ID for this subnet"
 msgstr "ID de VLAN per aquesta subxarxa"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr ""
@@ -9334,7 +9519,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9419,6 +9604,9 @@ msgstr ""
 
 msgid "You are not authorized to perform this action."
 msgstr "No esteu autoritzat a realitzar aquesta acció."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Esteu intentant de suprimir el vostre propi compte"
@@ -9612,6 +9800,9 @@ msgstr "no es pot suprimir des d'un compte intern protegit"
 msgid "cannot be removed from the last admin account"
 msgstr "No es pot suprimir des de l'últim compte d'administració"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "clona"
 
@@ -9729,6 +9920,9 @@ msgstr "filtre per al rol %s"
 msgid "filter results"
 msgstr "filtra els resultats"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "només per a EC2"
 
@@ -9743,6 +9937,9 @@ msgstr "només per a OpenStack"
 
 msgid "for VMware"
 msgstr "per a VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "per a oVirt, VMware Datacenter"
@@ -9894,7 +10091,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9937,8 +10134,7 @@ msgstr "enllaça el grup d'usuaris externs amb aquest grup d'usuaris"
 msgid "list"
 msgstr "llista"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Català"
 
@@ -9947,6 +10143,12 @@ msgstr "ubicació"
 
 msgid "locations"
 msgstr "ubicacions"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "l'amfitrió gestionat ha de tenir una interfície d'aprovisionament"
@@ -10010,6 +10212,9 @@ msgstr "ha de proporcionar un proveïdor"
 
 msgid "must set host and port"
 msgstr "s'han d'establir l'amfitrió i el port"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "nou"
@@ -10206,9 +10411,6 @@ msgstr "algunes interfícies no són vàlides"
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "ordena els resultats"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr ""
 
@@ -10306,6 +10508,9 @@ msgstr "vàlid"
 msgid "valid or pending"
 msgstr "vàlid o pendent"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10314,6 +10519,9 @@ msgstr "virtual"
 
 msgid "virtual attached to %s"
 msgstr "virtual adjuntat a %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/de/foreman.po
+++ b/locale/de/foreman.po
@@ -47,7 +47,10 @@ msgstr "Entfernen"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -106,6 +109,9 @@ msgid_plural "%s error messages"
 msgstr[0] "%s Fehlermeldung"
 msgstr[1] "%s Fehlermeldungen"
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s ist nun nicht mehr der VM zugewiesen"
 
@@ -132,6 +138,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "vor %s Monat"
 msgstr[1] "vor %s Monaten"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s ausgewählte Hosts"
@@ -291,6 +300,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' ist in der API v2 für POST- und PUT-Anfragen nicht unterstützt. Bitte verwenden Sie als 'Content-Type: application/json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Verschiedenes)"
@@ -475,9 +489,6 @@ msgstr "Parameter hinzufügen"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -553,6 +564,12 @@ msgstr "Administrator-E-Mail-Adresse"
 msgid "Administrator user account required"
 msgstr "Benutzer-Account mit Administratorrechten erforderlich"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Warnung"
 
@@ -567,9 +584,6 @@ msgstr "Alle"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Alle Puppet-Klassen für %s"
 
 msgid "All Reports"
 msgstr "Alle Berichte"
@@ -828,6 +842,12 @@ msgstr "Audit"
 
 msgid "Audit Comment"
 msgstr "Auditkommentar"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Auditzusammenfassung"
@@ -1139,14 +1159,26 @@ msgstr "Browser-Zeitzone"
 msgid "Build"
 msgstr "Erstellen"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Hosts erstellen"
 
 msgid "Build PXE Default"
 msgstr "PXE-Standard erstellen"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Von Betriebssytemabbild erstellen"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1277,6 +1309,9 @@ msgstr "Geänderte Umgebungen"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1322,6 +1357,12 @@ msgstr "Klassen"
 msgid "Clean up failed deployment"
 msgstr "Deployment fehlgeschlagen wegen Cleanup"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Klicken Sie auf den Link einer Rechenressource, um dessen Standard-VM-Attribute zu bearbeiten"
 
@@ -1330,9 +1371,6 @@ msgstr "Klicken, um %s hinzuzufügen"
 
 msgid "Click to log in again."
 msgstr "Klicken um erneut anzumelden."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Klicken um %s zu entfernen"
@@ -1453,6 +1491,10 @@ msgstr "Beschreibung"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1702,6 +1744,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1825,6 +1870,9 @@ msgstr "Smart-Variable erstellen"
 msgid "Create a subnet"
 msgstr "Subnetz erstellen"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Einen Benutzer erstellen"
 
@@ -1864,6 +1912,9 @@ msgstr "Überschreibungswert für eine bestimmte Smart-Variable erzeugen"
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Neues Boot Volumen von Abbild erstellen"
 
@@ -1878,6 +1929,9 @@ msgstr "Realm-Eintrag für %s erstellen"
 
 msgid "Created"
 msgstr "Erstellt"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Strg-Alt-Entf"
@@ -2053,9 +2107,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Hosts löschen"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Puppet-CA-Zertifikate für %s löschen"
 
@@ -2149,8 +2200,14 @@ msgstr "Smart-Variable löschen"
 msgid "Delete a subnet"
 msgstr "Subnetz löschen"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Vorlagenkombination löschen"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Benutzer löschen"
@@ -2290,10 +2347,16 @@ msgstr "Unterschiede anzeigen"
 msgid "Disable Notifications"
 msgstr "Benachrichtigungen deaktivieren"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Benachrichtigungen für ausgewählte Systeme deaktivieren"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2424,47 +2487,11 @@ msgstr "Bearbeiten"
 msgid "Edit %s"
 msgstr "%s bearbeiten"
 
-msgid "Edit Architecture"
-msgstr "Architektur bearbeiten"
-
-msgid "Edit Bookmark"
-msgstr "Lesezeichen bearbeiten"
-
 msgid "Edit Compute profile"
 msgstr "Rechenprofil bearbeiten"
 
-msgid "Edit Compute profile: %s"
-msgstr "Rechenprofil bearbeiten: %s"
-
-msgid "Edit Config group"
-msgstr "Konfigurationsgruppe bearbeiten"
-
-msgid "Edit Domain"
-msgstr "Domäne bearbeiten"
-
-msgid "Edit Environment"
-msgstr "Umgebung bearbeiten"
-
-msgid "Edit Filter"
-msgstr "Filter Bearbeiten"
-
-msgid "Edit Global Parameter"
-msgstr "Globale Parameter bearbeiten"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "Host bearbeiten"
-
-msgid "Edit LDAP Auth Source"
-msgstr "LDAP-Authentifizerungsquelle bearbeiten"
-
-msgid "Edit Medium"
-msgstr "Medium bearbeiten"
-
-msgid "Edit Model"
-msgstr "Modell bearbeiten"
 
 msgid "Edit Operating System"
 msgstr "Betriebssystem bearbeiten"
@@ -2472,23 +2499,11 @@ msgstr "Betriebssystem bearbeiten"
 msgid "Edit Parameters"
 msgstr "Parameter bearbeiten"
 
-msgid "Edit Partition Table"
-msgstr "Bearbeite die Partitionstabelle"
-
 msgid "Edit Properties"
 msgstr "Eigenschaften bearbeiten"
 
-msgid "Edit Proxy"
-msgstr "Proxy bearbeiten"
-
 msgid "Edit Puppet Class %s"
 msgstr "Puppet-Klasse %s bearbeiten"
-
-msgid "Edit Realm"
-msgstr "Realm bearbeiten"
-
-msgid "Edit Role"
-msgstr "Rolle bearbeiten"
 
 msgid "Edit Smart Variable"
 msgstr "Smart Variable bearbeiten"
@@ -2496,23 +2511,8 @@ msgstr "Smart Variable bearbeiten"
 msgid "Edit Smart class parameters"
 msgstr "Smart-Klassenparameter bearbeiten"
 
-msgid "Edit Subnet"
-msgstr "Subnetz bearbeiten"
-
-msgid "Edit Template"
-msgstr "Bearbeite Vorlage"
-
 msgid "Edit Trend %s"
 msgstr "Trend %s bearbeiten"
-
-msgid "Edit User"
-msgstr "Benutzer bearbeiten"
-
-msgid "Edit User group"
-msgstr "Benutzergruppe bearbeiten"
-
-msgid "Edit compute profile on %s"
-msgstr "Rechenprofil auf %s bearbeiten"
 
 msgid "Edit this host"
 msgstr "Diesen Host bearbeiten"
@@ -2543,6 +2543,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Benachrichtigungen aktivieren"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Benachrichtigungen für die ausgewählten Hosts aktivieren"
@@ -2664,6 +2667,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2788,11 +2800,11 @@ msgstr "Faktname"
 msgid "Fact Values"
 msgstr "Faktenwerte"
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "Faktendistributionsdiagramm"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2852,6 +2864,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] "Fehlgeschlagene Funktionen: %s"
 msgstr[1] "Fehlgeschlagene Funktionen: %s"
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Fehlgeschlagene Neustarts"
 
@@ -2863,9 +2878,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Fehler beim Löschen der alten Zertifikate oder Hinzufügen des Autosign-Eintrages, Erstellung wird abgebrochen!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Fehler beim Konfigurieren von %{host} zum Starten von %{device}: %{e}"
@@ -3048,11 +3060,11 @@ msgstr "Filterklassen"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filter"
-
-msgid "Filters for role %s"
-msgstr "Filter für Rolle %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3165,6 +3177,9 @@ msgstr "Foreman kann LDAP-basierte Services für Benutzerinformationen und -Auth
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman betrachtet eine Domain und eine DNS-Zone als gleich."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "Foreman-Domänen-Kennung der Schnittstelle. Erforderlich für Primärschnittstellen auf gemanagten Hosts."
 
@@ -3207,6 +3222,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatisiert die Zertifikatssignierung bei der Bereitstellung eines neuen Hosts"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman erstellt den Host, wenn ein Bericht erhalten wird"
 
@@ -3245,9 +3263,6 @@ msgstr "Foreman fragt den lokal konfigurierten Resolver ab anstelle der SOA/NS-E
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman legt dies als standardmäßigen Puppet-Modulpfad fest, falls automatisch keiner gefunden werden kann"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman kürzt Hostnamen auf \"puppet\", wenn diese mit \"puppet\" beginnen"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman aktualisiert die Umgebung eines Hosts basierend auf dessen Fakten"
@@ -3372,6 +3387,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Gute Systemberichte in den letzten %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Projektkennung"
 
@@ -3397,6 +3415,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3431,6 +3452,9 @@ msgstr ""
 
 msgid "Hide all values for this parameter."
 msgstr "Alle Werte für diesen Parameter verbergen."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Diesen Wert verbergen"
@@ -3541,6 +3565,10 @@ msgid "Host::Base|Build"
 msgstr "Build"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Zertifikatsname"
 
@@ -3567,6 +3595,10 @@ msgstr "Grub Pass"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Abbilddatei"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3703,6 +3735,12 @@ msgstr "Hosts, die nach einem Puppet-Durchlauf erstellt wurden, werden an dem vo
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Hosts, die nach einem Puppet-Durchlauf erstellt wurden, werden in der vom Fakt vorgegebenen Organisation abgelegt. Der Inhalt dieses Fakts sollte die vollständige Kennung der Organisation sein."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Systeme im Fehlerzustand"
@@ -4188,6 +4226,9 @@ msgstr "Eingabe"
 msgid "Installation Media"
 msgstr "Installationsmedien"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Konfiguration der Installationsmedien"
 
@@ -4372,9 +4413,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "Mehr dazu in der Dokumentation."
 
-msgid "Legacy Puppet hostname"
-msgstr "Veralteter Puppet-Hostname"
-
 msgid "Length"
 msgstr "Länge"
 
@@ -4437,6 +4475,15 @@ msgstr "Alle Audits auflisten"
 
 msgid "List all audits for a given host"
 msgstr "Alle Audits für einen angegebenen Host auflisten"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Alle Autosign-Einträge auflisten"
@@ -4603,6 +4650,9 @@ msgstr "Alle Benutzer auflisten"
 msgid "List all users for LDAP authentication source"
 msgstr "Aller Benutzer für die LDAP-Authentifizierungsquelle auflisten"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Alle Benutzer für den Standort auflisten"
 
@@ -4663,6 +4713,15 @@ msgstr "Umgebungen pro Standort auflisten"
 msgid "List environments per organization"
 msgstr "Umgebungen pro Organisation auflisten"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Hosts pro Umgebung auflisten"
 
@@ -4674,6 +4733,9 @@ msgstr "Hosts pro Organisation auflisten"
 
 msgid "List installed plugins"
 msgstr "Installierte Plugins auflisten"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4749,6 +4811,15 @@ msgstr "Liste von Subnetzen pro Standort"
 
 msgid "List of subnets per organization"
 msgstr "Liste von Subnetzen pro Organisation"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Betriebssysteme auflisten, für die diese Vorlage als Standard gesetzt ist"
@@ -4988,6 +5059,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr "MAC-basiert"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Systemtyp"
 
@@ -5184,6 +5267,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr "Eine der erforderlichen Berechtigungen fehlt: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modell"
@@ -5264,6 +5350,9 @@ msgstr "Name der Hostgruppe"
 msgid "Name of the parameter"
 msgstr "Name des Parameters"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Name der Variable"
 
@@ -5306,14 +5395,11 @@ msgstr "Netzwerktyp"
 msgid "New"
 msgstr "Neu"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Neuer Autosign-Eintrag"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5335,9 +5421,6 @@ msgstr "Neue virtuelle Maschine"
 
 msgid "New boot volume size (GB)"
 msgstr "Neue Boot Volumen Grösse (GB)"
-
-msgid "New compute profile on %s"
-msgstr "Neues Rechenprofil auf %s"
 
 msgid "New filter"
 msgstr "Neuer Filter"
@@ -5363,6 +5446,10 @@ msgstr "Bond-Optionen"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5437,10 +5524,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "Keine IPv4-Subnetze ausgewählt"
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6164,9 +6254,6 @@ msgstr ""
 msgid "Password"
 msgstr "Passwort"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Passwort für oVirt, EC2, VMware, OpenStack. Geheimer Schlüssel für EC2"
 
@@ -6190,6 +6277,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "Passwort:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Pfad"
@@ -6462,13 +6552,18 @@ msgstr "Name"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "Snippet"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Proxys"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6773,6 +6868,9 @@ msgstr "Berichtet um"
 msgid "Report|Status"
 msgstr "Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "SSL für Smart-Proxys erfordern"
 
@@ -6780,6 +6878,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr "Erforderlicher Parameter ohne Wert.<br/><b>Bitte überschreiben!</b><br/>"
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7044,9 +7145,6 @@ msgstr "Sekundärer DNS für dieses Subnetz"
 msgid "Secret Key"
 msgstr "Geheimer Schlüssel"
 
-msgid "Security group"
-msgstr "Sicherheitsgruppe"
-
 msgid "Security groups"
 msgstr "Sicherheitsgruppen"
 
@@ -7205,7 +7303,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "Zufälliges Passwort für die Verbindung generieren"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7394,6 +7492,9 @@ msgstr "Smart-Variable anzeigen"
 msgid "Show a subnet"
 msgstr "Subnetz anzeigen"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Benutzer anzeigen"
 
@@ -7427,6 +7528,9 @@ msgstr "E-Mail-Benachrichtigung anzeigen"
 msgid "Show an environment"
 msgstr "Umgebung anzeigen"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Externe Benutzergruppe für die LDAP-Authentifizierungsquelle anzeigen"
 
@@ -7438,6 +7542,9 @@ msgstr "Abbild anzeigen"
 
 msgid "Show an interface for host"
 msgstr "Schnittstelle für den Host anzeigen"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Betriebssystem anzeigen"
@@ -7520,9 +7627,6 @@ msgstr "Smart Proxys"
 msgid "Smart Proxy"
 msgstr "Smart Proxy"
 
-msgid "Smart Proxy: %s"
-msgstr "Smart-Proxy: %s"
-
 msgid "Smart Variables"
 msgstr "Smart-Variablen"
 
@@ -7536,6 +7640,9 @@ msgstr "Smart Proxy"
 msgid "Smart proxy IDs"
 msgstr "Smart-Proxy-Kennungen"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7548,11 +7655,18 @@ msgid "SmartProxy|Name"
 msgstr "Name"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7586,6 +7700,9 @@ msgstr "Es wurden keine Vorlagen konfiguriert."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Entschuldigung, diesen Hosts sind keine Parameter zugewiesen, diese müssen zuerst hinzugefügt werden."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7692,6 +7809,9 @@ msgstr "Subnetz-Kennungen"
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Subnetzname"
 
@@ -7735,6 +7855,10 @@ msgstr "Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Maske"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7856,6 +7980,21 @@ msgid "TFTP server"
 msgstr "TFTP-Server"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Besteuerbare Taxonomie"
 
@@ -7958,6 +8097,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7967,6 +8118,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8402,6 +8557,9 @@ msgstr "Umschalten"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Tokendauer"
 
@@ -8465,7 +8623,7 @@ msgstr "Trends"
 msgid "Trends for %s"
 msgstr "Trends für %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8564,6 +8722,9 @@ msgstr "Verbindung kann nicht hergestellt werden"
 
 msgid "Unable to connect to LDAP server"
 msgstr "Unfähig mit LDAP-Server zu verbinden"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Standard-TFTP-Bootmenü konnte nicht erstellt werden"
@@ -8775,6 +8936,12 @@ msgstr "System nicht mehr verwalten"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "Nicht unterstützter IPAM-Modus für %s"
 
@@ -8904,6 +9071,9 @@ msgstr "Architektur aktualisieren"
 msgid "Update an environment"
 msgstr "Umgebung aktualisieren"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Abbild aktualisieren"
 
@@ -8955,8 +9125,14 @@ msgstr "Hosts aktualisiert: Hostgruppe geändert"
 msgid "Updated hosts: changed owner"
 msgstr "Hosts aktualisiert: Besitzer geändert"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Fakten für einen Host hochladen mit Erstellung des Hosts, wenn erforderlich"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8966,6 +9142,9 @@ msgstr "UUID für Zertifikate verwenden"
 
 msgid "Use short name for VMs"
 msgstr "Kurzen Namen für VMs verwenden"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Benutze diesen Zugang für die Authentifizierung, <i>optional</i>"
@@ -8991,6 +9170,9 @@ msgstr "Benutzergruppen"
 
 msgid "User IDs"
 msgstr "Benutzerkennungen"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "Benutzerdaten-Vorlage"
@@ -9142,6 +9324,9 @@ msgstr "VCenter/Server"
 
 msgid "VLAN ID for this subnet"
 msgstr "VLAN-Kennung für dieses Subnetz"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN-Tag, dieses Atttribut hat Vorrang vor der Subnetz-VLAN-Kennung. Nur für virtuelle Schnittstellen."
@@ -9358,7 +9543,7 @@ msgstr "Ob der Klassenparameter von Foreman verwaltet wird."
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Ob der Smart-Klassenparameter von Foreman gemanagt wird"
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9443,6 +9628,9 @@ msgstr "Sie sind nicht berechtigt, eine Vorlage als Standard zu definieren."
 
 msgid "You are not authorized to perform this action."
 msgstr "Sie sind nicht berechtigt, diese Aktion durchzuführen."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Sie versuchen, Ihren eigenen Account zu löschen"
@@ -9636,6 +9824,9 @@ msgstr "kann von einem internen, geschützten Account nicht entfernt werden"
 msgid "cannot be removed from the last admin account"
 msgstr "kann vom letzten Administrator-Account nicht entfernt werden"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "klonen"
 
@@ -9753,6 +9944,9 @@ msgstr "filtere nach Rolle %s"
 msgid "filter results"
 msgstr "Ergebnisse filtern"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "nur für EC2"
 
@@ -9767,6 +9961,9 @@ msgstr "nur für OpenStack"
 
 msgid "for VMware"
 msgstr "für VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "für oVirt, VMware Datacenter"
@@ -9918,7 +10115,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "ist nicht möglich zu ändern"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9961,8 +10158,7 @@ msgstr "externe Benutzergruppe mit dieser Benutzergruppe verknüpfen"
 msgid "list"
 msgstr "Liste"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Deutsch"
 
@@ -9971,6 +10167,12 @@ msgstr "Standort"
 
 msgid "locations"
 msgstr "Standorte"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "gemanagter Host muss eine Bereitstellungsschnittstelle aufweisen"
@@ -10034,6 +10236,9 @@ msgstr "muss einen Provider angeben"
 
 msgid "must set host and port"
 msgstr "muss Host und Port festlegen"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "neu"
@@ -10230,9 +10435,6 @@ msgstr "einige Schnittstellen sind ungültig"
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "Ergebnisse sortieren"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "durch Leerzeichen getrennte Optionen, z.B. miimon=100"
 
@@ -10334,6 +10536,9 @@ msgstr "gültig"
 msgid "valid or pending"
 msgstr "gültig oder ausstehend"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10342,6 +10547,9 @@ msgstr "virtuell"
 
 msgid "virtual attached to %s"
 msgstr "virtuell angeschlossen an %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -25,7 +25,10 @@ msgstr ""
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -84,6 +87,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr ""
 
@@ -110,6 +116,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr ""
@@ -269,6 +278,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr ""
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr ""
@@ -447,9 +461,6 @@ msgstr ""
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -525,6 +536,12 @@ msgstr ""
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr ""
 
@@ -538,9 +555,6 @@ msgid "All"
 msgstr ""
 
 msgid "All Hosts"
-msgstr ""
-
-msgid "All Puppet Classes for %s"
 msgstr ""
 
 msgid "All Reports"
@@ -800,6 +814,12 @@ msgid "Audit"
 msgstr ""
 
 msgid "Audit Comment"
+msgstr ""
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
 msgstr ""
 
 msgid "Audit summary"
@@ -1113,13 +1133,25 @@ msgstr ""
 msgid "Build"
 msgstr ""
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr ""
 
 msgid "Build PXE Default"
 msgstr ""
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
+msgstr ""
+
+msgid "Build in progress"
 msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
@@ -1252,6 +1284,9 @@ msgstr "Environment"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr ""
 
@@ -1297,6 +1332,12 @@ msgstr ""
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr ""
 
@@ -1304,9 +1345,6 @@ msgid "Click to add %s"
 msgstr ""
 
 msgid "Click to log in again."
-msgstr ""
-
-msgid "Click to mark as read"
 msgstr ""
 
 msgid "Click to remove %s"
@@ -1428,6 +1466,10 @@ msgstr "Description"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1677,6 +1719,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1800,6 +1845,9 @@ msgstr ""
 msgid "Create a subnet"
 msgstr ""
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr ""
 
@@ -1839,6 +1887,9 @@ msgstr ""
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr ""
 
@@ -1852,6 +1903,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2031,9 +2085,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr ""
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr ""
 
@@ -2127,7 +2178,13 @@ msgstr ""
 msgid "Delete a subnet"
 msgstr ""
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
+msgstr ""
+
+msgid "Delete a trend counter"
 msgstr ""
 
 msgid "Delete a user"
@@ -2268,10 +2325,16 @@ msgstr ""
 msgid "Disable Notifications"
 msgstr ""
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr ""
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2404,46 +2467,10 @@ msgstr ""
 msgid "Edit %s"
 msgstr ""
 
-msgid "Edit Architecture"
-msgstr ""
-
-msgid "Edit Bookmark"
-msgstr ""
-
 msgid "Edit Compute profile"
 msgstr ""
 
-msgid "Edit Compute profile: %s"
-msgstr ""
-
-msgid "Edit Config group"
-msgstr ""
-
-msgid "Edit Domain"
-msgstr ""
-
-msgid "Edit Environment"
-msgstr ""
-
-msgid "Edit Filter"
-msgstr ""
-
-msgid "Edit Global Parameter"
-msgstr ""
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
-msgstr ""
-
-msgid "Edit LDAP Auth Source"
-msgstr ""
-
-msgid "Edit Medium"
-msgstr ""
-
-msgid "Edit Model"
 msgstr ""
 
 msgid "Edit Operating System"
@@ -2452,22 +2479,10 @@ msgstr ""
 msgid "Edit Parameters"
 msgstr ""
 
-msgid "Edit Partition Table"
-msgstr ""
-
 msgid "Edit Properties"
 msgstr ""
 
-msgid "Edit Proxy"
-msgstr ""
-
 msgid "Edit Puppet Class %s"
-msgstr ""
-
-msgid "Edit Realm"
-msgstr ""
-
-msgid "Edit Role"
 msgstr ""
 
 msgid "Edit Smart Variable"
@@ -2476,23 +2491,7 @@ msgstr ""
 msgid "Edit Smart class parameters"
 msgstr ""
 
-msgid "Edit Subnet"
-msgstr ""
-
-#, fuzzy
-msgid "Edit Template"
-msgstr "Provisioning template"
-
 msgid "Edit Trend %s"
-msgstr ""
-
-msgid "Edit User"
-msgstr ""
-
-msgid "Edit User group"
-msgstr ""
-
-msgid "Edit compute profile on %s"
 msgstr ""
 
 msgid "Edit this host"
@@ -2523,6 +2522,9 @@ msgid "Enable Caching"
 msgstr ""
 
 msgid "Enable Notifications"
+msgstr ""
+
+msgid "Enable PuppetCA autosigning for %s"
 msgstr ""
 
 msgid "Enable alerts for selected hosts"
@@ -2649,6 +2651,15 @@ msgstr ""
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr ""
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr ""
 
@@ -2771,10 +2782,10 @@ msgstr ""
 msgid "Fact Values"
 msgstr ""
 
-msgid "Fact Values | %{host_name}"
+msgid "Fact distribution chart"
 msgstr ""
 
-msgid "Fact distribution chart"
+msgid "Fact distribution chart - %s "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -2835,6 +2846,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr ""
 
@@ -2845,9 +2859,6 @@ msgid "Failed to acquire IP addresses from compute resource for %s"
 msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
-msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
 msgstr ""
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
@@ -3029,10 +3040,10 @@ msgstr ""
 msgid "Filter overriding has been disabled"
 msgstr ""
 
-msgid "Filters"
+msgid "Filter..."
 msgstr ""
 
-msgid "Filters for role %s"
+msgid "Filters"
 msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
@@ -3143,6 +3154,9 @@ msgstr ""
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3185,6 +3199,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr ""
 
@@ -3222,9 +3239,6 @@ msgid "Foreman will query the locally configured resolver instead of the SOA/NS 
 msgstr ""
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
-msgstr ""
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
 msgstr ""
 
 msgid "Foreman will update a host's environment from its facts"
@@ -3351,6 +3365,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr ""
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr ""
 
@@ -3376,6 +3393,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3409,6 +3429,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3523,6 +3546,10 @@ msgid "Host::Base|Build"
 msgstr "Build mode"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Certificate name"
 
@@ -3549,6 +3576,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Image filename"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3684,6 +3715,12 @@ msgid "Hosts created after a puppet run will be placed in the location this fact
 msgstr ""
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
+msgstr ""
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
 msgstr ""
 
 msgid "Hosts in error state"
@@ -4170,6 +4207,9 @@ msgstr ""
 msgid "Installation Media"
 msgstr ""
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr ""
 
@@ -4354,9 +4394,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr ""
 
-msgid "Legacy Puppet hostname"
-msgstr ""
-
 msgid "Length"
 msgstr ""
 
@@ -4418,6 +4455,15 @@ msgid "List all audits"
 msgstr ""
 
 msgid "List all audits for a given host"
+msgstr ""
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
 msgstr ""
 
 msgid "List all autosign entries"
@@ -4585,6 +4631,9 @@ msgstr ""
 msgid "List all users for LDAP authentication source"
 msgstr ""
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr ""
 
@@ -4645,6 +4694,15 @@ msgstr ""
 msgid "List environments per organization"
 msgstr ""
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr ""
 
@@ -4655,6 +4713,9 @@ msgid "List hosts per organization"
 msgstr ""
 
 msgid "List installed plugins"
+msgstr ""
+
+msgid "List internal authentication sources"
 msgstr ""
 
 msgid "List of HTTP Proxies"
@@ -4730,6 +4791,15 @@ msgid "List of subnets per location"
 msgstr ""
 
 msgid "List of subnets per organization"
+msgstr ""
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
 msgstr ""
 
 msgid "List operating systems where this template is set as a default"
@@ -4970,6 +5040,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr ""
 
@@ -5166,6 +5248,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr ""
@@ -5248,6 +5333,9 @@ msgstr "Host Group"
 msgid "Name of the parameter"
 msgstr ""
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr ""
 
@@ -5290,13 +5378,10 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
-msgstr ""
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
 msgstr ""
 
 msgid "New HTTP Proxy"
@@ -5318,9 +5403,6 @@ msgid "New Virtual Machine"
 msgstr ""
 
 msgid "New boot volume size (GB)"
-msgstr ""
-
-msgid "New compute profile on %s"
 msgstr ""
 
 msgid "New filter"
@@ -5347,6 +5429,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5421,10 +5507,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6154,9 +6243,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr ""
 
@@ -6179,6 +6265,9 @@ msgid "Password used to authenticate with the HTTP Proxy"
 msgstr ""
 
 msgid "Password:"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid "Path"
@@ -6452,13 +6541,18 @@ msgstr ""
 msgid "ProvisioningTemplate|Snippet"
 msgstr ""
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr ""
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6764,6 +6858,9 @@ msgstr "Report time"
 msgid "Report|Status"
 msgstr "Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr ""
 
@@ -6771,6 +6868,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7035,9 +7135,6 @@ msgstr ""
 msgid "Secret Key"
 msgstr ""
 
-msgid "Security group"
-msgstr ""
-
 msgid "Security groups"
 msgstr ""
 
@@ -7198,7 +7295,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr ""
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7387,6 +7484,9 @@ msgstr ""
 msgid "Show a subnet"
 msgstr ""
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr ""
 
@@ -7420,6 +7520,9 @@ msgstr ""
 msgid "Show an environment"
 msgstr ""
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr ""
 
@@ -7430,6 +7533,9 @@ msgid "Show an image"
 msgstr ""
 
 msgid "Show an interface for host"
+msgstr ""
+
+msgid "Show an internal authentication source"
 msgstr ""
 
 msgid "Show an operating system"
@@ -7513,9 +7619,6 @@ msgstr ""
 msgid "Smart Proxy"
 msgstr ""
 
-msgid "Smart Proxy: %s"
-msgstr ""
-
 msgid "Smart Variables"
 msgstr ""
 
@@ -7527,6 +7630,9 @@ msgid "Smart proxy"
 msgstr ""
 
 msgid "Smart proxy IDs"
+msgstr ""
+
+msgid "Smart variables"
 msgstr ""
 
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
@@ -7541,10 +7647,17 @@ msgid "SmartProxy|Name"
 msgstr "Name"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
@@ -7578,6 +7691,9 @@ msgid "Sorry but no templates were configured."
 msgstr ""
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
+msgstr ""
+
+msgid "Sort field and order, eg. ‘id DESC’"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7687,6 +7803,9 @@ msgstr ""
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr ""
 
@@ -7730,6 +7849,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Network mask"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7852,6 +7975,21 @@ msgid "TFTP server"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr ""
 
@@ -7954,6 +8092,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7963,6 +8113,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8393,6 +8547,9 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr ""
 
@@ -8456,7 +8613,7 @@ msgstr ""
 msgid "Trends for %s"
 msgstr ""
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8554,6 +8711,9 @@ msgid "Unable to connect"
 msgstr ""
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8766,6 +8926,12 @@ msgstr ""
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8895,6 +9061,9 @@ msgstr ""
 msgid "Update an environment"
 msgstr ""
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr ""
 
@@ -8946,7 +9115,13 @@ msgstr ""
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
+msgstr ""
+
+msgid "Use APIv4 (experimental)"
 msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
@@ -8956,6 +9131,9 @@ msgid "Use UUID for certificates"
 msgstr ""
 
 msgid "Use short name for VMs"
+msgstr ""
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
 msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
@@ -8981,6 +9159,9 @@ msgid "User Groups"
 msgstr ""
 
 msgid "User IDs"
+msgstr ""
+
+msgid "User Name:"
 msgstr ""
 
 msgid "User data template"
@@ -9134,6 +9315,9 @@ msgid "VCenter/Server"
 msgstr ""
 
 msgid "VLAN ID for this subnet"
+msgstr ""
+
+msgid "VLAN ID is not consistent accross subnets"
 msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
@@ -9351,7 +9535,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9435,6 +9619,9 @@ msgid "You are not authorized to make a template default."
 msgstr ""
 
 msgid "You are not authorized to perform this action."
+msgstr ""
+
+msgid "You are trying access the preferences of a different user"
 msgstr ""
 
 msgid "You are trying to delete your own account"
@@ -9629,6 +9816,9 @@ msgstr ""
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr ""
 
@@ -9746,6 +9936,9 @@ msgstr ""
 msgid "filter results"
 msgstr ""
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr ""
 
@@ -9759,6 +9952,9 @@ msgid "for OpenStack only"
 msgstr ""
 
 msgid "for VMware"
+msgstr ""
+
+msgid "for oVirt only"
 msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
@@ -9911,7 +10107,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9962,6 +10158,12 @@ msgid "location"
 msgstr ""
 
 msgid "locations"
+msgstr ""
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
 msgstr ""
 
 msgid "managed host must have one provision interface"
@@ -10025,6 +10227,9 @@ msgid "must provide a provider"
 msgstr ""
 
 msgid "must set host and port"
+msgstr ""
+
+msgid "name of the table"
 msgstr ""
 
 msgid "new"
@@ -10223,9 +10428,6 @@ msgstr ""
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr ""
-
 msgid "space separated options, e.g. miimon=100"
 msgstr ""
 
@@ -10324,6 +10526,9 @@ msgstr ""
 msgid "valid or pending"
 msgstr ""
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10331,6 +10536,9 @@ msgid "virtual"
 msgstr ""
 
 msgid "virtual attached to %s"
+msgstr ""
+
+msgid "with given ID not found"
 msgstr ""
 
 msgid "yaml"

--- a/locale/en_GB/foreman.po
+++ b/locale/en_GB/foreman.po
@@ -26,7 +26,10 @@ msgstr " Remove"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -85,6 +88,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr ""
 
@@ -111,6 +117,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr ""
@@ -270,6 +279,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr ""
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr ""
@@ -448,9 +462,6 @@ msgstr ""
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -526,6 +537,12 @@ msgstr ""
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr ""
 
@@ -539,9 +556,6 @@ msgid "All"
 msgstr ""
 
 msgid "All Hosts"
-msgstr ""
-
-msgid "All Puppet Classes for %s"
 msgstr ""
 
 msgid "All Reports"
@@ -800,6 +814,12 @@ msgid "Audit"
 msgstr ""
 
 msgid "Audit Comment"
+msgstr ""
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
 msgstr ""
 
 msgid "Audit summary"
@@ -1112,13 +1132,25 @@ msgstr ""
 msgid "Build"
 msgstr ""
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr ""
 
 msgid "Build PXE Default"
 msgstr ""
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
+msgstr ""
+
+msgid "Build in progress"
 msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
@@ -1250,6 +1282,9 @@ msgstr ""
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr ""
 
@@ -1295,6 +1330,12 @@ msgstr ""
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr ""
 
@@ -1302,9 +1343,6 @@ msgid "Click to add %s"
 msgstr ""
 
 msgid "Click to log in again."
-msgstr ""
-
-msgid "Click to mark as read"
 msgstr ""
 
 msgid "Click to remove %s"
@@ -1426,6 +1464,10 @@ msgstr "Description"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1675,6 +1717,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1798,6 +1843,9 @@ msgstr ""
 msgid "Create a subnet"
 msgstr ""
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr ""
 
@@ -1837,6 +1885,9 @@ msgstr ""
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr ""
 
@@ -1850,6 +1901,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2026,9 +2080,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr ""
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr ""
 
@@ -2122,7 +2173,13 @@ msgstr ""
 msgid "Delete a subnet"
 msgstr ""
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
+msgstr ""
+
+msgid "Delete a trend counter"
 msgstr ""
 
 msgid "Delete a user"
@@ -2263,10 +2320,16 @@ msgstr ""
 msgid "Disable Notifications"
 msgstr ""
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr ""
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2397,46 +2460,10 @@ msgstr ""
 msgid "Edit %s"
 msgstr ""
 
-msgid "Edit Architecture"
-msgstr ""
-
-msgid "Edit Bookmark"
-msgstr ""
-
 msgid "Edit Compute profile"
 msgstr ""
 
-msgid "Edit Compute profile: %s"
-msgstr ""
-
-msgid "Edit Config group"
-msgstr ""
-
-msgid "Edit Domain"
-msgstr ""
-
-msgid "Edit Environment"
-msgstr ""
-
-msgid "Edit Filter"
-msgstr ""
-
-msgid "Edit Global Parameter"
-msgstr ""
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
-msgstr ""
-
-msgid "Edit LDAP Auth Source"
-msgstr ""
-
-msgid "Edit Medium"
-msgstr ""
-
-msgid "Edit Model"
 msgstr ""
 
 msgid "Edit Operating System"
@@ -2445,22 +2472,10 @@ msgstr ""
 msgid "Edit Parameters"
 msgstr ""
 
-msgid "Edit Partition Table"
-msgstr ""
-
 msgid "Edit Properties"
 msgstr ""
 
-msgid "Edit Proxy"
-msgstr ""
-
 msgid "Edit Puppet Class %s"
-msgstr ""
-
-msgid "Edit Realm"
-msgstr ""
-
-msgid "Edit Role"
 msgstr ""
 
 msgid "Edit Smart Variable"
@@ -2469,22 +2484,7 @@ msgstr ""
 msgid "Edit Smart class parameters"
 msgstr ""
 
-msgid "Edit Subnet"
-msgstr ""
-
-msgid "Edit Template"
-msgstr ""
-
 msgid "Edit Trend %s"
-msgstr ""
-
-msgid "Edit User"
-msgstr ""
-
-msgid "Edit User group"
-msgstr ""
-
-msgid "Edit compute profile on %s"
 msgstr ""
 
 msgid "Edit this host"
@@ -2515,6 +2515,9 @@ msgid "Enable Caching"
 msgstr ""
 
 msgid "Enable Notifications"
+msgstr ""
+
+msgid "Enable PuppetCA autosigning for %s"
 msgstr ""
 
 msgid "Enable alerts for selected hosts"
@@ -2639,6 +2642,15 @@ msgstr ""
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr ""
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr ""
 
@@ -2761,11 +2773,11 @@ msgstr ""
 msgid "Fact Values"
 msgstr ""
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "Fact distribution chart"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2825,6 +2837,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr ""
 
@@ -2835,9 +2850,6 @@ msgid "Failed to acquire IP addresses from compute resource for %s"
 msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
-msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
 msgstr ""
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
@@ -3019,10 +3031,10 @@ msgstr ""
 msgid "Filter overriding has been disabled"
 msgstr ""
 
-msgid "Filters"
+msgid "Filter..."
 msgstr ""
 
-msgid "Filters for role %s"
+msgid "Filters"
 msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
@@ -3133,6 +3145,9 @@ msgstr ""
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3175,6 +3190,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr ""
 
@@ -3212,9 +3230,6 @@ msgid "Foreman will query the locally configured resolver instead of the SOA/NS 
 msgstr ""
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
-msgstr ""
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
 msgstr ""
 
 msgid "Foreman will update a host's environment from its facts"
@@ -3340,6 +3355,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr ""
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr ""
 
@@ -3365,6 +3383,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3398,6 +3419,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3509,6 +3533,10 @@ msgid "Host::Base|Build"
 msgstr "Build mode"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Certificate name"
 
@@ -3535,6 +3563,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Image filename"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3671,6 +3703,12 @@ msgstr ""
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Hosts created after a puppet run will be placed in the organisation this fact dictates. The content of this fact should be the full label of the organisation."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr ""
@@ -4156,6 +4194,9 @@ msgstr ""
 msgid "Installation Media"
 msgstr ""
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr ""
 
@@ -4340,9 +4381,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "Learn more about this in the documentation."
 
-msgid "Legacy Puppet hostname"
-msgstr ""
-
 msgid "Length"
 msgstr ""
 
@@ -4404,6 +4442,15 @@ msgid "List all audits"
 msgstr ""
 
 msgid "List all audits for a given host"
+msgstr ""
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
 msgstr ""
 
 msgid "List all autosign entries"
@@ -4571,6 +4618,9 @@ msgstr ""
 msgid "List all users for LDAP authentication source"
 msgstr ""
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr ""
 
@@ -4631,6 +4681,15 @@ msgstr ""
 msgid "List environments per organization"
 msgstr "List environments per organisation"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr ""
 
@@ -4641,6 +4700,9 @@ msgid "List hosts per organization"
 msgstr "List hosts per organisation"
 
 msgid "List installed plugins"
+msgstr ""
+
+msgid "List internal authentication sources"
 msgstr ""
 
 msgid "List of HTTP Proxies"
@@ -4717,6 +4779,15 @@ msgstr ""
 
 msgid "List of subnets per organization"
 msgstr "List of subnets per organisation"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr ""
@@ -4956,6 +5027,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr ""
 
@@ -5152,6 +5235,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Model"
@@ -5232,6 +5318,9 @@ msgstr ""
 msgid "Name of the parameter"
 msgstr ""
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr ""
 
@@ -5274,13 +5363,10 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
-msgstr ""
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
 msgstr ""
 
 msgid "New HTTP Proxy"
@@ -5302,9 +5388,6 @@ msgid "New Virtual Machine"
 msgstr ""
 
 msgid "New boot volume size (GB)"
-msgstr ""
-
-msgid "New compute profile on %s"
 msgstr ""
 
 msgid "New filter"
@@ -5331,6 +5414,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5405,10 +5492,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6132,9 +6222,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr ""
 
@@ -6157,6 +6244,9 @@ msgid "Password used to authenticate with the HTTP Proxy"
 msgstr ""
 
 msgid "Password:"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid "Path"
@@ -6430,13 +6520,18 @@ msgstr ""
 msgid "ProvisioningTemplate|Snippet"
 msgstr ""
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr ""
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6741,6 +6836,9 @@ msgstr "Report time"
 msgid "Report|Status"
 msgstr "Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr ""
 
@@ -6748,6 +6846,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7012,9 +7113,6 @@ msgstr ""
 msgid "Secret Key"
 msgstr ""
 
-msgid "Security group"
-msgstr ""
-
 msgid "Security groups"
 msgstr ""
 
@@ -7173,7 +7271,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr ""
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7362,6 +7460,9 @@ msgstr ""
 msgid "Show a subnet"
 msgstr ""
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr ""
 
@@ -7395,6 +7496,9 @@ msgstr ""
 msgid "Show an environment"
 msgstr ""
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr ""
 
@@ -7405,6 +7509,9 @@ msgid "Show an image"
 msgstr ""
 
 msgid "Show an interface for host"
+msgstr ""
+
+msgid "Show an internal authentication source"
 msgstr ""
 
 msgid "Show an operating system"
@@ -7488,9 +7595,6 @@ msgstr ""
 msgid "Smart Proxy"
 msgstr ""
 
-msgid "Smart Proxy: %s"
-msgstr ""
-
 msgid "Smart Variables"
 msgstr ""
 
@@ -7502,6 +7606,9 @@ msgid "Smart proxy"
 msgstr "Smart proxy"
 
 msgid "Smart proxy IDs"
+msgstr ""
+
+msgid "Smart variables"
 msgstr ""
 
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
@@ -7516,10 +7623,17 @@ msgid "SmartProxy|Name"
 msgstr "Name"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
@@ -7553,6 +7667,9 @@ msgid "Sorry but no templates were configured."
 msgstr "Sorry but no templates were configured."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
+msgstr ""
+
+msgid "Sort field and order, eg. ‘id DESC’"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7660,6 +7777,9 @@ msgstr ""
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr ""
 
@@ -7703,6 +7823,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Network mask"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7824,6 +7948,21 @@ msgid "TFTP server"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr ""
 
@@ -7926,6 +8065,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7935,6 +8086,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8364,6 +8519,9 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr ""
 
@@ -8427,7 +8585,7 @@ msgstr ""
 msgid "Trends for %s"
 msgstr ""
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8525,6 +8683,9 @@ msgid "Unable to connect"
 msgstr ""
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8737,6 +8898,12 @@ msgstr ""
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8866,6 +9033,9 @@ msgstr ""
 msgid "Update an environment"
 msgstr ""
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr ""
 
@@ -8917,8 +9087,14 @@ msgstr ""
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Upload facts for a host, creating the host if required"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8927,6 +9103,9 @@ msgid "Use UUID for certificates"
 msgstr ""
 
 msgid "Use short name for VMs"
+msgstr ""
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
 msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
@@ -8952,6 +9131,9 @@ msgid "User Groups"
 msgstr ""
 
 msgid "User IDs"
+msgstr ""
+
+msgid "User Name:"
 msgstr ""
 
 msgid "User data template"
@@ -9103,6 +9285,9 @@ msgid "VCenter/Server"
 msgstr ""
 
 msgid "VLAN ID for this subnet"
+msgstr ""
+
+msgid "VLAN ID is not consistent accross subnets"
 msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
@@ -9320,7 +9505,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9405,6 +9590,9 @@ msgstr "You are not authorised to make a template default."
 
 msgid "You are not authorized to perform this action."
 msgstr "You are not authorised to perform this action."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr ""
@@ -9598,6 +9786,9 @@ msgstr ""
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr ""
 
@@ -9715,6 +9906,9 @@ msgstr ""
 msgid "filter results"
 msgstr "filter results"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr ""
 
@@ -9728,6 +9922,9 @@ msgid "for OpenStack only"
 msgstr ""
 
 msgid "for VMware"
+msgstr ""
+
+msgid "for oVirt only"
 msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
@@ -9880,7 +10077,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9923,8 +10120,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "English (United Kingdom)"
 
@@ -9932,6 +10128,12 @@ msgid "location"
 msgstr ""
 
 msgid "locations"
+msgstr ""
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
 msgstr ""
 
 msgid "managed host must have one provision interface"
@@ -9995,6 +10197,9 @@ msgid "must provide a provider"
 msgstr ""
 
 msgid "must set host and port"
+msgstr ""
+
+msgid "name of the table"
 msgstr ""
 
 msgid "new"
@@ -10192,9 +10397,6 @@ msgstr ""
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "sort results"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr ""
 
@@ -10292,6 +10494,9 @@ msgstr ""
 msgid "valid or pending"
 msgstr ""
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10299,6 +10504,9 @@ msgid "virtual"
 msgstr ""
 
 msgid "virtual attached to %s"
+msgstr ""
+
+msgid "with given ID not found"
 msgstr ""
 
 msgid "yaml"

--- a/locale/es/foreman.po
+++ b/locale/es/foreman.po
@@ -40,8 +40,11 @@ msgstr "Quitar"
 msgid " in the provisioning template."
 msgstr "en la plantilla de aprovisionamiento."
 
-msgid "#{taxonomy} can be set on the All Hosts page"
-msgstr "#{taxonomy} se puede definir en la página Todos los hosts"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
+msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr "%s - Pulse Shift-F12 para liberar el cursor."
@@ -99,6 +102,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s ya no está asociado a la máquina virtual"
 
@@ -125,6 +131,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s hosts seleccionados"
@@ -284,6 +293,11 @@ msgstr "'%{object_name}' es '%{object_class}', se esperó una subred."
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Tipo de contenido: %s' no recibe soporte en la API v2 para solicitudes POST y PUT. Use 'Content-Type: application/json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Varios)"
@@ -468,9 +482,6 @@ msgstr "Añadir Parámetro"
 msgid "Add SSH Key"
 msgstr "Añadir clave SSH"
 
-msgid "Add SSH Key for %s"
-msgstr "Añadir clave SSH para %s"
-
 msgid "Add SSH key"
 msgstr "Añadir clave SSH"
 
@@ -546,6 +557,12 @@ msgstr "Dirección de correo electrónico del administrador"
 msgid "Administrator user account required"
 msgstr "La cuenta del usuario administrador es obligatoria."
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alerta"
 
@@ -560,9 +577,6 @@ msgstr "todos"
 
 msgid "All Hosts"
 msgstr "Todos los hosts"
-
-msgid "All Puppet Classes for %s"
-msgstr "Todas las clases Puppet para %s"
 
 msgid "All Reports"
 msgstr "Todos los Informes"
@@ -821,6 +835,12 @@ msgstr "Auditoría"
 
 msgid "Audit Comment"
 msgstr "Comentario de auditoría"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Resumen de auditoría"
@@ -1132,14 +1152,26 @@ msgstr "Zona horaria del explorador"
 msgid "Build"
 msgstr "Construir"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Construir hosts"
 
 msgid "Build PXE Default"
 msgstr "Generar 'PXE predeterminado'"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Crear desde imagen de SO"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr "De manera predeterminada, establecemos una conexión entre los grupos de usuarios con los objetos del grupo LDAP estándar. Los tipos de servidores FreeIPA y POSIX LDAP admiten una forma alternativa de agrupar a los usuarios a través de Netgroups. Marque esta casilla de verificación si utiliza Netgroups en lugar de los grupos estándar."
@@ -1270,6 +1302,9 @@ msgstr "Entornos modificados"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr "Los cambios implementados en %s se extenderán a los filtros heredados"
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chasis"
 
@@ -1315,6 +1350,12 @@ msgstr "Clases"
 msgid "Clean up failed deployment"
 msgstr "Eliminar la implementación fallida"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Haga clic en el enlace de un recurso de cómputo para editar los  atributos predeterminados para las máquinas virtuales.."
 
@@ -1323,9 +1364,6 @@ msgstr "Haga clic para añadir %s"
 
 msgid "Click to log in again."
 msgstr "Haga para reingresar"
-
-msgid "Click to mark as read"
-msgstr "Haga clic para marcar como leído"
 
 msgid "Click to remove %s"
 msgstr "Haga clic para eliminar %s"
@@ -1447,6 +1485,10 @@ msgstr "Descripción"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
 msgstr "ComputeResource|Dominio"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
@@ -1695,6 +1737,9 @@ msgstr "Crear proxy"
 msgid "Create Puppet Environment"
 msgstr "Crear entorno Puppet"
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "Crear reino"
 
@@ -1818,6 +1863,9 @@ msgstr "Crear una variable inteligente"
 msgid "Create a subnet"
 msgstr "Crear una subred"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Crear un usuario"
 
@@ -1857,6 +1905,9 @@ msgstr "Crear un valor de sobrescritura para una variable inteligente específic
 msgid "Create autosign entry"
 msgstr "Crear entrada de autofirmado"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Crear nuevo volumen de inicio desde la imagen"
 
@@ -1871,6 +1922,9 @@ msgstr "Crear entrada de reino para %s"
 
 msgid "Created"
 msgstr "Creado"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2046,9 +2100,6 @@ msgstr "Eliminar controlador"
 msgid "Delete Hosts"
 msgstr "Borrar hosts"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr "Eliminar entrada de autofirmado de PuppetCA para %s"
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Borrar certificados PuppetCA para %s"
 
@@ -2142,8 +2193,14 @@ msgstr "Borrar una variable inteligente"
 msgid "Delete a subnet"
 msgstr "Borrar una subred"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Borrar una combinación de plantillas"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Borrar un usuario"
@@ -2283,11 +2340,17 @@ msgstr "Vista Diff"
 msgid "Disable Notifications"
 msgstr "Inhabilitar Notificaciones"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Inhabilitar alertas para los hosts seleccionados"
 
 msgid "Disable all filters overriding"
 msgstr "Deshabilitar todas las anulaciones de filtro"
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
+msgstr ""
 
 msgid "Disable overriding"
 msgstr "Deshabilitar anulación"
@@ -2417,47 +2480,11 @@ msgstr "Editar"
 msgid "Edit %s"
 msgstr "Editar %s"
 
-msgid "Edit Architecture"
-msgstr "Editar arquitectura"
-
-msgid "Edit Bookmark"
-msgstr "Editar marcador"
-
 msgid "Edit Compute profile"
 msgstr "Editar perfil de cómputo"
 
-msgid "Edit Compute profile: %s"
-msgstr "Editar perfil de cómputo: %s"
-
-msgid "Edit Config group"
-msgstr "Modificar grupo de configuración"
-
-msgid "Edit Domain"
-msgstr "Editar dominio"
-
-msgid "Edit Environment"
-msgstr "Editar entorno"
-
-msgid "Edit Filter"
-msgstr "Modificar filtro"
-
-msgid "Edit Global Parameter"
-msgstr "Editar parámetro global"
-
-msgid "Edit HTTP Proxy"
-msgstr "Editar proxy HTTP"
-
 msgid "Edit Host"
 msgstr "Editar servidor"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Editar fuente de autorización LDAP"
-
-msgid "Edit Medium"
-msgstr "Editar medio"
-
-msgid "Edit Model"
-msgstr "Editar modelo"
 
 msgid "Edit Operating System"
 msgstr "Editar sistema operativo"
@@ -2465,23 +2492,11 @@ msgstr "Editar sistema operativo"
 msgid "Edit Parameters"
 msgstr "Editar parámetros"
 
-msgid "Edit Partition Table"
-msgstr "Editar tabla de particiones"
-
 msgid "Edit Properties"
 msgstr "Editar propiedades"
 
-msgid "Edit Proxy"
-msgstr "Editar Proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Editar clase Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Editar reino"
-
-msgid "Edit Role"
-msgstr "Editar rol"
 
 msgid "Edit Smart Variable"
 msgstr "Editar variable inteligente"
@@ -2489,23 +2504,8 @@ msgstr "Editar variable inteligente"
 msgid "Edit Smart class parameters"
 msgstr "Editar parámetros de clase inteligente"
 
-msgid "Edit Subnet"
-msgstr "Editar subred"
-
-msgid "Edit Template"
-msgstr "Editar plantilla"
-
 msgid "Edit Trend %s"
 msgstr "Editar tendencia %s"
-
-msgid "Edit User"
-msgstr "Editar usuario"
-
-msgid "Edit User group"
-msgstr "Editar grupo de usuarios"
-
-msgid "Edit compute profile on %s"
-msgstr "Editar perfil de cómputo en %s"
 
 msgid "Edit this host"
 msgstr "Editar este host"
@@ -2536,6 +2536,9 @@ msgstr "Habilitar el caché"
 
 msgid "Enable Notifications"
 msgstr "Habilitar notificaciones"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Habilitar alertas para los hosts seleccionados"
@@ -2659,6 +2662,15 @@ msgstr "Error al enviar datos:"
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr "Error al conectar con el servidor LDAP '%{name}' en '%{url}' durante la autenticación"
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr "Errores"
 
@@ -2781,11 +2793,11 @@ msgstr "Nombre de eventos"
 msgid "Fact Values"
 msgstr "Valores de eventos"
 
-msgid "Fact Values | %{host_name}"
-msgstr "Valores de eventos | %{host_name}"
-
 msgid "Fact distribution chart"
 msgstr "Cuadro de distribución de eventos"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2845,6 +2857,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Reinicios fallidos"
 
@@ -2856,9 +2871,6 @@ msgstr "No se pudieron adquirir las direcciones IP del recurso de cómputo para 
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr "Error al cancelar la versión pendiente de %{hostname} con los siguientes errores: %{errors}"
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Falló al limpiar certificados antiguos o al añadir la llave de autofirmado. ¡Finalizando la instalación!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Ha fallado la configuración de %{host} para arrancar desde %{device}: %{e}"
@@ -3041,11 +3053,11 @@ msgstr "Clases de filtro"
 msgid "Filter overriding has been disabled"
 msgstr "Se deshabilitó la anulación de filtros"
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtros"
-
-msgid "Filters for role %s"
-msgstr "Filtros para el rol %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr "Los filtros heredan %{orgs_and_locs} asociados con el rol de manera predeterminada. Si se habilita el campo de reemplazo, <br> el filtro puede reemplazar el conjunto de sus %{orgs_and_locs}. Los cambios de rol posteriores no afectarán dicho filtro.<br> Después de deshabilitar el campo de reemplazo, se aplica el rol %{orgs_and_locs} nuevamente."
@@ -3157,6 +3169,9 @@ msgstr "Foreman puede usar un servicio LDAP para autenticación e información d
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman considera que un dominio y una zona DNS son lo mismo."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "ID del dominio de Foreman de la interfaz. Requerida para interfaces principales en hosts administrados."
 
@@ -3199,6 +3214,9 @@ msgstr "Foreman anexará nombres de dominio cuando se aprovisionen los hosts nue
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatizará la firma de certificados tras el aprovisionamiento de un nuevo host"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman creará el host cuando se reciba un reporte"
 
@@ -3237,9 +3255,6 @@ msgstr "Foreman preguntará al servidor de nombres local en lugar de a las autor
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman establecerá este como "
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman cambiará el nombre de equipo a 'puppet' si éste empieza con puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman actualizará el entorno del host mediante eventos"
@@ -3364,6 +3379,9 @@ msgstr "Variables globales"
 msgid "Good host reports in the last %s"
 msgstr "Informes satisfactorios en los últimos %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "ID de Google Project"
 
@@ -3390,6 +3408,9 @@ msgstr "Proxy HTTP(S)"
 
 msgid "HTTP(S) proxy except hosts"
 msgstr "Hosts sin proxy HTTP(S)"
+
+msgid "HTTPS URL is required for API access"
+msgstr ""
 
 msgid "Hard disk"
 msgstr "Disco duro"
@@ -3423,6 +3444,9 @@ msgstr "Valor oculto"
 
 msgid "Hide all values for this parameter."
 msgstr "Ocultar todos los valores para este parámetro"
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Ocultar este valor"
@@ -3533,6 +3557,10 @@ msgid "Host::Base|Build"
 msgstr "Construir"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Nombre de Certificado"
 
@@ -3559,6 +3587,10 @@ msgstr "Llave de Grub"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Archivo de imagen"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3695,6 +3727,12 @@ msgstr "Los hosts creados tras una ejecución de Puppet se colocarán en la ubic
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Los hosts creados tras una ejecución de Puppet se colocarán en la organización descrita en este evento. El contenido de este evento debe ser la etiqueta completa de organización."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Hosts con estado error"
@@ -4180,6 +4218,9 @@ msgstr "Entrada"
 msgid "Installation Media"
 msgstr "Medio de Instalación"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configuración del medio de instalación"
 
@@ -4364,9 +4405,6 @@ msgstr "Lanzar consola"
 msgid "Learn more about this in the documentation."
 msgstr "Obtener más información acerca de esto en la documentación."
 
-msgid "Legacy Puppet hostname"
-msgstr "Nombre de host del Puppet legado"
-
 msgid "Length"
 msgstr "Longitud "
 
@@ -4429,6 +4467,15 @@ msgstr "Listar todas las auditorías"
 
 msgid "List all audits for a given host"
 msgstr "Listar todas las auditorías de un host determinado"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Listar todas las entradas autofirmadas"
@@ -4595,6 +4642,9 @@ msgstr "Listar todos los usuarios"
 msgid "List all users for LDAP authentication source"
 msgstr "Listar los usuarios por fuente de autenticación LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Listar todos los usuarios por ubicación"
 
@@ -4655,6 +4705,15 @@ msgstr "Listar entornos por ubicación"
 msgid "List environments per organization"
 msgstr "Listar entornos por organización"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Listar hosts por entorno"
 
@@ -4666,6 +4725,9 @@ msgstr "Listar hosts por organización"
 
 msgid "List installed plugins"
 msgstr "Listar complementos instalados"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "Lista de proxis HTTP"
@@ -4741,6 +4803,15 @@ msgstr "Lista de subredes por ubicación"
 
 msgid "List of subnets per organization"
 msgstr "Lista de subredes por organización"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Lista de sistemas operativos  en donde esta plantilla se establece de forma predeterminada"
@@ -4980,6 +5051,18 @@ msgstr "Dirección MAC para reutilizar la IP de este host"
 msgid "MAC-based"
 msgstr "Basado en MAC"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Tipo de máquina"
 
@@ -5176,6 +5259,9 @@ msgstr "Falta un permiso para editar %s principal"
 msgid "Missing one of the required permissions: %s"
 msgstr "Falta uno de los permisos requeridos: %s."
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modelo"
@@ -5256,6 +5342,9 @@ msgstr "Nombre del grupo de hosts"
 msgid "Name of the parameter"
 msgstr "Nombre del parámetro"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Nombre de la variable"
 
@@ -5298,14 +5387,11 @@ msgstr "Tipo de red"
 msgid "New"
 msgstr "nuevo"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nueva entrada autofirmado"
-
-msgid "New Event"
-msgstr "Nuevo evento"
-
-msgid "New Events"
-msgstr "Nuevos eventos"
 
 msgid "New HTTP Proxy"
 msgstr "Nuevo proxy HTTP"
@@ -5327,9 +5413,6 @@ msgstr "Nueva máquina virtual"
 
 msgid "New boot volume size (GB)"
 msgstr "Nuevo tamaño de volumen de inicio (GB)"
-
-msgid "New compute profile on %s"
-msgstr "Nuevo perfil de cómputo en %s"
 
 msgid "New filter"
 msgstr "Nuevo filtro"
@@ -5356,6 +5439,10 @@ msgstr "Opciones de vínculo"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
 msgstr "Nic::Base|Atributos de cómputo"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Identifier"
@@ -5429,11 +5516,14 @@ msgstr "No hay NIC del BMC disponible para el host %s"
 msgid "No Failed Features"
 msgstr "Ninguna funcionalidad con error."
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "No se seleccionaron subredes de IPv4"
 
-msgid "No Notifications"
-msgstr "No hay notificaciones"
+msgid "No Notifications Available"
+msgstr ""
 
 msgid "No TFTP feature"
 msgstr "Ninguna funcionalidad TFTP"
@@ -6158,9 +6248,6 @@ msgstr "Las plantillas de partición describen el diseño de partición con un d
 msgid "Password"
 msgstr "Contraseña"
 
-msgid "Password do not match"
-msgstr "La contraseña no coincide"
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Contraseña para oVirt, EC2, VMware, OpenStack. Llave secreta para EC2"
 
@@ -6184,6 +6271,9 @@ msgstr "Contraseña utilizada para autenticar con el proxy HTTP"
 
 msgid "Password:"
 msgstr "Contraseña:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Ruta"
@@ -6456,14 +6546,19 @@ msgstr "Plantilla de aprovisionamiento|Nombre"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "Plantilla de aprovisionamiento|Snippet"
 
-msgid "Proxied request failed with: %s"
-msgstr "La solicitud redirigida mediante proxy falló con: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
+msgstr ""
 
 msgid "Proxies"
 msgstr "Proxis"
 
 msgid "Proxy ID to use within this realm"
 msgstr "ID de proxy que se utilizará dentro de este dominio"
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
 
 msgid "Proxy request timeout"
 msgstr "Tiempo de espera de la solicitud de proxy"
@@ -6767,6 +6862,9 @@ msgstr "Generado Informe en"
 msgid "Report|Status"
 msgstr "Estado"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "Requiere SSL para proxy inteligentes"
 
@@ -6775,6 +6873,9 @@ msgstr "Parámetro requerido sin valor.<br/><b>¡Sustituir!</b><br/>"
 
 msgid "Required when user want to change own password"
 msgstr "Requerido cuando el usuario quiere modificar su propia contraseña"
+
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
 
 msgid "Reset to default"
 msgstr "Restablecer valores predeterminados"
@@ -7038,9 +7139,6 @@ msgstr "DNS secundaria para esta subred"
 msgid "Secret Key"
 msgstr "Llave secreta"
 
-msgid "Security group"
-msgstr "Grupo de seguridad"
-
 msgid "Security groups"
 msgstr "Grupos de Seguridad"
 
@@ -7199,8 +7297,8 @@ msgstr "Definir una contraseña generada en forma aleatoria en la conexión de l
 msgid "Set a randomly generated password on the display connection"
 msgstr "Configurar una contraseña generada en forma  aleatoria  en la conexión de la pantalla"
 
-msgid "Set hostnames to which requests are not to be proxied"
-msgstr "Definir nombres de hosts en los que las solicitudes no tendrán proxy"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
+msgstr ""
 
 msgid "Set parameters to defaults"
 msgstr "Restablecer los parámetros predeterminados"
@@ -7388,6 +7486,9 @@ msgstr "Mostrar una variable inteligente"
 msgid "Show a subnet"
 msgstr "Mostrar una subred"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Mostrar un usuario"
 
@@ -7421,6 +7522,9 @@ msgstr "Mostrar una notificación por correo electrónico"
 msgid "Show an environment"
 msgstr "Mostrar un entorno"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Mostrar un grupo de usuarios externo por fuente de autenticación LDAP"
 
@@ -7432,6 +7536,9 @@ msgstr "Mostrar una imagen"
 
 msgid "Show an interface for host"
 msgstr "Mostrar una interfaz para host"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Mostrar un sistema operativo"
@@ -7514,9 +7621,6 @@ msgstr "Proxis inteligentes"
 msgid "Smart Proxy"
 msgstr "Proxy Inteligente"
 
-msgid "Smart Proxy: %s"
-msgstr "Proxy inteligente: %s"
-
 msgid "Smart Variables"
 msgstr "Variables inteligentes"
 
@@ -7530,6 +7634,9 @@ msgstr "Proxy Inteligente"
 msgid "Smart proxy IDs"
 msgstr "ID de proxy inteligente"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr "Las variables inteligentes son herramientas que permiten proveer parámetros (datos de claves/valores) al ámbito (global) de primer nivel del ENC de Puppet, dependiendo de un conjunto de reglas."
 
@@ -7542,11 +7649,18 @@ msgid "SmartProxy|Name"
 msgstr "Nombre"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "Url"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr "Algunas clases de Pupptet no se encuentran disponibles en el entorno seleccionado"
@@ -7580,6 +7694,9 @@ msgstr "No se ha configurado ninguna plantilla"
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Estos hosts no tienen parámetros asignados. Debe añadírselos primero."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7686,6 +7803,9 @@ msgstr "ID de subred"
 msgid "Subnet description"
 msgstr "Descripción de subred"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nombre de subred"
 
@@ -7729,6 +7849,10 @@ msgstr "IPAM"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Máscara de red"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7850,6 +7974,21 @@ msgid "TFTP server"
 msgstr "Servidor TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxonomía gravable"
 
@@ -7952,6 +8091,18 @@ msgid "Template|Default"
 msgstr "Plantilla|Predeterminada"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Plantilla|Bloqueada"
 
@@ -7962,6 +8113,10 @@ msgstr "Plantilla|Nombre"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
 msgstr "Plantilla|Familia de SO"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Snippet"
@@ -8400,6 +8555,9 @@ msgstr "Alternar"
 msgid "Token"
 msgstr "Muestra"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Duración del símbolo"
 
@@ -8463,8 +8621,8 @@ msgstr "Tendencias"
 msgid "Trends for %s"
 msgstr "Tendencias para %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
-msgstr "Las tendencias en Foreman le permiten rastrear cambios en su infraestructura a lo largo del tiempo. Le permite rastrear tanto la información relacionada con Foreman como datos de Puppet. Las páginas de tendencias ofrecen un gráfico que muestra cómo han cambiado las cantidades de hosts con ese valor en el transcurso del tiempo y detalla los hosts actuales."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
@@ -8562,6 +8720,9 @@ msgstr "No se pudo conectar"
 
 msgid "Unable to connect to LDAP server"
 msgstr "No se pudo conectar al servidor LDAP."
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Ha sido imposible crear el menú de arranque para TFTP predeterminado"
@@ -8773,6 +8934,12 @@ msgstr "Host sin administrar"
 msgid "Unnamed"
 msgstr "Sin nombre"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "Modo IPAM no compatible para %s"
 
@@ -8902,6 +9069,9 @@ msgstr "Actualizar una arquitectura"
 msgid "Update an environment"
 msgstr "Actualizar un entorno"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Actualizar una imagen"
 
@@ -8953,8 +9123,14 @@ msgstr "Hosts actualizados: se cambió grupo de hosts"
 msgid "Updated hosts: changed owner"
 msgstr "Hosts actualizados: se cambió el propietario."
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Subir eventos para un host, si es necesario cree el host."
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "Usar NIS netgroups en lugar de grupos posix."
@@ -8964,6 +9140,9 @@ msgstr "Usar UUID para certificados"
 
 msgid "Use short name for VMs"
 msgstr "Utilizar nombre corto para VM"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Usar esta cuenta para autenticación, <i>optional</i>"
@@ -8989,6 +9168,9 @@ msgstr "Grupos de usuarios"
 
 msgid "User IDs"
 msgstr "ID de usuario"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "Plantilla de datos de usuario"
@@ -9140,6 +9322,9 @@ msgstr "VCenter/Servidor"
 
 msgid "VLAN ID for this subnet"
 msgstr "ID de VLAN para esta subred"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "Etiqueta VLAN, este atributo tiene precedencia sobre la ID de subred VLAN. Solo para interfaces virtuales."
@@ -9365,8 +9550,8 @@ msgstr "Independientemente de que el valor del parámetro de la clase sea admini
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Si el valor del parámetro de clase inteligente es administrado por Foreman"
 
-msgid "Whether to get RSS notifications or not"
-msgstr "Indica si se deben recibir notificaciones RSS o no"
+msgid "Whether to pull RSS notifications or not"
+msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
 msgstr "El cual es un offset de <b>%s</b>"
@@ -9450,6 +9635,9 @@ msgstr "No tiene autorización para realizar una plantilla predeterminada."
 
 msgid "You are not authorized to perform this action."
 msgstr "No está autorizado para realizar esta acción."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Está intentando borrar su propia cuenta"
@@ -9643,6 +9831,9 @@ msgstr "no se puede quitar de una cuenta protegida interna"
 msgid "cannot be removed from the last admin account"
 msgstr "no se puede quitar de la última cuenta de administración"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "Clonar"
 
@@ -9760,6 +9951,9 @@ msgstr "filtro para rol %s"
 msgid "filter results"
 msgstr "filtrar resultados"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "solo para EC2"
 
@@ -9774,6 +9968,9 @@ msgstr "solo para OpenStack"
 
 msgid "for VMware"
 msgstr "para VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "para oVirt, VMware Datacenter"
@@ -9925,8 +10122,8 @@ msgstr "no es una clave ssh pública válida"
 msgid "is not allowed to change"
 msgstr "no se permite modificar"
 
-msgid "is not defined for host's %s."
-msgstr "no está definido para el %s del host."
+msgid "is not defined for host's %s"
+msgstr ""
 
 msgid "is not found in the authentication source"
 msgstr "no se encontró en la fuente de autenticación"
@@ -9968,8 +10165,7 @@ msgstr "enlazar grupo de usuarios externos con este grupo de usuario"
 msgid "list"
 msgstr "lista"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Español"
 
@@ -9978,6 +10174,12 @@ msgstr "Ubicación"
 
 msgid "locations"
 msgstr "Ubicaciones"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "el host administrado debe tener una interfaz de aprovisionamiento"
@@ -10041,6 +10243,9 @@ msgstr " debe proporcionar un proveedor"
 
 msgid "must set host and port"
 msgstr " debe configurar un host  y un puerto"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "nuevo"
@@ -10237,9 +10442,6 @@ msgstr "algunas interfaces no son válidas"
 msgid "some permissions were not found"
 msgstr "no se hallaron ciertos permisos"
 
-msgid "sort results"
-msgstr "organizar resultados"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "opciones separadas por espacios, p.ej. miimon=100"
 
@@ -10341,6 +10543,9 @@ msgstr "válido"
 msgid "valid or pending"
 msgstr "válida o pendiente"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr "ver detalles del último informe"
 
@@ -10349,6 +10554,9 @@ msgstr "Virtual"
 
 msgid "virtual attached to %s"
 msgstr "virtual adjunto a %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "YAML"

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: foreman 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-12 10:51-0400\n"
-"PO-Revision-Date: 2018-03-12 10:51-0400\n"
+"POT-Creation-Date: 2018-07-19 14:36+0300\n"
+"PO-Revision-Date: 2018-07-19 14:36+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -18,42 +18,42 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../app/assets/javascripts/application.js:72
+#: ../app/assets/javascripts/application.js:75
 msgid "Failed to fetch: "
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:207
+#: ../app/assets/javascripts/application.js:210
 msgid "Sorry but no templates were configured."
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:345
+#: ../app/assets/javascripts/application.js:348
 #: ../app/models/config_report.rb:81
 msgid "Success"
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:347
-#: ../app/helpers/layout_helper.rb:84 ../app/models/host_status/global.rb:36
+#: ../app/assets/javascripts/application.js:350
+#: ../app/helpers/layout_helper.rb:96 ../app/models/host_status/global.rb:36
 msgid "Warning"
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:349
-#: ../app/controllers/application_controller.rb:346
-#: ../app/helpers/dashboard_helper.rb:59 ../app/helpers/layout_helper.rb:90
+#: ../app/assets/javascripts/application.js:352
+#: ../app/controllers/application_controller.rb:361
+#: ../app/helpers/dashboard_helper.rb:59 ../app/helpers/layout_helper.rb:102
 #: ../app/models/host_status/configuration_status.rb:71
 #: ../app/models/host_status/global.rb:38
 msgid "Error"
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:377
+#: ../app/assets/javascripts/application.js:380
 msgid "Unknown power state"
 msgstr ""
 
-#: ../app/assets/javascripts/application.js:404
+#: ../app/assets/javascripts/application.js:407
 msgid "Exit Full Screen"
 msgstr ""
 
-#: ../app/assets/javascripts/charts.js:207 ../app/views/audits/show.html.erb:19
-#: ../app/views/hosts/show.html.erb:10
+#: ../app/assets/javascripts/charts.js:207 ../app/views/audits/show.html.erb:28
+#: ../app/views/hosts/show.html.erb:11
 #: ../app/views/smart_proxies/show.html.erb:21
 msgid "Details"
 msgstr ""
@@ -146,27 +146,27 @@ msgstr ""
 msgid "Error loading interfaces information: %s"
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:57
+#: ../app/assets/javascripts/host_edit.js:59
 msgid "Loading virtual machine information ..."
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:217
-#: ../app/assets/javascripts/host_edit.js:479
+#: ../app/assets/javascripts/host_edit.js:222
+#: ../app/assets/javascripts/host_edit.js:488
 msgid "Loading parameters..."
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:603
+#: ../app/assets/javascripts/host_edit.js:612
 #: ../app/helpers/hosts_nic_helper.rb:22
 #: ../app/views/hostgroups/_form.html.erb:53
 #: ../app/views/hostgroups/_form.html.erb:60
 msgid "No subnets"
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:737
+#: ../app/assets/javascripts/host_edit.js:746
 msgid "Error generating IP: %s"
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:829
+#: ../app/assets/javascripts/host_edit.js:838
 msgid "Warning: This combination of loader and OS might not be able to boot."
 msgstr ""
 
@@ -181,7 +181,7 @@ msgid "Primary"
 msgstr ""
 
 #: ../app/assets/javascripts/host_edit_interfaces.js:179
-#: ../app/models/setting/provisioning.rb:85
+#: ../app/models/setting/provisioning.rb:84
 msgid "Provisioning"
 msgstr ""
 
@@ -209,9 +209,9 @@ msgstr ""
 msgid "physical"
 msgstr ""
 
-#: ../app/assets/javascripts/hosts.js:20 ../app/helpers/hosts_helper.rb:322
-#: ../app/helpers/hosts_helper.rb:457 ../app/helpers/hosts_helper.rb:459
-#: ../app/models/host_status/build_status.rb:8
+#: ../app/assets/javascripts/hosts.js:20 ../app/helpers/hosts_helper.rb:335
+#: ../app/helpers/hosts_helper.rb:470 ../app/helpers/hosts_helper.rb:472
+#: ../app/models/host_status/build_status.rb:9
 msgid "Build"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/assets/javascripts/jquery.multi-select.js:8
 #: ../app/helpers/form_helper.rb:206 ../app/views/common/_searchbar.html.erb:6
-#: ../app/views/filters/_form.html.erb:6 model_attributes.rb:148
+#: ../app/views/filters/_form.html.erb:6 model_attributes.rb:150
 msgid "Filter"
 msgstr ""
 
@@ -300,8 +300,8 @@ msgstr ""
 #: ../app/assets/javascripts/subnets.js:62
 #: ../app/assets/javascripts/subnets.js:82
 #: ../app/assets/javascripts/subnets.js:89
-#: ../app/models/lookup_keys/lookup_key.rb:173
-#: ../app/models/nic/interface.rb:84 ../app/models/nic/interface.rb:85
+#: ../app/models/lookup_keys/lookup_key.rb:175
+#: ../app/models/nic/interface.rb:101 ../app/models/nic/interface.rb:102
 #: ../app/models/subnet.rb:259
 #: ../app/services/foreman/parameters/validator.rb:29
 #: ../app/validators/email_validator.rb:14
@@ -335,7 +335,7 @@ msgid "Missing one of the required permissions: %s"
 msgstr ""
 
 #: ../app/controllers/api/base_controller.rb:331
-#: ../app/controllers/application_controller.rb:152
+#: ../app/controllers/application_controller.rb:167
 msgid "unknown permission for %s"
 msgstr ""
 
@@ -368,8 +368,8 @@ msgstr ""
 #: ../app/controllers/api/v2/parameters_controller.rb:99
 #: ../app/controllers/api/v2/parameters_controller.rb:120
 #: ../app/controllers/api/v2/parameters_controller.rb:140
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:20
-#: ../app/controllers/api/v2/ptables_controller.rb:15
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:21
+#: ../app/controllers/api/v2/ptables_controller.rb:16
 msgid "ID of operating system"
 msgstr ""
 
@@ -403,6 +403,34 @@ msgstr ""
 
 #: ../app/controllers/api/v2/audits_controller.rb:15
 msgid "Show an audit"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_externals_controller.rb:8
+msgid "List external authentication sources"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_externals_controller.rb:10
+msgid "List external authentication sources per location"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_externals_controller.rb:12
+msgid "List external authentication sources per organization"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_externals_controller.rb:20
+msgid "Show an external authentication source"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_externals_controller.rb:33
+msgid "Update an external authentication source"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_internals_controller.rb:6
+msgid "List internal authentication sources"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_source_internals_controller.rb:13
+msgid "Show an internal authentication source"
 msgstr ""
 
 #: ../app/controllers/api/v2/auth_source_ldaps_controller.rb:12
@@ -452,7 +480,7 @@ msgid "type of the LDAP server"
 msgstr ""
 
 #: ../app/controllers/api/v2/auth_source_ldaps_controller.rb:50
-#: ../app/views/auth_source_ldaps/_form.html.erb:36
+#: ../app/views/auth_source_ldaps/_form.html.erb:34
 msgid "LDAP filter"
 msgstr ""
 
@@ -470,6 +498,18 @@ msgstr ""
 
 #: ../app/controllers/api/v2/auth_source_ldaps_controller.rb:84
 msgid "Delete an LDAP authentication source"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_sources_controller.rb:6
+msgid "List all authentication sources"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_sources_controller.rb:7
+msgid "List all authentication sources per location"
+msgstr ""
+
+#: ../app/controllers/api/v2/auth_sources_controller.rb:8
+msgid "List all authentication sources per organization"
 msgstr ""
 
 #: ../app/controllers/api/v2/autosign_controller.rb:6
@@ -519,7 +559,7 @@ msgid "filter results"
 msgstr ""
 
 #: ../app/controllers/api/v2/base_controller.rb:20
-msgid "sort results"
+msgid "Sort field and order, eg. ‘id DESC’"
 msgstr ""
 
 #: ../app/controllers/api/v2/base_controller.rb:25
@@ -528,6 +568,27 @@ msgstr ""
 
 #: ../app/controllers/api/v2/base_controller.rb:26
 msgid "REPLACE organizations with given ids."
+msgstr ""
+
+#: ../app/controllers/api/v2/base_controller.rb:36
+msgid "use if you want update locked templates"
+msgstr ""
+
+#: ../app/controllers/api/v2/base_controller.rb:37
+msgid ""
+"determines when the template should associate objects based on metadata, new m"
+"eans only when new template is being created, always means both for new and ex"
+"isting template which is only being updated, never ignores metadata"
+msgstr ""
+
+#: ../app/controllers/api/v2/base_controller.rb:38
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+#: ../app/controllers/api/v2/base_controller.rb:39
+msgid ""
+"makes the template default meaning it will be automatically associated with ne"
+"wly created organizations and locations (false by default)"
 msgstr ""
 
 #: ../app/controllers/api/v2/bookmarks_controller.rb:9
@@ -652,113 +713,118 @@ msgid "for oVirt, VMware Datacenter"
 msgstr ""
 
 #: ../app/controllers/api/v2/compute_resources_controller.rb:39
+#: ../app/controllers/api/v2/compute_resources_controller.rb:40
+msgid "for oVirt only"
+msgstr ""
+
+#: ../app/controllers/api/v2/compute_resources_controller.rb:41
 msgid "for EC2 only"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:40
-#: ../app/controllers/api/v2/compute_resources_controller.rb:41
+#: ../app/controllers/api/v2/compute_resources_controller.rb:42
+#: ../app/controllers/api/v2/compute_resources_controller.rb:43
 msgid "for OpenStack only"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:42
+#: ../app/controllers/api/v2/compute_resources_controller.rb:44
 msgid "for VMware"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:43
+#: ../app/controllers/api/v2/compute_resources_controller.rb:45
 msgid "for Libvirt and VMware only"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:44
+#: ../app/controllers/api/v2/compute_resources_controller.rb:46
 msgid "for Libvirt only"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:45
+#: ../app/controllers/api/v2/compute_resources_controller.rb:47
 msgid "enable caching, for VMware only"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:50
+#: ../app/controllers/api/v2/compute_resources_controller.rb:52
 msgid "Create a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:58
+#: ../app/controllers/api/v2/compute_resources_controller.rb:60
 msgid "Update a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:66
+#: ../app/controllers/api/v2/compute_resources_controller.rb:68
 msgid "Delete a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:73
+#: ../app/controllers/api/v2/compute_resources_controller.rb:75
 msgid "List available images for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:79
+#: ../app/controllers/api/v2/compute_resources_controller.rb:81
 msgid "List available clusters for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:86
+#: ../app/controllers/api/v2/compute_resources_controller.rb:88
 msgid "List available flavors for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:93
+#: ../app/controllers/api/v2/compute_resources_controller.rb:95
 msgid "List available folders for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:100
+#: ../app/controllers/api/v2/compute_resources_controller.rb:102
 msgid "List available zone for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:107
+#: ../app/controllers/api/v2/compute_resources_controller.rb:109
 msgid "List available networks for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:108
+#: ../app/controllers/api/v2/compute_resources_controller.rb:110
 msgid "List available networks for a compute resource cluster"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:116
+#: ../app/controllers/api/v2/compute_resources_controller.rb:118
 msgid "List resource pools for a compute resource cluster"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:124
+#: ../app/controllers/api/v2/compute_resources_controller.rb:126
 msgid "List storage domains for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:125
+#: ../app/controllers/api/v2/compute_resources_controller.rb:127
 msgid "List attributes for a given storage domain"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:133
+#: ../app/controllers/api/v2/compute_resources_controller.rb:135
 msgid "List storage pods for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:134
+#: ../app/controllers/api/v2/compute_resources_controller.rb:136
 msgid "List attributes for a given storage pod"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:142
+#: ../app/controllers/api/v2/compute_resources_controller.rb:144
 msgid "List available security groups for a compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:149
+#: ../app/controllers/api/v2/compute_resources_controller.rb:151
 msgid "Associate VMs to Hosts"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:158
+#: ../app/controllers/api/v2/compute_resources_controller.rb:160
 msgid "Associating VMs is not supported for this compute resource"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:162
+#: ../app/controllers/api/v2/compute_resources_controller.rb:164
 msgid "Refresh Compute Resource Cache"
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:166
-#: ../app/controllers/compute_resources_controller.rb:86
+#: ../app/controllers/api/v2/compute_resources_controller.rb:168
+#: ../app/controllers/compute_resources_controller.rb:96
 msgid "Successfully refreshed the cache."
 msgstr ""
 
-#: ../app/controllers/api/v2/compute_resources_controller.rb:168
-#: ../app/controllers/compute_resources_controller.rb:91
+#: ../app/controllers/api/v2/compute_resources_controller.rb:170
+#: ../app/controllers/compute_resources_controller.rb:101
 msgid "Failed to refresh the cache."
 msgstr ""
 
@@ -833,89 +899,89 @@ msgid "Show the last report for a host"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:18
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:16
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:17
 msgid "List provisioning templates"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:19
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:17
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:18
 msgid "List provisioning templates per operating system"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:20
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:18
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:19
 msgid "List provisioning templates per location"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:21
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:19
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:20
 msgid "List provisioning templates per organization"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:31
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:29
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:30
 msgid "Show provisioning template details"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:39
 #: ../app/controllers/api/v2/config_templates_controller.rb:93
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:37
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:60
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:109
-#: ../app/controllers/api/v2/ptables_controller.rb:55
-#: ../app/controllers/api/v2/ptables_controller.rb:97
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:38
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:61
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:104
+#: ../app/controllers/api/v2/ptables_controller.rb:56
+#: ../app/controllers/api/v2/ptables_controller.rb:92
 msgid "template name"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:43
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:41
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:42
 msgid "not relevant for snippet"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:45
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:43
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:44
 msgid "Array of template combinations (hostgroup_id, environment_id)"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:46
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:44
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:45
 msgid "Array of operating system IDs to associate with the template"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:47
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:45
-#: ../app/controllers/api/v2/ptables_controller.rb:36
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:46
+#: ../app/controllers/api/v2/ptables_controller.rb:37
 msgid "Whether or not the template is locked for editing"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:52
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:50
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:51
 msgid "Create a provisioning template"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:60
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:77
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:72
 msgid "Update a provisioning template"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:69
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:86
-#: ../app/controllers/api/v2/ptables_controller.rb:73
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:81
+#: ../app/controllers/api/v2/ptables_controller.rb:68
 msgid "template version"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:76
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:93
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:88
 msgid "Delete a provisioning template"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:83
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:100
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:95
 msgid "Update the default PXE menu on all configured TFTP servers"
 msgstr ""
 
 #: ../app/controllers/api/v2/config_templates_controller.rb:97
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:113
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:108
 msgid "Clone a provision template"
 msgstr ""
 
@@ -956,7 +1022,7 @@ msgid "Hosts without changes or errors, with alerts enabled"
 msgstr ""
 
 #: ../app/controllers/api/v2/dashboard_controller.rb:28
-#: ../app/views/dashboard/_status_links.html.erb:35
+#: ../app/views/dashboard/_status_links.html.erb:38
 msgid "Out of sync hosts"
 msgstr ""
 
@@ -965,12 +1031,12 @@ msgid "Out of sync hosts with alerts enabled"
 msgstr ""
 
 #: ../app/controllers/api/v2/dashboard_controller.rb:30
-#: ../app/views/dashboard/_status_links.html.erb:49
+#: ../app/views/dashboard/_status_links.html.erb:55
 msgid "Hosts with alerts disabled"
 msgstr ""
 
 #: ../app/controllers/api/v2/dashboard_controller.rb:31
-#: ../app/views/dashboard/_status_links.html.erb:28
+#: ../app/views/dashboard/_status_links.html.erb:29
 msgid "Hosts that had pending changes"
 msgstr ""
 
@@ -1030,7 +1096,7 @@ msgstr ""
 
 #: ../app/controllers/api/v2/domains_controller.rb:38
 #: ../app/controllers/api/v2/hostgroups_controller.rb:32
-#: ../app/controllers/api/v2/hosts_controller.rb:64
+#: ../app/controllers/api/v2/hosts_controller.rb:65
 #: ../app/controllers/api/v2/operatingsystems_controller.rb:41
 #: ../app/controllers/api/v2/subnets_controller.rb:28
 #: ../app/controllers/concerns/api/v2/taxonomies_controller.rb:56
@@ -1047,7 +1113,7 @@ msgid "Description of the domain"
 msgstr ""
 
 #: ../app/controllers/api/v2/domains_controller.rb:50
-#: ../app/controllers/api/v2/subnets_controller.rb:52
+#: ../app/controllers/api/v2/subnets_controller.rb:53
 msgid "Array of parameters (name, value)"
 msgstr ""
 
@@ -1319,7 +1385,7 @@ msgid "Architecture ID"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:48
-#: ../app/controllers/api/v2/hosts_controller.rb:89
+#: ../app/controllers/api/v2/hosts_controller.rb:90
 msgid "DHCP filename option (Grub2/PXELinux by default)"
 msgstr ""
 
@@ -1344,7 +1410,7 @@ msgid "Realm ID"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:54
-#: ../app/controllers/api/v2/hosts_controller.rb:86
+#: ../app/controllers/api/v2/hosts_controller.rb:87
 msgid "IDs of associated config groups"
 msgstr ""
 
@@ -1355,14 +1421,14 @@ msgid "Array of parameters"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:56
-#: ../app/controllers/api/v2/hosts_controller.rb:100
+#: ../app/controllers/api/v2/hosts_controller.rb:101
 #: ../app/controllers/api/v2/operatingsystems_controller.rb:29
 #: ../app/controllers/api/v2/operatingsystems_controller.rb:55
 msgid "Name of the parameter"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:57
-#: ../app/controllers/api/v2/hosts_controller.rb:101
+#: ../app/controllers/api/v2/hosts_controller.rb:102
 #: ../app/controllers/api/v2/operatingsystems_controller.rb:30
 #: ../app/controllers/api/v2/operatingsystems_controller.rb:56
 msgid "Parameter value"
@@ -1393,12 +1459,12 @@ msgid "Clone a host group"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:108
-#: ../app/controllers/api/v2/hosts_controller.rb:293
+#: ../app/controllers/api/v2/hosts_controller.rb:294
 msgid "Rebuild orchestration config"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:110
-#: ../app/controllers/api/v2/hosts_controller.rb:295
+#: ../app/controllers/api/v2/hosts_controller.rb:296
 msgid "Limit rebuild steps, valid steps are %{host_rebuild_steps}"
 msgstr ""
 
@@ -1407,12 +1473,12 @@ msgid "Operate on child hostgroup hosts"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:120
-#: ../app/controllers/api/v2/hosts_controller.rb:300
+#: ../app/controllers/api/v2/hosts_controller.rb:301
 msgid "Configuration successfully rebuilt."
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:123
-#: ../app/controllers/api/v2/hosts_controller.rb:302
+#: ../app/controllers/api/v2/hosts_controller.rb:303
 msgid "Configuration rebuild failed for: %s."
 msgstr ""
 
@@ -1467,125 +1533,125 @@ msgstr ""
 msgid "ID of environment"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:62
+#: ../app/controllers/api/v2/hosts_controller.rb:63
 msgid "Show a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:74
+#: ../app/controllers/api/v2/hosts_controller.rb:75
 msgid "required if locations are enabled"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:75
+#: ../app/controllers/api/v2/hosts_controller.rb:76
 msgid "required if organizations are enabled"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:76
-#: ../app/controllers/api/v2/hosts_controller.rb:79
+#: ../app/controllers/api/v2/hosts_controller.rb:77
 #: ../app/controllers/api/v2/hosts_controller.rb:80
-#: ../app/controllers/api/v2/hosts_controller.rb:87
-#: ../app/controllers/api/v2/hosts_controller.rb:91
+#: ../app/controllers/api/v2/hosts_controller.rb:81
+#: ../app/controllers/api/v2/hosts_controller.rb:88
+#: ../app/controllers/api/v2/hosts_controller.rb:92
 msgid "required if host is managed and value is not inherited from host group"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:77
+#: ../app/controllers/api/v2/hosts_controller.rb:78
 msgid "not required if using a subnet with DHCP proxy"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:78
+#: ../app/controllers/api/v2/hosts_controller.rb:79
 msgid ""
 "required for managed host that is bare metal, not required if it's a virtual m"
 "achine"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:88
+#: ../app/controllers/api/v2/hosts_controller.rb:89
 msgid ""
 "required if not imaged based provisioning and host is managed and value is not"
 " inherited from host group"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:90
+#: ../app/controllers/api/v2/hosts_controller.rb:91
 msgid "required if host is managed and custom partition has not been defined"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:92
+#: ../app/controllers/api/v2/hosts_controller.rb:93
 msgid "nil means host is bare metal"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:93
+#: ../app/controllers/api/v2/hosts_controller.rb:94
 msgid ""
 "required if host is managed and value is not inherited from host group or defa"
 "ult password in settings"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:97
+#: ../app/controllers/api/v2/hosts_controller.rb:98
 msgid "Host's owner type"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:99
+#: ../app/controllers/api/v2/hosts_controller.rb:100
 msgid "Host's parameters (array or indexed hash)"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:104
+#: ../app/controllers/api/v2/hosts_controller.rb:105
 #: ../app/views/hosts/_form.html.erb:130
 msgid "Include this host within Foreman reporting"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:105
+#: ../app/controllers/api/v2/hosts_controller.rb:106
 msgid "The method used to provision the host."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:106
+#: ../app/controllers/api/v2/hosts_controller.rb:107
 msgid ""
 "True/False flag whether a host is managed or unmanaged. Note: this value also "
 "determines whether several parameters are required or not"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:107
+#: ../app/controllers/api/v2/hosts_controller.rb:108
 msgid "UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:108
+#: ../app/controllers/api/v2/hosts_controller.rb:109
 #: ../app/views/hosts/_form.html.erb:135
 msgid "Additional information about this host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:111
+#: ../app/controllers/api/v2/hosts_controller.rb:112
 msgid "Host's network interfaces."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:114
+#: ../app/controllers/api/v2/hosts_controller.rb:115
 msgid "Additional compute resource specific attributes."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:118
+#: ../app/controllers/api/v2/hosts_controller.rb:119
 msgid "Parameters for host's %s facet"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:126
+#: ../app/controllers/api/v2/hosts_controller.rb:127
 msgid "Create a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:149
+#: ../app/controllers/api/v2/hosts_controller.rb:150
 msgid "Update a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:165
+#: ../app/controllers/api/v2/hosts_controller.rb:166
 msgid "Delete a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:172
+#: ../app/controllers/api/v2/hosts_controller.rb:173
 msgid "Get ENC values of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:179
+#: ../app/controllers/api/v2/hosts_controller.rb:180
 msgid "Get configuration status of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:198
+#: ../app/controllers/api/v2/hosts_controller.rb:199
 msgid "Get status of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:200
+#: ../app/controllers/api/v2/hosts_controller.rb:201
 msgid ""
 "status type, can be one of\n"
 "* global\n"
@@ -1593,86 +1659,86 @@ msgid ""
 "* build\n"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:207
+#: ../app/controllers/api/v2/hosts_controller.rb:208
 msgid "Returns string representing a host status of a given type"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:217
+#: ../app/controllers/api/v2/hosts_controller.rb:218
 msgid "Get vm attributes of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:240
+#: ../app/controllers/api/v2/hosts_controller.rb:241
 msgid "Disassociate the host from a VM"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:247
+#: ../app/controllers/api/v2/hosts_controller.rb:248
 msgid "Run a power operation on host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:249
+#: ../app/controllers/api/v2/hosts_controller.rb:250
 msgid ""
 "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/"
 "reset), (state/status)"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:253
-#: ../app/controllers/hosts_controller.rb:278
+#: ../app/controllers/api/v2/hosts_controller.rb:254
+#: ../app/controllers/hosts_controller.rb:280
 msgid "Power operations are not enabled on this host."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:260
+#: ../app/controllers/api/v2/hosts_controller.rb:261
 msgid "Unknown power action: available methods are %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:264
+#: ../app/controllers/api/v2/hosts_controller.rb:265
 msgid "Boot host from specified device"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:266
+#: ../app/controllers/api/v2/hosts_controller.rb:267
 msgid "boot device, valid devices are disk, cdrom, pxe, bios"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:273
+#: ../app/controllers/api/v2/hosts_controller.rb:274
 msgid "Unknown device: available devices are %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:279
+#: ../app/controllers/api/v2/hosts_controller.rb:280
 msgid "Upload facts for a host, creating the host if required"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:280
+#: ../app/controllers/api/v2/hosts_controller.rb:281
 msgid "hostname of the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:281
+#: ../app/controllers/api/v2/hosts_controller.rb:282
 msgid "hash containing the facts for the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:282
+#: ../app/controllers/api/v2/hosts_controller.rb:283
 msgid "optional: certname of the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:283
+#: ../app/controllers/api/v2/hosts_controller.rb:284
 msgid "optional: the STI type of host to create"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:306
+#: ../app/controllers/api/v2/hosts_controller.rb:307
 msgid "Preview rendered provisioning template content"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:308
+#: ../app/controllers/api/v2/hosts_controller.rb:309
 msgid "Template kinds, available values: %{template_kinds}"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:312
+#: ../app/controllers/api/v2/hosts_controller.rb:313
 msgid "No template with kind %{kind} for %{host}"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:378
+#: ../app/controllers/api/v2/hosts_controller.rb:379
 msgid "Invalid type for host creation via facts: %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:381
+#: ../app/controllers/api/v2/hosts_controller.rb:382
 msgid "A problem occurred when detecting host type: %s"
 msgstr ""
 
@@ -1777,9 +1843,9 @@ msgstr ""
 
 #: ../app/controllers/api/v2/interfaces_controller.rb:16
 #: ../app/controllers/api/v2/interfaces_controller.rb:27
-#: ../app/controllers/api/v2/interfaces_controller.rb:70
-#: ../app/controllers/api/v2/interfaces_controller.rb:79
-#: ../app/controllers/api/v2/interfaces_controller.rb:88
+#: ../app/controllers/api/v2/interfaces_controller.rb:71
+#: ../app/controllers/api/v2/interfaces_controller.rb:80
+#: ../app/controllers/api/v2/interfaces_controller.rb:89
 msgid "ID or name of host"
 msgstr ""
 
@@ -1875,47 +1941,51 @@ msgid ""
 msgstr ""
 
 #: ../app/controllers/api/v2/interfaces_controller.rb:54
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
+#: ../app/controllers/api/v2/interfaces_controller.rb:55
 msgid ""
 "Identifier of the interface to which this interface belongs, e.g. eth1. Only f"
 "or virtual interfaces."
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:56
+#: ../app/controllers/api/v2/interfaces_controller.rb:57
 msgid "Bond mode of the interface, e.g. balance-rr. Only for bond interfaces."
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:57
+#: ../app/controllers/api/v2/interfaces_controller.rb:58
 msgid ""
 "Identifiers of attached interfaces, e.g. `['eth1', 'eth2']`. For bond interfac"
 "es those are the slaves. Only for bond and bridges interfaces."
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:58
+#: ../app/controllers/api/v2/interfaces_controller.rb:59
 msgid "Space separated options, e.g. miimon=100. Only for bond interfaces."
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:60
+#: ../app/controllers/api/v2/interfaces_controller.rb:61
 msgid "Additional compute resource specific attributes for the interface."
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:64
+#: ../app/controllers/api/v2/interfaces_controller.rb:65
 msgid "interface information"
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:69
+#: ../app/controllers/api/v2/interfaces_controller.rb:70
 msgid "Create an interface on a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:78
+#: ../app/controllers/api/v2/interfaces_controller.rb:79
 msgid "Update a host's interface"
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:80
-#: ../app/controllers/api/v2/interfaces_controller.rb:89
+#: ../app/controllers/api/v2/interfaces_controller.rb:81
+#: ../app/controllers/api/v2/interfaces_controller.rb:90
 msgid "ID of interface"
 msgstr ""
 
-#: ../app/controllers/api/v2/interfaces_controller.rb:87
+#: ../app/controllers/api/v2/interfaces_controller.rb:88
 msgid "Delete a host's interface"
 msgstr ""
 
@@ -2361,34 +2431,34 @@ msgstr ""
 msgid "List available resource types"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:11
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:9
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:12
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:21
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:27
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:45
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:12
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:22
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:28
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:45
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:10
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:19
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:25
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:43
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:10
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:20
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:26
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:43
 msgid "ID of the user"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:19
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:17
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:30
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:28
 msgid "Expiry Date"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:34
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:32
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:43
+#: ../app/controllers/api/v2/personal_access_tokens_controller.rb:41
 msgid "Revoke a Personal Access Token for a user"
 msgstr ""
 
@@ -2396,82 +2466,69 @@ msgstr ""
 msgid "List installed plugins"
 msgstr ""
 
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:58
-#: ../app/controllers/api/v2/ptables_controller.rb:53
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:59
+#: ../app/controllers/api/v2/ptables_controller.rb:54
 msgid "Import a provisioning template"
 msgstr ""
 
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:61
-#: ../app/controllers/api/v2/ptables_controller.rb:56
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:62
+#: ../app/controllers/api/v2/ptables_controller.rb:57
 msgid "template contents including metadata"
 msgstr ""
 
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:64
-#: ../app/controllers/api/v2/ptables_controller.rb:59
-msgid "use if you want update locked templates"
-msgstr ""
-
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:65
-#: ../app/controllers/api/v2/ptables_controller.rb:60
-msgid ""
-"determines when the template should associate objects based on metadata, new m"
-"eans only when new template is being created, always means both for new and ex"
-"isting template which is only being updated, never ignores metadata"
-msgstr ""
-
-#: ../app/controllers/api/v2/provisioning_templates_controller.rb:132
+#: ../app/controllers/api/v2/provisioning_templates_controller.rb:127
 msgid "Export a provisioning template to ERB"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:11
+#: ../app/controllers/api/v2/ptables_controller.rb:12
 msgid "List all partition tables"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:12
+#: ../app/controllers/api/v2/ptables_controller.rb:13
 msgid "List all partition tables for an operating system"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:13
+#: ../app/controllers/api/v2/ptables_controller.rb:14
 msgid "List all partition tables per location"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:14
+#: ../app/controllers/api/v2/ptables_controller.rb:15
 msgid "List all partition tables per organization"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:24
+#: ../app/controllers/api/v2/ptables_controller.rb:25
 msgid "Show a partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:38
+#: ../app/controllers/api/v2/ptables_controller.rb:39
 msgid "Array of operating system IDs to associate with the partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:39
+#: ../app/controllers/api/v2/ptables_controller.rb:40
 msgid "Array of host IDs to associate with the partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:40
+#: ../app/controllers/api/v2/ptables_controller.rb:41
 msgid "Array of host group IDs to associate with the partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:45
+#: ../app/controllers/api/v2/ptables_controller.rb:46
 msgid "Create a partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:80
+#: ../app/controllers/api/v2/ptables_controller.rb:75
 msgid "Update a partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:88
+#: ../app/controllers/api/v2/ptables_controller.rb:83
 msgid "Delete a partition table"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:101
+#: ../app/controllers/api/v2/ptables_controller.rb:96
 msgid "Clone a template"
 msgstr ""
 
-#: ../app/controllers/api/v2/ptables_controller.rb:112
+#: ../app/controllers/api/v2/ptables_controller.rb:107
 msgid "Export a partition template to ERB"
 msgstr ""
 
@@ -2770,23 +2827,23 @@ msgstr ""
 msgid "Delete a smart variable"
 msgstr ""
 
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:11
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:9
 msgid "List all SSH keys for a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:20
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:18
 msgid "Show an SSH key from a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:31
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:29
 msgid "Public SSH key"
 msgstr ""
 
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:35
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:33
 msgid "Add an SSH key for a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/ssh_keys_controller.rb:43
+#: ../app/controllers/api/v2/ssh_keys_controller.rb:41
 msgid "Delete an SSH key for a user"
 msgstr ""
 
@@ -2836,6 +2893,9 @@ msgid "Netmask for this subnet"
 msgstr ""
 
 #: ../app/controllers/api/v2/subnets_controller.rb:40
+msgid "Subnet gateway"
+msgstr ""
+
 #: ../app/controllers/api/v2/subnets_controller.rb:41
 msgid "Primary DNS for this subnet"
 msgstr ""
@@ -2863,43 +2923,84 @@ msgid "VLAN ID for this subnet"
 msgstr ""
 
 #: ../app/controllers/api/v2/subnets_controller.rb:47
+#: ../app/views/subnets/_fields.html.erb:25
+msgid "MTU for this subnet"
+msgstr ""
+
+#: ../app/controllers/api/v2/subnets_controller.rb:48
 #: ../app/views/subnets/_form.html.erb:25
 msgid "Domains in which this subnet is part"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:51
+#: ../app/controllers/api/v2/subnets_controller.rb:52
 msgid ""
 "Default boot mode for interfaces assigned to this subnet, valid values are \"St"
 "atic\", \"DHCP\""
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:57
+#: ../app/controllers/api/v2/subnets_controller.rb:58
 msgid "Create a subnet"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:65
+#: ../app/controllers/api/v2/subnets_controller.rb:66
 msgid "Update a subnet"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:66
-#: ../app/controllers/api/v2/subnets_controller.rb:74
+#: ../app/controllers/api/v2/subnets_controller.rb:67
+#: ../app/controllers/api/v2/subnets_controller.rb:75
 msgid "Subnet numeric identifier"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:73
+#: ../app/controllers/api/v2/subnets_controller.rb:74
 msgid "Delete a subnet"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:80
+#: ../app/controllers/api/v2/subnets_controller.rb:81
 msgid "Provides an unused IP address in this subnet"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:82
+#: ../app/controllers/api/v2/subnets_controller.rb:83
 msgid "MAC address to reuse the IP for this host"
 msgstr ""
 
-#: ../app/controllers/api/v2/subnets_controller.rb:83
+#: ../app/controllers/api/v2/subnets_controller.rb:84
 msgid "IP addresses that should be excluded from suggestion"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:9
+msgid "List of table preferences for a user"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:14
+msgid "Table preference details of a given table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:24
+msgid "Name of the table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:25
+msgid "List of user selected columns"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:29
+msgid "Creates a table preference for a given table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:36
+msgid "Updates a table preference for a given table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:42
+msgid "Delete a table preference for a given table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:43
+msgid "name of the table"
+msgstr ""
+
+#: ../app/controllers/api/v2/table_preferences_controller.rb:51
+msgid "You are trying access the preferences of a different user"
 msgstr ""
 
 #: ../app/controllers/api/v2/tasks_controller.rb:6
@@ -2956,6 +3057,22 @@ msgstr ""
 msgid "List all template kinds"
 msgstr ""
 
+#: ../app/controllers/api/v2/trends_controller.rb:8
+msgid "List of trends counters"
+msgstr ""
+
+#: ../app/controllers/api/v2/trends_controller.rb:13
+msgid "Show a trend"
+msgstr ""
+
+#: ../app/controllers/api/v2/trends_controller.rb:18
+msgid "Create a trend counter"
+msgstr ""
+
+#: ../app/controllers/api/v2/trends_controller.rb:31
+msgid "Delete a trend counter"
+msgstr ""
+
 #: ../app/controllers/api/v2/usergroups_controller.rb:9
 msgid "List all user groups"
 msgstr ""
@@ -2989,116 +3106,120 @@ msgid "List all users for LDAP authentication source"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:18
-msgid "List all users for user group"
+msgid "List all users for external authentication source"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:19
-msgid "List all users for role"
+msgid "List all users for user group"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:20
-msgid "List all users for location"
+msgid "List all users for role"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:21
-msgid "List all users for organization"
+msgid "List all users for location"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:22
-msgid "ID of LDAP authentication source"
+msgid "List all users for organization"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:23
-msgid "ID of user group"
+msgid "ID of LDAP authentication source"
 msgstr ""
 
 #: ../app/controllers/api/v2/users_controller.rb:24
+msgid "ID of user group"
+msgstr ""
+
+#: ../app/controllers/api/v2/users_controller.rb:25
 msgid "ID of role"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:33
+#: ../app/controllers/api/v2/users_controller.rb:34
 msgid "Show a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:45
+#: ../app/controllers/api/v2/users_controller.rb:46
 msgid "is an admin account"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:50
+#: ../app/controllers/api/v2/users_controller.rb:51
 msgid "User's timezone"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:51
+#: ../app/controllers/api/v2/users_controller.rb:52
 msgid "User's preferred locale"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:65
+#: ../app/controllers/api/v2/users_controller.rb:66
 msgid "Required when user want to change own password"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:69
+#: ../app/controllers/api/v2/users_controller.rb:70
 msgid "Create a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:84
+#: ../app/controllers/api/v2/users_controller.rb:85
 msgid "Update a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:102
+#: ../app/controllers/api/v2/users_controller.rb:103
 msgid "Delete a user"
 msgstr ""
 
-#: ../app/controllers/api/v2/users_controller.rb:107
+#: ../app/controllers/api/v2/users_controller.rb:108
 msgid "You are trying to delete your own account"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:79
+#: ../app/controllers/application_controller.rb:94
 msgid "An email address is required, please update your account details"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:95
+#: ../app/controllers/application_controller.rb:110
 msgid "Invalid query"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:224
+#: ../app/controllers/application_controller.rb:239
 msgid "Administrator user account required"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:257
+#: ../app/controllers/application_controller.rb:272
 msgid "Successfully created %s."
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:259
+#: ../app/controllers/application_controller.rb:274
 msgid "Successfully updated %s."
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:261
+#: ../app/controllers/application_controller.rb:276
 msgid "Successfully deleted %s."
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:263
+#: ../app/controllers/application_controller.rb:278
 msgid "Unknown action name for success message: %s"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:288
+#: ../app/controllers/application_controller.rb:303
 msgid "Conflict - %s"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:331
+#: ../app/controllers/application_controller.rb:346
 msgid "You must create at least one location before continuing."
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:333
+#: ../app/controllers/application_controller.rb:348
 msgid "You must create at least one organization before continuing."
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:346
+#: ../app/controllers/application_controller.rb:361
 #: ../app/helpers/dashboard_helper.rb:60 ../app/models/host_status/global.rb:34
 #: ../app/views/hosts/_dhcp_lease_errors.html.erb:18
 msgid "OK"
 msgstr ""
 
-#: ../app/controllers/application_controller.rb:375
+#: ../app/controllers/application_controller.rb:390
 msgid "Invalid authenticity token"
 msgstr ""
 
@@ -3106,21 +3227,29 @@ msgstr ""
 msgid "Bookmark was successfully updated"
 msgstr ""
 
-#: ../app/controllers/compute_resources_controller.rb:50
+#: ../app/controllers/compute_resources_controller.rb:42
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+#: ../app/controllers/compute_resources_controller.rb:55
 msgid "No VMs matched any host."
 msgstr ""
 
-#: ../app/controllers/compute_resources_controller.rb:52
+#: ../app/controllers/compute_resources_controller.rb:57
 msgid "%s VM was associated to a host."
 msgid_plural "%s VMs were each associated to hosts."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/controllers/compute_resources_controller.rb:55
+#: ../app/controllers/compute_resources_controller.rb:60
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../app/controllers/compute_resources_controller.rb:81
+msgid "Error while trying to update resource: %s"
+msgstr ""
 
 #: ../app/controllers/compute_resources_vms_controller.rb:26
 msgid "JSON VM listing is not supported for this compute resource."
@@ -3143,7 +3272,7 @@ msgid "The virtual machine is being deleted."
 msgstr ""
 
 #: ../app/controllers/compute_resources_vms_controller.rb:90
-#: ../app/controllers/hosts_controller.rb:349
+#: ../app/controllers/hosts_controller.rb:351
 msgid "Failed to set console: %s"
 msgstr ""
 
@@ -3192,7 +3321,7 @@ msgstr ""
 msgid "No changes to your environments detected"
 msgstr ""
 
-#: ../app/controllers/concerns/api/v2/lookup_keys_common_controller.rb:147
+#: ../app/controllers/concerns/api/v2/lookup_keys_common_controller.rb:149
 msgid "%{model} with id '%{id}' was not found"
 msgstr ""
 
@@ -3389,25 +3518,25 @@ msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:118
-#: ../app/controllers/hosts_controller.rb:814
+#: ../app/controllers/hosts_controller.rb:808
 msgid "No proxy selected!"
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:124
-#: ../app/controllers/hosts_controller.rb:820
+#: ../app/controllers/hosts_controller.rb:814
 msgid "Invalid proxy selected!"
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:146
-#: ../app/controllers/hosts_controller.rb:842
+#: ../app/controllers/hosts_controller.rb:836
 msgid "Failed to set %{proxy_type} proxy for %{host}."
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:153
-#: ../app/controllers/hosts_controller.rb:849
+#: ../app/controllers/hosts_controller.rb:843
 msgid "The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}"
 msgstr ""
 
@@ -3420,7 +3549,7 @@ msgstr ""
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:158
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:173
-#: ../app/controllers/hosts_controller.rb:854
+#: ../app/controllers/hosts_controller.rb:848
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
 msgstr[0] ""
@@ -3434,7 +3563,7 @@ msgstr ""
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:183
 #: ../app/models/concerns/host_common.rb:11 ../app/models/setting/puppet.rb:41
-#: ../app/registries/menu/loader.rb:76
+#: ../app/registries/menu/loader.rb:79
 msgid "Puppet"
 msgstr ""
 
@@ -3460,7 +3589,7 @@ msgstr ""
 msgid "Selected hosts are now assigned to %s"
 msgstr ""
 
-#: ../app/controllers/config_reports_controller.rb:36
+#: ../app/controllers/config_reports_controller.rb:37
 msgid "Successfully deleted report."
 msgstr ""
 
@@ -3484,269 +3613,272 @@ msgstr ""
 msgid "Cannot delete group %{current} because it has nested groups."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:17
-#: ../app/models/compute_resources/foreman/model/vmware.rb:192
-msgid "BIOS"
-msgstr ""
-
-#: ../app/controllers/hosts_controller.rb:17
+#: ../app/controllers/hosts_controller.rb:16
 #: ../app/views/compute_resources_vms/show/_libvirt.html.erb:45
 #: ../app/views/compute_resources_vms/show/_ovirt.html.erb:39
 msgid "Disk"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:17
+#: ../app/controllers/hosts_controller.rb:16
 msgid "CDROM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:17
+#: ../app/controllers/hosts_controller.rb:16
 msgid "PXE"
+msgstr ""
+
+#: ../app/controllers/hosts_controller.rb:16
+#: ../app/models/compute_resources/foreman/model/vmware.rb:198
+msgid "BIOS"
+msgstr ""
+
+#: ../app/controllers/hosts_controller.rb:27
+#: ../app/helpers/compute_resources_helper.rb:8
+#: ../app/helpers/compute_resources_helper.rb:13
+#: ../app/helpers/hosts_helper.rb:317
+msgid "On"
 msgstr ""
 
 #: ../app/controllers/hosts_controller.rb:28
 #: ../app/helpers/compute_resources_helper.rb:8
 #: ../app/helpers/compute_resources_helper.rb:13
-#: ../app/helpers/hosts_helper.rb:304
-msgid "On"
-msgstr ""
-
-#: ../app/controllers/hosts_controller.rb:29
-#: ../app/helpers/compute_resources_helper.rb:8
-#: ../app/helpers/compute_resources_helper.rb:13
-#: ../app/helpers/hosts_helper.rb:304 ../app/services/name_generator.rb:3
+#: ../app/helpers/hosts_helper.rb:317 ../app/services/name_generator.rb:3
 msgid "Off"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:30
+#: ../app/controllers/hosts_controller.rb:29
 #: ../app/helpers/application_helper.rb:56
 #: ../app/helpers/application_helper.rb:66 ../app/helpers/audits_helper.rb:7
-#: ../app/helpers/audits_helper.rb:26 ../app/helpers/audits_helper.rb:59
+#: ../app/helpers/audits_helper.rb:40 ../app/helpers/audits_helper.rb:73
+#: ../app/helpers/audits_helper.rb:125 ../app/helpers/audits_helper.rb:135
 #: ../app/helpers/compute_resources_vms_helper.rb:37
-#: ../app/helpers/fact_values_helper.rb:5 ../app/helpers/hosts_helper.rb:193
-#: ../app/helpers/hosts_helper.rb:200 ../app/helpers/reports_helper.rb:22
+#: ../app/helpers/fact_values_helper.rb:5 ../app/helpers/hosts_helper.rb:194
+#: ../app/helpers/hosts_helper.rb:201 ../app/helpers/hosts_helper.rb:254
+#: ../app/helpers/hosts_helper.rb:274 ../app/helpers/reports_helper.rb:22
+#: ../app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb:14
 #: ../app/views/fact_values/_fact.html.erb:7
-#: ../app/views/filters/index.html.erb:42
+#: ../app/views/filters/index.html.erb:52
 msgid "N/A"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:98
+#: ../app/controllers/hosts_controller.rb:96
 msgid "The marked fields will need reviewing"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:212
+#: ../app/controllers/hosts_controller.rb:210
 msgid "Unable to generate output, Check log files"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:220
+#: ../app/controllers/hosts_controller.rb:218
 msgid "Successfully executed, check log files for more details"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:238
+#: ../app/controllers/hosts_controller.rb:236
 msgid "Enabled %s for reboot and rebuild"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:240
+#: ../app/controllers/hosts_controller.rb:238
 msgid "Enabled %s for rebuild on next boot, but failed to power cycle the host"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:244
+#: ../app/controllers/hosts_controller.rb:242
 msgid "Failed to reboot %s."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:247
-#: ../app/controllers/hosts_controller.rb:250
+#: ../app/controllers/hosts_controller.rb:245
+#: ../app/controllers/hosts_controller.rb:248
 msgid "Enabled %s for rebuild on next boot"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:253
+#: ../app/controllers/hosts_controller.rb:251
 msgid "Failed to enable %{host} for installation: %{errors}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:259
+#: ../app/controllers/hosts_controller.rb:257
 msgid "Canceled pending build for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:261
+#: ../app/controllers/hosts_controller.rb:259
 msgid ""
 "Failed to cancel pending build for %{hostname} with the following errors: %{er"
 "rors}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:268
+#: ../app/controllers/hosts_controller.rb:270
 msgid "%{host} is about to %{action}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:270
+#: ../app/controllers/hosts_controller.rb:272
 msgid "Failed to %{action} %{host}: %{e}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:285
+#: ../app/controllers/hosts_controller.rb:287
 msgid "Failed to fetch power status: %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:338
+#: ../app/controllers/hosts_controller.rb:340
 msgid "%{host} now boots from %{device}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:340
+#: ../app/controllers/hosts_controller.rb:342
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:356
+#: ../app/controllers/hosts_controller.rb:358
 msgid "Foreman now manages the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:358
+#: ../app/controllers/hosts_controller.rb:360
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:362
+#: ../app/controllers/hosts_controller.rb:364
 msgid "Failed to modify the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:369
+#: ../app/controllers/hosts_controller.rb:371
 msgid "%s has been disassociated from VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:371
+#: ../app/controllers/hosts_controller.rb:373
 msgid "Host %s is not associated with a VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:390
+#: ../app/controllers/hosts_controller.rb:389
 msgid "No parameters were allocated to the selected hosts, can't mass assign"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:410
+#: ../app/controllers/hosts_controller.rb:409
 msgid "Updated all hosts!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:414
+#: ../app/controllers/hosts_controller.rb:413
 msgid "%s Parameters updated, see below for more information"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:424
+#: ../app/controllers/hosts_controller.rb:423
 msgid "No host group selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:435
+#: ../app/controllers/hosts_controller.rb:434
 msgid "Updated hosts: changed host group"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:446
+#: ../app/controllers/hosts_controller.rb:445
 msgid "No owner selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:457
+#: ../app/controllers/hosts_controller.rb:456
 msgid "Updated hosts: changed owner"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:470
+#: ../app/controllers/hosts_controller.rb:469
 msgid "Failed to set power state for %s."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:475
+#: ../app/controllers/hosts_controller.rb:474
 msgid "The power state of the selected hosts will be set to %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:501
+#: ../app/controllers/hosts_controller.rb:500
 msgid "%{config_type} rebuild failed for host: %{host_names}."
 msgid_plural "%{config_type} rebuild failed for hosts: %{host_names}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/controllers/hosts_controller.rb:508
+#: ../app/controllers/hosts_controller.rb:507
 msgid "Configuration successfully rebuilt"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:525
+#: ../app/controllers/hosts_controller.rb:524
 msgid "Failed to redeploy %s."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:534
+#: ../app/controllers/hosts_controller.rb:533
 msgid "The selected hosts were enabled for reboot and rebuild"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:536
+#: ../app/controllers/hosts_controller.rb:535
 msgid "The selected hosts will execute a build operation on next reboot"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:539
+#: ../app/controllers/hosts_controller.rb:538
 msgid "The following hosts failed the build operation: %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:548
+#: ../app/controllers/hosts_controller.rb:547
 msgid "Destroyed selected hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:550
+#: ../app/controllers/hosts_controller.rb:549
 msgid "The following hosts were not deleted: %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:578
+#: ../app/controllers/hosts_controller.rb:577
 msgid "Updated hosts: Disassociated from VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:584
+#: ../app/controllers/hosts_controller.rb:583
 msgid "Hosts with errors"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:589
+#: ../app/controllers/hosts_controller.rb:588
 msgid "Active Hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:594
+#: ../app/controllers/hosts_controller.rb:593
 msgid "Pending Hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:599
+#: ../app/controllers/hosts_controller.rb:598
 msgid "Hosts which didn't report in the last %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:604
+#: ../app/controllers/hosts_controller.rb:603
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:709
+#: ../app/controllers/hosts_controller.rb:703
 msgid "invalid type: %s requested"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:714
+#: ../app/controllers/hosts_controller.rb:708
 msgid "Something went wrong while changing host type - %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:744
+#: ../app/controllers/hosts_controller.rb:738
 msgid "No hosts were found with that id, name or query filter"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:749
+#: ../app/controllers/hosts_controller.rb:743
 msgid "No hosts selected"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:756
+#: ../app/controllers/hosts_controller.rb:750
 msgid "Something went wrong while selecting hosts - %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:769
+#: ../app/controllers/hosts_controller.rb:763
 msgid "%s selected hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:771
+#: ../app/controllers/hosts_controller.rb:765
 msgid "The following hosts were not %{action}: %{missed_hosts}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:798
+#: ../app/controllers/hosts_controller.rb:792
 msgid "No or invalid power state selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:851
+#: ../app/controllers/hosts_controller.rb:845
 msgid "The %{proxy_type} proxy of the selected hosts was cleared"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:866
+#: ../app/controllers/hosts_controller.rb:860
 msgid "No templates found"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:877
+#: ../app/controllers/hosts_controller.rb:871
 msgid "Failed to retrieve power status for %{host} within %{timeout} second."
 msgid_plural "Failed to retrieve power status for %{host} within %{timeout} seconds."
 msgstr[0] ""
@@ -3836,37 +3968,31 @@ msgstr ""
 msgid "Template unlocked"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:72
+#: ../app/controllers/unattended_controller.rb:88
 msgid "unable to find %{type} template for %{host} running %{os}"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:97
+#: ../app/controllers/unattended_controller.rb:113
 msgid "%{controller}: provisioning token for host %{host} expired"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:113
+#: ../app/controllers/unattended_controller.rb:129
 msgid "%{controller}: unable to find a host that matches the request from %{addr}"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:118
+#: ../app/controllers/unattended_controller.rb:134
 msgid "%{controller}: %{host}'s operating system is missing"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:123
+#: ../app/controllers/unattended_controller.rb:139
 msgid "%{controller}: %{host}'s operating system %{os} has no OS family"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:202
-msgid ""
-"Failed to clean any old certificates or add the autosign entry. Terminating th"
-"e build!"
-msgstr ""
-
-#: ../app/controllers/unattended_controller.rb:214
+#: ../app/controllers/unattended_controller.rb:217
 msgid "Failed to get a new realm OTP. Terminating the build!"
 msgstr ""
 
-#: ../app/controllers/unattended_controller.rb:259
+#: ../app/controllers/unattended_controller.rb:262
 msgid "There was an error rendering the %s template: "
 msgstr ""
 
@@ -3887,48 +4013,48 @@ msgstr ""
 msgid "Incorrect username or password"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:96
+#: ../app/controllers/users_controller.rb:97
 msgid "Some imported user account details cannot be saved: %s"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:130
+#: ../app/controllers/users_controller.rb:132
 msgid "Logged out - See you soon"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:143
+#: ../app/controllers/users_controller.rb:145
 msgid "Email address is missing"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:149
+#: ../app/controllers/users_controller.rb:151
 msgid "Unable to send email, check server logs for more information"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:152
+#: ../app/controllers/users_controller.rb:154
 msgid "Email was sent successfully"
 msgstr ""
 
-#: ../app/controllers/users_controller.rb:179
+#: ../app/controllers/users_controller.rb:182
 msgid "You have already logged in"
 msgstr ""
 
 #: ../app/helpers/application_helper.rb:78
-msgid "in %s"
-msgstr ""
-
-#: ../app/helpers/application_helper.rb:78
 #: ../app/helpers/compute_resources_vms_helper.rb:35
-#: ../app/helpers/hosts_helper.rb:192 ../app/helpers/users_helper.rb:3
+#: ../app/helpers/hosts_helper.rb:193 ../app/helpers/users_helper.rb:3
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:15
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:16
 #: ../app/views/ssh_keys/_ssh_key_row.html.erb:7
 msgid "%s ago"
 msgstr ""
 
+#: ../app/helpers/application_helper.rb:78
+msgid "in %s"
+msgstr ""
+
 #: ../app/helpers/application_helper.rb:113
 msgid "Click to add %s"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:169 ../app/helpers/hosts_helper.rb:348
+#: ../app/helpers/application_helper.rb:169 ../app/helpers/hosts_helper.rb:361
 #: ../app/views/hosts/_interfaces.html.erb:34
 #: ../app/views/puppetca/_list.html.erb:31
 msgid "Delete"
@@ -3975,11 +4101,13 @@ msgid "None found"
 msgstr ""
 
 #: ../app/helpers/application_helper.rb:451
+#: ../app/views/compute_resources/show/_ovirt.html.erb:11
 #: ../app/views/users/logout.html.erb:2
 msgid "Yes"
 msgstr ""
 
 #: ../app/helpers/application_helper.rb:451
+#: ../app/views/compute_resources/show/_ovirt.html.erb:11
 msgid "No"
 msgstr ""
 
@@ -3987,35 +4115,62 @@ msgstr ""
 msgid "NA"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:18
+#: ../app/helpers/audits_helper.rb:18 ../app/helpers/audits_helper.rb:26
+msgid "Missing(ID: %s)"
+msgstr ""
+
+#: ../app/helpers/audits_helper.rb:32
 msgid "[empty]"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:55
+#: ../app/helpers/audits_helper.rb:69
 msgid "Template content changed %s"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:57
+#: ../app/helpers/audits_helper.rb:71
 msgid "Password has been changed"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:59
+#: ../app/helpers/audits_helper.rb:73
 msgid "Owner changed to %s"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:64
+#: ../app/helpers/audits_helper.rb:78
 msgid "Global status changed from %{from} to %{to}"
 msgstr ""
 
-#: ../app/helpers/audits_helper.rb:66
+#: ../app/helpers/audits_helper.rb:80
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/audits_helper.rb:102 ../app/helpers/hosts_helper.rb:276
-#: ../app/registries/menu/loader.rb:13 ../app/views/users/_form.html.erb:6
-#: model_attributes.rb:626
+#: ../app/helpers/audits_helper.rb:116 ../app/helpers/hosts_helper.rb:289
+#: ../app/registries/menu/loader.rb:14 ../app/views/users/_form.html.erb:6
+#: model_attributes.rb:652
 msgid "User"
+msgstr ""
+
+#: ../app/helpers/audits_helper.rb:217 ../app/registries/menu/loader.rb:58
+#: ../app/views/architectures/index.html.erb:9
+#: ../app/views/config_groups/index.html.erb:12
+#: ../app/views/config_reports/index.html.erb:4
+#: ../app/views/domains/index.html.erb:9
+#: ../app/views/environments/index.html.erb:9
+#: ../app/views/hostgroups/index.html.erb:9 ../app/views/hosts/index.html.erb:8
+#: ../app/views/hosts/welcome.html.erb:1 ../app/views/hosts/welcome.html.erb:6
+#: ../app/views/models/index.html.erb:11
+#: ../app/views/operatingsystems/index.html.erb:9
+#: ../app/views/puppetclasses/index.html.erb:12
+#: ../app/views/realms/index.html.erb:9 ../app/views/subnets/index.html.erb:14
+#: ../app/views/taxonomies/index.html.erb:18
+#: ../app/views/trends/show.html.erb:16
+msgid "Hosts"
+msgstr ""
+
+#: ../app/helpers/audits_helper.rb:225 ../app/helpers/hosts_helper.rb:404
+#: ../app/registries/menu/loader.rb:51 ../app/views/audits/index.html.erb:2
+#: ../app/views/audits/show.html.erb:5
+msgid "Audits"
 msgstr ""
 
 #: ../app/helpers/auth_source_ldaps_helper.rb:9
@@ -4076,12 +4231,12 @@ msgid "Foreman will not send this parameter in classification output."
 msgstr ""
 
 #: ../app/helpers/common_parameters_helper.rb:43
-#: ../app/views/audits/show.html.erb:40
+#: ../app/views/audits/show.html.erb:74
 #: ../app/views/common_parameters/_form.html.erb:5
 #: ../app/views/common_parameters/_form.html.erb:14
 #: ../app/views/common_parameters/_inherited_parameters.html.erb:5
 #: ../app/views/common_parameters/_parameters.html.erb:6
-#: ../app/views/compute_resources/show.html.erb:27
+#: ../app/views/compute_resources/show.html.erb:28
 #: ../app/views/lookup_keys/_values.html.erb:10
 #: ../app/views/lookup_keys/_values.html.erb:15
 #: ../app/views/puppetclasses/_classes_parameters.html.erb:7
@@ -4110,7 +4265,7 @@ msgstr ""
 
 #: ../app/helpers/compute_resources_helper.rb:89
 #: ../app/helpers/compute_resources_helper.rb:101
-#: ../app/views/auth_source_ldaps/_form.html.erb:20
+#: ../app/views/auth_source_ldaps/_form.html.erb:18
 msgid "Test Connection"
 msgstr ""
 
@@ -4138,15 +4293,15 @@ msgstr ""
 msgid "Console"
 msgstr ""
 
-#: ../app/helpers/compute_resources_vms_helper.rb:60
+#: ../app/helpers/compute_resources_vms_helper.rb:61
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr ""
 
-#: ../app/helpers/compute_resources_vms_helper.rb:69
+#: ../app/helpers/compute_resources_vms_helper.rb:71
 msgid "Physical (Bridge)"
 msgstr ""
 
-#: ../app/helpers/compute_resources_vms_helper.rb:70
+#: ../app/helpers/compute_resources_vms_helper.rb:72
 msgid "Virtual (NAT)"
 msgstr ""
 
@@ -4156,8 +4311,9 @@ msgstr ""
 
 #: ../app/helpers/compute_resources_vms_helper.rb:252
 #: ../app/views/config_reports/_list.html.erb:5
+#: ../app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb:3
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:3
-#: ../app/views/fact_values/index.html.erb:15
+#: ../app/views/fact_values/index.html.erb:28
 #: ../app/views/hosts/_form.html.erb:12
 msgid "Host"
 msgstr ""
@@ -4229,19 +4385,14 @@ msgstr ""
 msgid "Number Of Clients"
 msgstr ""
 
-#: ../app/helpers/dashboard_helper.rb:90 ../app/helpers/hosts_helper.rb:218
-#: ../app/views/config_reports/_list.html.erb:9
-msgid "Applied"
-msgstr ""
-
 #. TRANSLATORS: initial character of Applied
 #: ../app/helpers/dashboard_helper.rb:90
 msgid "Applied|A"
 msgstr ""
 
-#: ../app/helpers/dashboard_helper.rb:92 ../app/helpers/hosts_helper.rb:222
-#: ../app/views/config_reports/_list.html.erb:10
-msgid "Restarted"
+#: ../app/helpers/dashboard_helper.rb:90 ../app/helpers/hosts_helper.rb:219
+#: ../app/views/config_reports/_list.html.erb:9
+msgid "Applied"
 msgstr ""
 
 #. TRANSLATORS: initial character of Restarted
@@ -4249,15 +4400,20 @@ msgstr ""
 msgid "Restarted|R"
 msgstr ""
 
-#: ../app/helpers/dashboard_helper.rb:94 ../app/helpers/hosts_helper.rb:219
-#: ../app/models/config_report.rb:79
-#: ../app/views/config_reports/_list.html.erb:11
-msgid "Failed"
+#: ../app/helpers/dashboard_helper.rb:92 ../app/helpers/hosts_helper.rb:223
+#: ../app/views/config_reports/_list.html.erb:10
+msgid "Restarted"
 msgstr ""
 
 #. TRANSLATORS: initial character of Failed
 #: ../app/helpers/dashboard_helper.rb:94
 msgid "Failed|F"
+msgstr ""
+
+#: ../app/helpers/dashboard_helper.rb:94 ../app/helpers/hosts_helper.rb:220
+#: ../app/models/config_report.rb:79
+#: ../app/views/config_reports/_list.html.erb:11
+msgid "Failed"
 msgstr ""
 
 #. TRANSLATORS: initial characters of Failed Restarts
@@ -4269,14 +4425,19 @@ msgstr ""
 msgid "Failed Restarts"
 msgstr ""
 
-#: ../app/helpers/dashboard_helper.rb:98 ../app/helpers/hosts_helper.rb:221
+#. TRANSLATORS: initial character of Skipped
+#: ../app/helpers/dashboard_helper.rb:98
+msgid "Skipped|S"
+msgstr ""
+
+#: ../app/helpers/dashboard_helper.rb:98 ../app/helpers/hosts_helper.rb:222
 #: ../app/views/config_reports/_list.html.erb:13
 msgid "Skipped"
 msgstr ""
 
-#. TRANSLATORS: initial character of Skipped
-#: ../app/helpers/dashboard_helper.rb:98
-msgid "Skipped|S"
+#. TRANSLATORS: initial character of Pending
+#: ../app/helpers/dashboard_helper.rb:100
+msgid "Pending|P"
 msgstr ""
 
 #: ../app/helpers/dashboard_helper.rb:100
@@ -4285,17 +4446,25 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#. TRANSLATORS: initial character of Pending
-#: ../app/helpers/dashboard_helper.rb:100
-msgid "Pending|P"
-msgstr ""
-
 #: ../app/helpers/dashboard_helper.rb:123
 msgid "Auto refresh on"
 msgstr ""
 
 #: ../app/helpers/dashboard_helper.rb:125
 msgid "Auto refresh off"
+msgstr ""
+
+#: ../app/helpers/dashboard_helper.rb:167
+#: ../app/models/host_status/build_status.rb:17
+msgid "Token expired"
+msgstr ""
+
+#: ../app/helpers/dashboard_helper.rb:172 ../app/helpers/hosts_helper.rb:273
+msgid "Build errors"
+msgstr ""
+
+#: ../app/helpers/dashboard_helper.rb:177
+msgid "Build in progress"
 msgstr ""
 
 #: ../app/helpers/environments_helper.rb:6
@@ -4372,7 +4541,7 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr ""
 
-#: ../app/helpers/home_helper.rb:66
+#: ../app/helpers/home_helper.rb:68
 msgid "Any #{tax.humanize}"
 msgstr ""
 
@@ -4381,7 +4550,7 @@ msgstr ""
 #: ../app/helpers/roles_helper.rb:34 ../app/helpers/smart_proxies_helper.rb:8
 #: ../app/helpers/smart_proxies_helper.rb:58
 #: ../app/views/architectures/index.html.erb:22
-#: ../app/views/auth_source_ldaps/index.html.erb:24
+#: ../app/views/auth_source_ldaps/index.html.erb:22
 #: ../app/views/bookmarks/index.html.erb:23
 #: ../app/views/common_parameters/index.html.erb:22
 #: ../app/views/compute_profiles/index.html.erb:18
@@ -4427,163 +4596,172 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/helpers/hosts_helper.rb:54
-msgid "#{taxonomy} can be set on the All Hosts page"
+#: ../app/helpers/hosts_helper.rb:64
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:70 ../app/registries/menu/loader.rb:57
+#: ../app/helpers/hosts_helper.rb:71 ../app/registries/menu/loader.rb:60
 #: ../app/views/hosts/index.html.erb:1 ../app/views/hosts/welcome.html.erb:10
 msgid "Create Host"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:92
+#: ../app/helpers/hosts_helper.rb:93
 msgid "view last report details"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:95
+#: ../app/helpers/hosts_helper.rb:96
 msgid "report already deleted"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:156
+#: ../app/helpers/hosts_helper.rb:157
 msgid "Change Group"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:157
+#: ../app/helpers/hosts_helper.rb:158
 msgid "Change Environment"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:158
+#: ../app/helpers/hosts_helper.rb:159
 msgid "Edit Parameters"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:159
+#: ../app/helpers/hosts_helper.rb:160
 msgid "Disable Notifications"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:160
+#: ../app/helpers/hosts_helper.rb:161
 msgid "Enable Notifications"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:161
+#: ../app/helpers/hosts_helper.rb:162
 msgid "Disassociate Hosts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:162
+#: ../app/helpers/hosts_helper.rb:163
 msgid "Rebuild Config"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:164
+#: ../app/helpers/hosts_helper.rb:165
 msgid "Build Hosts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:165
+#: ../app/helpers/hosts_helper.rb:166
 msgid "Assign Organization"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:166
+#: ../app/helpers/hosts_helper.rb:167
 msgid "Assign Location"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:167
+#: ../app/helpers/hosts_helper.rb:168
 msgid "Change Owner"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:168
+#: ../app/helpers/hosts_helper.rb:169
 msgid "Change Puppet Master"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:169
+#: ../app/helpers/hosts_helper.rb:170
 msgid "Change Puppet CA"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:171
+#: ../app/helpers/hosts_helper.rb:172
 msgid "Run Puppet"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:172
+#: ../app/helpers/hosts_helper.rb:173
 msgid "Change Power State"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:173
+#: ../app/helpers/hosts_helper.rb:174
 msgid "Delete Hosts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:178
+#: ../app/helpers/hosts_helper.rb:179
 msgid "Select Action"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:183
+#: ../app/helpers/hosts_helper.rb:184
 msgid "%s - The following hosts are about to be changed"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:220
+#: ../app/helpers/hosts_helper.rb:221
 msgid "Failed restarts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:231
+#: ../app/helpers/hosts_helper.rb:232
 msgid "Config Retrieval"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:231 ../app/views/hosts/show.html.erb:75
+#: ../app/helpers/hosts_helper.rb:232 ../app/views/hosts/show.html.erb:76
 msgid "Runtime"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:240
+#: ../app/helpers/hosts_helper.rb:241
 msgid "Found %{count} reports from the last %{days} days"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:256 ../app/views/about/index.html.erb:27
+#: ../app/helpers/hosts_helper.rb:266 ../app/views/about/index.html.erb:27
 #: ../app/views/about/index.html.erb:50 ../app/views/about/index.html.erb:77
 #: ../app/views/hosts/_bmc.html.erb:9
 #: ../app/views/smart_proxies/index.html.erb:20
 msgid "Status"
 msgstr ""
 
+#: ../app/helpers/hosts_helper.rb:272
+msgid "Build duration"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/hosts_helper.rb:262 ../app/views/domains/_form.html.erb:4
+#: ../app/helpers/hosts_helper.rb:274 model_attributes.rb:628
+msgid "Token"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: ../app/helpers/hosts_helper.rb:275 ../app/views/domains/_form.html.erb:4
 #: ../app/views/hostgroups/_form.html.erb:50
-#: ../app/views/subnets/_form.html.erb:25 model_attributes.rb:116
+#: ../app/views/subnets/_form.html.erb:25 model_attributes.rb:118
 msgid "Domain"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/hosts_helper.rb:263 ../app/views/hostgroups/_form.html.erb:65
+#: ../app/helpers/hosts_helper.rb:276 ../app/views/hostgroups/_form.html.erb:65
 #: ../app/views/realms/_form.html.erb:4
-#: ../app/views/smart_proxies/plugins/_realm.html.erb:2 model_attributes.rb:470
+#: ../app/views/smart_proxies/plugins/_realm.html.erb:2 model_attributes.rb:478
 msgid "Realm"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:264
+#: ../app/helpers/hosts_helper.rb:277
 msgid "IP Address"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:265
+#: ../app/helpers/hosts_helper.rb:278
 #: ../app/views/hosts/_interfaces.html.erb:17
-#: ../app/views/hosts/_nics.html.erb:22 ../app/views/nic/_base_form.html.erb:53
+#: ../app/views/hosts/_nics.html.erb:26 ../app/views/nic/_base_form.html.erb:53
 msgid "IPv6 Address"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:266
+#: ../app/helpers/hosts_helper.rb:279
 msgid "Comment"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:267
+#: ../app/helpers/hosts_helper.rb:280
 #: ../app/views/hosts/_interfaces.html.erb:15
 #: ../app/views/hosts/_nics.html.erb:14 ../app/views/nic/_base_form.html.erb:7
 msgid "MAC Address"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:268
+#: ../app/helpers/hosts_helper.rb:281 ../app/views/hosts/_list.html.erb:13
 msgid "Puppet Environment"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/hosts_helper.rb:269
+#: ../app/helpers/hosts_helper.rb:282
 #: ../app/views/common/os_selection/_initial.html.erb:3 model_attributes.rb:2
 msgid "Architecture"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:270
+#: ../app/helpers/hosts_helper.rb:283
 #: ../app/helpers/provisioning_templates_helper.rb:84
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:4
 #: ../app/views/hostgroups/_form.html.erb:10
@@ -4592,11 +4770,11 @@ msgstr ""
 msgid "Operating System"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:271
+#: ../app/helpers/hosts_helper.rb:284
 msgid "PXE Loader"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:272 ../app/helpers/trends_helper.rb:6
+#: ../app/helpers/hosts_helper.rb:285 ../app/helpers/trends_helper.rb:6
 #: ../app/views/host_mailer/_active_hosts.html.erb:6
 #: ../app/views/host_mailer/_nonactive_hosts.html.erb:6
 #: ../app/views/hosts/_assign_hosts.html.erb:16
@@ -4605,14 +4783,14 @@ msgstr ""
 msgid "Host group"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:273
+#: ../app/helpers/hosts_helper.rb:286
 #: ../app/views/home/_location_dropdown.html.erb:1
 #: ../app/views/hosts/_selected_hosts.html.erb:18
 #: ../app/views/hosts/select_multiple_location.html.erb:5 taxonomies.rb:10
 msgid "Location"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:274
+#: ../app/helpers/hosts_helper.rb:287
 #: ../app/views/home/_organization_dropdown.html.erb:1
 #: ../app/views/hosts/_selected_hosts.html.erb:19
 #: ../app/views/hosts/select_multiple_organization.html.erb:5
@@ -4620,31 +4798,31 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:277 ../app/helpers/hosts_helper.rb:279
+#: ../app/helpers/hosts_helper.rb:290 ../app/helpers/hosts_helper.rb:292
+#: ../app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb:4
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:5
 #: ../app/views/hosts/select_multiple_owner.html.erb:6
 msgid "Owner"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:282 ../app/views/puppetca/_list.html.erb:7
+#: ../app/helpers/hosts_helper.rb:295 ../app/views/puppetca/_list.html.erb:7
 msgid "Certificate Name"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:310 ../app/helpers/smart_proxies_helper.rb:50
+#: ../app/helpers/hosts_helper.rb:323 ../app/helpers/smart_proxies_helper.rb:50
 #: ../app/views/common/403.html.erb:14 ../app/views/common/404.html.erb:4
 #: ../app/views/common/500.html.erb:2 ../app/views/common/503.html.erb:2
 #: ../app/views/compute_profiles/show.html.erb:3
 #: ../app/views/compute_resources_vms/show.html.erb:7
-#: ../app/views/config_reports/show.html.erb:18
 msgid "Back"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:313 ../app/helpers/hosts_helper.rb:466
+#: ../app/helpers/hosts_helper.rb:326 ../app/helpers/hosts_helper.rb:479
 #: ../app/helpers/smart_proxies_helper.rb:6
 #: ../app/helpers/smart_proxies_helper.rb:54
 #: ../app/views/compute_resources/index.html.erb:19
 #: ../app/views/compute_resources/show.html.erb:7
-#: ../app/views/filters/index.html.erb:49
+#: ../app/views/filters/index.html.erb:59
 #: ../app/views/hosts/_interfaces.html.erb:33
 #: ../app/views/hosts/_list.html.erb:42
 #: ../app/views/hosts/_templates.html.erb:12
@@ -4655,144 +4833,156 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:314
+#: ../app/helpers/hosts_helper.rb:327
 msgid "Edit this host"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:315
+#: ../app/helpers/hosts_helper.rb:328
 #: ../app/helpers/provisioning_templates_helper.rb:17
 #: ../app/views/hostgroups/index.html.erb:29
-#: ../app/views/hosts/_list.html.erb:43 ../app/views/roles/index.html.erb:27
+#: ../app/views/hosts/_list.html.erb:43 ../app/views/roles/index.html.erb:28
 #: ../app/views/taxonomies/index.html.erb:31
 msgid "Clone"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:316
+#: ../app/helpers/hosts_helper.rb:329
 msgid "Clone this host"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:318
+#: ../app/helpers/hosts_helper.rb:331
 msgid "Cancel build"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:320
+#: ../app/helpers/hosts_helper.rb:333
 msgid "Cancel build request for this host"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:324
+#: ../app/helpers/hosts_helper.rb:337
 msgid "Enable rebuild on next host boot"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:336
+#: ../app/helpers/hosts_helper.rb:349
 msgid "Loading power state ..."
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:341
+#: ../app/helpers/hosts_helper.rb:354
 msgid "Run puppet"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:344
+#: ../app/helpers/hosts_helper.rb:357
 msgid "Trigger a puppetrun on a node; requires that puppet run is enabled"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:359
+#: ../app/helpers/hosts_helper.rb:372
 msgid ""
 "Are you sure you want to delete host %s? This will delete the virtual machine "
 "and its disks, and is irreversible."
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:361
+#: ../app/helpers/hosts_helper.rb:374
 msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:391 ../app/registries/menu/loader.rb:48
-#: ../app/views/audits/index.html.erb:1
-msgid "Audits"
-msgstr ""
-
-#: ../app/helpers/hosts_helper.rb:391
+#: ../app/helpers/hosts_helper.rb:404
 msgid "Host audit entries"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:392 ../app/helpers/trends_helper.rb:6
-#: ../app/registries/menu/loader.rb:45
+#: ../app/helpers/hosts_helper.rb:405 ../app/helpers/trends_helper.rb:6
+#: ../app/registries/menu/loader.rb:48
+#: ../app/views/fact_values/index.html.erb:6
 msgid "Facts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:392
+#: ../app/helpers/hosts_helper.rb:405
 msgid "Browse host facts"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:393 ../app/registries/menu/loader.rb:49
-#: ../app/views/config_reports/index.html.erb:1
+#: ../app/helpers/hosts_helper.rb:406 ../app/registries/menu/loader.rb:52
+#: ../app/views/config_reports/index.html.erb:12
+#: ../app/views/config_reports/index.html.erb:17
 #: ../app/views/config_reports/welcome.html.erb:5
 msgid "Reports"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:393
+#: ../app/helpers/hosts_helper.rb:406
 msgid "Browse host config management reports"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:394
+#: ../app/helpers/hosts_helper.rb:407
 msgid "YAML"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:394
+#: ../app/helpers/hosts_helper.rb:407
 msgid "Puppet external nodes YAML dump"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:402
+#: ../app/helpers/hosts_helper.rb:415
 msgid "Allocation (GB)"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:405 ../app/helpers/lookup_keys_helper.rb:49
+#: ../app/helpers/hosts_helper.rb:418 ../app/helpers/lookup_keys_helper.rb:51
 #: ../app/helpers/provisioning_templates_helper.rb:5
 #: ../app/helpers/provisioning_templates_helper.rb:6 ../app/services/ipam.rb:2
 msgid "None"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:405
+#: ../app/helpers/hosts_helper.rb:418
 msgid "Size"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:405
+#: ../app/helpers/hosts_helper.rb:418
 msgid "Full"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:427
+#: ../app/helpers/hosts_helper.rb:440
 #: ../app/views/compute_resources_vms/form/_networks.html.erb:6
 #: ../app/views/compute_resources_vms/form/_networks.html.erb:15
 msgid "remove network interface"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:436
+#: ../app/helpers/hosts_helper.rb:449
 msgid "Interface is up"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:438
+#: ../app/helpers/hosts_helper.rb:451
 msgid "Interface is down"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:459
+#: ../app/helpers/hosts_helper.rb:472
 msgid "Errors occurred, build may fail"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:467
+#: ../app/helpers/hosts_helper.rb:480 ../app/helpers/images_helper.rb:30
+#: ../app/views/architectures/edit.html.erb:1
+#: ../app/views/auth_source_ldaps/edit.html.erb:1
+#: ../app/views/bookmarks/edit.html.erb:1
+#: ../app/views/common_parameters/edit.html.erb:1
+#: ../app/views/compute_attributes/edit.html.erb:16
 #: ../app/views/compute_resources/edit.html.erb:1
-#: ../app/views/hostgroups/edit.html.erb:1 ../app/views/hosts/edit.html.erb:1
-#: ../app/views/images/edit.html.erb:1 ../app/views/taxonomies/edit.html.erb:1
+#: ../app/views/config_groups/edit.html.erb:1
+#: ../app/views/domains/edit.html.erb:1
+#: ../app/views/environments/edit.html.erb:1
+#: ../app/views/filters/edit.html.erb:6 ../app/views/hostgroups/edit.html.erb:1
+#: ../app/views/hosts/edit.html.erb:1 ../app/views/http_proxies/edit.html.erb:1
+#: ../app/views/media/edit.html.erb:1 ../app/views/models/edit.html.erb:1
+#: ../app/views/provisioning_templates/edit.html.erb:1
+#: ../app/views/ptables/edit.html.erb:1 ../app/views/realms/edit.html.erb:1
+#: ../app/views/roles/edit.html.erb:1
+#: ../app/views/smart_proxies/edit.html.erb:1
+#: ../app/views/subnets/edit.html.erb:1 ../app/views/taxonomies/edit.html.erb:1
+#: ../app/views/usergroups/edit.html.erb:1 ../app/views/users/edit.html.erb:1
 msgid "Edit %s"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:481
+#: ../app/helpers/hosts_helper.rb:494
 msgid "Select desired %s proxy"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:482
+#: ../app/helpers/hosts_helper.rb:495
 msgid "*Clear %s proxy*"
 msgstr ""
 
-#: ../app/helpers/hosts_helper.rb:490
+#: ../app/helpers/hosts_helper.rb:504
 msgid "Generate new random name. Visit Settings to disable this feature."
 msgstr ""
 
@@ -4805,11 +4995,11 @@ msgstr ""
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:7
 #: ../app/views/compute_resources_vms/form/gce/_base.html.erb:9
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:24
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:11
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:48
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:13
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:51
 #: ../app/views/compute_resources_vms/form/rackspace/_base.html.erb:9
 #: ../app/views/compute_resources_vms/form/vmware/_base.html.erb:39
-#: model_attributes.rb:242
+#: model_attributes.rb:248
 msgid "Image"
 msgstr ""
 
@@ -4819,6 +5009,27 @@ msgstr ""
 
 #: ../app/helpers/images_helper.rb:10
 msgid "Image ID as provided by the compute resource, e.g. ami-.."
+msgstr ""
+
+#: ../app/helpers/images_helper.rb:18 ../app/registries/menu/loader.rb:90
+#: ../app/views/about/index.html.erb:13
+#: ../app/views/compute_attributes/edit.html.erb:4
+#: ../app/views/compute_attributes/new.html.erb:5
+#: ../app/views/compute_resources/index.html.erb:1
+#: ../app/views/compute_resources/welcome.html.erb:5
+#: ../app/views/images/index.html.erb:4
+#: ../app/views/taxonomies/_form.html.erb:18
+msgid "Compute Resources"
+msgstr ""
+
+#: ../app/helpers/images_helper.rb:26
+#: ../app/views/compute_resources/show.html.erb:13
+#: ../app/views/images/index.html.erb:12
+msgid "Images"
+msgstr ""
+
+#: ../app/helpers/images_helper.rb:30
+msgid "Create image"
 msgstr ""
 
 #: ../app/helpers/key_pairs_helper.rb:4
@@ -4833,49 +5044,49 @@ msgstr ""
 msgid "Key not connected to any compute resource"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:37
+#: ../app/helpers/layout_helper.rb:49
 #: ../webpack/assets/javascripts/react_app/components/common/forms/Form.js:16
 msgid "Unable to save"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:63
+#: ../app/helpers/layout_helper.rb:75
 msgid "Warning!"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:64
+#: ../app/helpers/layout_helper.rb:76
 msgid "Alert"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:81 ../app/helpers/layout_helper.rb:87
+#: ../app/helpers/layout_helper.rb:93 ../app/helpers/layout_helper.rb:99
 #: ../app/helpers/puppet_related_helper.rb:72
 #: ../app/views/hosts/_compute.html.erb:3
 #: ../app/views/media/welcome.html.erb:14
 msgid "Notice"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:118
+#: ../app/helpers/layout_helper.rb:130
 #: ../app/views/config_reports/show.html.erb:35
 #: ../app/views/hosts/_interfaces.html.erb:58
 msgid "Close"
 msgstr ""
 
-#: ../app/helpers/layout_helper.rb:123 ../app/views/hosts/show.html.erb:76
-#: ../app/views/hosts/show.html.erb:83 ../app/views/trends/show.html.erb:7
+#: ../app/helpers/layout_helper.rb:135 ../app/views/hosts/show.html.erb:77
+#: ../app/views/hosts/show.html.erb:84 ../app/views/trends/show.html.erb:7
 msgid "last %s day"
 msgid_plural "last %s days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/helpers/layout_helper.rb:127
+#: ../app/helpers/layout_helper.rb:139
 msgid "Full screen"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:22
-#: ../app/helpers/lookup_keys_helper.rb:28
+#: ../app/helpers/lookup_keys_helper.rb:23
+#: ../app/helpers/lookup_keys_helper.rb:29
 msgid "Puppet class"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:24
+#: ../app/helpers/lookup_keys_helper.rb:25
 #: ../app/views/puppetclass_lookup_keys/index.html.erb:7
 #: ../app/views/puppetclasses/_classes_parameters.html.erb:4
 #: ../app/views/puppetclasses/_form.html.erb:7
@@ -4883,7 +5094,7 @@ msgstr ""
 msgid "Puppet Class"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:35
+#: ../app/helpers/lookup_keys_helper.rb:37
 msgid ""
 "<dl><dt>String</dt> <dd>Everything is taken as a string.</dd><dt>Boolean</dt> "
 "<dd>Common representation of boolean values are accepted.</dd><dt>Integer</dt>"
@@ -4894,30 +5105,30 @@ msgid ""
 "nput.</dd><dt>JSON</dt> <dd>Any valid JSON input.</dd></dl>"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:45
+#: ../app/helpers/lookup_keys_helper.rb:47
 msgid "How values are validated"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:52
+#: ../app/helpers/lookup_keys_helper.rb:54
 msgid ""
 "<dl><dt>List</dt> <dd>A list of the allowed values, specified in the Validator"
 " rule field.</dd><dt>Regexp</dt> <dd>Validates the input with the regular expr"
 "ession in the Validator rule field.</dd></dl>"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:56
+#: ../app/helpers/lookup_keys_helper.rb:58
 msgid "Validation types"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:93 ../app/models/hostgroup.rb:139
+#: ../app/helpers/lookup_keys_helper.rb:95 ../app/models/hostgroup.rb:154
 msgid "Default value"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:104
+#: ../app/helpers/lookup_keys_helper.rb:106
 msgid "Original value info"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:110
+#: ../app/helpers/lookup_keys_helper.rb:112
 msgid ""
 "<b>Description:</b> %{desc}<br/>\n"
 "     <b>Type:</b> %{type}<br/>\n"
@@ -4925,38 +5136,38 @@ msgid ""
 "     <b>Inherited value:</b> %{inherited_value}"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:122
+#: ../app/helpers/lookup_keys_helper.rb:124
 msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:125
+#: ../app/helpers/lookup_keys_helper.rb:127
 msgid ""
 "Optional parameter without value.<br/><i>Still managed by Foreman, the value w"
 "ill be empty.</i><br/>"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:133
+#: ../app/helpers/lookup_keys_helper.rb:135
 #: ../app/views/common_parameters/_inherited_parameters.html.erb:19
 msgid "Override this value"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:137
+#: ../app/helpers/lookup_keys_helper.rb:139
 msgid "Remove this override"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:145
+#: ../app/helpers/lookup_keys_helper.rb:147
 msgid "This value is not hidden"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:148
+#: ../app/helpers/lookup_keys_helper.rb:150
 msgid "Unhide this value"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:151
+#: ../app/helpers/lookup_keys_helper.rb:153
 msgid "Hide this value"
 msgstr ""
 
-#: ../app/helpers/lookup_keys_helper.rb:167
+#: ../app/helpers/lookup_keys_helper.rb:169
 msgid "Omit from classification output"
 msgstr ""
 
@@ -5142,7 +5353,7 @@ msgid_plural "Warning! This will remove %{name} from %{number} users. are you su
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/helpers/settings_helper.rb:4
+#: ../app/helpers/settings_helper.rb:5
 msgid ""
 "This setting is defined in the configuration file '%{filename}' and is read-on"
 "ly."
@@ -5175,7 +5386,7 @@ msgstr ""
 
 #: ../app/helpers/smart_proxies_helper.rb:52
 #: ../app/views/architectures/index.html.erb:10
-#: ../app/views/auth_source_ldaps/index.html.erb:14
+#: ../app/views/auth_source_ldaps/index.html.erb:12
 #: ../app/views/autosign/_list.html.erb:6
 #: ../app/views/bookmarks/index.html.erb:11
 #: ../app/views/common_parameters/_inherited_parameters.html.erb:6
@@ -5194,8 +5405,8 @@ msgstr ""
 #: ../app/views/config_reports/_list.html.erb:15
 #: ../app/views/domains/index.html.erb:10
 #: ../app/views/environments/index.html.erb:10
-#: ../app/views/fact_values/index.html.erb:21
-#: ../app/views/filters/index.html.erb:22
+#: ../app/views/fact_values/index.html.erb:34
+#: ../app/views/filters/index.html.erb:32
 #: ../app/views/hostgroups/index.html.erb:11
 #: ../app/views/hosts/_interfaces.html.erb:19
 #: ../app/views/hosts/_list.html.erb:17 ../app/views/hosts/_metrics.html.erb:5
@@ -5209,7 +5420,7 @@ msgstr ""
 #: ../app/views/ptables/index.html.erb:13
 #: ../app/views/puppetca/_list.html.erb:12
 #: ../app/views/puppetclasses/index.html.erb:15
-#: ../app/views/realms/index.html.erb:10 ../app/views/roles/index.html.erb:11
+#: ../app/views/realms/index.html.erb:10 ../app/views/roles/index.html.erb:12
 #: ../app/views/smart_proxies/index.html.erb:21
 #: ../app/views/ssh_keys/_ssh_keys_tab.html.erb:10
 #: ../app/views/subnets/index.html.erb:15
@@ -5369,12 +5580,11 @@ msgstr ""
 #: ../app/views/environments/_form.html.erb:4
 #: ../app/views/host_mailer/_active_hosts.html.erb:9
 #: ../app/views/host_mailer/_nonactive_hosts.html.erb:9
-#: ../app/views/hosts/_list.html.erb:13
 #: ../app/views/hosts/_selected_hosts.html.erb:16
 #: ../app/views/hosts/select_multiple_environment.html.erb:7
 #: ../app/views/provisioning_templates/_combination.html.erb:4
 #: ../app/views/smart_proxies/plugins/_puppet_envs.html.erb:4
-#: model_attributes.rb:122
+#: model_attributes.rb:124
 msgid "Environment"
 msgstr ""
 
@@ -5387,7 +5597,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/helpers/trends_helper.rb:6 ../app/views/hosts/_list.html.erb:14
-#: model_attributes.rb:340
+#: model_attributes.rb:346
 msgid "Model"
 msgstr ""
 
@@ -5399,6 +5609,10 @@ msgstr ""
 
 #: ../app/helpers/trends_helper.rb:13
 msgid "Trend of the last %s days."
+msgstr ""
+
+#: ../app/jobs/create_rss_notifications.rb:18
+msgid "Create RSS notifications"
 msgstr ""
 
 #: ../app/mailers/application_mailer.rb:44
@@ -5463,7 +5677,7 @@ msgstr ""
 msgid "Unable to connect to LDAP server"
 msgstr ""
 
-#: ../app/models/auth_sources/auth_source_ldap.rb:230
+#: ../app/models/auth_sources/auth_source_ldap.rb:242
 msgid "invalid LDAP filter syntax"
 msgstr ""
 
@@ -5471,39 +5685,39 @@ msgstr ""
 msgid "%s is an unknown attribute"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:78
+#: ../app/models/compute_resource.rb:77
 msgid "Libvirt, oVirt, OpenStack and Rackspace"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:88
+#: ../app/models/compute_resource.rb:87
 msgid "must provide a provider"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:92
+#: ../app/models/compute_resource.rb:91
 msgid "unknown provider"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:243
+#: ../app/models/compute_resource.rb:242
 msgid "%s console is not supported at this time"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:252 ../app/models/compute_resource.rb:260
-#: ../app/models/compute_resource.rb:264 ../app/models/compute_resource.rb:268
-#: ../app/models/compute_resource.rb:272 ../app/models/compute_resource.rb:276
-#: ../app/models/compute_resource.rb:280 ../app/models/compute_resource.rb:284
-#: ../app/models/compute_resource.rb:288 ../app/models/compute_resource.rb:294
+#: ../app/models/compute_resource.rb:251 ../app/models/compute_resource.rb:259
+#: ../app/models/compute_resource.rb:263 ../app/models/compute_resource.rb:267
+#: ../app/models/compute_resource.rb:271 ../app/models/compute_resource.rb:275
+#: ../app/models/compute_resource.rb:279 ../app/models/compute_resource.rb:283
+#: ../app/models/compute_resource.rb:287 ../app/models/compute_resource.rb:293
 msgid "Not implemented for %s"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:371
+#: ../app/models/compute_resource.rb:388
 msgid "Not implemented"
 msgstr ""
 
-#: ../app/models/compute_resource.rb:421
+#: ../app/models/compute_resource.rb:440
 msgid "cannot be changed"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/gce.rb:163
+#: ../app/models/compute_resources/foreman/model/gce.rb:179
 msgid "Unable to access key"
 msgstr ""
 
@@ -5525,11 +5739,17 @@ msgid ""
 "hed to localhost only"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/libvirt.rb:233
+#: ../app/models/compute_resources/foreman/model/libvirt.rb:234
+msgid ""
+"Unable to connect to libvirt due to: %s. Please make sure your libvirt compute"
+" resource is reachable and that you have appropriate access permissions."
+msgstr ""
+
+#: ../app/models/compute_resources/foreman/model/libvirt.rb:269
 msgid "At least one volume must be specified for image-based provisioning."
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/libvirt.rb:256
+#: ../app/models/compute_resources/foreman/model/libvirt.rb:292
 msgid ""
 "Please specify volume size. You may optionally use suffix 'G' to specify volum"
 "e size in gigabytes."
@@ -5543,15 +5763,19 @@ msgstr ""
 msgid "Hint data is missing"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/openstack.rb:154
+#: ../app/models/compute_resources/foreman/model/openstack.rb:155
 msgid "Failed to deploy vm %{name}, fault: %{e}"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/ovirt.rb:195
+#: ../app/models/compute_resources/foreman/model/ovirt.rb:174
+msgid "HTTPS URL is required for API access"
+msgstr ""
+
+#: ../app/models/compute_resources/foreman/model/ovirt.rb:209
 msgid "Cluster ID is required to list available networks"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/ovirt.rb:390
+#: ../app/models/compute_resources/foreman/model/ovirt.rb:445
 msgid ""
 "The remote system presented a public key signed by an unidentified certificate"
 " authority. If you are sure the remote system is authentic, go to the compute "
@@ -5559,57 +5783,63 @@ msgid ""
 "nd submit"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/ovirt.rb:417
+#: ../app/models/compute_resources/foreman/model/ovirt.rb:472
 msgid "Failed to create X509 certificate, error: %s"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:12
+#: ../app/models/compute_resources/foreman/model/vmware.rb:18
 msgid "not supported by this compute resource"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:30
+#: ../app/models/compute_resources/foreman/model/vmware.rb:36
 msgid "VNC"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:31
+#: ../app/models/compute_resources/foreman/model/vmware.rb:37
 msgid "VMRC"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:191
+#: ../app/models/compute_resources/foreman/model/vmware.rb:197
 msgid "Automatic"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:193
+#: ../app/models/compute_resources/foreman/model/vmware.rb:199
 msgid "EFI"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:199
+#: ../app/models/compute_resources/foreman/model/vmware.rb:205
 msgid "Persistent"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:200
+#: ../app/models/compute_resources/foreman/model/vmware.rb:206
 msgid "Independent - Persistent"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:201
+#: ../app/models/compute_resources/foreman/model/vmware.rb:207
 msgid "Independent - Nonpersistent"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:375
-#: ../app/views/editor/_toolbar.html.erb:46
+#: ../app/models/compute_resources/foreman/model/vmware.rb:381
+#: ../app/views/editor/_toolbar.html.erb:50
 #: ../app/views/templates/_form.html.erb:29
 msgid "Default"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:513
+#: ../app/models/compute_resources/foreman/model/vmware.rb:456
+msgid ""
+"Foreman could not find a required vSphere resource. Check if Foreman has the r"
+"equired permissions and the resource exists. Reason: %s"
+msgstr ""
+
+#: ../app/models/compute_resources/foreman/model/vmware.rb:530
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:587
+#: ../app/models/compute_resources/foreman/model/vmware.rb:604
 msgid "Could not find network %s on VMWare compute resource"
 msgstr ""
 
-#: ../app/models/compute_resources/foreman/model/vmware.rb:626
+#: ../app/models/compute_resources/foreman/model/vmware.rb:706
 msgid ""
 "The remote system presented a public key with hash %s but we're expecting a di"
 "fferent hash. If you are sure the remote system is authentic, go to the comput"
@@ -5622,7 +5852,7 @@ msgid "[redacted]"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/models/concerns/audit_extensions.rb:88 model_attributes.rb:6
+#: ../app/models/concerns/audit_extensions.rb:22 model_attributes.rb:6
 msgid "Audit"
 msgstr ""
 
@@ -5640,23 +5870,23 @@ msgstr ""
 msgid "%s is not a valid DNS record type"
 msgstr ""
 
-#: ../app/models/concerns/fog_extensions/libvirt/server.rb:33
+#: ../app/models/concerns/fog_extensions/libvirt/server.rb:35
 msgid "%{cpus} CPUs and %{memory} memory"
 msgstr ""
 
-#: ../app/models/concerns/fog_extensions/ovirt/server.rb:31
+#: ../app/models/concerns/fog_extensions/ovirt/server.rb:33
 msgid "%{cores} Cores and %{memory} memory"
 msgstr ""
 
-#: ../app/models/concerns/fog_extensions/vsphere/server.rb:30
+#: ../app/models/concerns/fog_extensions/vsphere/server.rb:32
 msgid "%{cpus} CPUs and %{memory} MB memory"
 msgstr ""
 
-#: ../app/models/concerns/foreman/thread_session.rb:92
+#: ../app/models/concerns/foreman/thread_session.rb:99
 msgid "Cannot find user %s when switching context"
 msgstr ""
 
-#: ../app/models/concerns/has_many_common.rb:87
+#: ../app/models/concerns/has_many_common.rb:89
 msgid "Could not find %{association} with name: %{name}"
 msgstr ""
 
@@ -5723,105 +5953,105 @@ msgstr ""
 msgid "invalid method %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:46
+#: ../app/models/concerns/orchestration/compute.rb:47
 msgid "Render user data template for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:48
+#: ../app/models/concerns/orchestration/compute.rb:50
 msgid "Set up compute instance %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:50
+#: ../app/models/concerns/orchestration/compute.rb:53
 msgid "Acquire IP addresses for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:52
+#: ../app/models/concerns/orchestration/compute.rb:56
 msgid "Query instance details for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:54
+#: ../app/models/concerns/orchestration/compute.rb:59
 msgid "Set IP addresses for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:56
+#: ../app/models/concerns/orchestration/compute.rb:63
 msgid "Power up compute instance %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:63
+#: ../app/models/concerns/orchestration/compute.rb:71
 msgid "Compute resource update for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:69
+#: ../app/models/concerns/orchestration/compute.rb:77
 msgid "Removing compute instance %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:80
+#: ../app/models/concerns/orchestration/compute.rb:88
 msgid ""
 "Failed to create a compute %{compute_resource} instance %{name}: %{message}\n"
 " "
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:90
+#: ../app/models/concerns/orchestration/compute.rb:98
 msgid ""
 "%{image} needs user data, but %{os_link} is not associated to any provisioning"
 " template of the kind user_data. Please associate it with a suitable template "
 "or uncheck 'User data' for %{compute_resource_image_link}."
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:116
-#: ../app/models/concerns/orchestration/ssh_provision.rb:77
+#: ../app/models/concerns/orchestration/compute.rb:123
+#: ../app/models/concerns/orchestration/ssh_provision.rb:80
 msgid "Failed to remove certificates for %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:138
+#: ../app/models/concerns/orchestration/compute.rb:145
 msgid "Failed to acquire IP addresses from compute resource for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:143
+#: ../app/models/concerns/orchestration/compute.rb:150
 msgid "failed to save %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:162
+#: ../app/models/concerns/orchestration/compute.rb:170
 msgid "Failed to get IP for %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:171
+#: ../app/models/concerns/orchestration/compute.rb:180
 msgid "Failed to set IPs via IPAM for %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:176
+#: ../app/models/concerns/orchestration/compute.rb:185
 msgid "Failed to set IP for %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:185
+#: ../app/models/concerns/orchestration/compute.rb:195
 msgid "Failed to destroy a compute %{compute_resource} instance %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:192
+#: ../app/models/concerns/orchestration/compute.rb:202
 msgid "Failed to power up a compute %{compute_resource} instance %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:199
+#: ../app/models/concerns/orchestration/compute.rb:209
 msgid "Failed to stop compute %{compute_resource} instance %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:206
+#: ../app/models/concerns/orchestration/compute.rb:216
 msgid "Failed to update a compute %{compute_resource} instance %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:213
+#: ../app/models/concerns/orchestration/compute.rb:223
 msgid "Failed to undo update compute %{compute_resource} instance %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:240
+#: ../app/models/concerns/orchestration/compute.rb:250
 msgid "Selected image does not belong to %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/compute.rb:331
+#: ../app/models/concerns/orchestration/compute.rb:341
 msgid "Could not find virtual machine network interface matching %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dhcp.rb:9 ../app/models/subnet.rb:7
+#: ../app/models/concerns/orchestration/dhcp.rb:9 ../app/models/subnet.rb:8
 #: ../app/services/ipam.rb:2
 #: ../app/views/smart_proxies/plugins/_dhcp.html.erb:2
 msgid "DHCP"
@@ -5843,51 +6073,51 @@ msgid "DHCP not supported for this NIC"
 msgstr ""
 
 #: ../app/models/concerns/orchestration/dhcp.rb:145
-#: ../app/models/concerns/orchestration/dhcp.rb:153
+#: ../app/models/concerns/orchestration/dhcp.rb:152
 msgid "Create DHCP Settings for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dhcp.rb:152
-#: ../app/models/concerns/orchestration/dhcp.rb:180
+#: ../app/models/concerns/orchestration/dhcp.rb:151
+#: ../app/models/concerns/orchestration/dhcp.rb:177
 msgid "Remove DHCP Settings for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dhcp.rb:189
+#: ../app/models/concerns/orchestration/dhcp.rb:185
 msgid "DHCP conflicts removal for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dhcp.rb:199
+#: ../app/models/concerns/orchestration/dhcp.rb:194
 msgid "DHCP records %s already exists"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:9 ../app/models/subnet.rb:55
+#: ../app/models/concerns/orchestration/dns.rb:9 ../app/models/subnet.rb:54
 #: ../app/views/compute_resources_vms/index/_ec2.html.erb:4
 #: ../app/views/smart_proxies/plugins/_dns.html.erb:2
 msgid "DNS"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:66
+#: ../app/models/concerns/orchestration/dns.rb:67
 msgid "Create %{type} for %{host}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:74
-#: ../app/models/concerns/orchestration/dns.rb:83
+#: ../app/models/concerns/orchestration/dns.rb:77
+#: ../app/models/concerns/orchestration/dns.rb:88
 msgid "Remove %{type} for %{host}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:93
+#: ../app/models/concerns/orchestration/dns.rb:100
 msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:113
+#: ../app/models/concerns/orchestration/dns.rb:121
 msgid "%{type} %{conflicts} already exists"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:119
+#: ../app/models/concerns/orchestration/dns.rb:127
 msgid "Error connecting to system DNS server(s) - check /etc/resolv.conf"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/dns.rb:121
+#: ../app/models/concerns/orchestration/dns.rb:129
 msgid ""
 "Error connecting to '%{domain}' domain DNS servers: %{servers} - check query_l"
 "ocal_nameservers and dns_conflict_timeout settings"
@@ -5897,12 +6127,24 @@ msgstr ""
 msgid "Failed to initialize the PuppetCA proxy: %s"
 msgstr ""
 
+#: ../app/models/concerns/orchestration/puppetca.rb:60
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
+
 #: ../app/models/concerns/orchestration/puppetca.rb:65
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+#: ../app/models/concerns/orchestration/puppetca.rb:67
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
+
+#: ../app/models/concerns/orchestration/puppetca.rb:91
 msgid "Delete PuppetCA certificates for %s"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/puppetca.rb:72
-msgid "Delete PuppetCA autosign entry for %s"
+#: ../app/models/concerns/orchestration/puppetca.rb:98
+msgid "Disable PuppetCA autosigning for %s"
 msgstr ""
 
 #: ../app/models/concerns/orchestration/realm.rb:18
@@ -5945,29 +6187,29 @@ msgstr ""
 msgid "Configure instance %s via SSH"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/ssh_provision.rb:53
+#: ../app/models/concerns/orchestration/ssh_provision.rb:55
 msgid "Unable to find proper authentication method"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/ssh_provision.rb:57
+#: ../app/models/concerns/orchestration/ssh_provision.rb:59
 msgid "Failed to login via SSH to %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/ssh_provision.rb:95
+#: ../app/models/concerns/orchestration/ssh_provision.rb:98
 msgid "Provision script had a non zero exit"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/ssh_provision.rb:98
+#: ../app/models/concerns/orchestration/ssh_provision.rb:101
 msgid "Failed to launch script on %{name}: %{e}"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/ssh_provision.rb:114
+#: ../app/models/concerns/orchestration/ssh_provision.rb:118
 msgid ""
 "No finish templates were found for this host, make sure you define at least on"
 "e in your %s settings"
 msgstr ""
 
-#: ../app/models/concerns/orchestration/tftp.rb:12 ../app/models/subnet.rb:49
+#: ../app/models/concerns/orchestration/tftp.rb:12 ../app/models/subnet.rb:48
 #: ../app/views/smart_proxies/plugins/_tftp.html.erb:2
 msgid "TFTP"
 msgstr ""
@@ -6018,17 +6260,21 @@ msgstr ""
 msgid "'%{loader}' is not one of %{loaders}"
 msgstr ""
 
-#: ../app/models/concerns/taxonomix.rb:223
+#: ../app/models/concerns/taxonomix.rb:224
 msgid ""
 "Invalid %{assoc} selection, you must select at least one of yours and have '%{"
 "perm}' permission."
+msgstr ""
+
+#: ../app/models/concerns/taxonomy_collision_finder.rb:8
+msgid "cannot be used, please choose another"
 msgstr ""
 
 #: ../app/models/concerns/user_time.rb:8
 msgid "is not valid"
 msgstr ""
 
-#: ../app/models/concerns/validate_os_family.rb:9 ../app/models/subnet.rb:76
+#: ../app/models/concerns/validate_os_family.rb:9 ../app/models/subnet.rb:75
 msgid "must be one of [ %s ]"
 msgstr ""
 
@@ -6062,160 +6308,160 @@ msgstr ""
 msgid "Can't find a valid Foreman Proxy with a Puppet feature"
 msgstr ""
 
-#: ../app/models/external_usergroup.rb:41
-#: ../app/models/external_usergroup.rb:50
+#: ../app/models/external_usergroup.rb:45
+#: ../app/models/external_usergroup.rb:54
 msgid "LDAP error - %{message}"
 msgstr ""
 
-#: ../app/models/external_usergroup.rb:48
+#: ../app/models/external_usergroup.rb:52
 msgid "is not found in the authentication source"
 msgstr ""
 
-#: ../app/models/external_usergroup.rb:55 ../app/models/user.rb:675
+#: ../app/models/external_usergroup.rb:59 ../app/models/user.rb:683
 msgid "is not permitted"
 msgstr ""
 
-#: ../app/models/external_usergroup.rb:64
+#: ../app/models/external_usergroup.rb:68
 msgid ""
 "Domain Users is a special group in AD. Unfortunately, we cannot obtain members"
 "hip information from a LDAP search and therefore sync it."
 msgstr ""
 
-#: ../app/models/filter.rb:14
+#: ../app/models/filter.rb:16
 msgid "invalid search query: %s"
 msgstr ""
 
-#: ../app/models/filter.rb:103
+#: ../app/models/filter.rb:104
 msgid "filter for %s role"
 msgstr ""
 
-#: ../app/models/filter.rb:211
+#: ../app/models/filter.rb:213
 msgid "must be of same resource type (%s) - Role (%s)"
 msgstr ""
 
-#: ../app/models/filter.rb:220
+#: ../app/models/filter.rb:223
 msgid "You must select at least one permission"
 msgstr ""
 
-#: ../app/models/filter.rb:225
+#: ../app/models/filter.rb:228
 msgid "You can't assign organizations to this resource"
 msgstr ""
 
-#: ../app/models/filter.rb:229
+#: ../app/models/filter.rb:232
 msgid "You can't assign locations to this resource"
 msgstr ""
 
-#: ../app/models/filter.rb:239
+#: ../app/models/filter.rb:242
 msgid "is locked for user modifications."
 msgstr ""
 
-#: ../app/models/host/base.rb:529
+#: ../app/models/host/base.rb:538
 msgid "host must have one primary interface"
 msgstr ""
 
-#: ../app/models/host/base.rb:535
+#: ../app/models/host/base.rb:544
 msgid "managed host must have one provision interface"
 msgstr ""
 
-#: ../app/models/host/base.rb:554
+#: ../app/models/host/base.rb:563
 msgid "some interfaces are invalid"
 msgstr ""
 
-#: ../app/models/host/base.rb:560
+#: ../app/models/host/base.rb:569
 msgid "cannot be enabled for an unmanaged host"
 msgstr ""
 
-#: ../app/models/host/managed.rb:171
+#: ../app/models/host/managed.rb:184
 msgid "invalid time range"
 msgstr ""
 
-#: ../app/models/host/managed.rb:220 ../app/models/hostgroup.rb:22
+#: ../app/models/host/managed.rb:229 ../app/models/hostgroup.rb:24
 msgid "should be 8 characters or more"
 msgstr ""
 
-#: ../app/models/host/managed.rb:221
+#: ../app/models/host/managed.rb:230
 msgid "should not be blank - consider setting a global or host group default"
 msgstr ""
 
-#: ../app/models/host/managed.rb:223
+#: ../app/models/host/managed.rb:232
 msgid "can't be blank unless a custom partition has been defined"
 msgstr ""
 
-#: ../app/models/host/managed.rb:225
+#: ../app/models/host/managed.rb:234
 msgid "is unknown"
 msgstr ""
 
-#: ../app/models/host/managed.rb:436
+#: ../app/models/host/managed.rb:432
 msgid ""
 "Failed to import %{klass} for %{name}: doesn't exists in our database - ignori"
 "ng"
 msgstr ""
 
-#: ../app/models/host/managed.rb:494
+#: ../app/models/host/managed.rb:490
 msgid "Network Based"
 msgstr ""
 
-#: ../app/models/host/managed.rb:495
+#: ../app/models/host/managed.rb:491
 msgid "Image Based"
 msgstr ""
 
-#: ../app/models/host/managed.rb:602
+#: ../app/models/host/managed.rb:599
 msgid "no puppet proxy defined - cant continue"
 msgstr ""
 
-#: ../app/models/host/managed.rb:608
+#: ../app/models/host/managed.rb:605
 msgid "failed to execute puppetrun: %s"
 msgstr ""
 
-#: ../app/models/host/managed.rb:696
+#: ../app/models/host/managed.rb:694
 msgid "No BMC NIC available for host %s"
 msgstr ""
 
-#: ../app/models/host/managed.rb:808
+#: ../app/models/host/managed.rb:807
 msgid ""
 "There are orchestration modules with methods for configuration rebuild that ha"
 "ve identical name: '%s'"
 msgstr ""
 
-#: ../app/models/host/managed.rb:845
+#: ../app/models/host/managed.rb:850
 msgid "Some interfaces are invalid"
 msgstr ""
 
-#: ../app/models/host/managed.rb:869
+#: ../app/models/host/managed.rb:875
 msgid "%{value} does not belong to %{os} operating system"
 msgstr ""
 
-#: ../app/models/host/managed.rb:876
+#: ../app/models/host/managed.rb:884
 msgid "%{e} does not belong to the %{environment} environment"
 msgstr ""
 
-#: ../app/models/host/managed.rb:889
+#: ../app/models/host/managed.rb:898
 msgid "is an unsupported provisioning method"
 msgstr ""
 
-#: ../app/models/host/managed.rb:894
+#: ../app/models/host/managed.rb:903
 msgid "can't be updated after host is provisioned"
 msgstr ""
 
-#: ../app/models/host/managed.rb:899 ../app/models/nic/interface.rb:121
+#: ../app/models/host/managed.rb:908 ../app/models/nic/interface.rb:138
 msgid "must not include periods"
 msgstr ""
 
-#: ../app/models/host_status/build_status.rb:14
+#: ../app/models/host_status/build_status.rb:15
 msgid "Pending installation"
 msgstr ""
 
-#: ../app/models/host_status/build_status.rb:16
-msgid "Token expired"
-msgstr ""
-
-#: ../app/models/host_status/build_status.rb:18
+#: ../app/models/host_status/build_status.rb:19
 #: ../app/views/about/index.html.erb:58
 #: ../app/views/dashboard/_new_hosts_widget_host_list.html.erb:7
 msgid "Installed"
 msgstr ""
 
-#: ../app/models/host_status/build_status.rb:20
+#: ../app/models/host_status/build_status.rb:21
+msgid "Installation error"
+msgstr ""
+
+#: ../app/models/host_status/build_status.rb:23
 msgid "Unknown build status"
 msgstr ""
 
@@ -6232,7 +6478,7 @@ msgid "No reports"
 msgstr ""
 
 #: ../app/models/host_status/configuration_status.rb:79
-#: ../webpack/assets/javascripts/foreman_editor.js:237
+#: ../webpack/assets/javascripts/foreman_editor.js:241
 msgid "No changes"
 msgstr ""
 
@@ -6240,55 +6486,55 @@ msgstr ""
 msgid "Global"
 msgstr ""
 
-#: ../app/models/hostgroup.rb:262 ../app/models/nic/base.rb:264
+#: ../app/models/hostgroup.rb:279 ../app/models/nic/base.rb:268
 msgid "must be of type Subnet::Ipv4."
 msgstr ""
 
-#: ../app/models/hostgroup.rb:263 ../app/models/nic/base.rb:265
+#: ../app/models/hostgroup.rb:280 ../app/models/nic/base.rb:269
 msgid "must be of type Subnet::Ipv6."
 msgstr ""
 
-#: ../app/models/image.rb:27
+#: ../app/models/image.rb:26
 msgid "could not be found in %s"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "string"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "boolean"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "integer"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "real"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "array"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "hash"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "yaml"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:6
+#: ../app/models/lookup_keys/lookup_key.rb:7
 msgid "json"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:7
+#: ../app/models/lookup_keys/lookup_key.rb:8
 msgid "regexp"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:7
+#: ../app/models/lookup_keys/lookup_key.rb:8
 msgid "list"
 msgstr ""
 
@@ -6297,19 +6543,19 @@ msgstr ""
 msgid "invalid"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:162
+#: ../app/models/lookup_keys/lookup_key.rb:164
 msgid "invalid path"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:196
+#: ../app/models/lookup_keys/lookup_key.rb:198
 msgid "can only be set for array or hash"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:202
+#: ../app/models/lookup_keys/lookup_key.rb:204
 msgid "can only be set for arrays that have merge_overrides set to true"
 msgstr ""
 
-#: ../app/models/lookup_keys/lookup_key.rb:208
+#: ../app/models/lookup_keys/lookup_key.rb:210
 msgid "can only be set when merge overrides is set"
 msgstr ""
 
@@ -6365,35 +6611,35 @@ msgstr ""
 msgid "%{record} is used by host in build mode %{what}"
 msgstr ""
 
-#: ../app/models/nic/base.rb:205
+#: ../app/models/nic/base.rb:209
 msgid "Unnamed"
 msgstr ""
 
-#: ../app/models/nic/base.rb:219
+#: ../app/models/nic/base.rb:223
 msgid "can't find domain with this id"
 msgstr ""
 
-#: ../app/models/nic/base.rb:235
+#: ../app/models/nic/base.rb:239
 msgid "can't delete primary interface of managed host"
 msgstr ""
 
-#: ../app/models/nic/base.rb:238
+#: ../app/models/nic/base.rb:242
 msgid "can't delete provision interface of managed host"
 msgstr ""
 
-#: ../app/models/nic/base.rb:247
+#: ../app/models/nic/base.rb:251
 msgid "host already has primary interface"
 msgstr ""
 
-#: ../app/models/nic/base.rb:254
+#: ../app/models/nic/base.rb:258
 msgid "host already has provision interface"
 msgstr ""
 
-#: ../app/models/nic/base.rb:273
+#: ../app/models/nic/base.rb:277
 msgid "must be a unicast MAC address"
 msgstr ""
 
-#: ../app/models/nic/base.rb:278
+#: ../app/models/nic/base.rb:282
 msgid "can't be changed once the interface is saved"
 msgstr ""
 
@@ -6401,7 +6647,7 @@ msgstr ""
 msgid "Unable to find a proxy with BMC feature"
 msgstr ""
 
-#: ../app/models/nic/bmc.rb:27 ../app/views/hosts/show.html.erb:34
+#: ../app/models/nic/bmc.rb:27 ../app/views/hosts/show.html.erb:35
 msgid "BMC"
 msgstr ""
 
@@ -6419,33 +6665,33 @@ msgstr ""
 msgid "Bridge"
 msgstr ""
 
-#: ../app/models/nic/interface.rb:90
+#: ../app/models/nic/interface.rb:107
 msgid "subnet boot mode is not %s"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:25
+#: ../app/models/operatingsystem.rb:26
 msgid "Operating System version is required"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:35
+#: ../app/models/operatingsystem.rb:36
 msgid "Operating system version already exists"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:232
+#: ../app/models/operatingsystem.rb:237
 msgid ""
 "Attempting to construct an operating system image filename but %s cannot be bu"
 "ilt from an image"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:259
+#: ../app/models/operatingsystem.rb:264
 msgid "%{os} medium was not set for host '%{host}'"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:260
+#: ../app/models/operatingsystem.rb:265
 msgid "Invalid medium '%{medium}' for '%{os}'"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:261
+#: ../app/models/operatingsystem.rb:266
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr ""
 
@@ -6514,31 +6760,31 @@ msgstr ""
 msgid "subnet"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:89
+#: ../app/models/provisioning_template.rb:95
 msgid "Must provide template kind"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:90
+#: ../app/models/provisioning_template.rb:96
 msgid "Must provide an operating system"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:144
+#: ../app/models/provisioning_template.rb:150
 msgid "No TFTP proxies defined, can't continue"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:150
+#: ../app/models/provisioning_template.rb:156
 msgid "Could not find a Configuration Template with the name \"%s\", please create one."
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:176
+#: ../app/models/provisioning_template.rb:182
 msgid "PXE files for templates %s have been deployed to all Smart Proxies"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:178
+#: ../app/models/provisioning_template.rb:184
 msgid "There was an error creating the PXE file: %s"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:232
+#: ../app/models/provisioning_template.rb:238
 msgid "specified template \"%s\" kind was not found"
 msgstr ""
 
@@ -6558,25 +6804,25 @@ msgstr ""
 msgid "Unable to create the default role."
 msgstr ""
 
-#: ../app/models/role.rb:277
+#: ../app/models/role.rb:278
 msgid ""
 "One or more of the associated filters are invalid which prevented the role to "
 "be saved"
 msgstr ""
 
-#: ../app/models/role.rb:278
+#: ../app/models/role.rb:279
 msgid "Unable to submit role: Problem with associated filter #{f.errors}"
 msgstr ""
 
-#: ../app/models/role.rb:293
+#: ../app/models/role.rb:294
 msgid "Cannot delete built-in role"
 msgstr ""
 
-#: ../app/models/role.rb:299
+#: ../app/models/role.rb:300
 msgid "This role is locked from being modified by users."
 msgstr ""
 
-#: ../app/models/role.rb:330
+#: ../app/models/role.rb:333
 msgid "some permissions were not found"
 msgstr ""
 
@@ -6612,30 +6858,40 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr ""
 
-#: ../app/models/setting/auth.rb:11
+#: ../app/models/setting/auth.rb:10
 msgid "Foreman will use OAuth for API authorization"
 msgstr ""
 
-#: ../app/models/setting/auth.rb:11
+#: ../app/models/setting/auth.rb:10
 msgid "OAuth active"
 msgstr ""
 
-#: ../app/models/setting/auth.rb:12
+#: ../app/models/setting/auth.rb:11
 msgid "OAuth consumer key"
 msgstr ""
 
-#: ../app/models/setting/auth.rb:13
+#: ../app/models/setting/auth.rb:12
 msgid "OAuth consumer secret"
 msgstr ""
 
-#: ../app/models/setting/auth.rb:14
+#: ../app/models/setting/auth.rb:13
 msgid ""
 "Foreman will map users by username in request-header. If this is set to false,"
 " OAuth requests will have admin rights."
 msgstr ""
 
-#: ../app/models/setting/auth.rb:14
+#: ../app/models/setting/auth.rb:13
 msgid "OAuth map users"
+msgstr ""
+
+#: ../app/models/setting/auth.rb:14
+msgid ""
+"Foreman will block user login after this number of failed login attempts for 5"
+" minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
+#: ../app/models/setting/auth.rb:14
+msgid "Failed login attempts limit"
 msgstr ""
 
 #: ../app/models/setting/auth.rb:15
@@ -6823,277 +7079,279 @@ msgstr ""
 msgid "Unable to unset websockets_ssl_cert when websockets_encrypt is on"
 msgstr ""
 
-#: ../app/models/setting/email.rb:11
+#: ../app/models/setting/email.rb:9
 msgid "Email reply address for emails that Foreman is sending"
 msgstr ""
 
-#: ../app/models/setting/email.rb:11
+#: ../app/models/setting/email.rb:9
 msgid "Email reply address"
 msgstr ""
 
-#: ../app/models/setting/email.rb:12
+#: ../app/models/setting/email.rb:10
 msgid "Prefix to add to all outgoing email"
 msgstr ""
 
-#: ../app/models/setting/email.rb:12
+#: ../app/models/setting/email.rb:10
 msgid "Email subject prefix"
 msgstr ""
 
-#: ../app/models/setting/email.rb:13
+#: ../app/models/setting/email.rb:11
 msgid "Send a welcome email including username and URL to new users"
 msgstr ""
 
-#: ../app/models/setting/email.rb:13
+#: ../app/models/setting/email.rb:11
 msgid "Send welcome email"
 msgstr ""
 
-#: ../app/models/setting/email.rb:14
+#: ../app/models/setting/email.rb:12
 msgid "Method used to deliver email"
 msgstr ""
 
-#: ../app/models/setting/email.rb:14
+#: ../app/models/setting/email.rb:12
 msgid "Delivery method"
 msgstr ""
 
-#: ../app/models/setting/email.rb:14
+#: ../app/models/setting/email.rb:12
 msgid "Sendmail"
 msgstr ""
 
-#: ../app/models/setting/email.rb:14
+#: ../app/models/setting/email.rb:12
 msgid "SMTP"
 msgstr ""
 
-#: ../app/models/setting/email.rb:15
+#: ../app/models/setting/email.rb:13
 msgid "SMTP automatic STARTTLS"
 msgstr ""
 
-#: ../app/models/setting/email.rb:15
+#: ../app/models/setting/email.rb:13
 msgid "SMTP enable StartTLS auto"
 msgstr ""
 
-#: ../app/models/setting/email.rb:16
+#: ../app/models/setting/email.rb:14
 msgid "When using TLS, you can set how OpenSSL checks the certificate"
 msgstr ""
 
-#: ../app/models/setting/email.rb:16
+#: ../app/models/setting/email.rb:14
 msgid "SMTP OpenSSL verify mode"
 msgstr ""
 
-#: ../app/models/setting/email.rb:16
+#: ../app/models/setting/email.rb:14
 msgid "Default verification mode"
 msgstr ""
 
-#: ../app/models/setting/email.rb:16 ../app/models/setting/email.rb:22
+#: ../app/models/setting/email.rb:14 ../app/models/setting/email.rb:20
 msgid "none"
 msgstr ""
 
-#: ../app/models/setting/email.rb:17
+#: ../app/models/setting/email.rb:15
 msgid "Address to connect to"
 msgstr ""
 
-#: ../app/models/setting/email.rb:17
+#: ../app/models/setting/email.rb:15
 msgid "SMTP address"
 msgstr ""
 
-#: ../app/models/setting/email.rb:18
+#: ../app/models/setting/email.rb:16
 msgid "Port to connect to"
 msgstr ""
 
-#: ../app/models/setting/email.rb:18
+#: ../app/models/setting/email.rb:16
 msgid "SMTP port"
 msgstr ""
 
-#: ../app/models/setting/email.rb:19
+#: ../app/models/setting/email.rb:17
 msgid "HELO/EHLO domain"
 msgstr ""
 
-#: ../app/models/setting/email.rb:19
+#: ../app/models/setting/email.rb:17
 msgid "SMTP HELO/EHLO domain"
 msgstr ""
 
-#: ../app/models/setting/email.rb:20
+#: ../app/models/setting/email.rb:18
 msgid "Username to use to authenticate, if required"
 msgstr ""
 
-#: ../app/models/setting/email.rb:20
+#: ../app/models/setting/email.rb:18
 msgid "SMTP username"
 msgstr ""
 
-#: ../app/models/setting/email.rb:21
+#: ../app/models/setting/email.rb:19
 msgid "Password to use to authenticate, if required"
 msgstr ""
 
-#: ../app/models/setting/email.rb:21
+#: ../app/models/setting/email.rb:19
 msgid "SMTP password"
 msgstr ""
 
-#: ../app/models/setting/email.rb:22
+#: ../app/models/setting/email.rb:20
 msgid "Specify authentication type, if required"
 msgstr ""
 
-#: ../app/models/setting/email.rb:22
+#: ../app/models/setting/email.rb:20
 msgid "SMTP authentication"
 msgstr ""
 
-#: ../app/models/setting/email.rb:23
+#: ../app/models/setting/email.rb:21
 msgid "Specify additional options to sendmail"
 msgstr ""
 
-#: ../app/models/setting/email.rb:23
+#: ../app/models/setting/email.rb:21
 msgid "Sendmail arguments"
 msgstr ""
 
-#: ../app/models/setting/email.rb:24
+#: ../app/models/setting/email.rb:22
 msgid "The location of the sendmail executable"
 msgstr ""
 
-#: ../app/models/setting/email.rb:24
+#: ../app/models/setting/email.rb:22
 msgid "Sendmail location"
 msgstr ""
 
-#: ../app/models/setting/general.rb:12
+#: ../app/models/setting/general.rb:11
 msgid "The default administrator email address"
 msgstr ""
 
-#: ../app/models/setting/general.rb:12
+#: ../app/models/setting/general.rb:11
 msgid "Administrator email address"
 msgstr ""
 
-#: ../app/models/setting/general.rb:13
+#: ../app/models/setting/general.rb:12
 msgid ""
 "URL where your Foreman instance is reachable (see also Provisioning > unattend"
 "ed_url)"
 msgstr ""
 
-#: ../app/models/setting/general.rb:13
+#: ../app/models/setting/general.rb:12
 msgid "Foreman URL"
 msgstr ""
 
-#: ../app/models/setting/general.rb:14
+#: ../app/models/setting/general.rb:13
 msgid "Number of records shown per page in Foreman"
 msgstr ""
 
-#: ../app/models/setting/general.rb:14
+#: ../app/models/setting/general.rb:13
 msgid "Entries per page"
 msgstr ""
 
-#: ../app/models/setting/general.rb:15
+#: ../app/models/setting/general.rb:14
 msgid "Fix DB cache on next Foreman restart"
 msgstr ""
 
-#: ../app/models/setting/general.rb:15
+#: ../app/models/setting/general.rb:14
 msgid "Fix DB cache"
 msgstr ""
 
-#: ../app/models/setting/general.rb:16
+#: ../app/models/setting/general.rb:15
 msgid "Max days for Trends graphs"
 msgstr ""
 
-#: ../app/models/setting/general.rb:16
+#: ../app/models/setting/general.rb:15
 msgid "Max trends"
 msgstr ""
 
-#: ../app/models/setting/general.rb:17
+#: ../app/models/setting/general.rb:16
 msgid ""
 "Should the `foreman-rake db:migrate` be executed on the next run of the instal"
 "ler modules?"
 msgstr ""
 
-#: ../app/models/setting/general.rb:17
+#: ../app/models/setting/general.rb:16
 msgid "DB pending migration"
 msgstr ""
 
-#: ../app/models/setting/general.rb:18
+#: ../app/models/setting/general.rb:17
 msgid ""
 "Should the `foreman-rake db:seed` be executed on the next run of the installer"
 " modules?"
 msgstr ""
 
-#: ../app/models/setting/general.rb:18
+#: ../app/models/setting/general.rb:17
 msgid "DB pending seed"
 msgstr ""
 
-#: ../app/models/setting/general.rb:19
+#: ../app/models/setting/general.rb:18
 msgid "Max timeout for REST client requests to smart-proxy"
 msgstr ""
 
-#: ../app/models/setting/general.rb:19
+#: ../app/models/setting/general.rb:18
 msgid "Proxy request timeout"
 msgstr ""
 
-#: ../app/models/setting/general.rb:20
+#: ../app/models/setting/general.rb:19
 msgid "Text to be shown in the login-page footer"
 msgstr ""
 
-#: ../app/models/setting/general.rb:20
+#: ../app/models/setting/general.rb:19
 msgid "Login page footer text"
 msgstr ""
 
-#: ../app/models/setting/general.rb:21
+#: ../app/models/setting/general.rb:20
 msgid ""
 "Show power status on host index page. This feature calls to compute resource p"
 "roviders which may lead to decreased performance on host listing page."
 msgstr ""
 
-#: ../app/models/setting/general.rb:21
+#: ../app/models/setting/general.rb:20
 msgid "Show host power status"
 msgstr ""
 
-#: ../app/models/setting/general.rb:22
+#: ../app/models/setting/general.rb:21
 msgid "Sets a proxy for all outgoing HTTP connections."
 msgstr ""
 
-#: ../app/models/setting/general.rb:22
+#: ../app/models/setting/general.rb:21
 msgid "HTTP(S) proxy"
 msgstr ""
 
-#: ../app/models/setting/general.rb:23
-msgid "Set hostnames to which requests are not to be proxied"
+#: ../app/models/setting/general.rb:22
+msgid ""
+"Set hostnames to which requests are not to be proxied. Requests to the local h"
+"ost are excluded by default."
 msgstr ""
 
-#: ../app/models/setting/general.rb:23
+#: ../app/models/setting/general.rb:22
 msgid "HTTP(S) proxy except hosts"
 msgstr ""
 
-#: ../app/models/setting/general.rb:24
+#: ../app/models/setting/general.rb:23
 msgid ""
 "Whether or not to show a menu to access experimental lab features (requires re"
 "load of page)"
 msgstr ""
 
-#: ../app/models/setting/general.rb:24
+#: ../app/models/setting/general.rb:23
 msgid "Show Experimental Labs"
 msgstr ""
 
-#: ../app/models/setting/general.rb:25
+#: ../app/models/setting/general.rb:24
 msgid "Foreman will append domain names when new hosts are provisioned"
 msgstr ""
 
-#: ../app/models/setting/general.rb:25
+#: ../app/models/setting/general.rb:24
 msgid "Append domain names to the host"
 msgstr ""
 
-#: ../app/models/setting/general.rb:26
+#: ../app/models/setting/general.rb:25
 msgid "Duration in minutes after servers are classed as out of sync."
 msgstr ""
 
-#: ../app/models/setting/general.rb:26
+#: ../app/models/setting/general.rb:25
 msgid "Out of sync interval"
 msgstr ""
 
-#: ../app/models/setting/general.rb:42
+#: ../app/models/setting/general.rb:41
 #: ../app/views/smart_proxies/plugins/_puppet.html.erb:3
 #: ../app/views/smart_proxies/plugins/_puppet_ca.html.erb:2
 #: ../app/views/users/_form.html.erb:63
 msgid "General"
 msgstr ""
 
-#: ../app/models/setting/general.rb:47
+#: ../app/models/setting/general.rb:46
 msgid "Not a valid URL for a HTTP proxy"
 msgstr ""
 
 #: ../app/models/setting/notification.rb:4
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 #: ../app/models/setting/notification.rb:4
@@ -7110,12 +7368,12 @@ msgstr ""
 
 #: ../app/models/setting/notification.rb:21
 #: ../app/views/users/_form.html.erb:72
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/index.js:36
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:50
 msgid "Notifications"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:38 ../app/registries/menu/loader.rb:31
-#: ../app/views/ssh_keys/new.html.erb:4
+#: ../app/models/setting/provisioning.rb:37 ../app/registries/menu/loader.rb:34
+#: ../app/views/ssh_keys/new.html.erb:6
 #: ../app/views/taxonomies/_form.html.erb:8
 #: ../app/views/usergroups/_form.html.erb:27
 #: ../app/views/usergroups/index.html.erb:9 ../app/views/users/index.html.erb:1
@@ -7123,248 +7381,248 @@ msgid "Users"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/models/setting/provisioning.rb:39 model_attributes.rb:668
+#: ../app/models/setting/provisioning.rb:38 model_attributes.rb:694
 msgid "Usergroup"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:42
+#: ../app/models/setting/provisioning.rb:41
 msgid "Default owner on provisioned hosts, if empty Foreman will use current user"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:42
+#: ../app/models/setting/provisioning.rb:41
 msgid "Host owner"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:42
+#: ../app/models/setting/provisioning.rb:41
 #: ../app/views/hosts/_form.html.erb:126
 msgid "Select an owner"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:43
+#: ../app/models/setting/provisioning.rb:42
 msgid "Default encrypted root password on provisioned hosts"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:43
+#: ../app/models/setting/provisioning.rb:42
 msgid "Root password"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:44
+#: ../app/models/setting/provisioning.rb:43
 msgid ""
 "URL hosts will retrieve templates from during build (normally http as many ins"
 "tallers don't support https)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:44
+#: ../app/models/setting/provisioning.rb:43
 msgid "Unattended URL"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:45
+#: ../app/models/setting/provisioning.rb:44
 msgid "Enable safe mode config templates rendering (recommended)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:45
+#: ../app/models/setting/provisioning.rb:44
 msgid "Safemode rendering"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:46
+#: ../app/models/setting/provisioning.rb:45
 msgid "Allow access to unattended URLs without build mode being used"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:46
+#: ../app/models/setting/provisioning.rb:45
 msgid "Access unattended without build"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:47
+#: ../app/models/setting/provisioning.rb:46
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:47
+#: ../app/models/setting/provisioning.rb:46
 msgid "Manage PuppetCA"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:48
+#: ../app/models/setting/provisioning.rb:47
 msgid ""
 "Stop updating IP address and MAC values from Puppet facts (affects all interfa"
 "ces)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:48
+#: ../app/models/setting/provisioning.rb:47
 msgid "Ignore Puppet facts for provisioning"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:49
+#: ../app/models/setting/provisioning.rb:48
 msgid ""
 "Enable host orchestration on puppet fact import. This could cause serious perf"
 "ormance issues as the number of hosts increase"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:49
+#: ../app/models/setting/provisioning.rb:48
 msgid "Enable orchestration on puppet fact import"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:50
+#: ../app/models/setting/provisioning.rb:49
 msgid ""
 "Ignore interfaces that match these values during facts importing, you can use "
 "* wildcard to match names with indexes e.g. macvtap*"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:50
+#: ../app/models/setting/provisioning.rb:49
 msgid "Ignore interfaces with matching identifier"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:51
+#: ../app/models/setting/provisioning.rb:50
 msgid "Stop updating Operating System from facts"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:51
+#: ../app/models/setting/provisioning.rb:50
 msgid "Ignore facts for operating system"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:52
+#: ../app/models/setting/provisioning.rb:51
 msgid "Stop updating domain values from facts"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:52
+#: ../app/models/setting/provisioning.rb:51
 msgid "Ignore facts for domain"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:53
+#: ../app/models/setting/provisioning.rb:52
 msgid ""
 "Foreman will query the locally configured resolver instead of the SOA/NS autho"
 "rities"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:53
+#: ../app/models/setting/provisioning.rb:52
 msgid "Query local nameservers"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:54
+#: ../app/models/setting/provisioning.rb:53
 msgid ""
 "If Foreman is running behind Passenger or a remote load balancer, the IP shoul"
 "d be set here. This is a regular expression, so it can support several load ba"
 "lancers, i.e: (10.0.0.1|127.0.0.1)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:54
+#: ../app/models/setting/provisioning.rb:53
 msgid "Remote address"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:55
+#: ../app/models/setting/provisioning.rb:54
 msgid ""
 "Time in minutes installation tokens should be valid for, 0 to disable token ge"
 "neration"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:55
+#: ../app/models/setting/provisioning.rb:54
 msgid "Token duration"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:56
+#: ../app/models/setting/provisioning.rb:55
 msgid ""
 "The IP address that should be used for the console listen address when provisi"
 "oning new virtual machines via Libvirt"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:56
+#: ../app/models/setting/provisioning.rb:55
 msgid "Libvirt default console address"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:57
+#: ../app/models/setting/provisioning.rb:56
 msgid "Foreman will update the host IP with the IP that made the built request"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:57
+#: ../app/models/setting/provisioning.rb:56
 msgid "Update IP from built request"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:58
+#: ../app/models/setting/provisioning.rb:57
 msgid ""
 "Foreman will use the short hostname instead of the FQDN for creating new virtu"
 "al machines"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:58
+#: ../app/models/setting/provisioning.rb:57
 msgid "Use short name for VMs"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:59
+#: ../app/models/setting/provisioning.rb:58
 msgid "Timeout for DNS conflict validation (in seconds)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:59
+#: ../app/models/setting/provisioning.rb:58
 msgid "DNS conflict timeout"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:60
+#: ../app/models/setting/provisioning.rb:59
 msgid ""
 "Foreman will delete virtual machine if provisioning script ends with non zero "
 "exit code"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:60
+#: ../app/models/setting/provisioning.rb:59
 msgid "Clean up failed deployment"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:61
+#: ../app/models/setting/provisioning.rb:60
 msgid ""
 "Random gives unique names, MAC-based are longer but stable (and only works wit"
 "h bare-metal)"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:61
+#: ../app/models/setting/provisioning.rb:60
 msgid "Type of name generator"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:62
+#: ../app/models/setting/provisioning.rb:61
 msgid ""
 "Default PXE (PXELinux, PXEGrub, PXEGrub2) menu item in global template - 'loca"
 "l', 'discovery' or custom"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:62
+#: ../app/models/setting/provisioning.rb:61
 msgid "Default PXE global template entry"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:63
+#: ../app/models/setting/provisioning.rb:62
 msgid ""
 "Default PXE (PXELinux, PXEGrub2) menu item in local template - 'local_chain_hd"
 "0', 'local' or custom"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:63
+#: ../app/models/setting/provisioning.rb:62
 msgid "Default PXE local template entry"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:66
+#: ../app/models/setting/provisioning.rb:65
 msgid ""
 "Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those f"
 "acts won't be stored in foreman's database. You can use * wildcard to match na"
 "mes with indexes e.g. macvtap*"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:68
+#: ../app/models/setting/provisioning.rb:67
 msgid "Exclude pattern for facts stored in foreman"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:90
+#: ../app/models/setting/provisioning.rb:89
 msgid "Unable to disable safemode_render when bmc_credentials_accessible is disabled"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:96
+#: ../app/models/setting/provisioning.rb:95
 msgid ""
 "Global default %s template. This template gets deployed to all configured TFTP"
 " servers. It will not be affected by upgrades."
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:96
+#: ../app/models/setting/provisioning.rb:95
 msgid "Global default %s template"
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:102
+#: ../app/models/setting/provisioning.rb:101
 msgid "Template that will be selected as %s default for local boot."
 msgstr ""
 
-#: ../app/models/setting/provisioning.rb:102
+#: ../app/models/setting/provisioning.rb:101
 msgid "Local boot %s template"
 msgstr ""
 
@@ -7377,138 +7635,140 @@ msgid "Puppet interval"
 msgstr ""
 
 #: ../app/models/setting/puppet.rb:5
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
+msgid ""
+"Disable host configuration status turning to out of sync for %s after report d"
+"oes not arrive within configured interval"
 msgstr ""
 
 #: ../app/models/setting/puppet.rb:5
-msgid "Default Puppet environment"
+msgid "%s out of sync disabled"
 msgstr ""
 
 #: ../app/models/setting/puppet.rb:6
+msgid "Foreman will default to this puppet environment if it cannot auto detect one"
+msgstr ""
+
+#: ../app/models/setting/puppet.rb:6
+msgid "Default Puppet environment"
+msgstr ""
+
+#: ../app/models/setting/puppet.rb:7
 msgid ""
 "Foreman will set this as the default Puppet module path if it cannot auto dete"
 "ct one"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:6
+#: ../app/models/setting/puppet.rb:7
 msgid "Module path"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:7
+#: ../app/models/setting/puppet.rb:8
 msgid "Enable puppetrun support"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:7
+#: ../app/models/setting/puppet.rb:8
 msgid "Puppetrun"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:8
+#: ../app/models/setting/puppet.rb:9
 msgid "Default Puppet server hostname"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:8
+#: ../app/models/setting/puppet.rb:9
 msgid "Puppet server"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:9
+#: ../app/models/setting/puppet.rb:10
 msgid "Foreman will evaluate host smart variables in this order by default"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:9
+#: ../app/models/setting/puppet.rb:10
 msgid "Default variables lookup path"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:10
+#: ../app/models/setting/puppet.rb:11
 msgid "Foreman smart variables will be exposed via the ENC yaml output"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:10
+#: ../app/models/setting/puppet.rb:11
 msgid "Enable smart variables in ENC"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:11
+#: ../app/models/setting/puppet.rb:12
 msgid "Foreman will use the new (2.6.5+) format for classes in the ENC yaml output"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:11
+#: ../app/models/setting/puppet.rb:12
 msgid "Parameterized classes in ENC"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:12
+#: ../app/models/setting/puppet.rb:13
 msgid "Foreman will parse ERB in parameters value in the ENC output"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:12
+#: ../app/models/setting/puppet.rb:13
 msgid "Interpolate ERB in parameters"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:13
+#: ../app/models/setting/puppet.rb:14
 msgid ""
 "Foreman will explicitly set the puppet environment in the ENC yaml output. Thi"
 "s will avoid conflicts between the environment in puppet.conf and the environm"
 "ent set in Foreman"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:13
+#: ../app/models/setting/puppet.rb:14
 msgid "ENC environment"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:14
+#: ../app/models/setting/puppet.rb:15
 msgid "Foreman will use random UUIDs for certificate signing instead of hostnames"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:14
+#: ../app/models/setting/puppet.rb:15
 msgid "Use UUID for certificates"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:15
+#: ../app/models/setting/puppet.rb:16
 msgid "Foreman will update a host's environment from its facts"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:15
+#: ../app/models/setting/puppet.rb:16
 msgid "Update environment from facts"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:16
+#: ../app/models/setting/puppet.rb:17
 msgid "Foreman will update a host's subnet from its facts"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:16
+#: ../app/models/setting/puppet.rb:17
 msgid "Update subnets from facts"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:17
+#: ../app/models/setting/puppet.rb:18
 msgid ""
 "Foreman host group matchers will be inherited by children when evaluating smar"
 "t class parameters"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:17
+#: ../app/models/setting/puppet.rb:18
 msgid "Host group matchers inheritance"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:18
+#: ../app/models/setting/puppet.rb:19
 msgid "Foreman will create the host when new facts are received"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:18
+#: ../app/models/setting/puppet.rb:19
 msgid "Create new host when facts are uploaded"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:19
+#: ../app/models/setting/puppet.rb:20
 msgid "Foreman will create the host when a report is received"
 msgstr ""
 
-#: ../app/models/setting/puppet.rb:19
+#: ../app/models/setting/puppet.rb:20
 msgid "Create new host when report is uploaded"
-msgstr ""
-
-#: ../app/models/setting/puppet.rb:20
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr ""
-
-#: ../app/models/setting/puppet.rb:20
-msgid "Legacy Puppet hostname"
 msgstr ""
 
 #: ../app/models/setting/puppet.rb:21
@@ -7566,119 +7826,119 @@ msgstr ""
 msgid "Only one declaration of a proxy is allowed"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:117
+#: ../app/models/smart_proxy.rb:101
 msgid ""
 "An invalid response was received while requesting available features from this"
 " proxy"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:126
+#: ../app/models/smart_proxy.rb:110
 msgid ""
 "Features \"%s\" in this proxy are not recognized by Foreman. If these features c"
 "ome from a Smart Proxy plugin, make sure Foreman has the plugin installed too."
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:129
+#: ../app/models/smart_proxy.rb:113
 msgid ""
 "No features found on this proxy, please make sure you enable at least one feat"
 "ure"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:133
+#: ../app/models/smart_proxy.rb:117
 msgid "Unable to communicate with the proxy: %s"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:134
+#: ../app/models/smart_proxy.rb:118
 msgid "Please check the proxy is configured and running on the host."
 msgstr ""
 
-#: ../app/models/ssh_key.rb:24
+#: ../app/models/ssh_key.rb:23
 msgid "must be in OpenSSH public key format"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:27
+#: ../app/models/ssh_key.rb:26
 msgid "should be a single line"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:31
+#: ../app/models/ssh_key.rb:30
 msgid "could not be generated"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:34
+#: ../app/models/ssh_key.rb:33
 msgid "could not be calculated"
 msgstr ""
 
-#: ../app/models/subnet.rb:6
+#: ../app/models/subnet.rb:7
 msgid "IPv4"
 msgstr ""
 
-#: ../app/models/subnet.rb:6
+#: ../app/models/subnet.rb:7
 msgid "IPv6"
 msgstr ""
 
-#: ../app/models/subnet.rb:7
+#: ../app/models/subnet.rb:8
 msgid "Static"
 msgstr ""
 
-#: ../app/models/subnet.rb:43 ../app/views/subnets/index.html.erb:13
+#: ../app/models/subnet.rb:42 ../app/views/subnets/index.html.erb:13
 msgid "DHCP Proxy"
 msgstr ""
 
-#: ../app/models/subnet.rb:44
+#: ../app/models/subnet.rb:43
 msgid "DHCP Proxy to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:45
+#: ../app/models/subnet.rb:44
 msgid "DHCP Proxy ID to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:50
+#: ../app/models/subnet.rb:49
 msgid "TFTP Proxy"
 msgstr ""
 
-#: ../app/models/subnet.rb:51
+#: ../app/models/subnet.rb:50
 msgid "TFTP Proxy ID to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:52
+#: ../app/models/subnet.rb:51
 msgid "TFTP Proxy to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:56
+#: ../app/models/subnet.rb:55
 msgid "Reverse DNS Proxy"
 msgstr ""
 
-#: ../app/models/subnet.rb:57
+#: ../app/models/subnet.rb:56
 msgid "DNS Proxy ID to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:58
+#: ../app/models/subnet.rb:57
 msgid ""
 "DNS Proxy to use within this subnet for managing PTR records, note that A and "
 "AAAA records are managed via Domain DNS proxy"
 msgstr ""
 
-#: ../app/models/subnet.rb:61 ../app/registries/menu/loader.rb:65
-#: ../app/views/hosts/show.html.erb:28
+#: ../app/models/subnet.rb:60 ../app/registries/menu/loader.rb:68
+#: ../app/views/hosts/show.html.erb:29
 #: ../app/views/operatingsystems/_form.html.erb:8
 msgid "Templates"
 msgstr ""
 
-#: ../app/models/subnet.rb:62
+#: ../app/models/subnet.rb:61
 msgid "Template Proxy"
 msgstr ""
 
-#: ../app/models/subnet.rb:63
+#: ../app/models/subnet.rb:62
 msgid "Template HTTP(S) Proxy ID to use within this subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:64
+#: ../app/models/subnet.rb:63
 msgid ""
 "Template HTTP(S) Proxy to use within this subnet to allow access templating en"
 "dpoint from isolated networks"
 msgstr ""
 
-#: ../app/models/subnet.rb:75
+#: ../app/models/subnet.rb:74
 msgid "not supported by this protocol"
 msgstr ""
 
@@ -7710,27 +7970,27 @@ msgstr ""
 msgid "unknown network_type"
 msgstr ""
 
-#: ../app/models/subnet/ipv6.rb:44 ../app/services/ipam/eui64.rb:22
+#: ../app/models/subnet/ipv6.rb:45 ../app/services/ipam/eui64.rb:22
 msgid "Prefix length must be /64 or less to use EUI-64"
 msgstr ""
 
-#: ../app/models/taxonomy.rb:250
+#: ../app/models/taxonomy.rb:260
 msgid "Missing a permission to edit parent %s"
 msgstr ""
 
-#: ../app/models/template.rb:174
+#: ../app/models/template.rb:197
 msgid "This template is locked and may not be removed."
 msgstr ""
 
-#: ../app/models/template.rb:183
+#: ../app/models/template.rb:206
 msgid "You are not authorized to lock templates."
 msgstr ""
 
-#: ../app/models/template.rb:189
+#: ../app/models/template.rb:212
 msgid "You are not authorized to make a template default."
 msgstr ""
 
-#: ../app/models/template.rb:194
+#: ../app/models/template.rb:220
 msgid "This template is locked. Please clone it to a new template to customize."
 msgstr ""
 
@@ -7774,68 +8034,68 @@ msgstr ""
 msgid "POAP PXE template"
 msgstr ""
 
-#: ../app/models/user.rb:85
+#: ../app/models/user.rb:91
 msgid "already exists"
 msgstr ""
 
-#: ../app/models/user.rb:200 ../app/models/user.rb:204
-#: ../app/models/user.rb:208
+#: ../app/models/user.rb:203 ../app/models/user.rb:207
+#: ../app/models/user.rb:211
 msgid "Anonymous admin user %s is missing, run foreman-rake db:seed"
 msgstr ""
 
-#: ../app/models/user.rb:581
+#: ../app/models/user.rb:589
 msgid "Incorrect password"
 msgstr ""
 
-#: ../app/models/user.rb:589
+#: ../app/models/user.rb:597
 msgid "A user group already exists with this name"
 msgstr ""
 
-#: ../app/models/user.rb:595
+#: ../app/models/user.rb:603
 msgid "Can't delete the last admin account"
 msgstr ""
 
-#: ../app/models/user.rb:603 ../app/models/usergroup.rb:118
+#: ../app/models/user.rb:611 ../app/models/usergroup.rb:109
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
-#: ../app/models/user.rb:612
+#: ../app/models/user.rb:620
 msgid "Can't delete internal admin account"
 msgstr ""
 
-#: ../app/models/user.rb:621
+#: ../app/models/user.rb:629
 msgid "cannot be removed from an internal protected account"
 msgstr ""
 
-#: ../app/models/user.rb:627
+#: ../app/models/user.rb:635
 msgid "cannot be changed on an internal protected account"
 msgstr ""
 
-#: ../app/models/user.rb:639
+#: ../app/models/user.rb:647
 msgid "you can't assign some of roles you selected"
 msgstr ""
 
-#: ../app/models/user.rb:646
+#: ../app/models/user.rb:654
 msgid "you can't change administrator flag"
 msgstr ""
 
-#: ../app/models/user.rb:657
+#: ../app/models/user.rb:665
 msgid "cannot be changed by a non-admin user"
 msgstr ""
 
-#: ../app/models/user.rb:663
+#: ../app/models/user.rb:671
 msgid "default locations need to be user locations first"
 msgstr ""
 
-#: ../app/models/user.rb:669
+#: ../app/models/user.rb:677
 msgid "default organizations need to be user organizations first"
 msgstr ""
 
-#: ../app/models/user.rb:682
+#: ../app/models/user.rb:690
 msgid "It is not possible to change external users login"
 msgstr ""
 
-#: ../app/models/user.rb:684
+#: ../app/models/user.rb:692
 msgid "You do not have permission to edit the login"
 msgstr ""
 
@@ -7843,39 +8103,39 @@ msgstr ""
 msgid "has this role already"
 msgstr ""
 
-#: ../app/models/usergroup.rb:113
+#: ../app/models/usergroup.rb:104
 msgid "is already used by a user account"
 msgstr ""
 
-#: ../app/models/usergroup.rb:126
+#: ../app/models/usergroup.rb:117
 msgid "Can't delete the last admin user group"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:169
+#: ../app/registries/foreman/plugin.rb:173
 msgid "%{id} plugin requires Foreman %{matcher} but current is %{current}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:179
+#: ../app/registries/foreman/plugin.rb:183
 msgid "%{id} plugin requires the %{plugin_name} plugin, not found"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:181
+#: ../app/registries/foreman/plugin.rb:185
 msgid ""
 "%{id} plugin requires the %{plugin_name} plugin %{matcher} but current is %{pl"
 "ugin_version}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:275
+#: ../app/registries/foreman/plugin.rb:279
 msgid "Could not create role '%{name}': %{message}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:277
+#: ../app/registries/foreman/plugin.rb:281
 msgid ""
 "Cannot continue because some permissions were not found, please run rake db:se"
 "ed and retry"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:363
+#: ../app/registries/foreman/plugin.rb:367
 msgid "Cannot register compute resource, wrong type supplied"
 msgstr ""
 
@@ -7899,24 +8159,24 @@ msgstr ""
 msgid "Could not extend role '%{name}': %{message}"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:15
+#: ../app/registries/menu/loader.rb:16
 msgid "My Account"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:19
+#: ../app/registries/menu/loader.rb:20
 msgid "Log Out"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:25
+#: ../app/registries/menu/loader.rb:28
 msgid "Administer"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:26
-#: ../app/views/auth_source_ldaps/_form.html.erb:10
+#: ../app/registries/menu/loader.rb:29
+#: ../app/views/auth_source_ldaps/_form.html.erb:8
 #: ../app/views/compute_resources/_form.html.erb:6
 #: ../app/views/domains/_form.html.erb:9
 #: ../app/views/environments/_form.html.erb:6
-#: ../app/views/filters/_form.html.erb:8 ../app/views/filters/_form.html.erb:68
+#: ../app/views/filters/_form.html.erb:8 ../app/views/filters/_form.html.erb:66
 #: ../app/views/hostgroups/_form.html.erb:15
 #: ../app/views/http_proxies/_form.html.erb:7
 #: ../app/views/locations/welcome.html.erb:5
@@ -7931,13 +8191,13 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:27
-#: ../app/views/auth_source_ldaps/_form.html.erb:13
+#: ../app/registries/menu/loader.rb:30
+#: ../app/views/auth_source_ldaps/_form.html.erb:11
 #: ../app/views/compute_resources/_form.html.erb:9
 #: ../app/views/domains/_form.html.erb:12
 #: ../app/views/environments/_form.html.erb:9
 #: ../app/views/filters/_form.html.erb:11
-#: ../app/views/filters/_form.html.erb:74
+#: ../app/views/filters/_form.html.erb:72
 #: ../app/views/hostgroups/_form.html.erb:18
 #: ../app/views/http_proxies/_form.html.erb:10
 #: ../app/views/media/_form.html.erb:10 ../app/views/realms/_form.html.erb:9
@@ -7951,87 +8211,72 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:30
-#: ../app/views/auth_source_ldaps/index.html.erb:3
+#: ../app/registries/menu/loader.rb:33
+#: ../app/views/auth_source_ldaps/index.html.erb:1
 msgid "LDAP Authentication"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:32
+#: ../app/registries/menu/loader.rb:35
 #: ../app/views/usergroups/_form.html.erb:25
 #: ../app/views/usergroups/index.html.erb:1
 #: ../app/views/usergroups/index.html.erb:10
 msgid "User Groups"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:33 ../app/views/roles/index.html.erb:1
-#: ../app/views/usergroups/_form.html.erb:5
+#: ../app/registries/menu/loader.rb:36 ../app/views/filters/edit.html.erb:4
+#: ../app/views/filters/index.html.erb:5 ../app/views/filters/new.html.erb:3
+#: ../app/views/roles/index.html.erb:1 ../app/views/usergroups/_form.html.erb:5
 #: ../app/views/usergroups/_form.html.erb:31
 #: ../app/views/users/_form.html.erb:14 ../app/views/users/_form.html.erb:92
 msgid "Roles"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:36 ../app/views/bookmarks/index.html.erb:1
+#: ../app/registries/menu/loader.rb:39 ../app/views/bookmarks/index.html.erb:1
 #: ../app/views/bookmarks/welcome.html.erb:1
 #: ../app/views/bookmarks/welcome.html.erb:6
 #: ../webpack/assets/javascripts/react_app/components/bookmarks/index.js:49
 msgid "Bookmarks"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:37 ../app/views/settings/index.html.erb:1
+#: ../app/registries/menu/loader.rb:40 ../app/views/settings/index.html.erb:1
 msgid "Settings"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:38 ../app/views/about/index.html.erb:1
+#: ../app/registries/menu/loader.rb:41 ../app/views/about/index.html.erb:1
 msgid "About"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:43
+#: ../app/registries/menu/loader.rb:46
 msgid "Monitor"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:44
+#: ../app/registries/menu/loader.rb:47
 msgid "Dashboard"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:46 ../app/views/statistics/index.html.erb:1
+#: ../app/registries/menu/loader.rb:49 ../app/views/statistics/index.html.erb:1
 msgid "Statistics"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:47 ../app/views/trends/index.html.erb:2
+#: ../app/registries/menu/loader.rb:50 ../app/views/trends/index.html.erb:2
 #: ../app/views/trends/welcome.html.erb:1
 #: ../app/views/trends/welcome.html.erb:6
 msgid "Trends"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:50
+#: ../app/registries/menu/loader.rb:53
 msgid "Config Management"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:55
-#: ../app/views/architectures/index.html.erb:9
-#: ../app/views/config_groups/index.html.erb:12
-#: ../app/views/domains/index.html.erb:9
-#: ../app/views/environments/index.html.erb:9
-#: ../app/views/hostgroups/index.html.erb:9 ../app/views/hosts/index.html.erb:8
-#: ../app/views/hosts/welcome.html.erb:1 ../app/views/hosts/welcome.html.erb:6
-#: ../app/views/models/index.html.erb:11
-#: ../app/views/operatingsystems/index.html.erb:9
-#: ../app/views/puppetclasses/index.html.erb:12
-#: ../app/views/realms/index.html.erb:9 ../app/views/subnets/index.html.erb:14
-#: ../app/views/taxonomies/index.html.erb:18
-#: ../app/views/trends/show.html.erb:16
-msgid "Hosts"
-msgstr ""
-
-#: ../app/registries/menu/loader.rb:56
+#: ../app/registries/menu/loader.rb:59
 msgid "All Hosts"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:60
+#: ../app/registries/menu/loader.rb:63
 msgid "Provisioning Setup"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:61
+#: ../app/registries/menu/loader.rb:64
 #: ../app/views/architectures/index.html.erb:1
 #: ../app/views/architectures/welcome.html.erb:1
 #: ../app/views/architectures/welcome.html.erb:6
@@ -8039,19 +8284,19 @@ msgstr ""
 msgid "Architectures"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:62 ../app/views/models/index.html.erb:1
+#: ../app/registries/menu/loader.rb:65 ../app/views/models/index.html.erb:1
 #: ../app/views/models/welcome.html.erb:1
 #: ../app/views/models/welcome.html.erb:6
 msgid "Hardware Models"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:63 ../app/views/media/index.html.erb:1
+#: ../app/registries/menu/loader.rb:66 ../app/views/media/index.html.erb:1
 #: ../app/views/operatingsystems/_form.html.erb:7
 #: ../app/views/operatingsystems/_form.html.erb:38
 msgid "Installation Media"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:64
+#: ../app/registries/menu/loader.rb:67
 #: ../app/views/architectures/_form.html.erb:4
 #: ../app/views/architectures/index.html.erb:8
 #: ../app/views/media/index.html.erb:12
@@ -8061,7 +8306,7 @@ msgstr ""
 msgid "Operating Systems"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:66
+#: ../app/registries/menu/loader.rb:69
 #: ../app/views/operatingsystems/_form.html.erb:35
 #: ../app/views/ptables/index.html.erb:1
 #: ../app/views/ptables/welcome.html.erb:1
@@ -8070,7 +8315,7 @@ msgstr ""
 msgid "Partition Tables"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:68
+#: ../app/registries/menu/loader.rb:71
 #: ../app/views/hosts/_operating_system.html.erb:30
 #: ../app/views/provisioning_templates/index.html.erb:1
 #: ../app/views/provisioning_templates/welcome.html.erb:1
@@ -8079,11 +8324,11 @@ msgstr ""
 msgid "Provisioning Templates"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:73
+#: ../app/registries/menu/loader.rb:76
 msgid "Configure"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:74
+#: ../app/registries/menu/loader.rb:77
 #: ../app/views/config_groups/index.html.erb:13
 #: ../app/views/hostgroups/index.html.erb:1
 #: ../app/views/puppetclasses/index.html.erb:11
@@ -8091,7 +8336,7 @@ msgstr ""
 msgid "Host Groups"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:75
+#: ../app/registries/menu/loader.rb:78
 #: ../app/views/common_parameters/index.html.erb:1
 #: ../app/views/common_parameters/welcome.html.erb:1
 #: ../app/views/common_parameters/welcome.html.erb:6
@@ -8100,7 +8345,7 @@ msgstr ""
 msgid "Global Parameters"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:77
+#: ../app/registries/menu/loader.rb:80
 #: ../app/views/environments/welcome.html.erb:6
 #: ../app/views/puppetclasses/index.html.erb:10
 #: ../app/views/smart_proxies/plugins/_puppet.html.erb:4
@@ -8108,19 +8353,19 @@ msgstr ""
 msgid "Environments"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:78
+#: ../app/registries/menu/loader.rb:81
 #: ../app/views/environments/index.html.erb:21
 msgid "Classes"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:79
+#: ../app/registries/menu/loader.rb:82
 #: ../app/views/config_groups/index.html.erb:3
 #: ../app/views/config_groups/welcome.html.erb:1
 #: ../app/views/config_groups/welcome.html.erb:6
 msgid "Config Groups"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:80
+#: ../app/registries/menu/loader.rb:83
 #: ../app/views/puppetclasses/_class_parameters.html.erb:22
 #: ../app/views/puppetclasses/_form.html.erb:9
 #: ../app/views/variable_lookup_keys/index.html.erb:1
@@ -8129,18 +8374,18 @@ msgstr ""
 msgid "Smart Variables"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:81
+#: ../app/registries/menu/loader.rb:84
 #: ../app/views/puppetclass_lookup_keys/index.html.erb:1
 #: ../app/views/puppetclass_lookup_keys/welcome.html.erb:1
 #: ../app/views/puppetclass_lookup_keys/welcome.html.erb:6
 msgid "Smart Class Parameters"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:84
+#: ../app/registries/menu/loader.rb:87
 msgid "Infrastructure"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:85 ../app/views/about/index.html.erb:10
+#: ../app/registries/menu/loader.rb:88 ../app/views/about/index.html.erb:10
 #: ../app/views/smart_proxies/index.html.erb:1
 #: ../app/views/smart_proxies/welcome.html.erb:1
 #: ../app/views/smart_proxies/welcome.html.erb:6
@@ -8148,21 +8393,16 @@ msgstr ""
 msgid "Smart Proxies"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:87 ../app/views/about/index.html.erb:13
-#: ../app/views/compute_resources/index.html.erb:1
-#: ../app/views/compute_resources/welcome.html.erb:5
-#: ../app/views/taxonomies/_form.html.erb:18
-msgid "Compute Resources"
-msgstr ""
-
-#: ../app/registries/menu/loader.rb:88
+#: ../app/registries/menu/loader.rb:91
+#: ../app/views/compute_attributes/edit.html.erb:12
+#: ../app/views/compute_attributes/new.html.erb:13
 #: ../app/views/compute_profiles/index.html.erb:1
 #: ../app/views/compute_profiles/welcome.html.erb:1
 #: ../app/views/compute_profiles/welcome.html.erb:6
 msgid "Compute Profiles"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:89
+#: ../app/registries/menu/loader.rb:92
 #: ../app/views/smart_proxies/plugins/_dhcp.html.erb:7
 #: ../app/views/subnets/index.html.erb:1
 #: ../app/views/subnets/welcome.html.erb:5
@@ -8170,7 +8410,7 @@ msgstr ""
 msgid "Subnets"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:90 ../app/views/domains/index.html.erb:1
+#: ../app/registries/menu/loader.rb:93 ../app/views/domains/index.html.erb:1
 #: ../app/views/domains/welcome.html.erb:5
 #: ../app/views/smart_proxies/plugins/_dns.html.erb:7
 #: ../app/views/subnets/_form.html.erb:6 ../app/views/subnets/index.html.erb:11
@@ -8178,13 +8418,13 @@ msgstr ""
 msgid "Domains"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:91
+#: ../app/registries/menu/loader.rb:94
 #: ../app/views/http_proxies/index.html.erb:1
 #: ../app/views/http_proxies/welcome.html.erb:5
 msgid "HTTP Proxies"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:92 ../app/views/realms/index.html.erb:1
+#: ../app/registries/menu/loader.rb:95 ../app/views/realms/index.html.erb:1
 #: ../app/views/realms/welcome.html.erb:1
 #: ../app/views/realms/welcome.html.erb:6
 #: ../app/views/smart_proxies/plugins/_realm.html.erb:7
@@ -8192,7 +8432,7 @@ msgstr ""
 msgid "Realms"
 msgstr ""
 
-#: ../app/registries/menu/loader.rb:98
+#: ../app/registries/menu/loader.rb:101
 msgid "Lab Features"
 msgstr ""
 
@@ -8209,8 +8449,8 @@ msgid "unknown permission %s"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/services/classification/values_hash_query.rb:146
-#: model_attributes.rb:268
+#: ../app/services/classification/values_hash_query.rb:147
+#: model_attributes.rb:274
 msgid "LookupKey|Default value"
 msgstr ""
 
@@ -8247,7 +8487,11 @@ msgstr ""
 msgid "New Hosts"
 msgstr ""
 
-#: ../app/services/fact_importer.rb:68
+#: ../app/services/dashboard/manager.rb:72
+msgid "Hosts in build mode"
+msgstr ""
+
+#: ../app/services/fact_importer.rb:73
 msgid "Import of facts failed for host %s"
 msgstr ""
 
@@ -8343,7 +8587,7 @@ msgstr ""
 msgid "Unable to find IP address for '%s'"
 msgstr ""
 
-#: ../app/services/password_crypt.rb:7
+#: ../app/services/password_crypt.rb:11
 msgid "Unsupported password hash function '%s'"
 msgstr ""
 
@@ -8412,6 +8656,10 @@ msgstr ""
 msgid "Error has occurred while communicating with %{cr}: %{e}"
 msgstr ""
 
+#: ../app/services/proxy_reference_registry.rb:19
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
+
 #: ../app/services/proxy_status/base.rb:43
 msgid "Unable to initialize ProxyAPI class %s"
 msgstr ""
@@ -8424,11 +8672,11 @@ msgstr ""
 msgid "Could not locate CA certificate."
 msgstr ""
 
-#: ../app/services/report_importer.rb:30
+#: ../app/services/report_importer.rb:32
 msgid "Invalid report"
 msgstr ""
 
-#: ../app/services/report_importer.rb:90
+#: ../app/services/report_importer.rb:96
 msgid "Invalid log level: %s"
 msgstr ""
 
@@ -8514,8 +8762,12 @@ msgstr ""
 msgid "must be comma separated"
 msgstr ""
 
-#: ../app/validators/belongs_to_host_taxonomy_validator.rb:16
-msgid "is not defined for host's %s."
+#: ../app/validators/association_exists_validator.rb:4
+msgid "with given ID not found"
+msgstr ""
+
+#: ../app/validators/belongs_to_host_taxonomy_validator.rb:17
+msgid "is not defined for host's %s"
 msgstr ""
 
 #: ../app/validators/belongs_to_subnet_validator.rb:11
@@ -8554,6 +8806,14 @@ msgstr ""
 
 #: ../app/validators/ssh_key_validator.rb:4
 msgid "is not a valid public ssh key"
+msgstr ""
+
+#: ../app/validators/subnets_consistency_validator.rb:10
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+#: ../app/validators/subnets_consistency_validator.rb:15
+msgid "VLAN ID is not consistent accross subnets"
 msgstr ""
 
 #: ../app/validators/url_schema_validator.rb:9
@@ -8596,7 +8856,7 @@ msgstr ""
 #: ../app/views/compute_resources_vms/index/_vmware.html.erb:3
 #: ../app/views/compute_resources_vms/show/_libvirt.html.erb:10
 #: ../app/views/compute_resources_vms/show/_ovirt.html.erb:10
-#: ../app/views/fact_values/index.html.erb:17
+#: ../app/views/fact_values/index.html.erb:30
 #: ../app/views/hosts/_list.html.erb:11
 #: ../app/views/hosts/_selected_hosts.html.erb:10
 #: ../app/views/http_proxies/index.html.erb:8
@@ -8621,7 +8881,7 @@ msgstr ""
 
 #: ../app/views/about/index.html.erb:49
 #: ../app/views/compute_resources/_form.html.erb:18
-#: ../app/views/compute_resources/show.html.erb:32
+#: ../app/views/compute_resources/show.html.erb:33
 msgid "Provider"
 msgstr ""
 
@@ -8660,7 +8920,7 @@ msgid "No plugins found"
 msgstr ""
 
 #: ../app/views/about/index.html.erb:101
-#: ../app/views/compute_resources/show.html.erb:37 apipie.rb:7
+#: ../app/views/compute_resources/show.html.erb:38 apipie.rb:7
 msgid "Description"
 msgstr ""
 
@@ -8769,10 +9029,6 @@ msgstr ""
 msgid "Possible values"
 msgstr ""
 
-#: ../app/views/architectures/edit.html.erb:1
-msgid "Edit Architecture"
-msgstr ""
-
 #: ../app/views/architectures/index.html.erb:2
 #: ../app/views/architectures/new.html.erb:1
 #: ../app/views/architectures/welcome.html.erb:14
@@ -8853,88 +9109,112 @@ msgstr ""
 msgid "Logged-in"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:3 ../app/views/audits/show.html.erb:5
-#: ../app/views/audits/show.html.erb:9
+#: ../app/views/audits/show.html.erb:13 ../app/views/audits/show.html.erb:15
+#: ../app/views/audits/show.html.erb:19
 #: ../app/views/config_reports/show.html.erb:20
 msgid "Host details"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:7
+#: ../app/views/audits/show.html.erb:17
 msgid "Associated Host"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:17
+#: ../app/views/audits/show.html.erb:26
 msgid "Template Diff"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:20
+#: ../app/views/audits/show.html.erb:29
 #: ../app/views/templates/_form.html.erb:12
 msgid "History"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:31
+#: ../app/views/audits/show.html.erb:39
+msgid "Audit Metadata:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:42
+msgid "Audit Time:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:46
+msgid "User Name:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:51
+msgid "Affected Organizations:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:57
+msgid "Affected Locations:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:62
+msgid "Changes:"
+msgstr ""
+
+#: ../app/views/audits/show.html.erb:65
 msgid "There are no changes"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:31
+#: ../app/views/audits/show.html.erb:65
 msgid " in the provisioning template."
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:35
+#: ../app/views/audits/show.html.erb:69
 msgid "Item"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:37
+#: ../app/views/audits/show.html.erb:71
 msgid "Old"
 msgstr ""
 
-#: ../app/views/audits/show.html.erb:38
+#: ../app/views/audits/show.html.erb:72
 #: ../app/views/common/_puppetclasses_or_envs_changed.html.erb:6
 msgid "New"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:6
+#: ../app/views/auth_source_ldaps/_form.html.erb:4
 msgid "LDAP server"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:7
+#: ../app/views/auth_source_ldaps/_form.html.erb:5
 msgid "Account"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:8
+#: ../app/views/auth_source_ldaps/_form.html.erb:6
 msgid "Attribute mappings"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:21
+#: ../app/views/auth_source_ldaps/_form.html.erb:19
 msgid "Test LDAP connectivity"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:26
+#: ../app/views/auth_source_ldaps/_form.html.erb:24
 msgid "Choose a server type"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:27
+#: ../app/views/auth_source_ldaps/_form.html.erb:25
 msgid "Server type"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:30
-#: ../app/views/auth_source_ldaps/_form.html.erb:31
+#: ../app/views/auth_source_ldaps/_form.html.erb:28
+#: ../app/views/auth_source_ldaps/_form.html.erb:29
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:32
+#: ../app/views/auth_source_ldaps/_form.html.erb:30
 msgid "Base DN"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:33
+#: ../app/views/auth_source_ldaps/_form.html.erb:31
 msgid "Groups base DN"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:34
+#: ../app/views/auth_source_ldaps/_form.html.erb:32
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:34
+#: ../app/views/auth_source_ldaps/_form.html.erb:32
 msgid ""
 "By default we map user groups to standard LDAP Group objects. FreeIPA and POSI"
 "X LDAP server types supports alternative way of grouping users through Netgrou"
@@ -8942,70 +9222,66 @@ msgid ""
 "roups."
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:36
+#: ../app/views/auth_source_ldaps/_form.html.erb:34
 msgid "Custom LDAP search filter, <i>optional</i>"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:38
+#: ../app/views/auth_source_ldaps/_form.html.erb:36
 msgid ""
 "LDAP users will have their Foreman account automatically created the first tim"
 "e they log into Foreman"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:40
+#: ../app/views/auth_source_ldaps/_form.html.erb:38
 msgid ""
 "External user groups will be synced on login, else relies on periodic cronjob "
 "to check group membership"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:43
+#: ../app/views/auth_source_ldaps/_form.html.erb:41
 msgid "e.g. uid"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:44
+#: ../app/views/auth_source_ldaps/_form.html.erb:42
 msgid "e.g. givenName"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:45
+#: ../app/views/auth_source_ldaps/_form.html.erb:43
 msgid "e.g. sn"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:46
+#: ../app/views/auth_source_ldaps/_form.html.erb:44
 msgid "e.g. mail"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:47
+#: ../app/views/auth_source_ldaps/_form.html.erb:45
 msgid "Photo attribute"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/_form.html.erb:47
+#: ../app/views/auth_source_ldaps/_form.html.erb:45
 msgid "e.g. jpegPhoto"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/edit.html.erb:1
-msgid "Edit LDAP Auth Source"
-msgstr ""
-
-#: ../app/views/auth_source_ldaps/index.html.erb:5
+#: ../app/views/auth_source_ldaps/index.html.erb:3
 msgid "Create LDAP Source"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/auth_source_ldaps/index.html.erb:10 model_attributes.rb:56
+#: ../app/views/auth_source_ldaps/index.html.erb:8 model_attributes.rb:56
 msgid "AuthSource|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/auth_source_ldaps/index.html.erb:11 model_attributes.rb:52
+#: ../app/views/auth_source_ldaps/index.html.erb:9 model_attributes.rb:52
 msgid "AuthSource|Host"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/auth_source_ldaps/index.html.erb:12 model_attributes.rb:58
+#: ../app/views/auth_source_ldaps/index.html.erb:10 model_attributes.rb:58
 msgid "AuthSource|Onthefly register"
 msgstr ""
 
-#: ../app/views/auth_source_ldaps/index.html.erb:13
+#: ../app/views/auth_source_ldaps/index.html.erb:11
 msgid "AuthSource|LDAPS"
 msgstr ""
 
@@ -9050,10 +9326,6 @@ msgstr ""
 
 #: ../app/views/autosign/_form.html.erb:5
 msgid "Save"
-msgstr ""
-
-#: ../app/views/bookmarks/edit.html.erb:1
-msgid "Edit Bookmark"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -9271,21 +9543,17 @@ msgstr ""
 msgid "Add Parameter"
 msgstr ""
 
-#: ../app/views/common_parameters/edit.html.erb:1
-msgid "Edit Global Parameter"
-msgstr ""
-
 #: ../app/views/common_parameters/index.html.erb:3
 msgid "Create Parameter"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/common_parameters/index.html.erb:10 model_attributes.rb:442
+#: ../app/views/common_parameters/index.html.erb:10 model_attributes.rb:450
 msgid "Parameter|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/common_parameters/index.html.erb:11 model_attributes.rb:446
+#: ../app/views/common_parameters/index.html.erb:11 model_attributes.rb:454
 msgid "Parameter|Value"
 msgstr ""
 
@@ -9302,18 +9570,14 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/compute_attributes/_form.html.erb:4
-#: ../app/views/compute_resources/show.html.erb:67
+#: ../app/views/compute_resources/show.html.erb:68
 #: ../app/views/hostgroups/_form.html.erb:39
 #: ../app/views/hosts/_form.html.erb:73 model_attributes.rb:88
 msgid "Compute profile"
 msgstr ""
 
-#: ../app/views/compute_attributes/edit.html.erb:1
-msgid "Edit compute profile on %s"
-msgstr ""
-
-#: ../app/views/compute_attributes/new.html.erb:1
-msgid "New compute profile on %s"
+#: ../app/views/compute_attributes/new.html.erb:17
+msgid "New %s"
 msgstr ""
 
 #: ../app/views/compute_profiles/edit.html.erb:1
@@ -9328,10 +9592,6 @@ msgstr ""
 
 #: ../app/views/compute_profiles/index.html.erb:17
 msgid "Rename"
-msgstr ""
-
-#: ../app/views/compute_profiles/show.html.erb:1
-msgid "Edit Compute profile: %s"
 msgstr ""
 
 #: ../app/views/compute_profiles/show.html.erb:6
@@ -9349,7 +9609,7 @@ msgid "VM Attributes (%s)"
 msgstr ""
 
 #: ../app/views/compute_profiles/show.html.erb:29
-#: ../app/views/compute_resources/show.html.erb:83
+#: ../app/views/compute_resources/show.html.erb:84
 msgid "unspecified"
 msgstr ""
 
@@ -9436,7 +9696,7 @@ msgid "Domain for V3 authentication"
 msgstr ""
 
 #: ../app/views/compute_resources/form/_openstack.html.erb:7
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:13
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:15
 #: ../app/views/compute_resources_vms/index/_openstack.html.erb:5
 msgid "Tenant"
 msgstr ""
@@ -9453,24 +9713,35 @@ msgstr ""
 msgid "e.g. https://ovirt.example.com/api"
 msgstr ""
 
-#: ../app/views/compute_resources/form/_ovirt.html.erb:2
-msgid "e.g. admin@internal"
+#: ../app/views/compute_resources/form/_ovirt.html.erb:3
+#: ../app/views/compute_resources/show/_ovirt.html.erb:10
+msgid "Use APIv4 (experimental)"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_ovirt.html.erb:4
+msgid ""
+"Use the new engine API. This feature is marked as experimental and should be u"
+"sed with caution."
 msgstr ""
 
 #: ../app/views/compute_resources/form/_ovirt.html.erb:5
+msgid "e.g. admin@internal"
+msgstr ""
+
+#: ../app/views/compute_resources/form/_ovirt.html.erb:8
 #: ../app/views/compute_resources/form/_vmware.html.erb:5
 msgid "Datacenter"
 msgstr ""
 
-#: ../app/views/compute_resources/form/_ovirt.html.erb:9
+#: ../app/views/compute_resources/form/_ovirt.html.erb:12
 msgid "Quota ID"
 msgstr ""
 
-#: ../app/views/compute_resources/form/_ovirt.html.erb:10
+#: ../app/views/compute_resources/form/_ovirt.html.erb:13
 msgid "X509 Certification Authorities"
 msgstr ""
 
-#: ../app/views/compute_resources/form/_ovirt.html.erb:11
+#: ../app/views/compute_resources/form/_ovirt.html.erb:14
 msgid ""
 "Optionally provide a CA, or a correctly ordered CA chain. If left blank, a sel"
 "f-signed CA will be populated automatically by the server during the first req"
@@ -9523,7 +9794,7 @@ msgid "Create Compute Resource"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/compute_resources/index.html.erb:8 model_attributes.rb:102
+#: ../app/views/compute_resources/index.html.erb:8 model_attributes.rb:104
 msgid "ComputeResource|Name"
 msgstr ""
 
@@ -9543,10 +9814,6 @@ msgstr ""
 msgid "Virtual Machines"
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:13
-msgid "Images"
-msgstr ""
-
 #: ../app/views/compute_resources/show.html.erb:16
 #: ../app/views/key_pairs/index.html.erb:44
 #: ../app/views/ssh_keys/_ssh_keys_tab.html.erb:25
@@ -9557,28 +9824,28 @@ msgstr ""
 msgid "Compute profiles"
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:26
+#: ../app/views/compute_resources/show.html.erb:27
 msgid "Property"
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:46
+#: ../app/views/compute_resources/show.html.erb:47
 msgid "Loading virtual machines information ..."
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:50
-#: ../app/views/images/new.html.erb:1
+#: ../app/views/compute_resources/show.html.erb:51
+#: ../app/views/images/index.html.erb:18
 msgid "Create Image"
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:52
+#: ../app/views/compute_resources/show.html.erb:53
 msgid "Loading images information ..."
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:59
+#: ../app/views/compute_resources/show.html.erb:60
 msgid "Loading SSH keys information ..."
 msgstr ""
 
-#: ../app/views/compute_resources/show.html.erb:68
+#: ../app/views/compute_resources/show.html.erb:69
 msgid "VM Attributes"
 msgstr ""
 
@@ -9647,7 +9914,7 @@ msgid "No networks found."
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/_volumes.html.erb:3
-#: ../webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js:65
+#: ../webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js:70
 msgid "Storage"
 msgstr ""
 
@@ -9677,19 +9944,19 @@ msgstr ""
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:7
 #: ../app/views/compute_resources_vms/form/gce/_base.html.erb:8
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:18
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:10
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:43
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:12
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:46
 #: ../app/views/compute_resources_vms/form/vmware/_base.html.erb:38
 msgid "Please select an image"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:9
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:7
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:8
 msgid "No preference"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:9
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:7
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:9
 msgid "Availability zone"
 msgstr ""
 
@@ -9699,12 +9966,13 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:15
-#: ../app/views/hosts/_nics.html.erb:31 ../app/views/subnets/_form.html.erb:5
-#: model_attributes.rb:538
+#: ../app/views/hosts/_nics.html.erb:35 ../app/views/subnets/_form.html.erb:5
+#: model_attributes.rb:548
 msgid "Subnet"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:22
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:17
 msgid "Security groups"
 msgstr ""
 
@@ -9756,7 +10024,7 @@ msgid "CPUs"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:7
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:31
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:34
 #: ../app/views/compute_resources_vms/index/_libvirt.html.erb:5
 #: ../app/views/compute_resources_vms/index/_ovirt.html.erb:5
 #: ../app/views/compute_resources_vms/index/_vmware.html.erb:6
@@ -9766,19 +10034,19 @@ msgid "Memory"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:11
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:34
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:37
 #: ../app/views/compute_resources_vms/form/vmware/_base.html.erb:27
 msgid "Power ON this machine"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:11
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:34
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:37
 #: ../app/views/compute_resources_vms/form/vmware/_base.html.erb:27
 msgid "Start"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/libvirt/_base.html.erb:23
-#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:47
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:50
 msgid "Image to use"
 msgstr ""
 
@@ -9809,35 +10077,31 @@ msgstr ""
 msgid "Storage pool"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:15
-msgid "Security group"
-msgstr ""
-
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:17
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:19
 msgid "Internal network"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:18
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:20
 msgid "Floating IP network"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:19
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:21
 msgid "Boot from volume"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:19
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:21
 msgid "Create new boot volume from image"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:20
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:22
 msgid "New boot volume size (GB)"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:20
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:22
 msgid "Defaults to image size if left blank"
 msgstr ""
 
-#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:21
+#: ../app/views/compute_resources_vms/form/openstack/_base.html.erb:23
 msgid "Scheduler hint filter"
 msgstr ""
 
@@ -9872,7 +10136,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:17
-#: ../app/views/templates/_form.html.erb:10 model_attributes.rb:582
+#: ../app/views/templates/_form.html.erb:10 model_attributes.rb:600
 msgid "Template"
 msgstr ""
 
@@ -9890,6 +10154,10 @@ msgstr ""
 
 #: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:30
 msgid "Cores"
+msgstr ""
+
+#: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:32
+msgid "Sockets"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/ovirt/_volume.html.erb:5
@@ -10026,7 +10294,7 @@ msgstr ""
 #: ../app/views/compute_resources_vms/show/_ovirt.html.erb:6
 #: ../app/views/compute_resources_vms/show/_rackspace.html.erb:5
 #: ../app/views/compute_resources_vms/show/_vmware.html.erb:5
-#: ../app/views/hosts/_overview.html.erb:4 ../app/views/hosts/show.html.erb:25
+#: ../app/views/hosts/_overview.html.erb:4 ../app/views/hosts/show.html.erb:26
 msgid "Properties"
 msgstr ""
 
@@ -10095,10 +10363,6 @@ msgstr ""
 msgid "Available Config Groups"
 msgstr ""
 
-#: ../app/views/config_groups/edit.html.erb:1
-msgid "Edit Config group"
-msgstr ""
-
 #: ../app/views/config_groups/index.html.erb:5
 #: ../app/views/config_groups/new.html.erb:1
 #: ../app/views/config_groups/welcome.html.erb:10
@@ -10137,21 +10401,20 @@ msgid "Delete report for %s?"
 msgstr ""
 
 #: ../app/views/config_reports/_metrics.html.erb:6
-#: ../app/views/config_reports/_metrics.html.erb:8
 msgid "Report Metrics"
 msgstr ""
 
-#: ../app/views/config_reports/_metrics.html.erb:14
+#: ../app/views/config_reports/_metrics.html.erb:13
 #: ../app/views/hosts/_metrics.html.erb:4
 msgid "Report Status"
 msgstr ""
 
-#: ../app/views/config_reports/_metrics.html.erb:15
+#: ../app/views/config_reports/_metrics.html.erb:14
 #: ../app/views/hosts/_resources.html.erb:1
 msgid "Number of Events"
 msgstr ""
 
-#: ../app/views/config_reports/_metrics.html.erb:34
+#: ../app/views/config_reports/_metrics.html.erb:33
 #: ../app/views/smart_proxies/plugins/_puppet_envs.html.erb:15
 msgid "Total"
 msgstr ""
@@ -10171,7 +10434,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/config_reports/_output.html.erb:6
 #: ../app/views/smart_proxies/logs/_list.html.erb:17
-#: ../app/views/smart_proxies/logs/_modal.html.erb:30 model_attributes.rb:334
+#: ../app/views/smart_proxies/logs/_modal.html.erb:30 model_attributes.rb:340
 msgid "Message"
 msgstr ""
 
@@ -10179,23 +10442,23 @@ msgstr ""
 msgid "Nothing to show"
 msgstr ""
 
-#: ../app/views/config_reports/show.html.erb:4
+#: ../app/views/config_reports/show.html.erb:5
 msgid "Reported at %s "
 msgstr ""
 
-#: ../app/views/config_reports/show.html.erb:7
+#: ../app/views/config_reports/show.html.erb:8
 msgid "Host times seem to be adrift!"
 msgstr ""
 
-#: ../app/views/config_reports/show.html.erb:8
+#: ../app/views/config_reports/show.html.erb:9
 msgid "Host reported time is <em>%s</em>"
 msgstr ""
 
-#: ../app/views/config_reports/show.html.erb:9
+#: ../app/views/config_reports/show.html.erb:10
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr ""
 
-#: ../app/views/config_reports/show.html.erb:10
+#: ../app/views/config_reports/show.html.erb:11
 msgid "Which is an offset of <b>%s</b>"
 msgstr ""
 
@@ -10234,6 +10497,22 @@ msgstr ""
 msgid "Run Distribution Chart"
 msgstr ""
 
+#: ../app/views/dashboard/_hosts_in_build_mode_widget.html.erb:4
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+#: ../app/views/dashboard/_hosts_in_build_mode_widget.html.erb:8
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
+#: ../app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb:5
+msgid "Build Duration"
+msgstr ""
+
+#: ../app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb:6
+msgid "Token Expiry"
+msgstr ""
+
 #: ../app/views/dashboard/_new_hosts_widget.html.erb:8
 msgid "No hosts available."
 msgstr ""
@@ -10251,11 +10530,11 @@ msgstr ""
 msgid "Host Configuration Chart"
 msgstr ""
 
-#: ../app/views/dashboard/_status_links.html.erb:7
+#: ../app/views/dashboard/_status_links.html.erb:6
 msgid "Hosts that had performed modifications without error"
 msgstr ""
 
-#: ../app/views/dashboard/_status_links.html.erb:14
+#: ../app/views/dashboard/_status_links.html.erb:13
 msgid "Hosts in error state"
 msgstr ""
 
@@ -10263,7 +10542,11 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr ""
 
-#: ../app/views/dashboard/_status_links.html.erb:42
+#: ../app/views/dashboard/_status_links.html.erb:21
+msgid "Good host with reports"
+msgstr ""
+
+#: ../app/views/dashboard/_status_links.html.erb:48
 msgid "Hosts with no reports"
 msgstr ""
 
@@ -10306,17 +10589,13 @@ msgstr ""
 msgid "Full name describing the domain"
 msgstr ""
 
-#: ../app/views/domains/edit.html.erb:1
-msgid "Edit Domain"
-msgstr ""
-
 #: ../app/views/domains/index.html.erb:3 ../app/views/domains/new.html.erb:1
 #: ../app/views/domains/welcome.html.erb:16
 msgid "Create Domain"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/domains/index.html.erb:8 model_attributes.rb:118
+#: ../app/views/domains/index.html.erb:8 model_attributes.rb:120
 msgid "Domain|Fullname"
 msgstr ""
 
@@ -10357,24 +10636,20 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: ../app/views/editor/_toolbar.html.erb:33
+#: ../app/views/editor/_toolbar.html.erb:34
 msgid "Fullscreen"
 msgstr ""
 
-#: ../app/views/editor/_toolbar.html.erb:37
+#: ../app/views/editor/_toolbar.html.erb:38
 msgid "Exit Fullscreen"
 msgstr ""
 
-#: ../app/views/editor/_toolbar.html.erb:42
+#: ../app/views/editor/_toolbar.html.erb:44
 msgid "Syntax Highlighting"
 msgstr ""
 
-#: ../app/views/editor/_toolbar.html.erb:46
+#: ../app/views/editor/_toolbar.html.erb:50
 msgid "Key Binding"
-msgstr ""
-
-#: ../app/views/environments/edit.html.erb:1
-msgid "Edit Environment"
 msgstr ""
 
 #: ../app/views/environments/index.html.erb:1
@@ -10383,7 +10658,7 @@ msgid "Puppet Environments"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/environments/index.html.erb:8 model_attributes.rb:124
+#: ../app/views/environments/index.html.erb:8 model_attributes.rb:126
 msgid "Environment|Name"
 msgstr ""
 
@@ -10408,34 +10683,26 @@ msgstr ""
 msgid "Show all %s facts with the same value"
 msgstr ""
 
-#: ../app/views/fact_values/_fact.html.erb:27
-msgid "View Chart"
+#: ../app/views/fact_values/index.html.erb:14
+msgid "values"
 msgstr ""
 
-#: ../app/views/fact_values/_fact.html.erb:29
-msgid "Show distribution chart"
-msgstr ""
-
-#: ../app/views/fact_values/index.html.erb:4
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
-#: ../app/views/fact_values/index.html.erb:6
+#: ../app/views/fact_values/index.html.erb:19
 #: ../app/views/fact_values/welcome.html.erb:1
 #: ../app/views/fact_values/welcome.html.erb:6
 msgid "Fact Values"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/fact_values/index.html.erb:18 model_attributes.rb:142
+#: ../app/views/fact_values/index.html.erb:31 model_attributes.rb:144
 msgid "FactValue|Value"
 msgstr ""
 
-#: ../app/views/fact_values/index.html.erb:19
+#: ../app/views/fact_values/index.html.erb:32
 msgid "FactValue|Origin"
 msgstr ""
 
-#: ../app/views/fact_values/index.html.erb:20
+#: ../app/views/fact_values/index.html.erb:33
 msgid "Reported at"
 msgstr ""
 
@@ -10458,17 +10725,17 @@ msgid "(Miscellaneous)"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/_form.html.erb:34 model_attributes.rb:448
+#: ../app/views/filters/_form.html.erb:34 model_attributes.rb:456
 msgid "Permission"
 msgstr ""
 
-#: ../app/views/filters/_form.html.erb:43
+#: ../app/views/filters/_form.html.erb:41
 msgid ""
 "Selected resource type does not support granular filtering, therefore you can'"
 "t configure granularity"
 msgstr ""
 
-#: ../app/views/filters/_form.html.erb:50
+#: ../app/views/filters/_form.html.erb:48
 msgid ""
 "Filters inherit %{orgs_and_locs} associated with the role by default. If overr"
 "ide field is enabled, <br> the filter can override the set of its %{orgs_and_l"
@@ -10476,7 +10743,7 @@ msgid ""
 "override field, the role %{orgs_and_locs} apply again."
 msgstr ""
 
-#: ../app/views/filters/_form.html.erb:56
+#: ../app/views/filters/_form.html.erb:54
 msgid ""
 "If the unlimited field is enabled, the filter applies to all resources of the "
 "selected type. If the unlimited </br> field is disabled, you can specify furth"
@@ -10485,72 +10752,70 @@ msgid ""
 "are scoped accordingly."
 msgstr ""
 
-#: ../app/views/filters/edit.html.erb:1
-msgid "Edit Filter"
-msgstr ""
-
-#: ../app/views/filters/index.html.erb:2
-msgid "Filters for role %s"
-msgstr ""
-
-#: ../app/views/filters/index.html.erb:4 ../app/views/roles/_form.html.erb:7
-#: ../app/views/roles/index.html.erb:25
+#: ../app/views/filters/edit.html.erb:4 ../app/views/filters/index.html.erb:14
+#: ../app/views/filters/new.html.erb:3 ../app/views/roles/_form.html.erb:7
+#: ../app/views/roles/index.html.erb:26
 msgid "Filters"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:7 ../app/views/filters/new.html.erb:1
+#: ../app/views/filters/edit.html.erb:5 ../app/views/filters/index.html.erb:9
+#: ../app/views/filters/new.html.erb:4
+msgid "%s filters"
+msgstr ""
+
+#: ../app/views/filters/index.html.erb:17 ../app/views/filters/new.html.erb:5
 msgid "Create Filter"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/index.html.erb:14 ../app/views/roles/_form.html.erb:5
-#: model_attributes.rb:486
+#: ../app/views/filters/index.html.erb:24 ../app/views/roles/_form.html.erb:5
+#: model_attributes.rb:494
 msgid "Role"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:16
+#: ../app/views/filters/index.html.erb:26
 msgid "Filter|Resource"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:17
+#: ../app/views/filters/index.html.erb:27
 msgid "Filter|Permissions"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:18
+#: ../app/views/filters/index.html.erb:28
 msgid "Filter|Unlimited"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/index.html.erb:19 model_attributes.rb:150
+#: ../app/views/filters/index.html.erb:29 model_attributes.rb:152
 msgid "Filter|Override"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/index.html.erb:20 model_attributes.rb:152
+#: ../app/views/filters/index.html.erb:30 model_attributes.rb:154
 msgid "Filter|Search"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:51
+#: ../app/views/filters/index.html.erb:61
 msgid "Disable overriding"
 msgstr ""
 
-#: ../app/views/filters/index.html.erb:55
+#: ../app/views/filters/index.html.erb:65
 msgid "Delete filter?"
 msgstr ""
 
-#: ../app/views/home/_location_dropdown.html.erb:3
+#: ../app/views/home/_location_dropdown.html.erb:2
 msgid "Any Location"
 msgstr ""
 
-#: ../app/views/home/_location_dropdown.html.erb:5
+#: ../app/views/home/_location_dropdown.html.erb:4
 msgid "Manage Locations"
 msgstr ""
 
-#: ../app/views/home/_organization_dropdown.html.erb:3
+#: ../app/views/home/_organization_dropdown.html.erb:2
 msgid "Any Organization"
 msgstr ""
 
-#: ../app/views/home/_organization_dropdown.html.erb:5
+#: ../app/views/home/_organization_dropdown.html.erb:4
 msgid "Manage Organizations"
 msgstr ""
 
@@ -10673,7 +10938,7 @@ msgstr ""
 #: ../app/views/hostgroups/_form.html.erb:6
 #: ../app/views/hosts/select_multiple_hostgroup.html.erb:5
 #: ../app/views/provisioning_templates/_combination.html.erb:2
-#: model_attributes.rb:208
+#: model_attributes.rb:214
 msgid "Hostgroup"
 msgstr ""
 
@@ -10727,7 +10992,7 @@ msgid "Create Host Group"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/hostgroups/index.html.erb:8 model_attributes.rb:220
+#: ../app/views/hostgroups/index.html.erb:8 model_attributes.rb:226
 msgid "Hostgroup|Name"
 msgstr ""
 
@@ -10922,12 +11187,12 @@ msgid "Identifier"
 msgstr ""
 
 #: ../app/views/hosts/_interfaces.html.erb:16
-#: ../app/views/hosts/_nics.html.erb:18 ../app/views/nic/_base_form.html.erb:41
+#: ../app/views/hosts/_nics.html.erb:22 ../app/views/nic/_base_form.html.erb:41
 msgid "IPv4 Address"
 msgstr ""
 
 #: ../app/views/hosts/_interfaces.html.erb:18
-#: ../app/views/hosts/_nics.html.erb:26
+#: ../app/views/hosts/_nics.html.erb:30
 msgid "FQDN"
 msgstr ""
 
@@ -10950,6 +11215,11 @@ msgstr ""
 
 #: ../app/views/hosts/_list.html.erb:55
 msgid "Please Confirm"
+msgstr ""
+
+#: ../app/views/hosts/_nics.html.erb:18
+#: ../app/views/subnets/_fields.html.erb:25
+msgid "MTU"
 msgstr ""
 
 #: ../app/views/hosts/_operating_system.html.erb:11
@@ -11069,15 +11339,15 @@ msgstr ""
 msgid "Canvas not supported."
 msgstr ""
 
-#: ../app/views/hosts/edit.html.erb:5
+#: ../app/views/hosts/edit.html.erb:6
 msgid "Unmanage host"
 msgstr ""
 
-#: ../app/views/hosts/edit.html.erb:5
+#: ../app/views/hosts/edit.html.erb:6
 msgid "Manage host"
 msgstr ""
 
-#: ../app/views/hosts/edit.html.erb:8
+#: ../app/views/hosts/edit.html.erb:9
 msgid "Disassociate host"
 msgstr ""
 
@@ -11207,77 +11477,68 @@ msgstr ""
 msgid "Select desired state"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:26
+#: ../app/views/hosts/show.html.erb:27
 msgid "Metrics"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:31
+#: ../app/views/hosts/show.html.erb:32
 msgid "VM"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:36
+#: ../app/views/hosts/show.html.erb:37
 msgid "NICs"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:41
+#: ../app/views/hosts/show.html.erb:42
 msgid "Loading host information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:46
+#: ../app/views/hosts/show.html.erb:47
 msgid "No puppet activity for this host in the last %s days"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:53
+#: ../app/views/hosts/show.html.erb:54
 msgid "Loading template information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:58
+#: ../app/views/hosts/show.html.erb:59
 msgid "Loading VM information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:62
+#: ../app/views/hosts/show.html.erb:63
 msgid "Loading NICs information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:66
+#: ../app/views/hosts/show.html.erb:67
 msgid "Loading BMC information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:78
+#: ../app/views/hosts/show.html.erb:79
 msgid "Loading runtime information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:82 apipie.rb:5
+#: ../app/views/hosts/show.html.erb:83 apipie.rb:5
 msgid "Resources"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:85
+#: ../app/views/hosts/show.html.erb:86
 msgid "Loading resources information ..."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:95
+#: ../app/views/hosts/show.html.erb:96
 msgid "Review build status for %s"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:98
+#: ../app/views/hosts/show.html.erb:99
 msgid "Warning: This will delete this host and all of its data!"
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:99
+#: ../app/views/hosts/show.html.erb:100
 msgid "This host's stored facts and reports will be deleted too."
 msgstr ""
 
-#: ../app/views/hosts/show.html.erb:116
+#: ../app/views/hosts/show.html.erb:117
 msgid "Please wait while your request is being processed"
-msgstr ""
-
-#: ../app/views/hosts/storeconfig_klasses.html.erb:1
-msgid "All Puppet Classes for %s"
-msgstr ""
-
-#: ../app/views/hosts/storeconfig_klasses.html.erb:5
-#: ../app/views/templates/_form.html.erb:109
-msgid "Class"
 msgstr ""
 
 #: ../app/views/hosts/update_multiple_parameters.html.erb:1
@@ -11314,10 +11575,6 @@ msgstr ""
 msgid "Test URL"
 msgstr ""
 
-#: ../app/views/http_proxies/edit.html.erb:1
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 #: ../app/views/http_proxies/index.html.erb:3
 #: ../app/views/http_proxies/new.html.erb:1
 #: ../app/views/http_proxies/welcome.html.erb:11
@@ -11331,22 +11588,22 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:4 model_attributes.rb:246
+#: ../app/views/images/_list.html.erb:4 model_attributes.rb:252
 msgid "Image|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:6 model_attributes.rb:252
+#: ../app/views/images/_list.html.erb:6 model_attributes.rb:258
 msgid "Image|Username"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:7 model_attributes.rb:254
+#: ../app/views/images/_list.html.erb:7 model_attributes.rb:260
 msgid "Image|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:8 model_attributes.rb:250
+#: ../app/views/images/_list.html.erb:8 model_attributes.rb:256
 msgid "Image|User data"
 msgstr ""
 
@@ -11396,6 +11653,10 @@ msgstr ""
 
 #: ../app/views/images/form/_vmware.html.erb:4
 msgid "Path to template, relative to datacenter (e.g. My templates/RHEL 6)"
+msgstr ""
+
+#: ../app/views/images/index.html.erb:8
+msgid "#{@compute_resource.to_s}"
 msgstr ""
 
 #: ../app/views/key_pairs/index.html.erb:1
@@ -11585,8 +11846,9 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/media/_form.html.erb:5
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:45
-#: model_attributes.rb:320
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:6
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:34
+#: model_attributes.rb:326
 msgid "Medium"
 msgstr ""
 
@@ -11624,21 +11886,17 @@ msgstr ""
 msgid "Operating System Family"
 msgstr ""
 
-#: ../app/views/media/edit.html.erb:1
-msgid "Edit Medium"
-msgstr ""
-
 #: ../app/views/media/index.html.erb:2 ../app/views/media/new.html.erb:1
 msgid "Create Medium"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/media/index.html.erb:9 model_attributes.rb:328
+#: ../app/views/media/index.html.erb:9 model_attributes.rb:334
 msgid "Medium|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/media/index.html.erb:10 model_attributes.rb:332
+#: ../app/views/media/index.html.erb:10 model_attributes.rb:338
 msgid "Medium|Path"
 msgstr ""
 
@@ -11708,16 +11966,12 @@ msgid ""
 "BIOS setup"
 msgstr ""
 
-#: ../app/views/models/edit.html.erb:1
-msgid "Edit Model"
-msgstr ""
-
 #: ../app/views/models/index.html.erb:3 ../app/views/models/new.html.erb:1
 msgid "Create Model"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/models/index.html.erb:8 model_attributes.rb:346
+#: ../app/views/models/index.html.erb:8 model_attributes.rb:352
 msgid "Model|Name"
 msgstr ""
 
@@ -11959,7 +12213,7 @@ msgid "Create Operating System"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/operatingsystems/index.html.erb:8 model_attributes.rb:436
+#: ../app/views/operatingsystems/index.html.erb:8 model_attributes.rb:444
 msgid "Operatingsystem|Title"
 msgstr ""
 
@@ -12023,10 +12277,6 @@ msgstr ""
 msgid "Template diff"
 msgstr ""
 
-#: ../app/views/provisioning_templates/edit.html.erb:1
-msgid "Edit Template"
-msgstr ""
-
 #: ../app/views/provisioning_templates/index.html.erb:3
 #: ../app/views/provisioning_templates/new.html.erb:1
 msgid "Create Template"
@@ -12077,10 +12327,6 @@ msgstr ""
 
 #: ../app/views/provisioning_templates/welcome.html.erb:10
 msgid "Create Provisioning Template"
-msgstr ""
-
-#: ../app/views/ptables/edit.html.erb:1
-msgid "Edit Partition Table"
 msgstr ""
 
 #: ../app/views/ptables/index.html.erb:2 ../app/views/ptables/new.html.erb:1
@@ -12140,7 +12386,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/puppetclass_lookup_keys/index.html.erb:6
-#: model_attributes.rb:438
+#: model_attributes.rb:446
 msgid "Parameter"
 msgstr ""
 
@@ -12231,7 +12477,7 @@ msgid "Edit Puppet Class %s"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/puppetclasses/index.html.erb:9 model_attributes.rb:468
+#: ../app/views/puppetclasses/index.html.erb:9 model_attributes.rb:476
 msgid "Puppetclass|Name"
 msgstr ""
 
@@ -12268,17 +12514,13 @@ msgstr ""
 msgid "Type of realm, e.g. FreeIPA"
 msgstr ""
 
-#: ../app/views/realms/edit.html.erb:1
-msgid "Edit Realm"
-msgstr ""
-
 #: ../app/views/realms/index.html.erb:2 ../app/views/realms/new.html.erb:1
 #: ../app/views/realms/welcome.html.erb:13
 msgid "Create Realm"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/realms/index.html.erb:8 model_attributes.rb:472
+#: ../app/views/realms/index.html.erb:8 model_attributes.rb:480
 msgid "Realm|Name"
 msgstr ""
 
@@ -12336,68 +12578,60 @@ msgstr ""
 msgid "Disable all filters overriding"
 msgstr ""
 
-#: ../app/views/roles/edit.html.erb:1
-msgid "Edit Role"
-msgstr ""
-
-#: ../app/views/roles/index.html.erb:2 ../app/views/roles/new.html.erb:1
+#: ../app/views/roles/index.html.erb:3 ../app/views/roles/new.html.erb:1
 msgid "Create Role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/roles/index.html.erb:8 model_attributes.rb:492
+#: ../app/views/roles/index.html.erb:9 model_attributes.rb:500
 msgid "Role|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/roles/index.html.erb:9 model_attributes.rb:490
+#: ../app/views/roles/index.html.erb:10 model_attributes.rb:498
 msgid "Role|Description"
 msgstr ""
 
-#: ../app/views/roles/index.html.erb:10
+#: ../app/views/roles/index.html.erb:11
 msgid "Role|Locked"
 msgstr ""
 
-#: ../app/views/roles/index.html.erb:23
+#: ../app/views/roles/index.html.erb:24
 msgid "This role is locked for editing."
 msgstr ""
 
-#: ../app/views/roles/index.html.erb:26
+#: ../app/views/roles/index.html.erb:27
 msgid "Add filter"
 msgstr ""
 
-#: ../app/views/settings/category/_email.html.erb:1
+#: ../app/views/settings/category/_email.html.erb:2
 #: ../app/views/users/_form.html.erb:66
 msgid "Test email"
 msgstr ""
 
-#: ../app/views/settings/category/_email.html.erb:2
+#: ../app/views/settings/category/_email.html.erb:3
 msgid ""
 "Send a test message to the current user's email address to confirm the configu"
 "ration is working."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/settings/index.html.erb:21 model_attributes.rb:508
+#: ../app/views/settings/index.html.erb:21 model_attributes.rb:516
 msgid "Setting|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/settings/index.html.erb:22 model_attributes.rb:512
+#: ../app/views/settings/index.html.erb:22 model_attributes.rb:520
 msgid "Setting|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/settings/index.html.erb:23 model_attributes.rb:502
+#: ../app/views/settings/index.html.erb:23 model_attributes.rb:510
 msgid "Setting|Description"
 msgstr ""
 
 #: ../app/views/smart_proxies/_form.html.erb:4
 msgid "Smart Proxy"
-msgstr ""
-
-#: ../app/views/smart_proxies/edit.html.erb:1
-msgid "Edit Proxy"
 msgstr ""
 
 #: ../app/views/smart_proxies/index.html.erb:3
@@ -12406,12 +12640,12 @@ msgid "Create Smart Proxy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/smart_proxies/index.html.erb:9 model_attributes.rb:518
+#: ../app/views/smart_proxies/index.html.erb:9 model_attributes.rb:526
 msgid "SmartProxy|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/smart_proxies/index.html.erb:11 model_attributes.rb:520
+#: ../app/views/smart_proxies/index.html.erb:11 model_attributes.rb:530
 msgid "SmartProxy|Url"
 msgstr ""
 
@@ -12504,10 +12738,6 @@ msgstr ""
 msgid "TFTP server"
 msgstr ""
 
-#: ../app/views/smart_proxies/show.html.erb:1
-msgid "Smart Proxy: %s"
-msgstr ""
-
 #: ../app/views/smart_proxies/show.html.erb:10
 msgid "Services"
 msgstr ""
@@ -12559,12 +12789,8 @@ msgid ""
 msgstr ""
 
 #: ../app/views/ssh_keys/_ssh_keys_tab.html.erb:45
-#: ../app/views/ssh_keys/new.html.erb:6
+#: ../app/views/ssh_keys/new.html.erb:14
 msgid "Add SSH Key"
-msgstr ""
-
-#: ../app/views/ssh_keys/new.html.erb:1
-msgid "Add SSH Key for %s"
 msgstr ""
 
 #: ../app/views/subnets/_fields.html.erb:5
@@ -12642,11 +12868,11 @@ msgstr ""
 msgid "Optional: VLAN ID for this subnet"
 msgstr ""
 
-#: ../app/views/subnets/_fields.html.erb:26
+#: ../app/views/subnets/_fields.html.erb:27
 msgid "Boot Mode"
 msgstr ""
 
-#: ../app/views/subnets/_fields.html.erb:26
+#: ../app/views/subnets/_fields.html.erb:27
 msgid ""
 "Default boot mode for interfaces assigned to this subnet, applied to hosts fro"
 "m provisioning templates"
@@ -12654,10 +12880,6 @@ msgstr ""
 
 #: ../app/views/subnets/_form.html.erb:7
 msgid "Proxies"
-msgstr ""
-
-#: ../app/views/subnets/edit.html.erb:1
-msgid "Edit Subnet"
 msgstr ""
 
 #: ../app/views/subnets/import.html.erb:3
@@ -12672,17 +12894,17 @@ msgid "Create Subnet"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:9 model_attributes.rb:556
+#: ../app/views/subnets/index.html.erb:9 model_attributes.rb:568
 msgid "Subnet|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:10 model_attributes.rb:558
+#: ../app/views/subnets/index.html.erb:10 model_attributes.rb:570
 msgid "Subnet|Network"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:12 model_attributes.rb:564
+#: ../app/views/subnets/index.html.erb:12 model_attributes.rb:576
 msgid "Subnet|Vlanid"
 msgstr ""
 
@@ -12782,7 +13004,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/taxonomies/index.html.erb:17 model_attributes.rb:578
+#: ../app/views/taxonomies/index.html.erb:17 model_attributes.rb:596
 msgid "Taxonomy|Name"
 msgstr ""
 
@@ -12915,6 +13137,10 @@ msgstr ""
 msgid "Safe mode methods and variables"
 msgstr ""
 
+#: ../app/views/templates/_form.html.erb:109
+msgid "Class"
+msgstr ""
+
 #: ../app/views/templates/_form.html.erb:110
 msgid "Allowed methods or members"
 msgstr ""
@@ -13032,9 +13258,9 @@ msgstr ""
 #: ../app/views/trends/welcome.html.erb:7
 msgid ""
 "Trends in Foreman allow you to track changes in your infrastructure over time."
-" It allows you to track both Foreman related information and any Puppet facts."
-" The Trend pages give a graph of how the number of hosts with that value have "
-"changed over time, and list the current hosts."
+" It allows you to track both Foreman related information and to any fact. The "
+"Trend pages give a graph of how the number of hosts with that value have chang"
+"ed over time, and list the current hosts."
 msgstr ""
 
 #: ../app/views/user_mailer/tester.html.erb:1
@@ -13087,7 +13313,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/usergroups/_form.html.erb:38
-#: ../app/views/usergroups/index.html.erb:8 model_attributes.rb:672
+#: ../app/views/usergroups/index.html.erb:8 model_attributes.rb:698
 msgid "Usergroup|Name"
 msgstr ""
 
@@ -13109,10 +13335,6 @@ msgstr ""
 
 #: ../app/views/usergroups/_form.html.erb:69
 msgid "link external user group with this user group"
-msgstr ""
-
-#: ../app/views/usergroups/edit.html.erb:1
-msgid "Edit User group"
 msgstr ""
 
 #: ../app/views/usergroups/index.html.erb:3
@@ -13209,10 +13431,6 @@ msgstr ""
 msgid "Version %{version}"
 msgstr ""
 
-#: ../app/views/users/edit.html.erb:1
-msgid "Edit User"
-msgstr ""
-
 #: ../app/views/users/extlogout.html.erb:13
 msgid "Click to log in again."
 msgstr ""
@@ -13222,32 +13440,32 @@ msgid "Create User"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:8 model_attributes.rb:642
+#: ../app/views/users/index.html.erb:8 model_attributes.rb:668
 msgid "User|Login"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:9 model_attributes.rb:634
+#: ../app/views/users/index.html.erb:9 model_attributes.rb:660
 msgid "User|Firstname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:10 model_attributes.rb:638
+#: ../app/views/users/index.html.erb:10 model_attributes.rb:664
 msgid "User|Lastname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:11 model_attributes.rb:646
+#: ../app/views/users/index.html.erb:11 model_attributes.rb:672
 msgid "User|Mail"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:12 model_attributes.rb:628
+#: ../app/views/users/index.html.erb:12 model_attributes.rb:654
 msgid "User|Admin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:13 model_attributes.rb:636
+#: ../app/views/users/index.html.erb:13 model_attributes.rb:662
 msgid "User|Last login on"
 msgstr ""
 
@@ -13260,7 +13478,7 @@ msgid "Success!"
 msgstr ""
 
 #: ../app/views/users/login.html.erb:30
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:32
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:27
 msgid "Password"
 msgstr ""
 
@@ -13273,7 +13491,12 @@ msgid "Are you sure you want to log out?"
 msgstr ""
 
 #: ../app/views/variable_lookup_keys/edit.html.erb:1
+#: ../app/views/variable_lookup_keys/edit.html.erb:10
 msgid "Edit Smart Variable"
+msgstr ""
+
+#: ../app/views/variable_lookup_keys/edit.html.erb:6
+msgid "Smart variables"
 msgstr ""
 
 #: ../app/views/variable_lookup_keys/index.html.erb:2
@@ -13312,44 +13535,46 @@ msgstr ""
 msgid "locale_name"
 msgstr ""
 
-#: ../lib/foreman/http_proxy.rb:20
-msgid "Proxied request failed with: %s"
+#: ../lib/foreman/http_proxy.rb:24
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:85
+#: ../lib/foreman/renderer.rb:84
 msgid ""
 "Parameter %{name} is not set in host %{host} ENC output, resolving failed on s"
 "tep %{step}"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:146
+#: ../lib/foreman/renderer.rb:145
 msgid ""
 "Syntax error occurred while parsing the template %{template_name}, make sure y"
 "ou have all ERB tags properly closed and the Ruby syntax is valid. The Ruby er"
 "ror: %{message}"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:197
+#: ../lib/foreman/renderer.rb:196
 msgid "The snippet '%{name}' threw an error: %{exc}"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:243
+#: ../lib/foreman/renderer.rb:242
 msgid "Template '%s' is either missing or has an invalid organization or location"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:280
+#: ../lib/foreman/renderer.rb:287
 msgid "Global setting \"%s\" is not accessible in safe-mode"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:288
+#: ../lib/foreman/renderer.rb:295
 msgid "This templates requires a host to render but none was specified"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:293
+#: ../lib/foreman/renderer.rb:300
 msgid "Parameter %{name} is not set for host %{host}"
 msgstr ""
 
-#: ../lib/foreman/renderer.rb:375
+#: ../lib/foreman/renderer.rb:386
 msgid "'%{object_name}' is a '%{object_class}', expected a subnet."
 msgstr ""
 
@@ -13553,28 +13778,82 @@ msgstr ""
 msgid "You are about to override the editor content, are you sure?"
 msgstr ""
 
-#: ../webpack/assets/javascripts/foreman_editor.js:268
+#: ../webpack/assets/javascripts/foreman_editor.js:272
 msgid "Rendering the template, please wait..."
 msgstr ""
 
-#: ../webpack/assets/javascripts/foreman_editor.js:276
+#: ../webpack/assets/javascripts/foreman_editor.js:280
 msgid ""
 "There was an error during rendering, return to the Code tab to edit the templa"
 "te."
 msgstr ""
 
-#: ../webpack/assets/javascripts/foreman_editor.js:289
+#: ../webpack/assets/javascripts/foreman_editor.js:293
 msgid ""
 "You are about to override the editor content with a previous version, are you "
 "sure?"
 msgstr ""
 
-#: ../webpack/assets/javascripts/foreman_editor.js:312
+#: ../webpack/assets/javascripts/foreman_editor.js:316
 msgid "Revert to revision from: %s"
 msgstr ""
 
 #: ../webpack/assets/javascripts/foreman_hostgroups.js:7
 msgid "Some Puppet Classes are unavailable in the selected environment"
+msgstr ""
+
+#: ../webpack/assets/javascripts/foreman_tools.js:26
+#: ../webpack/assets/javascripts/foreman_tools.js:38
+msgid "Filter..."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js:36
+msgid "Error: Unable to load resources."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:2
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:3
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:5
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:34
+msgid "Weak"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:4
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:33
+msgid "Too short"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:7
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:34
+msgid "Normal"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:8
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:34
+msgid "Strong"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:9
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:34
+msgid "Very strong"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:40
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/integration.test.js:52
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/integration.test.js:56
+msgid "Verify"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:42
+msgid "Passwords do not match"
 msgstr ""
 
 #:
@@ -13600,10 +13879,38 @@ msgid "Failed to load bookmarks: %s"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/common/SearchInput/index.js:29
+msgid "filter..."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/common/charts/DonutChart/index.js:10
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:52
 #: ../webpack/assets/javascripts/react_app/components/statistics/StatisticsChartsList.js:33
 msgid "No data available"
 msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:51
+msgid "Request Failed"
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:66
+msgid "Show distribution chart"
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:73
+msgid "View Chart"
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:81
+msgid "Fact distribution chart - %s "
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/factCharts/index.js:86
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 #:
 #: ../webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js:27
@@ -13651,68 +13958,32 @@ msgid "Delete Controller"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js:73
+#: ../webpack/assets/javascripts/react_app/components/hosts/storage/vmware/index.js:78
 msgid "Add Controller"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/index.js:28
-msgid "No Notifications"
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:51
+msgid "Unread Event"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/notification.js:24
-msgid "Click to mark as read"
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:52
+msgid "Unread Events"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/notificationGroup.js:27
-msgid "New Events"
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:53
+msgid "No Notifications Available"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/notificationGroup.js:28
-msgid "New Event"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/notifications/drawer/notificationGroup.js:48
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:54
 msgid "Mark All Read"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:42
-msgid "Too short"
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:55
+msgid "Clear All"
 msgstr ""
 
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:44
-msgid "Weak"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:46
-msgid "Normal"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:47
-msgid "Strong"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:48
-msgid "Very strong"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:59
-msgid "Verify"
-msgstr ""
-
-#:
-#: ../webpack/assets/javascripts/react_app/components/user/passwordStrength/index.js:61
-msgid "Password do not match"
+#: ../webpack/assets/javascripts/react_app/components/notifications/index.js:56
+msgid "Hide this notification"
 msgstr ""
 
 #: ../webpack/assets/javascripts/react_app/redux/actions/common/forms.js:22
@@ -13995,1211 +14266,1271 @@ msgid "ComputeResource|Domain"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:104
-msgid "ComputeResource|Password"
+#: model_attributes.rb:102
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:106
-msgid "ComputeResource|Url"
+msgid "ComputeResource|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:108
-msgid "ComputeResource|User"
+msgid "ComputeResource|Url"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:110
-msgid "ComputeResource|Uuid"
+msgid "ComputeResource|User"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:112
-msgid "Config group"
+msgid "ComputeResource|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:114
+msgid "Config group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:116
 msgid "ConfigGroup|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:120
+#: model_attributes.rb:122
 msgid "Domain|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:126
+#: model_attributes.rb:128
 msgid "External usergroup"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:128
+#: model_attributes.rb:130
 msgid "ExternalUsergroup|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:130
+#: model_attributes.rb:132
 msgid "Fact name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:132
+#: model_attributes.rb:134
 msgid "FactName|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:134
+#: model_attributes.rb:136
 msgid "FactName|Compose"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:136
+#: model_attributes.rb:138
 msgid "FactName|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:138
+#: model_attributes.rb:140
 msgid "FactName|Short name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:140
+#: model_attributes.rb:142
 msgid "Fact value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:144
+#: model_attributes.rb:146
 msgid "Feature"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:146
+#: model_attributes.rb:148
 msgid "Feature|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:154
+#: model_attributes.rb:156
 msgid "Filter|Taxonomy search"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:156
+#: model_attributes.rb:158
 msgid "Host::Base|Build"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:158
-msgid "Host::Base|Certname"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:160
-msgid "Host::Base|Comment"
+msgid "Host::Base|Build errors"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:162
-msgid "Host::Base|Disk"
+msgid "Host::Base|Certname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:164
-msgid "Host::Base|Enabled"
+msgid "Host::Base|Comment"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:166
-msgid "Host::Base|Global status"
+msgid "Host::Base|Disk"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:168
-msgid "Host::Base|Grub pass"
+msgid "Host::Base|Enabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:170
-msgid "Host::Base|Image file"
+msgid "Host::Base|Global status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:172
-msgid "Host::Base|Installed at"
+msgid "Host::Base|Grub pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:174
-msgid "Host::Base|Last compile"
+msgid "Host::Base|Image file"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:176
-msgid "Host::Base|Last report"
+msgid "Host::Base|Initiated at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:178
-msgid "Host::Base|Lookup value matcher"
+msgid "Host::Base|Installed at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:180
-msgid "Host::Base|Managed"
+msgid "Host::Base|Last compile"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:182
-msgid "Host::Base|Name"
+msgid "Host::Base|Last report"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:184
-msgid "Host::Base|Otp"
+msgid "Host::Base|Lookup value matcher"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:186
-msgid "Host::Base|Owner type"
+msgid "Host::Base|Managed"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:188
-msgid "Host::Base|Provision method"
+msgid "Host::Base|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:190
-msgid "Host::Base|Pxe loader"
+msgid "Host::Base|Otp"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:192
-msgid "Host::Base|Root pass"
+msgid "Host::Base|Owner type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:194
-msgid "Host::Base|Use image"
+msgid "Host::Base|Provision method"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:196
-msgid "Host::Base|Uuid"
+msgid "Host::Base|Pxe loader"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:198
-msgid "Host config group"
+msgid "Host::Base|Root pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:200
-msgid "HostConfigGroup|Host type"
+msgid "Host::Base|Use image"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:202
-msgid "Host status/status"
+msgid "Host::Base|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:204
-msgid "HostStatus::Status|Reported at"
+msgid "Host config group"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:206
-msgid "HostStatus::Status|Status"
+msgid "HostConfigGroup|Host type"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:208
+msgid "Host status/status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:210
-msgid "Hostgroup|Ancestry"
+msgid "HostStatus::Status|Reported at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:212
-msgid "Hostgroup|Description"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:214
-msgid "Hostgroup|Grub pass"
+msgid "HostStatus::Status|Status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:216
-msgid "Hostgroup|Image file"
+msgid "Hostgroup|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:218
-msgid "Hostgroup|Lookup value matcher"
+msgid "Hostgroup|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:220
+msgid "Hostgroup|Grub pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:222
-msgid "Hostgroup|Pxe loader"
+msgid "Hostgroup|Image file"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:224
-msgid "Hostgroup|Root pass"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:226
-msgid "Hostgroup|Title"
+msgid "Hostgroup|Lookup value matcher"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:228
-msgid "Hostgroup|Use image"
+msgid "Hostgroup|Pxe loader"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:230
-msgid "Hostgroup|Vm defaults"
+msgid "Hostgroup|Root pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:232
-msgid "Http proxy"
+msgid "Hostgroup|Title"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:234
-msgid "HttpProxy|Name"
+msgid "Hostgroup|Use image"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:236
-msgid "HttpProxy|Password"
+msgid "Hostgroup|Vm defaults"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:238
-msgid "HttpProxy|Url"
+msgid "Http proxy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:240
-msgid "HttpProxy|Username"
+msgid "HttpProxy|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:242
+msgid "HttpProxy|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:244
+msgid "HttpProxy|Url"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:246
+msgid "HttpProxy|Username"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:250
 msgid "Image|Iam role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:248
+#: model_attributes.rb:254
 msgid "Image|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:256
+#: model_attributes.rb:262
 msgid "Key pair"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:258
+#: model_attributes.rb:264
 msgid "KeyPair|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:260
+#: model_attributes.rb:266
 msgid "KeyPair|Public"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:262
+#: model_attributes.rb:268
 msgid "KeyPair|Secret"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:264
+#: model_attributes.rb:270
 msgid "Lookup key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:266
+#: model_attributes.rb:272
 msgid "LookupKey|Avoid duplicates"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:270
+#: model_attributes.rb:276
 msgid "LookupKey|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:272
+#: model_attributes.rb:278
 msgid "LookupKey|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:274
+#: model_attributes.rb:280
 msgid "LookupKey|Key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:276
+#: model_attributes.rb:282
 msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:278
+#: model_attributes.rb:284
 msgid "LookupKey|Merge default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:280
+#: model_attributes.rb:286
 msgid "LookupKey|Merge overrides"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:282
+#: model_attributes.rb:288
 msgid "LookupKey|Omit"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:284
+#: model_attributes.rb:290
 msgid "LookupKey|Override"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:286
+#: model_attributes.rb:292
 msgid "LookupKey|Path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:288
+#: model_attributes.rb:294
 msgid "LookupKey|Required"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:290
+#: model_attributes.rb:296
 msgid "LookupKey|Validator rule"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:292
+#: model_attributes.rb:298
 msgid "LookupKey|Validator type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:294
+#: model_attributes.rb:300
 msgid "Lookup value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:296
+#: model_attributes.rb:302
 msgid "LookupValue|Match"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:298
+#: model_attributes.rb:304
 msgid "LookupValue|Omit"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:300
+#: model_attributes.rb:306
 msgid "LookupValue|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:302
+#: model_attributes.rb:308
 msgid "Mail notification"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:304
+#: model_attributes.rb:310
 msgid "MailNotification|Default interval"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:306
+#: model_attributes.rb:312
 msgid "MailNotification|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:308
+#: model_attributes.rb:314
 msgid "MailNotification|Mailer"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:310
+#: model_attributes.rb:316
 msgid "MailNotification|Method"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:312
+#: model_attributes.rb:318
 msgid "MailNotification|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:314
+#: model_attributes.rb:320
 msgid "MailNotification|Queryable"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:316
+#: model_attributes.rb:322
 msgid "MailNotification|Subscriptable"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:318
+#: model_attributes.rb:324
 msgid "MailNotification|Subscription type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:322
+#: model_attributes.rb:328
 msgid "Medium|Config path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:324
+#: model_attributes.rb:330
 msgid "Medium|Image path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:326
+#: model_attributes.rb:332
 msgid "Medium|Media path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:330
+#: model_attributes.rb:336
 msgid "Medium|Os family"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:336
+#: model_attributes.rb:342
 msgid "Message|Digest"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:338
+#: model_attributes.rb:344
 msgid "Message|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:342
+#: model_attributes.rb:348
 msgid "Model|Hardware model"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:344
+#: model_attributes.rb:350
 msgid "Model|Info"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:348
+#: model_attributes.rb:354
 msgid "Model|Vendor class"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:350
+#: model_attributes.rb:356
 msgid "Nic::Base|Attached devices"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:352
+#: model_attributes.rb:358
 msgid "Nic::Base|Attached to"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:354
+#: model_attributes.rb:360
 msgid "Nic::Base|Attrs"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:356
+#: model_attributes.rb:362
 msgid "Nic::Base|Bond options"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:358
+#: model_attributes.rb:364
 msgid "Nic::Base|Compute attributes"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:360
-msgid "Nic::Base|Identifier"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:362
-msgid "Nic::Base|Ip"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:364
-msgid "Nic::Base|Ip6"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:366
-msgid "Nic::Base|Link"
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:368
-msgid "Nic::Base|Mac"
+msgid "Nic::Base|Identifier"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:370
-msgid "Nic::Base|Managed"
+msgid "Nic::Base|Ip"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:372
-msgid "Nic::Base|Mode"
+msgid "Nic::Base|Ip6"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:374
-msgid "Nic::Base|Name"
+msgid "Nic::Base|Link"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:376
-msgid "Nic::Base|Password"
+msgid "Nic::Base|Mac"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:378
-msgid "Nic::Base|Primary"
+msgid "Nic::Base|Managed"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:380
-msgid "Nic::Base|Provider"
+msgid "Nic::Base|Mode"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:382
-msgid "Nic::Base|Provision"
+msgid "Nic::Base|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:384
-msgid "Nic::Base|Tag"
+msgid "Nic::Base|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:386
-msgid "Nic::Base|Username"
+msgid "Nic::Base|Primary"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:388
-msgid "Nic::Base|Virtual"
+msgid "Nic::Base|Provider"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:390
-msgid "Notification"
+msgid "Nic::Base|Provision"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:392
-msgid "Notification|Actions"
+msgid "Nic::Base|Tag"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:394
-msgid "Notification|Audience"
+msgid "Nic::Base|Username"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:396
-msgid "Notification|Expired at"
+msgid "Nic::Base|Virtual"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:398
-msgid "Notification|Message"
+msgid "Notification"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:400
-msgid "Notification|Subject type"
+msgid "Notification|Actions"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:402
-msgid "Notification blueprint"
+msgid "Notification|Audience"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:404
-msgid "NotificationBlueprint|Actions"
+msgid "Notification|Expired at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:406
-msgid "NotificationBlueprint|Expires in"
+msgid "Notification|Message"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:408
-msgid "NotificationBlueprint|Group"
+msgid "Notification|Subject type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:410
-msgid "NotificationBlueprint|Level"
+msgid "Notification blueprint"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:412
-msgid "NotificationBlueprint|Message"
+msgid "NotificationBlueprint|Actions"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:414
-msgid "NotificationBlueprint|Name"
+msgid "NotificationBlueprint|Expires in"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:416
-msgid "Notification recipient"
+msgid "NotificationBlueprint|Group"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:418
-msgid "NotificationRecipient|Seen"
+msgid "NotificationBlueprint|Level"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:420
-msgid "Operatingsystem"
+msgid "NotificationBlueprint|Message"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:422
-msgid "Operatingsystem|Description"
+msgid "NotificationBlueprint|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:424
-msgid "Operatingsystem|Major"
+msgid "Notification recipient"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:426
-msgid "Operatingsystem|Minor"
+msgid "NotificationRecipient|Seen"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:428
-msgid "Operatingsystem|Name"
+msgid "Operatingsystem"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:430
-msgid "Operatingsystem|Nameindicator"
+msgid "Operatingsystem|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:432
-msgid "Operatingsystem|Password hash"
+msgid "Operatingsystem|Major"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:434
-msgid "Operatingsystem|Release name"
+msgid "Operatingsystem|Minor"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:436
+msgid "Operatingsystem|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:438
+msgid "Operatingsystem|Nameindicator"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:440
+msgid "Operatingsystem|Password hash"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:442
+msgid "Operatingsystem|Release name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:448
 msgid "Parameter|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:444
+#: model_attributes.rb:452
 msgid "Parameter|Priority"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:450
+#: model_attributes.rb:458
 msgid "Permission|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:452
+#: model_attributes.rb:460
 msgid "Permission|Resource type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:454
+#: model_attributes.rb:462
 msgid "Personal access token"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:456
+#: model_attributes.rb:464
 msgid "PersonalAccessToken|Expires at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:458
+#: model_attributes.rb:466
 msgid "PersonalAccessToken|Last used at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:460
+#: model_attributes.rb:468
 msgid "PersonalAccessToken|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:462
+#: model_attributes.rb:470
 msgid "PersonalAccessToken|Revoked"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:464
+#: model_attributes.rb:472
 msgid "PersonalAccessToken|Token"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:466
+#: model_attributes.rb:474
 msgid "Puppetclass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:474
+#: model_attributes.rb:482
 msgid "Realm|Realm type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:476
+#: model_attributes.rb:484
 msgid "Report"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:478
+#: model_attributes.rb:486
 msgid "Report|Metrics"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:480
+#: model_attributes.rb:488
 msgid "Report|Origin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:482
+#: model_attributes.rb:490
 msgid "Report|Reported at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:484
+#: model_attributes.rb:492
 msgid "Report|Status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:488
+#: model_attributes.rb:496
 msgid "Role|Builtin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:494
+#: model_attributes.rb:502
 msgid "Role|Origin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:496
+#: model_attributes.rb:504
 msgid "Setting"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:498
+#: model_attributes.rb:506
 msgid "Setting|Category"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:500
+#: model_attributes.rb:508
 msgid "Setting|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:504
+#: model_attributes.rb:512
 msgid "Setting|Encrypted"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:506
+#: model_attributes.rb:514
 msgid "Setting|Full name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:510
+#: model_attributes.rb:518
 msgid "Setting|Settings type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:514
+#: model_attributes.rb:522
 msgid "Smart proxy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:516
+#: model_attributes.rb:524
 msgid "SmartProxy|Expired logs"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:522
-msgid "Source"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:524
-msgid "Source|Digest"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:526
-msgid "Source|Value"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:528
-msgid "Ssh key"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:530
-msgid "SshKey|Fingerprint"
+msgid "SmartProxy|Pubkey"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:532
-msgid "SshKey|Key"
+msgid "Source"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:534
-msgid "SshKey|Length"
+msgid "Source|Digest"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:536
-msgid "SshKey|Name"
+msgid "Source|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:538
+msgid "Ssh key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:540
-msgid "Subnet|Boot mode"
+msgid "SshKey|Fingerprint"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:542
-msgid "Subnet|Description"
+msgid "SshKey|Key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:544
-msgid "Subnet|Dns primary"
+msgid "SshKey|Length"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:546
-msgid "Subnet|Dns secondary"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:548
-msgid "Subnet|From"
+msgid "SshKey|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:550
-msgid "Subnet|Gateway"
+msgid "Subnet|Boot mode"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:552
-msgid "Subnet|Ipam"
+msgid "Subnet|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:554
-msgid "Subnet|Mask"
+msgid "Subnet|Dns primary"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:556
+msgid "Subnet|Dns secondary"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:558
+msgid "Subnet|From"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:560
-msgid "Subnet|Priority"
+msgid "Subnet|Gateway"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:562
-msgid "Subnet|To"
+msgid "Subnet|Ipam"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:564
+msgid "Subnet|Mask"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:566
-msgid "Taxable taxonomy"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:568
-msgid "TaxableTaxonomy|Taxable type"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:570
-msgid "Taxonomy"
+msgid "Subnet|Mtu"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:572
-msgid "Taxonomy|Ancestry"
+msgid "Subnet|Priority"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:574
-msgid "Taxonomy|Description"
+msgid "Subnet|To"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:576
-msgid "Taxonomy|Ignore types"
+#: model_attributes.rb:578
+msgid "Table preference"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:580
-msgid "Taxonomy|Title"
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:582
+msgid "TablePreference|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:584
-msgid "Template|Default"
+msgid "Taxable taxonomy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:586
-msgid "Template|Locked"
+msgid "TaxableTaxonomy|Taxable type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:588
-msgid "Template|Name"
+msgid "Taxonomy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:590
-msgid "Template|Os family"
+msgid "Taxonomy|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:592
-msgid "Template|Snippet"
+msgid "Taxonomy|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:594
-msgid "Template|Template"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:596
-msgid "Template|Vendor"
+msgid "Taxonomy|Ignore types"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:598
-msgid "Template kind"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:600
-msgid "TemplateKind|Name"
+msgid "Taxonomy|Title"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:602
-msgid "Token"
+msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:604
-msgid "Token|Expires"
+msgid "Template|Description format"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:606
-msgid "Token|Value"
+msgid "Template|Execution timeout interval"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:608
-msgid "Trend"
+msgid "Template|Job category"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:610
-msgid "Trend|Fact name"
+msgid "Template|Locked"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:612
-msgid "Trend|Fact value"
+msgid "Template|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:614
-msgid "Trend|Name"
+msgid "Template|Os family"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:616
-msgid "Trend|Trendable type"
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:618
-msgid "Trend counter"
+msgid "Template|Snippet"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:620
-msgid "TrendCounter|Count"
+msgid "Template|Template"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:622
-msgid "TrendCounter|Interval end"
+msgid "Template|Vendor"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:624
-msgid "TrendCounter|Interval start"
+msgid "Template kind"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:626
+msgid "TemplateKind|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:630
-msgid "User|Avatar hash"
+msgid "Token|Expires"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:632
-msgid "User|Description"
+msgid "Token|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:634
+msgid "Trend"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:636
+msgid "Trend|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:638
+msgid "Trend|Fact value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:640
-msgid "User|Locale"
+msgid "Trend|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:642
+msgid "Trend|Trendable type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:644
-msgid "User|Lower login"
+msgid "Trend counter"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:646
+msgid "TrendCounter|Count"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:648
-msgid "User|Mail enabled"
+msgid "TrendCounter|Interval end"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:650
-msgid "User|Password hash"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:652
-msgid "User|Password salt"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:654
-msgid "User|Timezone"
+msgid "TrendCounter|Interval start"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:656
-msgid "User mail notification"
+msgid "User|Avatar hash"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:658
-msgid "UserMailNotification|Interval"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:660
-msgid "UserMailNotification|Last sent"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:662
-msgid "UserMailNotification|Mail query"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:664
-msgid "User role"
+msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:666
-msgid "UserRole|Owner type"
+msgid "User|Locale"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:670
-msgid "Usergroup|Admin"
+msgid "User|Lower login"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:674
-msgid "Usergroup member"
+msgid "User|Mail enabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:676
-msgid "UsergroupMember|Member type"
+msgid "User|Password hash"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:678
-msgid "Widget"
+msgid "User|Password salt"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:680
-msgid "Widget|Col"
+msgid "User|Timezone"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:682
-msgid "Widget|Data"
+msgid "User mail notification"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:684
-msgid "Widget|Name"
+msgid "UserMailNotification|Interval"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:686
-msgid "Widget|Row"
+msgid "UserMailNotification|Last sent"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:688
-msgid "Widget|Sizex"
+msgid "UserMailNotification|Mail query"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:690
-msgid "Widget|Sizey"
+msgid "User role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:692
+msgid "UserRole|Owner type"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:696
+msgid "Usergroup|Admin"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:700
+msgid "Usergroup member"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:702
+msgid "UsergroupMember|Member type"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:704
+msgid "Widget"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:706
+msgid "Widget|Col"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:708
+msgid "Widget|Data"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:710
+msgid "Widget|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:712
+msgid "Widget|Row"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:714
+msgid "Widget|Sizex"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:716
+msgid "Widget|Sizey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:718
 msgid "Widget|Template"
 msgstr ""

--- a/locale/fr/foreman.po
+++ b/locale/fr/foreman.po
@@ -43,8 +43,11 @@ msgstr "Supprimer"
 msgid " in the provisioning template."
 msgstr "dans le modèle de provisioning."
 
-msgid "#{taxonomy} can be set on the All Hosts page"
-msgstr "#{taxonomy} peut être défini sur la page Tous les hôtes"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
+msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr "%s - Appuyez sur Shift-F12 pour libérer le curseur."
@@ -102,6 +105,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s a été dissocié de la VM"
 
@@ -128,6 +134,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s hôtes sélectionnés"
@@ -287,6 +296,11 @@ msgstr "'%{object_name}' est un '%{object_class}', un sous-réseau est attendu."
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' n'est pas pris en charge en v2 de l'API que ce soit pour les requêtes POST ou PUT. Merci d'utiliser 'Content-Type: application/json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Divers)"
@@ -471,9 +485,6 @@ msgstr "Ajouter un paramètre"
 msgid "Add SSH Key"
 msgstr "Ajouter une clé SSH"
 
-msgid "Add SSH Key for %s"
-msgstr "Ajouter une clé SSH pour %s"
-
 msgid "Add SSH key"
 msgstr "Ajouter une clé SSH"
 
@@ -549,6 +560,12 @@ msgstr "L'adresse de courrier électronique de l'administrateur"
 msgid "Administrator user account required"
 msgstr "Un compte administrateur est requis"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alerte"
 
@@ -563,9 +580,6 @@ msgstr "Tout"
 
 msgid "All Hosts"
 msgstr "Tous les hôtes"
-
-msgid "All Puppet Classes for %s"
-msgstr "Toutes les Classes Puppet pour %s"
 
 msgid "All Reports"
 msgstr "Tous les Rapports"
@@ -824,6 +838,12 @@ msgstr "Audit"
 
 msgid "Audit Comment"
 msgstr "Commentaire d'Audit"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Rapport d'audit"
@@ -1135,14 +1155,26 @@ msgstr "Fuseau horaire du navigateur"
 msgid "Build"
 msgstr "Build"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Construire les hôtes"
 
 msgid "Build PXE Default"
 msgstr "Créer le fichier PXE par défaut"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Construire depuis l'image du système d'exploitation"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr "Par défaut, nous mappons les groupes d'utilisateurs aux objets du groupe LDAP standard. Les types de serveur LDAP FreeIPA et POSIX prennent en charge une autre manière de regrouper les utilisateurs via les Netgroups. Cochez cette case si l'utilisation des Netgroups est préférée à l'utilisation des groupes standards."
@@ -1273,6 +1305,9 @@ msgstr "Environnements modifiés"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr "Les modifications apportées à %s seront propagées à tous les filtres hérités"
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1318,6 +1353,12 @@ msgstr "Classes"
 msgid "Clean up failed deployment"
 msgstr "Échec  du nettoyage du déploiement"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Cliquer sur le lien d'une ressource de calcul pour modifier les attributs par défaut des VM."
 
@@ -1326,9 +1367,6 @@ msgstr "Cliquez pour ajouter %s"
 
 msgid "Click to log in again."
 msgstr "Cliquer pour ouvrir à nouveau la session"
-
-msgid "Click to mark as read"
-msgstr "Cliquer pour marquer comme lu"
 
 msgid "Click to remove %s"
 msgstr "Cliquez pour supprimer %s"
@@ -1450,6 +1488,10 @@ msgstr "Description"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
 msgstr "Domaine"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
@@ -1698,6 +1740,9 @@ msgstr "Créer un proxy"
 msgid "Create Puppet Environment"
 msgstr "Créer un environnement Puppet"
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "Créer un domaine"
 
@@ -1821,6 +1866,9 @@ msgstr "Créer une smart variable"
 msgid "Create a subnet"
 msgstr "Créer un sous-réseau"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Créer un utilisateur"
 
@@ -1860,6 +1908,9 @@ msgstr "Créer une valeur de substitution pour une variable d'une smart class sp
 msgid "Create autosign entry"
 msgstr "Créer une entrée de signature automatique"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Créer un nouveau volume de boot depuis une image"
 
@@ -1874,6 +1925,9 @@ msgstr "Créer l'entrée du doamine pour %s"
 
 msgid "Created"
 msgstr "Créé"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2049,9 +2103,6 @@ msgstr "Supprimer le contrôleur"
 msgid "Delete Hosts"
 msgstr "Supprimer ces hôtes"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr "Supprimer l'entrée signée automatiquement PuppetCA pour %s"
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Supprimer les certificats PuppetCA pour %s"
 
@@ -2145,8 +2196,14 @@ msgstr "Supprimer une smart variable"
 msgid "Delete a subnet"
 msgstr "Supprimer un sous-réseau"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Supprimer une combinaison de modèle"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Supprimer un utilisateur"
@@ -2286,11 +2343,17 @@ msgstr "Vue différencielle"
 msgid "Disable Notifications"
 msgstr "Désactiver les notifications"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Désactiver les alertes pour les hôtes sélectionnés"
 
 msgid "Disable all filters overriding"
 msgstr "Désactiver tous les filtres surchargés"
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
+msgstr ""
 
 msgid "Disable overriding"
 msgstr "Supprimer Remplacement"
@@ -2420,47 +2483,11 @@ msgstr "Modifier"
 msgid "Edit %s"
 msgstr "Modifier %s"
 
-msgid "Edit Architecture"
-msgstr "Modifier les Architectures"
-
-msgid "Edit Bookmark"
-msgstr "Modifier les Marque-pages"
-
 msgid "Edit Compute profile"
 msgstr "Modifier le profil de calcul"
 
-msgid "Edit Compute profile: %s"
-msgstr "Modifier le profil de calcul : %s"
-
-msgid "Edit Config group"
-msgstr "Modifier les Groupes de configuration"
-
-msgid "Edit Domain"
-msgstr "Modifier le Domaine"
-
-msgid "Edit Environment"
-msgstr "Modifier l'Environnement"
-
-msgid "Edit Filter"
-msgstr "Modifier le filtre"
-
-msgid "Edit Global Parameter"
-msgstr "Modifier les Paramètres Globaux"
-
-msgid "Edit HTTP Proxy"
-msgstr "Modifier le proxy HTTP"
-
 msgid "Edit Host"
 msgstr "Modifier l'hôte"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Modifier la source authentification LDAP"
-
-msgid "Edit Medium"
-msgstr "Modifier le Medium"
-
-msgid "Edit Model"
-msgstr "Modifier le Modèle"
 
 msgid "Edit Operating System"
 msgstr "Modifier le Système d'Exploitation"
@@ -2468,23 +2495,11 @@ msgstr "Modifier le Système d'Exploitation"
 msgid "Edit Parameters"
 msgstr "Modifier les paramètres"
 
-msgid "Edit Partition Table"
-msgstr "Modifier la table de partition"
-
 msgid "Edit Properties"
 msgstr "Modifier les Propriétés"
 
-msgid "Edit Proxy"
-msgstr "Modifier le Proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Modifier la classe Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Modifier le domaine"
-
-msgid "Edit Role"
-msgstr "Modifier le Rôle"
 
 msgid "Edit Smart Variable"
 msgstr "Modifier la Smart Variable"
@@ -2492,23 +2507,8 @@ msgstr "Modifier la Smart Variable"
 msgid "Edit Smart class parameters"
 msgstr "Modifier les paramètres smart class"
 
-msgid "Edit Subnet"
-msgstr "Modifier le Sous-réseau"
-
-msgid "Edit Template"
-msgstr "Éditer le modèle"
-
 msgid "Edit Trend %s"
 msgstr "Modifier la Tendance %s"
-
-msgid "Edit User"
-msgstr "Modifier l'Utilisateur"
-
-msgid "Edit User group"
-msgstr "Modifier les Groupes Utilisateur"
-
-msgid "Edit compute profile on %s"
-msgstr "Modifier le profil de calcul de %s"
 
 msgid "Edit this host"
 msgstr "Editer cet hôte"
@@ -2539,6 +2539,9 @@ msgstr "Activer la mise en cache"
 
 msgid "Enable Notifications"
 msgstr "Activer les notifications"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Activer les alertes pour les hôtes sélectionnés"
@@ -2662,6 +2665,15 @@ msgstr "Erreur lors de l'envoi des données :"
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr "Erreur lors de la connexion au serveur LDAP '%{name}' sur '%{url}' lors de l'authentification"
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr "Erreurs"
 
@@ -2784,11 +2796,11 @@ msgstr "Nom du fact"
 msgid "Fact Values"
 msgstr "Valeurs des Facts"
 
-msgid "Fact Values | %{host_name}"
-msgstr "%{host_name}"
-
 msgid "Fact distribution chart"
 msgstr "Diagramme de répartition des facts"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2848,6 +2860,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Redémarrages échoués"
 
@@ -2859,9 +2874,6 @@ msgstr "N'a pas pu obtenir les adresses IP de la ressource de calcul pour %s"
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr "Echec de l'annulation en cours de construction pour %{hostname} avec les erreurs suivantes : %{errors}"
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Échec de nettoyage des anciens certificats ou d'ajout d'entrée au fichier de signature automatique. Construction annulée."
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Erreur de configuration de %{host} pour démarrer depuis %{device}: %{e}"
@@ -3042,11 +3054,11 @@ msgstr "Filtrer les classes"
 msgid "Filter overriding has been disabled"
 msgstr "Remplacement des valeurs de filtre désactivé"
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtres"
-
-msgid "Filters for role %s"
-msgstr "Filtres pour le rôle %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr "Les filtres héritent des %{orgs_and_locs} associés à leur rôle par défaut. Si le champ de remplacement est activé, <br> le filtre peut remplacer l'ensemble de ses %{orgs_and_locs}. Les prochains changements de rôle n'affecteront pas<br> un tel filtre. Une fois que le champ de remplacement est désactivé, le rôle %{orgs_and_locs} s'appliquera à nouveau."
@@ -3159,6 +3171,9 @@ msgstr "Foreman peut utiliser des services basés sur LDAP pour l'authentificati
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman considère un domaine et une zone DNS comme étant la même chose."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "Domaine ID Foreman de l'interface. Requis pour les interfaces primaires des hôtes gérés."
 
@@ -3201,6 +3216,9 @@ msgstr "Foreman ajoutera des noms de domaine lorsque de nouveaux hôtes sont mis
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman signera automatiquement les certificats au provisioning de l'hôte"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman créera l'hôte à la réception d'un rapport"
 
@@ -3239,9 +3257,6 @@ msgstr "Foreman interrogera le resolver local au lieu des champs SOA/NS autorita
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "L'environnement Puppet par défaut si l'autodétection de Foreman échoue"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman va tronquer le nom d'hôte à 'puppet' si ce dernier commence par puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman mettra à jour l'environnement de l'hôte d'après les facts"
@@ -3366,6 +3381,9 @@ msgstr "Variables globales"
 msgid "Good host reports in the last %s"
 msgstr "Bons rapports dans les derniers %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "ID Projet Google"
 
@@ -3392,6 +3410,9 @@ msgstr "Proxy HTTP(S)"
 
 msgid "HTTP(S) proxy except hosts"
 msgstr "Proxy HTTP(S) à l'exception des hôtes"
+
+msgid "HTTPS URL is required for API access"
+msgstr ""
 
 msgid "Hard disk"
 msgstr "Disque dur"
@@ -3425,6 +3446,9 @@ msgstr "Valeur cachée"
 
 msgid "Hide all values for this parameter."
 msgstr "Cacher toutes les valeurs de ce paramètre."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Cacher cette valeur"
@@ -3535,6 +3559,10 @@ msgid "Host::Base|Build"
 msgstr "Mode Installation"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Nom du Certificat"
 
@@ -3561,6 +3589,10 @@ msgstr "Mot de passe Grub"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Fichier image"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3697,6 +3729,12 @@ msgstr "Les hôtes créés par un puppet run vont être placés dans l'endroit d
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Les hôtes créés par un puppet run vont être placés dans l'organisation décrite par ce fact. Le contenu du fact doit être le label complet de l'organisation."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Hôtes en erreur"
@@ -4182,6 +4220,9 @@ msgstr "Entrée"
 msgid "Installation Media"
 msgstr "Média d'installation"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configuration du medium d'installation"
 
@@ -4366,9 +4407,6 @@ msgstr "Lancer la console"
 msgid "Learn more about this in the documentation."
 msgstr "Approfondissez ce sujet dans la documentation."
 
-msgid "Legacy Puppet hostname"
-msgstr "Nom d'hôte du serveur Puppet"
-
 msgid "Length"
 msgstr "Durée"
 
@@ -4431,6 +4469,15 @@ msgstr "Afficher tous les audits"
 
 msgid "List all audits for a given host"
 msgstr "Afficher tous les audits d'un hôte"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Afficher toutes les entrées signées automatiquement"
@@ -4597,6 +4644,9 @@ msgstr "Afficher tous les utilisateurs"
 msgid "List all users for LDAP authentication source"
 msgstr "Afficher tous les utilisateurs d'une source d'authentification LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Afficher tous les utilisateurs d'un emplacement"
 
@@ -4657,6 +4707,15 @@ msgstr "Liste des environnements par emplacement"
 msgid "List environments per organization"
 msgstr "Liste des environnements par organisation"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Liste des hôtes par environnement"
 
@@ -4668,6 +4727,9 @@ msgstr "Liste des hôtes par organisation"
 
 msgid "List installed plugins"
 msgstr "Afficher les greffons installés"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "Liste de proxies HTTP"
@@ -4743,6 +4805,15 @@ msgstr "Liste des sous-réseaux par emplacement"
 
 msgid "List of subnets per organization"
 msgstr "Liste des sous-réseaux par organisation"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Liste des systèmes d'exploitation qui ont ce modèle comme modèle par défaut"
@@ -4982,6 +5053,18 @@ msgstr "Adresse MAC pour réutiliser l'IP de cet hôte"
 msgid "MAC-based"
 msgstr "Basé MAC"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Type de machine"
 
@@ -5178,6 +5261,9 @@ msgstr "Permission manquante pour modifier le parent %s"
 msgid "Missing one of the required permissions: %s"
 msgstr "Il manque une des permissions requises : %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modèle"
@@ -5258,6 +5344,9 @@ msgstr "Nom du groupe d'hôtes"
 msgid "Name of the parameter"
 msgstr "Nom du paramêtre"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Nom de la variable"
 
@@ -5300,14 +5389,11 @@ msgstr "Type de réseau"
 msgid "New"
 msgstr "Nouveau"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nouvelle entrée de signature automatique"
-
-msgid "New Event"
-msgstr "Nouvel événement"
-
-msgid "New Events"
-msgstr "Nouveaux événements"
 
 msgid "New HTTP Proxy"
 msgstr "Nouveau proxy HTTP"
@@ -5329,9 +5415,6 @@ msgstr "Nouvelle Machine Virtuelle"
 
 msgid "New boot volume size (GB)"
 msgstr "Taille du nouveau volume de boot (GB)"
-
-msgid "New compute profile on %s"
-msgstr "Nouveau profil de calcul pour %s"
 
 msgid "New filter"
 msgstr "Nouveau filtre"
@@ -5358,6 +5441,10 @@ msgstr "Options de l'aggrégat"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
 msgstr "Attributs de calcul"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Identifier"
@@ -5431,11 +5518,14 @@ msgstr "Aucun NIC BMC disponible pour l'hôte %s"
 msgid "No Failed Features"
 msgstr "Aucune fonction n'a échoué"
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "Aucun sous-réseau IPv4 selectionné"
 
-msgid "No Notifications"
-msgstr "Aucune notification"
+msgid "No Notifications Available"
+msgstr ""
 
 msgid "No TFTP feature"
 msgstr "Aucune fonction TFTP"
@@ -6160,9 +6250,6 @@ msgstr "Les modèles de partition décrivent la disposition des partitions, avec
 msgid "Password"
 msgstr "Mot de passe"
 
-msgid "Password do not match"
-msgstr "Les mots de passe ne correspondent pas"
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Mot de passe pour oVirt, EC2, VMware, OpenStack. Clé secrète pour EC2."
 
@@ -6186,6 +6273,9 @@ msgstr "Mot de passe utilisé pour s'authentifier auprès du proxy HTTP"
 
 msgid "Password:"
 msgstr "Mot de passe"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Chemin"
@@ -6458,14 +6548,19 @@ msgstr "Nom"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "Snippet"
 
-msgid "Proxied request failed with: %s"
-msgstr "La demande par proxy a échoué avec : %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
+msgstr ""
 
 msgid "Proxies"
 msgstr "Proxies"
 
 msgid "Proxy ID to use within this realm"
 msgstr "ID Proxy à utiliser dans ce domaine"
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
 
 msgid "Proxy request timeout"
 msgstr "Timeout sur l'interrogation du proxy"
@@ -6769,6 +6864,9 @@ msgstr "Rapporté le"
 msgid "Report|Status"
 msgstr "Statut"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "SSL pour les smart proxies requis"
 
@@ -6777,6 +6875,9 @@ msgstr "Paramètre requis sans valeur.<br/><b>Merci d'effectuer une substitution
 
 msgid "Required when user want to change own password"
 msgstr "Nécessaire lorsque l'utilisateur souhaite modifier son propre mot de passe"
+
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
 
 msgid "Reset to default"
 msgstr "Réinitialiser"
@@ -7040,9 +7141,6 @@ msgstr "DNS secondaire pour ce sous-réseau"
 msgid "Secret Key"
 msgstr "Clé privée"
 
-msgid "Security group"
-msgstr "Groupe de sécurité"
-
 msgid "Security groups"
 msgstr "Groupes de sécurité"
 
@@ -7201,8 +7299,8 @@ msgstr "Définir un mot de passe généré aléatoirement pour la connexion à l
 msgid "Set a randomly generated password on the display connection"
 msgstr "Définir un mot de passe généré aléatoirement pour la connexion à l'affichage"
 
-msgid "Set hostnames to which requests are not to be proxied"
-msgstr "Définir les noms d'hôtes auxquels les requêtes ne doivent pas être transmises par proxy"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
+msgstr ""
 
 msgid "Set parameters to defaults"
 msgstr "Positionner les paramètres aux valeurs par défaut"
@@ -7390,6 +7488,9 @@ msgstr "Afficher une smart variable"
 msgid "Show a subnet"
 msgstr "Afficher un sous-réseau"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Afficher un utilisateur"
 
@@ -7423,6 +7524,9 @@ msgstr "Voir une notification par courrier électronique"
 msgid "Show an environment"
 msgstr "Afficher un environnement"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Afficher un groupe d'utilisateurs d'une source d'authentification LDAP"
 
@@ -7434,6 +7538,9 @@ msgstr "Afficher une image"
 
 msgid "Show an interface for host"
 msgstr "Afficher une interface d'un hôte"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Afficher un système d'exploitation"
@@ -7516,9 +7623,6 @@ msgstr "Smart Proxies"
 msgid "Smart Proxy"
 msgstr "Smart Proxy"
 
-msgid "Smart Proxy: %s"
-msgstr "Smart proxy : %s"
-
 msgid "Smart Variables"
 msgstr "Smart Variables"
 
@@ -7532,6 +7636,9 @@ msgstr "Smart proxy"
 msgid "Smart proxy IDs"
 msgstr "ID des Smart proxies"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr "Les variables smart forment un outil permettant de fournir des paramètres (données clé/valeur) à la portée de niveau supérieur (globale) de votre ENC Puppet, en fonction d'un ensemble de règles."
 
@@ -7544,11 +7651,18 @@ msgid "SmartProxy|Name"
 msgstr "Nom"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr "Certaines classes Puppet sont indisponibles dans l'environnement sélectionné"
@@ -7582,6 +7696,9 @@ msgstr "Désolé mais aucun modèle n'a été configuré."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Désolé, ces hôtes n'ont pas de paramètres leur étant attribués, vous devez d'abord ajouter ces paramètres."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7688,6 +7805,9 @@ msgstr "ID des sous-réseaux"
 msgid "Subnet description"
 msgstr "Description du sous-réseau"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nom du sous-réseau"
 
@@ -7731,6 +7851,10 @@ msgstr "IPAM"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Masque"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7852,6 +7976,21 @@ msgid "TFTP server"
 msgstr "Serveur TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Classification taxinomique"
 
@@ -7954,6 +8093,18 @@ msgid "Template|Default"
 msgstr "Valeur par défaut"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Verrouillé"
 
@@ -7964,6 +8115,10 @@ msgstr "Nom"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
 msgstr "Famille de systèmes d'exploitation"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Snippet"
@@ -8400,6 +8555,9 @@ msgstr "Commuter"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Durée du token"
 
@@ -8463,8 +8621,8 @@ msgstr "Tendances"
 msgid "Trends for %s"
 msgstr "Tendances pour %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
-msgstr "Les tendances dans Foreman vous permettent de suivre les changements dans votre infrastructure au fil du temps. Elles vous permettent de suivre à la fois les informations relatives à Foreman et les faits Puppet. Les pages de tendances présentent un graphique de la façon dont le nombre d'hôtes avec cette valeur a changé au fil du temps et répertorient les hôtes actuels."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
@@ -8562,6 +8720,9 @@ msgstr "Impossible de se connecter"
 
 msgid "Unable to connect to LDAP server"
 msgstr "Impossible de se connecter au serveur LDAP"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Impossible de créer le menu par défaut TFTP"
@@ -8773,6 +8934,12 @@ msgstr "Ne plus gérer l'hôte"
 msgid "Unnamed"
 msgstr "Sans nom"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "mode IPAM non supporté pour %s"
 
@@ -8902,6 +9069,9 @@ msgstr "Mise à jour d'une architecture"
 msgid "Update an environment"
 msgstr "Mise à jour d'un environnement"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Mise à jour d'une image"
 
@@ -8953,8 +9123,14 @@ msgstr "Mise à jour des hôtes : le groupe d'hôtes a changé"
 msgid "Updated hosts: changed owner"
 msgstr "Mise à jour des hôtes : le propriétaire a changé"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Télécharge les facts d'un hôte, créé l'hôte si besoin"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "Utilisez les netgroups NIS au lieu des groupes posix."
@@ -8964,6 +9140,9 @@ msgstr "Utilisation des UUID des certificats"
 
 msgid "Use short name for VMs"
 msgstr "Nom court pour les VM"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Utiliser ce compte pour l'authentification, <i>facultatif</i>"
@@ -8989,6 +9168,9 @@ msgstr "Groupes utilisateurs"
 
 msgid "User IDs"
 msgstr "ID des utilisateurs"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "Modèle de donnée utilisateur"
@@ -9140,6 +9322,9 @@ msgstr "VCenter/Serveur"
 
 msgid "VLAN ID for this subnet"
 msgstr "ID VLAN de ce sous-réseau"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "Tag VLAN. Cet attribut a précédence sur l'ID VLAN du sous-réseau. Seulement pour les interfaces virtuelles."
@@ -9365,8 +9550,8 @@ msgstr "Dépend si la valeur du paramètre de classe est géré par Foreman."
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Dépend si le paramètre smart class est géré par Foreman"
 
-msgid "Whether to get RSS notifications or not"
-msgstr "Indique si les notifications RSS doivent être envoyées ou non"
+msgid "Whether to pull RSS notifications or not"
+msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
 msgstr "Qui est un offset de <b>%s</b>"
@@ -9450,6 +9635,9 @@ msgstr "Vous n'êtes pas autorisé à définir un modèle par défaut."
 
 msgid "You are not authorized to perform this action."
 msgstr "Vous n'êtes pas autorisé à effectuer cette action."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Vous essayez de supprimer votre propre compte"
@@ -9643,6 +9831,9 @@ msgstr "Impossible de supprimer depuis un compte interne protégé"
 msgid "cannot be removed from the last admin account"
 msgstr "Impossible de supprimer le dernier compte Admin"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "clone"
 
@@ -9760,6 +9951,9 @@ msgstr "filtre pour le rôle %s"
 msgid "filter results"
 msgstr "filtrer les résultats"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "Seulement pour EC2"
 
@@ -9774,6 +9968,9 @@ msgstr "seulement pour OpenStack"
 
 msgid "for VMware"
 msgstr "pour VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "pour oVirt, VMware Datacenter"
@@ -9925,8 +10122,8 @@ msgstr "n'est pas une clé ssh publique valide"
 msgid "is not allowed to change"
 msgstr "n'est pas autorisé à être changé"
 
-msgid "is not defined for host's %s."
-msgstr "non défini par %s de l'hôte."
+msgid "is not defined for host's %s"
+msgstr ""
 
 msgid "is not found in the authentication source"
 msgstr "n'est pas trouvé dans la source d'authenfication"
@@ -9968,8 +10165,7 @@ msgstr "joindre un group d'utilisateur externe avec ce groupe d'utilisateur"
 msgid "list"
 msgstr "liste"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Français"
 
@@ -9978,6 +10174,12 @@ msgstr "emplacement"
 
 msgid "locations"
 msgstr "emplacements"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "L'hôte géré doit posséder une interface de provisioning"
@@ -10041,6 +10243,9 @@ msgstr "saisie d'un fournisseur obligatoire"
 
 msgid "must set host and port"
 msgstr "hôte et port doivent être définis"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "nouveau"
@@ -10237,9 +10442,6 @@ msgstr "des interfaces sont invalides"
 msgid "some permissions were not found"
 msgstr "certaines autorisations n'ont pas été trouvées"
 
-msgid "sort results"
-msgstr "trier les résultats"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "Options séparées par des espaces. Ex : miimon=100"
 
@@ -10341,6 +10543,9 @@ msgstr "valide"
 msgid "valid or pending"
 msgstr "valide ou en attente"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr "afficher les détails du dernier rapport"
 
@@ -10349,6 +10554,9 @@ msgstr "Virtuel"
 
 msgid "virtual attached to %s"
 msgstr "virtuelle attachée à %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/gl/foreman.po
+++ b/locale/gl/foreman.po
@@ -25,7 +25,10 @@ msgstr "Eliminar"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -84,6 +87,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr ""
 
@@ -110,6 +116,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "Fai %s mes"
 msgstr[1] "Fai %s meses"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s equipos seleccionados"
@@ -269,6 +278,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr ""
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr ""
@@ -447,9 +461,6 @@ msgstr "Engadir Parámetro"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -525,6 +536,12 @@ msgstr ""
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alerta"
 
@@ -539,9 +556,6 @@ msgstr ""
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Tódalas Clases Puppet para %s"
 
 msgid "All Reports"
 msgstr "Tódolos Informes"
@@ -800,6 +814,12 @@ msgstr ""
 
 msgid "Audit Comment"
 msgstr "Comentario de auditoría"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr ""
@@ -1111,14 +1131,26 @@ msgstr ""
 msgid "Build"
 msgstr "Construir"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Construir Equipos"
 
 msgid "Build PXE Default"
 msgstr "Xenera 'PXE Predeterminado'"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Crear dende imaxe de SO"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1249,6 +1281,9 @@ msgstr ""
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chasis"
 
@@ -1294,6 +1329,12 @@ msgstr "Clases"
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr ""
 
@@ -1301,9 +1342,6 @@ msgid "Click to add %s"
 msgstr "Click para engadir %s"
 
 msgid "Click to log in again."
-msgstr ""
-
-msgid "Click to mark as read"
 msgstr ""
 
 msgid "Click to remove %s"
@@ -1425,6 +1463,10 @@ msgstr "Descripción"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1674,6 +1716,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1797,6 +1842,9 @@ msgstr ""
 msgid "Create a subnet"
 msgstr ""
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr ""
 
@@ -1836,6 +1884,9 @@ msgstr ""
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr ""
 
@@ -1849,6 +1900,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2025,9 +2079,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Borrar Equipos"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Borrar certificados PuppetCA para %s"
 
@@ -2121,7 +2172,13 @@ msgstr ""
 msgid "Delete a subnet"
 msgstr ""
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
+msgstr ""
+
+msgid "Delete a trend counter"
 msgstr ""
 
 msgid "Delete a user"
@@ -2262,10 +2319,16 @@ msgstr "Vista Diff"
 msgid "Disable Notifications"
 msgstr "Deshabilitar Notificacións"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Deshabilitar alertas para os equipos seleccionados"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2396,47 +2459,11 @@ msgstr "Editar"
 msgid "Edit %s"
 msgstr "Editar %s"
 
-msgid "Edit Architecture"
-msgstr "Editar Arquitectura"
-
-msgid "Edit Bookmark"
-msgstr "Editar Marcador"
-
 msgid "Edit Compute profile"
-msgstr ""
-
-msgid "Edit Compute profile: %s"
-msgstr ""
-
-msgid "Edit Config group"
-msgstr ""
-
-msgid "Edit Domain"
-msgstr "Editar Dominio"
-
-msgid "Edit Environment"
-msgstr "Editar Entorno"
-
-msgid "Edit Filter"
-msgstr ""
-
-msgid "Edit Global Parameter"
-msgstr "Editar Parámetro Global"
-
-msgid "Edit HTTP Proxy"
 msgstr ""
 
 msgid "Edit Host"
 msgstr ""
-
-msgid "Edit LDAP Auth Source"
-msgstr "Editar Fonte de Autorización LDAP"
-
-msgid "Edit Medium"
-msgstr "Editar Medio"
-
-msgid "Edit Model"
-msgstr "Editar Modelo"
 
 msgid "Edit Operating System"
 msgstr "Editar Sistema Operativo"
@@ -2444,23 +2471,11 @@ msgstr "Editar Sistema Operativo"
 msgid "Edit Parameters"
 msgstr "Editar Parámetros"
 
-msgid "Edit Partition Table"
-msgstr "Editar tabla de particións"
-
 msgid "Edit Properties"
 msgstr "Editar Propiedades"
 
-msgid "Edit Proxy"
-msgstr "Editar Proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Editar Clase Puppet %s"
-
-msgid "Edit Realm"
-msgstr ""
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "Editar Variable Intelixente"
@@ -2468,23 +2483,8 @@ msgstr "Editar Variable Intelixente"
 msgid "Edit Smart class parameters"
 msgstr ""
 
-msgid "Edit Subnet"
-msgstr "Editar Subrede"
-
-msgid "Edit Template"
-msgstr "Editar Plantilla"
-
 msgid "Edit Trend %s"
 msgstr "Editar Tendencia %s"
-
-msgid "Edit User"
-msgstr "Editar Usuario"
-
-msgid "Edit User group"
-msgstr "Editar Grupo de Usuarios"
-
-msgid "Edit compute profile on %s"
-msgstr ""
 
 msgid "Edit this host"
 msgstr ""
@@ -2515,6 +2515,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Habilitar Notificacións"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Habilitar alertas para os equipos seleccionados"
@@ -2636,6 +2639,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2760,10 +2772,10 @@ msgstr "Nome de Dato"
 msgid "Fact Values"
 msgstr "Valores de Datos"
 
-msgid "Fact Values | %{host_name}"
+msgid "Fact distribution chart"
 msgstr ""
 
-msgid "Fact distribution chart"
+msgid "Fact distribution chart - %s "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -2824,6 +2836,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Fallos de reinicio"
 
@@ -2835,9 +2850,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Fallo ao limpar certificados antiguos ou ó engadir la chave de autofirmado. ¡Finalizando a instalación!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Fallou a configuración de %{host} para arrancar dende %{device}"
@@ -3018,11 +3030,11 @@ msgstr "Clases de filtro"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtros"
-
-msgid "Filters for role %s"
-msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3132,6 +3144,9 @@ msgstr "Foreman pode usar un servicio LDAP para autenticación e información de
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3174,6 +3189,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr ""
 
@@ -3211,9 +3229,6 @@ msgid "Foreman will query the locally configured resolver instead of the SOA/NS 
 msgstr ""
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
-msgstr ""
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
 msgstr ""
 
 msgid "Foreman will update a host's environment from its facts"
@@ -3339,6 +3354,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Informes satisfactorios nos últimos %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr ""
 
@@ -3364,6 +3382,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3397,6 +3418,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3508,6 +3532,10 @@ msgid "Host::Base|Build"
 msgstr "Construir"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Nome de Certificado"
 
@@ -3534,6 +3562,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Arquivo de imaxe"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3669,6 +3701,12 @@ msgid "Hosts created after a puppet run will be placed in the location this fact
 msgstr ""
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
+msgstr ""
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
 msgstr ""
 
 msgid "Hosts in error state"
@@ -4155,6 +4193,9 @@ msgstr ""
 msgid "Installation Media"
 msgstr "Medio de Instalación"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configuración do Medio de Instalación"
 
@@ -4339,9 +4380,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr ""
 
-msgid "Legacy Puppet hostname"
-msgstr ""
-
 msgid "Length"
 msgstr ""
 
@@ -4403,6 +4441,15 @@ msgid "List all audits"
 msgstr ""
 
 msgid "List all audits for a given host"
+msgstr ""
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
 msgstr ""
 
 msgid "List all autosign entries"
@@ -4570,6 +4617,9 @@ msgstr ""
 msgid "List all users for LDAP authentication source"
 msgstr ""
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr ""
 
@@ -4630,6 +4680,15 @@ msgstr ""
 msgid "List environments per organization"
 msgstr ""
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr ""
 
@@ -4640,6 +4699,9 @@ msgid "List hosts per organization"
 msgstr ""
 
 msgid "List installed plugins"
+msgstr ""
+
+msgid "List internal authentication sources"
 msgstr ""
 
 msgid "List of HTTP Proxies"
@@ -4715,6 +4777,15 @@ msgid "List of subnets per location"
 msgstr ""
 
 msgid "List of subnets per organization"
+msgstr ""
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
 msgstr ""
 
 msgid "List operating systems where this template is set as a default"
@@ -4955,6 +5026,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Tipo de máquina"
 
@@ -5151,6 +5234,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modelo"
@@ -5231,6 +5317,9 @@ msgstr ""
 msgid "Name of the parameter"
 msgstr ""
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr ""
 
@@ -5273,14 +5362,11 @@ msgstr ""
 msgid "New"
 msgstr "Novo"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nova Chave de Autofirmado"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5301,9 +5387,6 @@ msgid "New Virtual Machine"
 msgstr "Nova máquina Virtual"
 
 msgid "New boot volume size (GB)"
-msgstr ""
-
-msgid "New compute profile on %s"
 msgstr ""
 
 msgid "New filter"
@@ -5330,6 +5413,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5404,10 +5491,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6131,9 +6221,6 @@ msgstr ""
 msgid "Password"
 msgstr "Contrasinal"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr ""
 
@@ -6156,6 +6243,9 @@ msgid "Password used to authenticate with the HTTP Proxy"
 msgstr ""
 
 msgid "Password:"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid "Path"
@@ -6429,13 +6519,18 @@ msgstr ""
 msgid "ProvisioningTemplate|Snippet"
 msgstr ""
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Proxies"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6740,6 +6835,9 @@ msgstr "Xerado Informe en"
 msgid "Report|Status"
 msgstr "Estado"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr ""
 
@@ -6747,6 +6845,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7011,9 +7112,6 @@ msgstr ""
 msgid "Secret Key"
 msgstr "Chave secreta"
 
-msgid "Security group"
-msgstr ""
-
 msgid "Security groups"
 msgstr ""
 
@@ -7172,7 +7270,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr ""
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7361,6 +7459,9 @@ msgstr ""
 msgid "Show a subnet"
 msgstr ""
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr ""
 
@@ -7394,6 +7495,9 @@ msgstr ""
 msgid "Show an environment"
 msgstr ""
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr ""
 
@@ -7404,6 +7508,9 @@ msgid "Show an image"
 msgstr ""
 
 msgid "Show an interface for host"
+msgstr ""
+
+msgid "Show an internal authentication source"
 msgstr ""
 
 msgid "Show an operating system"
@@ -7487,9 +7594,6 @@ msgstr "Proxies intelixentes"
 msgid "Smart Proxy"
 msgstr "Proxy Intelixente"
 
-msgid "Smart Proxy: %s"
-msgstr ""
-
 msgid "Smart Variables"
 msgstr "Variables Intelixentes"
 
@@ -7501,6 +7605,9 @@ msgid "Smart proxy"
 msgstr "Proxy intelixente"
 
 msgid "Smart proxy IDs"
+msgstr ""
+
+msgid "Smart variables"
 msgstr ""
 
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
@@ -7515,10 +7622,17 @@ msgid "SmartProxy|Name"
 msgstr "Nome"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "Url"
 
 msgid "Snippet"
+msgstr ""
+
+msgid "Sockets"
 msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
@@ -7553,6 +7667,9 @@ msgstr "Desculpe pero non se configurou ningunha plantilla."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Sentímolo, estos equipos non teñen parámetros asignados. Deberías engadirllos primeiro."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7659,6 +7776,9 @@ msgstr ""
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr ""
 
@@ -7702,6 +7822,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Máscara de rede"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7823,6 +7947,21 @@ msgid "TFTP server"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxonomía imponible"
 
@@ -7925,6 +8064,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7934,6 +8085,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8363,6 +8518,9 @@ msgstr ""
 msgid "Token"
 msgstr "Mostra"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr ""
 
@@ -8426,7 +8584,7 @@ msgstr "Tendencias"
 msgid "Trends for %s"
 msgstr "Tendencias para %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8524,6 +8682,9 @@ msgid "Unable to connect"
 msgstr ""
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8736,6 +8897,12 @@ msgstr "Equipo sen xestionar"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8865,6 +9032,9 @@ msgstr ""
 msgid "Update an environment"
 msgstr ""
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr ""
 
@@ -8916,7 +9086,13 @@ msgstr "Equipos actualizados: cambiado o grupo de equipos"
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
+msgstr ""
+
+msgid "Use APIv4 (experimental)"
 msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
@@ -8926,6 +9102,9 @@ msgid "Use UUID for certificates"
 msgstr ""
 
 msgid "Use short name for VMs"
+msgstr ""
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
 msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
@@ -8951,6 +9130,9 @@ msgid "User Groups"
 msgstr "Grupos de Usuarios"
 
 msgid "User IDs"
+msgstr ""
+
+msgid "User Name:"
 msgstr ""
 
 msgid "User data template"
@@ -9102,6 +9284,9 @@ msgid "VCenter/Server"
 msgstr "VCenter/Server"
 
 msgid "VLAN ID for this subnet"
+msgstr ""
+
+msgid "VLAN ID is not consistent accross subnets"
 msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
@@ -9319,7 +9504,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9403,6 +9588,9 @@ msgid "You are not authorized to make a template default."
 msgstr ""
 
 msgid "You are not authorized to perform this action."
+msgstr ""
+
+msgid "You are trying access the preferences of a different user"
 msgstr ""
 
 msgid "You are trying to delete your own account"
@@ -9597,6 +9785,9 @@ msgstr ""
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr ""
 
@@ -9714,6 +9905,9 @@ msgstr ""
 msgid "filter results"
 msgstr ""
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr ""
 
@@ -9727,6 +9921,9 @@ msgid "for OpenStack only"
 msgstr ""
 
 msgid "for VMware"
+msgstr ""
+
+msgid "for oVirt only"
 msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
@@ -9879,7 +10076,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "non se permite modificar"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9922,8 +10119,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Galego"
 
@@ -9932,6 +10128,12 @@ msgstr "lugar"
 
 msgid "locations"
 msgstr "lugares"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr ""
@@ -9995,6 +10197,9 @@ msgstr "débese proporcionar un proveedor"
 
 msgid "must set host and port"
 msgstr "débese configurar un equipo e un porto"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "novo"
@@ -10191,9 +10396,6 @@ msgstr ""
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr ""
-
 msgid "space separated options, e.g. miimon=100"
 msgstr ""
 
@@ -10291,6 +10493,9 @@ msgstr "válido"
 msgid "valid or pending"
 msgstr ""
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10298,6 +10503,9 @@ msgid "virtual"
 msgstr "virtual"
 
 msgid "virtual attached to %s"
+msgstr ""
+
+msgid "with given ID not found"
 msgstr ""
 
 msgid "yaml"

--- a/locale/it/foreman.po
+++ b/locale/it/foreman.po
@@ -27,7 +27,10 @@ msgstr " Rimuovi"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -86,6 +89,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "rimossa l'associazione di %s dalla VM"
 
@@ -112,6 +118,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s mese fa"
 msgstr[1] "%s mesi fa"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s host selezionato"
@@ -271,6 +280,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' non è supportato in API v2 per le richieste POST e PUT. Usare 'Content-Type: application/json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Altro)"
@@ -449,9 +463,6 @@ msgstr "Aggiungi parametro"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -527,6 +538,12 @@ msgstr ""
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Allerta"
 
@@ -541,9 +558,6 @@ msgstr "Tutte"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Tutte le classi Puppet per %s"
 
 msgid "All Reports"
 msgstr "Tutti i riporti"
@@ -802,6 +816,12 @@ msgstr "Controllo"
 
 msgid "Audit Comment"
 msgstr "Verifica commento"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr ""
@@ -1113,14 +1133,26 @@ msgstr ""
 msgid "Build"
 msgstr "Genera"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Creazione host"
 
 msgid "Build PXE Default"
 msgstr "Creazione PXE predefinito"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Creazione da una immagine OS"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1251,6 +1283,9 @@ msgstr "Ambienti modificati"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Struttura"
 
@@ -1296,6 +1331,12 @@ msgstr "Classi"
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Selezionare il link di una risorsa di calcolo per modificarne l'attributo predefinito della VM."
 
@@ -1304,9 +1345,6 @@ msgstr "Seleziona per aggiungere %s"
 
 msgid "Click to log in again."
 msgstr "Seleziona per un altro accesso."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Seleziona per rimuovere %s"
@@ -1427,6 +1465,10 @@ msgstr "Description"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1676,6 +1718,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1799,6 +1844,9 @@ msgstr "Crea una variabile smart"
 msgid "Create a subnet"
 msgstr "Crea una sottorete"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Crea un utente"
 
@@ -1838,6 +1886,9 @@ msgstr "Crea un valore override per una variabile smart specifica"
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr ""
 
@@ -1852,6 +1903,9 @@ msgstr "Crea una voce dell'area di autenticazione per %s"
 
 msgid "Created"
 msgstr "Creato"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2027,9 +2081,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Rimuovi host"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Cancellare i certificati PuppetCA per %s"
 
@@ -2123,8 +2174,14 @@ msgstr "Cancella una variabile smart"
 msgid "Delete a subnet"
 msgstr "Cancella una sottorete"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Cancella una combinazione di template"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Cancella un utente"
@@ -2264,10 +2321,16 @@ msgstr "Visualizza diff"
 msgid "Disable Notifications"
 msgstr "Disabilita notifiche"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Disabilita gli avvisi per host selezionati"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2398,47 +2461,11 @@ msgstr "Modifica"
 msgid "Edit %s"
 msgstr "Modifica %s"
 
-msgid "Edit Architecture"
-msgstr "Modifica architettura"
-
-msgid "Edit Bookmark"
-msgstr "Modificare Preferiti"
-
 msgid "Edit Compute profile"
 msgstr "Modifica profilo di calcolo"
 
-msgid "Edit Compute profile: %s"
-msgstr "Modifica profilo di calcolo: %s"
-
-msgid "Edit Config group"
-msgstr "Modifica gruppo di configurazioni"
-
-msgid "Edit Domain"
-msgstr "Modifica dominio"
-
-msgid "Edit Environment"
-msgstr "Modifica ambiente"
-
-msgid "Edit Filter"
-msgstr "Modifica filtro"
-
-msgid "Edit Global Parameter"
-msgstr "Modifica parametro globale"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "Modifica host"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Modifica sorgente di autorizzazione LDAP"
-
-msgid "Edit Medium"
-msgstr "Modifica supporto"
-
-msgid "Edit Model"
-msgstr "Modifica modello"
 
 msgid "Edit Operating System"
 msgstr "Modifica sistema operativo"
@@ -2446,23 +2473,11 @@ msgstr "Modifica sistema operativo"
 msgid "Edit Parameters"
 msgstr "Modifica parametri"
 
-msgid "Edit Partition Table"
-msgstr "Modifica tabella parametri"
-
 msgid "Edit Properties"
 msgstr "Modifica proprietà"
 
-msgid "Edit Proxy"
-msgstr "Modifica proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Modifica classe Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Modifica area di autenticazione"
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "Modifica variabile smart"
@@ -2470,23 +2485,8 @@ msgstr "Modifica variabile smart"
 msgid "Edit Smart class parameters"
 msgstr ""
 
-msgid "Edit Subnet"
-msgstr "Modifica sottorete"
-
-msgid "Edit Template"
-msgstr "Modifica modello"
-
 msgid "Edit Trend %s"
 msgstr "Modifica trend %s"
-
-msgid "Edit User"
-msgstr "Modifica utente"
-
-msgid "Edit User group"
-msgstr "Modifica gruppo utenti"
-
-msgid "Edit compute profile on %s"
-msgstr "Modifica profilo di calcolo su %s"
 
 msgid "Edit this host"
 msgstr ""
@@ -2517,6 +2517,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Abilita le notifiche"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Abilita gli avvisi per gli host selezionati"
@@ -2638,6 +2641,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2762,10 +2774,10 @@ msgstr "Nome evento"
 msgid "Fact Values"
 msgstr "Valori evento"
 
-msgid "Fact Values | %{host_name}"
+msgid "Fact distribution chart"
 msgstr ""
 
-msgid "Fact distribution chart"
+msgid "Fact distribution chart - %s "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -2826,6 +2838,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Riavvii falliti"
 
@@ -2837,9 +2852,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Impossibile rimuovere i certificati obsoleti o aggiungere la voce autosign. Interruzione compilazione in corso!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Impossibile configurare %{host} all'avvio da %{device}: %{e}"
@@ -3020,11 +3032,11 @@ msgstr "Classi del filtro"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtri"
-
-msgid "Filters for role %s"
-msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3134,6 +3146,9 @@ msgstr "Foreman è in grado di usare un servizio basato su LDAP per le informaio
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3176,6 +3191,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatizzerà la firma dei certificati previa presenza di un nuovo host "
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman creerà un host previa ricezione di un riporto"
 
@@ -3214,9 +3232,6 @@ msgstr "Foreman interrogherà il resolver configurato localmente al posto dei re
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman lo imposterà come percorso del modulo Puppet predefinito se non in grado di rilevarne uno"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman interromperà l'hostname a 'puppet', se inizia con puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman aggiornerà l'ambiente di un host usando i propri eventi"
@@ -3341,6 +3356,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Riporti host corretti negli ultimi %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3366,6 +3384,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3399,6 +3420,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3510,6 +3534,10 @@ msgid "Host::Base|Build"
 msgstr "Compilazione"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Nome certificato"
 
@@ -3536,6 +3564,10 @@ msgstr "Host::Base|Grub pass"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "File immagine"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3672,6 +3704,12 @@ msgstr "Gli host creati dopo l'esecuzione di un puppet verranno archiviati in un
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Gli host creati dopo l'esecuzione di un puppet verranno archiviati in una organizzazione indicata dalle informazioni fornite. Il contenuto delle informazioni deve rappresentare l'etichetta completa dell'organizzazione."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Host con uno stato d'errore"
@@ -4157,6 +4195,9 @@ msgstr "Ingresso"
 msgid "Installation Media"
 msgstr "Dispositivo d'installazione"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configurazione supporto di installazione"
 
@@ -4341,9 +4382,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr ""
 
-msgid "Legacy Puppet hostname"
-msgstr ""
-
 msgid "Length"
 msgstr ""
 
@@ -4406,6 +4444,15 @@ msgstr "Elenca tutte le verifiche"
 
 msgid "List all audits for a given host"
 msgstr "Elenca tutte le verifiche per un dato host"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Elenca tutte le voci autosign"
@@ -4572,6 +4619,9 @@ msgstr "Elenca tutti gli utenti"
 msgid "List all users for LDAP authentication source"
 msgstr "Elenca tutti gli utenti per il sorgente di autenticazione LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Elenca tutti gli utenti per la posizione"
 
@@ -4632,6 +4682,15 @@ msgstr "Elenca ambienti per posizione"
 msgid "List environments per organization"
 msgstr "Elenca gli ambienti per organizzazione"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Elenca host per ambiente"
 
@@ -4643,6 +4702,9 @@ msgstr "Elenca host per organizzazione"
 
 msgid "List installed plugins"
 msgstr "Elenca plugin installati"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4718,6 +4780,15 @@ msgstr "Elenco di sottoreti per posizione"
 
 msgid "List of subnets per organization"
 msgstr "Elenco di sottoreti per organizzazione"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Elenca i sistemi operativi dove questo template è impostato per impostazione predefinita"
@@ -4957,6 +5028,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Tipo di macchina"
 
@@ -5153,6 +5236,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modello"
@@ -5233,6 +5319,9 @@ msgstr ""
 msgid "Name of the parameter"
 msgstr ""
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr ""
 
@@ -5275,14 +5364,11 @@ msgstr "Tipo di rete"
 msgid "New"
 msgstr "Nuovo"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nuova voce per Autosign"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5304,9 +5390,6 @@ msgstr "Nuova Macchina Virtuale"
 
 msgid "New boot volume size (GB)"
 msgstr ""
-
-msgid "New compute profile on %s"
-msgstr "Nuovo profilo di calcolo su %s"
 
 msgid "New filter"
 msgstr "Nuovo filtro"
@@ -5332,6 +5415,10 @@ msgstr "Nic::Base|Opzioni di aggregazione"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5406,10 +5493,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6133,9 +6223,6 @@ msgstr ""
 msgid "Password"
 msgstr "Password"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr ""
 
@@ -6159,6 +6246,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "Password:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Percorso"
@@ -6431,13 +6521,18 @@ msgstr ""
 msgid "ProvisioningTemplate|Snippet"
 msgstr ""
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Proxy"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6742,6 +6837,9 @@ msgstr "Riportato"
 msgid "Report|Status"
 msgstr "Stato"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr ""
 
@@ -6749,6 +6847,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7013,9 +7114,6 @@ msgstr "DNS secondario per questa sottorete"
 msgid "Secret Key"
 msgstr "Chiave segreta"
 
-msgid "Security group"
-msgstr "Gruppo di sicurezza"
-
 msgid "Security groups"
 msgstr "Gruppi di sicurezza"
 
@@ -7174,7 +7272,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "Imposta una password generata randomicamente sulla connessione del display"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7363,6 +7461,9 @@ msgstr "Mostra una variabile smart"
 msgid "Show a subnet"
 msgstr "Mostra una sottorete"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Mostra un utente"
 
@@ -7396,6 +7497,9 @@ msgstr ""
 msgid "Show an environment"
 msgstr "Mostra un ambiente"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Mostra un gruppo di utenti esterni per il sorgente di autenticazione LDAP"
 
@@ -7407,6 +7511,9 @@ msgstr "Mostra una immagine"
 
 msgid "Show an interface for host"
 msgstr "Mostra una interfaccia per l'host"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Mostra un sistema operativo"
@@ -7489,9 +7596,6 @@ msgstr "Smart proxy"
 msgid "Smart Proxy"
 msgstr "Smart Proxy"
 
-msgid "Smart Proxy: %s"
-msgstr ""
-
 msgid "Smart Variables"
 msgstr "Variabili smart"
 
@@ -7505,6 +7609,9 @@ msgstr "Smart proxy"
 msgid "Smart proxy IDs"
 msgstr "ID Smart proxy"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7517,11 +7624,18 @@ msgid "SmartProxy|Name"
 msgstr "Nome"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "Url"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7555,6 +7669,9 @@ msgstr "Spiacenti ma non è stato fornito alcun modello."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Spiacenti, non è stato assegnato alcun parametro ai suddetti host, è necessario prima aggiungerli"
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7661,6 +7778,9 @@ msgstr "ID sottoreti"
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nome sottorete"
 
@@ -7704,6 +7824,10 @@ msgstr "Subnet|Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Maschera"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7825,6 +7949,21 @@ msgid "TFTP server"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "..."
 
@@ -7927,6 +8066,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7936,6 +8087,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8365,6 +8520,9 @@ msgstr "Attiva/Disattiva"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr ""
 
@@ -8428,7 +8586,7 @@ msgstr "Trend"
 msgid "Trends for %s"
 msgstr "Trend per %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8526,6 +8684,9 @@ msgid "Unable to connect"
 msgstr "Impossibile collegarsi"
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8738,6 +8899,12 @@ msgstr "Rimuovi gestione dell'host"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8867,6 +9034,9 @@ msgstr "Aggiorna una architettura"
 msgid "Update an environment"
 msgstr "Aggiorna un ambiente"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Aggiorna una immagine"
 
@@ -8918,8 +9088,14 @@ msgstr "Host aggiornati: gruppo di host modificato"
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Carica gli eventi per un host creando, se necessario, un host"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8928,6 +9104,9 @@ msgid "Use UUID for certificates"
 msgstr ""
 
 msgid "Use short name for VMs"
+msgstr ""
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
 msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
@@ -8954,6 +9133,9 @@ msgstr "Gruppi di utenti"
 
 msgid "User IDs"
 msgstr "ID Utenti"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr ""
@@ -9105,6 +9287,9 @@ msgstr "VCenter/Server"
 
 msgid "VLAN ID for this subnet"
 msgstr "ID VLAN per questa sottorete"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN tag, questo attributo ha la precedenza rispetto a VLAN ID. Solo per interfacce virtuali."
@@ -9321,7 +9506,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9406,6 +9591,9 @@ msgstr ""
 
 msgid "You are not authorized to perform this action."
 msgstr "Non sei autorizzato a eseguire questa azione."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Stai cercando di cancellare il tuo account"
@@ -9599,6 +9787,9 @@ msgstr "non può essere rimosso da un account protetto interno"
 msgid "cannot be removed from the last admin account"
 msgstr "non può essere rimosso dall'ultimo account ammin"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "clona"
 
@@ -9716,6 +9907,9 @@ msgstr "filtra ruolo %s"
 msgid "filter results"
 msgstr "filtra i risultati"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "solo per EC2"
 
@@ -9729,6 +9923,9 @@ msgid "for OpenStack only"
 msgstr ""
 
 msgid "for VMware"
+msgstr ""
+
+msgid "for oVirt only"
 msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
@@ -9881,7 +10078,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "non è possibile cambiare"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9924,8 +10121,7 @@ msgstr "collega il gruppo di utenti esterno a questo gruppo"
 msgid "list"
 msgstr "elenco"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -9934,6 +10130,12 @@ msgstr "posizione"
 
 msgid "locations"
 msgstr "posizioni"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr ""
@@ -9997,6 +10199,9 @@ msgstr "fornire un provider"
 
 msgid "must set host and port"
 msgstr "impostare host e porta"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "nuovo"
@@ -10193,9 +10398,6 @@ msgstr ""
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "ordina risultati"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "opzioni separate da spazi, es. miimon=100."
 
@@ -10293,6 +10495,9 @@ msgstr "valido"
 msgid "valid or pending"
 msgstr ""
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10300,6 +10505,9 @@ msgid "virtual"
 msgstr ""
 
 msgid "virtual attached to %s"
+msgstr ""
+
+msgid "with given ID not found"
 msgstr ""
 
 msgid "yaml"

--- a/locale/ja/foreman.po
+++ b/locale/ja/foreman.po
@@ -29,8 +29,11 @@ msgstr "削除"
 msgid " in the provisioning template."
 msgstr "変更はありません。"
 
-msgid "#{taxonomy} can be set on the All Hosts page"
-msgstr "#{taxonomy} はすべてのホストページで設定できます"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
+msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr "%s - マウスを使えるように、Shift+F12 を押して下さい"
@@ -88,6 +91,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s の VM との関連付けが解除されました"
 
@@ -114,6 +120,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s つの選択されたホスト"
@@ -273,6 +282,11 @@ msgstr "'%{object_name}' は '%{object_class}' で、サブネットが必要で
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'コンテンツタイプ: %s' は POST および PUT 要求の API v2 でサポートされていません。'コンテンツタイプ: アプリケーション/json' を使用してください。"
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(その他)"
@@ -457,9 +471,6 @@ msgstr "パラメーターの追加"
 msgid "Add SSH Key"
 msgstr "SSH キーの追加"
 
-msgid "Add SSH Key for %s"
-msgstr "%s の SSH キーの追加"
-
 msgid "Add SSH key"
 msgstr "SSH キーの追加"
 
@@ -535,6 +546,12 @@ msgstr "管理者の電子メールアドレス"
 msgid "Administrator user account required"
 msgstr "管理者ユーザーアカウントが必要"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "警告"
 
@@ -549,9 +566,6 @@ msgstr "すべて"
 
 msgid "All Hosts"
 msgstr "すべてのホスト"
-
-msgid "All Puppet Classes for %s"
-msgstr "%s のすべての Puppet クラス"
 
 msgid "All Reports"
 msgstr "すべてのレポート"
@@ -810,6 +824,12 @@ msgstr "監査"
 
 msgid "Audit Comment"
 msgstr "監査コメント"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "監査の概要"
@@ -1121,14 +1141,26 @@ msgstr "タイムゾーンの参照"
 msgid "Build"
 msgstr "ビルド"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "ホストのビルド"
 
 msgid "Build PXE Default"
 msgstr "PXE デフォルトのビルド"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "OS イメージからのビルド"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr "デフォルトでは、標準の LDAP グループオブジェクトにユーザーグループをマッピングします。FreeIPA と POSIX LDAP のサーバータイプでは、ネットグループを使用した別の方法でユーザーをグループ化することができます。標準グループではなく、ネットグループを使用する場合には、このチェックボックスを有効化してください。"
@@ -1259,6 +1291,9 @@ msgstr "変更済みの環境"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr "%s への変更は、継承されるすべてのフィルターに伝播します。"
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "シャーシ"
 
@@ -1304,6 +1339,12 @@ msgstr "クラス"
 msgid "Clean up failed deployment"
 msgstr "障害が発生したデプロイメントのクリーンアップ"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "デフォルトの VM 属性を編集するためにコンピュートリソースのリンクをクリックします。"
 
@@ -1312,9 +1353,6 @@ msgstr "クリックして %s を追加"
 
 msgid "Click to log in again."
 msgstr "クリックして再ログインします。"
-
-msgid "Click to mark as read"
-msgstr "クリックして既読にする"
 
 msgid "Click to remove %s"
 msgstr "クリックして %s を削除"
@@ -1436,6 +1474,10 @@ msgstr "説明"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
 msgstr "ドメイン"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
@@ -1684,6 +1726,9 @@ msgstr "プロキシーの作成"
 msgid "Create Puppet Environment"
 msgstr "Puppet 環境の作成"
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "レルムの作成"
 
@@ -1807,6 +1852,9 @@ msgstr "スマート変数の作成"
 msgid "Create a subnet"
 msgstr "サブネットの作成"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "ユーザーの作成"
 
@@ -1846,6 +1894,9 @@ msgstr "特定スマート変数の上書き値を作成"
 msgid "Create autosign entry"
 msgstr "自動署名エントリーの作成"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "イメージから新規起動ボリュームを作成"
 
@@ -1860,6 +1911,9 @@ msgstr "%s のレルムエントリーを作成"
 
 msgid "Created"
 msgstr "作成日時"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2035,9 +2089,6 @@ msgstr "コントローラーの削除"
 msgid "Delete Hosts"
 msgstr "ホストの削除"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr "%s の PuppetCA 自動署名エントリーを削除"
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "%s の Puppet CA 証明書を削除"
 
@@ -2131,8 +2182,14 @@ msgstr "スマート変数の削除"
 msgid "Delete a subnet"
 msgstr "サブネットの削除"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "テンプレートの組み合わせの削除"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "ユーザーの削除"
@@ -2272,11 +2329,17 @@ msgstr "差分表示"
 msgid "Disable Notifications"
 msgstr "通知の無効化"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "選択ホストの警告の無効化"
 
 msgid "Disable all filters overriding"
 msgstr "すべてのフィルターオーバーライドの無効化"
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
+msgstr ""
 
 msgid "Disable overriding"
 msgstr "オーバーライドの無効化"
@@ -2406,47 +2469,11 @@ msgstr "編集"
 msgid "Edit %s"
 msgstr "%s の編集"
 
-msgid "Edit Architecture"
-msgstr "アーキテクチャーの編集"
-
-msgid "Edit Bookmark"
-msgstr "ブックマークの編集"
-
 msgid "Edit Compute profile"
 msgstr "コンピュートプロファイルの編集"
 
-msgid "Edit Compute profile: %s"
-msgstr "コンピュートプロファイルの編集: %s"
-
-msgid "Edit Config group"
-msgstr "設定グループの編集"
-
-msgid "Edit Domain"
-msgstr "ドメインの編集"
-
-msgid "Edit Environment"
-msgstr "環境の編集"
-
-msgid "Edit Filter"
-msgstr "ファイルターの編集"
-
-msgid "Edit Global Parameter"
-msgstr "グローバルパラメーターの編集"
-
-msgid "Edit HTTP Proxy"
-msgstr "HTTP プロキシーを編集"
-
 msgid "Edit Host"
 msgstr "ホストの編集"
-
-msgid "Edit LDAP Auth Source"
-msgstr "LDAP 認証ソースの編集"
-
-msgid "Edit Medium"
-msgstr "メディアの編集"
-
-msgid "Edit Model"
-msgstr "モデルの編集"
 
 msgid "Edit Operating System"
 msgstr "オペレーティングシステムの編集"
@@ -2454,23 +2481,11 @@ msgstr "オペレーティングシステムの編集"
 msgid "Edit Parameters"
 msgstr "パラメーターの編集"
 
-msgid "Edit Partition Table"
-msgstr "パーティションテーブルの編集"
-
 msgid "Edit Properties"
 msgstr "プロパティーの編集"
 
-msgid "Edit Proxy"
-msgstr "プロキシーの編集"
-
 msgid "Edit Puppet Class %s"
 msgstr "Puppet クラス %s の編集"
-
-msgid "Edit Realm"
-msgstr "レルムの編集"
-
-msgid "Edit Role"
-msgstr "ロールの編集"
 
 msgid "Edit Smart Variable"
 msgstr "スマート変数の編集"
@@ -2478,23 +2493,8 @@ msgstr "スマート変数の編集"
 msgid "Edit Smart class parameters"
 msgstr "スマートクラスパラメーターの編集"
 
-msgid "Edit Subnet"
-msgstr "サブネットの編集"
-
-msgid "Edit Template"
-msgstr "テンプレートの編集"
-
 msgid "Edit Trend %s"
 msgstr "%sトレンド  の編集"
-
-msgid "Edit User"
-msgstr "ユーザーの編集"
-
-msgid "Edit User group"
-msgstr "ユーザーグループの編集"
-
-msgid "Edit compute profile on %s"
-msgstr "%s のコンピュートプロファイルの編集"
 
 msgid "Edit this host"
 msgstr "このホストの編集"
@@ -2525,6 +2525,9 @@ msgstr "キャッシングの有効化"
 
 msgid "Enable Notifications"
 msgstr "通知の有効化"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "選択ホストについての警告を有効化"
@@ -2648,6 +2651,15 @@ msgstr "データ送信時にエラーが発生しました:"
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr "認証中に '%{url}' の '%{name}' LDAP サーバーへの接続でエラー"
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr "エラー"
 
@@ -2770,11 +2782,11 @@ msgstr "ファクト名"
 msgid "Fact Values"
 msgstr "ファクト値"
 
-msgid "Fact Values | %{host_name}"
-msgstr "%{host_name}"
-
 msgid "Fact distribution chart"
 msgstr "ファクトディストリビューションチャート"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2834,6 +2846,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "再起動失敗"
 
@@ -2845,9 +2860,6 @@ msgstr "%s のコンピュートリソースからの IP アドレスの取得�
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr "%{hostname} の保留中のビルドの取り消しに失敗し、次のエラーが発生しました: %{errors}"
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "古い証明書の削除または自動署名エントリーの追加に失敗しました。ビルドを終了しています!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "%{device} から起動するための %{host} の設定に失敗しました: %{e}"
@@ -3030,11 +3042,11 @@ msgstr "クラスのフィルター"
 msgid "Filter overriding has been disabled"
 msgstr "フィルターのオーバーライドが無効です"
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "フィルター"
-
-msgid "Filters for role %s"
-msgstr "ロール %s のフィルター"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr "フィルターは、デフォルトでロールに関連付けられた %{orgs_and_locs} を継承します。オーバーライドフィールドが有効な場合、<br> フィルターは %{orgs_and_locs} のセットをオーバーライドできます。これ以降のロールの変更によってこのようなフィルターは <br> 影響を受けません。オーバーライドフィールドの無効後に、ロール %{orgs_and_locs} は再び適用されます"
@@ -3147,6 +3159,9 @@ msgstr "Foreman では、ユーザー情報と認証用に LDAP ベースのサ�
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman はドメインと DNS ゾーンを同じものと見なします。"
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "インターフェースの Foreman ドメイン ID。管理対象ホストのプライマリーインターフェースに必要"
 
@@ -3189,6 +3204,9 @@ msgstr "Foreman は、新規ホストのプロビジョニング時にドメイ�
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman は、新規ホストのプロビジョニング時に証明書の署名を自動化します"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman はレポートの受信時にホストを作成します"
 
@@ -3227,9 +3245,6 @@ msgstr "Foreman は SOA/NS 権限ではなく、ローカルで設定された�
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman は、自動検出できない場合にこれをデフォルトの Puppet モジュールパスとして設定します"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman は「puppet」で始まるホスト名を切り捨てて「puppet」にします"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman はホスト環境をそのファクトで更新します"
@@ -3354,6 +3369,9 @@ msgstr "グローバル変数"
 msgid "Good host reports in the last %s"
 msgstr "直近 %s 間での良好なホストレポート"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "グローバルプロジェクト ID"
 
@@ -3380,6 +3398,9 @@ msgstr "HTTP(S) プロキシー"
 
 msgid "HTTP(S) proxy except hosts"
 msgstr "ホスト以外の HTTP(S) プロキシー"
+
+msgid "HTTPS URL is required for API access"
+msgstr ""
 
 msgid "Hard disk"
 msgstr "ハードディスク"
@@ -3413,6 +3434,9 @@ msgstr "非表示の値"
 
 msgid "Hide all values for this parameter."
 msgstr "このパラメーターのすべての値を非表示にします。"
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "この値を非表示"
@@ -3523,6 +3547,10 @@ msgid "Host::Base|Build"
 msgstr "ビルド"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "証明書名"
 
@@ -3549,6 +3577,10 @@ msgstr "Grub パス"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "イメージファイル"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3685,6 +3717,12 @@ msgstr "puppetrun 後に作成されるホストは、このファクトが定�
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "puppetrun 後に作成されるホストは、このファクトが定める組織に置かれます。このファクトの内容と組織の全ラベルを同一にする必要があります。"
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "エラー状態のホスト"
@@ -4170,6 +4208,9 @@ msgstr "入力"
 msgid "Installation Media"
 msgstr "インストールメディア"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "インストールメディア設定"
 
@@ -4354,9 +4395,6 @@ msgstr "コンソールの起動"
 msgid "Learn more about this in the documentation."
 msgstr "この詳細についてはドキュメンテーションを参照してください。"
 
-msgid "Legacy Puppet hostname"
-msgstr "レガシー Puppet ホスト名"
-
 msgid "Length"
 msgstr "長さ"
 
@@ -4419,6 +4457,15 @@ msgstr "すべての監査を一覧表示"
 
 msgid "List all audits for a given host"
 msgstr "指定されたホストのすべての監査を一覧表示"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "すべての自動署名エントリーを一覧表示"
@@ -4585,6 +4632,9 @@ msgstr "すべてのユーザーの一覧表示"
 msgid "List all users for LDAP authentication source"
 msgstr "LDAP 認証ソースに対してすべてのユーザーを一覧表示"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "ロケーションに対してすべてのユーザーを一覧表示"
 
@@ -4645,6 +4695,15 @@ msgstr "ロケーションごとに環境を一覧表示"
 msgid "List environments per organization"
 msgstr "組織ごとに環境を一覧表示"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "環境ごとにホストを一覧表示"
 
@@ -4656,6 +4715,9 @@ msgstr "組織ごとにホストを一覧表示"
 
 msgid "List installed plugins"
 msgstr "インストールされたプラグインを一覧表示"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "HTTP プロキシーを一覧表示"
@@ -4731,6 +4793,15 @@ msgstr "ロケーションごとのサブネットの一覧"
 
 msgid "List of subnets per organization"
 msgstr "組織ごとのサブネットの一覧"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "このテンプレートがデフォルトで設定されるオペレーティングシステムを一覧表示"
@@ -4970,6 +5041,18 @@ msgstr "このホスト用の IP を再使用するための MAC アドレス"
 msgid "MAC-based"
 msgstr "MAC ベース"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "マシンタイプ"
 
@@ -5166,6 +5249,9 @@ msgstr "親 %s を編集するパーミッションがありません"
 msgid "Missing one of the required permissions: %s"
 msgstr "必要ないずれかのパーミッションがありません: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "モデル"
@@ -5246,6 +5332,9 @@ msgstr "ホストグループの名前"
 msgid "Name of the parameter"
 msgstr "パラメーター名"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "変数の名前"
 
@@ -5288,14 +5377,11 @@ msgstr "ネットワークタイプ"
 msgid "New"
 msgstr "新規"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "新規の自動署名エントリー"
-
-msgid "New Event"
-msgstr "新規イベント"
-
-msgid "New Events"
-msgstr "新規イベント"
 
 msgid "New HTTP Proxy"
 msgstr "新規 HTTP プロキシー"
@@ -5317,9 +5403,6 @@ msgstr "新規仮想マシン"
 
 msgid "New boot volume size (GB)"
 msgstr "新規起動ボリュームサイズ (GB)"
-
-msgid "New compute profile on %s"
-msgstr "%s の新規コンピュートプロファイル"
 
 msgid "New filter"
 msgstr "新規フィルター"
@@ -5346,6 +5429,10 @@ msgstr "ボンドオプション"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
 msgstr "コンピュート属性"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Identifier"
@@ -5419,11 +5506,14 @@ msgstr "ホスト %s に利用可能な BMC NIC はありません"
 msgid "No Failed Features"
 msgstr "失敗した機能はありません"
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "IPv4 サブネットが選択されていません"
 
-msgid "No Notifications"
-msgstr "通知なし"
+msgid "No Notifications Available"
+msgstr ""
 
 msgid "No TFTP feature"
 msgstr "TFTP 機能なし"
@@ -6148,9 +6238,6 @@ msgstr "パーティションテンプレートは、異なるサーバー機能
 msgid "Password"
 msgstr "パスワード"
 
-msgid "Password do not match"
-msgstr "パスワードが一致しません"
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "oVirt、EC2、VMware、OpenStack のパスワード。EC2 のシークレットキー"
 
@@ -6174,6 +6261,9 @@ msgstr "HTTP プロキシーでの認証に使用するパスワード。"
 
 msgid "Password:"
 msgstr "パスワード:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "パス"
@@ -6446,14 +6536,19 @@ msgstr "名前"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "スニペット"
 
-msgid "Proxied request failed with: %s"
-msgstr "プロキシー化されたリクエストが失敗しました: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
+msgstr ""
 
 msgid "Proxies"
 msgstr "プロキシー"
 
 msgid "Proxy ID to use within this realm"
 msgstr "このレルム内で使用するプロキシー ID"
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
 
 msgid "Proxy request timeout"
 msgstr "プロキシー要求のタイムアウト"
@@ -6757,6 +6852,9 @@ msgstr "レポート"
 msgid "Report|Status"
 msgstr "状態"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "スマートプロキシーに SSL が必要"
 
@@ -6765,6 +6863,9 @@ msgstr "値なしの必須パラメーターです。<br/><b>上書きしてく�
 
 msgid "Required when user want to change own password"
 msgstr "ユーザーが独自のパスワードを変更する場合に必須"
+
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
 
 msgid "Reset to default"
 msgstr "デフォルトにリセット"
@@ -7028,9 +7129,6 @@ msgstr "このサブネットのセカンダリー DNS"
 msgid "Secret Key"
 msgstr "シークレットキー"
 
-msgid "Security group"
-msgstr "セキュリティーグループ"
-
 msgid "Security groups"
 msgstr "セキュリティーグループ"
 
@@ -7189,8 +7287,8 @@ msgstr "VNC ディスプレイ接続時にランダムに生成されたパス�
 msgid "Set a randomly generated password on the display connection"
 msgstr "ディスプレイ接続時にランダムに生成されたパスワードを設定します"
 
-msgid "Set hostnames to which requests are not to be proxied"
-msgstr "プロキシーを設定しないリクエストへのホスト名を設定"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
+msgstr ""
 
 msgid "Set parameters to defaults"
 msgstr "パラメーターをデフォルトに設定"
@@ -7378,6 +7476,9 @@ msgstr "スマート変数の表示"
 msgid "Show a subnet"
 msgstr "サブネットの表示"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "ユーザーの表示"
 
@@ -7411,6 +7512,9 @@ msgstr "電子メール通知の表示"
 msgid "Show an environment"
 msgstr "環境の表示"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "LDAP 認証ソースの外部ユーザーグループの表示"
 
@@ -7422,6 +7526,9 @@ msgstr "イメージの表示"
 
 msgid "Show an interface for host"
 msgstr "ホストのインターフェースの表示"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "オペレーティングシステムの表示"
@@ -7504,9 +7611,6 @@ msgstr "スマートプロキシー"
 msgid "Smart Proxy"
 msgstr "スマートプロキシー"
 
-msgid "Smart Proxy: %s"
-msgstr "スマートプロキシー: %s"
-
 msgid "Smart Variables"
 msgstr "スマート変数"
 
@@ -7520,6 +7624,9 @@ msgstr "スマートプロキシー"
 msgid "Smart proxy IDs"
 msgstr "スマートプロキシー ID"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr "スマート変数は、ルールセットによって、Puppet ENC のトップレベル (グローバル) スコープにパラメーター (キー/値のデータ) を提供するツールです。"
 
@@ -7532,11 +7639,18 @@ msgid "SmartProxy|Name"
 msgstr "名前"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "スニペット"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr "一部の Puppet クラスは選択された環境では利用できません"
@@ -7570,6 +7684,9 @@ msgstr "設定されているテンプレートがありませんでした。"
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "これらのホストにはパラメーターが割り当てられていないため、まずそれらを追加する必要があります。"
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7676,6 +7793,9 @@ msgstr "サブネット ID"
 msgid "Subnet description"
 msgstr "サブネットの説明"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "サブネット名"
 
@@ -7719,6 +7839,10 @@ msgstr "IPAM"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "マスク"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7840,6 +7964,21 @@ msgid "TFTP server"
 msgstr "TFTP サーバー"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "分類のタクソノミー"
 
@@ -7942,6 +8081,18 @@ msgid "Template|Default"
 msgstr "デフォルト"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "ロック"
 
@@ -7952,6 +8103,10 @@ msgstr "名前"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
 msgstr "OS 種別"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Snippet"
@@ -8388,6 +8543,9 @@ msgstr "トグル"
 msgid "Token"
 msgstr "トークン"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "トークン期間"
 
@@ -8451,8 +8609,8 @@ msgstr "トレンド"
 msgid "Trends for %s"
 msgstr "%s のトレンド"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
-msgstr "Foreman のトレンドを使用すると、インフラストラクチャー内における長期での変更を追跡できます。Foreman 関連の情報と Puppet ファクトの両方が追跡できます。トレンドページでは、その値のホスト数が長期でどのように変化したかというグラフと、現行ホストの一覧が確認できます。"
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
@@ -8550,6 +8708,9 @@ msgstr "接続できません"
 
 msgid "Unable to connect to LDAP server"
 msgstr "LDAP サーバーに接続できません"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "デフォルトの TFTP ブートメニューを作成できません"
@@ -8761,6 +8922,12 @@ msgstr "ホストの管理解除"
 msgid "Unnamed"
 msgstr "名前なし"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "%s の未サポート IPAM モード"
 
@@ -8890,6 +9057,9 @@ msgstr "アーキテクチャーの更新"
 msgid "Update an environment"
 msgstr "環境の更新"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "イメージの更新"
 
@@ -8941,8 +9111,14 @@ msgstr "更新済みホスト: 変更済みホストグループ"
 msgid "Updated hosts: changed owner"
 msgstr "更新済みホスト: 変更済み所有者"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "ホストのファクトをアップロードし、必要な場合はホストを作成します"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "POSIX グループの代わりに NIS ネットグループを使用します。"
@@ -8952,6 +9128,9 @@ msgstr "証明書に UUID を使用"
 
 msgid "Use short name for VMs"
 msgstr "VM の短い名前の使用"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "認証用にこのアカウントを使用します。<i>オプション</i>"
@@ -8977,6 +9156,9 @@ msgstr "ユーザーグループ"
 
 msgid "User IDs"
 msgstr "ユーザー ID"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "ユーザーデータテンプレート"
@@ -9128,6 +9310,9 @@ msgstr "サーバー"
 
 msgid "VLAN ID for this subnet"
 msgstr "このサブネットの VLAN ID"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN タグ。この属性はサブネット VLAN ID より優先されます。仮想インターフェースの場合のみ使用されます。"
@@ -9347,8 +9532,8 @@ msgstr "クラスパラメーター値が Foreman によって管理されてい
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "スマートクラスパラメーター値が Foreman によって管理されているかどうか"
 
-msgid "Whether to get RSS notifications or not"
-msgstr "RSS 通知を取得するかどうか"
+msgid "Whether to pull RSS notifications or not"
+msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
 msgstr "<b>%s</b> のオフセットはどれか"
@@ -9432,6 +9617,9 @@ msgstr "テンプレートをデフォルトにする権限がありません。
 
 msgid "You are not authorized to perform this action."
 msgstr "このアクションを実行する権限がありません。"
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "ご自身のアカウントを削除しようとしています"
@@ -9625,6 +9813,9 @@ msgstr "内部で保護されたアカウントから削除できません"
 msgid "cannot be removed from the last admin account"
 msgstr "最後の管理者アカウントから削除できません"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "クローン"
 
@@ -9742,6 +9933,9 @@ msgstr "%s ロールのフィルター"
 msgid "filter results"
 msgstr "結果のフィルター"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "EC2 の場合のみ"
 
@@ -9756,6 +9950,9 @@ msgstr "OpenStack の場合のみ"
 
 msgid "for VMware"
 msgstr "VMware の場合"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "oVirt、VMware Datacenter の場合"
@@ -9907,8 +10104,8 @@ msgstr "有効な SSH 公開キーではありません"
 msgid "is not allowed to change"
 msgstr "変更することができません"
 
-msgid "is not defined for host's %s."
-msgstr "ホストの %s に定義されていません。"
+msgid "is not defined for host's %s"
+msgstr ""
 
 msgid "is not found in the authentication source"
 msgstr "認証ソースに見つかりません"
@@ -9950,8 +10147,7 @@ msgstr "外部ユーザーグループをこのユーザーグループにリン
 msgid "list"
 msgstr "list"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "日本語"
 
@@ -9960,6 +10156,12 @@ msgstr "ロケーション"
 
 msgid "locations"
 msgstr "ロケーション"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "管理対象ホストには 1  つのプロビジョンインターフェースが必要です"
@@ -10023,6 +10225,9 @@ msgstr "プロバイダーを指定する必要があります"
 
 msgid "must set host and port"
 msgstr "ホストとポートを設定する必要があります"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "新規"
@@ -10219,9 +10424,6 @@ msgstr "一部のインターフェースが無効です"
 msgid "some permissions were not found"
 msgstr "一部のパーミッションが見つかりませんでした"
 
-msgid "sort results"
-msgstr "結果のソート"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "スペース区切りのオプション (例: miimon=100)"
 
@@ -10323,6 +10525,9 @@ msgstr "有効な"
 msgid "valid or pending"
 msgstr "有効または保留"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr "最終レポートの詳細の表示"
 
@@ -10331,6 +10536,9 @@ msgstr "仮想"
 
 msgid "virtual attached to %s"
 msgstr "%s に接続された仮想"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/ko/foreman.po
+++ b/locale/ko/foreman.po
@@ -23,7 +23,10 @@ msgstr "삭제 "
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -80,6 +83,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s이(가) VM에서 연결 해제되었습니다 "
 
@@ -104,6 +110,9 @@ msgstr[0] "%s 분 전 "
 msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s 개월 전 "
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s 선택된 호스트 "
@@ -261,6 +270,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s'는 POST 및 PUT 요청의 API v2에서 지원되지 않습니다. 'Content-Type: application/json'을 사용하십시오. "
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(기타)"
@@ -445,9 +459,6 @@ msgstr "매개 변수 추가 "
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -523,6 +534,12 @@ msgstr "관리자 이메일 주소"
 msgid "Administrator user account required"
 msgstr "관리자의 사용자 계정 필요"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "경고 "
 
@@ -537,9 +554,6 @@ msgstr "모두"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "%s의 전체 Puppet 클래스 "
 
 msgid "All Reports"
 msgstr "전체 보고서 "
@@ -797,6 +811,12 @@ msgstr "감사 "
 
 msgid "Audit Comment"
 msgstr "감사 코멘트 "
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "감사 요약"
@@ -1108,14 +1128,26 @@ msgstr "브라우저 시간대"
 msgid "Build"
 msgstr "빌드 "
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "호스트 빌드 "
 
 msgid "Build PXE Default"
 msgstr "PXE 기본값 빌드 "
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "OS 이미지에서 빌드 "
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1246,6 +1278,9 @@ msgstr "변경된 환경 "
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "섀시 "
 
@@ -1291,6 +1326,12 @@ msgstr "클래스 "
 msgid "Clean up failed deployment"
 msgstr "실패한 배포 정리"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "기본값 VM 속성을 편집하기 위해 컴퓨팅 리소스 링크를 클릭합니다. "
 
@@ -1299,9 +1340,6 @@ msgstr "클릭하여 %s 추가 "
 
 msgid "Click to log in again."
 msgstr "클릭하여 다시 로그인합니다."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "클릭하여 %s 삭제 "
@@ -1422,6 +1460,10 @@ msgstr "설명 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1671,6 +1713,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1794,6 +1839,9 @@ msgstr "스마트 변수 생성 "
 msgid "Create a subnet"
 msgstr "서브넷 생성 "
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "사용자 생성 "
 
@@ -1833,6 +1881,9 @@ msgstr "특정 스마트 매개 변수의 덮어쓰기 값 생성 "
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "이미지의 새 부팅 볼륨 생성"
 
@@ -1847,6 +1898,9 @@ msgstr "%s의 영역 항목 생성 "
 
 msgid "Created"
 msgstr "생성 일시 "
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2022,9 +2076,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "호스트 삭제 "
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "%s의 PuppetCA 인증서 삭제 "
 
@@ -2118,8 +2169,14 @@ msgstr "스마트 변수 삭제 "
 msgid "Delete a subnet"
 msgstr "서브넷 삭제 "
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "템플릿 조합 삭제 "
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "사용자 삭제 "
@@ -2259,10 +2316,16 @@ msgstr "다른점 표시 "
 msgid "Disable Notifications"
 msgstr "통지 비활성화 "
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "선택한 호스트의 통지 비활성화 "
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2393,47 +2456,11 @@ msgstr "편집 "
 msgid "Edit %s"
 msgstr "%s 편집 "
 
-msgid "Edit Architecture"
-msgstr "아키텍처 편집 "
-
-msgid "Edit Bookmark"
-msgstr "북마크 편집 "
-
 msgid "Edit Compute profile"
 msgstr "컴퓨터 프로파일 편집 "
 
-msgid "Edit Compute profile: %s"
-msgstr "컴퓨터 프로파일 편집: %s"
-
-msgid "Edit Config group"
-msgstr "설정 그룹 편집 "
-
-msgid "Edit Domain"
-msgstr "도메인 편집 "
-
-msgid "Edit Environment"
-msgstr "환경 편집 "
-
-msgid "Edit Filter"
-msgstr "필터 편집 "
-
-msgid "Edit Global Parameter"
-msgstr "글로벌 매개 변수 편집 "
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "호스트 편집 "
-
-msgid "Edit LDAP Auth Source"
-msgstr "LDAP 인증 소스 편집 "
-
-msgid "Edit Medium"
-msgstr "미디어 편집 "
-
-msgid "Edit Model"
-msgstr "모델 편집 "
 
 msgid "Edit Operating System"
 msgstr "운영 체제 편집 "
@@ -2441,23 +2468,11 @@ msgstr "운영 체제 편집 "
 msgid "Edit Parameters"
 msgstr "매개 변수 편집 "
 
-msgid "Edit Partition Table"
-msgstr "파티션 테이블 편집 "
-
 msgid "Edit Properties"
 msgstr "속성 편집"
 
-msgid "Edit Proxy"
-msgstr "프록시 편집 "
-
 msgid "Edit Puppet Class %s"
 msgstr "Puppet 클래스 %s 편집 "
-
-msgid "Edit Realm"
-msgstr "영역 편집 "
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "스마트 변수 편집 "
@@ -2465,23 +2480,8 @@ msgstr "스마트 변수 편집 "
 msgid "Edit Smart class parameters"
 msgstr "스마트 클래스 매개 변수 편집"
 
-msgid "Edit Subnet"
-msgstr "서브넷 편집 "
-
-msgid "Edit Template"
-msgstr "템플릿 수정"
-
 msgid "Edit Trend %s"
 msgstr "트렌드 %s 편집 "
-
-msgid "Edit User"
-msgstr "사용자 편집 "
-
-msgid "Edit User group"
-msgstr "사용자 그룹 편집 "
-
-msgid "Edit compute profile on %s"
-msgstr "%s 상의 컴퓨터 프로파일 편집 "
 
 msgid "Edit this host"
 msgstr ""
@@ -2512,6 +2512,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "통지 활성화 "
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "선택한 호스트의 통지 활성화 "
@@ -2633,6 +2636,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2757,11 +2769,11 @@ msgstr "정보 이름 "
 msgid "Fact Values"
 msgstr "정보 값 "
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "팩트 배포 차트"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2821,6 +2833,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "다시 시작 실패 "
 
@@ -2832,9 +2847,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "이전 인증서 삭제 실패 또는 자동 서명 항목 추가에 실패했습니다. 빌드를 종료합니다!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "%{device}에서 부팅하도록 %{host} 설정에 실패했습니다: %{e}"
@@ -3017,11 +3029,11 @@ msgstr "필터 클래스 "
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "필터"
-
-msgid "Filters for role %s"
-msgstr "%s 역할에 대한 필터"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3134,6 +3146,9 @@ msgstr "Foreman은 사용자 정보 및 인증을 위해 LDAP 기반 서비스�
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman은 도메인과 DNS 영역을 같은 것으로 인식합니다."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "인터페이스의 Foreman 도메인 ID입니다. 관리형 호스트의 기본 인터페이스에 필요합니다."
 
@@ -3176,6 +3191,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman은 새 호스트의 프로비저닝에서 인증서 서명을 자동화합니다 "
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman은 보고서를 수신할 때 호스트를 생성합니다 "
 
@@ -3214,9 +3232,6 @@ msgstr "Foreman은 SOA/NS 권한 대신 로컬 설정 분석기를 쿼리합니�
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman은 자동 감지하지 못할 경우 이를 기본값 Puppet 모듈 경로로 설정합니다 "
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman은 puppet으로 시작할 경우 호스트 이름을 'puppet'으로 자릅니다 "
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman은 정보에서 호스트 환경을 업데이트합니다 "
@@ -3341,6 +3356,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "지난 %s의 호스트 보고서 "
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "글로벌 프로젝트 ID"
 
@@ -3366,6 +3384,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3400,6 +3421,9 @@ msgstr ""
 
 msgid "Hide all values for this parameter."
 msgstr "이 매개 변수의 값을 모두 숨깁니다."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "이 값 숨기기"
@@ -3510,6 +3534,10 @@ msgid "Host::Base|Build"
 msgstr "빌드 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "인증서 이름 "
 
@@ -3536,6 +3564,10 @@ msgstr "Grub 경로 "
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "이미지 파일 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3672,6 +3704,12 @@ msgstr "puppet 실행 후 생성되는 호스트는 정보가 정하는 위치�
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "puppet 실행 후 생성되는 호스트는 이 정보가 정하는 조직에 배치됩니다. 이러한 정보의 내용은 조직 전체 레이블이 되어야 합니다."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "오류 상태에 있는 호스트 "
@@ -4157,6 +4195,9 @@ msgstr "입력"
 msgid "Installation Media"
 msgstr "설치 미디어 "
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "설치 미디어 설정 "
 
@@ -4341,9 +4382,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "설명서에서 자세한 내용을 참조하십시오."
 
-msgid "Legacy Puppet hostname"
-msgstr "레거시 Puppet 호스트 이름"
-
 msgid "Length"
 msgstr ""
 
@@ -4406,6 +4444,15 @@ msgstr "모든 감사를 나열 "
 
 msgid "List all audits for a given host"
 msgstr "지정된 호스트의 모든 감사를 나열 "
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "모든 자동 서명 항목 나열 "
@@ -4572,6 +4619,9 @@ msgstr "모든 사용자 나열 "
 msgid "List all users for LDAP authentication source"
 msgstr "LDAP 인증 소스에 대한 모든 사용자 나열 "
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "위치에 대한 모든 사용자 나열 "
 
@@ -4632,6 +4682,15 @@ msgstr "위치 별 환경 나열 "
 msgid "List environments per organization"
 msgstr "조직 별 환경 나열 "
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "환경 별 호스트 나열 "
 
@@ -4643,6 +4702,9 @@ msgstr "조직 별 호스트 나열 "
 
 msgid "List installed plugins"
 msgstr "설치된 플러그인 나열 "
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4718,6 +4780,15 @@ msgstr "위치별 서브넷 목록"
 
 msgid "List of subnets per organization"
 msgstr "조직별 서브넷 목록"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "템플릿이 기본값으로 설정되는 운영 체제를 나열 "
@@ -4957,6 +5028,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "시스템 유형 "
 
@@ -5153,6 +5236,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr "필요한 권한 중 하나가 없습니다: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "모델 "
@@ -5233,6 +5319,9 @@ msgstr "호스트 그룹의 이름"
 msgid "Name of the parameter"
 msgstr "매개 변수의 이름"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "변수 이름"
 
@@ -5275,14 +5364,11 @@ msgstr "네트워크 유형 "
 msgid "New"
 msgstr "신규"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "새 자동 서명 항목 "
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5304,9 +5390,6 @@ msgstr "새 가상 머신 "
 
 msgid "New boot volume size (GB)"
 msgstr "새 부팅 볼륨 크기(GB)"
-
-msgid "New compute profile on %s"
-msgstr "%s의 새 컴퓨터 프로파일 "
 
 msgid "New filter"
 msgstr "새 필터 "
@@ -5332,6 +5415,10 @@ msgstr "본드 옵션 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5406,10 +5493,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6133,9 +6223,6 @@ msgstr ""
 msgid "Password"
 msgstr "암호 "
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "oVirt, EC2, VMware, OpenStack의 암호. EC2의 비밀 키"
 
@@ -6159,6 +6246,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "암호:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "경로"
@@ -6431,13 +6521,18 @@ msgstr "ProvisioningTemplate|이름"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "ProvisioningTemplate|조각 모음"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "프록시 "
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6742,6 +6837,9 @@ msgstr "보고 "
 msgid "Report|Status"
 msgstr "상태 "
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "스마트 프록시에 대해 SSL 요구"
 
@@ -6749,6 +6847,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr "필수 매개 변수에 값이 없습니다.<br/><b>덮어쓰십시오.</b><br/>"
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7013,9 +7114,6 @@ msgstr "서브넷의 2차 DNS "
 msgid "Secret Key"
 msgstr "비밀 키 "
 
-msgid "Security group"
-msgstr "보안 그룹 "
-
 msgid "Security groups"
 msgstr "보안 그룹 "
 
@@ -7174,7 +7272,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "디스플레이 연결 시 임의로 생성된 암호를 설정합니다"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7363,6 +7461,9 @@ msgstr "스마트 변수 표시 "
 msgid "Show a subnet"
 msgstr "서브넷 표시"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "사용자 표시 "
 
@@ -7396,6 +7497,9 @@ msgstr "이메일 통지 표시"
 msgid "Show an environment"
 msgstr "환경 표시 "
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "LDAP 인증 소스에 대한 모든 외부 사용자 그룹 표시 "
 
@@ -7407,6 +7511,9 @@ msgstr "이미지 보기 "
 
 msgid "Show an interface for host"
 msgstr "호스트의 인터페이스 표시 "
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "운영 체제 표시 "
@@ -7489,9 +7596,6 @@ msgstr "스마트 프록시 "
 msgid "Smart Proxy"
 msgstr "스마트 프록시 "
 
-msgid "Smart Proxy: %s"
-msgstr "스마트 프록시: %s"
-
 msgid "Smart Variables"
 msgstr "스마트 매개 변수 "
 
@@ -7505,6 +7609,9 @@ msgstr "스마트 프록시 "
 msgid "Smart proxy IDs"
 msgstr "스마트 프록시 ID "
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7517,11 +7624,18 @@ msgid "SmartProxy|Name"
 msgstr "이름 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "Url"
 
 msgid "Snippet"
 msgstr "조각 모음 "
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7555,6 +7669,9 @@ msgstr "죄송합니다. 설정된 템플릿이 없습니다. "
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "죄송합니다. 이 호스트에 할당된 매개 변수가 없습니다. 먼저 매개 변수를 추가해야 합니다. "
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7661,6 +7778,9 @@ msgstr "서브넷 ID "
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "서브넷 이름 "
 
@@ -7704,6 +7824,10 @@ msgstr "Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "마스크 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7825,6 +7949,21 @@ msgid "TFTP server"
 msgstr "TFTP 서버"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "분류 텍소노미  "
 
@@ -7927,6 +8066,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7936,6 +8087,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8370,6 +8525,9 @@ msgstr "토글 "
 msgid "Token"
 msgstr "토큰 "
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "토큰 기간"
 
@@ -8433,7 +8591,7 @@ msgstr "트렌드 "
 msgid "Trends for %s"
 msgstr "%s의 트렌드 "
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8532,6 +8690,9 @@ msgstr "연결할 수 없음"
 
 msgid "Unable to connect to LDAP server"
 msgstr "LDAP 서버에 연결할 수 없습니다."
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "기본값 TFTP 부트 메뉴를 생성할 수 없습니다 "
@@ -8743,6 +8904,12 @@ msgstr "관리되지 않는 호스트 "
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8872,6 +9039,9 @@ msgstr "아키텍처 업데이트 "
 msgid "Update an environment"
 msgstr "환경 업데이트 "
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "이미지 업데이트 "
 
@@ -8923,8 +9093,14 @@ msgstr "업데이트된 호스트: 변경된 호스트 그룹 "
 msgid "Updated hosts: changed owner"
 msgstr "업데이트된 호스트: 변경된 소유자"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "호스트의 팩트를 업로드하고 필요한 경우 호스트를 생성합니다 "
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8934,6 +9110,9 @@ msgstr "인증서에 UUID 사용"
 
 msgid "Use short name for VMs"
 msgstr "VM에 약어 사용"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "인증을 위해 이 계정을 사용합니다. <i>옵션</i>"
@@ -8959,6 +9138,9 @@ msgstr "사용자 그룹"
 
 msgid "User IDs"
 msgstr "사용자 ID"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr ""
@@ -9110,6 +9292,9 @@ msgstr "VCenter/서버"
 
 msgid "VLAN ID for this subnet"
 msgstr "서브넷의 VLAN ID"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN 태그입니다. 이 속성은 서브넷 VLAN ID 보다 우선합니다. 가상 인터페이스의 경우에만 사용됩니다. "
@@ -9326,7 +9511,7 @@ msgstr "클래스 매개 변수 값을 Foreman에서 관리하는지 여부"
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "스마트 클래스 매개 변수 값을 Foreman에서 관리하는지 여부"
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9411,6 +9596,9 @@ msgstr "템플릿을 기본 템플릿으로 설정할 권한이 없습니다."
 
 msgid "You are not authorized to perform this action."
 msgstr "이 작업을 수행할 권한이 없습니다."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "자신의 계정을 삭제하려 하고 있습니다 "
@@ -9604,6 +9792,9 @@ msgstr "내부적으로 보안된 계정에서 삭제할 수 없습니다 "
 msgid "cannot be removed from the last admin account"
 msgstr "마지막 관리 계정에서 삭제할 수 없음 "
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "복제 "
 
@@ -9721,6 +9912,9 @@ msgstr "%s 역할 필터 "
 msgid "filter results"
 msgstr "필터 결과 "
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "EC2의 경우에만"
 
@@ -9735,6 +9929,9 @@ msgstr "OpenStack만 해당"
 
 msgid "for VMware"
 msgstr "VMware의 경우"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "oVirt, VMware Datacenter의 경우"
@@ -9886,7 +10083,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "변경할 수 없음 "
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9928,8 +10125,7 @@ msgstr "외부 사용자 그룹이 이 사용자 그룹에 연결되어 있습�
 msgid "list"
 msgstr "목록"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "한국어"
 
@@ -9938,6 +10134,12 @@ msgstr "위치 "
 
 msgid "locations"
 msgstr "위치 "
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "관리되는 호스트에 프로비저닝 인터페이스가 1개 필요합니다."
@@ -10001,6 +10203,9 @@ msgstr "공급자를 지정해야 합니다 "
 
 msgid "must set host and port"
 msgstr "호스트 및 포트를 설정해야 합니다 "
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "새"
@@ -10197,9 +10402,6 @@ msgstr "일부 인터페이스가 유효하지 않습니다."
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "결과 정렬 "
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "공백으로 구분된 옵션 (예: miimon=100)"
 
@@ -10301,6 +10503,9 @@ msgstr "유효함"
 msgid "valid or pending"
 msgstr "유효 또는 보류 중"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10309,6 +10514,9 @@ msgstr "가상"
 
 msgid "virtual attached to %s"
 msgstr "%s에 연결된 가상 머신"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/model_attributes.rb
+++ b/locale/model_attributes.rb
@@ -99,6 +99,8 @@ _('ComputeResource|Description')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('ComputeResource|Domain')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('ComputeResource|Filtered api')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('ComputeResource|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('ComputeResource|Password')
@@ -155,6 +157,8 @@ _('Filter|Taxonomy search')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Build')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Host::Base|Build errors')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Certname')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Comment')
@@ -168,6 +172,8 @@ _('Host::Base|Global status')
 _('Host::Base|Grub pass')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Image file')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Host::Base|Initiated at')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Installed at')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -357,6 +363,8 @@ _('Nic::Base|Bond options')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Nic::Base|Compute attributes')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Nic::Base|Execution')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Nic::Base|Identifier')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Nic::Base|Ip')
@@ -517,6 +525,8 @@ _('SmartProxy|Expired logs')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('SmartProxy|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('SmartProxy|Pubkey')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('SmartProxy|Url')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Source')
@@ -553,6 +563,8 @@ _('Subnet|Ipam')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Mask')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Subnet|Mtu')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Network')
@@ -562,6 +574,12 @@ _('Subnet|Priority')
 _('Subnet|To')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Vlanid')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Table preference')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('TablePreference|Columns')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('TablePreference|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Taxable taxonomy')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -583,11 +601,19 @@ _('Template')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Default')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Template|Description format')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Template|Execution timeout interval')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Template|Job category')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Locked')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Os family')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Template|Provider type')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Snippet')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages

--- a/locale/pl/foreman.po
+++ b/locale/pl/foreman.po
@@ -27,7 +27,10 @@ msgstr "Usuń"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -92,6 +95,9 @@ msgstr[1] "%s wiadomości o błędach"
 msgstr[2] "%s wiadomości o błędach"
 msgstr[3] "%s wiadomości o błędach"
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s został wyodrębniony z VM"
 
@@ -124,6 +130,9 @@ msgstr[0] "%s miesiąc temu"
 msgstr[1] "%s miesięcy temu"
 msgstr[2] "%s miesięcy temu"
 msgstr[3] "%s miesięcy temu"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s wybranych hostów"
@@ -293,6 +302,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "\"Content-Type: %s' nie jest obsługiwany w API v2 dla żądań POST i PUT. Proszę użyć 'Content-Type: application / json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Różne)"
@@ -480,9 +494,6 @@ msgstr "Dodaj parametr"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -558,6 +569,12 @@ msgstr "Adres e-mail administratora"
 msgid "Administrator user account required"
 msgstr "Wymagane konto administratora"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alarm"
 
@@ -572,9 +589,6 @@ msgstr "Wszystkie"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Wszystkie klasy Puppet dla %s"
 
 msgid "All Reports"
 msgstr "Wszystkie raporty"
@@ -835,6 +849,12 @@ msgstr ""
 
 msgid "Audit Comment"
 msgstr "Komentarz do audytu"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Audyt podsumowania"
@@ -1146,14 +1166,26 @@ msgstr "strefa czasowa przeglądarki "
 msgid "Build"
 msgstr "Zbuduj"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Budowanie hostów"
 
 msgid "Build PXE Default"
 msgstr "Domyślnie zbuduj PXE"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Zbuduj z obrazu systemu"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1284,6 +1316,9 @@ msgstr "Zmieniono środowisko"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Rama"
 
@@ -1329,6 +1364,12 @@ msgstr "Klasy"
 msgid "Clean up failed deployment"
 msgstr "Wyczyść nieudane wdrożenie"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Kliknij na link zasobu obliczeniowego aby edytować swoje domyślne atrybuty VM."
 
@@ -1337,9 +1378,6 @@ msgstr "Kliknij, aby dodać %s"
 
 msgid "Click to log in again."
 msgstr "Kliknij, aby zalogować się ponownie."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Kliknij, aby usunąć %s"
@@ -1460,6 +1498,10 @@ msgstr "ZasóbObliczeniowy|Opis"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1709,6 +1751,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1832,6 +1877,9 @@ msgstr "Tworzenie zmiennej inteligentnych"
 msgid "Create a subnet"
 msgstr "Tworzenie podsieci"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Tworzenie użytkownika"
 
@@ -1871,6 +1919,9 @@ msgstr "Utwórz wartość nadpisaną dla określanej smart variable"
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Utwórz nowy nośnik bootowania z obrazu"
 
@@ -1884,6 +1935,9 @@ msgid "Create realm entry for %s"
 msgstr "Tworzenie wpisu o domenie dla %s"
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2060,9 +2114,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Usuń hosty"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Usuń certyfikaty PuppetCA dla %s"
 
@@ -2156,8 +2207,14 @@ msgstr "Usuń zmienną inteligentną"
 msgid "Delete a subnet"
 msgstr "Usuń podsieć"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Usuń połączenie szablonu"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Usuń użytkownika"
@@ -2297,10 +2354,16 @@ msgstr "Zobacz zmiany"
 msgid "Disable Notifications"
 msgstr "Wyłącz powiadomienia"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Wyłącz powiadomienia dla wybranych hostów"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2433,47 +2496,11 @@ msgstr "Edytuj"
 msgid "Edit %s"
 msgstr "Edytuj %s"
 
-msgid "Edit Architecture"
-msgstr "Edytuj architekturę"
-
-msgid "Edit Bookmark"
-msgstr "Edytuj zakładkę"
-
 msgid "Edit Compute profile"
 msgstr "Edytuj profil obliczeń"
 
-msgid "Edit Compute profile: %s"
-msgstr "Edytuj profil obliczeń: %s"
-
-msgid "Edit Config group"
-msgstr "Edytuj grupy konfiguracji"
-
-msgid "Edit Domain"
-msgstr "Edytuj domenę"
-
-msgid "Edit Environment"
-msgstr "Edytuj środowisko"
-
-msgid "Edit Filter"
-msgstr "Edytuj filtr"
-
-msgid "Edit Global Parameter"
-msgstr "Edytuj parametry globalne"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "Edytuj host"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Edytuj źródło uwierzytelniania LDAP"
-
-msgid "Edit Medium"
-msgstr "Edytuj nośnik"
-
-msgid "Edit Model"
-msgstr "Edytuj model"
 
 msgid "Edit Operating System"
 msgstr "Edytuj system operacyjny"
@@ -2481,23 +2508,11 @@ msgstr "Edytuj system operacyjny"
 msgid "Edit Parameters"
 msgstr "Edytuj parametry"
 
-msgid "Edit Partition Table"
-msgstr "Edytuj tablice partcji"
-
 msgid "Edit Properties"
 msgstr "Edytuj właściwości"
 
-msgid "Edit Proxy"
-msgstr "Edytuj Proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Edytuj klasę Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Edytuj domenę"
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "Edytuj Smart Variable"
@@ -2505,23 +2520,8 @@ msgstr "Edytuj Smart Variable"
 msgid "Edit Smart class parameters"
 msgstr "Edycja parametrów inteligentnych klas"
 
-msgid "Edit Subnet"
-msgstr "Edytuj podsieć"
-
-msgid "Edit Template"
-msgstr "Edytuj szablon"
-
 msgid "Edit Trend %s"
 msgstr "Edytuj trend %s"
-
-msgid "Edit User"
-msgstr "Edytuj użytkownika"
-
-msgid "Edit User group"
-msgstr "Edytuj grupę użytkowników"
-
-msgid "Edit compute profile on %s"
-msgstr "Edytuj profil obliczeń na %s"
 
 msgid "Edit this host"
 msgstr ""
@@ -2552,6 +2552,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Włącz powiadomienia"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Włącz powiadomienia dla wybranych hostów"
@@ -2673,6 +2676,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2797,11 +2809,11 @@ msgstr "Nazwa faktu"
 msgid "Fact Values"
 msgstr "Wartości faktów"
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "wykres rozkładu zdarzeń"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2863,6 +2875,9 @@ msgstr[1] "Nieudanych funkcji: %s"
 msgstr[2] "Nieudanych funkcji: %s"
 msgstr[3] "Nieudanych funkcji: %s"
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Nieudany restart"
 
@@ -2874,9 +2889,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Nie udało się wyczyścić wszystkich starych certyfikatów lub dodać autosign.  Zakończenie budowania!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Nie udało się skonfigurować %{host} aby urchomić z urządzenia %{device}: %{e}"
@@ -3057,11 +3069,11 @@ msgstr "Filtruj klasy"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtry"
-
-msgid "Filters for role %s"
-msgstr "Filtry mające za zadanie: %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3174,6 +3186,9 @@ msgstr "Foreman może używać LDAP bazując na na informacji o użytkownikach i
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman uważa że domena i strefa DNS są tym samym."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "ID domeny interfejsu Foremana. Wymagany dla pierwszego interfejsu zarządzanego hostu"
 
@@ -3216,6 +3231,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman będzie automatycznie podpisywać certyfikaty po złożeniu nowego hosta"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman stworzy hosta po otrzymaniu raportu"
 
@@ -3254,9 +3272,6 @@ msgstr "Foreman będzie pytał lokalnie skonfigurowane narzędzie rozpoznawania 
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman będzie ustawiony jako domyślna ścieżka modułu Puppet jeśli automatycznie nie wykryje innego"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman obetnie nazwę hosta do \"puppet\", jeśli zaczyna się od puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman będzie aktualizować środowisko hosta od jej Informacji"
@@ -3381,6 +3396,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Dobre raporty hostów w ciągu ostatnich %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3406,6 +3424,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3440,6 +3461,9 @@ msgstr ""
 
 msgid "Hide all values for this parameter."
 msgstr "Ukryj wszystkie wartości dla tego parametru."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Ukryj wartość"
@@ -3550,6 +3574,10 @@ msgid "Host::Base|Build"
 msgstr "Host::Base|Build"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Host::Base|NazwaCertyfikatu"
 
@@ -3576,6 +3604,10 @@ msgstr "Host::Base|Hasło Grub"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Host::Base|Obraz pliku"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3712,6 +3744,12 @@ msgstr "Hosty utworzone po przebiegu puppet zostaną umieszczone w miejscu,któr
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Hosty utworzone po przebiegu puppet zostaną umieszczone w organizacji która ten fakt narzuca. Zawartością tego faktu powinna być pełna etykieta organizacji."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Hosty zgłaszające błędy"
@@ -4197,6 +4235,9 @@ msgstr "Wejście"
 msgid "Installation Media"
 msgstr "Nośniki instalacyjne"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Konfiguracja instalacji nośnika"
 
@@ -4381,9 +4422,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "Dowiedz się więcej na ten temat w dokumentacji."
 
-msgid "Legacy Puppet hostname"
-msgstr "Dziedzictwo hosta Puppet "
-
 msgid "Length"
 msgstr ""
 
@@ -4446,6 +4484,15 @@ msgstr "Lista wszystkich kontroli"
 
 msgid "List all audits for a given host"
 msgstr "Lista wszystkich kontroli dla danego hosta"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Lista wszystkich podpisanych przez siebie wpisów"
@@ -4612,6 +4659,9 @@ msgstr "Lista wszystkich użytkowników"
 msgid "List all users for LDAP authentication source"
 msgstr "Lista wszystkich użytkowników do źródła uwierzytelniania LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Lista wszystkich użytkowników do lokalizacji"
 
@@ -4672,6 +4722,15 @@ msgstr "Lista środowisk na lokalizację"
 msgid "List environments per organization"
 msgstr "Lista środowisk na organizację"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Lista hostów na środowisko"
 
@@ -4683,6 +4742,9 @@ msgstr "Lista hostów na organizację"
 
 msgid "List installed plugins"
 msgstr "Lista zainstalowanych wtyczek"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4758,6 +4820,15 @@ msgstr "Lista podsieci w danej lokalizacji"
 
 msgid "List of subnets per organization"
 msgstr "Lista podsieci na organizację"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Lista systemów operacyjnych, gdzie ten szablon jest ustawiony jako domyślny"
@@ -4997,6 +5068,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Typ Maszyny"
 
@@ -5193,6 +5276,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr "Brakuje jednego z wymaganych zezwoleń: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Model"
@@ -5273,6 +5359,9 @@ msgstr "Nazwa grupy hostów"
 msgid "Name of the parameter"
 msgstr "Nazwa parametru"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Nazwa zmiennej"
 
@@ -5315,14 +5404,11 @@ msgstr "Typ sieci"
 msgid "New"
 msgstr "Nowy"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nowe wejście dla autosign"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5344,9 +5430,6 @@ msgstr "Nowa Maszyna Wirtualna"
 
 msgid "New boot volume size (GB)"
 msgstr "Nowy rozmiar nośnika bootowania (GB) "
-
-msgid "New compute profile on %s"
-msgstr "Nowy profil obliczeń na %s"
 
 msgid "New filter"
 msgstr "Nowy filtr"
@@ -5372,6 +5455,10 @@ msgstr "Nic::Base|Bond options"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5446,10 +5533,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6173,9 +6263,6 @@ msgstr ""
 msgid "Password"
 msgstr "Hasło"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Hasło dla oVirt, EC2, VMware, OpenStack. Klucz prywatny dla EC2"
 
@@ -6199,6 +6286,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "Hasło:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Ścieżka"
@@ -6471,13 +6561,18 @@ msgstr "SzablonDostawy|Nazwa"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "SzablonDostawy|Snippet"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Proxies"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6782,6 +6877,9 @@ msgstr "Raport|Zgłoszone w "
 msgid "Report|Status"
 msgstr "Report|Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "Wymagane SSL dla smart proxies"
 
@@ -6789,6 +6887,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr "Wymagany parametr nie ma wartości.<br/><b>Proszę nadpisać!</b><br/>"
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7053,9 +7154,6 @@ msgstr "Secondary DNS dla danej podsieci"
 msgid "Secret Key"
 msgstr "Sekretny klucz"
 
-msgid "Security group"
-msgstr "Grupa zabezpieczeń"
-
 msgid "Security groups"
 msgstr "Grupy zabezpieczeń"
 
@@ -7214,7 +7312,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "Ustaw losowo wygenerowane hasło na wyświetlacz połączenia"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7403,6 +7501,9 @@ msgstr "Pokaż zmienną inteligentną"
 msgid "Show a subnet"
 msgstr "Pokaż podsieć"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Pokaż użytkownika"
 
@@ -7436,6 +7537,9 @@ msgstr "Pokaż mailowe powiadomienia"
 msgid "Show an environment"
 msgstr "Pokaż środowisko"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Pokaż zewnętrzną grupę użytkowników dla źródła uwierzytelniania LDAP"
 
@@ -7447,6 +7551,9 @@ msgstr "Pokaż obraz"
 
 msgid "Show an interface for host"
 msgstr "Pokaż interfejs dla hosta"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Pokaż system operacyjny"
@@ -7529,9 +7636,6 @@ msgstr "Smart Proxies"
 msgid "Smart Proxy"
 msgstr "Inteligentne proxy"
 
-msgid "Smart Proxy: %s"
-msgstr "Smart Proxy: %s"
-
 msgid "Smart Variables"
 msgstr "Smart Variables"
 
@@ -7545,6 +7649,9 @@ msgstr "Smart proxy"
 msgid "Smart proxy IDs"
 msgstr "ID inteligentnych proxy"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7557,11 +7664,18 @@ msgid "SmartProxy|Name"
 msgstr "InteligentneProxy|Nazwa"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "InteligentneProxy|URL"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7595,6 +7709,9 @@ msgstr "Przepraszamy, ale nie ma żadnych skonfigurowanych szablonów."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Niestety, te hosty nie mają parametrów przypisanych do nich, należy dodać je w pierwszej kolejności."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7701,6 +7818,9 @@ msgstr "ID podsieci"
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nazwa podsieci"
 
@@ -7744,6 +7864,10 @@ msgstr "Podsieć|IPAM"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Podsieć|Maska"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7865,6 +7989,21 @@ msgid "TFTP server"
 msgstr "Serwer TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxable taxonomy"
 
@@ -7967,6 +8106,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7976,6 +8127,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8413,6 +8568,9 @@ msgstr "Przełącznik"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Czas trwania tokenu"
 
@@ -8478,7 +8636,7 @@ msgstr "Trendy"
 msgid "Trends for %s"
 msgstr "Tendencje dla %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8577,6 +8735,9 @@ msgstr "Nie udało się połączyć"
 
 msgid "Unable to connect to LDAP server"
 msgstr "Nie można połączyć się z serwerem LDAP"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Nie można utworzyć domyślnego menu bootowania TFTP"
@@ -8788,6 +8949,12 @@ msgstr "niezarządzany host"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8917,6 +9084,9 @@ msgstr "Zaktualizuj architekturę"
 msgid "Update an environment"
 msgstr "Edytuj środowisko"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Aktualizuj obraz"
 
@@ -8968,8 +9138,14 @@ msgstr "Zaktualizowane hosty: Zmieniono grupę hostów"
 msgid "Updated hosts: changed owner"
 msgstr "Zaktualizowano hosty: zmieniono właściciela"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Wyślij informacje dla hosta, tworząc go w razie potrzeby"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8979,6 +9155,9 @@ msgstr "Użyj UUID dla certyfikatów"
 
 msgid "Use short name for VMs"
 msgstr "Użyj skróconej nazwy dla maszyn wirtualnych"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Użyj tego konta w celu uwierzytelnienia, <i> opcjonalne </i>"
@@ -9004,6 +9183,9 @@ msgstr "Grupy użytkowników"
 
 msgid "User IDs"
 msgstr "identyfikatory użytkowników"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr ""
@@ -9155,6 +9337,9 @@ msgstr "VCenter/Serwer"
 
 msgid "VLAN ID for this subnet"
 msgstr "VLAN ID dla tej podsieci"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN tag, ten atrybut ma pierwszeństwo przed podsiecią VLAN ID. tylko dla wirtualnych interfejsów."
@@ -9371,7 +9556,7 @@ msgstr "Czy wartość parametru klasy jest zarządzana przez Foremana."
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Czy inteligentna wartość parametru klasy jest zarządzana przez Foreman"
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9456,6 +9641,9 @@ msgstr "Nie masz wystarczających uprawnień, aby ustawić szablon jako domyśln
 
 msgid "You are not authorized to perform this action."
 msgstr "Nie masz wystarczających uprawnień, aby wykonać tą akcję."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Próbujesz usunąć własne konto"
@@ -9649,6 +9837,9 @@ msgstr "nie można usunąć z wewnętrznie chronionego konta"
 msgid "cannot be removed from the last admin account"
 msgstr "nie mogą zostać usunięte z ostatniego konta administratora"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "Klonuj"
 
@@ -9766,6 +9957,9 @@ msgstr "filtruj by znaleźć %s rolę"
 msgid "filter results"
 msgstr "rezultat filtrowania"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "tylko dla EC2"
 
@@ -9780,6 +9974,9 @@ msgstr "tylko dla OpenStack"
 
 msgid "for VMware"
 msgstr "dla VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "dla oVirt, VMware Datacenter"
@@ -9931,7 +10128,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "Nie może zostać zmieniony"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9978,8 +10175,7 @@ msgstr "Link zewnętrzny grupy użytkowników z tej grupy użytkowników"
 msgid "list"
 msgstr "list"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -9988,6 +10184,12 @@ msgstr "lokalizacja"
 
 msgid "locations"
 msgstr "lokalizacje"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "zarządzany host musi mieć jeden dostarczony interfejs "
@@ -10051,6 +10253,9 @@ msgstr "musi dostarczać dostawcę"
 
 msgid "must set host and port"
 msgstr "musisz ustawić host i port"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "nowy"
@@ -10247,9 +10452,6 @@ msgstr "niektóre interfejsy są nieprawidłowe"
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "rezultat sortowania"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "Opcje oddzielone odstępem, np. miiom=100"
 
@@ -10351,6 +10553,9 @@ msgstr "ważny"
 msgid "valid or pending"
 msgstr "ważne lub do czasu"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10359,6 +10564,9 @@ msgstr "wirtualny"
 
 msgid "virtual attached to %s"
 msgstr "wirtualnie dopisany do %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/pt_BR/foreman.po
+++ b/locale/pt_BR/foreman.po
@@ -44,8 +44,11 @@ msgstr "Remover"
 msgid " in the provisioning template."
 msgstr "no modelo de provisionamento."
 
-msgid "#{taxonomy} can be set on the All Hosts page"
-msgstr "#{taxonomy} pode ser definido na página Todos os hosts"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
+msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr "%s - Pressione Shift-F12 para liberar o cursor."
@@ -103,6 +106,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s foi desassociada da VM"
 
@@ -129,6 +135,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s hosts selecinados"
@@ -288,6 +297,11 @@ msgstr "'%{object_name}' é um '%{object_class}', espera-se uma sub-rede."
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' não é suportado pela API v2 para requisições POST e PUT. Por favor use 'Content-Type: application/json'."
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(Diversos)"
@@ -472,9 +486,6 @@ msgstr "Adicionar parâmetro"
 msgid "Add SSH Key"
 msgstr "Adicionar chave SSH"
 
-msgid "Add SSH Key for %s"
-msgstr "Adicionar chave SSH para %s"
-
 msgid "Add SSH key"
 msgstr "Adicionar chave SSH"
 
@@ -550,6 +561,12 @@ msgstr "Endereço de email do administrador"
 msgid "Administrator user account required"
 msgstr "Conta do usuário administrador necessária "
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Alerta"
 
@@ -564,9 +581,6 @@ msgstr "Todos"
 
 msgid "All Hosts"
 msgstr "Todos os hosts"
-
-msgid "All Puppet Classes for %s"
-msgstr "Todas as classes do Puppet para %s"
 
 msgid "All Reports"
 msgstr "Todos os relatórios"
@@ -825,6 +839,12 @@ msgstr "Auditoria"
 
 msgid "Audit Comment"
 msgstr "Comentário de auditoria"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Resumo de auditoria "
@@ -1136,14 +1156,26 @@ msgstr "Fuso horário do navegador "
 msgid "Build"
 msgstr "Compilar"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Compilar Hosts"
 
 msgid "Build PXE Default"
 msgstr "Compilar Padrão PXE"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Construir a partir de uma imagem de SO"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr "Por padrão, mapeamos os grupos de usuários para padronizar objetos do grupo LDAP. Os tipos de servidores FreeIPA e LDAP POSIX são compatíveis com modos alternativos de agrupar usuários por grupos de redes. Marcar essa caixa de seleção ao usar grupos de redes é preferido, em vez de grupos padrão."
@@ -1274,6 +1306,9 @@ msgstr "Modificar ambiente"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr "Alterações no %s se propagarão a todos os filtros herdados"
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1319,6 +1354,12 @@ msgstr "Classes"
 msgid "Clean up failed deployment"
 msgstr "Limpar implantação com falha "
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Clique no link de um recurso de computação para editar seus atributos de VM padrão."
 
@@ -1327,9 +1368,6 @@ msgstr "Clique para adicionar %s"
 
 msgid "Click to log in again."
 msgstr "Clique para autenticar novamente."
-
-msgid "Click to mark as read"
-msgstr "Clique para marcar como lido"
 
 msgid "Click to remove %s"
 msgstr "Clique para remover %s"
@@ -1451,6 +1489,10 @@ msgstr "ComputeResource|Descrição"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
 msgstr "ComputeResource|Domínio"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
@@ -1699,6 +1741,9 @@ msgstr "Criar proxy"
 msgid "Create Puppet Environment"
 msgstr "Criar ambiente Puppet"
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "Criar realm"
 
@@ -1822,6 +1867,9 @@ msgstr "Criar uma variável inteligente"
 msgid "Create a subnet"
 msgstr "Criar uma subrete"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Criar um usuário"
 
@@ -1861,6 +1909,9 @@ msgstr "Criar um valor de substituição para uma variável inteligente específ
 msgid "Create autosign entry"
 msgstr "Criar entrada de autoassinatura"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Criar novo volume de inicialização a partir da imagem "
 
@@ -1875,6 +1926,9 @@ msgstr "Criar entrada de realm para %s"
 
 msgid "Created"
 msgstr "Criado"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2050,9 +2104,6 @@ msgstr "Excluir controlador"
 msgid "Delete Hosts"
 msgstr "Apagar hosts"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr "Excluir a entrada de autoassinatura Puppet CA para %s"
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Apagar certificados PuppetCA para %s"
 
@@ -2146,8 +2197,14 @@ msgstr "Remover uma variável inteligente"
 msgid "Delete a subnet"
 msgstr "Apagar uma subrede"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Apagar uma combinação de template"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Apagar um usuário"
@@ -2287,11 +2344,17 @@ msgstr "Visualizar dif"
 msgid "Disable Notifications"
 msgstr "Desabilitar notificações"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Desabilitar alertas para os hosts selecionados"
 
 msgid "Disable all filters overriding"
 msgstr "Desativar toda a substituição de filtros"
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
+msgstr ""
 
 msgid "Disable overriding"
 msgstr "Desativar substituição"
@@ -2421,47 +2484,11 @@ msgstr "Editar"
 msgid "Edit %s"
 msgstr "Editar %s"
 
-msgid "Edit Architecture"
-msgstr "Editar arquitetura"
-
-msgid "Edit Bookmark"
-msgstr "Editar marcador"
-
 msgid "Edit Compute profile"
 msgstr "Editar perfil computacional"
 
-msgid "Edit Compute profile: %s"
-msgstr "Editar perfil computacional: %s"
-
-msgid "Edit Config group"
-msgstr "Editar grupo de usuário"
-
-msgid "Edit Domain"
-msgstr "Editar domínio"
-
-msgid "Edit Environment"
-msgstr "Editar ambiente"
-
-msgid "Edit Filter"
-msgstr "Editar filtro"
-
-msgid "Edit Global Parameter"
-msgstr "Editar parâmetro global"
-
-msgid "Edit HTTP Proxy"
-msgstr "Editar proxy HTTP"
-
 msgid "Edit Host"
 msgstr "Editar host"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Editar fonte de autenticação LDAP"
-
-msgid "Edit Medium"
-msgstr "Editar médio"
-
-msgid "Edit Model"
-msgstr "Editar modelo"
 
 msgid "Edit Operating System"
 msgstr "Editar sistema operacional"
@@ -2469,23 +2496,11 @@ msgstr "Editar sistema operacional"
 msgid "Edit Parameters"
 msgstr "Editar parâmetros"
 
-msgid "Edit Partition Table"
-msgstr "Editar tabela de partição"
-
 msgid "Edit Properties"
 msgstr "Editar propriedades"
 
-msgid "Edit Proxy"
-msgstr "Editar proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Editar classe Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Editar Realm"
-
-msgid "Edit Role"
-msgstr "Editar função"
 
 msgid "Edit Smart Variable"
 msgstr "Editar variável inteligente"
@@ -2493,23 +2508,8 @@ msgstr "Editar variável inteligente"
 msgid "Edit Smart class parameters"
 msgstr "Editar parâmetros da classe inteligentes"
 
-msgid "Edit Subnet"
-msgstr "Editar subrede"
-
-msgid "Edit Template"
-msgstr "Editar template"
-
 msgid "Edit Trend %s"
 msgstr "Editar tendência %s"
-
-msgid "Edit User"
-msgstr "Editar usuário"
-
-msgid "Edit User group"
-msgstr "Editar grupo de usuário"
-
-msgid "Edit compute profile on %s"
-msgstr "Editar perfil computacional no %s"
 
 msgid "Edit this host"
 msgstr "Editar esse host"
@@ -2540,6 +2540,9 @@ msgstr "Ativar cache"
 
 msgid "Enable Notifications"
 msgstr "Habilitar notificações"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Habilitar alertas para os hosts selecionados"
@@ -2663,6 +2666,15 @@ msgstr "Erro ao enviar dados:"
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr "Erro ao conectar-se ao servidor LDAP  '%{name}' em '%{url}' durante a autenticação"
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr "Erros"
 
@@ -2785,11 +2797,11 @@ msgstr "Nome do fato"
 msgid "Fact Values"
 msgstr "Valores do fato"
 
-msgid "Fact Values | %{host_name}"
-msgstr "Fatos Valores | %{host_name}"
-
 msgid "Fact distribution chart"
 msgstr "Gráfico de distribuição de fatos"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2849,6 +2861,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Reinício falhou"
 
@@ -2860,9 +2875,6 @@ msgstr "Falha ao adquirir endereços IP do recurso de computação para %s"
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr "Falha ao cancelar a compilação pendente de %{hostname} com os seguintes erros: %{errors}"
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Falha ao limpar os certificados antigos ou adicionar o registro de autosign. Terminando a construção!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Falha ao configurar o  %{host} para inicializar a partir do %{device}: %{e}"
@@ -3043,11 +3055,11 @@ msgstr "Filtrar classes"
 msgid "Filter overriding has been disabled"
 msgstr "A substituição de filtros foi desativada"
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filtros"
-
-msgid "Filters for role %s"
-msgstr "Filtros para a função %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr "Os filtros herdam %{orgs_and_locs} associados à função por padrão. Se o campo de substituição estiver ativado, <br> o filtro pode substituir o conjunto de seus %{orgs_and_locs}. Alterações posteriores nas funções não afetarão esse filtro.<br> Depois de desativar o campo de substituição, a função %{orgs_and_locs} é aplicada novamente."
@@ -3160,6 +3172,9 @@ msgstr "Foreman pode utilizar um serviço LDAP para informação de usuário e a
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman considera domínios e zonas DNS como a mesma coisa. "
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "Foreman ID de domínio da interface. Necessário para as interfaces primárias em hosts gerenciados."
 
@@ -3202,6 +3217,9 @@ msgstr "O Foreman acrescentará nomes de domínio quando novos hosts forem provi
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "O Foreman automatizará a assinatura de certificados sob a provisão de um novo host"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "O Foreman criará o host ao receber um relatório"
 
@@ -3240,9 +3258,6 @@ msgstr "O Foreman pesquisará o resolvedor configurado localmente em vez de auto
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "O Foreman definirá este como o caminho do módulo Puppet padrão se não conseguir detectar um automaticamente."
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "O Foreman truncará o nome do host para 'puppet', caso inicie com puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "O Foreman atualizará um ambiente de host a partir de seus fatos"
@@ -3367,6 +3382,9 @@ msgstr "Variáveis globais"
 msgid "Good host reports in the last %s"
 msgstr "Relatórios de host positivos nos últimos %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "ID do Projeto do Google"
 
@@ -3393,6 +3411,9 @@ msgstr "Proxy de HTTP(S)"
 
 msgid "HTTP(S) proxy except hosts"
 msgstr "Hosts de exceção do proxy HTTP(S)"
+
+msgid "HTTPS URL is required for API access"
+msgstr ""
 
 msgid "Hard disk"
 msgstr "Disco rígido"
@@ -3426,6 +3447,9 @@ msgstr "Valor oculto"
 
 msgid "Hide all values for this parameter."
 msgstr "Ocultar todos os valores para este parâmetro."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Ocultar este valor"
@@ -3536,6 +3560,10 @@ msgid "Host::Base|Build"
 msgstr "Compilar"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Nome do certificado"
 
@@ -3562,6 +3590,10 @@ msgstr "Host::Base|Grub pass"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Arquivo de imagem"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3698,6 +3730,12 @@ msgstr "Os hosts criados após uma execução do puppet serão colocados na loca
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Hosts criados após uma execução de puppet, a qual não enviou um fato da organização, será colocado nesta organização."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Hosts em estado de erro"
@@ -4185,6 +4223,9 @@ msgstr "Entrada"
 msgid "Installation Media"
 msgstr "Mídia de Instalação"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Configuração de mídia de instalação"
 
@@ -4369,9 +4410,6 @@ msgstr "Iniciar console"
 msgid "Learn more about this in the documentation."
 msgstr "Para saber mais sobre isto, acesse a documentação."
 
-msgid "Legacy Puppet hostname"
-msgstr "Nome do host do Puppet legado "
-
 msgid "Length"
 msgstr "Comprimento"
 
@@ -4434,6 +4472,15 @@ msgstr "Listar todas as auditorias"
 
 msgid "List all audits for a given host"
 msgstr "Listar todas auditorias para um host específico"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Listar todas entradas de auto-assinatura"
@@ -4600,6 +4647,9 @@ msgstr "Listar todos os usuários"
 msgid "List all users for LDAP authentication source"
 msgstr "Listar todos os usuários da origem de autenticação LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Listar todos os usuários para local"
 
@@ -4660,6 +4710,15 @@ msgstr "Listar ambientes por localização"
 msgid "List environments per organization"
 msgstr "Listar ambientes por organização"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Listar hosts por ambiente"
 
@@ -4671,6 +4730,9 @@ msgstr "Listar hosts por organização"
 
 msgid "List installed plugins"
 msgstr "Lista de plugins instalados"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "Lista de proxies HTTP"
@@ -4746,6 +4808,15 @@ msgstr "Listar as sub-redes por localização"
 
 msgid "List of subnets per organization"
 msgstr "Listar as sub-redes por organização"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Lista de sistema operacional onde ha um modelo padrão definido"
@@ -4985,6 +5056,18 @@ msgstr "Endereço MAC para reutilização do IP para este host"
 msgid "MAC-based"
 msgstr "Base em MAC"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Tipo de máquina"
 
@@ -5181,6 +5264,9 @@ msgstr "Uma permissão para editar o pai %s está ausente"
 msgid "Missing one of the required permissions: %s"
 msgstr "Uma das permissões necessárias está ausente: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modelo"
@@ -5261,6 +5347,9 @@ msgstr "Nome do grupo de hosts"
 msgid "Name of the parameter"
 msgstr "Nome do parâmetro"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Nome da variável"
 
@@ -5303,14 +5392,11 @@ msgstr "Tipo de rede"
 msgid "New"
 msgstr "Novo"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nova entrada auto assinada"
-
-msgid "New Event"
-msgstr "Novo evento"
-
-msgid "New Events"
-msgstr "Novos eventos"
 
 msgid "New HTTP Proxy"
 msgstr "Novo proxy HTTP"
@@ -5332,9 +5418,6 @@ msgstr "Nova Máquina Virtual"
 
 msgid "New boot volume size (GB)"
 msgstr "Novo tamanho de volume de inicialização (GB) "
-
-msgid "New compute profile on %s"
-msgstr "Novo perfil computacional em %s"
 
 msgid "New filter"
 msgstr "Novo filtro"
@@ -5361,6 +5444,10 @@ msgstr "Nic::Base|Bond options"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
 msgstr "Nic::Base|Atributos de computação"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Identifier"
@@ -5434,11 +5521,14 @@ msgstr "Nenhuma NIC BMC disponível para o host %s"
 msgid "No Failed Features"
 msgstr "Nenhum recurso com falha"
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "Nenhuma rede IPV4 selecionada"
 
-msgid "No Notifications"
-msgstr "Nenhuma notificação"
+msgid "No Notifications Available"
+msgstr ""
 
 msgid "No TFTP feature"
 msgstr "Nenhum recurso TFTP"
@@ -6163,9 +6253,6 @@ msgstr "Os modelos de partição descrevem o layout da partição, com apenas um
 msgid "Password"
 msgstr "Senha"
 
-msgid "Password do not match"
-msgstr "A senha não corresponde"
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Senha para oVirt, VMware, OpenStack, Secret key para EC2"
 
@@ -6189,6 +6276,9 @@ msgstr "A senha usada para autenticar com o proxy HTTP"
 
 msgid "Password:"
 msgstr "Senha:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Caminho"
@@ -6461,14 +6551,19 @@ msgstr "ProvisioningTemplate|Nome"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "ProvisioningTemplate|Snippet"
 
-msgid "Proxied request failed with: %s"
-msgstr "Solicitação com proxy apresentou falha com: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
+msgstr ""
 
 msgid "Proxies"
 msgstr "Proxies"
 
 msgid "Proxy ID to use within this realm"
 msgstr "ID do proxy a ser usado neste realm"
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
 
 msgid "Proxy request timeout"
 msgstr "Tempo limite da solicitação de Proxy "
@@ -6772,6 +6867,9 @@ msgstr "Reportado em"
 msgid "Report|Status"
 msgstr "Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "Solicitar SSL para proxies inteligentes"
 
@@ -6780,6 +6878,9 @@ msgstr "Parâmetro necessário sem valor. <br/><b>Por favor, substitua-o!</b><br
 
 msgid "Required when user want to change own password"
 msgstr "Exigido quando o usuário quer alterar sua senha"
+
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
 
 msgid "Reset to default"
 msgstr "Reconfigurar como padrão"
@@ -7043,9 +7144,6 @@ msgstr "DNS secundário para essa sub-rede"
 msgid "Secret Key"
 msgstr "Chave Secreta"
 
-msgid "Security group"
-msgstr "Security group"
-
 msgid "Security groups"
 msgstr "Grupos de segurança"
 
@@ -7204,8 +7302,8 @@ msgstr "Definir uma senha gerada aleatoriamente na conexão de exibição VCN"
 msgid "Set a randomly generated password on the display connection"
 msgstr "Definir uma senha gerada aleatóriamente na conexão de exibição"
 
-msgid "Set hostnames to which requests are not to be proxied"
-msgstr "Definir nomes de hosts aos quais as solicitações não podem sofrer proxy"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
+msgstr ""
 
 msgid "Set parameters to defaults"
 msgstr "Definir parâmetros para padrão"
@@ -7393,6 +7491,9 @@ msgstr "Exibir uma variável inteligente"
 msgid "Show a subnet"
 msgstr "Mostrar uma sub-rede"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Mostrar um usuário"
 
@@ -7426,6 +7527,9 @@ msgstr "Mostrar uma notificação por email"
 msgid "Show an environment"
 msgstr "Mostrar um ambiente"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Mostrar um grupo de usuário externo para fonte de autenticação LDAP"
 
@@ -7437,6 +7541,9 @@ msgstr "Exibir uma imagem"
 
 msgid "Show an interface for host"
 msgstr "Exibir uma interface para host"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Mostrat um sistema operacional"
@@ -7519,9 +7626,6 @@ msgstr "Proxies Inteligentes"
 msgid "Smart Proxy"
 msgstr "Proxy Inteligente"
 
-msgid "Smart Proxy: %s"
-msgstr "Proxy Inteligente: %s"
-
 msgid "Smart Variables"
 msgstr "Variáveis Inteligentes"
 
@@ -7535,6 +7639,9 @@ msgstr "Proxy inteligente"
 msgid "Smart proxy IDs"
 msgstr "IDs do proxy inteligente"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr "As variáveis são uma ferramenta para fornecer parâmetros (dados de chave/valor), para o escopo de nível principal (global) de seu ENC puppet, dependendo do conjunto de regras. "
 
@@ -7547,11 +7654,18 @@ msgid "SmartProxy|Name"
 msgstr "SmartProxy|Nome"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "Snippet"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr "Algumas classes Puppet estão indisponíveis no ambiente selecionado"
@@ -7585,6 +7699,9 @@ msgstr "Desculpe mas não há nenhum modelo configurado."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Por favor, estes hosts não possuem parâmetros atribuídos a eles, você precisa adicioná-los primeiro."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7691,6 +7808,9 @@ msgstr "Ids de Subrede"
 msgid "Subnet description"
 msgstr "Descrição da sub-rede"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Nome da subnet"
 
@@ -7734,6 +7854,10 @@ msgstr "Subnet|Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Máscara"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7855,6 +7979,21 @@ msgid "TFTP server"
 msgstr "Servidor TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxonomia Tributável"
 
@@ -7957,6 +8096,18 @@ msgid "Template|Default"
 msgstr "Modelo|Padrão"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Modelo|Bloqueado"
 
@@ -7967,6 +8118,10 @@ msgstr "Modelo|Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
 msgstr "Modelo|Família de SO"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Snippet"
@@ -8407,6 +8562,9 @@ msgstr "Alternar"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Duração do token"
 
@@ -8470,8 +8628,8 @@ msgstr "Tendências"
 msgid "Trends for %s"
 msgstr "Tendências para %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
-msgstr "As tendências no Foreman permitem que você rasteie alterações em sua infraestrutura ao longo do tempo. Ele permite que você rastreie as informações relacionadas ao Foreman e todos os fatos Puppet. A página Tendência mostra um gráfico de como o número de hosts com um valor vem sendo alterado ao longo do tempo e lista os hosts atuais."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
@@ -8569,6 +8727,9 @@ msgstr "Não foi possível conectar"
 
 msgid "Unable to connect to LDAP server"
 msgstr "Não é possível conectar-se ao servidor LDAP"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Não foi possível criar menu de inicialização TFTP padrão"
@@ -8780,6 +8941,12 @@ msgstr "Hosto não gerenciado"
 msgid "Unnamed"
 msgstr "Não nomeado"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "Modo IPAM não suportado para %s"
 
@@ -8909,6 +9076,9 @@ msgstr "Atualizar uma arquitetura"
 msgid "Update an environment"
 msgstr "Atualizar um ambiente"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Atualizar uma imagem"
 
@@ -8960,8 +9130,14 @@ msgstr "Hosts atualizados: grupo de host modificado"
 msgid "Updated hosts: changed owner"
 msgstr "Hosts atualizados: proprietário alterado"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Enviar fatos para um host, criando o host se necessário"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "Usar grupos de redes NIS, em vez de grupos POSIX."
@@ -8971,6 +9147,9 @@ msgstr "Usar UUID para certificados"
 
 msgid "Use short name for VMs"
 msgstr "Use nomes curtos para MVs"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Use esta conta para autenticação, <i>opcional</i>"
@@ -8996,6 +9175,9 @@ msgstr "Grupos de Usuários"
 
 msgid "User IDs"
 msgstr "IDs dos Usuários"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "Modelo de dados do usuário "
@@ -9147,6 +9329,9 @@ msgstr "Vcenter/Servidor"
 
 msgid "VLAN ID for this subnet"
 msgstr "ID da VLAN para essa sub-rede"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN tag, este atributo tem precedência sobre a sub-rede  VLAN ID . Apenas para interfaces virtuais"
@@ -9372,8 +9557,8 @@ msgstr "Se o valor do parâmetro de classe é gerenciado ou não pelo Foreman."
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Se o valor do parâmetro da classe inteligente é gerenciado ou não pelo Foreman."
 
-msgid "Whether to get RSS notifications or not"
-msgstr "Se deve receber notificações RSS ou não"
+msgid "Whether to pull RSS notifications or not"
+msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
 msgstr "A qual é um offset de <b>%s</b>"
@@ -9457,6 +9642,9 @@ msgstr "Você não está autorizado a fazer um modelo padrão. "
 
 msgid "You are not authorized to perform this action."
 msgstr "Você não está autorizado a executar essa ação."
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Você está tentando remover sua conta pessoal"
@@ -9650,6 +9838,9 @@ msgstr "não pode ser removido de uma conta protegida interna"
 msgid "cannot be removed from the last admin account"
 msgstr "não pode ser removido de uma última conta de admin"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "clone"
 
@@ -9767,6 +9958,9 @@ msgstr "filtrar por função %s"
 msgid "filter results"
 msgstr "filtrar resultados"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "Somente para EC2"
 
@@ -9781,6 +9975,9 @@ msgstr "Somente para OpenStack"
 
 msgid "for VMware"
 msgstr "para VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "para oVirt, Vmware Datacenter"
@@ -9932,8 +10129,8 @@ msgstr "não é uma chave SSH pública válida"
 msgid "is not allowed to change"
 msgstr "não é permitido mudar"
 
-msgid "is not defined for host's %s."
-msgstr "não está definido para o %s do host."
+msgid "is not defined for host's %s"
+msgstr ""
 
 msgid "is not found in the authentication source"
 msgstr "não foi encontrado na fonte de autenticação"
@@ -9975,8 +10172,7 @@ msgstr "grupo de usuário externo com este grupo de usuário"
 msgid "list"
 msgstr "lista"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Português (Brasil)"
 
@@ -9985,6 +10181,12 @@ msgstr "localização"
 
 msgid "locations"
 msgstr "localizações"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "host gerenciado deve ter uma interface de provisão "
@@ -10048,6 +10250,9 @@ msgstr "deve fornecer um provedor"
 
 msgid "must set host and port"
 msgstr "deve definir host e porta"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "novo"
@@ -10244,9 +10449,6 @@ msgstr "algumas interfaces são inválidas"
 msgid "some permissions were not found"
 msgstr "algumas permissões não foram encontradas"
 
-msgid "sort results"
-msgstr "ordenar resultados"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "opções separadas com espaço, ex:  miimon=100"
 
@@ -10348,6 +10550,9 @@ msgstr "válido"
 msgid "valid or pending"
 msgstr "válido ou pendente"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr "visualizar detalhes do último relatório"
 
@@ -10356,6 +10561,9 @@ msgstr "virtual(is)"
 
 msgid "virtual attached to %s"
 msgstr "virtual anexado a %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/ru/foreman.po
+++ b/locale/ru/foreman.po
@@ -35,7 +35,10 @@ msgstr "Удалить"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -100,6 +103,9 @@ msgstr[1] "%s сообщения об ошибках"
 msgstr[2] "%s сообщений об ошибках"
 msgstr[3] "%s сообщений об ошибках"
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s больше не связан с виртуальной машиной"
 
@@ -132,6 +138,9 @@ msgstr[0] "%s месяц назад"
 msgstr[1] "%s месяца назад"
 msgstr[2] "%s месяцев назад"
 msgstr[3] "%s месяцев назад"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s выбранных узлов"
@@ -301,6 +310,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' не поддерживается в API v2 для POST и PUT запросов. Пожалуйста используйте 'Content-Type: application/json'"
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "(другое)"
@@ -485,9 +499,6 @@ msgstr "Добавить параметр"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -563,6 +574,12 @@ msgstr "Адрес администратора"
 msgid "Administrator user account required"
 msgstr "Необходима учетная запись администратора"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Уведомление"
 
@@ -577,9 +594,6 @@ msgstr "Все"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Все Puppet классы для %s"
 
 msgid "All Reports"
 msgstr "Все отчеты"
@@ -840,6 +854,12 @@ msgstr "Аудит"
 
 msgid "Audit Comment"
 msgstr "Комментарий"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "Сводка аудита"
@@ -1151,14 +1171,26 @@ msgstr "Часовой пояс браузера"
 msgid "Build"
 msgstr "Сборка"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Сборка узлов"
 
 msgid "Build PXE Default"
 msgstr "Создать PXE default"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Создать из образа ОС"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1289,6 +1321,9 @@ msgstr "Изменение окружений"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Шасси"
 
@@ -1334,6 +1369,12 @@ msgstr "Классы"
 msgid "Clean up failed deployment"
 msgstr "Удалять неудачное развертывание"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Выберите вычислительный ресурс, чтобы изменить исходные атрибуты его виртуальных машин."
 
@@ -1342,9 +1383,6 @@ msgstr "Нажмите, чтобы добавить %s"
 
 msgid "Click to log in again."
 msgstr "Нажмите, чтобы войти заново."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Нажмите, чтобы удалить %s"
@@ -1465,6 +1503,10 @@ msgstr "Описание"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1714,6 +1756,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1837,6 +1882,9 @@ msgstr "Создать смарт-переменную"
 msgid "Create a subnet"
 msgstr "Создать подсеть"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "Создать пользователя"
 
@@ -1876,6 +1924,9 @@ msgstr "Создать переопределение для смарт-пере
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "Создать новый загрузочный том из образа"
 
@@ -1890,6 +1941,9 @@ msgstr "Создать запись области определения для
 
 msgid "Created"
 msgstr "Создано"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2065,9 +2119,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Удалить узлы"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Удалить сертификаты PuppetCA %s"
 
@@ -2161,8 +2212,14 @@ msgstr "Удалить смарт-переменную"
 msgid "Delete a subnet"
 msgstr "Удалить подсеть"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "Удалить комбинацию шаблонов"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "Удалить пользователя"
@@ -2302,10 +2359,16 @@ msgstr "Список отличий"
 msgid "Disable Notifications"
 msgstr "Отключить уведомления"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Отключить уведомления для выбранных узлов"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2438,47 +2501,11 @@ msgstr "Изменить"
 msgid "Edit %s"
 msgstr "Изменить %s"
 
-msgid "Edit Architecture"
-msgstr "Изменить архитектуру"
-
-msgid "Edit Bookmark"
-msgstr "Изменить закладку"
-
 msgid "Edit Compute profile"
 msgstr "Изменить вычислительный профиль"
 
-msgid "Edit Compute profile: %s"
-msgstr "Изменение вычислительного профиля: %s"
-
-msgid "Edit Config group"
-msgstr "Изменение группы конфигурации"
-
-msgid "Edit Domain"
-msgstr "Изменить домен"
-
-msgid "Edit Environment"
-msgstr "Изменить окружение"
-
-msgid "Edit Filter"
-msgstr "Изменить фильтр"
-
-msgid "Edit Global Parameter"
-msgstr "Изменить глобальный параметр"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "Редактировать узел"
-
-msgid "Edit LDAP Auth Source"
-msgstr "Изменить источник идентификации LDAP"
-
-msgid "Edit Medium"
-msgstr "Изменить носитель"
-
-msgid "Edit Model"
-msgstr "Изменить модель"
 
 msgid "Edit Operating System"
 msgstr "Изменить операционную систему"
@@ -2486,23 +2513,11 @@ msgstr "Изменить операционную систему"
 msgid "Edit Parameters"
 msgstr "Изменить параметры"
 
-msgid "Edit Partition Table"
-msgstr "Изменить таблицу разделов"
-
 msgid "Edit Properties"
 msgstr "Измените свойства"
 
-msgid "Edit Proxy"
-msgstr "Изменение капсулы"
-
 msgid "Edit Puppet Class %s"
 msgstr "Изменение класса Puppet %s"
-
-msgid "Edit Realm"
-msgstr "Изменить область"
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "Изменить смарт-переменную"
@@ -2510,23 +2525,8 @@ msgstr "Изменить смарт-переменную"
 msgid "Edit Smart class parameters"
 msgstr "Изменить смарт-параметры класса"
 
-msgid "Edit Subnet"
-msgstr "Изменить подсеть"
-
-msgid "Edit Template"
-msgstr "Изменить шаблон"
-
 msgid "Edit Trend %s"
 msgstr "Изменение динамики %s"
-
-msgid "Edit User"
-msgstr "Параметры пользователя"
-
-msgid "Edit User group"
-msgstr "Параметры группы пользователей"
-
-msgid "Edit compute profile on %s"
-msgstr "Изменение вычислительного профиля %s"
 
 msgid "Edit this host"
 msgstr ""
@@ -2557,6 +2557,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Включить уведомления"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Включить уведомления для выбранных узлов"
@@ -2678,6 +2681,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2802,11 +2814,11 @@ msgstr "Имя факта"
 msgid "Fact Values"
 msgstr "Значения фактов"
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "График распределения"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2868,6 +2880,9 @@ msgstr[1] "Нерабочих функций: %s"
 msgstr[2] "Нерабочих функций: %s"
 msgstr[3] "Нерабочих функций: %s"
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Неудачный перезапуск"
 
@@ -2879,9 +2894,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Не удалось очистить старые сертификаты или добавить новую запись автоматической подписи. Сборка будет отменена."
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Не удалось настроить загрузку %{host} с %{device}: %{e}"
@@ -3062,11 +3074,11 @@ msgstr "Фильтр классов"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Фильтры"
-
-msgid "Filters for role %s"
-msgstr "Фильтры для  %s"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3179,6 +3191,9 @@ msgstr "Для идентификации пользователей Foreman м�
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "В терминологии Foreman понятия доменов и DNS-зон являются взаимозаменяемыми."
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "Код домена Foreman для интерфейса. Требуется для первичного интерфейса на управляемых узлах."
 
@@ -3221,6 +3236,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Автоматизировать процесс подписи сертификатов при подготовке новых узлов"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman будет создавать новый узел на основании загруженного отчета."
 
@@ -3259,9 +3277,6 @@ msgstr "Опрашивать локальный сервер преобразо�
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Путь к модулям Puppet, который будет использоваться по умолчанию, если Foreman не сможет обнаружить его автоматически"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Имена узлов, начинающиеся с «puppet», будут сокращаться до «puppet»"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Обновлять окружение узла на основании фактов статистики"
@@ -3386,6 +3401,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Наличие отчетов о подтверждении состояния узлов за %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3411,6 +3429,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3445,6 +3466,9 @@ msgstr ""
 
 msgid "Hide all values for this parameter."
 msgstr "Скрывать значения этого параметра."
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "Скрыть значение"
@@ -3555,6 +3579,10 @@ msgid "Host::Base|Build"
 msgstr "Сборка"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Сертификат"
 
@@ -3581,6 +3609,10 @@ msgstr "Пароль загрузчика"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Образ"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3717,6 +3749,12 @@ msgstr "Этот факт определяет местоположение дл
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "Этот факт определяет организацию, в которую будут добавляться новые узлы. Должен содержать полное название организации."
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "Узлы в состоянии ошибки"
@@ -4202,6 +4240,9 @@ msgstr "Ввод"
 msgid "Installation Media"
 msgstr "Установочный носитель"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Конфигурация установочного носителя"
 
@@ -4386,9 +4427,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "Обратиться к документации"
 
-msgid "Legacy Puppet hostname"
-msgstr "Традиционное имя узла Puppet"
-
 msgid "Length"
 msgstr ""
 
@@ -4451,6 +4489,15 @@ msgstr "Список всех проверок"
 
 msgid "List all audits for a given host"
 msgstr "Список всех проверок для данного узла"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "Показать все записи автоматической подписи"
@@ -4617,6 +4664,9 @@ msgstr "Список всех пользователей"
 msgid "List all users for LDAP authentication source"
 msgstr "Список всех пользователей из источника идентификации LDAP"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "Список всех пользователей местоположения"
 
@@ -4677,6 +4727,15 @@ msgstr "Список окружений по местоположениям"
 msgid "List environments per organization"
 msgstr "Список окружений по организациям"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Список узлов по окружениям"
 
@@ -4688,6 +4747,9 @@ msgstr "Список узлов по организациям"
 
 msgid "List installed plugins"
 msgstr "Список установленных дополнений"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4763,6 +4825,15 @@ msgstr "Список подсетей местоположения"
 
 msgid "List of subnets per organization"
 msgstr "Список подсетей организации"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "Список операционных систем, для которых данный шаблон установлен как по умолчанию"
@@ -5002,6 +5073,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Тип машины"
 
@@ -5198,6 +5281,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr "Отсутствует одно из обязательных разрешений: %s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Модель"
@@ -5278,6 +5364,9 @@ msgstr "Имя группы узлов"
 msgid "Name of the parameter"
 msgstr "Название параметра"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "Имя переменной"
 
@@ -5320,14 +5409,11 @@ msgstr "Тип"
 msgid "New"
 msgstr "Новое"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Новая запись автоматической подписи"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5349,9 +5435,6 @@ msgstr "Новая виртуальная машина"
 
 msgid "New boot volume size (GB)"
 msgstr "Размер нового загрузочного тома (ГБ)"
-
-msgid "New compute profile on %s"
-msgstr "Новый вычислительный профиль %s"
 
 msgid "New filter"
 msgstr "Новый фильтр"
@@ -5377,6 +5460,10 @@ msgstr "Параметры агрегации"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5451,10 +5538,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6178,9 +6268,6 @@ msgstr ""
 msgid "Password"
 msgstr "Пароль"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Пароль для oVirt, EC2, VMware, OpenStack. Секретный ключ для EC2"
 
@@ -6204,6 +6291,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "Пароль:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "Путь"
@@ -6476,13 +6566,18 @@ msgstr "Название"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "Фрагмент"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Прокси"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6787,6 +6882,9 @@ msgstr "Время"
 msgid "Report|Status"
 msgstr "Статус"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "Требовать SSL для капсул"
 
@@ -6794,6 +6892,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr "Обязательный параметр без значения.<br/><b>Необходимо переопределить.</b><br/>"
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7058,9 +7159,6 @@ msgstr "Вторичный DNS для этой подсети"
 msgid "Secret Key"
 msgstr "Секретный ключ"
 
-msgid "Security group"
-msgstr "Группа безопасности"
-
 msgid "Security groups"
 msgstr "Группы безопасности"
 
@@ -7219,7 +7317,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "Создать случайный пароль при подключении к дисплею"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7408,6 +7506,9 @@ msgstr "Показать смарт-переменную"
 msgid "Show a subnet"
 msgstr "Показать подсеть"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "Показать пользователя"
 
@@ -7441,6 +7542,9 @@ msgstr "Показать почтовое уведомление"
 msgid "Show an environment"
 msgstr "Показать окружение"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "Показать внешнюю группу пользователя для источника идентификации LDAP"
 
@@ -7452,6 +7556,9 @@ msgstr "Показать образ"
 
 msgid "Show an interface for host"
 msgstr "Показать интерфейс узла"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "Показать операционную систему"
@@ -7534,9 +7641,6 @@ msgstr "Капсулы"
 msgid "Smart Proxy"
 msgstr "Капсула"
 
-msgid "Smart Proxy: %s"
-msgstr "Капсула: %s"
-
 msgid "Smart Variables"
 msgstr "Смарт-переменные"
 
@@ -7550,6 +7654,9 @@ msgstr "Смарт-прокси"
 msgid "Smart proxy IDs"
 msgstr "Код капсулы"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7562,11 +7669,18 @@ msgid "SmartProxy|Name"
 msgstr "Имя"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "Фрагмент"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7600,6 +7714,9 @@ msgstr "Нет настроенных шаблонов."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Сначала необходимо настроить параметры для этих узлов."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7706,6 +7823,9 @@ msgstr "Код подсети"
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "Имя подсети"
 
@@ -7749,6 +7869,10 @@ msgstr "Назначение IP"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Маска"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7870,6 +7994,21 @@ msgid "TFTP server"
 msgstr "Сервер TFTP"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Разбиение классификации"
 
@@ -7972,6 +8111,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7981,6 +8132,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8420,6 +8575,9 @@ msgstr "Состояние"
 msgid "Token"
 msgstr "Токен"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "Время действия установочного ключа"
 
@@ -8485,7 +8643,7 @@ msgstr "Динамика"
 msgid "Trends for %s"
 msgstr "Динамика %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8584,6 +8742,9 @@ msgstr "Не удалось подключиться"
 
 msgid "Unable to connect to LDAP server"
 msgstr "Не удалось подключиться к серверу LDAP"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "Не удалось создать исходное меню загрузки TFTP"
@@ -8795,6 +8956,12 @@ msgstr "Отменить управление узлом"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8924,6 +9091,9 @@ msgstr "Изменить архитектуру"
 msgid "Update an environment"
 msgstr "Изменить окружение"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Изменить образ"
 
@@ -8975,8 +9145,14 @@ msgstr "Обновление узлов: группа изменена"
 msgid "Updated hosts: changed owner"
 msgstr "Обновление узлов: изменен владелец"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "Загрузить факты узла, требуемые для создания узла"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8986,6 +9162,9 @@ msgstr "Использовать UUID для сертификата"
 
 msgid "Use short name for VMs"
 msgstr "Краткие имена ВМ"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "Использовать для авторизации (<i>дополнительно</i>)"
@@ -9011,6 +9190,9 @@ msgstr "Группы пользователей"
 
 msgid "User IDs"
 msgstr "Код пользователя"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "Шаблон пользовательских данных"
@@ -9162,6 +9344,9 @@ msgstr "VCenter/Сервер"
 
 msgid "VLAN ID for this subnet"
 msgstr "Идентификатор VLAN для этой подсети"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "Метка VLAN, этот атрибут имеет приоритет над подсетью VLAN ID. Только для виртуальных интерфейсов."
@@ -9378,7 +9563,7 @@ msgstr "Разрешает Foreman контролировать значение
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "Разрешает Foreman контролировать значение смарт-параметра"
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9463,6 +9648,9 @@ msgstr "Вы не авторизованы для создания шаблон�
 
 msgid "You are not authorized to perform this action."
 msgstr "Недостаточно полномочий для выполнения операции"
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "Вы пытаетесь удалить свою собственную учетную запись"
@@ -9656,6 +9844,9 @@ msgstr "не может быть удален из внутренней защи
 msgid "cannot be removed from the last admin account"
 msgstr "нельзя удалить из последней учетной записи администратора"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "клонировать"
 
@@ -9773,6 +9964,9 @@ msgstr "фильтр для роли %s"
 msgid "filter results"
 msgstr "отфильтровать результаты"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "только для EC2"
 
@@ -9787,6 +9981,9 @@ msgstr "только для OpenStack"
 
 msgid "for VMware"
 msgstr "для VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "для oVirt, VMware Datacenter"
@@ -9938,7 +10135,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "не может изменяться"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9985,8 +10182,7 @@ msgstr "связать внешнюю группу пользователей с
 msgid "list"
 msgstr "список"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "Русский"
 
@@ -9995,6 +10191,12 @@ msgstr "местоположение"
 
 msgid "locations"
 msgstr "местоположения"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "управляемый узел должен иметь один подготовительный интерфейс"
@@ -10058,6 +10260,9 @@ msgstr "провайдер должен быть определен"
 
 msgid "must set host and port"
 msgstr "должно определять имя узла и порт"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "новое"
@@ -10254,9 +10459,6 @@ msgstr "некоторые интерфейсы недействительны"
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "отсортировать результаты"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "список параметров, разделенных пробелами (например, miimon=100)"
 
@@ -10358,6 +10560,9 @@ msgstr "действителен"
 msgid "valid or pending"
 msgstr "действителен или ожидает"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10366,6 +10571,9 @@ msgstr "виртуальный"
 
 msgid "virtual attached to %s"
 msgstr "виртуально подключено к %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "YAML"

--- a/locale/sv_SE/foreman.po
+++ b/locale/sv_SE/foreman.po
@@ -29,7 +29,10 @@ msgstr "Ta bort:"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -88,6 +91,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr ""
 
@@ -114,6 +120,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s månad sedan"
 msgstr[1] "%s månader sedan"
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s valda värdar"
@@ -273,6 +282,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr ""
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr ""
@@ -451,9 +465,6 @@ msgstr "Lägg till Parameter"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -529,6 +540,12 @@ msgstr ""
 msgid "Administrator user account required"
 msgstr ""
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "Varning"
 
@@ -543,9 +560,6 @@ msgstr ""
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "Alla Puppetklasser för %s"
 
 msgid "All Reports"
 msgstr "Alla Rapporter"
@@ -804,6 +818,12 @@ msgstr ""
 
 msgid "Audit Comment"
 msgstr "Revisionskommentar"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr ""
@@ -1115,14 +1135,26 @@ msgstr ""
 msgid "Build"
 msgstr "Bygg"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "Bygg Värdar"
 
 msgid "Build PXE Default"
 msgstr "Bygg PXE Default"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "Bygg från OS-avbild"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1253,6 +1285,9 @@ msgstr "Ändrade miljöer"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "Chassi"
 
@@ -1298,6 +1333,12 @@ msgstr "Klasser"
 msgid "Clean up failed deployment"
 msgstr ""
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "Klicka på länken för en beräkningsresurs för att redigera dess standardattribut för VMs."
 
@@ -1306,9 +1347,6 @@ msgstr "Klicka för att lägga till %s"
 
 msgid "Click to log in again."
 msgstr "Klicka för att logga in igen."
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "Klicka för att ta bort %s"
@@ -1429,6 +1467,10 @@ msgstr "Beskrivning"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1678,6 +1720,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1801,6 +1846,9 @@ msgstr ""
 msgid "Create a subnet"
 msgstr ""
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr ""
 
@@ -1840,6 +1888,9 @@ msgstr ""
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr ""
 
@@ -1853,6 +1904,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Creates a table preference for a given table"
 msgstr ""
 
 msgid "Ctrl-Alt-Del"
@@ -2029,9 +2083,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "Radera värd"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "Radera PuppetCA certifikat för %s"
 
@@ -2125,7 +2176,13 @@ msgstr ""
 msgid "Delete a subnet"
 msgstr ""
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
+msgstr ""
+
+msgid "Delete a trend counter"
 msgstr ""
 
 msgid "Delete a user"
@@ -2266,10 +2323,16 @@ msgstr "Skillnadsvy"
 msgid "Disable Notifications"
 msgstr "Inaktivera notifieringar"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "Inaktivera Notifieringar"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2400,47 +2463,11 @@ msgstr "Redigera"
 msgid "Edit %s"
 msgstr "Redigera %s"
 
-msgid "Edit Architecture"
-msgstr "Redigera arkitektur"
-
-msgid "Edit Bookmark"
-msgstr "Redigera Bokmärke"
-
 msgid "Edit Compute profile"
 msgstr "Redigera Beräkningsprofil"
 
-msgid "Edit Compute profile: %s"
-msgstr "Beräkningsprofil: %s"
-
-msgid "Edit Config group"
-msgstr ""
-
-msgid "Edit Domain"
-msgstr "Redigera Domän"
-
-msgid "Edit Environment"
-msgstr "Redigera Miljö"
-
-msgid "Edit Filter"
-msgstr ""
-
-msgid "Edit Global Parameter"
-msgstr "Redigera Globala Parametrar"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr ""
-
-msgid "Edit LDAP Auth Source"
-msgstr "Redigera LDAP Autenticeringskälla"
-
-msgid "Edit Medium"
-msgstr "Redigera Medium"
-
-msgid "Edit Model"
-msgstr "Redigera Modell"
 
 msgid "Edit Operating System"
 msgstr "Redigera Operativsystem"
@@ -2448,23 +2475,11 @@ msgstr "Redigera Operativsystem"
 msgid "Edit Parameters"
 msgstr "Redigera Parametrar"
 
-msgid "Edit Partition Table"
-msgstr "Redigera Partitionstabell"
-
 msgid "Edit Properties"
 msgstr "Redigera Egenskaper"
 
-msgid "Edit Proxy"
-msgstr "Redigera Proxy"
-
 msgid "Edit Puppet Class %s"
 msgstr "Redigera Puppetklass %s"
-
-msgid "Edit Realm"
-msgstr ""
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "Redigera Smart Variabel"
@@ -2472,23 +2487,8 @@ msgstr "Redigera Smart Variabel"
 msgid "Edit Smart class parameters"
 msgstr ""
 
-msgid "Edit Subnet"
-msgstr "Redigera Subnät"
-
-msgid "Edit Template"
-msgstr "Redigera Mall"
-
 msgid "Edit Trend %s"
 msgstr "Redigera Trend %s"
-
-msgid "Edit User"
-msgstr "Redigera Användare"
-
-msgid "Edit User group"
-msgstr "Redigera Användargrupp"
-
-msgid "Edit compute profile on %s"
-msgstr "Redigera beräkningsprofil på %s"
 
 msgid "Edit this host"
 msgstr ""
@@ -2519,6 +2519,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "Aktivera Notifieringar"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "Aktivera larm för valda värdar"
@@ -2640,6 +2643,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2764,10 +2776,10 @@ msgstr "Faktanamn"
 msgid "Fact Values"
 msgstr "Faktavärden"
 
-msgid "Fact Values | %{host_name}"
+msgid "Fact distribution chart"
 msgstr ""
 
-msgid "Fact distribution chart"
+msgid "Fact distribution chart - %s "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -2828,6 +2840,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "Misslyckade omstarter"
 
@@ -2839,9 +2854,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "Misslyckades med att rensa gamla certifikat eller att lägga till autosigneringsvärdet. Avbryter bygget!"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "Misslyckades att konfigurera %{host} att starta från %{device}: %{e}"
@@ -3022,11 +3034,11 @@ msgstr "Filterklasser"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "Filter"
-
-msgid "Filters for role %s"
-msgstr ""
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3136,6 +3148,9 @@ msgstr "Foreman kan använda LDAP för användarinformation och autentisering"
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr ""
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr ""
 
@@ -3178,6 +3193,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman kommer skapa värden när en rapport tas emot"
 
@@ -3216,9 +3234,6 @@ msgstr ""
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr ""
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "Foreman kommer att trunkera värdnamnet till 'puppet' om det startar med puppet"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr ""
@@ -3343,6 +3358,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "Bra värdrapporter senaste %s"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3368,6 +3386,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3401,6 +3422,9 @@ msgid "Hidden Value"
 msgstr ""
 
 msgid "Hide all values for this parameter."
+msgstr ""
+
+msgid "Hide this notification"
 msgstr ""
 
 msgid "Hide this value"
@@ -3512,6 +3536,10 @@ msgid "Host::Base|Build"
 msgstr "Bygg"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "Certifikatnamn"
 
@@ -3538,6 +3566,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "Avbildningsfil"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3673,6 +3705,12 @@ msgid "Hosts created after a puppet run will be placed in the location this fact
 msgstr ""
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
+msgstr ""
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
 msgstr ""
 
 msgid "Hosts in error state"
@@ -4159,6 +4197,9 @@ msgstr ""
 msgid "Installation Media"
 msgstr "Installationsmedia"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "Inställningar för installationsmedia"
 
@@ -4343,9 +4384,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr ""
 
-msgid "Legacy Puppet hostname"
-msgstr ""
-
 msgid "Length"
 msgstr ""
 
@@ -4407,6 +4445,15 @@ msgid "List all audits"
 msgstr ""
 
 msgid "List all audits for a given host"
+msgstr ""
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
 msgstr ""
 
 msgid "List all autosign entries"
@@ -4574,6 +4621,9 @@ msgstr ""
 msgid "List all users for LDAP authentication source"
 msgstr ""
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr ""
 
@@ -4634,6 +4684,15 @@ msgstr "Lista miljöer per plats"
 msgid "List environments per organization"
 msgstr "Lista miljöer per organisation"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "Lista värdar per miljö"
 
@@ -4644,6 +4703,9 @@ msgid "List hosts per organization"
 msgstr "Lista värdar per organisation"
 
 msgid "List installed plugins"
+msgstr ""
+
+msgid "List internal authentication sources"
 msgstr ""
 
 msgid "List of HTTP Proxies"
@@ -4719,6 +4781,15 @@ msgid "List of subnets per location"
 msgstr ""
 
 msgid "List of subnets per organization"
+msgstr ""
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
 msgstr ""
 
 msgid "List operating systems where this template is set as a default"
@@ -4959,6 +5030,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "Maskintyp"
 
@@ -5155,6 +5238,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr ""
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "Modell"
@@ -5235,6 +5321,9 @@ msgstr "Värdgruppens namn"
 msgid "Name of the parameter"
 msgstr "Parameterns namn"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr ""
 
@@ -5277,14 +5366,11 @@ msgstr "Nätvärkstyp"
 msgid "New"
 msgstr "Ny"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "Nytt Autosigneringsvärde"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5306,9 +5392,6 @@ msgstr "Ny Virtuell Maskin"
 
 msgid "New boot volume size (GB)"
 msgstr ""
-
-msgid "New compute profile on %s"
-msgstr "Ny beräkningsprofil på %s"
 
 msgid "New filter"
 msgstr ""
@@ -5334,6 +5417,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5408,10 +5495,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6135,9 +6225,6 @@ msgstr ""
 msgid "Password"
 msgstr "Lösenord"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr ""
 
@@ -6160,6 +6247,9 @@ msgid "Password used to authenticate with the HTTP Proxy"
 msgstr ""
 
 msgid "Password:"
+msgstr ""
+
+msgid "Passwords do not match"
 msgstr ""
 
 msgid "Path"
@@ -6433,13 +6523,18 @@ msgstr ""
 msgid "ProvisioningTemplate|Snippet"
 msgstr ""
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "Proxies"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6744,6 +6839,9 @@ msgstr "Rapporterades vid"
 msgid "Report|Status"
 msgstr "Status"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr ""
 
@@ -6751,6 +6849,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7015,9 +7116,6 @@ msgstr ""
 msgid "Secret Key"
 msgstr "Hemlig Nyckel"
 
-msgid "Security group"
-msgstr "Säkerhetsgrupp"
-
 msgid "Security groups"
 msgstr "Säkerhetsgrupper"
 
@@ -7176,7 +7274,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "Sätt ett slumpgenererat lösenord för skärmanslutningen"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7365,6 +7463,9 @@ msgstr ""
 msgid "Show a subnet"
 msgstr ""
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr ""
 
@@ -7398,6 +7499,9 @@ msgstr ""
 msgid "Show an environment"
 msgstr "Visa en miljö"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr ""
 
@@ -7408,6 +7512,9 @@ msgid "Show an image"
 msgstr "Visa en avbildning"
 
 msgid "Show an interface for host"
+msgstr ""
+
+msgid "Show an internal authentication source"
 msgstr ""
 
 msgid "Show an operating system"
@@ -7491,9 +7598,6 @@ msgstr "Smarta Proxies"
 msgid "Smart Proxy"
 msgstr "Smart Proxy"
 
-msgid "Smart Proxy: %s"
-msgstr ""
-
 msgid "Smart Variables"
 msgstr "Smarta Variabler"
 
@@ -7505,6 +7609,9 @@ msgid "Smart proxy"
 msgstr "Smart proxy"
 
 msgid "Smart proxy IDs"
+msgstr ""
+
+msgid "Smart variables"
 msgstr ""
 
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
@@ -7519,11 +7626,18 @@ msgid "SmartProxy|Name"
 msgstr "Namn"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "Url"
 
 msgid "Snippet"
 msgstr "Remsa"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7557,6 +7671,9 @@ msgstr "Tyvärr, men inga mallar blev konfigurerade."
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "Förlåt, dessa värdar har inga parametrar tilldelade till sig, du måste lägga till det först."
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7663,6 +7780,9 @@ msgstr ""
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr ""
 
@@ -7706,6 +7826,10 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "Mask"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7827,6 +7951,21 @@ msgid "TFTP server"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Beskattningsbar taxonomi"
 
@@ -7929,6 +8068,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7938,6 +8089,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8367,6 +8522,9 @@ msgstr "Skifta"
 msgid "Token"
 msgstr "Token"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr ""
 
@@ -8430,7 +8588,7 @@ msgstr "Trender"
 msgid "Trends for %s"
 msgstr "Trend för %s"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8528,6 +8686,9 @@ msgid "Unable to connect"
 msgstr ""
 
 msgid "Unable to connect to LDAP server"
+msgstr ""
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
 msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
@@ -8740,6 +8901,12 @@ msgstr "Sluta managera värd"
 msgid "Unnamed"
 msgstr ""
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8869,6 +9036,9 @@ msgstr "Uppdatera en arkitektur"
 msgid "Update an environment"
 msgstr "Uppdatera en miljö"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "Uppdatera en avbildning"
 
@@ -8920,7 +9090,13 @@ msgstr "Uppdaterade värdar: ändrad värdgrupp"
 msgid "Updated hosts: changed owner"
 msgstr ""
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
+msgstr ""
+
+msgid "Use APIv4 (experimental)"
 msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
@@ -8930,6 +9106,9 @@ msgid "Use UUID for certificates"
 msgstr ""
 
 msgid "Use short name for VMs"
+msgstr ""
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
 msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
@@ -8955,6 +9134,9 @@ msgid "User Groups"
 msgstr "Användargrupper"
 
 msgid "User IDs"
+msgstr ""
+
+msgid "User Name:"
 msgstr ""
 
 msgid "User data template"
@@ -9106,6 +9288,9 @@ msgid "VCenter/Server"
 msgstr "VCenter/Server"
 
 msgid "VLAN ID for this subnet"
+msgstr ""
+
+msgid "VLAN ID is not consistent accross subnets"
 msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
@@ -9323,7 +9508,7 @@ msgstr ""
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr ""
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9407,6 +9592,9 @@ msgid "You are not authorized to make a template default."
 msgstr ""
 
 msgid "You are not authorized to perform this action."
+msgstr ""
+
+msgid "You are trying access the preferences of a different user"
 msgstr ""
 
 msgid "You are trying to delete your own account"
@@ -9601,6 +9789,9 @@ msgstr ""
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr ""
 
@@ -9718,6 +9909,9 @@ msgstr ""
 msgid "filter results"
 msgstr "filtrera resultat"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "endast för EC2"
 
@@ -9732,6 +9926,9 @@ msgstr "endast för OpenStack"
 
 msgid "for VMware"
 msgstr "för VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "för oVirt, VMWare Datacenter"
@@ -9883,7 +10080,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "tillåts inte att ändras"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9926,8 +10123,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -9936,6 +10132,12 @@ msgstr "lokation"
 
 msgid "locations"
 msgstr "lokationer"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr ""
@@ -9999,6 +10201,9 @@ msgstr "måste tillhandahålla en leverantör"
 
 msgid "must set host and port"
 msgstr "måste ange värd och port"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "ny"
@@ -10195,9 +10400,6 @@ msgstr ""
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "sortera resultat"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr ""
 
@@ -10295,6 +10497,9 @@ msgstr "giltig"
 msgid "valid or pending"
 msgstr ""
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10302,6 +10507,9 @@ msgid "virtual"
 msgstr "virtuell"
 
 msgid "virtual attached to %s"
+msgstr ""
+
+msgid "with given ID not found"
 msgstr ""
 
 msgid "yaml"

--- a/locale/zh_CN/foreman.po
+++ b/locale/zh_CN/foreman.po
@@ -31,8 +31,11 @@ msgstr "删除"
 msgid " in the provisioning template."
 msgstr "在预配模板中。"
 
-msgid "#{taxonomy} can be set on the All Hosts page"
-msgstr "#{taxonomy} 可在所有主机页面上设置"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
+msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
 msgstr "%s - 点击 Shift-F12 刷新。"
@@ -90,6 +93,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "已断开 %s 与 VM 的关联"
 
@@ -116,6 +122,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s 所选主机"
@@ -275,6 +284,11 @@ msgstr "'%{object_name}' 是 '%{object_class}'，应该是一个子网。"
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "API v2 不支持 'Content-Type: %s' 的 POST 和 PUT 请求。请使用 'Content-Type: application/json'。"
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "（其他）"
@@ -459,9 +473,6 @@ msgstr "增加参数"
 msgid "Add SSH Key"
 msgstr "添加 SSH 密钥"
 
-msgid "Add SSH Key for %s"
-msgstr "为 %s 添加 SSH 密钥"
-
 msgid "Add SSH key"
 msgstr "添加 SSH 密钥"
 
@@ -537,6 +548,12 @@ msgstr "管理员邮箱"
 msgid "Administrator user account required"
 msgstr "需要管理员用户帐户"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "告警"
 
@@ -551,9 +568,6 @@ msgstr "全部"
 
 msgid "All Hosts"
 msgstr "所有主机"
-
-msgid "All Puppet Classes for %s"
-msgstr "%s 所有的puppet 类"
 
 msgid "All Reports"
 msgstr "所有的报告"
@@ -812,6 +826,12 @@ msgstr "审计"
 
 msgid "Audit Comment"
 msgstr "审计备注"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "审核小结"
@@ -1123,14 +1143,26 @@ msgstr "浏览器时区"
 msgid "Build"
 msgstr "构建"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "创建主机"
 
 msgid "Build PXE Default"
 msgstr "创建默认PXE"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "从系统介质创建"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr "我们默认将用户组映射至标准 LDAP 组对象。FreeIPA 和 POSIX LDAP 服务器类型通过网络组支持可选的用户分组方式。如果要使用网络组代替标准组，则启用此复选框。"
@@ -1261,6 +1293,9 @@ msgstr "改变环境"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr "对 %s 的更改会传播到所有继承过滤器"
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "机架"
 
@@ -1306,6 +1341,12 @@ msgstr "类型"
 msgid "Clean up failed deployment"
 msgstr "清理失败的部署"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "点击计算资源链接编辑器默认 VM 属性。"
 
@@ -1314,9 +1355,6 @@ msgstr "点击添加%s"
 
 msgid "Click to log in again."
 msgstr "点击再次登录。"
-
-msgid "Click to mark as read"
-msgstr "点击，标记为已读"
 
 msgid "Click to remove %s"
 msgstr "点击删除 %s"
@@ -1438,6 +1476,10 @@ msgstr "描述"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
 msgstr "计算资源|域"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Name"
@@ -1686,6 +1728,9 @@ msgstr "创建代理服务器"
 msgid "Create Puppet Environment"
 msgstr "创建 Puppet 环境"
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr "创建范围"
 
@@ -1809,6 +1854,9 @@ msgstr "创建智能变量"
 msgid "Create a subnet"
 msgstr "创建子网"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "创建用户"
 
@@ -1848,6 +1896,9 @@ msgstr "为具体智能变量生创建替代值"
 msgid "Create autosign entry"
 msgstr "创建自动签名条目"
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "使用映象创建新引导卷"
 
@@ -1862,6 +1913,9 @@ msgstr "为 %s 创建 realm 条目"
 
 msgid "Created"
 msgstr "创建时间"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "重启"
@@ -2037,9 +2091,6 @@ msgstr "删除控制器"
 msgid "Delete Hosts"
 msgstr "删除主机"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr "删除 %s 的 PuppetCA 自动签名条目"
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "删除 %s的证书"
 
@@ -2133,8 +2184,14 @@ msgstr "删除智能参数"
 msgid "Delete a subnet"
 msgstr "删除子网"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "删除模板组合"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "删除用户"
@@ -2274,11 +2331,17 @@ msgstr "差异视图"
 msgid "Disable Notifications"
 msgstr "停用通知"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "停止选择主机的警告"
 
 msgid "Disable all filters overriding"
 msgstr "禁用所有过滤器覆盖"
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
+msgstr ""
 
 msgid "Disable overriding"
 msgstr "禁用覆盖"
@@ -2408,47 +2471,11 @@ msgstr "编辑"
 msgid "Edit %s"
 msgstr "编辑 %s"
 
-msgid "Edit Architecture"
-msgstr "编辑架构"
-
-msgid "Edit Bookmark"
-msgstr "编辑收藏"
-
 msgid "Edit Compute profile"
 msgstr "编辑计算配置文件"
 
-msgid "Edit Compute profile: %s"
-msgstr "编辑计算配置文件：%s"
-
-msgid "Edit Config group"
-msgstr "编辑 Config 组"
-
-msgid "Edit Domain"
-msgstr "编辑域"
-
-msgid "Edit Environment"
-msgstr "编辑环境"
-
-msgid "Edit Filter"
-msgstr "编辑过滤器"
-
-msgid "Edit Global Parameter"
-msgstr "编辑全局参数"
-
-msgid "Edit HTTP Proxy"
-msgstr "编辑 HTTP 代理服务器"
-
 msgid "Edit Host"
 msgstr "编辑主机"
-
-msgid "Edit LDAP Auth Source"
-msgstr "编辑LDAP认证源"
-
-msgid "Edit Medium"
-msgstr "编辑媒体"
-
-msgid "Edit Model"
-msgstr "编辑模型"
 
 msgid "Edit Operating System"
 msgstr "编辑操作系统"
@@ -2456,23 +2483,11 @@ msgstr "编辑操作系统"
 msgid "Edit Parameters"
 msgstr "编辑参数"
 
-msgid "Edit Partition Table"
-msgstr "编辑分区表"
-
 msgid "Edit Properties"
 msgstr "编辑属性"
 
-msgid "Edit Proxy"
-msgstr "编辑代理"
-
 msgid "Edit Puppet Class %s"
 msgstr "编辑 %s"
-
-msgid "Edit Realm"
-msgstr "编辑范围"
-
-msgid "Edit Role"
-msgstr "编辑角色"
 
 msgid "Edit Smart Variable"
 msgstr "编辑智能参数"
@@ -2480,23 +2495,8 @@ msgstr "编辑智能参数"
 msgid "Edit Smart class parameters"
 msgstr "编辑智能分类参数"
 
-msgid "Edit Subnet"
-msgstr "编辑子网"
-
-msgid "Edit Template"
-msgstr "编辑模板"
-
 msgid "Edit Trend %s"
 msgstr "编辑 %s 的走势"
-
-msgid "Edit User"
-msgstr "编辑用户"
-
-msgid "Edit User group"
-msgstr "编辑用户组"
-
-msgid "Edit compute profile on %s"
-msgstr "编辑 %s 中的计算配置文件"
 
 msgid "Edit this host"
 msgstr "编辑此主机"
@@ -2527,6 +2527,9 @@ msgstr "启用缓存"
 
 msgid "Enable Notifications"
 msgstr "启用提醒"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "启用选择主机的告警"
@@ -2650,6 +2653,15 @@ msgstr "提交数据时出错："
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
 msgstr "认证期间，连接到 '%{url}' 上的 '%{name}' LDAP 服务器时出错"
 
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
+msgstr ""
+
 msgid "Errors"
 msgstr "错误"
 
@@ -2772,11 +2784,11 @@ msgstr "图表名称"
 msgid "Fact Values"
 msgstr "Fact 值"
 
-msgid "Fact Values | %{host_name}"
-msgstr "详情值 | %{host_name}"
-
 msgid "Fact distribution chart"
 msgstr "信息详情分布图表"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2836,6 +2848,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "重启失败"
 
@@ -2847,9 +2862,6 @@ msgstr "无法从计算资源获取 %s 的 IP 地址"
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr "未能取消 %{hostname} 的未完成构建，发生如下错误：%{errors}"
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "无法清除任何旧的证书或添加自动签名条目。终止构建！"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "配置 %{host} 从 %{device} 启动失败: %{e}"
@@ -3032,11 +3044,11 @@ msgstr "筛选类"
 msgid "Filter overriding has been disabled"
 msgstr "过滤覆盖已被禁用"
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "筛选"
-
-msgid "Filters for role %s"
-msgstr "用于角色 %s 的过滤器"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr "过滤器默认继承与角色关联的 %{orgs_and_locs}。如果启用了覆盖字段，<br>过滤器可以覆盖其 %{orgs_and_locs} 的集合。后续角色更改不会影响此过滤器。<br>在禁用了覆盖字段后，会再次应用角色 %{orgs_and_locs}。"
@@ -3149,6 +3161,9 @@ msgstr "Foreman 可使用基于 LDAP 的服务提供用户信息及认证。"
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman 将域和 DNS 区域视为同样的事物。"
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "接口的 Foreman 域 ID。所管理主机中的主接口需要这个选项。"
 
@@ -3191,6 +3206,9 @@ msgstr "配置新主机后，Foreman 将会附加域名"
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman 会在供应新主机时自动进行证书签署"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman 会在收到报告后创建主机"
 
@@ -3229,9 +3247,6 @@ msgstr "Foreman 将在本地查询配置的解析程序，而不是通过 SOA/NS
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "如果没有自动探测到路径，Foreman 会将其设置为默认 Puppet 模块路径。"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "如果使用 puppet 开头，Foreman 会将主机名截取为 'puppet'。"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman 将根据其详情更新主机环境"
@@ -3356,6 +3371,9 @@ msgstr "全局变量"
 msgid "Good host reports in the last %s"
 msgstr "在过去 %s 内的报告良好的主机"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3382,6 +3400,9 @@ msgstr "HTTP(S) 代理服务器"
 
 msgid "HTTP(S) proxy except hosts"
 msgstr "HTTP(S) 代理服务器除外主机"
+
+msgid "HTTPS URL is required for API access"
+msgstr ""
 
 msgid "Hard disk"
 msgstr "硬盘"
@@ -3415,6 +3436,9 @@ msgstr "隐藏值"
 
 msgid "Hide all values for this parameter."
 msgstr "隐藏这个参数的所有值。"
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "隐藏此值"
@@ -3525,6 +3549,10 @@ msgid "Host::Base|Build"
 msgstr "创建"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "证书"
 
@@ -3551,6 +3579,10 @@ msgstr "Grub 通过"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "镜像文件"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3687,6 +3719,12 @@ msgstr "将在一次 puppet run 之后创建的主机放在这个详情描述的
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "将在一次 puppet run 之后创建的主机放在这个详情描述的机构。这个详情的内容应为该机构的完整标签。"
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "主机处于错误状态"
@@ -4172,6 +4210,9 @@ msgstr "输入"
 msgid "Installation Media"
 msgstr "安装介质"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "配置安装媒体"
 
@@ -4356,9 +4397,6 @@ msgstr "启动控制台"
 msgid "Learn more about this in the documentation."
 msgstr "了解更多本文档中的内容。"
 
-msgid "Legacy Puppet hostname"
-msgstr "旧的 Puppet 主机名"
-
 msgid "Length"
 msgstr "长度"
 
@@ -4421,6 +4459,15 @@ msgstr "列出所有审核"
 
 msgid "List all audits for a given host"
 msgstr "列出给定主机的所有审核"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "列出所有自动签名条目"
@@ -4587,6 +4634,9 @@ msgstr "列出所有用户"
 msgid "List all users for LDAP authentication source"
 msgstr "列出 LDAP 认证源的所有用户"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "列出位置的所有用户"
 
@@ -4647,6 +4697,15 @@ msgstr "列出每个位置的环境"
 msgid "List environments per organization"
 msgstr "列出每个机构的环境"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "列出每个位置的主机"
 
@@ -4658,6 +4717,9 @@ msgstr "列出每个机构的主机"
 
 msgid "List installed plugins"
 msgstr "列出已安装插件"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr "HTTP 代理服务器列表"
@@ -4733,6 +4795,15 @@ msgstr "每个位置的子网列表"
 
 msgid "List of subnets per organization"
 msgstr "每个机构的子网列表"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "列出将这个模板设定为默认模板的操作系统"
@@ -4972,6 +5043,18 @@ msgstr "用于重复使用此主机 IP 的 MAC 地址"
 msgid "MAC-based"
 msgstr "基于 MAC"
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "机器型号"
 
@@ -5168,6 +5251,9 @@ msgstr "缺少搜索父项 %s 的许可"
 msgid "Missing one of the required permissions: %s"
 msgstr "缺少所需权限之一：%s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "型号"
@@ -5248,6 +5334,9 @@ msgstr "主机组名称"
 msgid "Name of the parameter"
 msgstr "参数名称"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "变量名称"
 
@@ -5290,14 +5379,11 @@ msgstr "网络类型"
 msgid "New"
 msgstr "新建"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "新建自动签名"
-
-msgid "New Event"
-msgstr "新事件"
-
-msgid "New Events"
-msgstr "新事件"
 
 msgid "New HTTP Proxy"
 msgstr "新 HTTP 代理服务器"
@@ -5319,9 +5405,6 @@ msgstr "新建虚拟主机"
 
 msgid "New boot volume size (GB)"
 msgstr "新引导卷大小（GB）"
-
-msgid "New compute profile on %s"
-msgstr "在 %s 中新建计算配置文件"
 
 msgid "New filter"
 msgstr "新建过滤器"
@@ -5348,6 +5431,10 @@ msgstr "捆绑选项"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
 msgstr "Nic::基础|计算属性"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Identifier"
@@ -5421,11 +5508,14 @@ msgstr "没有可供主机 %s 使用的 BMC NIC"
 msgid "No Failed Features"
 msgstr "无失败的功能"
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr "未选择 IPv4 子网"
 
-msgid "No Notifications"
-msgstr "无通知"
+msgid "No Notifications Available"
+msgstr ""
 
 msgid "No TFTP feature"
 msgstr "TFTP 功能"
@@ -6148,9 +6238,6 @@ msgstr "分区模板描述了分区布局，仅仅通过不同的磁盘布局来
 msgid "Password"
 msgstr "密码"
 
-msgid "Password do not match"
-msgstr "密码不匹配"
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "oVirt、EC2、VMware、OpenStack 的密码。EC2 的访问密钥。"
 
@@ -6174,6 +6261,9 @@ msgstr "进行 HTTP 代理服务器验证时使用的密码"
 
 msgid "Password:"
 msgstr "密码:"
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "路径"
@@ -6446,14 +6536,19 @@ msgstr "名称"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "片段"
 
-msgid "Proxied request failed with: %s"
-msgstr "代理请求失败：%s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
+msgstr ""
 
 msgid "Proxies"
 msgstr "代理"
 
 msgid "Proxy ID to use within this realm"
 msgstr "要在此域中使用的代理 ID"
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
+msgstr ""
 
 msgid "Proxy request timeout"
 msgstr "代理服务器请求"
@@ -6757,6 +6852,9 @@ msgstr "报告于"
 msgid "Report|Status"
 msgstr "状态"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "智能代理服务器需要 SSL"
 
@@ -6765,6 +6863,9 @@ msgstr "没有赋值的必填参数。<br/><b>请覆盖！</b><br/>"
 
 msgid "Required when user want to change own password"
 msgstr "用户想要更改自己的密码时需要"
+
+msgid "Reset PuppetCA certname for %s"
+msgstr ""
 
 msgid "Reset to default"
 msgstr "重置为默认"
@@ -7028,9 +7129,6 @@ msgstr "这个子网的辅 DNS"
 msgid "Secret Key"
 msgstr "密钥"
 
-msgid "Security group"
-msgstr "安全组"
-
 msgid "Security groups"
 msgstr "安全组"
 
@@ -7189,8 +7287,8 @@ msgstr "在 VNC 显示连接上设置随机生成的密码"
 msgid "Set a randomly generated password on the display connection"
 msgstr "在显示连接中设定随机创建的密码"
 
-msgid "Set hostnames to which requests are not to be proxied"
-msgstr "设置不将请求代理到主机名称"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
+msgstr ""
 
 msgid "Set parameters to defaults"
 msgstr "将参数设定为默认"
@@ -7378,6 +7476,9 @@ msgstr "显示智能变量"
 msgid "Show a subnet"
 msgstr "显示子网"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "显示用户"
 
@@ -7411,6 +7512,9 @@ msgstr "显示电子邮件通知"
 msgid "Show an environment"
 msgstr "显示环境"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "显示 LDAP 认证源的外部用户组"
 
@@ -7422,6 +7526,9 @@ msgstr "显示映像"
 
 msgid "Show an interface for host"
 msgstr "显示主机接口"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "显示操作系统"
@@ -7504,9 +7611,6 @@ msgstr "智能代理"
 msgid "Smart Proxy"
 msgstr "智能代理"
 
-msgid "Smart Proxy: %s"
-msgstr "智能代理服务器：%s"
-
 msgid "Smart Variables"
 msgstr "智能变量"
 
@@ -7520,6 +7624,9 @@ msgstr "智能代理"
 msgid "Smart proxy IDs"
 msgstr "智能代理服务器 ID"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr "智能变量是一种工具，用于根据一组规则向您的 Puppet ENC 的顶层（全局）范围提供参数（键/值数据）。"
 
@@ -7532,11 +7639,18 @@ msgid "SmartProxy|Name"
 msgstr "名称"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "地址"
 
 msgid "Snippet"
 msgstr "片段"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr "有些 Puppet 类别在所选环境中不可用"
@@ -7570,6 +7684,9 @@ msgstr "抱歉，但没有配置任何模板。"
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "抱歉，没有为这些主机分配任何参数，必须首先为其添加参数。"
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7676,6 +7793,9 @@ msgstr "子网 ID"
 msgid "Subnet description"
 msgstr "子网描述"
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "子网名"
 
@@ -7719,6 +7839,10 @@ msgstr "Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "掩码"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7840,6 +7964,21 @@ msgid "TFTP server"
 msgstr "TFTP 服务器"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxable taxonomy"
 
@@ -7942,6 +8081,18 @@ msgid "Template|Default"
 msgstr "模板|默认"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "模板|已锁定"
 
@@ -7952,6 +8103,10 @@ msgstr "模板|名称"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
 msgstr "模板|操作系统集"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Snippet"
@@ -8392,6 +8547,9 @@ msgstr "切换"
 msgid "Token"
 msgstr "符号"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "令牌持续时间"
 
@@ -8455,8 +8613,8 @@ msgstr "趋势"
 msgid "Trends for %s"
 msgstr "%s 的趋势"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
-msgstr "Foreman 中的趋势让您可以随时间跟踪您基础设施中的更改。您可以跟踪与 Foreman 相关的信息和任何 Puppet 详情。趋势页面提供了一幅图表，显示采用该值的主机数量如何随时间变化，并列出当前的主机。"
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Trend|Fact name"
@@ -8554,6 +8712,9 @@ msgstr "无法连接"
 
 msgid "Unable to connect to LDAP server"
 msgstr "无法连接到 LDAP 服务器"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "无法创建默认 TFTP 引导菜单"
@@ -8765,6 +8926,12 @@ msgstr "取消管理主机"
 msgid "Unnamed"
 msgstr "未命名"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr "%s 不支持的 IPAM 模式"
 
@@ -8894,6 +9061,9 @@ msgstr "更新架构"
 msgid "Update an environment"
 msgstr "更新环境"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "更新映像"
 
@@ -8945,8 +9115,14 @@ msgstr "已更新主机：更改主机组"
 msgid "Updated hosts: changed owner"
 msgstr "更新的主机：更改的所有者"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "上传主机的系统详情，如需要，请创建主机。"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr "使用 NIS 网络组代替 posix 组。"
@@ -8956,6 +9132,9 @@ msgstr "在证书中使用 UUID"
 
 msgid "Use short name for VMs"
 msgstr "在 VM 中使用短名称"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "使用此账号验证, <i>可选</i>"
@@ -8981,6 +9160,9 @@ msgstr "用户组"
 
 msgid "User IDs"
 msgstr "用户 ID"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr "用户数据模版"
@@ -9132,6 +9314,9 @@ msgstr "VCenter/服务器"
 
 msgid "VLAN ID for this subnet"
 msgstr "这个子网的 VLAN ID"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN 标签，这个属性优先于子网 VLAN ID。仅用于虚拟接口。"
@@ -9357,8 +9542,8 @@ msgstr "分类参数值是否由 Foreman 管理。"
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "是否由 Foreman 管理智能类别参数值"
 
-msgid "Whether to get RSS notifications or not"
-msgstr "是否获取 RSS 通知"
+msgid "Whether to pull RSS notifications or not"
+msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
 msgstr "是 <b>%s</b> 偏移。"
@@ -9442,6 +9627,9 @@ msgstr "您没有设置默认模板的授权。"
 
 msgid "You are not authorized to perform this action."
 msgstr "您没有执行这个操作的授权。"
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "您要删除您自己的账户"
@@ -9635,6 +9823,9 @@ msgstr "不能从内部包保护账户中删除"
 msgid "cannot be removed from the last admin account"
 msgstr "不能从最后一个管理员帐户中删除"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "克隆"
 
@@ -9752,6 +9943,9 @@ msgstr "%s 角色的过滤器"
 msgid "filter results"
 msgstr "过滤结果"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "仅用于 EC2"
 
@@ -9766,6 +9960,9 @@ msgstr "仅用于 OpenStack"
 
 msgid "for VMware"
 msgstr "用于 VMware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "用于 oVirt、VMware 数据库"
@@ -9917,8 +10114,8 @@ msgstr "不是有效的 ssh 公钥"
 msgid "is not allowed to change"
 msgstr "不允许更改"
 
-msgid "is not defined for host's %s."
-msgstr "没有为主机的 %s 定义。"
+msgid "is not defined for host's %s"
+msgstr ""
 
 msgid "is not found in the authentication source"
 msgstr "在认证源中没有找到"
@@ -9960,8 +10157,7 @@ msgstr "将外部用户组与这个用户组关联"
 msgid "list"
 msgstr "列表"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "简体中文"
 
@@ -9970,6 +10166,12 @@ msgstr "位置"
 
 msgid "locations"
 msgstr "位置"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "管理的主机必须有一个预配接口"
@@ -10033,6 +10235,9 @@ msgstr "必须提供供应者"
 
 msgid "must set host and port"
 msgstr "必须设置主机和端口"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "新建"
@@ -10229,9 +10434,6 @@ msgstr "有些接口无效"
 msgid "some permissions were not found"
 msgstr "未找到某些权限"
 
-msgid "sort results"
-msgstr "结果排序"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "使用空格分开的选项，例如：miimon=100"
 
@@ -10333,6 +10535,9 @@ msgstr "有效"
 msgid "valid or pending"
 msgstr "有效或待处理"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr "查看上一次的报告详情"
 
@@ -10341,6 +10546,9 @@ msgstr "虚拟"
 
 msgid "virtual attached to %s"
 msgstr "虚拟附加到 %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/locale/zh_TW/foreman.po
+++ b/locale/zh_TW/foreman.po
@@ -27,7 +27,10 @@ msgstr "移除"
 msgid " in the provisioning template."
 msgstr ""
 
-msgid "#{taxonomy} can be set on the All Hosts page"
+msgid "#{@compute_resource.to_s}"
+msgstr ""
+
+msgid "#{taxonomy} can be changed using bulk action on the All Hosts page"
 msgstr ""
 
 msgid "%s - Press Shift-F12 to release the cursor."
@@ -86,6 +89,9 @@ msgid_plural "%s error messages"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "%s filters"
+msgstr ""
+
 msgid "%s has been disassociated from VM"
 msgstr "%s 和 VM 之間的關聯性已解除"
 
@@ -112,6 +118,9 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "%s out of sync disabled"
+msgstr ""
 
 msgid "%s selected hosts"
 msgstr "%s 選擇的主機"
@@ -271,6 +280,11 @@ msgstr ""
 
 msgid "'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."
 msgstr "'Content-Type: %s' 在 POST 和 PUT 請求的 API v2 中不受支援。請使用 'Content-Type: application/json'。"
+
+msgid "(%s host)"
+msgid_plural "(%s hosts)"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "(Miscellaneous)"
 msgstr "（雜項）"
@@ -455,9 +469,6 @@ msgstr "新增參數"
 msgid "Add SSH Key"
 msgstr ""
 
-msgid "Add SSH Key for %s"
-msgstr ""
-
 msgid "Add SSH key"
 msgstr ""
 
@@ -533,6 +544,12 @@ msgstr "管理員電子郵件地址"
 msgid "Administrator user account required"
 msgstr "需要管理者帳號"
 
+msgid "Affected Locations:"
+msgstr ""
+
+msgid "Affected Organizations:"
+msgstr ""
+
 msgid "Alert"
 msgstr "告警"
 
@@ -547,9 +564,6 @@ msgstr "全部"
 
 msgid "All Hosts"
 msgstr ""
-
-msgid "All Puppet Classes for %s"
-msgstr "%s 的所有 Puppet 類別"
 
 msgid "All Reports"
 msgstr "所有報告"
@@ -808,6 +822,12 @@ msgstr "稽核"
 
 msgid "Audit Comment"
 msgstr "稽核備註"
+
+msgid "Audit Metadata:"
+msgstr ""
+
+msgid "Audit Time:"
+msgstr ""
 
 msgid "Audit summary"
 msgstr "稽核摘要"
@@ -1119,14 +1139,26 @@ msgstr "瀏覽器時區"
 msgid "Build"
 msgstr "組建"
 
+msgid "Build Duration"
+msgstr ""
+
 msgid "Build Hosts"
 msgstr "組建主機"
 
 msgid "Build PXE Default"
 msgstr "組建 PXE 預設值"
 
+msgid "Build duration"
+msgstr ""
+
+msgid "Build errors"
+msgstr ""
+
 msgid "Build from OS image"
 msgstr "由 OS 映像檔組建"
+
+msgid "Build in progress"
+msgstr ""
 
 msgid "By default we map user groups to standard LDAP Group objects. FreeIPA and POSIX LDAP server types supports alternative way of grouping users through Netgroups. Enable this checkbox if using Netgroups is preferred instead of standard groups."
 msgstr ""
@@ -1257,6 +1289,9 @@ msgstr "已更改的環境"
 msgid "Changes to %s will propagate to all inheriting filters"
 msgstr ""
 
+msgid "Changes:"
+msgstr ""
+
 msgid "Chassis"
 msgstr "底座"
 
@@ -1302,6 +1337,12 @@ msgstr "類別"
 msgid "Clean up failed deployment"
 msgstr "清除失敗的建置"
 
+msgid "Cleanup PuppetCA certificates for %s"
+msgstr ""
+
+msgid "Clear All"
+msgstr ""
+
 msgid "Click on the link of a compute resource to edit its default VM attributes."
 msgstr "點選運算資源的連結來編輯其預設 VM 屬性。"
 
@@ -1310,9 +1351,6 @@ msgstr "點選以新增 %s"
 
 msgid "Click to log in again."
 msgstr "點選以再次登入。"
-
-msgid "Click to mark as read"
-msgstr ""
 
 msgid "Click to remove %s"
 msgstr "點選以移除 %s"
@@ -1433,6 +1471,10 @@ msgstr "描述"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "ComputeResource|Domain"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ComputeResource|Filtered api"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -1682,6 +1724,9 @@ msgstr ""
 msgid "Create Puppet Environment"
 msgstr ""
 
+msgid "Create RSS notifications"
+msgstr ""
+
 msgid "Create Realm"
 msgstr ""
 
@@ -1805,6 +1850,9 @@ msgstr "建立智慧型變數"
 msgid "Create a subnet"
 msgstr "建立子網路"
 
+msgid "Create a trend counter"
+msgstr ""
+
 msgid "Create a user"
 msgstr "建立使用者"
 
@@ -1844,6 +1892,9 @@ msgstr "為特定智慧型變數建立置換值"
 msgid "Create autosign entry"
 msgstr ""
 
+msgid "Create image"
+msgstr ""
+
 msgid "Create new boot volume from image"
 msgstr "從映像檔建立新卷冊"
 
@@ -1858,6 +1909,9 @@ msgstr "為 %s 建立領域項目"
 
 msgid "Created"
 msgstr "已建立"
+
+msgid "Creates a table preference for a given table"
+msgstr ""
 
 msgid "Ctrl-Alt-Del"
 msgstr "Ctrl-Alt-Del"
@@ -2033,9 +2087,6 @@ msgstr ""
 msgid "Delete Hosts"
 msgstr "刪除主機"
 
-msgid "Delete PuppetCA autosign entry for %s"
-msgstr ""
-
 msgid "Delete PuppetCA certificates for %s"
 msgstr "刪除 %s 的 PuppetCA 憑證"
 
@@ -2129,8 +2180,14 @@ msgstr "刪除智慧變數"
 msgid "Delete a subnet"
 msgstr "刪除子網路"
 
+msgid "Delete a table preference for a given table"
+msgstr ""
+
 msgid "Delete a template combination"
 msgstr "刪除範本組合"
+
+msgid "Delete a trend counter"
+msgstr ""
 
 msgid "Delete a user"
 msgstr "刪除使用者"
@@ -2270,10 +2327,16 @@ msgstr "差異視域"
 msgid "Disable Notifications"
 msgstr "停用通知"
 
+msgid "Disable PuppetCA autosigning for %s"
+msgstr ""
+
 msgid "Disable alerts for selected hosts"
 msgstr "停用所選主機的警示"
 
 msgid "Disable all filters overriding"
+msgstr ""
+
+msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2404,47 +2467,11 @@ msgstr "編輯"
 msgid "Edit %s"
 msgstr "編輯 %s"
 
-msgid "Edit Architecture"
-msgstr "編輯架構"
-
-msgid "Edit Bookmark"
-msgstr "編輯書籤"
-
 msgid "Edit Compute profile"
 msgstr "編輯運算設定檔"
 
-msgid "Edit Compute profile: %s"
-msgstr "編輯運算設定檔：%s"
-
-msgid "Edit Config group"
-msgstr "編輯配置群組"
-
-msgid "Edit Domain"
-msgstr "編輯網域"
-
-msgid "Edit Environment"
-msgstr "編輯環境"
-
-msgid "Edit Filter"
-msgstr "編輯篩選器"
-
-msgid "Edit Global Parameter"
-msgstr "編輯全域參數"
-
-msgid "Edit HTTP Proxy"
-msgstr ""
-
 msgid "Edit Host"
 msgstr "編輯主機"
-
-msgid "Edit LDAP Auth Source"
-msgstr "編輯 LDAP Auth 來源"
-
-msgid "Edit Medium"
-msgstr "編輯媒介"
-
-msgid "Edit Model"
-msgstr "編輯型號"
 
 msgid "Edit Operating System"
 msgstr "編輯作業系統"
@@ -2452,23 +2479,11 @@ msgstr "編輯作業系統"
 msgid "Edit Parameters"
 msgstr "編輯參數"
 
-msgid "Edit Partition Table"
-msgstr "編輯分割表"
-
 msgid "Edit Properties"
 msgstr "編輯內容"
 
-msgid "Edit Proxy"
-msgstr "編輯代理伺服器"
-
 msgid "Edit Puppet Class %s"
 msgstr "編輯 Puppet 類別 %s"
-
-msgid "Edit Realm"
-msgstr "編輯領域"
-
-msgid "Edit Role"
-msgstr ""
 
 msgid "Edit Smart Variable"
 msgstr "編輯智慧變數"
@@ -2476,23 +2491,8 @@ msgstr "編輯智慧變數"
 msgid "Edit Smart class parameters"
 msgstr "編輯智慧類別參數"
 
-msgid "Edit Subnet"
-msgstr "編輯子網路"
-
-msgid "Edit Template"
-msgstr "編輯範本"
-
 msgid "Edit Trend %s"
 msgstr "編輯趨勢 %s"
-
-msgid "Edit User"
-msgstr "編輯使用者"
-
-msgid "Edit User group"
-msgstr "編輯使用者群組"
-
-msgid "Edit compute profile on %s"
-msgstr "編輯 %s 上的運算設定檔"
 
 msgid "Edit this host"
 msgstr ""
@@ -2523,6 +2523,9 @@ msgstr ""
 
 msgid "Enable Notifications"
 msgstr "啟用通知"
+
+msgid "Enable PuppetCA autosigning for %s"
+msgstr ""
 
 msgid "Enable alerts for selected hosts"
 msgstr "啟用所選主機的警示"
@@ -2644,6 +2647,15 @@ msgid "Error submitting data:"
 msgstr ""
 
 msgid "Error while connecting to '%{name}' LDAP server at '%{url}' during authentication"
+msgstr ""
+
+msgid "Error while trying to create resource: %s"
+msgstr ""
+
+msgid "Error while trying to update resource: %s"
+msgstr ""
+
+msgid "Error: Unable to load resources."
 msgstr ""
 
 msgid "Errors"
@@ -2768,11 +2780,11 @@ msgstr "詳情名稱"
 msgid "Fact Values"
 msgstr "詳情值"
 
-msgid "Fact Values | %{host_name}"
-msgstr ""
-
 msgid "Fact distribution chart"
 msgstr "詳情散佈圖表"
+
+msgid "Fact distribution chart - %s "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Fact name"
@@ -2832,6 +2844,9 @@ msgid_plural "Failed features: %s"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "Failed login attempts limit"
+msgstr ""
+
 msgid "Failed restarts"
 msgstr "重新啟動失敗"
 
@@ -2843,9 +2858,6 @@ msgstr ""
 
 msgid "Failed to cancel pending build for %{hostname} with the following errors: %{errors}"
 msgstr ""
-
-msgid "Failed to clean any old certificates or add the autosign entry. Terminating the build!"
-msgstr "清除舊憑證或新增 autosign 項目失敗。正在終止組建！"
 
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr "配置 %{host} 以透過 %{device} 啟動失敗：%{e}"
@@ -3026,11 +3038,11 @@ msgstr "篩選器類別"
 msgid "Filter overriding has been disabled"
 msgstr ""
 
+msgid "Filter..."
+msgstr ""
+
 msgid "Filters"
 msgstr "篩選器"
-
-msgid "Filters for role %s"
-msgstr "為角色 %s 篩選"
 
 msgid "Filters inherit %{orgs_and_locs} associated with the role by default. If override field is enabled, <br> the filter can override the set of its %{orgs_and_locs}. Later role changes will not affect such filter.<br> After disabling the override field, the role %{orgs_and_locs} apply again."
 msgstr ""
@@ -3143,6 +3155,9 @@ msgstr "Foreman 能使用基於 LDAP 的服務來配置使用者資訊及驗證�
 msgid "Foreman considers a domain and a DNS zone as the same thing."
 msgstr "Foreman 將網域和 DNS 區域視為相同的東西。"
 
+msgid "Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s"
+msgstr ""
+
 msgid "Foreman domain ID of interface. Required for primary interfaces on managed hosts."
 msgstr "介面卡的 Foreman 區域 ID。在受管理主機上的主介面所需。"
 
@@ -3185,6 +3200,9 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman 將會在佈建新主機時自動化憑證簽署"
 
+msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgstr ""
+
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman 將會在收到回報後建立主機"
 
@@ -3223,9 +3241,6 @@ msgstr "Foreman 將會查詢本機配置的解析器，而非 SOA/NS 授權"
 
 msgid "Foreman will set this as the default Puppet module path if it cannot auto detect one"
 msgstr "Foreman 若無法自動偵測，便會將此設為預設的 Puppet 模組路徑"
-
-msgid "Foreman will truncate hostname to 'puppet' if it starts with puppet"
-msgstr "若主機名稱以 puppet 為起始，Foreman 會將主機名稱截斷為 'puppet'"
 
 msgid "Foreman will update a host's environment from its facts"
 msgstr "Foreman 會藉由主機的環境之詳情來更新它"
@@ -3350,6 +3365,9 @@ msgstr ""
 msgid "Good host reports in the last %s"
 msgstr "在最後 %s 間的良好主機回報"
 
+msgid "Good host with reports"
+msgstr ""
+
 msgid "Google Project ID"
 msgstr "Google Project ID"
 
@@ -3375,6 +3393,9 @@ msgid "HTTP(S) proxy"
 msgstr ""
 
 msgid "HTTP(S) proxy except hosts"
+msgstr ""
+
+msgid "HTTPS URL is required for API access"
 msgstr ""
 
 msgid "Hard disk"
@@ -3409,6 +3430,9 @@ msgstr ""
 
 msgid "Hide all values for this parameter."
 msgstr "為這參數隱藏所有值。"
+
+msgid "Hide this notification"
+msgstr ""
 
 msgid "Hide this value"
 msgstr "隱藏此值"
@@ -3519,6 +3543,10 @@ msgid "Host::Base|Build"
 msgstr "組建"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Build errors"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Certname"
 msgstr "憑證名稱"
 
@@ -3545,6 +3573,10 @@ msgstr "Grub pass"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Image file"
 msgstr "映像檔"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host::Base|Initiated at"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Host::Base|Installed at"
@@ -3681,6 +3713,12 @@ msgstr "在 puppet run 之後建立的主機將會被放置在此詳情所指定
 
 msgid "Hosts created after a puppet run will be placed in the organization this fact dictates. The content of this fact should be the full label of the organization."
 msgstr "在 puppet run 之後建立的主機將會被放置在此詳情所指定的組織中。此詳情的內容應該要是組織的完整標籤。"
+
+msgid "Hosts in Build mode or with Build errors"
+msgstr ""
+
+msgid "Hosts in build mode"
+msgstr ""
 
 msgid "Hosts in error state"
 msgstr "狀態為錯誤的主機"
@@ -4166,6 +4204,9 @@ msgstr "輸入"
 msgid "Installation Media"
 msgstr "安裝媒介"
 
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation medium configuration"
 msgstr "安裝媒介配置"
 
@@ -4350,9 +4391,6 @@ msgstr ""
 msgid "Learn more about this in the documentation."
 msgstr "欲知更多，請參閱文件。"
 
-msgid "Legacy Puppet hostname"
-msgstr "舊式 Puppet 主機"
-
 msgid "Length"
 msgstr ""
 
@@ -4415,6 +4453,15 @@ msgstr "列出所有稽核"
 
 msgid "List all audits for a given host"
 msgstr "列出一部主機的所有稽核"
+
+msgid "List all authentication sources"
+msgstr ""
+
+msgid "List all authentication sources per location"
+msgstr ""
+
+msgid "List all authentication sources per organization"
+msgstr ""
 
 msgid "List all autosign entries"
 msgstr "列出所有 autosign 項目"
@@ -4581,6 +4628,9 @@ msgstr "列出所有使用者"
 msgid "List all users for LDAP authentication source"
 msgstr "列出 LDAP 認證來源的所有使用者"
 
+msgid "List all users for external authentication source"
+msgstr ""
+
 msgid "List all users for location"
 msgstr "列出位置中的所有使用者"
 
@@ -4641,6 +4691,15 @@ msgstr "列出各個位置的環境"
 msgid "List environments per organization"
 msgstr "列出各個組織的環境"
 
+msgid "List external authentication sources"
+msgstr ""
+
+msgid "List external authentication sources per location"
+msgstr ""
+
+msgid "List external authentication sources per organization"
+msgstr ""
+
 msgid "List hosts per environment"
 msgstr "列出各個環境中的主機"
 
@@ -4652,6 +4711,9 @@ msgstr "列出各個組織中的主機"
 
 msgid "List installed plugins"
 msgstr "列出已安裝的外掛程式"
+
+msgid "List internal authentication sources"
+msgstr ""
 
 msgid "List of HTTP Proxies"
 msgstr ""
@@ -4727,6 +4789,15 @@ msgstr "各個位置上的子網路之清單"
 
 msgid "List of subnets per organization"
 msgstr "各個組織中的子網路之清單"
+
+msgid "List of table preferences for a user"
+msgstr ""
+
+msgid "List of trends counters"
+msgstr ""
+
+msgid "List of user selected columns"
+msgstr ""
 
 msgid "List operating systems where this template is set as a default"
 msgstr "列出作業系統，而此範本已被設為預設值"
@@ -4966,6 +5037,18 @@ msgstr ""
 msgid "MAC-based"
 msgstr ""
 
+msgid "MTU"
+msgstr ""
+
+msgid "MTU for this subnet"
+msgstr ""
+
+msgid "MTU is not consistent accross subnets"
+msgstr ""
+
+msgid "MTU, this attribute has precedence over the subnet MTU."
+msgstr ""
+
 msgid "Machine Type"
 msgstr "機器類型"
 
@@ -5162,6 +5245,9 @@ msgstr ""
 msgid "Missing one of the required permissions: %s"
 msgstr "找不到所需權限之一：%s"
 
+msgid "Missing(ID: %s)"
+msgstr ""
+
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Model"
 msgstr "型號"
@@ -5242,6 +5328,9 @@ msgstr "主機群組的名稱"
 msgid "Name of the parameter"
 msgstr "參數名稱"
 
+msgid "Name of the table"
+msgstr ""
+
 msgid "Name of variable"
 msgstr "變數名稱"
 
@@ -5284,14 +5373,11 @@ msgstr "網路類型"
 msgid "New"
 msgstr "新增"
 
+msgid "New %s"
+msgstr ""
+
 msgid "New Autosign Entry"
 msgstr "新增 Autosign 項目"
-
-msgid "New Event"
-msgstr ""
-
-msgid "New Events"
-msgstr ""
 
 msgid "New HTTP Proxy"
 msgstr ""
@@ -5313,9 +5399,6 @@ msgstr "新增虛擬機器"
 
 msgid "New boot volume size (GB)"
 msgstr "新的開機卷冊大小（GB）"
-
-msgid "New compute profile on %s"
-msgstr "新增 %s 上的運算設定檔"
 
 msgid "New filter"
 msgstr "新增篩選器"
@@ -5341,6 +5424,10 @@ msgstr "Bond 選項"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Nic::Base|Compute attributes"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Nic::Base|Execution"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -5415,10 +5502,13 @@ msgstr ""
 msgid "No Failed Features"
 msgstr ""
 
+msgid "No Hosts are in build mode or have build errors."
+msgstr ""
+
 msgid "No IPv4 subnets selected"
 msgstr ""
 
-msgid "No Notifications"
+msgid "No Notifications Available"
 msgstr ""
 
 msgid "No TFTP feature"
@@ -6142,9 +6232,6 @@ msgstr ""
 msgid "Password"
 msgstr "密碼"
 
-msgid "Password do not match"
-msgstr ""
-
 msgid "Password for oVirt, EC2, VMware, OpenStack. Secret key for EC2"
 msgstr "Ovirt、EC2、Vmware、Openstack 的密碼。EC2 的祕密金鑰"
 
@@ -6168,6 +6255,9 @@ msgstr ""
 
 msgid "Password:"
 msgstr "密碼："
+
+msgid "Passwords do not match"
+msgstr ""
 
 msgid "Path"
 msgstr "路徑"
@@ -6440,13 +6530,18 @@ msgstr "ProvisioningTemplate|Name"
 msgid "ProvisioningTemplate|Snippet"
 msgstr "ProvisioningTemplate|Snippet"
 
-msgid "Proxied request failed with: %s"
+msgid ""
+"Proxied request failed with: %s\n"
+"%s"
 msgstr ""
 
 msgid "Proxies"
 msgstr "代理伺服器"
 
 msgid "Proxy ID to use within this realm"
+msgstr ""
+
+msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
 msgid "Proxy request timeout"
@@ -6751,6 +6846,9 @@ msgstr "回報於"
 msgid "Report|Status"
 msgstr "狀態"
 
+msgid "Request Failed"
+msgstr ""
+
 msgid "Require SSL for smart proxies"
 msgstr "智慧型代理伺服器需要 SSL"
 
@@ -6758,6 +6856,9 @@ msgid "Required parameter without value.<br/><b>Please override!</b><br/>"
 msgstr "必要的參數未提供值。<br/><b>請覆寫！</b> <br/>"
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
 msgid "Reset to default"
@@ -7022,9 +7123,6 @@ msgstr "這個子網路的次要 DNS"
 msgid "Secret Key"
 msgstr "密鑰"
 
-msgid "Security group"
-msgstr "安全性群組"
-
 msgid "Security groups"
 msgstr "安全性群組"
 
@@ -7183,7 +7281,7 @@ msgstr ""
 msgid "Set a randomly generated password on the display connection"
 msgstr "在顯示連線上設置一組隨機產生的密碼"
 
-msgid "Set hostnames to which requests are not to be proxied"
+msgid "Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default."
 msgstr ""
 
 msgid "Set parameters to defaults"
@@ -7372,6 +7470,9 @@ msgstr "顯示智慧變數"
 msgid "Show a subnet"
 msgstr "顯示子網路"
 
+msgid "Show a trend"
+msgstr ""
+
 msgid "Show a user"
 msgstr "顯示使用者"
 
@@ -7405,6 +7506,9 @@ msgstr "顯示電子郵件通知"
 msgid "Show an environment"
 msgstr "顯示環境"
 
+msgid "Show an external authentication source"
+msgstr ""
+
 msgid "Show an external user group for LDAP authentication source"
 msgstr "顯示 LDAP 認證來源的外部使用者群組"
 
@@ -7416,6 +7520,9 @@ msgstr "顯示映像檔"
 
 msgid "Show an interface for host"
 msgstr "顯示主機的介面卡"
+
+msgid "Show an internal authentication source"
+msgstr ""
 
 msgid "Show an operating system"
 msgstr "顯示作業系統"
@@ -7498,9 +7605,6 @@ msgstr "智慧型代理伺服器"
 msgid "Smart Proxy"
 msgstr "智慧型代理伺服器"
 
-msgid "Smart Proxy: %s"
-msgstr "智慧代理：%s"
-
 msgid "Smart Variables"
 msgstr "智慧變數"
 
@@ -7514,6 +7618,9 @@ msgstr "智慧代理"
 msgid "Smart proxy IDs"
 msgstr "智慧型代理伺服器的 ID"
 
+msgid "Smart variables"
+msgstr ""
+
 msgid "Smart variables are a tool to provide parameters (key/value data), to the top-level (global) scope of your Puppet ENC, depending on a set of rules."
 msgstr ""
 
@@ -7526,11 +7633,18 @@ msgid "SmartProxy|Name"
 msgstr "名稱"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "SmartProxy|Pubkey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "SmartProxy|Url"
 msgstr "URL"
 
 msgid "Snippet"
 msgstr "程式碼片段"
+
+msgid "Sockets"
+msgstr ""
 
 msgid "Some Puppet Classes are unavailable in the selected environment"
 msgstr ""
@@ -7564,6 +7678,9 @@ msgstr "抱歉，未配置任何範本。"
 
 msgid "Sorry, these hosts do not have parameters assigned to them, you must add them first."
 msgstr "抱歉，這些主機尚未被指定參數，您必須先加入參數。"
+
+msgid "Sort field and order, eg. ‘id DESC’"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source"
@@ -7670,6 +7787,9 @@ msgstr "子網路的 ID"
 msgid "Subnet description"
 msgstr ""
 
+msgid "Subnet gateway"
+msgstr ""
+
 msgid "Subnet name"
 msgstr "子網路名稱"
 
@@ -7713,6 +7833,10 @@ msgstr "Ipam"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Mask"
 msgstr "遮罩"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Mtu"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Name"
@@ -7834,6 +7958,21 @@ msgid "TFTP server"
 msgstr "TFTP 伺服器"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Table preference"
+msgstr ""
+
+msgid "Table preference details of a given table"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TablePreference|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Taxable taxonomy"
 msgstr "Taxable taxonomy"
 
@@ -7936,6 +8075,18 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description format"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Execution timeout interval"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Job category"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -7945,6 +8096,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Os family"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Provider type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8380,6 +8535,9 @@ msgstr "切換"
 msgid "Token"
 msgstr "權杖"
 
+msgid "Token Expiry"
+msgstr ""
+
 msgid "Token duration"
 msgstr "權杖持續時間"
 
@@ -8443,7 +8601,7 @@ msgstr "趨勢"
 msgid "Trends for %s"
 msgstr "%s 的趨勢"
 
-msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and any Puppet facts. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
+msgid "Trends in Foreman allow you to track changes in your infrastructure over time. It allows you to track both Foreman related information and to any fact. The Trend pages give a graph of how the number of hosts with that value have changed over time, and list the current hosts."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8542,6 +8700,9 @@ msgstr "無法連線"
 
 msgid "Unable to connect to LDAP server"
 msgstr "無法連接至 LDAP 伺服器"
+
+msgid "Unable to connect to libvirt due to: %s. Please make sure your libvirt compute resource is reachable and that you have appropriate access permissions."
+msgstr ""
 
 msgid "Unable to create default TFTP boot menu"
 msgstr "無法建立預設的 TFTP 開機選項"
@@ -8753,6 +8914,12 @@ msgstr "未受管理的主機"
 msgid "Unnamed"
 msgstr "未命名"
 
+msgid "Unread Event"
+msgstr ""
+
+msgid "Unread Events"
+msgstr ""
+
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
@@ -8882,6 +9049,9 @@ msgstr "更新架構"
 msgid "Update an environment"
 msgstr "更新環境"
 
+msgid "Update an external authentication source"
+msgstr ""
+
 msgid "Update an image"
 msgstr "更新映像檔"
 
@@ -8933,8 +9103,14 @@ msgstr "已更新主機：已更改的主機群組"
 msgid "Updated hosts: changed owner"
 msgstr "已更新主機：已更改的擁有者"
 
+msgid "Updates a table preference for a given table"
+msgstr ""
+
 msgid "Upload facts for a host, creating the host if required"
 msgstr "上傳主機的詳情，並視需求建立主機"
+
+msgid "Use APIv4 (experimental)"
+msgstr ""
 
 msgid "Use NIS netgroups instead of posix groups."
 msgstr ""
@@ -8944,6 +9120,9 @@ msgstr "為憑證使用 UUID"
 
 msgid "Use short name for VMs"
 msgstr "使用 VM 的短名稱"
+
+msgid "Use the new engine API. This feature is marked as experimental and should be used with caution."
+msgstr ""
 
 msgid "Use this account to authenticate, <i>optional</i>"
 msgstr "使用此帳號來進行認證，<i>選用性</i>"
@@ -8969,6 +9148,9 @@ msgstr "使用者群組"
 
 msgid "User IDs"
 msgstr "使用者 ID"
+
+msgid "User Name:"
+msgstr ""
 
 msgid "User data template"
 msgstr ""
@@ -9120,6 +9302,9 @@ msgstr "VCenter/Server"
 
 msgid "VLAN ID for this subnet"
 msgstr "這個子網路的 VLAN ID"
+
+msgid "VLAN ID is not consistent accross subnets"
+msgstr ""
 
 msgid "VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces."
 msgstr "VLAN 標籤，這個屬性擁有比子網路 VLAN ID 更高的優先權。僅適用於虛擬介面卡。"
@@ -9336,7 +9521,7 @@ msgstr "類別參數值是否是由 Foreman 所管理。"
 msgid "Whether the smart class parameter value is managed by Foreman"
 msgstr "智慧 類別 參數值是否是由 Foreman 所管理"
 
-msgid "Whether to get RSS notifications or not"
+msgid "Whether to pull RSS notifications or not"
 msgstr ""
 
 msgid "Which is an offset of <b>%s</b>"
@@ -9421,6 +9606,9 @@ msgstr "您未經許可製作預設範本。"
 
 msgid "You are not authorized to perform this action."
 msgstr "您未經許可執行這項動作。"
+
+msgid "You are trying access the preferences of a different user"
+msgstr ""
 
 msgid "You are trying to delete your own account"
 msgstr "您正要嘗試刪除您自己的帳號"
@@ -9614,6 +9802,9 @@ msgstr "不可從一個內部受保護的帳號上移除"
 msgid "cannot be removed from the last admin account"
 msgstr "不可從最後一個管理員帳號移除"
 
+msgid "cannot be used, please choose another"
+msgstr ""
+
 msgid "clone"
 msgstr "複製"
 
@@ -9731,6 +9922,9 @@ msgstr "%s 角色的篩選器"
 msgid "filter results"
 msgstr "篩選結果"
 
+msgid "filter..."
+msgstr ""
+
 msgid "for EC2 only"
 msgstr "僅適用於 EC2"
 
@@ -9745,6 +9939,9 @@ msgstr "僅適用於 Openstack"
 
 msgid "for VMware"
 msgstr "適用於 Vmware"
+
+msgid "for oVirt only"
+msgstr ""
 
 msgid "for oVirt, VMware Datacenter"
 msgstr "適用於 Ovirt、Vmware Datacenter"
@@ -9896,7 +10093,7 @@ msgstr ""
 msgid "is not allowed to change"
 msgstr "不允許更改"
 
-msgid "is not defined for host's %s."
+msgid "is not defined for host's %s"
 msgstr ""
 
 msgid "is not found in the authentication source"
@@ -9939,8 +10136,7 @@ msgstr "將外部使用者群組連上這個使用者群組"
 msgid "list"
 msgstr "清單"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch
-#. or Portugues)
+#. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Portugues)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -9949,6 +10145,12 @@ msgstr "位置"
 
 msgid "locations"
 msgstr "位置"
+
+msgid "lock imported templates (false by default)"
+msgstr ""
+
+msgid "makes the template default meaning it will be automatically associated with newly created organizations and locations (false by default)"
+msgstr ""
 
 msgid "managed host must have one provision interface"
 msgstr "受管理的主機必須有一個佈建介面"
@@ -10012,6 +10214,9 @@ msgstr "必須提供供應者"
 
 msgid "must set host and port"
 msgstr "必須設置主機和連接埠"
+
+msgid "name of the table"
+msgstr ""
 
 msgid "new"
 msgstr "新增"
@@ -10208,9 +10413,6 @@ msgstr "一些介面不合規定"
 msgid "some permissions were not found"
 msgstr ""
 
-msgid "sort results"
-msgstr "排序結果"
-
 msgid "space separated options, e.g. miimon=100"
 msgstr "以空格隔開的選項，例如 miimon=100"
 
@@ -10312,6 +10514,9 @@ msgstr "有效"
 msgid "valid or pending"
 msgstr "有效或正在處理"
 
+msgid "values"
+msgstr ""
+
 msgid "view last report details"
 msgstr ""
 
@@ -10320,6 +10525,9 @@ msgstr "虛擬"
 
 msgid "virtual attached to %s"
 msgstr "虛擬連結至 %s"
+
+msgid "with given ID not found"
+msgstr ""
 
 msgid "yaml"
 msgstr "yaml"

--- a/webpack/assets/javascripts/react_app/components/factCharts/index.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/index.js
@@ -83,7 +83,7 @@ class FactChart extends React.Component {
                 <small>
                   {// eslint-disable-next-line no-undef
                   Jed.sprintf(
-                    __('(%s host)', '(%s hosts)', factChart.hostsCount),
+                    n__('(%s host)', '(%s hosts)', factChart.hostsCount),
                     factChart.hostsCount,
                   )}
                 </small>


### PR DESCRIPTION
This was failing before due to a `__(` instead of `n__(` in
`webpack/assets/javascripts/react_app/components/factCharts/index.js`



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
