### PR TITLE
Fixes #24712 - Fix performance regression on API

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -60,12 +60,12 @@ module Api
       end
 
       def metadata_total
-        @total ||= resource_scope.try(:count).to_i
+        @total ||= resource_scope.try(:size).to_i
       end
 
       def metadata_subtotal
         if params[:search].present?
-          @subtotal ||= instance_variable_get("@#{controller_name}").try(:count).to_i
+          @subtotal ||= instance_variable_get("@#{controller_name}").try(:size).to_i
         else
           @subtotal ||= metadata_total
         end

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -218,4 +218,19 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  test "should return subnets when searching by location as non-admin user and role has taxonomies" do
+    org = FactoryBot.create(:organization)
+    loc = FactoryBot.create(:location)
+    FactoryBot.create(:subnet_ipv4, :organizations => [org], :locations => [loc])
+    manager = roles(:manager)
+    role = manager.clone :name => "Clonned manager", :organizations => [org], :locations => [loc]
+    role.save!
+    user = FactoryBot.create(:user, :organizations => [org], :locations => [loc], :default_organization_id => org.id,
+                             :default_location_id => loc.id, :roles => [role])
+    as_user user do
+      get :index, params: { :location_id => loc.id }
+    end
+    assert_response :success
+  end
 end


### PR DESCRIPTION
This commit improves on the fix in 01809199 which has been found to
cause significant performance regressions. It also adds several other
improvements to the API scope performance, the most significant one
being only checking that the scope work in `parent_scope` rather than
loading all of it into an in-memory array which can be very heavy.

The original fix was needed because of a bug in the way Rails merges
scopes, which will be fixed in Rails 5.2 by
https://github.com/rails/rails/pull/29413. Once we upgrade to Rails 5.2
the workaround can be removed since it still comes with worse
performance compared to the previous implementation.

(cherry picked from commit e65038056d56257b32d20b61e2c683fe4b8f3c3a)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
