### PR TITLE
Fixes #8112 - Org/loc aren't documented when taxo are disabled

### DIFF
--- a/app/controllers/api/v2/auth_source_externals_controller.rb
+++ b/app/controllers/api/v2/auth_source_externals_controller.rb
@@ -6,10 +6,14 @@ module Api
       before_action :find_resource, :only => %w{show update}
 
       api :GET, "/auth_source_externals/", N_("List external authentication sources")
-      api :GET, '/locations/:location_id/auth_source_externals/',
+      if SETTINGS[:locations_enabled]
+        api :GET, '/locations/:location_id/auth_source_externals/',
           N_('List external authentication sources per location')
-      api :GET, '/organizations/:organization_id/auth_source_externals/',
+      end
+      if SETTINGS[:organizations_enabled]
+        api :GET, '/organizations/:organization_id/auth_source_externals/',
           N_('List external authentication sources per organization')
+      end
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -10,10 +10,14 @@ module Api
       before_action :find_resource, :only => %w{show update destroy test}
 
       api :GET, "/auth_source_ldaps/", N_("List all LDAP authentication sources")
-      api :GET, '/locations/:location_id/auth_source_ldaps/',
-        N_('List LDAP authentication sources per location')
-      api :GET, '/organizations/:organization_id/auth_source_ldaps/',
-        N_('List LDAP authentication sources per organization')
+      if SETTINGS[:locations_enabled]
+        api :GET, '/locations/:location_id/auth_source_ldaps/',
+          N_('List LDAP authentication sources per location')
+      end
+      if SETTINGS[:organizations_enabled]
+        api :GET, '/organizations/:organization_id/auth_source_ldaps/',
+          N_('List LDAP authentication sources per organization')
+      end
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
       add_scoped_search_description_for(AuthSourceLdap)

--- a/app/controllers/api/v2/auth_sources_controller.rb
+++ b/app/controllers/api/v2/auth_sources_controller.rb
@@ -4,8 +4,8 @@ module Api
       before_action :find_resource, :only => %w{show}
 
       api :GET, "/auth_sources/", N_("List all authentication sources")
-      api :GET, '/locations/:location_id/auth_sources/', N_('List all authentication sources per location')
-      api :GET, '/organizations/:organization_id/auth_sources/', N_('List all authentication sources per organization')
+      api :GET, '/locations/:location_id/auth_sources/', N_('List all authentication sources per location') if SETTINGS[:locations_enabled]
+      api :GET, '/organizations/:organization_id/auth_sources/', N_('List all authentication sources per organization') if SETTINGS[:organizations_enabled]
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
 

--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -16,8 +16,8 @@ module Api
 
       api :GET, "/config_templates/", N_("List provisioning templates")
       api :GET, "/operatingsystems/:operatingsystem_id/config_templates", N_("List provisioning templates per operating system")
-      api :GET, "/locations/:location_id/config_templates/", N_("List provisioning templates per location")
-      api :GET, "/organizations/:organization_id/config_templates/", N_("List provisioning templates per organization")
+      api :GET, "/locations/:location_id/config_templates/", N_("List provisioning templates per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/config_templates/", N_("List provisioning templates per organization") if SETTINGS[:organizations_enabled]
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -22,8 +22,8 @@ module Api
 
       api :GET, "/domains/", N_("List of domains")
       api :GET, "/subnets/:subnet_id/domains", N_("List of domains per subnet")
-      api :GET, "/locations/:location_id/domains", N_("List of domains per location")
-      api :GET, "/organizations/:organization_id/domains", N_("List of domains per organization")
+      api :GET, "/locations/:location_id/domains", N_("List of domains per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/domains", N_("List of domains per organization") if SETTINGS[:organizations_enabled]
       param :subnet_id, String, :desc => N_("ID of subnet")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -10,8 +10,8 @@ module Api
 
       api :GET, "/environments/", N_("List all environments")
       api :GET, "/puppetclasses/:puppetclass_id/environments", N_("List environments of Puppet class")
-      api :GET, "/locations/:location_id/environments", N_("List environments per location")
-      api :GET, "/organizations/:organization_id/environments", N_("List environments per organization")
+      api :GET, "/locations/:location_id/environments", N_("List environments per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/environments", N_("List environments per organization") if SETTINGS[:organizations_enabled]
       param :puppetclass_id, String, :desc => N_("ID of Puppet class")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -12,8 +12,8 @@ module Api
 
       api :GET, "/hostgroups/", N_("List all host groups")
       api :GET, "/puppetclasses/:puppetclass_id/hostgroups", N_("List all host groups for a Puppet class")
-      api :GET, "/locations/:location_id/hostgroups", N_("List all host groups per location")
-      api :GET, "/organizations/:organization_id/hostgroups", N_("List all host groups per organization")
+      api :GET, "/locations/:location_id/hostgroups", N_("List all host groups per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/hostgroups", N_("List all host groups per organization") if SETTINGS[:organizations_enabled]
       param :puppetclass_id, String, :desc => N_("ID of Puppet class")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -29,8 +29,8 @@ module Api
 
       api :GET, "/hosts/", N_("List all hosts")
       api :GET, "/hostgroups/:hostgroup_id/hosts", N_("List all hosts for a host group")
-      api :GET, "/locations/:location_id/hosts", N_("List hosts per location")
-      api :GET, "/organizations/:organization_id/hosts", N_("List hosts per organization")
+      api :GET, "/locations/:location_id/hosts", N_("List hosts per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/hosts", N_("List hosts per organization") if SETTINGS[:organizations_enabled]
       api :GET, "/environments/:environment_id/hosts", N_("List hosts per environment")
       param :thin, :bool, :desc => N_("Only list ID and name of hosts")
       param :hostgroup_id, String, :desc => N_("ID of host group")

--- a/app/controllers/api/v2/locations_controller.rb
+++ b/app/controllers/api/v2/locations_controller.rb
@@ -1,9 +1,11 @@
 module Api
   module V2
     class LocationsController < V2::BaseController
-      apipie_concern_subst(:a_resource => N_("a location"), :resource => "location")
-      include Api::V2::TaxonomiesController
-      include Foreman::Controller::Parameters::Location
+      if SETTINGS[:locations_enabled]
+        apipie_concern_subst(:a_resource => N_("a location"), :resource => "location")
+        include Api::V2::TaxonomiesController
+        include Foreman::Controller::Parameters::Location
+      end
     end
   end
 end

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -22,8 +22,8 @@ Solaris and Debian media may also use $release.
 
       api :GET, "/media/", N_("List all installation media")
       api :GET, "/operatingsystems/:operatingsystem_id/media", N_("List all media for an operating system")
-      api :GET, "/locations/:location_id/media", N_("List all media per location")
-      api :GET, "/organizations/:organization_id/media", N_("List all media per organization")
+      api :GET, "/locations/:location_id/media", N_("List all media per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/media", N_("List all media per organization") if SETTINGS[:organizations_enabled]
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/organizations_controller.rb
+++ b/app/controllers/api/v2/organizations_controller.rb
@@ -1,9 +1,11 @@
 module Api
   module V2
     class OrganizationsController < V2::BaseController
-      apipie_concern_subst(:a_resource => N_("an organization"), :resource => "organization")
-      include Api::V2::TaxonomiesController
-      include Foreman::Controller::Parameters::Organization
+      if SETTINGS[:organizations_enabled]
+        apipie_concern_subst(:a_resource => N_("an organization"), :resource => "organization")
+        include Api::V2::TaxonomiesController
+        include Foreman::Controller::Parameters::Organization
+      end
     end
   end
 end

--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -18,8 +18,8 @@ module Api
       api :GET, "/hostgroups/:hostgroup_id/parameters", N_("List all parameters for a host group")
       api :GET, "/domains/:domain_id/parameters", N_("List all parameters for a domain")
       api :GET, "/operatingsystems/:operatingsystem_id/parameters", N_("List all parameters for an operating system")
-      api :GET, "/locations/:location_id/parameters", N_("List all parameters for a location")
-      api :GET, "/organizations/:organization_id/parameters", N_("List all parameters for an organization")
+      api :GET, "/locations/:location_id/parameters", N_("List all parameters for a location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/parameters", N_("List all parameters for an organization") if SETTINGS[:organizations_enabled]
       api :GET, "/subnets/:subnet_id/parameters", N_("List all parameters for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
@@ -42,8 +42,8 @@ module Api
       api :GET, "/hostgroups/:hostgroup_id/parameters/:id", N_("Show a nested parameter for a host group")
       api :GET, "/domains/:domain_id/parameters/:id", N_("Show a nested parameter for a domain")
       api :GET, "/operatingsystems/:operatingsystem_id/parameters/:id", N_("Show a nested parameter for an operating system")
-      api :GET, "/locations/:location_id/parameters/:id", N_("Show a nested parameter for a location")
-      api :GET, "/organizations/:organization_id/parameters/:id", N_("Show a nested parameter for an organization")
+      api :GET, "/locations/:location_id/parameters/:id", N_("Show a nested parameter for a location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/parameters/:id", N_("Show a nested parameter for an organization") if SETTINGS[:organizations_enabled]
       api :GET, "/subnets/:subnet_id/parameters/:id", N_("Show a nested parameter for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
@@ -69,8 +69,8 @@ module Api
       api :POST, "/hostgroups/:hostgroup_id/parameters/", N_("Create a nested parameter for a host group")
       api :POST, "/domains/:domain_id/parameters/", N_("Create a nested parameter for a domain")
       api :POST, "/operatingsystems/:operatingsystem_id/parameters/", N_("Create a nested parameter for an operating system")
-      api :POST, "/locations/:location_id/parameters/", N_("Create a nested parameter for a location")
-      api :POST, "/organizations/:organization_id/parameters/", N_("Create a nested parameter for an organization")
+      api :POST, "/locations/:location_id/parameters/", N_("Create a nested parameter for a location") if SETTINGS[:locations_enabled]
+      api :POST, "/organizations/:organization_id/parameters/", N_("Create a nested parameter for an organization") if SETTINGS[:organizations_enabled]
       api :POST, "/subnets/:subnet_id/parameters/", N_("Create a nested parameter for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
@@ -90,8 +90,8 @@ module Api
       api :PUT, "/hostgroups/:hostgroup_id/parameters/:id", N_("Update a nested parameter for a host group")
       api :PUT, "/domains/:domain_id/parameters/:id", N_("Update a nested parameter for a domain")
       api :PUT, "/operatingsystems/:operatingsystem_id/parameters/:id", N_("Update a nested parameter for an operating system")
-      api :PUT, "/locations/:location_id/parameters/:id", N_("Update a nested parameter for a location")
-      api :PUT, "/organizations/:organization_id/parameters/:id", N_("Update a nested parameter for an organization")
+      api :PUT, "/locations/:location_id/parameters/:id", N_("Update a nested parameter for a location") if SETTINGS[:locations_enabled]
+      api :PUT, "/organizations/:organization_id/parameters/:id", N_("Update a nested parameter for an organization") if SETTINGS[:organizations_enabled]
       api :PUT, "/subnets/:subnet_id/parameters/:id", N_("Update a nested parameter for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
@@ -111,8 +111,8 @@ module Api
       api :DELETE, "/hostgroups/:hostgroup_id/parameters/:id", N_("Delete a nested parameter for a host group")
       api :DELETE, "/domains/:domain_id/parameters/:id", N_("Delete a nested parameter for a domain")
       api :DELETE, "/operatingsystems/:operatingsystem_id/parameters/:id", N_("Delete a nested parameter for an operating system")
-      api :DELETE, "/locations/:location_id/parameters/:id", N_("Delete a nested parameter for a location")
-      api :DELETE, "/organizations/:organization_id/parameters/:id", N_("Delete a nested parameter for an organization")
+      api :DELETE, "/locations/:location_id/parameters/:id", N_("Delete a nested parameter for a location") if SETTINGS[:locations_enabled]
+      api :DELETE, "/organizations/:organization_id/parameters/:id", N_("Delete a nested parameter for an organization") if SETTINGS[:organizations_enabled]
       api :DELETE, "/subnets/:subnet_id/parameters/:id", N_("Delete a nested parameter for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")
@@ -131,8 +131,8 @@ module Api
       api :DELETE, "/hostgroups/:hostgroup_id/parameters", N_("Delete all nested parameters for a host group")
       api :DELETE, "/domains/:domain_id/parameters", N_("Delete all nested parameters for a domain")
       api :DELETE, "/operatingsystems/:operatingsystem_id/parameters", N_("Delete all nested parameters for an operating system")
-      api :DELETE, "/locations/:location_id/parameters", N_("Delete all nested parameter for a location")
-      api :DELETE, "/organizations/:organization_id/parameters", N_("Delete all nested parameter for an organization")
+      api :DELETE, "/locations/:location_id/parameters", N_("Delete all nested parameter for a location") if SETTINGS[:locations_enabled]
+      api :DELETE, "/organizations/:organization_id/parameters", N_("Delete all nested parameter for an organization") if SETTINGS[:organizations_enabled]
       api :DELETE, "/subnets/:subnet_id/parameters", N_("Delete all nested parameters for a subnet")
       param :host_id, String, :desc => N_("ID of host")
       param :hostgroup_id, String, :desc => N_("ID of host group")

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -15,8 +15,8 @@ module Api
 
       api :GET, "/provisioning_templates/", N_("List provisioning templates")
       api :GET, "/operatingsystems/:operatingsystem_id/provisioning_templates", N_("List provisioning templates per operating system")
-      api :GET, "/locations/:location_id/provisioning_templates/", N_("List provisioning templates per location")
-      api :GET, "/organizations/:organization_id/provisioning_templates/", N_("List provisioning templates per organization")
+      api :GET, "/locations/:location_id/provisioning_templates/", N_("List provisioning templates per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/provisioning_templates/", N_("List provisioning templates per organization") if SETTINGS[:organizations_enabled]
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -11,8 +11,8 @@ module Api
 
       api :GET, "/ptables/", N_("List all partition tables")
       api :GET, "/operatingsystems/:operatingsystem_id/ptables", N_("List all partition tables for an operating system")
-      api :GET, "/locations/:location_id/ptables/", N_("List all partition tables per location")
-      api :GET, "/organizations/:organization_id/ptables/", N_("List all partition tables per organization")
+      api :GET, "/locations/:location_id/ptables/", N_("List all partition tables per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/ptables/", N_("List all partition tables per organization") if SETTINGS[:organizations_enabled]
       param :operatingsystem_id, String, :desc => N_("ID of operating system")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -10,8 +10,8 @@ module Api
       before_action :find_resource, :only => %w{show update destroy clone export generate}
 
       api :GET, "/report_templates/", N_("List all report templates")
-      api :GET, "/locations/:location_id/report_templates/", N_("List all report templates per location")
-      api :GET, "/organizations/:organization_id/report_templates/", N_("List all report templates per organization")
+      api :GET, "/locations/:location_id/report_templates/", N_("List all report templates per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/report_templates/", N_("List all report templates per organization") if SETTINGS[:organizations_enabled]
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController
       add_scoped_search_description_for(ReportTemplate)

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -12,8 +12,8 @@ module Api
 
       api :GET, '/subnets', N_("List of subnets")
       api :GET, "/domains/:domain_id/subnets", N_("List of subnets for a domain")
-      api :GET, "/locations/:location_id/subnets", N_("List of subnets per location")
-      api :GET, "/organizations/:organization_id/subnets", N_("List of subnets per organization")
+      api :GET, "/locations/:location_id/subnets", N_("List of subnets per location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/subnets", N_("List of subnets per organization") if SETTINGS[:organizations_enabled]
       param :domain_id, String, :desc => N_("ID of domain")
       param_group :taxonomy_scope, ::Api::V2::BaseController
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -18,8 +18,8 @@ module Api
       api :GET, "/auth_source_externals/:auth_source_external_id/users", N_("List all users for external authentication source")
       api :GET, "/usergroups/:usergroup_id/users", N_("List all users for user group")
       api :GET, "/roles/:role_id/users", N_("List all users for role")
-      api :GET, "/locations/:location_id/users", N_("List all users for location")
-      api :GET, "/organizations/:organization_id/users", N_("List all users for organization")
+      api :GET, "/locations/:location_id/users", N_("List all users for location") if SETTINGS[:locations_enabled]
+      api :GET, "/organizations/:organization_id/users", N_("List all users for organization") if SETTINGS[:organizations_enabled]
       param :auth_source_ldap_id, String, :desc => N_("ID of LDAP authentication source")
       param :usergroup_id, String, :desc => N_("ID of user group")
       param :role_id, String, :desc => N_("ID of role")


### PR DESCRIPTION
At least one bug is still reproducible: when Ansible plugin is used and taxonomies are disabled, there will be still documented nested location/organization routes in Job templates. 