### PR TITLE
Fixes #23505 - Viewing children fact values as a user with limited view_host permissions results in "PG::Error: ERROR: column reference "ancestry" is ambiguous"

### DIFF
--- a/app/models/fact_name.rb
+++ b/app/models/fact_name.rb
@@ -15,7 +15,7 @@ class FactName < ApplicationRecord
   scope :with_parent_id, lambda { |find_ids|
     conds, binds = [], []
     [find_ids].flatten.each do |find_id|
-      conds.push "(fact_names.ancestry LIKE '%/?' OR ancestry = '?')"
+      conds.push "(fact_names.ancestry LIKE '%/?' OR fact_names.ancestry = '?')"
       binds.push find_id, find_id
     end
     where(conds.join(' OR '), *binds)


### PR DESCRIPTION
See the following open bugs: 

https://projects.theforeman.org/issues/23505
https://projects.theforeman.org/issues/17121

If you have users with limited host_group scopes for view_hosts, you encounter something similar to what's reported in both issues. The fix is to explicate the second comparison of `ancestry` to use `fact_names.ancestry` instead. This corrects the generated SQL.
