### PR TITLE
Fixes #24871 - Serve intermediate iPXE script

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -62,6 +62,7 @@ class Setting::Provisioning < Setting
       self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
       self.set('default_pxe_item_global', N_("Default PXE menu item in global template - 'local', 'discovery' or custom, use blank for template default"), nil, N_("Default PXE global template entry")),
       self.set('default_pxe_item_local', N_("Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"), nil, N_("Default PXE local template entry")),
+      self.set('intermediate_ipxe_script', N_('Intermediate iPXE script for unattended installations'), 'iPXE intermediate script', N_('iPXE intermediate script'), nil, { :collection => Proc.new { Hash[ProvisioningTemplate.unscoped.of_kind(:iPXE).map { |tmpl| [tmpl.name, tmpl.name] }] } }),
       self.set(
         'destroy_vm_on_host_delete',
         N_("Destroy associated VM on host delete. When enabled, VMs linked to Hosts will be deleted on Compute Resource, meaning they can be re-associated or imported back to Foreman again. This does not automatically power off the VM"),

--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_intermediate_script.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_intermediate_script.erb
@@ -1,0 +1,22 @@
+<%#
+kind: iPXE
+model: ProvisioningTemplate
+name: iPXE intermediate script
+snippet: false
+-%>
+#!ipxe
+# Intermediate iPXE script to report MAC address to Foreman
+
+<% (0..32).each do |i| -%>
+:net<%= i %>
+isset ${net<%= i -%>/mac} || goto no_nic
+dhcp net<%= i -%> || goto net<%= i + 1 %>
+chain <%= foreman_url('iPXE') %>?mac=${net<%= i -%>/mac} || goto net<%= i + 1 %>
+
+<% end %>
+exit 0
+
+:no_nic
+echo Failed to chainload from any network interface
+sleep 30
+exit 1

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -700,5 +700,27 @@ class UnattendedControllerTest < ActionController::TestCase
         assert_includes @response.body, 'Test build'
       end
     end
+
+    context 'with a host in bootstrap mode' do
+      test 'should render an ipxe error message' do
+        get :host_template, params: { kind: 'iPXE', bootstrap: 1 }, session: set_session_user
+        assert_response :not_found
+        assert_includes @response.body, 'iPXE intermediate'
+      end
+
+      test 'should render an intermediate template' do
+        FactoryBot.create(
+          :provisioning_template,
+          template_kind: ipxe_kind,
+          name: Setting[:intermediate_ipxe_script],
+          template: "#!ipxe\necho Test intermediate\nexit"
+        )
+
+        get :host_template, params: { kind: 'iPXE', bootstrap: 1 }, session: set_session_user
+
+        assert_response :success
+        assert_include @response.body, 'Test intermediate'
+      end
+    end
   end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -389,3 +389,8 @@ attribute82:
   category: Setting::Provisioning
   default: true
   description: 'Destroy associated VM on host delete. When enabled, VMs linked to Hosts will be deleted on Compute Resource, meaning they can be re-associated or imported back to Foreman again. This does not automatically power off the VM'
+attribute83:
+  name: intermediate_ipxe_script
+  category: Setting::Provisioning
+  default: nil
+  description: 'Intermidiate iPXE script'

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -46,6 +46,7 @@ files:
   - app/views/unattended/provisioning_templates/provision/xenserver_default_answerfile.erb
   - app/views/unattended/provisioning_templates/finish/xenserver_default_finish.erb
   - app/views/unattended/provisioning_templates/PXELinux/xenserver_default_pxelinux.erb
+  - app/views/unattended/provisioning_templates/iPXE/ipxe_intermediate_script.erb
   - app/views/unattended/provisioning_templates/snippet/_ansible_tower_callback_script.erb
   - app/views/unattended/provisioning_templates/snippet/_ansible_tower_callback_service.erb
   - app/views/unattended/provisioning_templates/snippet/_chef_client.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE intermediate script.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE intermediate script.snap.txt
@@ -1,0 +1,175 @@
+#!ipxe
+# Intermediate iPXE script to report MAC address to Foreman
+
+:net0
+isset ${net0/mac} || goto no_nic
+dhcp net0 || goto net1
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net0/mac} || goto net1
+
+:net1
+isset ${net1/mac} || goto no_nic
+dhcp net1 || goto net2
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net1/mac} || goto net2
+
+:net2
+isset ${net2/mac} || goto no_nic
+dhcp net2 || goto net3
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net2/mac} || goto net3
+
+:net3
+isset ${net3/mac} || goto no_nic
+dhcp net3 || goto net4
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net3/mac} || goto net4
+
+:net4
+isset ${net4/mac} || goto no_nic
+dhcp net4 || goto net5
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net4/mac} || goto net5
+
+:net5
+isset ${net5/mac} || goto no_nic
+dhcp net5 || goto net6
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net5/mac} || goto net6
+
+:net6
+isset ${net6/mac} || goto no_nic
+dhcp net6 || goto net7
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net6/mac} || goto net7
+
+:net7
+isset ${net7/mac} || goto no_nic
+dhcp net7 || goto net8
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net7/mac} || goto net8
+
+:net8
+isset ${net8/mac} || goto no_nic
+dhcp net8 || goto net9
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net8/mac} || goto net9
+
+:net9
+isset ${net9/mac} || goto no_nic
+dhcp net9 || goto net10
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net9/mac} || goto net10
+
+:net10
+isset ${net10/mac} || goto no_nic
+dhcp net10 || goto net11
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net10/mac} || goto net11
+
+:net11
+isset ${net11/mac} || goto no_nic
+dhcp net11 || goto net12
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net11/mac} || goto net12
+
+:net12
+isset ${net12/mac} || goto no_nic
+dhcp net12 || goto net13
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net12/mac} || goto net13
+
+:net13
+isset ${net13/mac} || goto no_nic
+dhcp net13 || goto net14
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net13/mac} || goto net14
+
+:net14
+isset ${net14/mac} || goto no_nic
+dhcp net14 || goto net15
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net14/mac} || goto net15
+
+:net15
+isset ${net15/mac} || goto no_nic
+dhcp net15 || goto net16
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net15/mac} || goto net16
+
+:net16
+isset ${net16/mac} || goto no_nic
+dhcp net16 || goto net17
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net16/mac} || goto net17
+
+:net17
+isset ${net17/mac} || goto no_nic
+dhcp net17 || goto net18
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net17/mac} || goto net18
+
+:net18
+isset ${net18/mac} || goto no_nic
+dhcp net18 || goto net19
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net18/mac} || goto net19
+
+:net19
+isset ${net19/mac} || goto no_nic
+dhcp net19 || goto net20
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net19/mac} || goto net20
+
+:net20
+isset ${net20/mac} || goto no_nic
+dhcp net20 || goto net21
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net20/mac} || goto net21
+
+:net21
+isset ${net21/mac} || goto no_nic
+dhcp net21 || goto net22
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net21/mac} || goto net22
+
+:net22
+isset ${net22/mac} || goto no_nic
+dhcp net22 || goto net23
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net22/mac} || goto net23
+
+:net23
+isset ${net23/mac} || goto no_nic
+dhcp net23 || goto net24
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net23/mac} || goto net24
+
+:net24
+isset ${net24/mac} || goto no_nic
+dhcp net24 || goto net25
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net24/mac} || goto net25
+
+:net25
+isset ${net25/mac} || goto no_nic
+dhcp net25 || goto net26
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net25/mac} || goto net26
+
+:net26
+isset ${net26/mac} || goto no_nic
+dhcp net26 || goto net27
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net26/mac} || goto net27
+
+:net27
+isset ${net27/mac} || goto no_nic
+dhcp net27 || goto net28
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net27/mac} || goto net28
+
+:net28
+isset ${net28/mac} || goto no_nic
+dhcp net28 || goto net29
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net28/mac} || goto net29
+
+:net29
+isset ${net29/mac} || goto no_nic
+dhcp net29 || goto net30
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net29/mac} || goto net30
+
+:net30
+isset ${net30/mac} || goto no_nic
+dhcp net30 || goto net31
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net30/mac} || goto net31
+
+:net31
+isset ${net31/mac} || goto no_nic
+dhcp net31 || goto net32
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net31/mac} || goto net32
+
+:net32
+isset ${net32/mac} || goto no_nic
+dhcp net32 || goto net33
+chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net32/mac} || goto net33
+
+
+exit 0
+
+:no_nic
+echo Failed to chainload from any network interface
+sleep 30
+exit 1


### PR DESCRIPTION
This adds a new iPXE templated adopted from the wiki on [DHCP setup - unmanaged server](https://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP/23#DHCP-setup-unmanaged-server)

The naming for the script and the settings entry description and labelling is not final and welcomes feedback!
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
