### PR TITLE
Fixes #24640 - Cast all lookup keys and values (#5956)

### DIFF
--- a/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
+++ b/db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
@@ -21,20 +21,22 @@ class MigrateTemplateToParametersMacros < ActiveRecord::Migration[4.2]
     end
 
     LookupKey.descendants.each do |klass|
-      klass.all.each do |parameter|
-        parameter.default_value = convert(parameter.default_value.to_s)
-        if parameter.default_value_changed?
+      klass.all.find_each do |parameter|
+        next unless parameter.default_value.contains_erb?
+        value = convert(parameter.default_value.to_s)
+        if parameter.default_value.to_s != value
           # we need to skip validations so we use #update_attributes
-          parameter.update_attribute :default_value, parameter.value
+          parameter.update_attribute :default_value, value
         end
       end
     end
 
-    LookupValue.all.each do |parameter|
-      parameter.value = convert(parameter.value.to_s)
-      if parameter.value_changed?
+    LookupValue.all.find_each do |parameter|
+      next unless parameter.value.contains_erb?
+      value = convert(parameter.value.to_s)
+      if parameter.value.to_s != value
         # we need to skip validations so we use #update_attributes
-        parameter.update_attribute :value, parameter.value
+        parameter.update_attribute :value, value
       end
     end
   end

--- a/db/migrate/20180816134832_cast_lookup_key_values.rb
+++ b/db/migrate/20180816134832_cast_lookup_key_values.rb
@@ -1,0 +1,37 @@
+class CastLookupKeyValues < ActiveRecord::Migration[5.1]
+  def up
+    # Different LookupKey types handle casting a bit differently
+    PuppetclassLookupKey.unscoped.preload(:lookup_values).where(override: true).where.not(key_type: 'string').find_each do |key|
+      cast_key_and_values(key)
+    end
+
+    VariableLookupKey.unscoped.preload(:lookup_values).where.not(key_type: 'string').find_each do |key|
+      cast_key_and_values(key)
+    end
+  end
+
+  private
+
+  def cast_key_and_values(key)
+    fix_value(key, :default_value)
+    key.lookup_values.each do |lv|
+      fix_value(lv, :value)
+    end
+  end
+
+  def safemode
+    @box ||= Safemode::Box.new
+  end
+
+  def fix_value(obj, attribute)
+    return if obj.omit
+    value = obj.send(attribute)
+    return unless value.is_a? String
+    return if value.contains_erb?
+    fixed = safemode.eval(value)
+    obj.update_column(attribute, fixed)
+  rescue StandardError => e
+    puts "Error casting #{attribute} #{value} for #{obj.inspect} with error #{e.message}. Perhaps it is invalid?"
+    puts e.backtrace
+  end
+end


### PR DESCRIPTION

db/migrate/20170112175131_migrate_template_to_parameters_macros.rb
caused all LookupKey default values and LookupValue values to be saved
as strings, because it updated the attributes without calling callbacks,
causing cast_default_value or cast_value callbacks to be ignored.
This causes any values not of string type to break.

(cherry picked from commit e719d906764d500f862803b762bb1da8a506dfd0)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
