### PR TITLE
Refs #10521 - Consider HostStatuses might be added by plugins

### DIFF
--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -154,8 +154,8 @@ module RenderersSharedTests
       source = OpenStruct.new(content: '<%= all_host_statuses.map { |s| s.status_name }.join(",") %>')
       statuses = renderer.render(source, @scope).split(',')
 
-      refute_nil statuses.index('Build')
-      refute_nil statuses.index('Configuration')
+      assert_includes statuses, 'Build'
+      assert_includes statuses, 'Configuration'
       assert(statuses.index('Build') < statuses.index('Configuration'))
     end
   end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -152,7 +152,9 @@ module RenderersSharedTests
 
     test "should find all registered host statuses" do
       source = OpenStruct.new(content: '<%= all_host_statuses.map { |s| s.status_name }.join(",") %>')
-      assert_equal(renderer.render(source, @scope), "Build,Configuration")
+      statuses = renderer.render(source, @scope).split(',')
+      assert_includes statuses, 'Build'
+      assert_includes statuses, 'Configuration'
     end
   end
 end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -153,8 +153,10 @@ module RenderersSharedTests
     test "should find all registered host statuses" do
       source = OpenStruct.new(content: '<%= all_host_statuses.map { |s| s.status_name }.join(",") %>')
       statuses = renderer.render(source, @scope).split(',')
-      assert_includes statuses, 'Build'
-      assert_includes statuses, 'Configuration'
+
+      refute_nil statuses.index('Build')
+      refute_nil statuses.index('Configuration')
+      assert(statuses.index('Build') < statuses.index('Configuration'))
     end
   end
 end


### PR DESCRIPTION
Originally the test assumed there are exactly two HostStatuses. This
made plugin tests fail when they added another Status.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
