### PR TITLE
Fixes #24478 - properly sanitize class name

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -26,6 +26,8 @@ class Authorizer
 
   def find_collection(resource_class, options = {})
     permission = options.delete :permission
+    resource_class = Host if resource_class.to_s =~ /\AHost::.*\Z/
+
     Foreman::Logging.logger('permissions').debug "checking permission #{permission} for class #{resource_class}"
 
     # retrieve all filters relevant to this permission for the user

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -344,4 +344,14 @@ class AuthorizerTest < ActiveSupport::TestCase
     assert_includes collection, report1
     refute_includes collection, report2
   end
+
+  test "#find_collection(Host::Base) works with taxonomies thanks to class name sanitization" do
+    permission = Permission.find_by_name('view_hosts')
+    FactoryBot.create(:filter, :role => @role, :permissions => [permission], :unlimited => true, :organization_ids => [taxonomies(:organization1).id])
+    auth = Authorizer.new(@user)
+
+    assert_nothing_raised do
+      auth.find_collection(Host::Base)
+    end
+  end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
To reproduce:

1) clone org admin role and assign the clone to some org and loc
2) create a user with this role (make sure he's also in the org and loc)
3) create a subnet in the very same org and loc
4) create a host that is assigned to this subnet
5) try to delete the subnet under user from step 2, you got an exception

the reason is, association checkers gets `Host::Base` as a class for a `subnet.host` reflection, but that class does not have any scoped search definition, we need to pass Host instead (which in fact uses Host::Managed)