### PR TITLE
Fixes #24685 - fix minor issues in the storybook

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,6 @@
+<style>
+  /* Workaround to hide additional scrollbars that appear around the content iframe in some browsers */
+  .Pane1 {
+    overflow: hidden !important;
+  }
+</style>

--- a/webpack/assets/javascripts/react_app/components/common/DocumentationLink/DocumentationLink.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/DocumentationLink/DocumentationLink.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import DocumentationLink, { DocumentLinkContent } from './index';
 
-storiesOf('DocumentationLink', module)
+storiesOf('Components/DocumentationLink', module)
   .add('Default', () => (
     <div>
       <ul>

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
@@ -4,7 +4,7 @@ import { text, select, boolean, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import DefaultEmptyState, { EmptyStatePattern } from './index';
 
-storiesOf('Empty State Pattern', module)
+storiesOf('Components/Empty State Pattern', module)
   .addDecorator(withKnobs)
   .add('Default', () => (
     <EmptyStatePattern

--- a/webpack/stories/docs/gettingStarted.md
+++ b/webpack/stories/docs/gettingStarted.md
@@ -69,7 +69,7 @@ The webpack processed code is placed in the following folder structure:
        ╰─ react_app/       ┈ react components and related code
 ```
 
-More detailed description of a folder structure for components is in chapter [Adding new component](/?selectedKind=Introduction&selectedStory=Adding%20new%20component).
+More detailed description of a folder structure for components is in chapter [Adding new component](./?selectedKind=Introduction&selectedStory=Adding%20new%20component).
 There are still obsolete `redux` folders at some places. They used to be a place for files containing Redux actions and reducers before a standardized folder structure was introduced. We're migrating away from them. Please don't put additional code there.
 
 


### PR DESCRIPTION
- all components moved under "Components" in the menu
- link to "Adding new components" works on gh-pages now
- hides additional scrollbars around the content iframe