### PR TITLE
fixes #24590 - adds missing packages to the vendor bundle

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -6,6 +6,7 @@ module.exports = [
   'react',
   'react-dom',
   'react-bootstrap',
+  'react-debounce-input',
   'react-ellipsis-with-tooltip',
   'react-numeric-input',
   'react-onclickoutside',
@@ -59,6 +60,7 @@ module.exports = [
   /**
    * Other packages
    */
+  'axios',
   'diff',
   'ipaddr.js',
   'jstz',


### PR DESCRIPTION
This reduces plugin bundles, for example:

Before
```
         foreman_ansible-5d349cbac84354973187.js     191 kB
foreman_remote_execution-f5d74437300f4b3c5b05.js     151 kB
                  vendor-006110822861b6733af8.js    3.87 MB
                  bundle-f60c9313893e777715a8.js     183 kB
```
After
```
         foreman_ansible-195d8978baa8035f4120.js     168 kB
foreman_remote_execution-b9b0d6b91ed13025743c.js     128 kB
                  vendor-b6241de5b97d3aac0bf8.js    3.89 MB
                  bundle-a70a5008863bfd5b2929.js     161 kB
```
The large percentage remaining is the component registry it self, which
should be shared, but probably in another PR.