### PR TITLE
fixes #24935 - validate existence of proxy assocations

### DIFF
--- a/app/models/concerns/belongs_to_proxies.rb
+++ b/app/models/concerns/belongs_to_proxies.rb
@@ -17,7 +17,7 @@ module BelongsToProxies
     def register_smart_proxy(name, options)
       self.registered_smart_proxies = registered_smart_proxies.merge(name => options)
       belongs_to name, :class_name => 'SmartProxy'
-      validates name, :proxy_features => { :feature => options[:feature] }
+      validates name, :proxy_features => { :feature => options[:feature], :required => options[:required] }
     end
 
     def register_smart_proxies_from_plugins

--- a/app/validators/proxy_features_validator.rb
+++ b/app/validators/proxy_features_validator.rb
@@ -5,6 +5,10 @@ class ProxyFeaturesValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
+    if !value && @options[:required]
+      record.errors.add("#{attribute}_id", _('was not found'))
+    end
+
     if value && !value.has_feature?(@options[:feature])
       if @options[:message].nil?
         message = _('does not have the %s feature') % @options[:feature]

--- a/test/controllers/api/v2/realms_controller_test.rb
+++ b/test/controllers/api/v2/realms_controller_test.rb
@@ -19,6 +19,11 @@ class Api::V2::RealmsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
+  test "should not create realm with no proxy" do
+    post :create, params: { :realm => { :name => 'realm.net', :realm_proxy_id => 0, :realm_type => 'FreeIPA' }}
+    assert_response :unprocessable_entity
+  end
+
   test "should create valid realm" do
     post :create, params: { :realm => { :name => "realm.net", :realm_proxy_id => smart_proxies(:realm).to_param, :realm_type => "FreeIPA" } }
     assert_response :created


### PR DESCRIPTION
You can set invalid proxy ID's, which ends up hitting database constraints, but most of the belongs_to_proxy associations have a `:required` option that's ignored.

For example:

```
$ hammer -u admin -p changeme realm create --name Potato --realm-proxy-id '941' --realm-type FreeIPA
Could not create the realm:
  PG::ForeignKeyViolation: ERROR:  insert or update on table "realms" violates foreign key constraint "realms_realm_proxy_id_fk" 
  DETAIL:  Key (realm_proxy_id)=(941) is not present in table "smart_proxies".
  : INSERT INTO "realms" ("name", "realm_type", "realm_proxy_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id" 
```

Whereas it should say something like this:

```
$ hammer -u admin -p changeme realm create --name Potato --realm-proxy-id '941' --realm-type FreeIPA
Could not create the realm:
  Realm proxy was not found
```
