### PR TITLE
Fixes #24551 - Change all matcher attributes to lowercase

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -27,7 +27,7 @@ class LookupKey < ApplicationRecord
   validates :key_type, :inclusion => {:in => KEY_TYPES, :message => N_("invalid")}, :allow_blank => true, :allow_nil => true
   validates_associated :lookup_values
 
-  before_save :sanitize_path
+  before_validation :sanitize_path
   attr_name :key
 
   def self.inherited(child)
@@ -150,7 +150,7 @@ class LookupKey < ApplicationRecord
   end
 
   def sorted_values
-    prio = path.split
+    prio = path.downcase.split
     lookup_values.sort_by {|val| [prio.index(val.path), val.match]}
   end
 

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -68,7 +68,13 @@ class LookupValue < ApplicationRecord
 
   # TODO check multi match with matchers that have space (hostgroup = web servers,environment = production)
   def sanitize_match
-    self.match = match.split(LookupKey::KEY_DELM).map {|s| s.split(LookupKey::EQ_DELM).map(&:strip).join(LookupKey::EQ_DELM)}.join(LookupKey::KEY_DELM) if match.present?
+    return true unless match.present?
+    self.match = match.split(LookupKey::KEY_DELM).map do |m|
+      split_match = m.split(LookupKey::EQ_DELM)
+      matcher_attribute = split_match.first.downcase.strip
+      matcher_value = (split_match.count > 1) ? split_match.last.strip : ""
+      [matcher_attribute, matcher_value].join(LookupKey::EQ_DELM)
+    end.join(LookupKey::KEY_DELM)
   end
 
   def validate_and_cast_value

--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -320,4 +320,15 @@ EOF
       end
     end
   end
+
+  test "should save matcher types as lowercase" do
+    key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param,
+                            :override => true, :key_type => 'string', :path => "HOSTGROUP\nFQDN",
+                            :default_value => "test123", :puppetclass => puppetclasses(:one))
+
+    lv = LookupValue.new(:value => "lookup_value_lower_test", :match => "HOSTGROUP=Common", :lookup_key => key)
+    assert lv.save!
+    assert_equal "hostgroup\nfqdn", key.path
+    assert_equal "hostgroup=Common", lv.match
+  end
 end


### PR DESCRIPTION
This was a result of `sorted_values` getting the path before sanitizing + the fact that we didn't change the matcher to lowercase even though the path is changed to lowercase.