### PR TITLE
Refs #23373 - Remove the api fix and fix tests

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -156,7 +156,6 @@ module Api
         @all_parameters = true
 
         @host.attributes = host_attributes(host_params, @host)
-        @host.attributes.delete(:compute_profile_id)
         apply_compute_profile(@host) if (params[:host] && params[:host][:compute_attributes].present?) || @host.compute_profile_id_changed?
 
         process_response @host.save

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -621,15 +621,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal hostgroup.root_pass, Host.find_by(:name => hostname).root_pass
   end
 
-  test 'host update shouldnt diassociate from VM' do
-    hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_os, :with_compute_resource)
-    host = FactoryBot.create(:host, :hostgroup => hostgroup)
-    put :update, params: { :commit => "Update", :id => host.id, :params => {:compute_resource_id => ""}}, session: set_session_user
-    assert_response :success
-    host.reload
-    assert_not_nil host.compute_resource_id
-  end
-
   test 'when ":restrict_registered_smart_proxies" is false, HTTP requests should be able to import facts' do
     User.current = users(:one) # use an unprivileged user, not apiadmin
     Setting[:restrict_registered_smart_proxies] = false

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1264,12 +1264,15 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "#host update shouldn't diassociate from VM" do
-    hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_os, :with_compute_resource)
-    host = FactoryBot.create(:host, :hostgroup => hostgroup)
-    put :update, params: { :commit => "Update", :id => host.id, :params => {:compute_resource_id => ""}}, session: set_session_user
+    hostgroup = FactoryBot.create(:hostgroup, :with_environment, :with_subnet, :with_domain, :with_os)
+    compute_resource = compute_resources(:ovirt)
+    host = FactoryBot.create(:host, :hostgroup => hostgroup, :compute_resource => compute_resource)
+    host_attributes = host.attributes
+    host_attributes.delete("compute_resource_id")
+    put :update, params: { :commit => "Update", :id => host.id, :host => host_attributes}, session: set_session_user
     assert_response :redirect
     host.reload
-    assert_not_nil host.compute_resource_id
+    assert host.compute_resource_id
   end
 
   test '#update_multiple_disassociate' do


### PR DESCRIPTION
The First FIx included fix in the API which didn't quite work and it wasn't relevant to the issue (which was caused because the compute resource id was disabled in an update)
So in this fix, I'm removing the API fix and also fixing the test.