### PR TITLE
Fixes #24539 - don't initialize dynflow in db:create

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -278,7 +278,7 @@ module Foreman
     end
 
     config.after_initialize do
-      init_dynflow unless Foreman.in_rake?('db:drop')
+      init_dynflow unless Foreman.in_rake?('db:create') || Foreman.in_rake?('db:drop')
       setup_auditing
     end
 


### PR DESCRIPTION
It fails on Rails 5.2