### PR TITLE
Refs #24350 - Adjust puppet_interval to include grace time

### DIFF
--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -1,7 +1,7 @@
 class Setting::Puppet < Setting
   def self.default_settings
     [
-      self.set('puppet_interval', N_("Puppet interval in minutes"), 30, N_('Puppet interval')),
+      self.set('puppet_interval', N_("Duration in minutes after servers reporting via Puppet are classed as out of sync."), 35, N_('Puppet interval')),
       self.set('puppet_out_of_sync_disabled', N_("Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval") % 'Puppet', false, N_('%s out of sync disabled') % 'Puppet'),
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map{|env| [env[:name], env[:name]]}]} }),
       self.set('modulepath', N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),

--- a/db/migrate/20180724152638_adjust_puppet_out_of_sync_interval.rb
+++ b/db/migrate/20180724152638_adjust_puppet_out_of_sync_interval.rb
@@ -1,0 +1,18 @@
+class AdjustPuppetOutOfSyncInterval < ActiveRecord::Migration[5.1]
+  def up
+    return unless puppet_outofsync_setting
+    puppet_outofsync_setting.update_attribute(:default, 35)
+    puppet_outofsync_setting.update_attribute(:value, 35) if puppet_outofsync_setting.value == 30
+  end
+
+  def down
+    return unless puppet_outofsync_setting
+    puppet_outofsync_setting.update_attribute(:default, 30)
+  end
+
+  private
+
+  def puppet_outofsync_setting
+    @setting ||= Setting.where(:name => 'puppet_interval').first
+  end
+end


### PR DESCRIPTION
This migrates the `puppet_interval` setting to 35 minutes to include a 5 minute grace period, that was previously provided by using the `outofsync_interval` setting.
