### PR TITLE
fixes #24881 - cloud-init nocloud support

### DIFF
--- a/app/controllers/concerns/foreman/controller/ip_from_request_env.rb
+++ b/app/controllers/concerns/foreman/controller/ip_from_request_env.rb
@@ -1,0 +1,18 @@
+module Foreman
+  module Controller
+    module IpFromRequestEnv
+      extend ActiveSupport::Concern
+
+      protected
+
+      def ip_from_request_env
+        ip = request.env['REMOTE_ADDR']
+
+        # check if someone is asking on behalf of another system (load balancer etc)
+        ip = request.env['HTTP_X_FORWARDED_FOR'] if request.env['HTTP_X_FORWARDED_FOR'].present? && (ip =~ Regexp.new(Setting[:remote_addr]))
+
+        ip
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/foreman/controller/template_rendering.rb
+++ b/app/controllers/concerns/foreman/controller/template_rendering.rb
@@ -1,0 +1,35 @@
+module Foreman
+  module Controller
+    module TemplateRendering
+      extend ActiveSupport::Concern
+
+      private
+
+      def render_template(template:, type:)
+        return safe_render(template) if template
+
+        error_message = N_("unable to find %{type} template for %{host} running %{os}")
+        render_error(:not_found, error_message, {type: type, host: @host.name, os: @host.operatingsystem})
+      end
+
+      def safe_render(template)
+        render plain: template.render(host: @host, params: params).html_safe
+      rescue StandardError => error
+        Foreman::Logging.exception("Error rendering the #{template.name} template", error)
+        render_error(
+          :message => 'There was an error rendering the %{name} template: %{error}',
+          :name => template.name,
+          :error => error.message,
+          :status => :internal_server_error
+        )
+      end
+
+      def render_error(options)
+        message = options.delete(:message)
+        status = options.delete(:status) || :not_found
+        logger.error message % options
+        render plain: "#{message % options}\n", :status => status
+      end
+    end
+  end
+end

--- a/app/controllers/userdata_controller.rb
+++ b/app/controllers/userdata_controller.rb
@@ -1,0 +1,69 @@
+class UserdataController < ApplicationController
+  include ::Foreman::Controller::IpFromRequestEnv
+  include ::Foreman::Controller::TemplateRendering
+
+  layout false
+
+  skip_before_action :require_login, :session_expiry, :update_activity_time, :set_taxonomy, :authorize, :verify_authenticity_token
+
+  before_action :set_admin_user
+  before_action :skip_secure_headers
+  before_action :skip_session
+  before_action :find_host
+
+  def userdata
+    render_userdata_template
+  end
+
+  def metadata
+    data = {
+      :'instance-id' => "i-#{Digest::SHA1.hexdigest(@host.id.to_s)[0..17]}",
+      :hostname => @host.name,
+      :mac => @host.mac,
+      :'local-ipv4' => @host.ip,
+      :'local-hostname' => @host.name
+    }
+    render plain: data.map { |key, value| "#{key}: #{value}" }.join("\n")
+  end
+
+  private
+
+  def render_userdata_template
+    template = @host.provisioning_template(kind: 'cloud-init')
+    template ||= @host.provisioning_template(kind: 'user_data')
+    unless template
+      render_error(
+        :message => 'Unable to find user-data or cloud-init template for host %{host} running %{os}',
+        :status => :not_found,
+        :host => @host.name,
+        :os => @host.operatingsystem
+      )
+      return
+    end
+    safe_render(template)
+  end
+
+  def skip_secure_headers
+    SecureHeaders.opt_out_of_all_protection(request)
+  end
+
+  def skip_session
+    request.session_options[:skip] = true
+  end
+
+  def find_host
+    query_params = {
+      ip: ip_from_request_env
+    }
+
+    @host = Foreman::UnattendedInstallation::HostFinder.new(query_params: query_params).search
+
+    return true if @host
+    render_error(
+      :message => 'Could not find host for request %{request_ip}',
+      :status => :not_found,
+      :request_ip => ip_from_request_env
+    )
+    false
+  end
+end

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -20,7 +20,8 @@ class TemplateKind < ApplicationRecord
       "script" => N_("Script template"),
       "user_data" => N_("User data template"),
       "ZTP" => N_("ZTP PXE template"),
-      "POAP" => N_("POAP PXE template")
+      "POAP" => N_("POAP PXE template"),
+      "cloud-init" => N_("Cloud-init template")
     }
   end
 
@@ -35,7 +36,8 @@ class TemplateKind < ApplicationRecord
       "script" => N_("An arbitrary script, must be manually downloaded using wget/curl."),
       "user_data" => N_("Template with seed data for virtual or cloud instances when 'user data' flag is set, typically cloud-init or ignition format."),
       "ZTP" => N_("Provisioning Junos devices (Junos 12.2+)."),
-      "POAP" => N_("Provisioning for switches running NX-OS.")
+      "POAP" => N_("Provisioning for switches running NX-OS."),
+      "cloud-init" => N_("Template for cloud-init unattended endpoint.")
     }
   end
 

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -1,0 +1,39 @@
+<%#
+kind: cloud-init
+name: CloudInit default
+model: ProvisioningTemplate
+oses:
+- CentOS
+- Fedora
+- Debian
+- Ubuntu
+-%>
+<%#
+This template accepts the following parameters:
+- force-puppet: boolean (default=false)
+- enable-puppetlabs-repo: boolean (default=false)
+- enable-puppetlabs-pc1-repo: boolean (default=false)
+- enable-puppetlabs-puppet5-repo: boolean (default=false)
+-%>
+<%
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || host_param_true?('force-puppet')
+-%>
+#cloud-config
+hostname: <%= @host.name %>
+fqdn: <%= @host %>
+manage_etc_hosts: true
+users: {}
+<% if puppet_enabled %>
+runcmd:
+- |
+<% if host_param_true?('enable-puppetlabs-pc1-repo') || host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<%= snippet 'puppetlabs_repo' %>
+<% end -%>
+<%= indent(2) { snippet('puppet_setup', :variables => { :full_puppet_run => true }) } %>
+<% end -%>
+
+phone_home:
+  url: <%= foreman_url('built') %>
+  post: []
+  tries: 10

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -143,7 +143,7 @@ $puppet_agent_args = @(
   "agent",
   "--config", "<%= etc_path %>\puppet.conf",
   "--onetime",
-  <%= host_param_true?('run-puppet-in-installer') ? '' : '"--tags no_such_tag",' %>
+  <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '"--tags no_such_tag",' %>
   <%= @host.puppetmaster.blank? ? '' : "\"--server #{@host.puppetmaster}\"," %>
   "--no-daemonize"
 )
@@ -151,7 +151,7 @@ Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -N
 <% else -%>
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') ? '' : '--tags no_such_tag' %> <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '--tags no_such_tag' %> <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% if os_family == 'Suse' || (os_name == 'Debian' && os_major > 8) || (os_name == 'Ubuntu' && os_major >= 15) -%>
 <%= bin_path %>/puppet resource service puppet enable=true
 <% if @host.provision_method == 'image' -%>

--- a/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
@@ -1,0 +1,36 @@
+<%#
+kind: user_data
+name: UserData open-vm-tools
+model: ProvisioningTemplate
+oses:
+- CentOS
+- Fedora
+- Debian
+- Ubuntu
+-%>
+# Template for VMWare customization via open-vm-tools
+
+identity:
+  LinuxPrep:
+    domain: <%= @host.domain %>
+    hostName: <%= @host.shortname %>
+    hwClockUTC: true
+    timeZone: <%= host_param('time-zone') || 'UTC' %>
+
+globalIPSettings:
+  dnsSuffixList: [<%= @host.domain %>]
+  <%- @host.interfaces.each do |interface| -%>
+  <%- next unless interface.subnet -%>
+  dnsServerList: [<%= interface.subnet.dns_servers.join(', ') %>]
+  <%- end -%>
+
+nicSettingMap:
+<%- @host.interfaces.each do |interface| -%>
+<%- next unless interface.subnet -%>
+  - adapter:
+      dnsDomain: <%= interface.domain %>
+      dnsServerList: [<%= interface.subnet.dns_servers.join(', ') %>]
+      gateway: [<%= interface.subnet.gateway %>]
+      ip: <%= interface.ip %>
+      subnetMask: <%= interface.subnet.mask %>
+<%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -488,6 +488,9 @@ Foreman::Application.routes.draw do
   # get for all unattended scripts
   get 'unattended/(:kind/(:id(:format)))', :controller => 'unattended', :action => 'host_template', :format => 'text'
 
+  get 'userdata/meta-data', controller: 'userdata', action: 'metadata', format: 'text'
+  get 'userdata/user-data', controller: 'userdata', action: 'userdata', format: 'text'
+
   resources :tasks, :only => [:show]
 
   resources :locations, :except => [:show] do

--- a/test/controllers/userdata_controller_test.rb
+++ b/test/controllers/userdata_controller_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class UserdataControllerTest < ActionController::TestCase
+  context '#user-data' do
+    let(:organization) { FactoryBot.create(:organization) }
+    let(:tax_location) { FactoryBot.create(:location) }
+    let(:user_data_content) { 'template content user_data' }
+    let(:cloud_init_content) { 'template content cloud-init' }
+    let(:user_data_template_kind) { FactoryBot.create(:template_kind, name: 'user_data') }
+    let(:cloud_init_template_kind) { FactoryBot.create(:template_kind, name: 'cloud-init') }
+    let(:user_data_template) do
+      FactoryBot.create(
+        :provisioning_template,
+        template_kind: user_data_template_kind,
+        template: user_data_content,
+        locations: [tax_location],
+        organizations: [organization]
+      )
+    end
+    let(:cloud_init_template) do
+      FactoryBot.create(
+        :provisioning_template,
+        template_kind: cloud_init_template_kind,
+        template: cloud_init_content,
+        locations: [tax_location],
+        organizations: [organization]
+      )
+    end
+    let(:os) do
+      FactoryBot.create(
+        :operatingsystem,
+        :with_associations,
+        family: 'Redhat',
+        provisioning_templates: [
+          user_data_template,
+          cloud_init_template
+        ]
+      )
+    end
+    let(:host) do
+      FactoryBot.create(
+        :host,
+        :managed,
+        operatingsystem: os,
+        organization: organization,
+        location: tax_location
+      )
+    end
+
+    setup do
+      FactoryBot.create(
+        :os_default_template,
+        template_kind: user_data_template_kind,
+        provisioning_template: user_data_template,
+        operatingsystem: os
+      )
+      @request.env['REMOTE_ADDR'] = host.ip
+    end
+
+    context 'with user_data template' do
+      test 'should get rendered userdata template' do
+        get :userdata
+        assert_response :success
+        assert_equal user_data_content, @response.body
+      end
+
+      context 'with unknown ip address' do
+        test 'should display an error' do
+          @request.env['REMOTE_ADDR'] = '198.51.100.1'
+          get :userdata
+          assert_response :not_found
+          assert_includes @response.body, 'Could not find host for request 198.51.100.1'
+        end
+      end
+    end
+
+    context 'with cloud-init template' do
+      setup do
+        FactoryBot.create(
+          :os_default_template,
+          :template_kind => cloud_init_template_kind,
+          :provisioning_template => cloud_init_template,
+          :operatingsystem => os
+        )
+      end
+
+      test 'should get rendered cloud-init template' do
+        get :userdata
+        assert_response :success
+        assert_equal cloud_init_content, @response.body
+      end
+    end
+  end
+
+  context '#metadata' do
+    let(:host) { FactoryBot.create(:host, :managed) }
+    setup do
+      @request.env['REMOTE_ADDR'] = host.ip
+    end
+
+    test 'should get metadata of a host' do
+      get :metadata
+      assert_response :success
+      response = @response.body
+      parsed = YAML.safe_load(response)
+      assert_equal host.mac, parsed['mac']
+      assert_equal host.hostname, parsed['hostname']
+    end
+  end
+end

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -2,6 +2,7 @@
 
 files:
   - provision/alterator_default.erb
+  - cloud_init/cloud_init_default.erb
   - PXELinux/pxelinux_global_default.erb
   - PXEGrub/pxegrub_global_default.erb
   - PXEGrub2/pxegrub2_global_default.erb
@@ -18,6 +19,7 @@ files:
   - provision/autoyast_sles_default.erb
   - PXELinux/autoyast_default_pxelinux.erb
   - user_data/autoyast_default_user_data.erb
+  - user_data/userdata_open_vm_tools.erb
   - provision/coreos_provision.erb
   - PXELinux/coreos_pxelinux.erb
   - finish/freebsd_(mfsbsd)_finish.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
@@ -1,0 +1,10 @@
+#cloud-config
+hostname: snapshothost
+fqdn: snapshothost
+manage_etc_hosts: true
+users: {}
+
+phone_home:
+  url: http://foreman.some.host.fqdn/unattended/built
+  post: []
+  tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud_init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud_init/CloudInit default.snap.txt
@@ -1,0 +1,10 @@
+#cloud-config
+hostname: snapshothost
+fqdn: snapshothost
+manage_etc_hosts: true
+users: {}
+
+phone_home:
+  url: http://foreman.some.host.fqdn/unattended/built
+  post: []
+  tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData open-vm-tools.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData open-vm-tools.snap.txt
@@ -1,0 +1,20 @@
+# Template for VMWare customization via open-vm-tools
+
+identity:
+  LinuxPrep:
+    domain: snapshotdomain.com
+    hostName: 
+    hwClockUTC: true
+    timeZone: UTC
+
+globalIPSettings:
+  dnsSuffixList: [snapshotdomain.com]
+  dnsServerList: []
+
+nicSettingMap:
+  - adapter:
+      dnsDomain: snapshotdomain.com
+      dnsServerList: []
+      gateway: []
+      ip: 127.0.0.1
+      subnetMask: 255.255.255.0


### PR DESCRIPTION
This ports [the foreman_userdata plug-in](https://github.com/theforeman/foreman_userdata) to core.

## Abstract

vSphere offers the functionality to clone vm from templates and customize the templates during cloning. This is very handy for changing the network settings of a newly cloned VM. Foreman fully supports this feature via a userdata template that is converted to cloud-init. The amount of things vSphere allows a user to customize are very limited, though. It's not possible to run a finish script or setup puppet with valid certificates on the new VM. This can be worked around by setting up a two step process: vSphere customization is just used to set up the network config of the host. Cloud-init is used to do the rest of the customization on first boot.

As part of this PR, Foreman should be able to serve cloud-init templates.

This leads to this workflow:
1. An administrator creates a vSphere VM template and makes sure the cloud-init application is installed in the template VM as described below in the client setup section.
2. Foreman creates a new cloned VM in vSphere and passes the userdata template (UserData open-vm-tools) to vSphere if the template is properly assigned to the host.
3. vSphere changes the network settings of the new host as defined in the userdata template and boots the new VM.
4. The VM runs cloud-init and asks Foreman for the cloud-init template (CloudInit default) if the template has been properly assinged to the host. Your VM needs network access to Foreman on ports `tcp/80` and `tcp/443`. Cloud-init then runs the template and executes the defined actions.
5. Cloud-init signals Foreman that the host has been built successfully.

## Client setup

On RHEL7 using cloud-init from EPEL:

```
yum install cloud-init -y

cat << EOF > /etc/cloud/cloud.cfg.d/10_foreman.cfg
datasource_list: [NoCloud]
datasource:
  NoCloud:
    seedfrom: http://foreman.example.com/userdata/
EOF
```

## Client debug

```
# Purge all cloud-init data
rm -rf /var/lib/cloud/*

# Run in foreground with debug mode enabled
/usr/bin/cloud-init -d init
```

## Development

To test this plugin manually during development, you can request a template for a specific host by spoofing the host's IP address via a request header.

```
curl -D - -H 'X-FORWARDED-FOR: 192.168.1.1' http://localhost:3000/userdata/user-data
```

## TODOs

* [x] Wait for #6009 and dry up the code with unattended controller
* [x] Make sure this works with smart-proxy's templates module (https://github.com/theforeman/smart-proxy/pull/606)
* [x] open a PR at community-templates to add the templates there (https://github.com/theforeman/community-templates/pull/514)
* [x] Add a helper to the subnet module that returns a list of DNS servers (#6541)
* [ ] Document this behavior in the Foreman manual (after merge)

cc: @lzap, @sean797 