### PR TITLE
[1.18 CP] Fixes #24298 - Some audits show 'Missing ID' instead of name

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -3,7 +3,7 @@ module AuditsHelper
                     Location Organization Domain Subnet SmartProxy AuthSource Image Role Usergroup Bookmark ConfigGroup Ptable)
 
   # lookup the Model representing the numerical id and return its label
-  def id_to_label(name, change, truncate = true)
+  def id_to_label(name, change, audit: @audit, truncate: true)
     return _("N/A") if change.nil?
     case name
       when "ancestry"
@@ -12,13 +12,13 @@ module AuditsHelper
         label = change.to_s(:short)
       when /.*_id$/
         begin
-          label = key_to_class(name)&.find(change)&.to_label
+          label = key_to_class(name, audit)&.find(change)&.to_label
         rescue NameError
           # fallback to the value only instead of N/A that is in generic rescue below
           return _("Missing(ID: %s)") % change
         end
       when /.*_ids$/
-        existing = key_to_class(name)&.where(id: change)&.index_by(&:id)
+        existing = key_to_class(name, audit)&.where(id: change)&.index_by(&:id)
         label = change.map do |id|
           if existing&.has_key?(id)
             existing[id].to_label
@@ -77,7 +77,10 @@ module AuditsHelper
           to = HostStatus::Global.new(base[1]).to_label
           _("Global status changed from %{from} to %{to}") % { :from => from, :to => to }
         else
-          _("%{name} changed from %{label1} to %{label2}") % { :name => name.humanize, :label1 => id_to_label(name, change[0]), :label2 => id_to_label(name, change[1]) }
+          _("%{name} changed from %{label1} to %{label2}") % {
+            :name => name.humanize,
+            :label1 => id_to_label(name, change[0], audit: audit),
+            :label2 => id_to_label(name, change[1], audit: audit) }
         end
       end
     elsif !main_object? audit
@@ -235,7 +238,8 @@ module AuditsHelper
     MAIN_OBJECTS.include?(type)
   end
 
-  def key_to_class(key)
-    @audit.auditable_type.constantize.reflect_on_association(key.sub(/_id(s?)$/, '\1'))&.klass
+  def key_to_class(key, audit)
+    auditable_type = (audit.auditable_type == 'Host::Base') ? 'Host::Managed' : audit.auditable_type
+    auditable_type.constantize.reflect_on_association(key.sub(/_id(s?)$/, '\1'))&.klass
   end
 end

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -84,10 +84,10 @@
             <td><%= name.humanize %></td>
             <% if @audit.action == 'update' %>
               <% change.each do |v| %>
-                <td><%= id_to_label(name,v,false) %></td>
+                <td><%= id_to_label(name, v, truncate: false) %></td>
               <% end %>
             <% else %>
-              <td><%= id_to_label(name,change,false) %></td>
+              <td><%= id_to_label(name, change, truncate: false) %></td>
             <% end %>
           </tr>
         <% end %>


### PR DESCRIPTION
This happens when you're visiting the index page. The helper relies on
'@audit' to generate some of the audits. This does not work, since
@audit is only set when you view the details page of an audit.

For this reason, as an example changing fields of a host with
associations, like the puppet proxy, does not show the proper value in
the index, but it does show the proper value on the details page.

See the issue in Redmine for a reproduced with Katello sync plans.

(cherry picked from commit f501c49ecc5da707a41d787e75baa07e29277bc6)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
