### PR TITLE
Fixes #24232 - Return taxed and untaxed audits in list

### DIFF
--- a/app/controllers/api/v2/audits_controller.rb
+++ b/app/controllers/api/v2/audits_controller.rb
@@ -17,6 +17,10 @@ module Api
 
       def show
       end
+
+      def resource_base(*args)
+        super(*args).taxed_and_untaxed
+      end
     end
   end
 end

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,7 +4,7 @@ class AuditsController < ApplicationController
   before_action :setup_search_options, :only => :index
 
   def index
-    @audits = resource_base_search_and_page.with_taxonomy_scope.preload(:user)
+    @audits = resource_base_search_and_page.preload(:user)
     @host = resource_finder(Host.authorized(:view_hosts), params[:host_id]) if params[:host_id]
   end
 
@@ -14,6 +14,10 @@ class AuditsController < ApplicationController
   end
 
   private
+
+  def resource_base(*args)
+    super(*args).taxed_and_untaxed
+  end
 
   def controller_permission
     'audit_logs'

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -91,7 +91,7 @@ module Authorizable
     end
 
     def allows_taxonomy_filtering?(taxonomy)
-      scoped_search_definition.fields.has_key?(taxonomy)
+      scoped_search_definition&.fields&.has_key?(taxonomy)
     end
 
     def allows_organization_filtering?

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -128,11 +128,17 @@ class Authorizer
   #   for normal user we allow user taxonomies only
   def allowed_taxonomies(resource_class, type)
     taxonomy_ids = []
-    if resource_class.respond_to?("used_#{type}_ids")
-      taxonomy_ids = resource_class.send("used_#{type}_ids")
-      if taxonomy_ids.empty? && !user.try(:admin?)
-        taxonomy_ids = user.try("#{type}_ids")
-      end
+    if resource_class&.allows_taxonomy_filtering?("#{type}_id") &&
+       resource_class.respond_to?("used_#{type}_ids")
+      taxonomy_ids = used_taxonomy_ids_for(resource_class, type)
+    end
+    taxonomy_ids
+  end
+
+  def used_taxonomy_ids_for(resource_class, type)
+    taxonomy_ids = resource_class.send("used_#{type}_ids")
+    if taxonomy_ids.empty? && !user.try(:admin?)
+      taxonomy_ids = user.try("#{type}_ids")
     end
     taxonomy_ids
   end

--- a/db/migrate/20181001141138_ignore_taxonomies_for_audit_filters.rb
+++ b/db/migrate/20181001141138_ignore_taxonomies_for_audit_filters.rb
@@ -1,0 +1,15 @@
+class IgnoreTaxonomiesForAuditFilters < ActiveRecord::Migration[5.2]
+  def up
+    unless (permission = Permission.find_by_name('view_audit_logs'))
+      permission.filters.uniq.each do |filter|
+        next if filter.role.locked?
+
+        filter.organizations = []
+        filter.locations = []
+        filter.override = false
+        filter.taxonomy_search = nil
+        filter.save!
+      end
+    end
+  end
+end

--- a/test/controllers/audits_controller_test.rb
+++ b/test/controllers/audits_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class AuditsControllerTest < ActionController::TestCase
+  setup do
+    @factory_options = [:auditable_type => 'Architecture']
+  end
+
   basic_pagination_per_page_test
   basic_pagination_rendered_test
 
@@ -16,7 +20,7 @@ class AuditsControllerTest < ActionController::TestCase
   end
 
   def test_show_diff
-    audit = FactoryBot.create(:audit, :with_diff)
+    audit = FactoryBot.create(:audit, :with_diff, *@factory_options)
     get :show, params: { :id => audit.id }, session: set_session_user
     assert_response :success
     assert_template 'show'

--- a/test/controllers/shared/basic_rest_response_test.rb
+++ b/test/controllers/shared/basic_rest_response_test.rb
@@ -88,7 +88,7 @@ module BasicRestResponseTest
       context 'GET #index' do
         setup do
           @old = Setting[:entries_per_page]
-          FactoryBot.create(get_factory_name) if @controller.resource_class.count.zero?
+          FactoryBot.create(get_factory_name, *@factory_options) if @controller.resource_class.count.zero?
           Setting[:entries_per_page] = @controller.resource_class.count
         end
 

--- a/test/integration/audit_js_test.rb
+++ b/test/integration/audit_js_test.rb
@@ -5,7 +5,7 @@ class AuditJSTest < IntegrationTestWithJavascript
   # AuditJSTest.test_0001_show audit with diff
 
   test "show audit with diff" do
-    audit = FactoryBot.create(:audit, :with_diff)
+    audit = FactoryBot.create(:audit, :with_diff, :auditable_type => 'Architecture')
     visit audit_path(audit)
     assert has_content?('-old')
     assert has_content?('+new')


### PR DESCRIPTION
This adds two new scopes, one `untaxed` and a `taxed_and_untaxed` which combines the first with the `with_taxonomy_scope` scope to also have audits of resources that have no taxonomy included, when a Location or Organization is currently set.
