### PR TITLE
Fixes #24652 - subnet_for returns highest CIDR prefix

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -287,13 +287,13 @@ class Subnet < ApplicationRecord
       supported_ipam_modes.map {|mode| [_(IPAM::MODES[mode]), IPAM::MODES[mode]]}
     end
 
-    # Given an IP returns the subnet that contains that IP
+    # Given an IP returns the subnet that contains that IP preferring highest CIDR prefix
     # [+ip+] : IPv4 or IPv6 address
     # Returns : Subnet object or nil if not found
     def subnet_for(ip)
       return unless ip.present?
       ip = IPAddr.new(ip)
-      Subnet.all.detect {|s| s.family == ip.family && s.contains?(ip)}
+      Subnet.unscoped.all.select {|s| s.family == ip.family && s.contains?(ip)}.max_by(&:cidr)
     end
 
     # This casts Subnet to Subnet::Ipv4 if no type is set

--- a/test/models/subnet/ipv4_test.rb
+++ b/test/models/subnet/ipv4_test.rb
@@ -45,6 +45,18 @@ class Subnet::Ipv4Test < ActiveSupport::TestCase
     assert_equal @subnet, Subnet::Ipv4.subnet_for("123.123.123.1")
   end
 
+  test "should find the subnet with highest CIDR prefix (24) by IP" do
+    Subnet::Ipv4.create!(:network => "128.150.0.0", :mask => "255.255.0.0", :name => "net_16")
+    to_find = Subnet::Ipv4.create!(:network => "128.150.143.0", :mask => "255.255.255.0", :name => "net_24")
+    assert_equal to_find, Subnet::Ipv4.subnet_for("128.150.143.31")
+  end
+
+  test "should find the subnet with highest CIDR prefix (30) by IP" do
+    to_find = Subnet::Ipv4.create!(:network => "128.150.143.128", :mask => "255.255.255.252", :name => "net_30")
+    Subnet::Ipv4.create!(:network => "128.150.0.0", :mask => "255.255.0.0", :name => "net_16")
+    assert_equal to_find, Subnet::Ipv4.subnet_for("128.150.143.129")
+  end
+
   test "from cant be bigger than to range" do
     s      = subnets(:one)
     s.to   = "2.3.4.15"

--- a/test/models/subnet/ipv6_test.rb
+++ b/test/models/subnet/ipv6_test.rb
@@ -63,6 +63,22 @@ class Subnet::Ipv6Test < ActiveSupport::TestCase
     refute s.valid?
   end
 
+  test "should find the subnet with highest CIDR prefix by IP order A" do
+    Subnet::Ipv6.create!(:network => "2001:db8::/32", :mask => "ffff:ffff::", :name => "net_32")
+    to_find = Subnet::Ipv6.create!(:network => "2001:db8::/33", :mask => "  ffff:ffff:8000::", :name => "net_33")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::1")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::13")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::cafe")
+  end
+
+  test "should find the subnet with highest CIDR prefix by IP order B" do
+    to_find = Subnet::Ipv6.create!(:network => "2001:db8::/33", :mask => "  ffff:ffff:8000::", :name => "net_33")
+    Subnet::Ipv6.create!(:network => "2001:db8::/32", :mask => "ffff:ffff::", :name => "net_32")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::1")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::13")
+    assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::cafe")
+  end
+
   test "#known_ips includes all host and interfaces IPs assigned to this subnet" do
     subnet = FactoryBot.create(:subnet_ipv6, :name => 'my_subnet', :network => '2001:db8::', :dns_primary => '2001:db8::1', :gateway => '2001:db8::2', :ipam => IPAM::MODES[:db])
     host = FactoryBot.create(:host, :subnet6 => subnet, :ip6 => '2001:db8::3')


### PR DESCRIPTION
It returns randomly sorted by VLANID which can be used as a workaround.
This patch sorts them by CIDR prefix, which we unfortunately don'ŧ store
in the database so we need to sort in-memory.

Proper solution would be to store both probably, with a database index.
Let's do this in another path tho.