### PR TITLE
Fixes #25005 - hosts with no report link on widget

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -138,11 +138,11 @@ module DashboardHelper
     end
   end
 
-  def search_filter_with_origin(filter, origin, within_interval = false)
+  def search_filter_with_origin(filter, origin, within_interval = false, ignore_interval = false)
     interval_setting = report_origin_interval_setting(origin)
     additional_filters = []
     additional_filters << "origin = #{origin}" if origin
-    additional_filters << "last_report #{within_interval ? '<' : '>'} \"#{interval_setting} minutes ago\"" if out_of_sync_enabled?(origin)
+    additional_filters << "last_report #{within_interval ? '<' : '>'} \"#{interval_setting} minutes ago\"" if out_of_sync_enabled?(origin) && !ignore_interval
     (additional_filters + [filter]).join(' and ')
   end
 

--- a/app/views/dashboard/_status_links.html.erb
+++ b/app/views/dashboard/_status_links.html.erb
@@ -48,7 +48,9 @@
 <%= searchable_links _('Hosts with no reports'),
                      search_filter_with_origin(
                        "not has last_report and status.enabled = true",
-                       origin
+                       origin,
+                       true,
+                       true
                      ),
                      :reports_missing
 %>


### PR DESCRIPTION
Steps to Reproduce:
1.Create some hosts 
2.Goto Dashboard 
3.Look at "Host Configuration Status for all" component => "hosts with no reports", that should show a number > 0 of not reported hosts
4.Click on "hosts with no reports"

Actual results:
No hosts listed

Expected results:
The same number of hosts indicated in the dashboard "hosts with no reports"

Additional info:
1- The query associated with "hosts with no reports" should be wrong, now the query is as following

'last_report > "30 minutes ago" and not has last_report and status.enabled = true'

should be

'not has last_report and status.enabled = true'