### PR TITLE
Fixes #24476: add SR-IOV virtual functions to the ignored NIC list

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -16,6 +16,7 @@ class Setting::Provisioning < Setting
 
   IGNORED_INTERFACES = [
     'lo',
+    'en*v*',
     'usb*',
     'vnet*',
     'macvtap*',

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -265,7 +265,7 @@ attributes57:
 attributes58:
   name: ignored_interface_identifiers
   category: Setting::Provisioning
-  default: "['lo', 'usb*', 'vnet*', 'macvtap*']"
+  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
   description: 'Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
 attributes59:
   name: always_show_configuration_status
@@ -367,7 +367,7 @@ attribute77:
 attributes78:
   name: excluded_facts
   category: Setting::Provisioning
-  default: "['lo', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
+  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
 attribute79:
   name: append_domain_name_for_hosts


### PR DESCRIPTION
this new naming was introduced in udev v239
(https://github.com/systemd/systemd/commit/609948c7043a40008b8299529c978ed8e11de8f6)