### PR TITLE
Fixes #24961 - all_params permission check in API fixed

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -43,7 +43,7 @@ end
 
 if @parameters
   node do |host|
-    { :parameters => partial("api/v2/parameters/index", :object => host.host_parameters.authorized) }
+    { :parameters => partial("api/v2/parameters/index", :object => host.host_parameters.authorized(:view_params)) }
   end
 end
 


### PR DESCRIPTION
This was probably copy and paste error, in model context the auth stack
uses `self` when there is no permission passed in to detect it, but in
RABL this is not available. Therefore the API had empty array there.