### PR TITLE
Fixes #24622 - UEFI HTTP boot loader options

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -832,7 +832,9 @@ function pxeLoaderCompatibilityCheck() {
   var compatible = tfm.hosts.checkPXELoaderCompatibility(osTitle, pxeLoader);
   if (compatible === false) {
     $('#host_pxe_loader').closest('.form-group').addClass('has-warning');
-    $('#host_pxe_loader').closest('.form-group').find('.help-inline').html('<span class="error-message">' + __("Warning: This combination of loader and OS might not be able to boot.") + '</span>');
+    $('#host_pxe_loader').closest('.form-group').find('.help-inline').html('<span class="error-message">' +
+      __("Warning: This combination of loader and OS might not be able to boot.") + ' ' +
+      __("Manual configuration is needed.") + '</span>');
   } else {
     $('#host_pxe_loader').closest('.form-group').removeClass('has-warning');
     $('#host_pxe_loader').closest('.form-group').find('.help-inline').html('');

--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -1,10 +1,12 @@
 module PxeLoaderSupport
   extend ActiveSupport::Concern
 
+  # mapping from filename or loader name to template kind
   PXE_KINDS = {
-    :PXELinux => /^(pxelinux|PXELinux).*/,
-    :PXEGrub => /^(grub\/|Grub ).*/,
-    :PXEGrub2 => /^(grub2|Grub2).*/
+    :PXELinux => /^(pxelinux.*|PXELinux (BIOS|UEFI))$/,
+    :PXEGrub => /^(grub\/|Grub UEFI).*/,
+    :PXEGrub2 => /^(grub2\/|Grub2 UEFI|http.*grub2\/).*/,
+    :iPXE => /^(iPXE|http.*\/ipxe-).*/
   }.with_indifferent_access.freeze
 
   # preference order is defined in Operatingsystem#template_kinds
@@ -15,14 +17,18 @@ module PxeLoaderSupport
   }.with_indifferent_access.freeze
 
   class_methods do
-    def all_loaders_map(precision = 'x64')
+    def all_loaders_map(precision = 'x64', httpboot_host = "httpboot_host")
       {
         "None" => "",
         "PXELinux BIOS" => "pxelinux.0",
         "PXELinux UEFI" => "pxelinux.efi",
         "Grub UEFI" => "grub/grub#{precision}.efi",
         "Grub2 UEFI" => "grub2/grub#{precision}.efi",
-        "Grub2 UEFI SecureBoot" => "grub2/shim#{precision}.efi"
+        "Grub2 UEFI SecureBoot" => "grub2/shim#{precision}.efi",
+        "Grub2 UEFI HTTP" => "http://#{httpboot_host}/httpboot/grub2/grub#{precision}.efi",
+        "Grub2 UEFI HTTPS" => "https://#{httpboot_host}/httpboot/grub2/grub#{precision}.efi",
+        "Grub2 UEFI HTTPS SecureBoot" => "https://#{httpboot_host}/httpboot/grub2/shim#{precision}.efi",
+        "iPXE UEFI HTTP" => "http://#{httpboot_host}/httpboot/ipxe-#{precision}.efi"
       }.freeze
     end
 

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -228,7 +228,9 @@ class Operatingsystem < ApplicationRecord
 
   def boot_filename(host = nil)
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
-    self.class.all_loaders_map(host.arch.nil? ? '' : host.arch.bootfilename_efi)[host.pxe_loader]
+    architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
+    boot_uri = URI.parse(host.subnet.httpboot? ? host.subnet.httpboot.url : Setting[:unattended_url])
+    self.class.all_loaders_map(architecture, "#{boot_uri.host}:#{boot_uri.port}")[host.pxe_loader]
   end
 
   # Does this OS family use release_name in its naming scheme

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -50,6 +50,12 @@ class Subnet < ApplicationRecord
     :api_description => N_('TFTP Proxy ID to use within this subnet'),
     :description => N_('TFTP Proxy to use within this subnet')
 
+  belongs_to_proxy :httpboot,
+    :feature => N_('HTTPBoot'),
+    :label => N_('HTTPBoot Proxy'),
+    :api_description => N_('HTTPBoot Proxy ID to use within this subnet'),
+    :description => N_('HTTPBoot Proxy to use within this subnet')
+
   belongs_to_proxy :dns,
     :feature => N_('DNS'),
     :label => N_('Reverse DNS Proxy'),
@@ -164,6 +170,14 @@ class Subnet < ApplicationRecord
     @tftp_proxy ||= ProxyAPI::TFTP.new({:url => tftp.url}.merge(attrs)) if tftp?
   end
 
+  def httpboot?
+    !!(httpboot && httpboot.url && httpboot.url.present?)
+  end
+
+  def httpboot_proxy(attrs = {})
+    @httpboot_proxy ||= ProxyAPI::TFTP.new({:url => httpboot.url}.merge(attrs)) if httpboot?
+  end
+
   # do we support DNS PTR records for this subnet
   def dns?
     !!(dns && dns.url && dns.url.present?)
@@ -210,7 +224,7 @@ class Subnet < ApplicationRecord
   end
 
   def proxies
-    [dhcp, tftp, dns].compact
+    [dhcp, tftp, dns, httpboot].compact
   end
 
   def has_vlanid?

--- a/db/migrate/20180816110716_add_httpboot_do_subnet.rb
+++ b/db/migrate/20180816110716_add_httpboot_do_subnet.rb
@@ -1,0 +1,6 @@
+class AddHttpbootDoSubnet < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subnets, :httpboot_id, :integer
+    add_index :subnets, :httpboot_id
+  end
+end

--- a/db/seeds.d/110-smart_proxy_features.rb
+++ b/db/seeds.d/110-smart_proxy_features.rb
@@ -1,5 +1,5 @@
 # Proxy features
-[ "TFTP", "DNS", "DHCP", "Puppet", "Puppet CA", "BMC", "Realm", "Facts", "Logs" ].each do |input|
+[ "TFTP", "DNS", "DHCP", "Puppet", "Puppet CA", "BMC", "Realm", "Facts", "Logs", "HTTPBoot" ].each do |input|
   f = Feature.where(:name => input).first_or_create
   raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
 end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -383,6 +383,10 @@ FactoryBot.define do
       subnet { FactoryBot.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]) }
     end
 
+    trait :with_tftp_and_httpboot_subnet do
+      subnet { FactoryBot.build(:subnet_ipv4, :tftp, :httpboot, locations: [location], organizations: [organization]) }
+    end
+
     trait :with_templates_subnet do
       subnet { FactoryBot.build(:subnet_ipv4, :template, locations: [location], organizations: [organization]) }
     end
@@ -408,6 +412,18 @@ FactoryBot.define do
     trait :with_tftp_orchestration do
       managed
       with_tftp_subnet
+      interfaces do
+        [FactoryBot.build(:nic_managed, :primary => true,
+                                         :provision => true,
+                                         :domain => FactoryBot.build(:domain),
+                                         :subnet => subnet,
+                                         :ip => subnet.network.sub(/0\Z/, '2'))]
+      end
+    end
+
+    trait :with_tftp_orchestration_and_httpboot do
+      managed
+      with_tftp_and_httpboot_subnet
       interfaces do
         [FactoryBot.build(:nic_managed, :primary => true,
                                          :provision => true,

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
       association :tftp, :factory => :template_smart_proxy
     end
 
+    trait :httpboot do
+      association :httpboot, :factory => :template_smart_proxy
+    end
+
     trait :dhcp do
       association :dhcp, :factory => :dhcp_smart_proxy
     end

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -7,7 +7,7 @@ end
 class PxeLoaderSupportTest < ActiveSupport::TestCase
   def setup
     @subject = DummyPxeLoader.new
-    @host = FactoryBot.create(:host)
+    @host = FactoryBot.create(:host, :with_tftp_orchestration)
     @subject.stubs(:template_kinds).returns(Operatingsystem.new.template_kinds)
   end
 
@@ -60,6 +60,51 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
     test "PXEGrub2 is found for given loader name" do
       @host.pxe_loader = "Grub2 UEFI"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for UEFI HTTP loader name" do
+      @host.pxe_loader = "Grub2 UEFI HTTP"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for UEFI HTTPS loader name" do
+      @host.pxe_loader = "Grub2 UEFI HTTPS"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for UEFI HTTPS SecureBoot loader name" do
+      @host.pxe_loader = "Grub2 UEFI HTTPS SecureBoot"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for http://smart_proxy/tftp/grub2/grubx64.efi filename" do
+      @host.pxe_loader = "http://smart_proxy/tftp/grub2/grubx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/grubx64.efi filename" do
+      @host.pxe_loader = "https://smart_proxy/tftp/grub2/grubx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/shimx64.efi filename" do
+      @host.pxe_loader = "https://smart_proxy/tftp/grub2/shimx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/shimx64.efi filename" do
+      @host.pxe_loader = "https://smart_proxy/tftp/grub2/shimx64.efi"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "iPXE is found for iPXE UEFI HTTP loader name" do
+      @host.pxe_loader = "iPXE UEFI HTTP"
+      assert_equal :iPXE, @subject.pxe_loader_kind(@host)
+    end
+
+    test "iPXE is found for http://smart_proxy/tftp/ipxe-x64.efi filename" do
+      @host.pxe_loader = "http://smart_proxy/tftp/ipxe-x64.efi"
+      assert_equal :iPXE, @subject.pxe_loader_kind(@host)
     end
   end
 


### PR DESCRIPTION
UEFI clients are capable of booting from HTTP or HTTPS if they are given a valid URL via DHCP filename option.

Let's create such PXE Loader options. The only difference from existing options is that it must contain hostname of the boot server. By default this will be TFTP Smart Proxy if set, Foreman unattended_url otherwise.

For better flexibility, two new provisioning settings will be introduced: port number and root path. This allows users easily run their own web server exposing TFTP directory with grub2 configuration files over HTTP on arbitrary root path.