### PR TITLE
fixes #24484 - snippets find template by source

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -349,7 +349,7 @@ class Host::Managed < Host::Base
   # returns the host correct disk layout, custom or common
   def diskLayout
     raise Foreman::Renderer::Errors::RenderingError, 'Neither disk nor partition table defined for host' unless disk_layout_source
-    scope = Foreman::Renderer.get_scope(host: self)
+    scope = Foreman::Renderer.get_scope(host: self, source: disk_layout_source)
     Foreman::Renderer.render(disk_layout_source, scope)
   end
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -149,7 +149,7 @@ class Template < ApplicationRecord
 
   def render(host: nil, params: {}, variables: {}, mode: Foreman::Renderer::REAL_MODE)
     source = Foreman::Renderer.get_source(template: self, host: host)
-    scope = Foreman::Renderer.get_scope(host: host, params: params, variables: variables, mode: mode, template: self)
+    scope = Foreman::Renderer.get_scope(host: host, params: params, variables: variables, mode: mode, template: self, source: source)
     Foreman::Renderer.render(source, scope)
   end
 

--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -16,7 +16,7 @@ module Foreman
       end
 
       def render_template_to_tempfile(template:, prefix:, host: nil, params: {}, variables: {}, options: {})
-        file = ""
+        file = ''
         source = get_source(template: template, host: host)
         scope = get_scope(host: host, params: params, variables: variables)
         Tempfile.open(prefix, Rails.root.join('tmp')) do |f|
@@ -32,9 +32,10 @@ module Foreman
         klass.new(template)
       end
 
-      def get_scope(klass: nil, host: nil, params: {}, variables: {}, mode: REAL_MODE, template: nil)
+      def get_scope(source: nil, klass: nil, host: nil, params: {}, variables: {}, mode: REAL_MODE, template: nil)
+        source ||= get_source(template: template)
         klass ||= template&.default_render_scope_class || Foreman::Renderer::Scope::Provisioning
-        klass.new(host: host, params: params, variables: variables, mode: mode)
+        klass.new(source: source, host: host, params: params, variables: variables, mode: mode)
       end
 
       def renderer

--- a/lib/foreman/renderer/base_renderer.rb
+++ b/lib/foreman/renderer/base_renderer.rb
@@ -6,7 +6,6 @@ module Foreman
       def initialize(source, scope)
         @source = source
         @scope = scope
-        @scope.instance_variable_set('@template_name', source_name)
       end
 
       def render

--- a/lib/foreman/renderer/scope/base.rb
+++ b/lib/foreman/renderer/scope/base.rb
@@ -7,16 +7,18 @@ module Foreman
         include Foreman::Renderer::Scope::Macros::TemplateLogging
         include Foreman::Renderer::Scope::Macros::SnippetRendering
 
-        def initialize(host: nil, params: {}, variables: {}, mode: Foreman::Renderer::REAL_MODE)
+        def initialize(source:, host: nil, params: {}, variables: {}, mode: Foreman::Renderer::REAL_MODE)
+          @source = source
           @host = host
           @params = params
           @variables_keys = variables.keys
           @mode = mode
+          @template_name = source.name
           variables.each { |k, v| instance_variable_set("@#{k}", v) }
           load_variables
         end
 
-        attr_reader :host, :params, :variables_keys, :mode
+        attr_reader :host, :params, :variables_keys, :mode, :source
 
         def get_binding
           binding

--- a/lib/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/lib/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -9,29 +9,30 @@ module Foreman
 
           # provide embedded snippets support as simple erb templates
           def snippets(file, options = {})
-            if ::Template.where(:name => file, :snippet => true).empty?
-              render :partial => "unattended/snippets/#{file}"
-            else
+            if source.find_snippet(file)
               snippet(file.gsub(/^_/, ""), options)
+            else
+              render :partial => "unattended/snippets/#{file}"
             end
           end
 
           def snippet(name, options = {}, variables: {})
-            if (template = ::Template.where(:name => name, :snippet => true).first)
-              begin
-                snippet_variables = variables.merge(options[:variables] || {})
-                source = Foreman::Renderer.get_source(template: template, host: @host)
-                scope = Foreman::Renderer.get_scope(host: @host, variables: snippet_variables)
-                return Foreman::Renderer.render(source, scope)
-              rescue ::Foreman::Exception
-                raise
-              rescue StandardError => exc
-                e = ::Foreman::Exception.new(N_("The snippet '%{name}' threw an error: %{exc}"), { :name => name, :exc => exc })
-                e.set_backtrace exc.backtrace
-                raise e
-              end
-            else
+            template = source.find_snippet(name)
+            unless template
               raise "The specified snippet '#{name}' does not exist, or is not a snippet." unless options[:silent]
+              return
+            end
+
+            begin
+              snippet_variables = variables.merge(options[:variables] || {})
+              template.render(host: host, variables: snippet_variables, mode: mode)
+            rescue ::Foreman::Exception => e
+              Foreman::Logging.exception('Error while rendering a snippet', e)
+              raise
+            rescue StandardError => exc
+              e = ::Foreman::Exception.new(N_("The snippet '%{name}' threw an error: %{exc}"), { :name => name, :exc => exc })
+              e.set_backtrace exc.backtrace
+              raise e
             end
           end
         end

--- a/lib/foreman/renderer/source/base.rb
+++ b/lib/foreman/renderer/source/base.rb
@@ -14,6 +14,10 @@ module Foreman
           raise NotImplementedError
         end
 
+        def find_snippet(name)
+          raise NotImplementedError
+        end
+
         attr_reader :template
       end
     end

--- a/lib/foreman/renderer/source/database.rb
+++ b/lib/foreman/renderer/source/database.rb
@@ -5,6 +5,10 @@ module Foreman
         def content
           @content ||= template.template
         end
+
+        def find_snippet(name)
+          ::Template.where(name: name, snippet: true).first
+        end
       end
     end
   end

--- a/lib/foreman/renderer/source/string.rb
+++ b/lib/foreman/renderer/source/string.rb
@@ -7,6 +7,10 @@ module Foreman
           @content = content
         end
 
+        def find_snippet(name)
+          nil
+        end
+
         attr_reader :name, :content
       end
     end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -3,12 +3,19 @@ module RenderersSharedTests
 
   included do
     setup do
+      @template = OpenStruct.new(
+        name: 'abc',
+        template: 'Test'
+      )
+      source = Foreman::Renderer::Source::Database.new(
+        @template
+      )
       @host = FactoryBot.create(:host, architecture: FactoryBot.create(:architecture, :name => 'SPARC-T2'),
                                        operatingsystem: operatingsystems(:redhat))
       @scope = Class.new(Foreman::Renderer::Scope::Base) do
         include Foreman::Renderer::Scope::Macros::Base
         include Foreman::Renderer::Scope::Macros::SnippetRendering
-      end.send(:new, host: @host)
+      end.send(:new, host: @host, source: source)
     end
 
     test "should evaluate template variables" do
@@ -110,7 +117,7 @@ module RenderersSharedTests
     end
 
     test "should render template name" do
-      source = OpenStruct.new(name: 'abc', content: 'x <%= @template_name %> <%= template_name %>')
+      source = OpenStruct.new(name: @template.name, content: 'x <%= @template_name %> <%= template_name %>')
       assert_equal 'x abc abc', renderer.render(source, @scope)
     end
 

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -3,9 +3,16 @@ require 'test_helper'
 class BaseMacrosTest < ActiveSupport::TestCase
   setup do
     host = FactoryBot.build_stubbed(:host)
+    template = OpenStruct.new(
+      name: 'Test',
+      template: 'Test'
+    )
+    source = Foreman::Renderer::Source::Database.new(
+      template
+    )
     @subject = Class.new(Foreman::Renderer::Scope::Base) do
       include Foreman::Renderer::Scope::Macros::Base
-    end.send(:new, host: host)
+    end.send(:new, host: host, source: source)
   end
 
   describe '#template_name' do

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -3,9 +3,16 @@ require 'test_helper'
 class HostTemplateTest < ActiveSupport::TestCase
   setup do
     host = FactoryBot.build_stubbed(:host)
+    template = OpenStruct.new(
+      name: 'Test',
+      template: 'Test'
+    )
+    source = Foreman::Renderer::Source::Database.new(
+      template
+    )
     @subject = Class.new(Foreman::Renderer::Scope::Base) do
       include Foreman::Renderer::Scope::Macros::HostTemplate
-    end.send(:new, host: host)
+    end.send(:new, host: host, source: source)
   end
 
   describe '#host_enc' do

--- a/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
@@ -3,18 +3,21 @@ require 'test_helper'
 class SnippetRenderingTest < ActiveSupport::TestCase
   setup do
     host = FactoryBot.build_stubbed(:host)
+    template = OpenStruct.new(
+      name: 'Test',
+      template: 'Test'
+    )
+    source = Foreman::Renderer::Source::Database.new(
+      template
+    )
     @subject = Class.new(Foreman::Renderer::Scope::Base) do
       include Foreman::Renderer::Scope::Macros::SnippetRendering
-    end.send(:new, host: host)
+    end.send(:new, host: host, source: source)
   end
 
   test "should render a snippet" do
-    snippet = mock("snippet")
-    snippet.stubs(:name).returns("test")
-    snippet.stubs(:template).returns("content")
-    snippet.stubs(:log_render_results?).returns(false)
-    Template.expects(:where).with(:name => "test", :snippet => true).returns([snippet])
-    assert_equal 'content', @subject.snippet('test')
+    snippet = FactoryBot.create(:provisioning_template, :snippet, template: 'content')
+    assert_equal 'content', @subject.snippet(snippet.name)
   end
 
   test "should render a snippet with variables" do

--- a/test/unit/foreman/renderer/scope/variables/base_test.rb
+++ b/test/unit/foreman/renderer/scope/variables/base_test.rb
@@ -2,6 +2,13 @@ require 'test_helper'
 
 class BaseVariablesTest < ActiveSupport::TestCase
   setup do
+    template = OpenStruct.new(
+      name: 'Test',
+      template: 'Test'
+    )
+    @source = Foreman::Renderer::Source::Database.new(
+      template
+    )
     @subject = Class.new(Foreman::Renderer::Scope::Base) do
       include Foreman::Renderer::Scope::Variables::Base
     end
@@ -11,7 +18,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
     test "do not set @preseed_server and @preseed_path if @host does not have medium and os" do
       host = FactoryBot.build_stubbed(:host)
 
-      scope = @subject.new(host: host)
+      scope = @subject.new(host: host, source: @source)
 
       assert_nil scope.instance_variable_get('@preseed_path')
       assert_nil scope.instance_variable_get('@preseed_server')
@@ -26,7 +33,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
       host.operatingsystem = os
       host.medium = medium
 
-      scope = @subject.new(host: host)
+      scope = @subject.new(host: host, source: @source)
 
       assert_equal scope.instance_variable_get('@preseed_path'), '/my_path'
       assert_equal scope.instance_variable_get('@preseed_server'), 'my-example.com:80'
@@ -37,7 +44,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
     test "does not fail if @host does not have medium" do
       host = FactoryBot.build_stubbed(:host)
 
-      scope = @subject.new(host: host)
+      scope = @subject.new(host: host, source: @source)
 
       assert_nil scope.instance_variable_get('@mediapath')
     end
@@ -52,7 +59,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
     host.operatingsystem = os
     host.medium = medium
 
-    scope = @subject.new(host: host)
+    scope = @subject.new(host: host, source: @source)
 
     assert scope.instance_variable_get('@initrd').present?
     assert scope.instance_variable_get('@kernel').present?


### PR DESCRIPTION
This refactors snippet rendering so that the template source is defined by the rendering source.