### PR TITLE
Fixes #24886 - fixed audit in seeds test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -160,3 +160,11 @@ def restore_plugins
   @klass.clear
   @klass.instance_variable_set('@registered_plugins', @plugins_backup)
 end
+
+def with_auditing(klass)
+  auditing_was_enabled = klass.auditing_enabled
+  klass.enable_auditing
+  yield
+ensure
+  klass.disable_auditing unless auditing_was_enabled
+end


### PR DESCRIPTION
For some reason, audit was disabled randomly for all model classes. This
has to do with how Audited gem is loaded by bundler perhaps, not sure.
This patch enables it explicitly.

It also makes seeds test faster by only seeding minimum files required
for individual tests.