### PR TITLE
fixes #25007 - fix medium providers for plugins

### DIFF
--- a/app/registries/foreman/plugin/medium_providers_registry.rb
+++ b/app/registries/foreman/plugin/medium_providers_registry.rb
@@ -19,6 +19,10 @@ module Foreman
         provider
       end
 
+      def unregister(provider)
+        @providers.delete(provider.to_s)
+      end
+
       # Find a provider that can provide a URI for a given entity.
       def find_provider(entity)
         raise Foreman::Exception.new('Must supply an entity to find a medium provider') unless entity
@@ -27,7 +31,7 @@ module Foreman
         valid_providers = provider_instances.select { |provider| provider.valid? }
         if valid_providers.count > 1
           logger.error(
-            _('Found more than one provider for %{entity}. Valid providers: %{providers}') %
+            'Found more than one provider for %{entity}. Valid providers: %{providers}' %
             {
               entity: entity,
               providers: providers.map { |provider| provider.class.friendly_name }
@@ -36,7 +40,7 @@ module Foreman
 
         unless valid_providers.present?
           logger.error(
-            _('Could not find a provider for %{entity}. Providers returned %{errors}') %
+            'Could not find a provider for %{entity}. Providers returned %{errors}' %
             {
               entity: entity,
               errors: provider_instances.map { |provider| [provider.class.friendly_name, provider.errors] }.to_h

--- a/app/registries/foreman/plugin/medium_providers_registry.rb
+++ b/app/registries/foreman/plugin/medium_providers_registry.rb
@@ -5,6 +5,7 @@ module Foreman
     # This is used by provisioning framework to supply download location for various files
     # used during the provisioning.
     class MediumProvidersRegistry
+      delegate :logger, to: Rails
       attr_reader :providers
 
       def initialize
@@ -25,8 +26,8 @@ module Foreman
         provider_instances = providers.map { |provider| provider.constantize.new(entity) }
         valid_providers = provider_instances.select { |provider| provider.valid? }
         if valid_providers.count > 1
-          raise Foreman::Exception.new(
-            'Found more than one provider for %{entity}. Valid providers: %{providers}',
+          logger.error(
+            _('Found more than one provider for %{entity}. Valid providers: %{providers}') %
             {
               entity: entity,
               providers: providers.map { |provider| provider.class.friendly_name }
@@ -34,8 +35,8 @@ module Foreman
         end
 
         unless valid_providers.present?
-          raise Foreman::Exception.new(
-            'Could not find a provider for %{entity}. Providers returned %{errors}',
+          logger.error(
+            _('Could not find a provider for %{entity}. Providers returned %{errors}') %
             {
               entity: entity,
               errors: provider_instances.map { |provider| [provider.class.friendly_name, provider.errors] }.to_h

--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -2,13 +2,14 @@ module MediumProviders
   class Default < Provider
     def validate
       errors = []
-      os = entity.operatingsystem
-      medium = entity.medium
-      arch = entity.architecture
+      os = entity.try(:operatingsystem)
+      medium = entity.try(:medium)
+      arch = entity.try(:architecture)
 
+      errors << N_("Operating system was not set for host '%{host}'") % { :host => entity } if os.nil?
       errors << N_("%{os} medium was not set for host '%{host}'") % { :host => entity, :os => os } if medium.nil?
-      errors << N_("Invalid medium '%{medium}' for '%{os}'") % { :medium => medium, :os => os } unless os.media.include?(medium)
-      errors << N_("Invalid architecture '%{arch}' for '%{os}'") % { :arch => arch, :os => os } unless os.architectures.include?(arch)
+      errors << N_("Invalid medium '%{medium}' for '%{os}'") % { :medium => medium, :os => os } unless os&.media&.include?(medium)
+      errors << N_("Invalid architecture '%{arch}' for '%{os}'") % { :arch => arch, :os => os } unless os&.architectures&.include?(arch)
       errors
     end
 
@@ -28,6 +29,10 @@ module MediumProviders
         full_uniq = super
         "#{entity.medium.name.parameterize}-#{full_uniq[1..10]}"
       end
+    end
+
+    def valid?
+      entity.respond_to?(:medium) && errors.empty?
     end
 
     private

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -25,7 +25,7 @@ module Foreman
           end
 
           def load_variables_base
-            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if host.respond_to?(:medium) && medium
+            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if host
             if operatingsystem&.respond_to?(:pxe_type)
               send "#{operatingsystem.pxe_type}_attributes"
               pxe_config
@@ -73,7 +73,7 @@ module Foreman
             @dynamic   = !!(disk_layout_source_content =~ /^#Dynamic/) if disk_layout_source_content
             @arch      = architecture_name
             @osver     = major.try(:to_i)
-            @mediapath = mediumpath(@medium_provider) if medium
+            @mediapath = mediumpath(@medium_provider) if @medium_provider
             @repos     = repos(host)
           end
 
@@ -86,16 +86,16 @@ module Foreman
 
           def yast_attributes
             @dynamic   = !!(disk_layout_source_content =~ /^#Dynamic/) if disk_layout_source_content
-            @mediapath = mediumpath(@medium_provider) if medium
+            @mediapath = mediumpath(@medium_provider) if @medium_provider
           end
 
           def xenserver_attributes
-            @mediapath = mediumpath(@medium_provider) if medium
+            @mediapath = mediumpath(@medium_provider) if @medium_provider
             @xen = xen(arch)
           end
 
           def pxe_config
-            return unless medium
+            return unless @medium_provider
             @kernel = kernel(@medium_provider)
             @initrd = initrd(@medium_provider)
             @kernel_uri, @initrd_uri = operatingsystem.boot_files_uri(@medium_provider)

--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class DefaultMediumProviderTest < ActiveSupport::TestCase
+  test 'returns default provider for managed host' do
+    host = FactoryBot.create(:host, :managed)
+    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+    assert_instance_of MediumProviders::Default, medium_provider
+  end
+
   test 'interpolated $version does not include dots if only major is specified' do
     operatingsystem = FactoryBot.build_stubbed(:operatingsystem, :name => 'foo', :major => '4')
     architecture = FactoryBot.build_stubbed(:architecture, :name => 'x64')

--- a/test/unit/medium_providers/plugin_test.rb
+++ b/test/unit/medium_providers/plugin_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class PluginMediumProviderTest < ActiveSupport::TestCase
+  class PluginMediumProvider < MediumProviders::Provider
+    def medium_uri(path = "", &block)
+      '/medium'
+    end
+
+    def valid?
+      true
+    end
+  end
+
+  setup do
+    Foreman::Plugin.medium_providers.register(PluginMediumProvider)
+  end
+
+  teardown do
+    Foreman::Plugin.medium_providers.unregister(PluginMediumProvider)
+  end
+
+  test 'plugin can provide media without medium set' do
+    host = FactoryBot.create(:host, :with_operatingsystem, medium: nil)
+    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+    assert_nil host.medium
+    assert_instance_of PluginMediumProvider, medium_provider
+  end
+end


### PR DESCRIPTION
Katello doesn't have medium set, since the medium is being provided
through the medium provider.  This makes @medium_provider not load
and result in empty `@kernel` and `@initrd` in pxe templates.

This changes the approach so that the default medium provider is the one that checks if medium is blank.  Also adds tests.