### PR TITLE
Fixes #24824 - Allow UI notifications when login is disabled

### DIFF
--- a/app/controllers/notification_recipients_controller.rb
+++ b/app/controllers/notification_recipients_controller.rb
@@ -1,7 +1,6 @@
 class NotificationRecipientsController < Api::V2::BaseController
   include Foreman::Controller::Parameters::NotificationRecipient
   skip_before_action :update_activity_time, :only => [:index]
-  before_action :require_login
   before_action :find_resource, :only => [:update, :destroy]
 
   def index
@@ -44,10 +43,6 @@ class NotificationRecipientsController < Api::V2::BaseController
   end
 
   private
-
-  def require_login
-    not_found unless SETTINGS[:login]
-  end
 
   def find_resource
     super

--- a/app/views/home/_topbar.html.erb
+++ b/app/views/home/_topbar.html.erb
@@ -18,7 +18,7 @@
       <nav class="collapse navbar-collapse">
         <div id="turbolinks-progress"><div class="spinner spinner-inverse"></div></div>
         <ul class="nav navbar-nav navbar-right navbar-iconic navbar-utility">
-        <%= render 'home/user_dropdown' if SETTINGS[:login] %>
+        <%= render 'home/user_dropdown' %>
         </ul>
     </nav>
   <% end %>

--- a/app/views/home/_user_dropdown.html.erb
+++ b/app/views/home/_user_dropdown.html.erb
@@ -1,16 +1,17 @@
 <li id='notifications_container' class="drawer-pf-trigger dropdown notifification-dropdown"> </li>
-<li class="dropdown">
-  <%= user_header %>
-  <ul class="dropdown-menu pull-right">
-    <% authorized_menu_actions(Menu::Manager.items(:side_menu)).map do |item| %>
-        <% case item %>
-        <% when Menu::Item %>
-          <%= menu_item_tag item %>
-        <% when Menu::Divider %>
-          <%= content_tag(:li, "", :class => "divider") %>
-        <% end %>
-    <% end %>
-  </ul>
-</li>
-
+<% if SETTINGS[:login] %>
+  <li class="dropdown">
+    <%= user_header %>
+    <ul class="dropdown-menu pull-right">
+      <% authorized_menu_actions(Menu::Manager.items(:side_menu)).map do |item| %>
+          <% case item %>
+          <% when Menu::Item %>
+            <%= menu_item_tag item %>
+          <% when Menu::Divider %>
+            <%= content_tag(:li, "", :class => "divider") %>
+          <% end %>
+      <% end %>
+    </ul>
+  </li>
+<% end %>
 <%= mount_react_component('NotificationContainer','#notifications_container',{:url => notification_recipients_path}.to_json) %>

--- a/test/controllers/notification_recipients_controller_test.rb
+++ b/test/controllers/notification_recipients_controller_test.rb
@@ -51,13 +51,6 @@ class NotificationRecipientsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
-  test "should not get notifications if settings login is disabled" do
-    SETTINGS[:login] = false
-    get :index, params: { :format => 'json' }
-    SETTINGS[:login] = true
-    assert_response :not_found
-  end
-
   test "should not respond with expired notifications" do
     notification = add_notification
     notification.update_attribute(:expired_at, Time.now.utc - 48.hours)


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
