### PR TITLE
Fixes #24132, #24315 - fix breadcrumbs index links

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -68,7 +68,7 @@ module Menu
             menu.item :media,           :caption => N_('Installation Media')
             menu.item :operatingsystems, :caption => N_('Operating Systems')
             menu.divider :caption => N_('Templates')
-            menu.item :partition_tables, :caption => N_('Partition Tables'),
+            menu.item :ptables, :caption => N_('Partition Tables'),
                       :url_hash => { :controller => 'ptables', :action => 'index' }
             menu.item :provisioning_templates, :caption => N_('Provisioning Templates'),
                       :url_hash => { :controller => 'provisioning_templates', :action => 'index' }

--- a/app/registries/menu/manager.rb
+++ b/app/registries/menu/manager.rb
@@ -36,6 +36,14 @@ module Menu
       def to_hash(menu_name)
         items(menu_name).children.map(&:to_hash)
       end
+
+      def get_resource_caption(resource)
+        items = (@items[:top_menu].children + @items[:admin_menu].children)
+        menu_title = items.map do |submenu|
+          submenu.children.find { |item| item.name == resource }&.caption
+        end.compact.first
+        menu_title ? menu_title : resource.to_s.pluralize.titleize
+      end
     end
 
     class Mapper

--- a/app/services/breadcrumbs_options.rb
+++ b/app/services/breadcrumbs_options.rb
@@ -30,8 +30,8 @@ class BreadcrumbsOptions
     end
 
     {
-      caption: _(resource_name.pluralize.humanize),
-      url: resource_path(class_name)
+      caption: _(Menu::Manager.get_resource_caption(controller.controller_name.to_s.downcase.pluralize.to_sym)),
+      url: resource_path(class_name) || resource_path(resource_name)
     }
   end
 

--- a/test/unit/breadcrumbs_options_test.rb
+++ b/test/unit/breadcrumbs_options_test.rb
@@ -10,6 +10,10 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
       'string'
     end
 
+    def controller_name
+      'string'
+    end
+
     def controller_path
       'strings'
     end

--- a/test/unit/menu_manager_test.rb
+++ b/test/unit/menu_manager_test.rb
@@ -38,6 +38,11 @@ class MenuManagerTest < ActiveSupport::TestCase
     assert_equal menu_hash, items
   end
 
+  def test_should_return_caption
+    caption = Menu::Manager.get_resource_caption(:test_item)
+    assert_equal caption, 'Test Items'
+  end
+
   private
 
   def menu_hash
@@ -47,7 +52,8 @@ class MenuManagerTest < ActiveSupport::TestCase
       :children =>
         [{:type => :item, :name => "Item", :url => "some url"},
          {:type => :divider, :name => nil},
-         {:type => :item, :name => "Item 2", :url => "some url"}]},
+         {:type => :item, :name => "Item 2", :url => "some url"},
+         {:type => :item, :name => "Test Items", :url => "some url"}]},
      {:type => :sub_menu,
       :name => "User",
       :icon => "fa-icon",
@@ -63,6 +69,9 @@ class MenuManagerTest < ActiveSupport::TestCase
         menu.divider
         menu.item :item_two,
                   caption: 'Item 2',
+                  url: 'some url'
+        menu.item :test_item,
+                  caption: 'Test Items',
                   url: 'some url'
       end
       menu.sub_menu :sub_menu_two, :caption => 'User', :icon => 'fa-icon' do


### PR DESCRIPTION
[#24132 ](https://projects.theforeman.org/issues/24132)

the hosts link - 
![image](https://user-images.githubusercontent.com/15361156/42985979-685cc5e4-8bfc-11e8-8693-cd4c9de0021b.png)

after click, redirects to /hosts -
![image](https://user-images.githubusercontent.com/15361156/42986013-9cb2f458-8bfc-11e8-98cd-fe3623934d8c.png)

[#24315](https://projects.theforeman.org/issues/24315)

before - 

![image](https://user-images.githubusercontent.com/15361156/42986083-e5847d6e-8bfc-11e8-993a-463cac1f6b60.png)

after - 

![image](https://user-images.githubusercontent.com/15361156/42986146-2b91aa3e-8bfd-11e8-8400-3b36b36959aa.png)
