### PR TITLE
Refs #24640 - Cast omitted default with merge_overrides

### DIFF
--- a/db/migrate/20180816134832_cast_lookup_key_values.rb
+++ b/db/migrate/20180816134832_cast_lookup_key_values.rb
@@ -24,14 +24,16 @@ class CastLookupKeyValues < ActiveRecord::Migration[5.1]
   end
 
   def fix_value(obj, attribute)
-    return if obj.omit
+    return if obj.omit && !obj.try(:merge_default)
     value = obj.send(attribute)
     return unless value.is_a? String
     return if value.contains_erb?
     fixed = safemode.eval(value)
     obj.update_column(attribute, fixed)
   rescue StandardError => e
-    puts "Error casting #{attribute} #{value} for #{obj.inspect} with error #{e.message}. Perhaps it is invalid?"
-    puts e.backtrace
+    say "Failed to cast #{attribute} for #{obj.inspect}:"
+    say "Value: #{value}", subitem: true
+    say "Error: #{e.message}", subitem: true
+    say "Perhaps it is invalid? Casting skipped, manual action may be needed.", subitem: true
   end
 end


### PR DESCRIPTION
In case the default value is omitted and the merge_override option is
selcted, the previous version of this migration didn't cast the default
leading to a failure when merging overrides.
Error message was also improved to be clearer and less frightening than
a stack trace.

(cherry picked from commit 705d8644a527b3b682279b1309c73be33689d993)