### PR TITLE
Fixes #24545 - keep the pw field as it was

### DIFF
--- a/app/helpers/compute_resources_helper.rb
+++ b/app/helpers/compute_resources_helper.rb
@@ -82,7 +82,7 @@ module ComputeResourcesHelper
   end
 
   def unset_password?
-    action_name == "edit" || action_name == "test_connection"
+    action_name == "edit" || (action_name == "test_connection" && params[:cr_id].present?)
   end
 
   def test_connection_button_f(f, success, caption = nil)

--- a/webpack/assets/javascripts/foreman_compute_resource.js
+++ b/webpack/assets/javascripts/foreman_compute_resource.js
@@ -72,6 +72,7 @@ export function testConnection(item) {
   }
 
   const password = $('input#compute_resource_password').val();
+  const passwordDisabled = $('#compute_resource_password').prop('disabled');
 
   $('.tab-error').removeClass('tab-error');
   $('#test_connection_indicator').show();
@@ -100,7 +101,7 @@ export function testConnection(item) {
     complete(result) {
       // we need to restore the password field as it is not sent back from the server.
       $('input#compute_resource_password').val(password);
-      $('#compute_resource_password').prop('disabled', false);
+      $('#compute_resource_password').prop('disabled', passwordDisabled);
       $('#test_connection_indicator').hide();
       // eslint-disable-next-line no-undef
       reloadOnAjaxComplete('#test_connection_indicator');


### PR DESCRIPTION
@tbrisker mind to take a look since you worked on the original issue?

reproducing steps;
1) go to existing CR edit form
2) see the password field is disabled
3) click test connection
4) password field becomes enabled
5) click submit
6) you get a failure for empty password

fix: keep the state as it was before test connection

I also pushed minor fix for showing the enable/disable button when creating new CR as during testing it become obvious, we shouldn't display it

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
