### PR TITLE
Fixes #24737 - add read_attribute_before_type_cast for settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -228,6 +228,11 @@ class Setting < ApplicationRecord
     SETTINGS[name]
   end
 
+  def read_attribute_before_type_cast(attr_name)
+    return value if attr_name == :value
+    super(attr_name)
+  end
+
   def self.create_existing(s, opts)
     bypass_readonly(s) do
       attrs = column_check([:default, :description, :full_name, :encrypted])


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
