### PR TITLE
Fixes #24473 - Return other OS when oVirt os is not found

### DIFF
--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -67,6 +67,9 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
 
       @host.operatingsystem = operatingsystems(:ubuntu1210)
       @compute_resource.determine_os_type(@host).must_equal "ubuntu_12_10"
+
+      @host.operatingsystem = FactoryBot.create(:operatingsystem)
+      @compute_resource.determine_os_type(@host).must_equal "other"
     end
 
     it 'respects host param ovirt_ostype' do


### PR DESCRIPTION
(cherry picked from commit 9f3477a23957a4113aa04ca0ab41cccff26320f5)