### PR TITLE
[1.19] fixes #24702 - fix bulk taxonomy update w/ scoped search

### DIFF
--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -35,6 +35,8 @@ module Foreman::Controller::TaxonomyMultiple
       return
     end
 
+    # Workaround for https://github.com/rails/rails/issues/28863
+    @hosts = @hosts.klass.where(:id => @hosts.pluck(:id))
     taxonomy = Taxonomy.find_by_id(id)
 
     if params[type][:optimistic_import] == 'yes'

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1129,6 +1129,22 @@ class HostsControllerTest < ActionController::TestCase
     assert_redirected_to :controller => :hosts, :action => :index
     assert_equal "Updated hosts: Changed Organization", flash[:success]
   end
+  test "update multiple organization succeeds with search" do
+    @request.env['HTTP_REFERER'] = hosts_path
+    organization1 = taxonomies(:organization1)
+    organization2 = taxonomies(:organization2)
+    hosts = FactoryBot.create_list(:host, 2, :managed, organization: organization1)
+
+    post :update_multiple_organization, params: {
+      organization: {id: organization2.id, optimistic_import: 'yes'},
+      search: 'domain ~ example'
+    }, session: set_session_user
+    assert_redirected_to :controller => :hosts, :action => :index
+    assert_equal "Updated hosts: Changed Organization", flash[:success]
+
+    hosts = hosts.map(&:reload)
+    assert hosts.all? { |host| host.organization == organization2 }
+  end
   test "update multiple organization updates organization of hosts if succeeds on optimistic import" do
     @request.env['HTTP_REFERER'] = hosts_path
     organization = taxonomies(:organization1)


### PR DESCRIPTION
If you go to the All Hosts page, and perform a search on a host
relation, like "model ~ Standard" *and* the results page is
more than per_page, *and* you select all results not just the first
page, it will fail with a SQL error: rails isn't correctly generated
the joins for the relation.  This is fixed in Rails 5.2.x.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
