### PR TITLE
Fixes #24759 - Fix failing API FactValueController tests

### DIFF
--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -7,7 +7,7 @@ class FactValue < ApplicationRecord
   delegate :name, :short_name, :compose, :origin, :to => :fact_name
   has_many :hostgroup, :through => :host
 
-  has_one :parent_fact_name, :through => :fact_name, :source => :parent
+  has_one :parent_fact_name, :through => :fact_name, :source => :parent, :class_name => 'FactName'
 
   if SETTINGS[:locations_enabled]
     has_one :location, :through => :host


### PR DESCRIPTION
API FactValueController test failed randomly with `undefined method 
'class_name' for nil:NilClass`. This was caused by Rails not knowing
how to calculate the class name for the parent_fact_name relation,
leading the `parent_scope` function in the API base controller to fail
whenever the search in the associations hit the parent_fact_name prior
to finding the requested name. Explicitly naming the class name prevents
the error.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
