### PR TITLE
Fixes #24600 - crypt salt is always valid

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -7,9 +7,15 @@ class PasswordCrypt
     ALGORITHMS['MD5'] = '$1$'
   end
 
+  def self.generate_linux_salt
+    # Linux crypt accepts maximum 16 [a-zA-Z0-9./] characters, on Ruby 2.5+ use alphanumeric
+    # method, on older rubies let's use safe base64 downgraded to base63
+    SecureRandom.respond_to?(:alphanumeric) ? SecureRandom.alphanumeric(16) : SecureRandom.base64(12).tr('+=', '..')
+  end
+
   def self.passw_crypt(passwd, hash_alg = 'SHA256')
     raise Foreman::Exception.new(N_("Unsupported password hash function '%s'"), hash_alg) unless ALGORITHMS.has_key?(hash_alg)
-    result = (hash_alg == 'Base64') ? Base64.strict_encode64(passwd) : passwd.crypt("#{ALGORITHMS[hash_alg]}#{SecureRandom.base64(6)}")
+    result = (hash_alg == 'Base64') ? Base64.strict_encode64(passwd) : passwd.crypt("#{ALGORITHMS[hash_alg]}#{self.generate_linux_salt}")
     result.force_encoding(Encoding::UTF_8) if result.encoding != Encoding::UTF_8
     result
   end


### PR DESCRIPTION
See the issue for explanation. In short, our salt was *sometimes*
invalid and password was encrypted as `*0`.