### PR TITLE
Fixes #22742 - Add link delay option to subnet

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/subnet.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/subnet.rb
@@ -23,6 +23,7 @@ module Foreman::Controller::Parameters::Subnet
           :type,
           :vlanid,
           :mtu,
+          :nic_delay,
           :domain_ids => [], :domain_names => [],
           :subnet_parameters_attributes => [parameter_params_filter(::SubnetParameter)]
         add_taxonomix_params_filter(filter)

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -81,7 +81,7 @@ module Nic
       allow :managed?, :subnet, :subnet6, :virtual?, :physical?, :mac, :ip, :ip6, :identifier, :attached_to,
             :link, :tag, :domain, :vlanid, :mtu, :bond_options, :attached_devices, :mode,
             :attached_devices_identifiers, :primary, :provision, :alias?, :inheriting_mac,
-            :children_mac_addresses, :fqdn, :shortname
+            :children_mac_addresses, :nic_delay, :fqdn, :shortname
     end
 
     # include STI inheritance column in audits

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -17,7 +17,7 @@ class Subnet < ApplicationRecord
   include BelongsToProxies
 
   attr_exportable :name, :network, :mask, :gateway, :dns_primary, :dns_secondary, :from, :to, :boot_mode,
-    :ipam, :vlanid, :mtu, :network_type, :description
+    :ipam, :vlanid, :mtu, :nic_delay, :network_type, :description
 
   # This sets the rails model name of all child classes to the
   # model name of the parent class, i.e. Subnet.
@@ -84,6 +84,7 @@ class Subnet < ApplicationRecord
   validates :name, :length => {:maximum => 255}, :uniqueness => true
   validates :vlanid, numericality: { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 4096}, :allow_blank => true
   validates :mtu, numericality: { :only_integer => true, :greater_than_or_equal_to => 68}, :presence => true
+  validates :nic_delay, numericality: { :only_integer => true, :greater_than_or_equal_to => 0, :less_than => 1024, allow_nil: true}, :allow_blank => true
 
   before_validation :normalize_addresses
   validate :ensure_ip_addrs_valid
@@ -98,7 +99,7 @@ class Subnet < ApplicationRecord
   }
 
   scoped_search :on => [:name, :network, :mask, :gateway, :dns_primary, :dns_secondary,
-                        :vlanid, :mtu, :ipam, :boot_mode, :type], :complete_value => true
+                        :vlanid, :mtu, :nic_delay, :ipam, :boot_mode, :type], :complete_value => true
 
   scoped_search :relation => :domains, :on => :name, :rename => :domain, :complete_value => true
   scoped_search :relation => :subnet_parameters, :on => :value, :on_key => :name, :complete_value => true, :only_explicit => true, :rename => :params
@@ -107,7 +108,7 @@ class Subnet < ApplicationRecord
 
   class Jail < ::Safemode::Jail
     allow :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary, :dns_servers,
-          :vlanid, :mtu, :boot_mode, :dhcp?, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?
+          :vlanid, :mtu, :nic_delay, :boot_mode, :dhcp?, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?
   end
 
   # Subnets are displayed in the form of their network network/network mask

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -23,6 +23,7 @@
 </div>
 <%= number_f f, :vlanid, :min => 0, :max => 4095, :help_inline => _("Optional: VLAN ID for this subnet") %>
 <%= number_f f, :mtu, :label => _('MTU'), :min => 68, :max => 4294967295, :help_inline => _('MTU for this subnet') %>
+<%= number_f f, :nic_delay, :label => _('Link Delay'), :min => 0, :max => 900, :help_inline => _('Delay network activity during install for X seconds') %>
 <%= selectable_f f, :boot_mode, Subnet.boot_modes_with_translations, {},
                  :label => _("Boot Mode"), :help_inline => _("Default boot mode for interfaces assigned to this subnet, applied to hosts from provisioning templates") %>
 <%= hidden_field_tag :redirect, params[:redirect] %>

--- a/db/migrate/20180904142922_add_nic_delay_to_subnet.rb
+++ b/db/migrate/20180904142922_add_nic_delay_to_subnet.rb
@@ -1,0 +1,5 @@
+class AddNicDelayToSubnet < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subnets, :nic_delay, :integer, :limit => 4
+  end
+end

--- a/test/fixtures/subnets.yml
+++ b/test/fixtures/subnets.yml
@@ -18,6 +18,7 @@ two:
   tftp: two
   vlanid: 42
   mtu: 1496
+  nic_delay: 3
 
 three:
   name: three

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -93,6 +93,7 @@ class NicTest < ActiveSupport::TestCase
     assert_equal subnet6.network, interface.network6
     assert_equal subnet.vlanid, interface.vlanid
     assert_equal 42, interface.vlanid
+    assert_equal 3, subnet.nic_delay
     assert_equal 1496, interface.mtu
     assert_equal subnet.mtu, interface.mtu
   end

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -146,6 +146,10 @@ class SubnetTest < ActiveSupport::TestCase
     assert_equal 1500, Subnet.new.mtu
   end
 
+  test "should have nic_delay set to nil by default" do
+    assert_nil Subnet.new.nic_delay
+  end
+
   describe '#dns_servers' do
     test 'should display a list of dns servers' do
       subnet = FactoryBot.create(:subnet_ipv4, dns_primary: '192.0.2.1', dns_secondary: '192.0.2.2')


### PR DESCRIPTION
This commit adds a link delay option to a subnet.

This is primarily useful on links where there can be a few delays in getting connectivity.