### PR TITLE
Fixes #24944 - removes LC_ALL from debug script [skip ci]

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -1,7 +1,6 @@
 #!/bin/bash
 # vim:sw=2:ts=2:et
 
-export LC_ALL=C
 export SCLNAME=tfm
 
 usage() {


### PR DESCRIPTION
Honestly I don't remember why I added it, it can break things in UTF-8 these days. This is a left over I have in my head from the pre-UTF8 era.