### PR TITLE
Fixes #24800 - Notify deprecation of taxonomy, login settings

### DIFF
--- a/db/seeds.d/170-notification_blueprints.rb
+++ b/db/seeds.d/170-notification_blueprints.rb
@@ -34,18 +34,25 @@ blueprints = [
     }
   },
   {
-    group: _('Community'),
+    group: N_('Community'),
     name: 'rss_post',
     level: 'info',
-    message: _('RSS post message goes here'),
+    message: N_('RSS post message goes here'),
     actions:
     {
       links:
       [
-        title: _('URL'),
+        title: N_('URL'),
         external: true
       ]
     }
+  },
+  {
+    group: N_('Deprecations'),
+    name: 'setting_deprecation',
+    level: 'warning',
+    message: N_('The %{setting} setting has been deprecated and will be removed in version %{version}'),
+    expires_in: 30.days
   }
 ]
 


### PR DESCRIPTION
<strike>Includes 2 commits: first one allows displaying notifications when login is disabled, second actually creates the relevant notification.</strike>
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
