### PR TITLE
Fixes #24660 - Make EmptyState more flexible

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,7 +1,7 @@
 module ReactjsHelper
-  def mount_react_component(name, selector, data = [])
+  def mount_react_component(name, selector, data = [], opts = {})
     javascript_tag defer: 'defer' do
-      "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}));".html_safe
+      "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}, #{opts[:flatten_data] || false}));".html_safe
     end
   end
 

--- a/app/views/ptables/welcome.html.erb
+++ b/app/views/ptables/welcome.html.erb
@@ -1,12 +1,15 @@
 <% content_for(:title, _("Partition Tables")) %>
-<div class="blank-slate-pf">
-  <div class="blank-slate-pf-icon">
-    <%= icon_text("table", "", :kind => "fa") %>
-  </div>
-  <h1><%= _('Partition Tables') %></h1>
-  <p><%= _("Partition templates describe the partition layout, with just a different disk layout to account for different server capabilities.") %></p>
-  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4.4PartitionTables")%></p>
-  <div class="blank-slate-pf-main-action">
-    <%= new_link(_("Create Partition Table"), :class => 'btn-lg') %>
-  </div>
-</div>
+
+<div id="ptable-empty-state"></div>
+<% description = _("Partition templates describe the partition layout, with just a different disk layout to account for different server capabilities.")%>
+<%= mount_react_component('EmptyState',
+                          '#ptable-empty-state',
+                          { :icon => 'table',
+                            :iconType => 'fa',
+                            :header => _('Partition Tables'),
+                            :description => description,
+                            :documentation => { :url => documentation_url("4.4.4PartitionTables") },
+                            :action => { :title => _("Create Partition Table"), :url => new_ptable_path }
+                          }.to_json,
+                          { :flatten_data => true }
+)%>

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -21,13 +21,20 @@ document.addEventListener('page:before-unload', () => {
   }
 });
 
-export function mount(component, selector, data) {
+export function mount(component, selector, data, flattenData = false) {
   const reactNode = document.querySelector(selector);
 
   if (reactNode) {
     ReactDOM.unmountComponentAtNode(reactNode);
     ReactDOM.render(
-      <Provider store={store}>{componentRegistry.markup(component, data, store)}</Provider>,
+      <Provider store={store}>
+        {componentRegistry.markup(
+          component,
+          data,
+          store,
+          flattenData,
+        )}
+      </Provider>,
       reactNode,
     );
 

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
@@ -23,6 +23,7 @@ const documentationBlock = ({
 const DefaultEmptyState = (props) => {
   const {
     icon,
+    iconType,
     header,
     description,
     documentation,
@@ -33,6 +34,7 @@ const DefaultEmptyState = (props) => {
   return (
     <EmptyStatePattern
       icon={icon}
+      iconType={iconType}
       header={header}
       description={description}
       documentation={documentation ? documentationBlock(documentation) : null}
@@ -47,6 +49,7 @@ DefaultEmptyState.propTypes = defaultEmptyStatePropTypes;
 DefaultEmptyState.defaultProps = {
   icon: 'add-circle-o',
   secondaryActions: [],
+  iconType: 'pf',
 };
 
 export default DefaultEmptyState;

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import DefaultEmptyState, { EmptyStatePattern } from './index';
+import PrimaryActionButton from './EmptyStatePrimaryActionButton';
+import SecondaryActionButtons from './EmptyStateSecondaryActionButtons';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 
 const defaultEmptyStateFixtures = {
@@ -62,20 +64,26 @@ const emptyStatePatternFixtures = {
       </div>
     ),
   },
-  'should render main action when given one': {
+  'should render main action when given title and url': {
     icon: 'printer',
     header: 'printers',
     description: 'printers print a file from the computer',
-    action: <button>action-title</button>,
+    action: <PrimaryActionButton action={{ title: 'my title', url: 'https://somewhere.com' }} />,
+  },
+  'should render main action when given title and onClick': {
+    icon: 'printers',
+    header: 'printers',
+    description: 'printers print a file from the computer',
+    action: <PrimaryActionButton action={{ title: 'my title again', onClick: () => '' }} />,
   },
   'should render secondary action when given one': {
     icon: 'printer',
     header: 'printers',
     description: 'printers print a file from the computer',
-    secondaryActions: [
-      <button key="y">action-y</button>,
-      <button key="x">action-x</button>,
-    ],
+    secondaryActions: <SecondaryActionButtons actions={[
+      { title: 'x', url: 'some-url' },
+      { title: 'y', url: 'random-url' },
+    ]} />,
   },
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -3,12 +3,21 @@ import { EmptyState as PfEmptyState } from 'patternfly-react';
 import { emptyStatePatternPropTypes } from './EmptyStatePropTypes';
 
 const EmptyStatePattern = (props) => {
-  const { documentation, action, secondaryActions } = props;
+  const {
+    documentation,
+    action,
+    secondaryActions,
+    icon,
+    iconType,
+    header,
+    description,
+  } = props;
+
   return (
     <PfEmptyState>
-      <PfEmptyState.Icon type="pf" name={props.icon} />
-      <PfEmptyState.Title>{props.header}</PfEmptyState.Title>
-      <PfEmptyState.Info>{props.description}</PfEmptyState.Info>
+      <PfEmptyState.Icon type={iconType} name={icon} />
+      <PfEmptyState.Title>{header}</PfEmptyState.Title>
+      <PfEmptyState.Info>{description}</PfEmptyState.Info>
       {documentation && <PfEmptyState.Help>{documentation}</PfEmptyState.Help>}
       {action && <PfEmptyState.Action>{action}</PfEmptyState.Action>}
       {secondaryActions && (

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePrimaryActionButton.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePrimaryActionButton.js
@@ -3,8 +3,30 @@ import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 import { actionButtonPropTypes } from './EmptyStatePropTypes';
 
-const PrimaryActionButton = ({ action: { title, url } }) => (
-  <Button url={url} bsStyle="primary" bsSize="large">
+const PrimaryActionButton = ({ action }) => {
+  if (!action) {
+    return null;
+  }
+
+  if (action.url) {
+    return urlButton(action);
+  }
+
+  if (action.onClick) {
+    return onClickButton(action);
+  }
+
+  throw new Error('Primary action button expects action with either url or onClick');
+};
+
+const urlButton = ({ url, title }) => (
+  <Button href={url} bsStyle="primary" bsSize="large">
+    {title}
+  </Button>
+);
+
+const onClickButton = ({ onClick, title }) => (
+  <Button onClick={onClick} bsStyle="primary" bsSize="large">
     {title}
   </Button>
 );

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 
 export const actionButtonPropTypes = {
   title: PropTypes.node.isRequired,
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  onChange: PropTypes.func,
 };
 
 export const emptyStatePatternPropTypes = {
@@ -22,6 +23,6 @@ export const defaultEmptyStatePropTypes = {
     buttonLabel: PropTypes.string,
     url: PropTypes.string.isRequired,
   }),
-  action: PropTypes.shape(actionButtonPropTypes).isRequired,
+  action: PropTypes.shape(actionButtonPropTypes),
   secondaryActions: PropTypes.arrayOf(PropTypes.shape(actionButtonPropTypes)),
 };

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/__snapshots__/EmptyState.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/__snapshots__/EmptyState.test.js.snap
@@ -16,6 +16,7 @@ exports[`Default Empty State icon, header, description and main action are manda
   documentation={null}
   header="header1"
   icon="add-circle-o"
+  iconType="pf"
   secondaryActions={
     <SecondaryActionButtons
       actions={Array []}
@@ -64,14 +65,14 @@ exports[`Default Empty State should render documentation when given a url 1`] = 
   <div
     className="blank-slate-pf-main-action"
   >
-    <button
+    <a
       className="btn btn-lg btn-primary"
-      disabled={false}
-      type="button"
-      url="action-url"
+      href="action-url"
+      onClick={[Function]}
+      onKeyDown={[Function]}
     >
       action-title
-    </button>
+    </a>
   </div>
   <div
     className="blank-slate-pf-secondary-action"
@@ -95,6 +96,7 @@ exports[`Default Empty State should render secondary actions 1`] = `
   documentation={null}
   header="Printers"
   icon="add-circle-o"
+  iconType="pf"
   secondaryActions={
     <SecondaryActionButtons
       actions={
@@ -200,7 +202,42 @@ exports[`Empty State Pattern should render description when given one as a text 
 </EmptyState>
 `;
 
-exports[`Empty State Pattern should render main action when given one 1`] = `
+exports[`Empty State Pattern should render main action when given title and onClick 1`] = `
+<EmptyState
+  className=""
+>
+  <EmptyStateIcon
+    className=""
+    name="printers"
+    type="pf"
+  />
+  <EmptyStateTitle
+    className=""
+  >
+    printers
+  </EmptyStateTitle>
+  <EmptyStateInfo
+    className=""
+  >
+    printers print a file from the computer
+  </EmptyStateInfo>
+  <EmptyStateAction
+    className=""
+    secondary={false}
+  >
+    <PrimaryActionButton
+      action={
+        Object {
+          "onClick": [Function],
+          "title": "my title again",
+        }
+      }
+    />
+  </EmptyStateAction>
+</EmptyState>
+`;
+
+exports[`Empty State Pattern should render main action when given title and url 1`] = `
 <EmptyState
   className=""
 >
@@ -223,9 +260,14 @@ exports[`Empty State Pattern should render main action when given one 1`] = `
     className=""
     secondary={false}
   >
-    <button>
-      action-title
-    </button>
+    <PrimaryActionButton
+      action={
+        Object {
+          "title": "my title",
+          "url": "https://somewhere.com",
+        }
+      }
+    />
   </EmptyStateAction>
 </EmptyState>
 `;
@@ -253,16 +295,20 @@ exports[`Empty State Pattern should render secondary action when given one 1`] =
     className=""
     secondary={true}
   >
-    <button
-      key="y"
-    >
-      action-y
-    </button>
-    <button
-      key="x"
-    >
-      action-x
-    </button>
+    <SecondaryActionButtons
+      actions={
+        Array [
+          Object {
+            "title": "x",
+            "url": "some-url",
+          },
+          Object {
+            "title": "y",
+            "url": "random-url",
+          },
+        ]
+      }
+    />
   </EmptyStateAction>
 </EmptyState>
 `;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -13,6 +13,7 @@ import Pagination from './Pagination/Pagination';
 import AuditsList from './AuditsList';
 import SearchBar from './SearchBar';
 import Layout from './Layout';
+import EmptyState from './common/EmptyState';
 
 const componentRegistry = {
   registry: {},
@@ -43,7 +44,7 @@ const componentRegistry = {
     return Object.keys(this.registry).join(', ');
   },
 
-  markup(name, data, store) {
+  markup(name, data, store, flattenData) {
     const currentComponent = this.getComponent(name);
 
     if (!currentComponent) {
@@ -51,6 +52,14 @@ const componentRegistry = {
     }
     const ComponentName = currentComponent.type;
 
+    if (flattenData) {
+      return (
+        <ComponentName
+          store={currentComponent.store ? store : undefined}
+          { ...data }
+        />
+      );
+    }
     return (
       <ComponentName
         data={currentComponent.data ? data : undefined}
@@ -74,6 +83,7 @@ const coreComponets = [
   { name: 'Pagination', type: Pagination },
   { name: 'AuditsList', type: AuditsList },
   { name: 'Layout', type: Layout },
+  { name: 'EmptyState', type: EmptyState },
 ];
 
 componentRegistry.registerMultiple(coreComponets);


### PR DESCRIPTION
Main changes:
* Katello passes a function to `onClick` for primary button on Subscriptions page so we need to support it
* overriding icon type
* new optional param `flattenData` for component mounter to make sure props passed from erb are on correct level, default behaviour remains the same.
* partition tables welcome page now uses the component as a live example how to use it