### PR TITLE
Fixes #24387 - defined telemetry buckets in seconds

### DIFF
--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -7,7 +7,7 @@ module Foreman
     extend Forwardable
     attr_accessor :prefix, :sinks
 
-    DEFAULT_BUCKETS = [10, 50, 200, 1000, 15000].freeze
+    DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10].freeze
 
     def initialize
       @sinks = []


### PR DESCRIPTION
Also, add more granular buckets, the scale inspired by
https://github.com/prometheus/client_golang\
/blob/1ba60c7d585/prometheus/histogram.go#L59