### PR TITLE
Fixes #24350 - Change general out of sync interval to 30 minutes

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -22,7 +22,7 @@ class Setting::General < Setting
       self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default.'), [], N_('HTTP(S) proxy except hosts')),
       self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
-      self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 5, N_('Out of sync interval'))
+      self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 30, N_('Out of sync interval'))
     ]
   end
 

--- a/db/migrate/20180724062531_change_out_of_sync_default.rb
+++ b/db/migrate/20180724062531_change_out_of_sync_default.rb
@@ -1,0 +1,18 @@
+class ChangeOutOfSyncDefault < ActiveRecord::Migration[5.1]
+  def up
+    return unless outofsync_setting
+    outofsync_setting.update_attribute(:default, 30)
+    outofsync_setting.update_attribute(:value, 30) if outofsync_setting.value == 5
+  end
+
+  def down
+    return unless outofsync_setting
+    outofsync_setting.update_attribute(:default, 5)
+  end
+
+  private
+
+  def outofsync_setting
+    @setting ||= Setting.where(:name => 'outofsync_interval').first
+  end
+end


### PR DESCRIPTION
This changes the default out of sync interval back to 30 minutes to have a saner timeout for hosts to report.
