### PR TITLE
Fixes #24471 - Markings removed from fields in Hostgroup

### DIFF
--- a/app/views/common/os_selection/_architecture.html.erb
+++ b/app/views/common/os_selection/_architecture.html.erb
@@ -3,7 +3,8 @@
     {:selected => item.operatingsystem_id, :include_blank => blank_or_inherit_f(f, :operatingsystem) },
     { :label => _("Operating system"),
       :help_inline => :indicator,
-      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize, :required => true,
+      :onchange => 'os_selected(this);', :'data-url' => method_path('os_selected'), :'data-type' => controller_name.singularize,
+      :required => !item.is_a?(Hostgroup),
       :placeholder => arch_oss.empty? ? _("No options available for selected Architecture") : nil }
   %>
 <% end %>

--- a/app/views/common/os_selection/_operatingsystem.html.erb
+++ b/app/views/common/os_selection/_operatingsystem.html.erb
@@ -3,11 +3,11 @@
     {:include_blank => blank_or_inherit_f(f, :medium), :selected => item.medium_id},
     {:label => _("Media"), :help_inline => :indicator, :onchange => 'medium_selected(this);',
      :'data-url' => method_path('medium_selected'), :'data-type' => controller_name.singularize,
-     :required => true, :placeholder => os_media.empty? ? _("No options available for selected Operating System") : nil }
+     :required => !item.is_a?(Hostgroup), :placeholder => os_media.empty? ? _("No options available for selected Operating System") : nil }
   %>
   <%= select_f f, :ptable_id, os_ptable, :id, :to_label,
     {:include_blank => blank_or_inherit_f(f, :ptable), :selected => item.ptable_id},
-    {:label => _("Partition Table"), :required => true, :placeholder => os_ptable.empty? ? _("No options available for selected Operating System") : nil }
+    {:label => _("Partition Table"), :required => !item.is_a?(Hostgroup), :placeholder => os_ptable.empty? ? _("No options available for selected Operating System") : nil }
   %>
 
   <% if @operatingsystem && @operatingsystem.supports_image %>


### PR DESCRIPTION
The mandatory marking (*) is removed from HG section for operating
system, partition table and media fields