### PR TITLE
Fixes #24697 - Don't remove permissions from default role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -300,9 +300,13 @@ class Role < ApplicationRecord
     errors.empty?
   end
 
-  def find_filter(resource_type, current_filters, search)
-    Filter.where(:search => search, :role_id => id).joins(:permissions)
-          .where("permissions.resource_type" => resource_type).first
+  def find_filter(resource_type, current_filters, search = :skip)
+    # rubocop:disable Rails/FindBy
+    filter = Filter.where(:role_id => id).joins(:permissions)
+          .where("permissions.resource_type" => resource_type)
+    filter = filter.where(search: search) unless search == :skip
+    filter.first
+    # rubocop:enable Rails/FindBy
   end
 
   def filter_for_permission_add(resource_type, current_filters, search)
@@ -316,7 +320,7 @@ class Role < ApplicationRecord
   end
 
   def filter_for_permissions_remove(resource_type, current_filters)
-    filter_record = find_filter resource_type, current_filters, nil
+    filter_record = find_filter resource_type, current_filters
     find_current_filter current_filters, filter_record
   end
 

--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -87,6 +87,10 @@ class SeedHelper
           role.add_permissions(missing_permissions, :save! => true)
         end
 
+        # The built in role may have additional permissions added to it by users.
+        # To remove permissions from the default role use an explicit migration.
+        return if role.builtin == Role::BUILTIN_DEFAULT_ROLE
+
         extra_permissions = existing_permissions - desired_permissions
         if extra_permissions.present?
           role.remove_permissions!(extra_permissions)

--- a/test/unit/seed_helper_test.rb
+++ b/test/unit/seed_helper_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require Rails.root + 'db/seeds.d/020-roles_list.rb'
 
 class SeedHelperTest < ActiveSupport::TestCase
   test "should create locked role" do
@@ -47,6 +48,31 @@ class SeedHelperTest < ActiveSupport::TestCase
     # keeps existing permissions
     assert_includes permissions, 'edit_domains'
     assert_includes permissions, 'view_domains'
+  end
+
+  test 'Does not fail on modified default role' do
+    role = Role.default
+    role.add_permissions!(:view_domains)
+    permissions = role.permissions.pluck(:name)
+    assert_includes permissions, 'view_domains'
+
+    name, opts = RolesList.default_role.first
+    SeedHelper.create_role(name, opts, Role::BUILTIN_DEFAULT_ROLE)
+    permissions = role.permissions.pluck(:name)
+    assert_includes permissions, 'view_domains'
+  end
+
+  test 'Does not fail on modified default role with filter' do
+    role = Role.default
+    role.add_permissions!(:view_domains, search: 'name = example.com')
+    permissions = role.permissions.pluck(:name)
+    assert_includes permissions, 'view_domains'
+
+    name, opts = RolesList.default_role.first
+    SeedHelper.create_role(name, opts, Role::BUILTIN_DEFAULT_ROLE)
+    permissions = role.permissions.pluck(:name)
+    assert_includes permissions, 'view_domains'
+    assert_includes role.filters.pluck(:search), 'name = example.com'
   end
 
   test "should recognize object was modified" do


### PR DESCRIPTION
The default role may have permissions added by users. They should remain
without removal. If a seeded permissions needs removal from the default
role, it should be explicitly removed in a migration.
Additionally, attempting to remove permissions with filters from a role
led to a failure due to an incorrect search parameter which has now been
fixed.

(cherry picked from commit ada7d6ef42de7a574bdf4e1f5998964fb4226368)
