### PR TITLE
Fixes #24807 - unsafe html in toast notification

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/Alert/AlertBody.js
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/AlertBody.js
@@ -10,7 +10,7 @@ const AlertBody = ({
 
     {title && <strong>{title}</strong>}
 
-    <span dangerouslySetInnerHTML={{ __html: message }} />
+    {message}
 
     {children}
   </span>

--- a/webpack/assets/javascripts/react_app/components/common/Alert/__snapshots__/AlertBody.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/__snapshots__/AlertBody.test.js.snap
@@ -10,13 +10,7 @@ exports[`AlertBody should render With all props 1`] = `
   <strong>
     some title
   </strong>
-  <span
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "some message",
-      }
-    }
-  />
+  some message
   <span>
     a Child
   </span>
@@ -25,13 +19,6 @@ exports[`AlertBody should render With all props 1`] = `
 
 exports[`AlertBody should render with childrens 1`] = `
 <span>
-  <span
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": undefined,
-      }
-    }
-  />
   <span>
     a Child
   </span>
@@ -45,13 +32,6 @@ exports[`AlertBody should render with link 1`] = `
   >
     link text
   </AlertLink>
-  <span
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": undefined,
-      }
-    }
-  />
 </span>
 `;
 
@@ -60,12 +40,6 @@ exports[`AlertBody should render with title and message 1`] = `
   <strong>
     some title
   </strong>
-  <span
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "some message",
-      }
-    }
-  />
+  some message
 </span>
 `;

--- a/webpack/assets/javascripts/react_app/components/toastNotifications/__snapshots__/ToastsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/toastNotifications/__snapshots__/ToastsList.test.js.snap
@@ -231,13 +231,7 @@ exports[`ToastList should render with multipleMessagesState 1`] = `
                   message="Message number 1."
                 >
                   <span>
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "Message number 1.",
-                        }
-                      }
-                    />
+                    Message number 1.
                   </span>
                 </AlertBody>
               </div>
@@ -340,13 +334,7 @@ exports[`ToastList should render with multipleMessagesState 1`] = `
                         </a>
                       </div>
                     </AlertLink>
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "Message number 2.",
-                        }
-                      }
-                    />
+                    Message number 2.
                   </span>
                 </AlertBody>
               </div>
@@ -449,13 +437,7 @@ exports[`ToastList should render with multipleMessagesState 1`] = `
                         </a>
                       </div>
                     </AlertLink>
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "Message number 3.",
-                        }
-                      }
-                    />
+                    Message number 3.
                   </span>
                 </AlertBody>
               </div>
@@ -615,13 +597,7 @@ exports[`ToastList should render with singleMessageState 1`] = `
                   message="Widget positions successfully saved."
                 >
                   <span>
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "Widget positions successfully saved.",
-                        }
-                      }
-                    />
+                    Widget positions successfully saved.
                   </span>
                 </AlertBody>
               </div>
@@ -804,13 +780,7 @@ exports[`ToastList should render with singleMessageWithLinkState 1`] = `
                         </a>
                       </div>
                     </AlertLink>
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "Widget positions successfully saved.",
-                        }
-                      }
-                    />
+                    Widget positions successfully saved.
                   </span>
                 </AlertBody>
               </div>


### PR DESCRIPTION
toast notification sends strings through as HTML

@tbrisker 