### PR TITLE
Fixes #24844 - find correctly audited objects

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -84,7 +84,7 @@ module AuditsHelper
         end
       end
     elsif !main_object? audit
-      ["#{audit_action_name(audit).humanize} #{id_to_label audit.audited_changes.keys[0], audit.audited_changes.values[0]}
+      ["#{audit_action_name(audit).humanize} #{id_to_label audit.audited_changes.keys[0], audit.audited_changes.values[0], audit: audit}
        #{(audit_action_name(audit) == 'removed') ? 'from' : 'to'} #{audit.associated_name || id_to_label(audit.audited_changes.keys[1], audit.audited_changes.values[1])}"]
     else
       []


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->

The original fix #5857 fixed it on most places by passing audit object to `id_to_label` helper, but one place was missed. For objects that are not listed as main (usually plugins) the detail message still results to Missing. This now passes the audit object too. Easy fix for merge.

Can be reproduced with plugin, I can share repro environment too. Original fix was CP-ed back to 1.18 so I set the RM issue accordingly