### PR TITLE
Fixes #24546 - add uniq constraint on subnet.name

### DIFF
--- a/app/services/migrations/deduplicate_subnets.rb
+++ b/app/services/migrations/deduplicate_subnets.rb
@@ -1,0 +1,62 @@
+module Migrations
+  # A migration class to ensure there are no subnets with duplicate name.
+  # This is being used in 20180806151925_add_subnet_name_unique_constraint.rb
+  # before introducing unique db constraint on the subnet.name
+  class DeduplicateSubnets
+    attr_reader :duplicate_names
+    def initialize
+      @duplicate_names = Subnet.unscoped.select(:name).group(:name).having('count(name) > 1').pluck(:name)
+    end
+
+    def run
+      duplicate_names.each do |name|
+        subnets = Subnet.unscoped.where(name: name)
+        deduplicate_subnets(subnets)
+      end
+    end
+
+    def deduplicate_subnets(subnets)
+      name = subnets.first.name
+      subnet_groups = group_identic_subnets(subnets)
+      result_subnets = []
+      suffix = 0
+      subnet_groups.each do |subnet_group|
+        if suffix == 0
+          new_name = name
+        else
+          new_name = "#{name}-#{suffix}"
+        end
+        suffix = suggest_unique_suffix(name, suffix)
+        result_subnets << merge_subnets(new_name, subnet_group)
+      end
+      result_subnets
+    end
+
+    def merge_subnets(new_name, subnets)
+      winner, *loosers = subnets
+      Rails.logger.info("Merging duplicate subnets with name '#{winner.name}', " \
+                        "keeping #{winner.id}, merging with #{loosers.map(&:id)}, "\
+                        "new name is '#{new_name}'")
+      Hostgroup.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+      Nic::Base.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+      SubnetParameter.unscoped.where(:reference_id => loosers.map(&:id)).update_all(:reference_id => winner.id)
+      Subnet.unscoped.where(id: loosers).destroy_all
+      winner.update_attribute(:name, new_name)
+      winner
+    end
+
+    def suggest_unique_suffix(name, current_suffix)
+      new_suffix = current_suffix + 1
+      new_suffix += 1 while Subnet.unscoped.where(name: "#{name}-#{new_suffix}").any?
+      new_suffix
+    end
+
+    def group_identic_subnets(subnets)
+      subnets.group_by do |subnet|
+        attrs = subnet.attributes.except('id', 'created_at', 'updated_at')
+        attrs.merge!(organization_ids: subnet.organization_ids,
+                     location_ids: subnet.location_ids)
+      end.values
+    end
+  end
+end

--- a/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
+++ b/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
@@ -1,58 +1,15 @@
 class AddSubnetNameUniqueConstraint < ActiveRecord::Migration[5.1]
   def up
-    deduplicate_subnets
-    # we need to specify the lenght to make MySQL happy
+    deduplicator = Migrations::DeduplicateSubnets.new
+    say_with_time("Deduplicating the following subnet names: #{deduplicator.duplicate_names.inspect}") do
+      deduplicator.run
+    end
+
+    # we need to specify the length to make MySQL happy
     add_index :subnets, :name, :unique => true, length: { name: 255 }
   end
 
   def down
     remove_index :subnets, :name
-  end
-
-  private
-
-  def deduplicate_subnets
-    duplicate_names = Subnet.unscoped.select(:name).group(:name).having('count(name) > 1').pluck(:name)
-    Rails.logger.info("Found #{duplicate_names} duplicate subnet names.")
-    duplicate_names.each do |name|
-      suffix = 0
-      subnets = Subnet.unscoped.where(name: name)
-      subnet_groups = group_identic_subnets(subnets)
-      subnet_groups.each do |subnet_group|
-        if suffix == 0
-          new_name = name
-        else
-          new_name = "#{name}-#{suffix}"
-        end
-        suffix = suggest_unique_suffix(name, suffix)
-        merge_subnets(new_name, subnet_group)
-      end
-    end
-  end
-
-  def merge_subnets(new_name, subnets)
-    winner, *loosers = subnets
-    Rails.logger.info("Merging duplicate subnets with name '#{winner.name}', " \
-                        "keeping #{winner.id}, merging with #{loosers.map(&:id)}, "\
-                        "new name is '#{new_name}'")
-    Hostgroup.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
-    Nic::Base.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
-    SubnetParameter.unscoped.where(:reference_id => loosers.map(&:id)).update_all(:reference_id => winner.id)
-    Subnet.unscoped.where(id: loosers).destroy_all
-    winner.update_attribute(:name, new_name)
-  end
-
-  def suggest_unique_suffix(name, current_suffix)
-    new_suffix = current_suffix + 1
-    new_suffix += 1 while Subnet.unscoped.where(name: "#{name}-#{new_suffix}").any?
-    new_suffix
-  end
-
-  def group_identic_subnets(subnets)
-    subnets.group_by do |subnet|
-      attrs = subnet.attributes.except('id', 'created_at', 'updated_at')
-      attrs.merge!(organization_ids: subnet.organization_ids,
-                   location_ids: subnet.location_ids)
-    end.values
   end
 end

--- a/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
+++ b/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
@@ -1,0 +1,27 @@
+class AddSubnetNameUniqueConstraint < ActiveRecord::Migration[5.1]
+  def up
+    merge_duplicate_subnets
+    # we need to specify the lenght to make MySQL happy
+    add_index :subnets, :name, :unique => true, length: { name: 255 }
+  end
+
+  def down
+    remove_index :subnets, :name
+  end
+
+  private
+
+  def merge_duplicate_subnets
+    duplicate_names = Subnet.unscoped.select(:name).group(:name).having('count(name) > 1').pluck(:name)
+    Rails.logger.info("Found #{duplicate_names} duplicate subnet names.")
+    duplicate_names.each do |name|
+      winner, *loosers = Subnet.unscoped.where(name: name)
+      Rails.logger.info("Merging duplicate subnets with name '#{name}', " \
+                        "keeping #{winner.id}, merging with #{loosers.map(&:id)}")
+      Hostgroup.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+      Nic::Base.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+      SubnetParameter.unscoped.where(:reference_id => loosers.map(&:id)).update_all(:reference_id => winner.id)
+      loosers.each(&:destroy!)
+    end
+  end
+end

--- a/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
+++ b/db/migrate/20180806151925_add_subnet_name_unique_constraint.rb
@@ -1,6 +1,6 @@
 class AddSubnetNameUniqueConstraint < ActiveRecord::Migration[5.1]
   def up
-    merge_duplicate_subnets
+    deduplicate_subnets
     # we need to specify the lenght to make MySQL happy
     add_index :subnets, :name, :unique => true, length: { name: 255 }
   end
@@ -11,17 +11,48 @@ class AddSubnetNameUniqueConstraint < ActiveRecord::Migration[5.1]
 
   private
 
-  def merge_duplicate_subnets
+  def deduplicate_subnets
     duplicate_names = Subnet.unscoped.select(:name).group(:name).having('count(name) > 1').pluck(:name)
     Rails.logger.info("Found #{duplicate_names} duplicate subnet names.")
     duplicate_names.each do |name|
-      winner, *loosers = Subnet.unscoped.where(name: name)
-      Rails.logger.info("Merging duplicate subnets with name '#{name}', " \
-                        "keeping #{winner.id}, merging with #{loosers.map(&:id)}")
-      Hostgroup.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
-      Nic::Base.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
-      SubnetParameter.unscoped.where(:reference_id => loosers.map(&:id)).update_all(:reference_id => winner.id)
-      loosers.each(&:destroy!)
+      suffix = 0
+      subnets = Subnet.unscoped.where(name: name)
+      subnet_groups = group_identic_subnets(subnets)
+      subnet_groups.each do |subnet_group|
+        if suffix == 0
+          new_name = name
+        else
+          new_name = "#{name}-#{suffix}"
+        end
+        suffix = suggest_unique_suffix(name, suffix)
+        merge_subnets(new_name, subnet_group)
+      end
     end
+  end
+
+  def merge_subnets(new_name, subnets)
+    winner, *loosers = subnets
+    Rails.logger.info("Merging duplicate subnets with name '#{winner.name}', " \
+                        "keeping #{winner.id}, merging with #{loosers.map(&:id)}, "\
+                        "new name is '#{new_name}'")
+    Hostgroup.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+    Nic::Base.unscoped.where(:subnet_id => loosers.map(&:id)).update_all(:subnet_id => winner.id)
+    SubnetParameter.unscoped.where(:reference_id => loosers.map(&:id)).update_all(:reference_id => winner.id)
+    Subnet.unscoped.where(id: loosers).destroy_all
+    winner.update_attribute(:name, new_name)
+  end
+
+  def suggest_unique_suffix(name, current_suffix)
+    new_suffix = current_suffix + 1
+    new_suffix += 1 while Subnet.unscoped.where(name: "#{name}-#{new_suffix}").any?
+    new_suffix
+  end
+
+  def group_identic_subnets(subnets)
+    subnets.group_by do |subnet|
+      attrs = subnet.attributes.except('id', 'created_at', 'updated_at')
+      attrs.merge!(organization_ids: subnet.organization_ids,
+                   location_ids: subnet.location_ids)
+    end.values
   end
 end

--- a/test/unit/migrations/deduplicate_subnets_test.rb
+++ b/test/unit/migrations/deduplicate_subnets_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Migrations::DeduplicateSubnetsTest < ActiveSupport::TestCase
+  describe Migrations::DeduplicateSubnets do
+    def setup
+      @name, @network = 'my-duplicate-subnet', '192.168.42.0'
+      @original_subnet = FactoryBot.build(:subnet_ipv4, name: @name, network: @network)
+      @duplicate_subnet = FactoryBot.build(:subnet_ipv4, name: @name, network: @network)
+      @different_network_subnet = FactoryBot.build(:subnet_ipv4, name: @name, network: '10.0.0.1')
+      @different_org_subnet = FactoryBot.build(:subnet_ipv4, name: @name, network: @network).tap do |subnet|
+        subnet.organizations = [] # simulate different org assignemnt
+      end
+      @different_loc_subnet = FactoryBot.build(:subnet_ipv4, name: @name, network: @network).tap do |subnet|
+        subnet.locations = [] # simulate different loc assignemnt
+      end
+
+      # simulate we already have a network there that would colide
+      # with new network names with suffix
+      FactoryBot.create(:subnet_ipv4, name: "#{@name}-1", network: @network)
+
+      @subnets = [
+        @original_subnet,
+        @duplicate_subnet,
+        @different_network_subnet,
+        @different_org_subnet,
+        @different_loc_subnet
+      ]
+    end
+    it 'deduplicates the subnets with the same name' do
+      deduplicator = Migrations::DeduplicateSubnets.new
+      result = deduplicator.deduplicate_subnets(@subnets)
+      result.must_equal [@original_subnet, @different_network_subnet,
+                         @different_org_subnet, @different_loc_subnet]
+      result.each do |subnet|
+        refute subnet.changed? # test we saved the changes
+      end
+      @original_subnet.name.must_equal @name
+      @different_network_subnet.name.must_equal "#{@name}-2"
+      @different_org_subnet.name.must_equal "#{@name}-3"
+      @different_loc_subnet.name.must_equal "#{@name}-4"
+    end
+  end
+end


### PR DESCRIPTION
Concurrent requests on subnet create can lead to duplicate records. This
is calling issues in production when bulk importing hosts from the same
subnet via user scripting.

- [x] - ~~merge taxonomies of the merged subnets~~ - don't merge subnets from different taxonomies
- [x] - ensure we don't merge subnets with different network, but ensure uniqueness there.