### PR TITLE
Fixes #24639 - medium provider works with discovery

### DIFF
--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -25,8 +25,8 @@ module Foreman
           end
 
           def load_variables_base
-            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if medium
-            if operatingsystem.respond_to?(:pxe_type)
+            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if host.respond_to?(:medium) && medium
+            if operatingsystem&.respond_to?(:pxe_type)
               send "#{operatingsystem.pxe_type}_attributes"
               pxe_config
             end

--- a/test/unit/foreman/renderer/scope/variables/base_test.rb
+++ b/test/unit/foreman/renderer/scope/variables/base_test.rb
@@ -64,4 +64,11 @@ class BaseVariablesTest < ActiveSupport::TestCase
     assert scope.instance_variable_get('@initrd').present?
     assert scope.instance_variable_get('@kernel').present?
   end
+
+  test "set @provisioning_type for bare host" do
+    class Host::BareHost < ::Host::Base; end
+    host = Host::BareHost.new
+    scope = @scope.new(host: host, source: @source)
+    assert_equal "host", scope.instance_variable_get('@provisioning_type')
+  end
 end


### PR DESCRIPTION
The new code introduced by medium provider patch assumes there is an existing method `medium` available. That's not the case for discovered hosts.