### PR TITLE
Fixes #24619 - handle Rails env in db:create

### DIFF
--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -37,7 +37,7 @@ module Facets
         klass.class_eval do
           has_one facet_config.name, :class_name => facet_config.model.name, :foreign_key => :host_id, :inverse_of => :host, :dependent => facet_config.dependent
           accepts_nested_attributes_for facet_config.name, :update_only => true, :reject_if => :all_blank
-          if Foreman.in_rake?("db:migrate")
+          if Foreman.in_setup_db_rake?
             # To prevent running into issues in old migrations when new facet is defined but not migrated yet.
             # We define it only when in migration to avoid this unnecessary checks outside for the migration
             @facet_relation_db_migrate_extensions ||= {} # prevent duplicates

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -315,7 +315,7 @@ module Foreman #:nodoc:
     # Add plugin permissions to Manager and Viewer roles. Use this method if there are no special cases that need to be taken care of.
     # Otherwise add_permissions_to_default_roles or add_resource_permissions_to_default_roles might be the methods you are looking for.
     def add_all_permissions_to_default_roles
-      return if Foreman.in_rake?('db:migrate') || !permission_table_exists?
+      return if Foreman.in_setup_db_rake? || !permission_table_exists?
       Role.without_auditing do
         Filter.without_auditing do
           Plugin::RbacSupport.new.add_all_permissions_to_default_roles(Permission.where(:name => @rbac_registry.permission_names))
@@ -324,6 +324,7 @@ module Foreman #:nodoc:
     end
 
     def pending_migrations
+      return true if Foreman.in_setup_db_rake?
       migration_paths = ActiveRecord::Migrator.migrations(
         ActiveRecord::Migrator.migrations_paths)
       pending_migrations = ActiveRecord::Migrator.new(:up, migration_paths).

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -121,7 +121,7 @@ class ActiveRecord::Base
   def self.audited(*args)
     # do not audit data changes during db migrations
     super
-    self.auditing_enabled = false if Foreman.in_rake?('db:migrate')
+    self.auditing_enabled = false if Foreman.in_setup_db_rake?
   end
 end
 

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -12,10 +12,14 @@ module Foreman
     !!(str =~ UUID_REGEXP)
   end
 
-  def self.in_rake?(rake_task = nil)
+  def self.in_rake?(*rake_tasks)
     return false unless defined?(Rake) && Rake.respond_to?(:application)
     Rake.application.top_level_tasks.any? do |running_rake_task|
-      rake_task.nil? || running_rake_task.start_with?(rake_task)
+      rake_tasks.empty? || rake_tasks.any? { |rake_task| running_rake_task.start_with?(rake_task) }
     end
+  end
+
+  def self.in_setup_db_rake?
+    in_rake?('db:create', 'db:migrate', 'db:drop')
   end
 end

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -168,7 +168,7 @@ class FacetTest < ActiveSupport::TestCase
 
   context 'inside db:migrate task' do
     setup do
-      Foreman.stubs(:in_rake?).with("db:migrate").returns(true)
+      Foreman.stubs(:in_setup_db_rake?).returns(true)
     end
 
     test 'facet can be registered more than once' do


### PR DESCRIPTION
This is a change needed for migration to Rails 5.2