### PR TITLE
fixes #24561 - adds webpack analyze support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "uglifyjs-webpack-plugin": "^1.2.2",
     "url-loader": "^1.0.1",
     "webpack": "^3.4.1",
+    "webpack-bundle-analyzer": "^2.13.1",
     "webpack-dev-server": "^2.5.1",
     "webpack-stats-plugin": "^0.1.5"
   },
@@ -105,7 +106,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
-    "postinstall": "node ./script/npm_install_plugins.js"
+    "postinstall": "node ./script/npm_install_plugins.js",
+    "analyze": "./script/webpack-analyze"
   },
   "jest": {
     "automock": true,

--- a/script/webpack-analyze
+++ b/script/webpack-analyze
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+NODE_ENV=production
+FOREMAN_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+FOREMAN_PATH="${FOREMAN_PATH}/.."
+PATH="$FOREMAN_PATH/node_modules/.bin:$PATH"
+WEBPACK="webpack --config $FOREMAN_PATH/config/webpack.config.js"
+WEBPACK_DIR="$FOREMAN_PATH/public/webpack"
+REPORT="${WEBPACK_DIR}/report.html"
+
+$WEBPACK --profile --json > $WEBPACK_DIR/stats.json && \
+webpack-bundle-analyzer --mode static -r $REPORT $WEBPACK_DIR/stats.json


### PR DESCRIPTION
to use, simply execute:

```npm run analyze```