### PR TITLE
Fixes #24870 - show a setting does not have a default value

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -445,9 +445,10 @@ module ApplicationHelper
     update_url = options[:update_url] || url_for(object)
     type       = options[:type]
     title      = options[:title]
+    placeholder = options[:placeholder]
     select_values = [true, false].include?(value) ? [_('Yes'), _('No')] : options[:select_values]
 
-    editable(object, property, {:type => type, :title => title, :value => value, :class => klass, :source => select_values, :url => update_url}.compact)
+    editable(object, property, {:type => type, :title => title, :value => value, :class => klass, :source => select_values, :url => update_url, :placeholder => placeholder}.compact)
   end
 
   def documentation_url(section = "", options = {})

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -10,8 +10,9 @@ module SettingsHelper
         {:title => setting.full_name_with_default, :select_values => self.send("#{setting.name}_collection") })
     end
 
-    return edit_textarea(setting, :value, {:title => setting.full_name_with_default, :helper => :show_value}) if setting.settings_type == 'array'
-    edit_textfield(setting, :value, {:title => setting.full_name_with_default, :helper => :show_value})
+    placeholder = setting.has_default? ? setting.default : "No default value was set"
+    return edit_textarea(setting, :value, {:title => setting.full_name_with_default, :helper => :show_value, :placeholder => placeholder}) if setting.settings_type == 'array'
+    edit_textfield(setting, :value, {:title => setting.full_name_with_default, :helper => :show_value, :placeholder => placeholder})
   end
 
   def show_value(setting)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -296,7 +296,21 @@ class Setting < ApplicationRecord
   # End methods for loading default settings
 
   def full_name_with_default
-    _("%{full_name} (Default: %{default})") % {full_name: _(full_name), default: default}
+    _("%{full_name} (Default: %{default})") % {full_name: _(full_name), default: has_default? ? default : "Not set" }
+  end
+
+  def has_default?
+    default_type = settings_type || default.class.to_s.downcase
+    case default_type
+    when "array", "hash", "string"
+      !default.empty?
+    when "boolean", "integer", "falseclass", "trueclass"
+      true
+    when "nilclass"
+      false
+    else
+      !default.nil?
+    end
   end
 
   private

--- a/test/helpers/settings_helper_test.rb
+++ b/test/helpers/settings_helper_test.rb
@@ -28,4 +28,32 @@ class SettingsHelperTest < ActionView::TestCase
     self.expects(:edit_select).with(setting, :value, :title => setting.full_name_with_default, :select_values => { :size => expected_hostgroup_count })
     value(setting)
   end
+
+  test "create a setting with no default of settings_type array" do
+    setting = Setting.create({:name => "name",
+      :value => "", :description => "description", :default => [], :settings_type => "array", :full_name => "full_name"})
+    self.expects(:edit_textarea).with(setting, :value, :title => setting.full_name_with_default, :helper => :show_value, :placeholder => "No default value was set")
+    value(setting)
+  end
+
+  test "create a setting with default of settings_type array" do
+    setting = Setting.create({:name => "name",
+      :value => "", :description => "description", :default => "default value", :settings_type => "array", :full_name => "full_name"})
+    self.expects(:edit_textarea).with(setting, :value, :title => setting.full_name_with_default, :helper => :show_value, :placeholder => "default value")
+    value(setting)
+  end
+
+  test "create a setting with no default of settings_type string" do
+    setting = Setting.create({:name => "name",
+      :value => "", :description => "description", :default => "", :settings_type => "string", :full_name => "full_name"})
+    self.expects(:edit_textfield).with(setting, :value, :title => setting.full_name_with_default, :helper => :show_value, :placeholder => "No default value was set")
+    value(setting)
+  end
+
+  test "create a setting with default of settings_type string" do
+    setting = Setting.create({:name => "name",
+      :value => "", :description => "description", :default => "default value", :settings_type => "string", :full_name => "full_name"})
+    self.expects(:edit_textfield).with(setting, :value, :title => setting.full_name_with_default, :helper => :show_value, :placeholder => "default value")
+    value(setting)
+  end
 end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -622,7 +622,42 @@ class SettingTest < ActiveSupport::TestCase
 
   test 'full_name_with_default without default value' do
     setting = FactoryBot.build_stubbed(:setting, :name => 'foo', :default => '', :description => 'test foo', :full_name => 'Foo Name')
-    assert_equal('Foo Name (Default: )', setting.full_name_with_default)
+    assert_equal('Foo Name (Default: Not set)', setting.full_name_with_default)
+  end
+
+  test 'has_default? returns false on empty array/string/hash' do
+    ['', [], {}].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => default_value.class.to_s.downcase, :name => 'foo', :default => default_value)
+      assert !setting.has_default?
+    end
+
+    ['h', [''], {:one => 1}].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => default_value.class.to_s.downcase, :name => 'foo', :default => default_value)
+      assert setting.has_default?
+    end
+  end
+
+  test 'has_default? returns true on setting_type boolean/integer' do
+    [0, 1, -1].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => default_value.class.to_s.downcase, :name => 'foo', :default => default_value)
+      assert setting.has_default?
+    end
+    [false, true].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => "boolean", :name => 'foo', :default => default_value)
+      assert setting.has_default?
+    end
+  end
+
+  test 'has_default? for other settings_type' do
+    ['', [], {}].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => nil, :name => 'foo', :default => default_value)
+      assert !setting.has_default?
+    end
+
+    ['h', [''], {:one => 1}].each do |default_value|
+      setting = FactoryBot.build_stubbed(:setting, :settings_type => 'somethingelse', :name => 'foo', :default => default_value)
+      assert setting.has_default?
+    end
   end
 
   test 'orders settings alphabetically' do


### PR DESCRIPTION
I have no idea how to change `Empty` to something else. Could it be that `x-editable-rails` does that?

// cc @ares 