### PR TITLE
Fixes #24957 - correctly filter taxonomies in API

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -39,7 +39,7 @@ module Api::V2::TaxonomiesController
   api :GET, '/:resource_id', N_('List all :resource_id')
   param_group :search_and_pagination, ::Api::V2::BaseController
   def index
-    taxonomy_scope = if @nested_obj
+    taxonomy_scope = if @nested_obj.respond_to?("#{taxonomy_single}_ids")
                        taxonomy_class.where(:id => @nested_obj.send("#{taxonomy_single}_ids"))
                      else
                        taxonomy_class


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->

cc @amitkarsale as you started to look at the same issue, other reviewers are also appreciated :-)

The issue is that on e.g. organizations index API endpoint, we detect organizations being nested if `organization_id` is specified. This parameter is commonly sent if hammer has set default organization. The `@nested_obj` there was there for nesting under location. The same obviously happens the other way around, on locations index endpoint.