### PR TITLE
Fixes #24522 - Fix selected cluster in ovirt network

### DIFF
--- a/app/views/compute_attributes/_compute_form.html.erb
+++ b/app/views/compute_attributes/_compute_form.html.erb
@@ -3,7 +3,7 @@
             :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :hide_image => true }.merge(args_for_compute_resource_partial(@host)) %>
 
 <!--NICS-->
-<%= render :partial => 'compute_resources_vms/form/networks', :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :item_layout => 'deletable' } %>
+<%= render :partial => 'compute_resources_vms/form/networks', :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :item_layout => 'deletable', :selected_cluster => selected_cluster } %>
 
 <!--Storage-->
 <%= render :partial => 'compute_resources_vms/form/volumes', :locals => { :f => f, :compute_resource => compute_resource, :new_host => true, :new_vm => true, :item_layout => 'deletable' } %>

--- a/app/views/compute_resources_vms/form/_networks.html.erb
+++ b/app/views/compute_resources_vms/form/_networks.html.erb
@@ -12,7 +12,7 @@
         <%= f.fields_for compute_resource.interfaces_attrs_name do |i| %>
 
           <%= render :partial => provider_partial(compute_resource, 'network'),
-              :locals => { :f => i, :compute_resource => compute_resource, :new_host => new_host, :new_vm => new_vm, :remove_title => _('remove network interface') },
+              :locals => { :f => i, :compute_resource => compute_resource, :new_host => new_host, :new_vm => new_vm, :remove_title => _('remove network interface'), :selected_cluster => selected_cluster },
               :layout => 'compute_resources_vms/form/deletable_layout' %>
 
         <% end %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -1,5 +1,7 @@
 <%= text_f f, :name, :disabled => !new_vm, :class => "ovirt_name", :label => _('Name'), :label_size => "col-md-3" %>
-<% selected_cluster ||= compute_resource.clusters.first.id %>
+
+<% selected_cluster ||= params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil) %>
+<% selected_cluster ||= compute_resource.clusters.first.try(:id) %>
 <%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
              { }, :disabled => !new_vm, :class => "ovirt_network",
              :label         => _('Network'), :label_size => "col-md-3" %>


### PR DESCRIPTION
The bug fixes 2 issues:
1. When updating/creating a new compute profile, the form doesn't present the selected cluster and network.
2. When creating a host with compute profile, the network doesn't get filled by the compute profile selected.