### PR TITLE
Fixes #24831 - Remove Rails 5.1 workaround for slow api call

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -56,13 +56,7 @@ module Api
 
     # overwrites resource_scope in FindCommon to consider nested objects
     def resource_scope(options = {})
-      if Rails.version.start_with?('5.2')
-        super(options).merge(parent_scope).readonly(false)
-      else
-        # workaround for https://github.com/rails/rails/pull/29413
-        # TODO: Remove once rails 5.2 migration is complete
-        super(options).where(id: parent_scope.select(:id))
-      end
+      super(options).merge(parent_scope).readonly(false)
     end
 
     def parent_scope
@@ -93,7 +87,7 @@ module Api
       # In such cases, we resolve the scope first, and then call 'where'
       # on the results
       resource_class.joins(association.name).
-        where(association.name => scope.pluck(:id))
+        where(association.name => scope.select(:id))
     end
 
     def resource_class_join(association, scope)


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
