### PR TITLE
Fixes #25124 - Add ability to indicate a host substatus

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -101,7 +101,8 @@ module HostsHelper
   # method that reformat the hostname column by adding the status icons
   def name_column(host)
     style = host_global_status_icon_class_for_host(host)
-    tooltip = host.host_statuses.select(&:relevant?).sort_by(&:type).map { |status| "#{_(status.name)}: #{_(status.to_label)}" }.join(', ')
+    displayable_statuses = host.host_statuses.select { |status| status.relevant? && !status.substatus? }
+    tooltip = displayable_statuses.sort_by(&:type).map { |status| "#{_(status.name)}: #{_(status.to_label)}" }.join(', ')
 
     content = content_tag(:span, "", {:rel => "twipsy", :class => style, :"data-original-title" => tooltip})
     content += link_to("  #{host}", host_path(host))
@@ -298,7 +299,7 @@ module HostsHelper
 
   def host_detailed_status_list(host)
     host.host_statuses.sort_by(&:type).map do |status|
-      next unless status.relevant?
+      next unless status.relevant? && !status.substatus?
       [
         _(status.name),
         content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +

--- a/app/models/host_status/global.rb
+++ b/app/models/host_status/global.rb
@@ -8,7 +8,7 @@ module HostStatus
 
     def self.build(statuses, options = {})
       relevant_statuses = statuses.select do |s|
-        s.relevant?(options)
+        s.relevant?(options) && !s.substatus?
       end
 
       max_status = relevant_statuses.map { |s| s.to_global(options) }.max

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -57,6 +57,12 @@ module HostStatus
       true
     end
 
+    # a substatus is used by some other status in order to determine its own status
+    # this type of status does not affect the global status
+    def substatus?(options = {})
+      false
+    end
+
     private
 
     def update_timestamp

--- a/test/models/host_status/global_test.rb
+++ b/test/models/host_status/global_test.rb
@@ -1,13 +1,17 @@
 require 'test_helper'
 
 class GlobalTest < ActiveSupport::TestCase
-  class StatusMock < Struct.new(:global, :relevant)
+  class StatusMock < Struct.new(:global, :relevant, :substatus)
     def relevant?(options = {})
       relevant
     end
 
     def to_global(options = {})
       global
+    end
+
+    def substatus?(options = {})
+      substatus
     end
   end
 
@@ -20,6 +24,15 @@ class GlobalTest < ActiveSupport::TestCase
   test '.build(statuses) builds new global status with highest status code' do
     global = HostStatus::Global.build([@status1, @status2, @status3])
     assert_equal HostStatus::Global::ERROR, global.status
+  end
+
+  test '.build(statuses) ignores substatus' do
+    status1 = StatusMock.new(HostStatus::Global::WARN, true)
+    status2 = StatusMock.new(HostStatus::Global::ERROR, true, true)
+
+    global = HostStatus::Global.build([status1, status2])
+
+    assert_equal HostStatus::Global::WARN, global.status
   end
 
   test '.build(statuses, :last_reports => [reports]) uses reports cache for configuration statuses' do


### PR DESCRIPTION
We are working on a feature in Katello in which we are adding 4 new statuses, and one additional 'parent' status that will look at those 4 in order to find its own status. The 4 sub-statuses on their own should not affect the global status of the host - only the parent will. This will give us a way to indicate that kind of relationship.

This change will also hide any substatus from being shown in the UI separately - but ordinary status will still be shown.

The PR for Katello which would benefit from this is https://github.com/Katello/katello/pull/7734 - but it does not yet have the parent status I've mentioned here.
