### PR TITLE
fixes #24702 - fix bulk taxonomy update w/ scoped search

### DIFF
--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1172,6 +1172,22 @@ class HostsControllerTest < ActionController::TestCase
     assert_redirected_to :controller => :hosts, :action => :index
     assert_equal "Updated hosts: Changed Organization", flash[:success]
   end
+  test "update multiple organization succeeds with search" do
+    @request.env['HTTP_REFERER'] = hosts_path
+    organization1 = taxonomies(:organization1)
+    organization2 = taxonomies(:organization2)
+    hosts = FactoryBot.create_list(:host, 2, :managed, organization: organization1)
+
+    post :update_multiple_organization, params: {
+      organization: {id: organization2.id, optimistic_import: 'yes'},
+      search: 'domain ~ example'
+    }, session: set_session_user
+    assert_redirected_to :controller => :hosts, :action => :index
+    assert_equal "Updated hosts: Changed Organization", flash[:success]
+
+    hosts = hosts.map(&:reload)
+    assert hosts.all? { |host| host.organization == organization2 }
+  end
   test "update multiple organization updates organization of hosts if succeeds on optimistic import" do
     @request.env['HTTP_REFERER'] = hosts_path
     organization = taxonomies(:organization1)


### PR DESCRIPTION
If you go to the All Hosts page, and perform a search on a host
relation, like "model ~ Standard" *and* the results page is
more than per_page, *and* you select all results not just the first
page, it will fail with a SQL error: rails isn't correctly generated
the joins for the relation.  This is fixed in Rails 5.2.x.

I realize we're about to upgrade to Rails 5.2, so this would be a
short-lived fix unless we want it to be backported to other versions
of Foreman.  My workaround is super hacky and creates an additional
SQL query.  Would appreciate some other ideas.