### PR TITLE
Fixes #24665 - mount breadcrumbs only when for 200 response

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -19,7 +19,7 @@ module LayoutHelper
   def mount_breadcrumbs(options = {}, &block)
     options = BreadcrumbsOptions.new(@page_header, controller, action_name, block_given? ? yield : options)
 
-    mount_react_component("BreadcrumbBar", "#breadcrumb", options.bar_props.to_json) unless @welcome
+    mount_react_component("BreadcrumbBar", "#breadcrumb", options.bar_props.to_json) if !@welcome && response.ok?
   end
 
   def breadcrumbs(options = {}, &block)

--- a/test/helpers/layout_helper_test.rb
+++ b/test/helpers/layout_helper_test.rb
@@ -21,4 +21,18 @@ class LayoutHelperTest < ActionView::TestCase
   test "table css classes should return the regular classes for table plus the added classes" do
     assert_equal table_css_classes("test-class"), "table table-bordered table-striped table-hover test-class"
   end
+
+  test "breadcrumbs are not mounted on non-ok pages" do
+    response.stubs(:ok?).returns(false)
+    expects(:mount_react_component).never
+
+    mount_breadcrumbs
+  end
+
+  test "breadcrumbs are not mounted on welcome pages" do
+    @welcome = true
+    expects(:mount_react_component).never
+
+    mount_breadcrumbs
+  end
 end


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
