### PR TITLE
Revert "Fixes #23961 - Update Foreman Fog-Vsphere select_nic method."

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -37,16 +37,16 @@ module FogExtensions
 
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
-        all_networks = service.list_networks(datacenter: datacenter)
-        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network[:name], network[:key]].compact.include?(nic_attrs['network']) }
-        vm_network ||= all_networks.detect { |network| network[:_ref] == nic_attrs['network'] }
+        all_networks = service.raw_networks(datacenter)
+        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network.name, network.try(:key)].include?(nic_attrs['network']) }
+        vm_network ||= all_networks.detect { |network| network._ref == nic_attrs['network'] }
         unless vm_network
           Rails.logger.info "Could not find Vsphere network for #{nic_attrs.inspect}"
           return
         end
-        selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:name] } # grab any nic on the same network
+        selected_nic = fog_nics.detect { |fn| fn.network == vm_network.name } # grab any nic on the same network
         if selected_nic.nil? && vm_network.respond_to?(:key)
-          selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:key] } # try to match on portgroup
+          selected_nic = fog_nics.detect { |fn| fn.network == vm_network.key } # try to match on portgroup
         end
         selected_nic
       end

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 2.3.0'
+  gem 'fog-vsphere', '2.1.1'
 end


### PR DESCRIPTION
This reverts commit a88c2489cce9a8cd6ab1efe68b5892c634fc0cdb.

This is a standby PR in case @chris1984 confirm the regression this causes can't be fixed in time for 1.18.1.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
