### PR TITLE
Fixes #24313 - load data to switcher in smart class parameters

### DIFF
--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -194,4 +194,10 @@ module LookupKeysHelper
     return 'host' if params.has_key?(:host) || params[:controller] == 'hosts'
     'hostgroup'
   end
+
+  def lookup_keys_breadcrumbs
+    breadcrumbs(resource_url: "/api/v2/smart_class_parameters",
+                name_field: "parameter",
+                switcher_item_url: "/puppetclass_lookup_keys/:id-:name/edit")
+  end
 end

--- a/app/views/puppetclass_lookup_keys/edit.html.erb
+++ b/app/views/puppetclass_lookup_keys/edit.html.erb
@@ -1,2 +1,3 @@
 <% title(_("Edit Smart class parameters")) %>
+<% lookup_keys_breadcrumbs %>
 <%= render 'lookup_keys/edit', :lookup_key => @puppetclass_lookup_key %>

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
@@ -44,11 +44,14 @@ export const loadSwitcherResourcesByResource = (resource, { page = 1, searchQuer
     dispatch({ type: BREADCRUMB_BAR_RESOURCES_FAILURE, payload: { error, resourceUrl } });
 
   const formatResults = ({ data }) => {
-    const switcherItems = flatten(Object.values(data.results)).map(result => ({
-      name: get(result, nameField),
-      id: result.id,
-      url: switcherItemUrl.replace(':id', result.id),
-    }));
+    const switcherItems = flatten(Object.values(data.results)).map((result) => {
+      const itemName = get(result, nameField);
+      return ({
+        name: itemName,
+        id: result.id,
+        url: switcherItemUrl.replace(':id', result.id).replace(':name', itemName),
+      });
+    });
 
     return {
       items: switcherItems,


### PR DESCRIPTION
The error occurs because the expected url does not match the default url template. Added adaptations to resolve it.
/cc @amirfefer 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
