### PR TITLE
Fixes #25070 - keep variables optional

### DIFF
--- a/lib/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/lib/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -4,7 +4,7 @@ module Foreman
       module Macros
         module SnippetRendering
           def snippet_if_exists(name, options = {})
-            snippet(name, { silent: true }, variables: options[:variables])
+            snippet(name, { silent: true }, variables: options[:variables] || {})
           end
 
           def snippets(file, options = {})

--- a/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/snippet_rendering_test.rb
@@ -47,4 +47,9 @@ class SnippetRenderingTest < ActiveSupport::TestCase
     Template.expects(:where).with(:name => "test", :snippet => true).returns([])
     assert_nil @scope.snippet_if_exists('test')
   end
+
+  test "should render a snippet_if_exists without variables" do
+    snippet = FactoryBot.create(:provisioning_template, :snippet, :template => "test")
+    assert_equal 'test', @scope.snippet_if_exists(snippet.name)
+  end
 end


### PR DESCRIPTION
a regression caused by template refactoring in #5683

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
