### PR TITLE
Fixes #24900 - expiration task no longer error out

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -69,7 +69,7 @@ class Report < ApplicationRecord
   # Expire reports based on time and status
   # Defaults to expire reports older than a week regardless of the status
   # This method will IS very slow, use only from rake task.
-  def self.expire(conditions = {}, batch_size = 1000, sleep_time = 0.2)
+  def self.expire(conditions, batch_size, sleep_time)
     timerange = conditions[:timerange] || 1.week
     status = conditions[:status]
     created = (Time.now.utc - timerange).to_formatted_s(:db)

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -32,7 +32,9 @@ namespace :reports do
     conditions = {}
     conditions[:timerange] = ENV['days'].to_i.days if ENV['days']
     conditions[:status] = ENV['status'].to_i if ENV['status']
+    batch_size = 1000
     batch_size = ENV['batch_size'].to_i if ENV['batch_size']
+    sleep_time = 0.2
     sleep_time = ENV['sleep_time'].to_f if ENV['sleep_time']
 
     User.as_anonymous_admin do

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -14,7 +14,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal report_count * 2, Report.count
     assert_difference('Report.count', -1 * report_count) do
       assert_difference(['Log.count', 'Message.count', 'Source.count'], -1 * report_count * 5) do
-        Report.expire
+        Report.expire({}, 1000, 0.2)
       end
     end
   end
@@ -111,7 +111,7 @@ class ReportTest < ActiveSupport::TestCase
     test '.expire should delete only the class which calls it' do
       FactoryBot.create_list(:config_report, 5, :old_report)
       FactoryBot.create_list(:report, 5, :old_report, :type => 'TestReport')
-      TestReport.expire
+      TestReport.expire({}, 1000, 0.2)
       refute(TestReport.all.any?)
       assert(ConfigReport.all.any?)
     end


### PR DESCRIPTION
This was just bad handling of default values. To reproduce you need to
have some reports in the DB. Or just swap the sleep line with loop break
to avoid exit to see that nil exception.