### PR TITLE
Refs #24940 - refresh hosts now loads puppet tab

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -680,7 +680,7 @@ class HostsController < ApplicationController
   define_action_permission ['multiple_destroy', 'submit_multiple_destroy'], :destroy
 
   def refresh_host
-    @host = Host::Base.authorized(:view_hosts, Host).find_by_id(params[:host].delete(:id))
+    @host = Host::Base.authorized(:view_hosts, Host).find_by_id(params[:host_id] || params.dig(:host, :id))
     @host ||= Host.new(host_params)
 
     unless @host.is_a?(Host::Managed)


### PR DESCRIPTION
I fail to find a better way, but we broke integration tests with this
one: https://github.com/theforeman/foreman/pull/6072

This is an attempt to fix this. Let me describe the issue - our JS code
uses data-type-changed field to detect if host type was changed to catch
special case when hostgroup changed parent (host_edit.js function
hostgroup_changed).

At the same time, discovery reuses edit host form and passes in an
instance of discovered host converted to managed host, therefore
type-changed field is set to true.

For this reason, the host id is not passed in as `host_id` but as
regular `host[:id]`. We changed this as I missed a broken test and I was
testing this on New Host form where everything works fine, this is an
issue only for Edit Host form.

This solution is not ideal, I can't figure out better.