### PR TITLE
[1.17 CP] Fixes #24298 - Some audits show 'Missing ID' instead of name

### DIFF
--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -50,10 +50,10 @@
             <td><%= name.humanize %></td>
             <% if change.is_a?(Array) %>
               <% change.each do |v| %>
-                <td><%= id_to_label(name,v,false) %></td>
+                <td><%= id_to_label(name, v, truncate: false) %></td>
               <% end %>
             <% else %>
-              <td><%= id_to_label(name,change,false) %></td>
+              <td><%= id_to_label(name, change, truncate: false) %></td>
             <% end %>
           </tr>
         <% end %>


### PR DESCRIPTION
This happens when you're visiting the index page. The helper relies on
'@Audit' to generate some of the audits. This does not work, since
@Audit is only set when you view the details page of an audit.

For this reason, as an example changing fields of a host with
associations, like the puppet proxy, does not show the proper value in
the index, but it does show the proper value on the details page.

See the issue in Redmine for a reproduced with Katello sync plans.

(cherry picked from commit f501c49)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
