### PR TITLE
Fixes #24564, #24746 - bump version of fog-ovirt

### DIFF
--- a/bundler.d/ovirt.rb
+++ b/bundler.d/ovirt.rb
@@ -1,3 +1,3 @@
 group :ovirt do
-  gem 'fog-ovirt', '~> 1.1.1'
+  gem 'fog-ovirt', '~> 1.1.2'
 end


### PR DESCRIPTION
Now clusters shown for ovirt are only those in the datacenter.
Associate VMs for API v4 was fixed by changing filter to only add
pagination when needed.

Update: packaging PR: https://github.com/theforeman/foreman-packaging/pull/2913



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
