### PR TITLE
Fixes #24704 - Update Foreman to new fog-vsphere

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -37,16 +37,16 @@ module FogExtensions
 
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
-        all_networks = service.raw_networks(datacenter)
-        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network.name, network.try(:key)].include?(nic_attrs['network']) }
-        vm_network ||= all_networks.detect { |network| network._ref == nic_attrs['network'] }
+        all_networks = service.list_networks(datacenter: datacenter)
+        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network[:name], network[:id], network[:_ref]].compact.include?(nic_attrs['network']) }
+        vm_network ||= all_networks.detect { |network| network[:_ref] == nic_attrs['network'] }
         unless vm_network
           Rails.logger.info "Could not find Vsphere network for #{nic_attrs.inspect}"
           return
         end
-        selected_nic = fog_nics.detect { |fn| fn.network == vm_network.name } # grab any nic on the same network
-        if selected_nic.nil? && vm_network.respond_to?(:key)
-          selected_nic = fog_nics.detect { |fn| fn.network == vm_network.key } # try to match on portgroup
+        selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:name] } # grab any nic on the same network
+        if selected_nic.nil? && vm_network[:id].present?
+          selected_nic = fog_nics.detect { |fn| fn.network == vm_network[:id] } # try to match on portgroup
         end
         selected_nic
       end

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,3 @@
 group :vmware do
-  gem 'fog-vsphere', '2.1.1'
+  gem 'fog-vsphere', '>= 2.3.0'
 end


### PR DESCRIPTION
Bumping the version of fog-vsphere to 2.3.0 and bringing in the updated network pr to work with the new gem version. Tested here and working.

PXE:

Normal VM creation with single HDD on Local Datastore - Passed
Normal VM creation with added HDD on Local Datastore - Passed
Normal VM creation with single HDD on Storage Pod - Passed
Normal VM creation with added HDD on Storage Pod - Passed

Bootdisk:

Normal VM creation with single HDD on Local Datastore - Passed
Normal VM creation with added HDD on Local Datastore - Passed
Normal VM creation with single HDD on Storage Pod - Passed
Normal VM creation with added HDD on Storage Pod - Passed

Image:

Normal VM creation with single HDD on Local Datastore - Passed
Normal VM creation with added HDD on Local Datastore - Passed
Normal VM creation with single HDD on Storage Pod - Passed
Normal VM creation with added HDD on Storage Pod -  Failed( does not work in 6.2 or upstream so not regression)

Network:

Normal VM creation with NIC in portgroup on Standard Switch - Passed
Normal VM creation with NIC in portgroup on Distributed Switch - Passed
Normal VM creation with NIC in portgroup on Distributed Switch with VLAN - Passed