### PR TITLE
Fixes #21177 - missing warning icon on ssh keys

### DIFF
--- a/app/views/ssh_keys/_form.html.erb
+++ b/app/views/ssh_keys/_form.html.erb
@@ -2,14 +2,7 @@
   <%= base_errors_for @ssh_key %>
   <% if @ssh_key.errors.include?(:fingerprint) || @ssh_key.errors.include?(:length) %>
     <p><%= _('Please correct the error(s) below and submit your changes again.') %></p>
-
-    <div class="alert alert-warning alert-block base">
-      <% [:fingerprint, :length].each do |field|%>
-        <% @ssh_key.errors.full_messages_for(field).each do |e| %>
-          <li><%= e %></li>
-        <% end %>
-      <% end %>
-    </div>
+    <%= alert :close => false, :class => "alert-warning alert-block base", :text => [:fingerprint, :length].map { |field| @ssh_key.errors.full_messages_for(field).map { |e| '<li>'.html_safe + e + '</li>'.html_safe }.join }.join.html_safe  %>
   <% end %>
   <%= textarea_f f, :key, :size => 'col-md-8', :rows=> '3', :autofocus => true, :onfocusout => "tfm.sshKeys.autofillSshKeyName()" %>
   <%= text_f f, :name, :focus_on_load => false %>


### PR DESCRIPTION
### Before
![before](https://projects.theforeman.org/attachments/download/2504/usersshwarning.png)
### After
![screenshot_2018-09-06 screenshot](https://user-images.githubusercontent.com/2453279/45177488-cd1ea980-b21b-11e8-9c89-5057cb631212.png)


