### PR TITLE
Fixes #25540 - Allow disabling out of sync in widget for All

### DIFF
--- a/app/views/dashboard/_status_links.html.erb
+++ b/app/views/dashboard/_status_links.html.erb
@@ -34,7 +34,7 @@
                      :pending_hosts_enabled
 %>
 
-<% if out_of_sync_enabled?(origin) %>
+<% if @data.report[:out_of_sync_hosts] || @data.report[:out_of_sync_hosts_enabled] %>
   <%= searchable_links _('Out of sync hosts'),
                        search_filter_with_origin(
                          "status.enabled = true",

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -9,10 +9,10 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
     Setting[:outofsync_interval] = 35
   end
 
-  def assert_dashboard_link(text)
+  def assert_dashboard_link(text, widget = 'Host Configuration Status for All')
     visit_dashboard
     assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
-    within "li[data-name='Host Configuration Status for All']" do
+    within "li[data-name='#{widget}']" do
       click_link(text)
     end
     assert_current_path hosts_path, :ignore_query => true
@@ -47,7 +47,7 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
   end
 
   test "dashboard link out of sync hosts" do
-    assert_dashboard_link 'Out of sync hosts'
+    assert_dashboard_link 'Out of sync hosts', 'Host Configuration Status for Puppet'
   end
 
   context 'with origin' do


### PR DESCRIPTION
When all origins have out of sync disabled the widget for
all hosts will now discard the link too.
