### PR TITLE
Fixes #24261 - pagination CSS is wrong on assign hosts for taxonomy

### DIFF
--- a/app/views/common/_pagination.html.erb
+++ b/app/views/common/_pagination.html.erb
@@ -1,7 +1,7 @@
-<form
+<div
   class='col-md-12 <%= options[:pagination_classes] %> content-view-pf-pagination table-view-pf-pagination paginate' id='pagination'
   data-count=<%= collection.total_entries %> data-per-page=<%= per_page(collection) %>
-  onsubmit='return tfm.tools.updateTable(this);'>
+  >
   <div class='form-group'>
     <%= select_tag('per_page',
                    options_for_select(per_page_options,
@@ -12,7 +12,7 @@
     <span><%= _('per page') %></span>
   </div>
 
-  <div class='form-group'>
+  <div onkeypress='tfm.tools.onEnter(tfm.tools.updateTable, this)(event);' class='form-group'>
     <span>
       <span class='pagination-pf-items-current'>
         <%= collection.offset + 1 %>-<%= collection.offset + collection.length %>
@@ -24,4 +24,4 @@
     </span>
     <%= will_paginate(collection, options) %>
   </div>
-</form>
+</div>

--- a/test/controllers/shared/basic_rest_response_test.rb
+++ b/test/controllers/shared/basic_rest_response_test.rb
@@ -102,7 +102,7 @@ module BasicRestResponseTest
           FactoryBot.create(get_factory_name, *@factory_options)
           get :index, session: set_session_user
           assert_response :success
-          assert_select "form[id='pagination']"
+          assert_select "div[id='pagination']"
         end
 
         test 'should not render pagination when no search results' do

--- a/test/integration/organization_js_test.rb
+++ b/test/integration/organization_js_test.rb
@@ -15,4 +15,16 @@ class OrganizationJSTest < IntegrationTestWithJavascript
       end
     end
   end
+
+  test "test per page in hosts assign" do
+    FactoryBot.create_list(:host, 10, organization: nil)
+    org = FactoryBot.create(:organization)
+    visit assign_hosts_organization_path(org)
+    # to validate that the pagination doesn't look odd look for ".content-view-pf-pagination"
+    assert page.has_css?(".content-view-pf-pagination")
+    assert page.has_content?("1-10")
+    assert page.has_css?('#per_page')
+    page.find("select > option[value='5']").select_option
+    assert page.has_content?("1-5")
+  end
 end

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -100,6 +100,14 @@ export function initTypeAheadSelect(input) {
   });
 }
 
+export function onEnter(callback, element) {
+  return (event) => {
+    if (event.keyCode === 13) {
+      callback(element);
+    }
+  };
+}
+
 // handle table updates via turoblinks
 export function updateTable(element) {
   const uri = new URI(window.location.href);

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -115,7 +115,7 @@ describe('updateTableTest', () => {
   </div>
 </form>
 <table></table>
-<form onsubmit="return tfm.tools.updateTable(this);" class="content-view-pf-pagination table-view-pf-pagination paginate" id="pagination" data-count="7" data-per-page="7">
+<div class="content-view-pf-pagination table-view-pf-pagination paginate" id="pagination" data-count="7" data-per-page="7">
   <div class="form-group">
     <select name="per_page" id="per_page" label="per page" onchange="tfm.tools.updateTable(this)" class="pagination-pf-pagesize without_select2 per-page"><option selected="selected" value="5">5</option>
 <option value="10">10</option>
@@ -126,7 +126,7 @@ describe('updateTableTest', () => {
     <span>per page</span>
   </div>
 
-  <div class="form-group">
+  <div onkeypress="tfm.tools.onEnter(tfm.tools.updateTable, this)(event);" class="form-group">
     <span>
       <span class="pagination-pf-items-current">
         1-5
@@ -138,7 +138,7 @@ describe('updateTableTest', () => {
     </span>
     <ul class="pagination pagination-pf-back"><li class="firs first_page disabled"><a href="#"><span class="fa fa-angle-double-left "></span> </a></li><li class="prev previous_page disabled"><a href="#"><span class="fa fa-angle-left "></span> </a></li></ul> <input class="pagination-pf-page" type="text" value="1" id="cur_page_num"><label class="sr-only" for="cur_page_num">Current Page</label><span>of <span class="pagination-pf-pages">2</span></span> <ul class="pagination pagination-pf-forward"><li class="next next_page "><a rel="next" href="/hosts?page=2&amp;per_page=5&amp;search=environment+%3D++testing"><span class="fa fa-angle-right "></span> </a></li><li class="last last_page "><a rel="next" href="/hosts?page=2&amp;per_page=5&amp;search=environment+%3D++testing"><span class="fa fa-angle-double-right "></span> </a></li></ul>
   </div>
-</form>
+</div>
 </div>
     `;
   });
@@ -150,12 +150,20 @@ describe('updateTableTest', () => {
     expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=1&search=name+%3D+y&per_page=${PerPage}`);
   });
 
-  it('should change page', () => {
+  it('should reset page to 1 when per_page change', () => {
     const PerPage = $('#per_page').val();
 
     $('#cur_page_num').val('4');
-    $('#pagination').submit();
-    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=4&per_page=${PerPage}`);
+    $('#per_page').change();
+    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=1&per_page=${PerPage}`);
+  });
+
+  it('should change page on enter', () => {
+    const PerPage = $('#per_page').val();
+    const curPageNum = '2';
+
+    $('#cur_page_num').val(curPageNum).trigger($.Event('keypress', { which: 13, keyCode: 13 }));
+    expect(global.Turbolinks.visit).toHaveBeenLastCalledWith(`http://localhost/?page=${curPageNum}&per_page=${PerPage}`);
   });
 
   it('should use find search term and add it to the url considering per page value and pagination', () => {
@@ -177,7 +185,7 @@ describe('updateTableTest', () => {
   it('should not reset search when set the per_page param', () => {
     window.location.href = 'http://localhost/?search=blue';
     $('#per_page').val('20');
-    $('#pagination').submit();
+    $('#per_page').change();
     expect(global.Turbolinks.visit).toHaveBeenLastCalledWith('http://localhost/?search=blue&page=1&per_page=20');
   });
 


### PR DESCRIPTION
The reason why this happens is because there is a nested form:
the host pagination nested under hosts assign.

Because of that the form tag in pagination is not rendered.
To fix this, the form tag in pagination was replaced by div.

Why?:
It seems like the pagination does not have to be a form. It
can be a div element that its select handles the onchange event
which calls `turbolinks.visit`.

/cc @ohadlevy @lizagilman 