### PR TITLE
Fixes #24301 - Create user in LDAP does not require password

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -44,7 +44,7 @@ module Api
         param :mail, String, :required => true
         param :description, String, :required => false
         param :admin, :bool, :required => false, :desc => N_("is an admin account")
-        param :password, String, :required => true
+        param :password, String, :desc => N_("Required unless user is in an external authentication source")
         param :default_location_id, Integer if SETTINGS[:locations_enabled]
         param :default_organization_id, Integer if SETTINGS[:organizations_enabled]
         param :auth_source_id, Integer, :required => true


### PR DESCRIPTION
When creating a user on Foreman with hammer having external
authentication source LDAP/AD gives an error if password not mentioned
while the user gets added if password parameter is mentioned. As the
user created will be authenticated with the authentication source
password and not by the password provided by us while creating user, it
should not be mandatory to create user with password parameter.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
