### PR TITLE
Fixes #24381 - Remove modulepath setting

### DIFF
--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -4,7 +4,6 @@ class Setting::Puppet < Setting
       self.set('puppet_interval', N_("Duration in minutes after servers reporting via Puppet are classed as out of sync."), 35, N_('Puppet interval')),
       self.set('puppet_out_of_sync_disabled', N_("Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval") % 'Puppet', false, N_('%s out of sync disabled') % 'Puppet'),
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map{|env| [env[:name], env[:name]]}]} }),
-      self.set('modulepath', N_("Foreman will set this as the default Puppet module path if it cannot auto detect one"), "/etc/puppet/modules", N_('Module path')),
       self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
       self.set('puppet_server', N_("Default Puppet server hostname"), "puppet", N_('Puppet server')),
       self.set('Default_variables_Lookup_Path', N_("Foreman will evaluate host smart variables in this order by default"), ["fqdn", "hostgroup", "os", "domain"], N_('Default variables lookup path')),

--- a/db/migrate/20180903154354_remove_modulepath_setting.rb
+++ b/db/migrate/20180903154354_remove_modulepath_setting.rb
@@ -1,0 +1,9 @@
+class RemoveModulepathSetting < ActiveRecord::Migration[5.1]
+  def up
+    Setting.where(:name => 'modulepath').delete_all
+  end
+
+  def down
+    # settings would be created by Setting on code version that uses it
+  end
+end

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -73,7 +73,6 @@ module Foreman
         :puppet_interval,
         :outofsync_interval,
         :default_puppet_environment,
-        :modulepath,
         :puppetrun,
         :puppet_server,
         :update_ip_from_built_request

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -46,11 +46,6 @@ attributes9:
   category: Setting::Puppet
   default: production
   description: "The Setting::Puppet environment foreman would default to in case it can't auto detect it"
-attributes10:
-  name: modulepath
-  category: Setting::Puppet
-  default: /etc/puppet/modules
-  description: "The Setting::Puppet default module path in case that Foreman can't auto detect it"
 attributes12:
   name: puppet_server
   category: Setting::Puppet


### PR DESCRIPTION
This setting was used by the puppetclasses support but as part of b1dad4cd18dfc69faa8f1509b0b5b9a361976d59 that code has been removed.  This setting is now useless.