### PR TITLE
Fixes #24234 - Don't set taxonomies on audit for untaxable resources

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -29,6 +29,10 @@ module AuditExtensions
     def ensure_taxonomies_not_escalated
       true
     end
+
+    # Audits should never execute what Taxonomix#set_current_taxonomy does
+    def set_current_taxonomy
+    end
   end
 
   private

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -50,6 +50,15 @@ class AuditExtensionsTest < ActiveSupport::TestCase
       assert_equal [@org.id], audit.organization_ids
     end
 
+    test 'sets no current taxonomies for audits on none-taxable resources (like Architecture)' do
+      Taxonomy.as_taxonomy(@org, @loc) do
+        arch = FactoryBot.create(:architecture, :with_auditing)
+        audit = arch.audits.last
+        assert_not audit.location_ids.include? @loc
+        assert_not audit.organization_ids.include? @org
+      end
+    end
+
     test 'records on update' do
       domain = FactoryBot.create(:domain, :with_auditing, :locations => [], :organizations => [])
       audit = domain.audits.last


### PR DESCRIPTION
When a resource is not taxable, related audits should not have a location or organization set and have the audit visible under all taxonomies.