### PR TITLE
Fixes #24782 - [Single Page Application] Show hosts count in API

### DIFF
--- a/app/controllers/api/v2/models_controller.rb
+++ b/app/controllers/api/v2/models_controller.rb
@@ -11,6 +11,7 @@ module Api
 
       def index
         @models = resource_scope_for_index
+        @hosts_count = HostCounter.new(:model)
       end
 
       api :GET, "/models/:id/", N_("Show a hardware model")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -488,16 +488,7 @@ module ApplicationHelper
   end
 
   def hosts_count(resource_name = controller.resource_name)
-    hosts_scope = Host::Managed.reorder('')
-    case resource_name
-    when 'organization', 'location'
-      # If we are on /organizations or /locations, this allows to display the
-      # count for hosts not in the current organization & location.
-      hosts_scope = hosts_scope.unscoped
-    when 'subnet'
-      hosts_scope = hosts_scope.joins(:primary_interface)
-    end
-    @hosts_count ||= hosts_scope.authorized.group(:"#{resource_name}_id").count
+    @hosts_count ||= HostCounter.new(resource_name).hosts_count
   end
 
   def webpack_dev_server

--- a/app/services/host_counter.rb
+++ b/app/services/host_counter.rb
@@ -1,0 +1,28 @@
+class HostCounter
+  def initialize(association)
+    @association = association
+  end
+
+  def [](instance)
+    counted_hosts[instance&.id] || 0
+  end
+
+  def hosts_count
+    counted_hosts
+  end
+
+  private
+
+  def counted_hosts
+    hosts_scope = Host::Managed.reorder('')
+    case @association.to_s
+    when 'organization', 'location'
+      # If we are on /organizations or /locations, this allows to display the
+      # count for hosts not in the current organization & location.
+      hosts_scope = hosts_scope.unscoped
+    when 'subnet'
+      hosts_scope = hosts_scope.joins(:primary_interface)
+    end
+    @counted_hosts ||= hosts_scope.authorized(:view_hosts).group("#{@association}_id").count
+  end
+end

--- a/app/views/api/v2/models/main.json.rabl
+++ b/app/views/api/v2/models/main.json.rabl
@@ -3,3 +3,5 @@ object @model
 extends "api/v2/models/base"
 
 attributes :info, :created_at, :updated_at, :vendor_class, :hardware_model
+
+node(:hosts_count) { |model| @hosts_count[model] } unless @hosts_count.nil?

--- a/test/controllers/api/v2/models_controller_test.rb
+++ b/test/controllers/api/v2/models_controller_test.rb
@@ -51,4 +51,12 @@ class Api::V2::ModelsControllerTest < ActionController::TestCase
     assert assigns(:model).present?
     assert_equal new_model.id, assigns(:model).id
   end
+
+  test "should return hosts_count" do
+    get :index
+    resp = ActiveSupport::JSON.decode(@response.body)
+    resp["results"].map do |m|
+      assert_equal 0, m["hosts_count"]
+    end
+  end
 end

--- a/test/unit/host_counter_test.rb
+++ b/test/unit/host_counter_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class HostCounterTest < ActiveSupport::TestCase
+  def setup
+    User.current = users :admin
+  end
+
+  test 'it should get number of hosts associated to model' do
+    m = Model.create(:name => "model-1")
+    Host.create(:model => m)
+    count = HostCounter.new(:model)
+    assert_equal 1, count[m]
+  end
+
+  test 'it should get number of hosts associated to architecture' do
+    os = Architecture.create(:name => "arch-1")
+    Host.create(:architecture => os)
+    Host.create(:architecture => os)
+    count = HostCounter.new(:architecture)
+    assert_equal 2, count[os]
+  end
+
+  test 'it should count only hosts if user has view_hosts permissions' do
+    model = Model.first
+    assert Host.create(:model => model)
+
+    as_admin do
+      count = HostCounter.new(:model)
+      assert_equal 1, count[model]
+    end
+
+    # user "one" does not have view hosts permissions
+    as_user(:one) do
+      count = HostCounter.new(:model)
+      assert_equal 0, count[model]
+    end
+  end
+
+  test 'it should count only hosts in user location/organization' do
+    m1 = Model.create(:name => "blabla")
+    assert Host.create(:model => m1, :location => Location.first, :organization => Organization.second).save
+    assert Host.create(:model => m1, :location => Location.second, :organization => Organization.third).save
+    assert_equal 2, HostCounter.new(:model)[m1]
+
+    Location.current = Location.first
+    Organization.current = nil
+    assert_equal 1, HostCounter.new(:model)[m1]
+
+    Location.current = nil
+    Organization.current = Organization.second
+    assert_equal 1, HostCounter.new(:model)[m1]
+
+    Location.current = Location.second
+    Organization.current = Organization.second
+    assert_equal 0, HostCounter.new(:model)[m1]
+  end
+
+  test 'it should count hosts associated to location/organization even though current location/organization is set' do
+    assert Host.create(:location => Location.first, :organization => Organization.second).save
+    assert Host.create(:location => Location.second, :organization => Organization.third).save
+    Location.current = Location.first
+    Organization.current = Organization.second
+    assert_equal 2, HostCounter.new(:organization).hosts_count.count
+    assert_equal 2, HostCounter.new(:location).hosts_count.count
+  end
+end


### PR DESCRIPTION
I separated `host_counter` from #5814  for convenient purposes 

This PR contains the code that adds `hosts_count` to API while #5814 will focus on the permissions part.

// cc @timogoebel @ares @tbrisker @ohadlevy 