### PR TITLE
Fixes #24620 - suggest Dynflow logger to be info by default

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -95,6 +95,7 @@
 #    :enabled: true
 #  :dynflow:
 #    :enabled: true
+#    :level: info
 #  :telemetry:
 #    :enabled: true
 #  :blob:


### PR DESCRIPTION
Not many people are that interested into Dynflow internals.