### PR TITLE
Refs #24478 - reverts "properly sanitize class name"

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -26,8 +26,6 @@ class Authorizer
 
   def find_collection(resource_class, options = {})
     permission = options.delete :permission
-    resource_class = Host if resource_class.to_s =~ /\AHost::.*\Z/
-
     Foreman::Logging.logger('permissions').debug "checking permission #{permission} for class #{resource_class}"
 
     # retrieve all filters relevant to this permission for the user

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -344,14 +344,4 @@ class AuthorizerTest < ActiveSupport::TestCase
     assert_includes collection, report1
     refute_includes collection, report2
   end
-
-  test "#find_collection(Host::Base) works with taxonomies thanks to class name sanitization" do
-    permission = Permission.find_by_name('view_hosts')
-    FactoryBot.create(:filter, :role => @role, :permissions => [permission], :unlimited => true, :organization_ids => [taxonomies(:organization1).id])
-    auth = Authorizer.new(@user)
-
-    assert_nothing_raised do
-      auth.find_collection(Host::Base)
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit b01beb9407db94cb14bf8860712fc9a5e94069db.

This is causing failures for discovery tests. Let's rethink this. I am
unable to find a proper solution in reasonable time, I need to unblock
discovery tests and I expect some changes need to be done in order to
properly support STI in filters.

Reproducer of the problem is simple, filter stack returns Managed host
when I ask for Discovered type:

```
> Authorizer.new(User.current).find_collection(Host::Discovered).pluck(:id, :type)
checking permission  for class Host
organization_ids: []
location_ids: []
no filters found for given permission
=> [[286, "Host::Managed"]]
```

https://github.com/theforeman/foreman/pull/5888