### PR TITLE
Fixes #24371 - Improve plugin webpack detection

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -6,23 +6,17 @@ module ReactjsHelper
   end
 
   def webpacked_plugins_js_for(*plugin_names)
-    tags = create_tags(plugin_names)
-    return nil if tags.empty?
-    tags.inject(&:concat).html_safe
+    js_tags_for(select_requested_plugins(plugin_names)).join.html_safe
   end
 
-  def create_tags(plugin_names)
-    js_tags_for select_requested_plugins(all_webpacked_plugins.map(&:id), plugin_names)
-  end
-
-  def select_requested_plugins(webpacked_plugin_ids, plugin_names)
-    plugin_names.select { |plugin_name| webpacked_plugin_ids.include?(plugin_name) }
-  end
-
-  def all_webpacked_plugins
-    Foreman::Plugin.registered_plugins.values.select do |plugin|
-      File.exist? File.join(plugin.path, 'webpack/index.js')
+  def select_requested_plugins(plugin_names)
+    available_plugins = Foreman::Plugin.with_webpack.map(&:id)
+    missing_plugins = plugin_names - available_plugins
+    if missing_plugins.any?
+      logger.error { "Failed to include webpack assets for plugins: #{missing_plugins}" }
+      raise ::Foreman::Exception.new("Failed to include webpack assets for plugins: #{missing_plugins}") if Rails.env.development?
     end
+    plugin_names & available_plugins
   end
 
   def js_tags_for(requested_plugins)

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -105,6 +105,10 @@ module Foreman #:nodoc:
       def registered_report_scanners
         report_scanner_registry.report_scanners
       end
+
+      def with_webpack
+        all.select(&:uses_webpack?)
+      end
     end
 
     prepend Foreman::Plugin::Assets

--- a/app/registries/foreman/plugin/assets.rb
+++ b/app/registries/foreman/plugin/assets.rb
@@ -25,6 +25,15 @@ module Foreman
         @automatic_assets = !!enabled
       end
 
+      def webpack_manifest_path
+        manifest_path = File.join(path, 'public', 'webpack', id.to_s, 'manifest.json')
+        File.file?(manifest_path) ? manifest_path : nil
+      end
+
+      def uses_webpack?
+        File.file?(File.join(path, 'webpack', 'index.js')) || webpack_manifest_path.present?
+      end
+
       private
 
       def find_assets(root)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -111,15 +111,14 @@ Foreman::Application.configure do |app|
       if (webpack_manifest_file = Dir.glob("#{Rails.root}/public/webpack/manifest.json").first)
         webpack_manifest = JSON.parse(File.read(webpack_manifest_file))
 
-        Foreman::Plugin.all.each do |plugin|
-          manifest_path = File.join(plugin.path, 'public', 'webpack', plugin.id.to_s, 'manifest.json')
+        Foreman::Plugin.with_webpack.each do |plugin|
+          manifest_path = plugin.webpack_manifest_path
+          next unless manifest_path
 
-          if File.file?(manifest_path)
-            Rails.logger.debug { "Loading #{plugin.id} webpack asset manifest from #{manifest_path}" }
-            assets = JSON.parse(File.read(manifest_path))
+          Rails.logger.debug { "Loading #{plugin.id} webpack asset manifest from #{manifest_path}" }
+          assets = JSON.parse(File.read(manifest_path))
 
-            webpack_manifest['assetsByChunkName'][plugin.id.to_s] = assets['assetsByChunkName'][plugin.id.to_s] if assets['assetsByChunkName'].key?(plugin.id.to_s)
-          end
+          webpack_manifest['assetsByChunkName'][plugin.id.to_s] = assets['assetsByChunkName'][plugin.id.to_s] if assets['assetsByChunkName'].key?(plugin.id.to_s)
         end
 
         Webpack::Rails::Manifest.manifest = webpack_manifest

--- a/test/helpers/reactjs_helper_test.rb
+++ b/test/helpers/reactjs_helper_test.rb
@@ -10,13 +10,17 @@ class ReactjsHelperTest < ActionView::TestCase
   setup do
     Foreman::Plugin.register(:foreman_react) {}
     Foreman::Plugin.register(:foreman_angular) {}
-    @plugins = [Foreman::Plugin.find(:foreman_react), Foreman::Plugin.find(:foreman_angular)]
-    self.stubs(:all_webpacked_plugins).returns(@plugins)
+    Foreman::Plugin.any_instance.stubs(:uses_webpack?).returns(true)
+  end
+
+  teardown do
+    Foreman::Plugin.unregister(:foreman_react)
+    Foreman::Plugin.unregister(:foreman_angular)
   end
 
   test "should select requested plugins" do
     plugin_names = [:foreman_react, :foreman_backbone]
-    selected_plugins = select_requested_plugins(all_webpacked_plugins.map(&:id), plugin_names)
+    selected_plugins = select_requested_plugins(plugin_names)
     assert selected_plugins.include?(:foreman_react)
     assert_equal 1, selected_plugins.size
   end
@@ -27,7 +31,7 @@ class ReactjsHelperTest < ActionView::TestCase
   end
 
   test "should not create js for plugins without webpacked js" do
-    refute webpacked_plugins_js_for(:foreman_meteor)
+    assert_empty webpacked_plugins_js_for(:foreman_meteor)
   end
 
   test "should create js for plugins with webpacked js" do


### PR DESCRIPTION
(cherry picked from commit b6078503f94976c48894afe7a99d04d305cb7025)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
