### PR TITLE
fixes #24645 - remove unused brace dependencies

### DIFF
--- a/app/views/editor/_toolbar.html.erb
+++ b/app/views/editor/_toolbar.html.erb
@@ -41,7 +41,7 @@
     <ul class="nav navbar-nav navbar-right navbar-editor">
       <li>
         <select id="mode" class="form-control input-sm without_select2">
-          <%= content_tag(:optgroup, options_for_select(['text', 'json', 'ruby', 'erb', 'sh', 'javascript', 'xml', 'yaml']), :label => _('Syntax Highlighting')) %>
+          <%= content_tag(:optgroup, options_for_select(['text', 'json', 'ruby', 'erb', 'sh', 'xml', 'yaml']), :label => _('Syntax Highlighting')) %>
         </select>
       </li>
 

--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -43,7 +43,6 @@ module.exports = [
    * Brace related
    */
   'brace',
-  'brace/mode/javascript',
   'brace/mode/ruby',
   'brace/mode/html_ruby',
   'brace/mode/json',

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -3,21 +3,19 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable import/first */
 import $ from 'jquery';
-import ace from 'brace';
+import * as ace from 'brace';
 
-require('brace/mode/javascript');
-require('brace/mode/ruby');
-require('brace/mode/html_ruby');
-require('brace/mode/json');
-require('brace/mode/sh');
-require('brace/mode/xml');
-require('brace/mode/yaml');
-require('brace/mode/diff');
-require('brace/theme/twilight');
-require('brace/theme/clouds');
-require('brace/keybinding/vim');
-require('brace/keybinding/emacs');
-require('brace/ext/searchbox');
+import 'brace/mode/ruby';
+import 'brace/mode/json';
+import 'brace/mode/sh';
+import 'brace/mode/xml';
+import 'brace/mode/yaml';
+import 'brace/mode/diff';
+import 'brace/theme/twilight';
+import 'brace/theme/clouds';
+import 'brace/keybinding/vim';
+import 'brace/keybinding/emacs';
+import 'brace/ext/searchbox';
 
 import { initTypeAheadSelect } from './foreman_tools';
 
@@ -77,7 +75,6 @@ function setMode(mode) {
     'ace/mode/json',
     'ace/mode/ruby',
     'ace/mode/html_ruby',
-    'ace/mode/javascript',
     'ace/mode/sh',
     'ace/mode/xml',
     'ace/mode/yaml',


### PR DESCRIPTION
before:
```
vendor-d10491cbfddd4cacd626.js    4.14 MB       3  [emitted]  [big]  vendor
```
after:
```
vendor-0faa77d94a2f160c2733.js    3.15 MB       3  [emitted]  [big]  vendor
```