### PR TITLE
Fixes #24958 - allow sourcemaps in production

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -160,13 +160,14 @@ module.exports = env => {
         uglifyOptions: {
           compress: { warnings: false },
         },
-        sourceMap: false
+        sourceMap: true
       }),
       new SimpleNamedModulesPlugin(),
       new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.optimize.OccurrenceOrderPlugin(),
       new CompressionPlugin()
     );
+    config.devtool = 'source-map';
   } else {
     config.plugins.push(
       new webpack.HotModuleReplacementPlugin() // Enable HMR


### PR DESCRIPTION
Turns on generating sourcemaps into a separate .map files for production webpack builds to enable debugging js issues on production installations.