### PR TITLE
Fixes #24691 - interfaces are incorrectly updated

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -142,7 +142,7 @@ class FactParser
         attributes[:tag] = Regexp.last_match(2)
       elsif name =~ VIRTUAL
         # Legacy: facter < v3.0
-        # vlans fact has been reomved in facter 3.0
+        # vlans fact has been removed in facter 3.0
         attributes[:attached_to] = Regexp.last_match(1)
         tag = Regexp.last_match(2)
         if @facts[:vlans].present?

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -3,7 +3,9 @@ class FactParser
   VIRTUAL = /\A([a-z0-9]+)_([a-z0-9]+)\Z/
   BRIDGES = /\A(vir)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
-  VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
+  ALIASES = /(\A[a-z0-9\.]+):([a-z0-9]+)\Z/
+  VLANS = /\A([a-z0-9]+)\.([0-9]+)\Z/
+  VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
   def self.parser_for(type)
     parsers[type.to_s]
@@ -132,12 +134,19 @@ class FactParser
       attributes[:virtual] = true
       if Regexp.last_match(1).nil? && name =~ BRIDGES
         attributes[:bridge] = true
-      else
+      elsif name =~ ALIASES
         attributes[:attached_to] = Regexp.last_match(1)
-
+        attributes[:tag] = ''
+      elsif name =~ VLANS
+        attributes[:attached_to] = Regexp.last_match(1)
+        attributes[:tag] = Regexp.last_match(2)
+      elsif name =~ VIRTUAL
+        # Legacy: facter < v3.0
+        # vlans fact has been reomved in facter 3.0
+        attributes[:attached_to] = Regexp.last_match(1)
+        tag = Regexp.last_match(2)
         if @facts[:vlans].present?
           vlans = @facts[:vlans].split(',')
-          tag = name.split('_').last
           attributes[:tag] = vlans.include?(tag) ? tag : ''
         end
       end

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -12,6 +12,7 @@ class FactParserTest < ActiveSupport::TestCase
     assert_match FactParser::BONDS, 'lagg0'
     refute_match FactParser::BONDS, 'bond0.0'
     refute_match FactParser::BONDS, 'bond0:0'
+    refute_match FactParser::BONDS, 'bond0.0:0'
   end
 
   test "bridge regexp matches bridges" do
@@ -135,7 +136,7 @@ class FactParserTest < ActiveSupport::TestCase
     end
   end
 
-  test "#find_virtual_interface finds a vlan interface" do
+  test "#find_virtual_interface finds a vlan interface (facter < v3.0)" do
     parser.stub(:get_interfaces, ['eth0', 'eth0_0']) do
       parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0_0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
@@ -145,12 +146,32 @@ class FactParserTest < ActiveSupport::TestCase
     end
   end
 
-  test "#find_virtual_interface finds an interface with an alphanum alias" do
+  test "#find_virtual_interface finds a vlan interface (facter >= v3.0)" do
+    parser.stub(:get_interfaces, ['eth0', 'eth0.0']) do
+      parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0.0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
+      result = parser.send(:find_virtual_interface, parser.interfaces)
+      assert_includes result, 'eth0.0'
+      refute_includes result, 'eth0'
+    end
+  end
+
+  test "#find_virtual_interface finds an interface with an alphanum alias (facter < v3.0)" do
     parser.stub(:get_interfaces, ['eth0', 'eth0_bar']) do
       parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('eth0_bar').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       result = parser.send(:find_virtual_interface, parser.interfaces)
       assert_includes result, 'eth0_bar'
+      refute_includes result, 'eth0'
+    end
+  end
+
+  test "#find_virtual_interface finds an interface with an alias (facter >= v3.0)" do
+    parser.stub(:get_interfaces, ['eth0', 'eth0:1']) do
+      parser.expects(:get_facts_for_interface).with('eth0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0:1').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
+      result = parser.send(:find_virtual_interface, parser.interfaces)
+      assert_includes result, 'eth0:1'
       refute_includes result, 'eth0'
     end
   end
@@ -167,11 +188,17 @@ class FactParserTest < ActiveSupport::TestCase
   end
 
   test "#find_physical_interface does not find virtual interfaces" do
-    parser.stub(:get_interfaces, ['eth0_0', 'br42', 'virbr0', 'bond7']) do
+    parser.stub(:get_interfaces, ['eth0_0', 'br42', 'virbr0', 'bond7', 'eth0.100', 'eth0:1', 'eth0.100:1', 'bond7:1', 'bond7.100', 'bond7.100:1']) do
       parser.expects(:get_facts_for_interface).with('eth0_0').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('br42').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('virbr0').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
       parser.expects(:get_facts_for_interface).with('bond7').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.1'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0.100').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB', 'ipaddress' => '192.168.100.2'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0:1').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('eth0.100:1').returns({'link' => 'false', 'macaddress' => '00:00:00:00:00:AB', 'ipaddress' => '192.168.100.2'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('bond7:1').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.0.2'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('bond7.100').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.100.1'}.with_indifferent_access)
+      parser.expects(:get_facts_for_interface).with('bond7.100:1').returns({'link' => 'true', 'macaddress' => '00:00:00:00:00:cd', 'ipaddress' => '192.168.100.2'}.with_indifferent_access)
       result = parser.send(:find_physical_interface, parser.interfaces)
       assert_nil result
     end
@@ -185,7 +212,7 @@ class FactParserTest < ActiveSupport::TestCase
     refute result[:virtual]
   end
 
-  test "#set_additional_attributes detects virtual interface" do
+  test "#set_additional_attributes detects virtual interface (facter < v3.0)" do
     parser = get_parser(:vlans => '1,2')
 
     result = parser.send(:set_additional_attributes, {}, 'eth0_0')
@@ -209,6 +236,44 @@ class FactParserTest < ActiveSupport::TestCase
     result = parser.send(:set_additional_attributes, {}, 'eth0_4')
     assert result[:virtual]
     assert_equal 'eth0', result[:attached_to]
+    assert_equal '', result[:tag]
+    refute result[:bridge]
+  end
+
+  test "#set_additional_attributes detects virtual interface facter >= v3.0" do
+    result = parser.send(:set_additional_attributes, {}, 'eth0.100')
+    assert result[:virtual]
+    assert_equal 'eth0', result[:attached_to]
+    assert_equal '100', result[:tag]
+    refute result[:bridge]
+
+    result = parser.send(:set_additional_attributes, {}, 'eth0:1')
+    assert result[:virtual]
+    assert_equal 'eth0', result[:attached_to]
+    assert_equal '', result[:tag]
+    refute result[:bridge]
+
+    result = parser.send(:set_additional_attributes, {}, 'bond0.100')
+    assert result[:virtual]
+    assert_equal 'bond0', result[:attached_to]
+    assert_equal '100', result[:tag]
+    refute result[:bridge]
+
+    result = parser.send(:set_additional_attributes, {}, 'bond0:1')
+    assert result[:virtual]
+    assert_equal 'bond0', result[:attached_to]
+    assert_equal '', result[:tag]
+    refute result[:bridge]
+
+    result = parser.send(:set_additional_attributes, {}, 'eth0.100:1')
+    assert result[:virtual]
+    assert_equal 'eth0.100', result[:attached_to]
+    assert_equal '', result[:tag]
+    refute result[:bridge]
+
+    result = parser.send(:set_additional_attributes, {}, 'bond0.100:1')
+    assert result[:virtual]
+    assert_equal 'bond0.100', result[:attached_to]
     assert_equal '', result[:tag]
     refute result[:bridge]
   end


### PR DESCRIPTION
Corrects virtual interfaces facts parsing when running facter > v3.0.
- facter >= v3.0 no longer replaces the . (dot) and : (colon) in the
  interface name with an _ (underscore)
- the 'vlans' fact has been removed in facter >= v3.0

The fix does not alter the behavior when running facter < v3.0.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
