### PR TITLE
fixes #24388 - validate media and reset if os changes

### DIFF
--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -635,6 +635,30 @@ class HostTest < ActiveSupport::TestCase
       assert_equal 'CentOS 6.7', host.operatingsystem.to_s
     end
 
+    test 'operatingsystem from facts resets medium if medium is for different OS' do
+      os1 = FactoryBot.create(:operatingsystem, :with_media)
+      os2 = FactoryBot.create(:operatingsystem)
+      medium = os1.media.first
+      host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
+      host.import_facts(:operatingsystem => os2.name, :lsbdistrelease => os2.major.to_s)
+
+      assert_equal host.operatingsystem, os2
+      assert_nil host.medium
+    end
+
+    test 'operatingsystem from facts keeps medium if medium supports OS' do
+      os1 = FactoryBot.create(:operatingsystem, :with_media)
+      os2 = FactoryBot.create(:operatingsystem)
+      medium = os1.media.first
+      medium.operatingsystems << os2
+
+      host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
+      host.import_facts(:operatingsystem => os2.name, :lsbdistrelease => os2.major.to_s)
+
+      assert_equal host.operatingsystem, os2
+      assert_equal host.medium, medium
+    end
+
     test 'operatingsystem not updated from facts when ignore_facts_for_operatingsystem false' do
       host = Host.import_host('host')
       assert host.import_facts(:lsbdistrelease => '6.7', :operatingsystem => 'CentOS')
@@ -3042,6 +3066,15 @@ class HostTest < ActiveSupport::TestCase
       'puppet',
       nil)
     assert host.operatingsystem.architectures.include?(host.architecture), "no association between operatingsystem and architecture"
+  end
+
+  test 'check operatingsystem and medium assocation' do
+    host = FactoryBot.create(:host, :managed, :build => true)
+    assert host.valid?
+
+    host.operatingsystem.media = []
+    refute host.valid?
+    assert_match /must belong/, host.errors[:medium_id].first
   end
 
   context "lookup value attributes" do


### PR DESCRIPTION
If facts update a host's operating system, the medium is not reset even when that medium potentially doesn't support the new version of the OS any more.
