### PR TITLE
fixes #24503 - remove snippets macro

### DIFF
--- a/lib/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/lib/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -7,13 +7,9 @@ module Foreman
             snippet(name, { silent: true }, variables: options[:variables])
           end
 
-          # provide embedded snippets support as simple erb templates
           def snippets(file, options = {})
-            if source.find_snippet(file)
-              snippet(file.gsub(/^_/, ""), options)
-            else
-              render :partial => "unattended/snippets/#{file}"
-            end
+            Foreman::Deprecation.deprecation_warning('1.22', 'The snippets template macro is deprecated. Please use snippet instead.')
+            snippet(file.gsub(/^_/, ''), options)
           end
 
           def snippet(name, options = {}, variables: {})

--- a/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
@@ -31,6 +31,7 @@ class SnippetRenderingTest < ActiveSupport::TestCase
   end
 
   test "should render a snippets with variables" do
+    Foreman::Deprecation.expects(:deprecation_warning).once
     snippet = FactoryBot.create(:provisioning_template, :snippet, :template => "A <%= @b + ' ' + @c -%> D")
     assert_equal 'A B C D', @subject.snippets(snippet.name, :variables => { :b => 'B', :c => 'C' })
   end


### PR DESCRIPTION
To sum up: The macro has been broken for a while and we haven't received any bug reports. I think it's safe to assume this is not used by anyone.