### PR TITLE
Fixes #24338 - Can set filename for CSV response

### DIFF
--- a/app/controllers/concerns/foreman/controller/csv_responder.rb
+++ b/app/controllers/concerns/foreman/controller/csv_responder.rb
@@ -1,10 +1,11 @@
 module Foreman::Controller::CsvResponder
   extend ActiveSupport::Concern
 
-  def csv_response(resources, columns = csv_columns, header = nil)
+  def csv_response(resources, columns = csv_columns, header = nil, filename = nil)
+    filename ||= "#{controller_name}-#{Date.today}.csv"
     headers["Cache-Control"] = "no-cache"
     headers["Content-Type"] = "text/csv; charset=utf-8"
-    headers["Content-Disposition"] = %(attachment; filename="#{controller_name}-#{Date.today}.csv")
+    headers["Content-Disposition"] = %(attachment; filename="#{filename}")
     self.response_body = CsvExporter.export(resources, columns, header)
   end
 

--- a/test/controllers/concerns/csv_responder_test.rb
+++ b/test/controllers/concerns/csv_responder_test.rb
@@ -16,11 +16,21 @@ class Api::V2::FakeController < Api::V2::BaseController
   end
 end
 
+class Api::V2::FakeWithFilenameController < Api::V2::BaseController
+  FILENAME = "Test-Filename-100.csv"
+  include Foreman::Controller::CsvResponder
+
+  def index
+    csv_response(Domain.unscoped, [:name], nil, FILENAME)
+  end
+end
+
 # add the fake controllers to the routes table
 Rails.application.routes.disable_clear_and_finalize = true
 Rails.application.routes.draw do
   get '/fake' => 'fake#index'
   get '/fake_api' => 'api/v2/fake#index'
+  get '/fake_with_filename_api' => 'api/v2/fake_with_filename#index'
 end
 
 class CsvResponderTest < ActionController::TestCase
@@ -45,6 +55,20 @@ class CsvApiResponderTest < ActionController::TestCase
     assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
     assert_equal "no-cache", response.headers["Cache-Control"]
     assert_equal "attachment; filename=\"fake-#{Date.today}.csv\"", response.headers["Content-Disposition"]
+    buf = response.stream.instance_variable_get(:@buf)
+    assert buf.is_a? Enumerator
+    assert_equal "Name\n", buf.next
+  end
+end
+
+class CsvApiFileNameResponderTest < ActionController::TestCase
+  tests Api::V2::FakeWithFilenameController
+
+  test "response is streamed correctly with right headers and file name" do
+    get :index, session: set_session_user
+    assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "no-cache", response.headers["Cache-Control"]
+    assert_equal "attachment; filename=\"#{Api::V2::FakeWithFilenameController::FILENAME}\"", response.headers["Content-Disposition"]
     buf = response.stream.instance_variable_get(:@buf)
     assert buf.is_a? Enumerator
     assert_equal "Name\n", buf.next


### PR DESCRIPTION
This commit adds the ability to set a custom filename as a part of the
csv response



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` or `Refs #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Extract all strings for i18n, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress from bots triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
