### PR TITLE
Fixes #24392 - Title "Global Parameters" removed from Host Group

### DIFF
--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -81,12 +81,11 @@
       <br/>
       <% if authorized_for(:controller => "host_editing", :action => "view_params") %>
         <fieldset>
-          <h2><%= _('Global Parameters') %></h2>
           <% if @hostgroup.parent.present? %>
               <h4><%= _('Parent Parameters') %></h4>
               <%= render "common_parameters/inherited_parameters", { :inherited_parameters => @hostgroup.parent_params(true), :parameters => @hostgroup.group_parameters } %>
           <% end %>
-          <h4><%= _('Host Group Parameters') %></h4>
+          <h2><%= _('Host Group Parameters') %></h2>
           <%= render "common_parameters/parameters", { :f => f, :type => :group_parameters } %>
         </fieldset>
       <% end %>


### PR DESCRIPTION
The parameters available for selection when creating a Host Group are not all
the global parameters that exist. The title Global Parameters is removed.