### PR TITLE
Fixes #24778 - Notice unassigned primary/provision interface

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -242,6 +242,7 @@ class Host::Managed < Host::Base
                           :if => Proc.new { |host| host.operatingsystem && host.medium }
     validate :provision_method_in_capabilities
     validate :short_name_periods
+    validate :check_interfaces
     before_validation :set_compute_attributes, :on => :create, :if => Proc.new { compute_attributes_empty? }
     validate :check_if_provision_method_changed, :on => :update, :if => Proc.new { |host| host.managed }
     validates :uuid, uniqueness: { :allow_blank => true }
@@ -657,6 +658,11 @@ class Host::Managed < Host::Base
     host
   end
 
+  def check_interfaces
+    errors.add(:base, _("An interface marked as provision is missing")) if self.interfaces.detect(&:provision).nil?
+    errors.add(:base, _("An interface marked as primary is missing")) if self.interfaces.detect(&:primary).nil?
+  end
+
   def bmc_nic
     interfaces.bmc.first
   end
@@ -925,10 +931,10 @@ class Host::Managed < Host::Base
   # but we should trigger it only for existing records and unless interfaces also changed (then validation is run
   # on them automatically)
   def trigger_nic_orchestration
-    self.primary_interface.valid? unless self.primary_interface.changed?
-
-    if self.primary_interface != self.provision_interface && !self.provision_interface.changed?
-      self.provision_interface.valid?
+    self.primary_interface.valid? if self.primary_interface && !self.primary_interface.changed?
+    unless self.provision_interface.nil?
+      return if self.primary_interface == self.provision_interface
+      self.provision_interface.valid? if self.provision_interface && !self.provision_interface.changed?
     end
   end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -44,6 +44,36 @@ class HostTest < ActiveSupport::TestCase
     assert host.save
   end
 
+  test "host without primary interface should rise error" do
+    host = FactoryBot.build(:host, :managed)
+    host.interfaces = [] # remove existing primary interface
+    host.interfaces = [ FactoryBot.create(:nic_managed, :primary => false, :provision => true, :host => host,
+                                          :domain => FactoryBot.create(:domain)) ]
+    refute host.valid?
+    assert_equal [:interfaces, :base], host.errors.keys
+    assert_equal "An interface marked as primary is missing", host.errors[:base].first
+  end
+
+  test "host without primary interface should rise error" do
+    host = FactoryBot.build(:host, :managed)
+    host.interfaces = [] # remove existing primary interface
+    host.interfaces = [ FactoryBot.create(:nic_managed, :primary => true, :provision => false, :host => host,
+                                          :domain => FactoryBot.create(:domain)) ]
+    assert_equal [:interfaces, :base], host.errors.keys
+    assert_equal "An interface marked as provision is missing", host.errors[:base].first
+  end
+
+  test "host without primary and provision interface should rise error" do
+    host = FactoryBot.build(:host, :managed)
+    host.interfaces = [] # remove existing primary interface
+    host.interfaces = [ FactoryBot.create(:nic_managed, :primary => false, :provision => false, :host => host,
+                                          :domain => FactoryBot.create(:domain)) ]
+    refute host.valid?
+    assert_equal [:interfaces, :base], host.errors.keys
+    assert_equal "An interface marked as provision is missing", host.errors[:base].first
+    assert_equal "An interface marked as primary is missing", host.errors[:base].last
+  end
+
   test "should fix mac address hyphens" do
     host = Host.create :name => "myhost", :mac => "aa-bb-cc-dd-ee-ff"
     assert_equal "aa:bb:cc:dd:ee:ff", host.mac


### PR DESCRIPTION
User is now noticed if hosts have no primary or provision interface.