### PR TITLE
Fixes #24548 - make SSH timeout configurable

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -52,7 +52,7 @@ class Setting::Provisioning < Setting
       self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),
       self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1", N_('Remote address')),
       self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6, N_('Token duration')),
-      self.set('ssh_timeout', N_("Time in seconds before SSH provisioning times out"), 60 * 6, N_('SSH timeout')),
+      self.set('ssh_timeout', N_("Time in seconds before SSH provisioning times out"), 60 * 2, N_('SSH timeout')),
       self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0", N_('Libvirt default console address')),
       self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false, N_('Update IP from built request')),
       self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -52,6 +52,7 @@ class Setting::Provisioning < Setting
       self.set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),
       self.set('remote_addr', N_("If Foreman is running behind Passenger or a remote load balancer, the IP should be set here. This is a regular expression, so it can support several load balancers, i.e: (10.0.0.1|127.0.0.1)"), "127.0.0.1", N_('Remote address')),
       self.set('token_duration', N_("Time in minutes installation tokens should be valid for, 0 to disable token generation"), 60 * 6, N_('Token duration')),
+      self.set('ssh_timeout', N_("Time in seconds before SSH provisioning times out"), 60 * 6, N_('SSH timeout')),
       self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0", N_('Libvirt default console address')),
       self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false, N_('Update IP from built request')),
       self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -72,7 +72,7 @@ class Foreman::Provision::SSH
   end
 
   def initiate_connection!
-    Timeout.timeout(Setting[:ssh_timeout]) do
+    Timeout.timeout(Setting[:ssh_timeout].to_i) do
       begin
         Timeout.timeout(8) do
           ssh.run('pwd')

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -72,7 +72,7 @@ class Foreman::Provision::SSH
   end
 
   def initiate_connection!
-    Timeout.timeout(360) do
+    Timeout.timeout(Setting[:ssh_timeout]) do
       begin
         Timeout.timeout(8) do
           ssh.run('pwd')

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -384,3 +384,8 @@ attribute81:
   category: Setting::General
   default: "--- \n"
   description: 'Text to be shown in the login-page footer'
+attribute82:
+  name: ssh_timeout
+  category: Setting::Provisioning
+  default: 120
+  description: 'Time in seconds before SSH provisioning times out'


### PR DESCRIPTION
I found that I needed to increase this value when SSH provisioning a very slow machine.  Making this configurable could help others who have the same problem.