### PR TITLE
Fixes #24271 - Edit Host as non-admin is slower than admin

### DIFF
--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -70,9 +70,31 @@ module CommonParametersHelper
 
   def authorized_resource_parameters(resource, type)
     parameters_by_type = resource.send(type)
-    parameter_ids_to_view = parameters_by_type.authorized(:view_params).map(&:id)
-    resource_parameters = parameters_by_type.select { |p| parameter_ids_to_view.include?(p.id) }
+    @allowed_ids_hash = find_allowed_param_ids_per_action(parameters_by_type)
+    resource_parameters = parameters_by_type.select { |p| @allowed_ids_hash[:ids_to_view].include?(p.id) }
     resource_parameters += parameters_by_type.select(&:new_record?)
     resource_parameters
+  end
+
+  def can_edit_parameter?(parameter)
+    @allowed_ids_hash[:ids_to_edit].include?(parameter.id)
+  end
+
+  def can_destroy_parameter?(parameter)
+    @allowed_ids_hash[:ids_to_destroy].include?(parameter.id)
+  end
+
+  def can_create_parameter?(parameter)
+    @can_create_param ||= authorizer.can?(:create_params)
+  end
+
+  private
+
+  def find_allowed_param_ids_per_action(parameters_by_type)
+    {
+      ids_to_view: parameters_by_type.authorized(:view_params).pluck(:id),
+      ids_to_edit: parameters_by_type.authorized(:edit_params).pluck(:id),
+      ids_to_destroy: parameters_by_type.authorized(:destroy_params).pluck(:id)
+    }
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -359,8 +359,10 @@ module FormHelper
   # +partial+    : String containing an optional partial into which we render
   def link_to_add_fields(name, f, association, partial = nil, options = {})
     new_object = f.object.class.reflect_on_association(association).klass.new
+    locals_option = options.delete(:locals) || {}
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
-      render((partial.nil? ? association.to_s.singularize + "_fields" : partial), :f => builder)
+      render((partial.nil? ? association.to_s.singularize + "_fields" : partial),
+             { :f => builder }.merge(locals_option))
     end
     options[:class] = link_to_add_fields_classes(options)
     link_to_function(name, "add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}')".html_safe, options)

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -25,9 +25,6 @@ class Authorizer
   end
 
   def find_collection(resource_class, options = {})
-    return resource_class.where('1=0') if user.nil?
-    return resource_class.where(nil) if user.admin?
-
     permission = options.delete :permission
     resource_class = Host if resource_class == Host::Base
 

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -25,6 +25,9 @@ class Authorizer
   end
 
   def find_collection(resource_class, options = {})
+    return resource_class.where('1=0') if user.nil?
+    return resource_class.where(nil) if user.admin?
+
     permission = options.delete :permission
     resource_class = Host if resource_class == Host::Base
 

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,5 +1,5 @@
 <tr class="fields <%= 'has-error' if f.object.errors.any? %>" id="<%= dom_id(f.object) + '_row' %>">
-  <% authorized = f.object.new_record? ? authorizer.can?(:create_params) : authorizer.can?(:edit_params, f.object) %>
+  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : can_edit_parameter?(f.object) %>
   <td>
     <%= f.text_field(:name,  :class => "form-control", :disabled => !authorized, :placeholder => _("Name")) %>
   </td>
@@ -8,7 +8,7 @@
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if authorized %>
-    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || authorizer.can?(:destroy_params, f.object) %>
+    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || can_destroy_parameter?(f.object) %>
   </td>
 </tr>
 <% if f.object.errors.any? %>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,5 +1,5 @@
 <tr class="fields <%= 'has-error' if f.object.errors.any? %>" id="<%= dom_id(f.object) + '_row' %>">
-  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : @params_authorizer.can?(:edit_params, f.object) %>
+  <% authorized = f.object.new_record? ? can_create_parameter?(f.object, @params_authorizer) : @params_authorizer.can?(:edit_params, f.object) %>
   <td>
     <%= f.text_field(:name,  :class => "form-control", :disabled => !authorized, :placeholder => _("Name")) %>
   </td>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,5 +1,5 @@
 <tr class="fields <%= 'has-error' if f.object.errors.any? %>" id="<%= dom_id(f.object) + '_row' %>">
-  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : @authorizer_for_params.can?(:edit_params, f.object) %>
+  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : @params_authorizer.can?(:edit_params, f.object) %>
   <td>
     <%= f.text_field(:name,  :class => "form-control", :disabled => !authorized, :placeholder => _("Name")) %>
   </td>
@@ -8,7 +8,7 @@
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if authorized %>
-    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || @authorizer_for_params.can?(:destroy_params, f.object) %>
+    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || @params_authorizer.can?(:destroy_params, f.object) %>
   </td>
 </tr>
 <% if f.object.errors.any? %>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,5 +1,5 @@
 <tr class="fields <%= 'has-error' if f.object.errors.any? %>" id="<%= dom_id(f.object) + '_row' %>">
-  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : can_edit_parameter?(f.object) %>
+  <% authorized = f.object.new_record? ? can_create_parameter?(f.object) : @authorizer_for_params.can?(:edit_params, f.object) %>
   <td>
     <%= f.text_field(:name,  :class => "form-control", :disabled => !authorized, :placeholder => _("Name")) %>
   </td>
@@ -8,7 +8,7 @@
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if authorized %>
-    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || can_destroy_parameter?(f.object) %>
+    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || @authorizer_for_params.can?(:destroy_params, f.object) %>
   </td>
 </tr>
 <% if f.object.errors.any? %>

--- a/app/views/common_parameters/_parameter.html.erb
+++ b/app/views/common_parameters/_parameter.html.erb
@@ -1,5 +1,5 @@
 <tr class="fields <%= 'has-error' if f.object.errors.any? %>" id="<%= dom_id(f.object) + '_row' %>">
-  <% authorized = f.object.new_record? ? can_create_parameter?(f.object, @params_authorizer) : @params_authorizer.can?(:edit_params, f.object) %>
+  <% authorized = f.object.new_record? ? can_create_parameter?(params_authorizer) : params_authorizer.can?(:edit_params, f.object) %>
   <td>
     <%= f.text_field(:name,  :class => "form-control", :disabled => !authorized, :placeholder => _("Name")) %>
   </td>
@@ -8,7 +8,7 @@
   </td>
   <td>
     <%= f.check_box(:hidden_value, :class => 'set_hidden_value hide', :checked => f.object.hidden_value?) if authorized %>
-    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || @params_authorizer.can?(:destroy_params, f.object) %>
+    <%= link_to_remove_fields(_('Remove'), f) if f.object.new_record? || params_authorizer.can?(:destroy_params, f.object) %>
   </td>
 </tr>
 <% if f.object.errors.any? %>

--- a/app/views/common_parameters/_parameters.html.erb
+++ b/app/views/common_parameters/_parameters.html.erb
@@ -10,14 +10,14 @@
     <tbody>
       <%
         parameters_by_type = f.object.send(type)
-        @params_authorizer = Authorizer.new(User.current, :collection => parameters_by_type)
+        params_authorizer = Authorizer.new(User.current, :collection => parameters_by_type)
       %>
-      <% authorized_resource_parameters(@params_authorizer, parameters_by_type).each do |parameter| %>
+      <% authorized_resource_parameters(params_authorizer, parameters_by_type).each do |parameter| %>
         <%= f.fields_for type, parameter do |builder| %>
-          <%= render "common_parameters/parameter", :f => builder %>
+          <%= render "common_parameters/parameter", :f => builder, :params_authorizer => params_authorizer %>
         <% end %>
       <% end %>
     </tbody>
   </table>
-  <%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields('+ ' + _("Add Parameter"), f, type, "common_parameters/parameter", :target => '#global_parameters_table tbody') : "" %>
+  <%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields('+ ' + _("Add Parameter"), f, type, "common_parameters/parameter", { :target => '#global_parameters_table tbody', :locals => { :params_authorizer => params_authorizer }}) : "" %>
 </div>

--- a/app/views/common_parameters/_parameters.html.erb
+++ b/app/views/common_parameters/_parameters.html.erb
@@ -8,7 +8,11 @@
     </tr>
     </thead>
     <tbody>
-      <% authorized_resource_parameters(f.object, type).each do |parameter| %>
+      <%
+        parameters_by_type = f.object.send(type)
+        @params_authorizer = Authorizer.new(User.current, :collection => parameters_by_type)
+      %>
+      <% authorized_resource_parameters(@params_authorizer, parameters_by_type).each do |parameter| %>
         <%= f.fields_for type, parameter do |builder| %>
           <%= render "common_parameters/parameter", :f => builder %>
         <% end %>


### PR DESCRIPTION
For non-admin users, it takes more time in processing
common_parameters partials as comparative to admin.
Removed '.can?' method calls for checking edit & destroy
permissions on parameters and pre-calculated these permissions.

