### PR TITLE
Fixes #20940 - Interfaces shows extra fields in API /api/hosts/id

### DIFF
--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -3,7 +3,7 @@ object @host
 extends "api/v2/hosts/main"
 
 child :interfaces => :interfaces do
-  extends "api/v2/interfaces/base"
+  extends "api/v2/interfaces/main"
 end
 
 child :puppetclasses do


### PR DESCRIPTION
This fix is to have a consistency between REST API /api/hosts/:id and /api/hosts/:id/interfaces where many important flags such as managed, virtual are hidden in the former call and shows additional details in interfaces API call.