### PR TITLE
Fixes #25075: fix provisioning template preview

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -142,13 +142,13 @@ class UnattendedController < ApplicationController
   end
 
   def allowed_to_install?
-    @host.build || @spoof || Setting[:access_unattended_without_build]
+    @host.build? || spoof || Setting[:access_unattended_without_build]
   end
 
   # Reset realm OTP. This is run as a before_action for provisioning templates.
   def handle_realm
     # We don't do anything if we are in spoof mode.
-    return true if @spoof
+    return true if spoof
 
     # This should terminate the before_action and the action. We return a HTTP
     # error so the installer knows something is wrong. This is tested with
@@ -203,5 +203,9 @@ class UnattendedController < ApplicationController
 
   def render_ipxe_message(message: _('An error occured.'), status: :not_found)
     render(plain: Foreman::Ipxe::MessageRenderer.new(message: message).to_s, status: status, content_type: 'text/plain')
+  end
+
+  def spoof
+    @spoof ||= @host.present? && (params.key?(:spoof) || params.key?(:hostname))
   end
 end

--- a/app/views/hosts/_templates.html.erb
+++ b/app/views/hosts/_templates.html.erb
@@ -6,18 +6,19 @@
     </tr>
   </thead>
   <tbody>
-    <% @templates.each do |tmpl| %>
-      <tr>
-        <td><%= _(tmpl.template_kind.to_s) %></td>
+    <% @templates.each do |template| %>
+      <tr id=<%= "template_#{template.id}" %>>
+        <td><%= _(template.template_kind.to_s) %></td>
         <td><%= action_buttons(display_link_if_authorized(_("Edit"),
-                                 hash_for_edit_provisioning_template_path(:id => tmpl.to_param),
-                                 :rel => "external"),
+                                                          hash_for_edit_provisioning_template_path(id: template.to_param),
+                                                          rel: "external"),
                                link_to(_("Review"),
-                                 url_for(:controller => '/unattended',
-                                          :action => 'host_template',
-                                          :kind => tmpl.template_kind.name,
-                                          :hostname => @host.name),
-                                 :rel => 'external', :"data-provisioning-template" => true)) %>
+                                       url_for(controller: '/unattended',
+                                               action: 'host_template',
+                                               kind: template.template_kind.name,
+                                               hostname: @host.name),
+                                       rel: 'external',
+                                       "data-provisioning-template": true)) %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
This fixes a bug which was introduced in https://github.com/theforeman/foreman/pull/6009 a bug that caused the review functionality to stop working.

Also the tests have been fixed so that they guard against future failures as they were previously not covering it properly.