### PR TITLE
Fixes #24940,#24951 - hostgroup does not fill for non-managed host

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -607,7 +607,7 @@ class HostsController < ApplicationController
     @hostgroup = Hostgroup.find(params[:host][:hostgroup_id]) if params[:host][:hostgroup_id].to_i > 0
     return head(:not_found) unless @hostgroup
     refresh_host
-    @host.attributes = host.apply_inherited_attributes(host_params) unless @host.new_record?
+    @host.attributes = @host.apply_inherited_attributes(host_params) unless @host.new_record?
 
     @host.set_hostgroup_defaults true
     @host.set_compute_attributes unless params[:host][:compute_profile_id]
@@ -680,7 +680,7 @@ class HostsController < ApplicationController
   define_action_permission ['multiple_destroy', 'submit_multiple_destroy'], :destroy
 
   def refresh_host
-    @host = Host::Base.authorized(:view_hosts, Host).find_by_id(params.delete(:host_id))
+    @host = Host::Base.authorized(:view_hosts, Host).find_by_id(params[:host].delete(:id))
     @host ||= Host.new(host_params)
 
     unless @host.is_a?(Host::Managed)

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1550,6 +1550,21 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
+  test '#process_hostgroup such that it autofils values for an existing host' do
+    group1 = FactoryBot.create(:hostgroup, :compute_profile => compute_profiles(:two))
+    host = FactoryBot.create(:host, :type => "Host::Base", :hostgroup => group1)
+    # remove unneeded expectation to :queue_compute
+    host.unstub(:queue_compute)
+    host.hostgroup = group1
+
+    attrs = host_attributes(host)
+    attrs["id"] = host.id
+
+    put :process_hostgroup, params: { :host => attrs }, session: set_session_user, xhr: true
+    assert_response :success
+    assert_template :partial => '_form'
+  end
+
   test '#process_hostgroup works on Host subclasses' do
     class Host::Test < Host::Base; end
     user = FactoryBot.create(:user, :with_mail, :admin => false)


### PR DESCRIPTION
Apparently, while provisioning a discovered host, existing host must be fetched and used to create host rather a new host was being created, therefore we were getting 404.

When we try to provision a discovered host, the hash sent has the required param in `params[:host][:id]` and there exists no params key as `host_id`. 

Another way to do this would be to add a line like below in disocvery(which IMO looks not so nice):
`params[:host_id] = params[:host][:id]`.

@lzap can you check this one out? thanks.
