### PR TITLE
Fixes #24849 - PXE global default option is local

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -12,7 +12,7 @@ class Setting < ApplicationRecord
   FROZEN_ATTRS = %w{name category full_name}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page max_trend outofsync_interval}
   BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text
-                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list ssl_certificate ssl_ca_file ssl_priv_key }
+                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local }
   ARRAY_HOSTNAMES = %w{trusted_hosts}
   URI_ATTRS = %w{foreman_url unattended_url}
   URI_BLANK_ATTRS = %w{login_delegation_logout_url}

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -60,8 +60,8 @@ class Setting::Provisioning < Setting
       self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
       self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
       self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
-      self.set('default_pxe_item_global', N_("Default PXE (PXELinux, PXEGrub, PXEGrub2) menu item in global template - 'local', 'discovery' or custom"), 'local', N_("Default PXE global template entry")),
-      self.set('default_pxe_item_local', N_("Default PXE (PXELinux, PXEGrub2) menu item in local template - 'local_chain_hd0', 'local' or custom"), 'local_chain_hd0', N_("Default PXE local template entry")),
+      self.set('default_pxe_item_global', N_("Default PXE menu item in global template - 'local', 'discovery' or custom, use blank for template default"), nil, N_("Default PXE global template entry")),
+      self.set('default_pxe_item_local', N_("Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"), nil, N_("Default PXE local template entry")),
       self.set(
         'excluded_facts',
         N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
@@ -4,8 +4,18 @@ name: PXEGrub default local boot
 model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
-
-default=0
+<%
+  # Grub1 only supports numeric default statement, this allows conversion to number. First define
+  # array of directories we will search for EFI booloaders:
+  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  # Add remaining entries to it and use this to convert to number:
+  items = paths.push("local_chain_hd0")
+  # Read default setting but since "local" is missing, use the first path available.
+  default_setting = global_setting("default_pxe_item_local", paths.first)
+  default_setting = paths.first if default_setting == 'local'
+  default_item = items.index(default_setting) || 0
+%>
+default=<%= default_item %>
 timeout=20
 
-<%= snippet "pxegrub_chainload" %>
+<%= snippet "pxegrub_chainload", variables: {paths: paths} %>

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -5,14 +5,20 @@ model: ProvisioningTemplate
 %>
 <%# Used to boot unknown hosts, do not associate or change the name. %>
 <%
-  # Grub1 only supports numeric default statement, this array allows conversion to number
-  items = ["local", "discovery"]
-  default_item = items.index(global_setting("default_pxe_item_global", "local")) || 0
+  # Grub1 only supports numeric default statement, this allows conversion to number. First define
+  # array of directories we will search for EFI booloaders:
+  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  # Add remaining entries to it and use this to convert to number:
+  items = paths.push("local_chain_hd0", "discovery")
+  # Read default setting but since "local" is missing, use the first path available.
+  default_setting = global_setting("default_pxe_item_global", paths.first)
+  default_setting = paths.first if default_setting == 'local'
+  default_item = items.index(default_setting) || 0
 %>
 default=<%= default_item %>
 timeout=20
 
-<%= snippet "pxegrub_chainload" %>
+<%= snippet "pxegrub_chainload", variables: {paths: paths} %>
 
 <%= snippet "pxegrub_discovery" %>
 

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
@@ -5,7 +5,7 @@ model: ProvisioningTemplate
 %>
 <%# Used to boot provisioned hosts, do not associate or change the name. %>
 
-set default=<%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
+set default=<%= global_setting("default_pxe_item_local", "local") %>
 set timeout=20
 
 <%= snippet "pxegrub2_chainload" %>

--- a/app/views/unattended/provisioning_templates/snippet/_pxegrub_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/_pxegrub_chainload.erb
@@ -5,13 +5,19 @@ model: ProvisioningTemplate
 snippet: true
 %>
 <%
-  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  # paths variable must be passed into the snippet, otherwise no EFI items are rendered
+  if !@paths.nil? && @paths.size > 1
 -%>
-fallback=<%= (1..paths.size).to_a.join(' ') %>
-<% paths.each do |path| %>
-title Chainload Grub from /EFI/<%= path %>
+fallback=<%= (1..@paths.size).to_a.join(' ') %>
+  <% @paths.each do |path| %>
+title Chainload Grub from /EFI/<%= path %> or try next
   rootnoverify (hd0,0)
   chainloader /EFI/<%= path %>/grubx64.efi
+  <% end -%>
+<% else -%>
+title Update your PXEGrub local template to get EFI options
+  root (hd0,0)
+  chainloader +1
 <% end -%>
 
 title Chainload into bootloader on first disk

--- a/db/migrate/20180918135943_change_default_pxe_items.rb
+++ b/db/migrate/20180918135943_change_default_pxe_items.rb
@@ -1,0 +1,10 @@
+class ChangeDefaultPxeItems < ActiveRecord::Migration[5.2]
+  def up
+    Setting.without_auditing do
+      ['default_pxe_item_global', 'default_pxe_item_local'].each do |name|
+        setting = Setting.where(:name => name).first
+        setting&.update_attribute(:default, '')
+      end
+    end
+  end
+end

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -20,7 +20,8 @@ module Foreman
         :load_hosts,
         :all_host_statuses,
         :host_status,
-        :preview?
+        :preview?,
+        :raise
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -352,12 +352,12 @@ attribute75:
 attribute76:
   name: default_pxe_item_global
   category: Setting::Provisioning
-  default: "local"
+  default: nil
   description: 'Default PXE global template entry'
 attribute77:
   name: default_pxe_item_local
   category: Setting::Provisioning
-  default: "local_chain_hd0"
+  default: nil
   description: 'Default PXE local template entry'
 attributes78:
   name: excluded_facts


### PR DESCRIPTION
We have a mechanism via `global_setting` helper to set default global
and local boot option. It used to be `local` but due to problems with
2nd boot option on PXELinux BIOS fallback we changed this to
`local_chain_hd0`.

The problem is that it changed for Grub templates as well which lead to
issue - EFI-based system is unable to chainboot from MBR. We want the
`local_chain_hd0` only for PXELinux and for others (Grub1,2) we want
still to have `local`.

This patch changes the default setting from `local_chain_hd0` which was
causing issues for EFI system to blank value. What this means is that
templates can decide their default values on their own - it's either
`local` or `local_chain_hd0`.

I am not doing any migration to prevent unwanted changes during upgrade
tho. If user seeded database already, we will keep it on
`local_chain_hd0` and manual change would be required. This is open
question - we could change the setting to blank value since it's sane
default, it should be safe thing to do.

Templates need update too, I am doing change both in core and community
templates as cherry picking might be needed if necessary.