### PR TITLE
Fixes #22119 - use SHA instead of MD5 for digesting

### DIFF
--- a/config/initializers/0_fips.rb
+++ b/config/initializers/0_fips.rb
@@ -1,0 +1,5 @@
+# Configure the environment to use non-MD5 hashing algorithms, as they are
+# disabled in FIPS mode
+
+require 'digest/sha1'
+ActiveSupport::Digest.hash_digest_class = ::Digest::SHA1


### PR DESCRIPTION
MD5 is disabled in FIPS environments.




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->