### PR TITLE
Fixes #24647 - assign environment for hostgroup related

### DIFF
--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -469,6 +469,10 @@ FactoryBot.define do
     organizations { [Organization.find_by_name('Organization 1')] } if SETTINGS[:organizations_enabled]
     locations { [Location.find_by_name('Location 1')] } if SETTINGS[:locations_enabled]
 
+    after(:build) do |host, evaluator|
+      set_environment_taxonomies(host)
+    end
+
     trait :with_parent do
       association :parent, :factory => :hostgroup
     end

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -369,6 +369,9 @@ class TaxonomixTest < ActiveSupport::TestCase
     context 'via resource association' do
       setup do
         @hg = FactoryBot.create(:hostgroup, environment: @unreachable_env, locations: [taxonomies(:location2)], organizations: [taxonomies(:organization1)])
+        # factory corrected environment taxonomy - put it outside of user one
+        @unreachable_env.organizations = [taxonomies(:organization1)]
+        @unreachable_env.locations = [taxonomies(:location1)]
       end
 
       test 'via resource association with no reachable environments' do


### PR DESCRIPTION
Discovery tests are broken because environment taxonomy is now enforced.
Recently we added `set_environment_taxonomies` for host related
factories but not for hostgroups.