### PR TITLE
Refs #24640 - Cast omitted default with merge_overrides

### DIFF
--- a/db/migrate/20180816134832_cast_lookup_key_values.rb
+++ b/db/migrate/20180816134832_cast_lookup_key_values.rb
@@ -24,14 +24,16 @@ class CastLookupKeyValues < ActiveRecord::Migration[5.1]
   end
 
   def fix_value(obj, attribute)
-    return if obj.omit
+    return if obj.omit && !obj.try(:merge_default)
     value = obj.send(attribute)
     return unless value.is_a? String
     return if value.contains_erb?
     fixed = safemode.eval(value)
     obj.update_column(attribute, fixed)
   rescue StandardError => e
-    puts "Error casting #{attribute} #{value} for #{obj.inspect} with error #{e.message}. Perhaps it is invalid?"
-    puts e.backtrace
+    say "Failed to cast #{attribute} for #{obj.inspect}:"
+    say "Value: #{value}", subitem: true
+    say "Error: #{e.message}", subitem: true
+    say "Perhaps it is invalid? Casting skipped, manual action may be needed.", subitem: true
   end
 end


### PR DESCRIPTION
In case the default value is omitted and the merge_override option is
selcted, the previous version of this migration didn't cast the default
leading to a failure when merging overrides.
Error message was also improved to be clearer and less frightening than
a stack trace.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
