### PR TITLE
Fixes #24745 - new variables kernel/initrd_uri

### DIFF
--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -41,6 +41,8 @@ module Foreman
         :host,
         :initrd,
         :kernel,
+        :initrd_uri,
+        :kernel_uri,
         :mediapath,
         :mediaserver,
         :osver,

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -98,6 +98,7 @@ module Foreman
             return unless medium
             @kernel = kernel(@medium_provider)
             @initrd = initrd(@medium_provider)
+            @kernel_uri, @initrd_uri = operatingsystem.boot_files_uri(@medium_provider)
           end
         end
       end

--- a/test/unit/foreman/renderer/scope/variables/base_test.rb
+++ b/test/unit/foreman/renderer/scope/variables/base_test.rb
@@ -50,7 +50,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
     end
   end
 
-  test "set @initrd and @kernel" do
+  test "set kernel and init RAM disk variables" do
     host = FactoryBot.build_stubbed(:host, :managed)
     architecture = FactoryBot.build_stubbed(:architecture)
     medium = FactoryBot.build_stubbed(:medium, :path => 'http://my-example.com/my_path')
@@ -61,7 +61,9 @@ class BaseVariablesTest < ActiveSupport::TestCase
 
     scope = @scope.new(host: host, source: @source)
 
-    assert scope.instance_variable_get('@initrd').present?
     assert scope.instance_variable_get('@kernel').present?
+    assert scope.instance_variable_get('@initrd').present?
+    assert scope.instance_variable_get('@kernel_uri').present?
+    assert scope.instance_variable_get('@initrd_uri').present?
   end
 end


### PR DESCRIPTION
In our rendering there are two variables kernel_uri and initrd_uri, but these are relative. It is useful to have absolute URI addresses for various kinds of provisioning, including Discovery kexec. Previously discovery was monkey patching this, if these variables are present in default foreman core renderer context this would make discovery code cleaner. It can be useful also for other provisioning types like iPXE.

Although this is reachable via `medium_provider.medium_uri + @kernel` or
`@initrd` this is convinient to have it in variables.

@ShimShtein 