### PR TITLE
Fixes #24481 - update log level on plugin assets

### DIFF
--- a/app/registries/foreman/plugin/assets.rb
+++ b/app/registries/foreman/plugin/assets.rb
@@ -52,7 +52,7 @@ module Foreman
         end
 
         if outside_prefix.present?
-          Rails.logger.warn "Plugin #{id} has assets outside of its namespace, these will be ignored: #{outside_prefix.join(', ')}"
+          Rails.logger.debug "Plugin #{id} has assets outside of its namespace, these will be ignored: #{outside_prefix.join(', ')}"
         end
 
         new_assets

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -563,7 +563,8 @@ class PluginTest < ActiveSupport::TestCase
         FileUtils.touch File.join(root, 'app', 'assets', 'javascripts', 'test_outside.js')
         FileUtils.touch File.join(root, 'app', 'assets', 'javascripts', 'test_assets_from_root', 'test_assets_example.js')
 
-        Rails.logger.expects(:warn).with(regexp_matches(/test_outside\.js/))
+        Rails.logger.stubs(:debug)
+        Rails.logger.expects(:debug).with(regexp_matches(/test_outside\.js/))
         plugin = Foreman::Plugin.register(:test_assets_from_root) do
           path root
         end


### PR DESCRIPTION
Reasons for changing the log level from warn to debug:

1. the plugin can still register the assets manually

2. in some cases, they even should not be namespaced (seems like it's
needed for example with custom favicon)

We should limit the log messages we propagate to production to just
those that can have influence on the production setup.