### PR TITLE
Fixes #24320 - stop dropping vmware fields

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -139,9 +139,6 @@ function submit_with_all_params(){
   clear_errors();
   animate_progress();
 
-  // clean the dom from react components before replacing the dom-content
-  tfm.reactMounter.unmountComponents('#content');
-
   $.ajax({
     type:'POST',
     url: url,

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -7,46 +7,21 @@ import componentRegistry from '../components/componentRegistry';
 
 export { default as registerReducer } from '../redux/reducers/registerReducer';
 
-let mountedNodesCache = [];
+const mountedNodes = [];
 
 // In order to support turbolinks with react, need to
 // unmount all root components before turbolinks do the unload
 // TODO: remove it when migrating into (webpacker-react or react-rails)
-document.addEventListener('page:before-unload', () => unmountComponents());
+document.addEventListener('page:before-unload', () => {
+  let node = mountedNodes.shift();
 
-const unmountComponentsByNodes = nodes =>
-  nodes.forEach(node => ReactDOM.unmountComponentAtNode(node));
-
-/**
- * Will unmount all react-components from the dom
- * @param  {string} selector unmount component inside the selector
- * @return {number}          amount of unmounted nodes
- */
-export const unmountComponents = (selector) => {
-  const nodesToUnmount = [];
-  const nodesToKeep = [];
-
-  if (selector) {
-    const reactNode = document.querySelector(selector);
-
-    mountedNodesCache.forEach((node) => {
-      if (reactNode.contains(node)) {
-        nodesToUnmount.push(node);
-      } else {
-        nodesToKeep.push(node);
-      }
-    });
-  } else {
-    nodesToUnmount.push(...mountedNodesCache);
+  while (node) {
+    ReactDOM.unmountComponentAtNode(node);
+    node = mountedNodes.shift();
   }
+});
 
-  unmountComponentsByNodes(nodesToUnmount);
-  mountedNodesCache = nodesToKeep;
-
-  return nodesToUnmount.length;
-};
-
-export const mount = (component, selector, data) => {
+export function mount(component, selector, data) {
   const reactNode = document.querySelector(selector);
 
   if (reactNode) {
@@ -56,9 +31,9 @@ export const mount = (component, selector, data) => {
       reactNode,
     );
 
-    mountedNodesCache.push(reactNode);
+    mountedNodes.push(reactNode);
   } else {
     // eslint-disable-next-line no-console
     console.log(`Cannot find '${selector}' element for mounting the '${component}'`);
   }
-};
+}


### PR DESCRIPTION
This is definitely a 1.18.1 candidate, honestly I can't even reproduce the issue described in https://projects.theforeman.org/issues/23290 if I comment the entire unmount line. Perhaps it was meanwhile fixed differently? Anyway this should limit unmounting to resource switcher which seemed to be the problematic part.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
