### PR TITLE
Fixes #24743 - medium provider template check works

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -74,7 +74,7 @@ module HostCommon
     end
   end
 
-  def host_medium_provider
+  def medium_provider
     @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self)
   end
 
@@ -116,7 +116,7 @@ module HostCommon
       # We encode the hw_model into the image file name as not all Sparc flashes can contain all possible hw_models. The user can always
       # edit it if required or use symlinks if they prefer.
       hw_model = model.try :hardware_model if defined?(model_id)
-      host_medium_provider.interpolate_vars(nfs_path) + \
+      medium_provider.interpolate_vars(nfs_path) + \
         "#{operatingsystem.file_prefix}.#{architecture}#{hw_model.empty? ? '' : '.' + hw_model.downcase}.#{operatingsystem.image_extension}"
     else
       ""

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -35,6 +35,6 @@ module HostTemplateHelpers
   end
 
   def medium_provider
-    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(@host)
+    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self)
   end
 end

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -108,7 +108,7 @@ module Orchestration::TFTP
     logger.info "Fetching required TFTP boot files for #{host.name}"
     valid = []
 
-    host.operatingsystem.pxe_files(host_medium_provider).each do |bootfile_info|
+    host.operatingsystem.pxe_files(medium_provider).each do |bootfile_info|
       for prefix, path in bootfile_info do
         valid << each_unique_feasible_tftp_proxy do |proxy|
           proxy.fetch_boot_file(:prefix => prefix.to_s, :path => path)
@@ -193,9 +193,5 @@ module Orchestration::TFTP
       yield(proxy)
     end
     results.all?
-  end
-
-  def host_medium_provider
-    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self.host)
   end
 end

--- a/lib/tasks/exports.rake
+++ b/lib/tasks/exports.rake
@@ -45,7 +45,7 @@ end
 exporter_template(:enabled, :managed_hosts_bootfiles) do |header, data|
   header << ["Host", "Boot files"]
   Host::Managed.all.find_each do |host|
-    bootfiles = host.operatingsystem.send(:boot_files_uri, host.host_medium_provider) rescue []
+    bootfiles = host.operatingsystem.send(:boot_files_uri, host.medium_provider) rescue []
     data << [
       host.name,
       bootfiles.join(' + ')

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3703,6 +3703,18 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test "host have a valid media provider" do
+    hostgroup = FactoryBot.create(:hostgroup, :with_domain, :with_os)
+    host = FactoryBot.create(:host, :managed, :hostgroup => hostgroup)
+    assert host.medium_provider
+  end
+
+  test "host have a media provider providing a valid URL" do
+    hostgroup = FactoryBot.create(:hostgroup, :with_domain, :with_os)
+    host = FactoryBot.create(:host, :managed, :hostgroup => hostgroup)
+    assert_match /^http:/, host.medium_provider.medium_uri.to_s
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)


### PR DESCRIPTION
Click on a Build button and the error appears, for me on Kickstart default iPXE template - all the others are valid for some reason. Full stack:

```
Rendering Kickstart default iPXE
Review template error
 | Foreman::Exception: ERF42-1709 [Foreman::Exception]: Must supply an entity to find a medium provider
 | /home/lzap/work/foreman/app/registries/foreman/plugin/medium_providers_registry.rb:23:in `find_provider'
 | /home/lzap/work/foreman/app/models/concerns/host_template_helpers.rb:38:in `medium_provider'
 | /home/lzap/work/foreman/app/models/concerns/host_common.rb:83:in `url_for_boot'
 | /home/lzap/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/safemode-1.3.5/lib/safemode/jail.rb:31:in `method_missing'
 | Kickstart default iPXE:69:in `bind'
 | /home/lzap/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/safemode-1.3.5/lib/safemode.rb:51:in `eval'
 | /home/lzap/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/safemode-1.3.5/lib/safemode.rb:51:in `eval'
 | /home/lzap/work/foreman/lib/foreman/renderer/safe_mode_renderer.rb:7:in `render'
 | /home/lzap/work/foreman/lib/foreman/renderer/base_renderer.rb:16:in `render'
 | /home/lzap/work/foreman/lib/foreman/renderer.rb:45:in `render'
 | /home/lzap/work/foreman/app/models/template.rb:153:in `render'
 | /home/lzap/work/foreman/app/models/host/base.rb:351:in `render_template'
 | /home/lzap/work/foreman/app/services/host_build_status.rb:36:in `block in templates_status'
 | /home/lzap/work/foreman/app/services/host_build_status.rb:33:in `each'
 | /home/lzap/work/foreman/app/services/host_build_status.rb:33:in `templates_status'
 | /home/lzap/work/foreman/app/services/host_build_status.rb:15:in `check_all_statuses'
 | /home/lzap/work/foreman/app/models/host/managed.rb:733:in `build_status_checker'
 | /home/lzap/work/foreman/app/controllers/hosts_controller.rb:226:in `review_before_build'
```