### PR TITLE
Fixes #25097,#25277 - Expose resources nested in taxed resources

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -104,15 +104,6 @@ module AuditExtensions
 
       private
 
-      def has_association?(association, model = self)
-        associations = model.reflect_on_all_associations.map(&:name)
-        associations.include?(association)
-      end
-
-      def has_any_association_to?(tax_type, model)
-        [has_association?(tax_type.to_sym, model), has_association?(tax_type.to_s.pluralize.to_sym, model)].any?
-      end
-
       def has_taxonomix?(model)
         model.include?(Taxonomix)
       end

--- a/app/models/concerns/expose_associations.rb
+++ b/app/models/concerns/expose_associations.rb
@@ -1,0 +1,51 @@
+module ExposeAssociations
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_accessor :exposed_association_groups
+
+    def group_exposed_association(association_name, target_association_name)
+      self.exposed_association_groups ||= {}
+      self.exposed_association_groups[association_name] ||= []
+      self.exposed_association_groups[association_name].push(target_association_name)
+      define_exposed_association_groups_getter(association_name)
+    end
+
+    def define_exposed_association_groups_getter(association_name)
+      return if has_association?(association_name)
+      group_class = association_name.to_s.singularize.camelize.constantize
+      exposed_association_groups = self.exposed_association_groups[association_name].uniq
+      self.send(:define_method, association_name) do
+        group_ids = exposed_association_groups.flat_map do |association|
+          if self.class.has_association?(association)
+            send(association).pluck(:id) rescue [] # in some cases the association doesn't seem to be present, but appears in reflect_on_all_associations
+          end
+        end
+        group_class.where("#{group_class.table_name}.id IN (?)", (group_ids || []))
+      end
+    end
+
+    def define_association_to_target_model(target_model, through, exposed_model)
+      association_name = target_model.to_s.pluralize.underscore.to_sym
+      exposed_model = exposed_model.to_s.singularize.camelize.constantize
+      exposed_model.class_eval do
+        has_many association_name, :through => through.to_s.singularize.to_sym unless has_association?(association_name)
+      end
+    end
+
+    def expose_association(association_name, target_class = nil, options = {})
+      return if target_class.nil?
+      self_name = self.to_s
+      target_association_name = "#{self_name.pluralize.underscore}_#{association_name.to_s.pluralize.underscore}".to_sym
+      self_name = self_name.pluralize.downcase.to_sym
+      [target_class, *target_class.descendants].each do |target_model|
+        define_association_to_target_model(target_model, self_name, association_name)
+        target_model.class_eval do
+          include ExposeAssociations
+          has_many(target_association_name, options.merge(:through => self_name, :source => association_name))
+          group_exposed_association(association_name, target_association_name)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -27,6 +27,15 @@ module HasManyCommon
       self.column_names.include?(field)
     end
 
+    def has_association?(association, model = self)
+      associations = model.reflect_on_all_associations.map(&:name)
+      associations.include?(association)
+    end
+
+    def has_any_association_to?(tax_type, model = self)
+      [has_association?(tax_type.to_sym, model), has_association?(tax_type.to_s.pluralize.to_sym, model)].any?
+    end
+
     # class method in model to overwrite default attribute_name
     # Ex.
     # Class Hostgroup

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -1,6 +1,7 @@
 module Taxonomix
   extend ActiveSupport::Concern
   include DirtyAssociations
+  include ExposeAssociations
   TAXONOMY_JOIN_TABLE = :taxable_taxonomies
 
   included do
@@ -152,6 +153,10 @@ module Taxonomix
         # and the same taxable_id on taxable_taxonomy objects
         scope.where("#{self.table_name}.id IN (#{cached_ids.join(',')})")
       end
+    end
+
+    def expose_to_taxonomy(association_name)
+      expose_association(association_name, Taxonomy)
     end
   end
 

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -13,11 +13,15 @@ class Environment < ApplicationRecord
   has_many :puppetclasses, -> { distinct }, :through => :environment_classes
   has_many_hosts
   has_many :hostgroups
+  has_many :config_reports, :through => :hosts
 
   validates :name, :uniqueness => true, :presence => true, :alphanumeric => true
   has_many :trends, :as => :trendable, :class_name => "ForemanTrend"
   has_many :template_combinations, :dependent => :destroy
   has_many :provisioning_templates, :through => :template_combinations
+
+  expose_to_taxonomy :puppetclasses
+  expose_to_taxonomy :config_reports
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -22,6 +22,7 @@ class Host::Managed < Host::Base
   has_many :reports, :foreign_key => :host_id, :class_name => 'ConfigReport'
   has_one :last_report_object, -> { order("#{Report.table_name}.id DESC") }, :foreign_key => :host_id, :class_name => 'ConfigReport'
   has_many :all_reports, :foreign_key => :host_id
+  has_many :config_reports, :foreign_key => :host_id
 
   belongs_to :image
   has_many :host_statuses, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -12,6 +12,8 @@ class Report < ApplicationRecord
   has_many :sources, :through => :logs
   has_one :environment, :through => :host
   has_one :hostgroup, :through => :host
+  has_one :organization, :through => :host
+  has_one :location, :through => :host
 
   validates :host_id, :status, :presence => true
   validates :reported_at, :presence => true, :uniqueness => {:scope => [:host_id, :type]}
@@ -20,6 +22,8 @@ class Report < ApplicationRecord
     child.instance_eval do
       scoped_search :relation => :host,        :on => :name,  :complete_value => true, :rename => :host
       scoped_search :relation => :environment, :on => :name,  :complete_value => true, :rename => :environment
+      scoped_search :relation => :organization,:on => :id,    :complete_value => true, :rename => :organization
+      scoped_search :relation => :location,    :on => :id,    :complete_value => true, :rename => :location
       scoped_search :relation => :messages,    :on => :value,                          :rename => :log, :only_explicit => true
       scoped_search :relation => :sources,     :on => :value,                          :rename => :resource, :only_explicit => true
       scoped_search :relation => :hostgroup,   :on => :name,  :complete_value => true, :rename => :hostgroup

--- a/test/controllers/api/v2/config_reports_controller_test.rb
+++ b/test/controllers/api/v2/config_reports_controller_test.rb
@@ -130,6 +130,29 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
     assert !reports['results'].empty?
   end
 
+  context "with organization given" do
+    let(:config_report_org) { Organization.first }
+    let(:config_report_loc) { Location.first }
+    let(:config_report_env) do
+      FactoryBot.create(:environment, :organizations => [config_report_org], :locations => [config_report_loc])
+    end
+    let(:reporting_host) do
+      FactoryBot.create(:host, :environment => config_report_env, :location => config_report_loc, :organization => config_report_org)
+    end
+    let(:config_report) do
+      FactoryBot.create(:config_report, :host => reporting_host)
+    end
+
+    test "should get config reports in organization" do
+      config_report.save!
+      get :index, params: { :organization_id => config_report_org.id }
+      assert_response :success
+      assert_not_nil assigns(:config_reports)
+      reports = ActiveSupport::JSON.decode(@response.body)
+      assert !reports['results'].empty?
+    end
+  end
+
   test "should show individual record" do
     report = FactoryBot.create(:config_report)
     get :show, params: { :id => report.to_param }

--- a/test/controllers/api/v2/puppetclasses_controller_test.rb
+++ b/test/controllers/api/v2/puppetclasses_controller_test.rb
@@ -11,6 +11,43 @@ class Api::V2::PuppetclassesControllerTest < ActionController::TestCase
     assert puppetclasses['results'].is_a?(Hash)
   end
 
+  context 'with taxonomy given' do
+    let(:default_organization) { Organization.first }
+    let(:default_location) { Location.first }
+    let(:example_environment) do
+      FactoryBot.create(:environment, :locations => [default_location], :organizations => [default_organization])
+    end
+    let(:example_puppetclass) { FactoryBot.create(:puppetclass, :environments => [example_environment]) }
+    let(:eager_load) { [default_organization, default_location, example_environment, example_puppetclass]}
+
+    setup do
+      eager_load
+    end
+
+    test 'index should return puppetclasses only in Organization' do
+      get :index, params: { :organization_id => default_organization.id }
+      includes_example_puppetclass
+      assert_response :success
+    end
+
+    test 'index should return puppetclasses only in Organization' do
+      get :index, params: { :location_id => default_location.id }
+      includes_example_puppetclass
+      assert_response :success
+    end
+
+    test 'index should return puppetclasses only in Organization' do
+      get :index, params: { :location_id => default_location.id, :organization_id => default_organization.id }
+      includes_example_puppetclass
+      assert_response :success
+    end
+
+    def includes_example_puppetclass
+      puppetclasses = ActiveSupport::JSON.decode(@response.body)
+      assert_include puppetclasses['results'].map { |_, v| v[0]['id'] }, example_puppetclass.id
+    end
+  end
+
   test "should get index with style=list" do
     get :index, params: { :style => 'list' }
     assert_response :success

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -398,4 +398,22 @@ class TaxonomixTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe '.expose_to_taxonomy' do
+    test 'creates an association on Taxonomy for a given association' do
+      assoctiation_class = Puppetclass
+      asso_name = assoctiation_class.to_s.pluralize.to_sym
+      target_association_name = "#{@dummy.class.to_s.pluralize.underscore}_#{asso_name.to_s.pluralize.underscore}".to_sym
+
+      assoctiation_class.expects(:has_many).twice.returns(nil)
+      [Taxonomy, *Taxonomy.descendants].each do |taxonomy_model|
+        taxonomy_model.expects(:has_many)
+                      .with(target_association_name,
+                            {:through => @dummy.class.to_s.pluralize.downcase.to_sym,
+                             :source => asso_name}).returns(nil)
+      end
+
+      @dummy.class.expose_to_taxonomy(asso_name)
+    end
+  end
 end


### PR DESCRIPTION
The result of this PR should be to be able to query nested resources, like for example `puppetclasses` in `environments` that are in an `organization`, via:
 ```ruby 
Organizartion.find(ID).environments_puppetclasses
```
as well as query all `puppetclasses`, regardless of which resource they are nested in, in a certain `organisation` via: 
```ruby 
Organization.find(ID).puppetclasses
```

The initial idea for a solution is a method `expose_to_taxonomy` that allows resources like `Environment` to define associations that should be available to `Taxonomy` and establishes the association. 

This fixes issues with listing puppet classes on the API with a (default) organization or location given.

To verify the fix hammer can be used by running `hammer puppet-class list` with a default organization or location set for `hammer`. Without the PR applied this will as described in the issue raise an error, with the PR applied it will list puppet classes scoped by a given taxonomy. 
The same applies to `hammer config-report list`