### PR TITLE
Fixes #5421 - API for cloning hosts

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -657,6 +657,23 @@ class Host::Managed < Host::Base
     host
   end
 
+  def api_clone
+    host = self.selective_clone
+    if self.interfaces.length == 1
+      host.interfaces = self.interfaces.map(&:clone)
+    else
+      primary_interface = self.interfaces.select(&:primary)
+      host.interfaces = primary_interface.map(&:clone)
+    end
+
+    if self.compute_resource
+      host.compute_attributes = host.compute_resource.vm_compute_attributes_for(self.uuid)
+    end
+
+    host.refresh_global_status
+    host
+  end
+
   def bmc_nic
     interfaces.bmc.first
   end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -321,7 +321,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :puppetclasses => pc_ajax_actions,
                                     :subnets => subnets_ajax_actions,
                                     :interfaces => [:new, :random_name],
-                                     :"api/v2/hosts" => [:create],
+                                     :"api/v2/hosts" => [:create, :clone],
                                      :"api/v2/interfaces" => [:create],
                                      :"api/v2/tasks" => [:index]
                                   }

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -373,6 +373,7 @@ Foreman::Application.routes.draw do
           put :power, :on => :member
           put :rebuild_config, :on => :member
           post :facts, :on => :collection
+          post :clone, :on => :member
           resources :audits, :only => :index
           resources :facts,  :only => :index, :controller => :fact_values
           resources :host_classes, :path => :puppetclass_ids, :only => [:index, :create, :destroy]


### PR DESCRIPTION
Now is possible clone hosts via API/hammer with minimal options: id(of cloned host), name(of new host),  and ip(of new host).