### PR TITLE
Fixes #25125 - Rename timestamps to avoid collision

### DIFF
--- a/db/migrate/20150616080016_create_core_template_input.rb
+++ b/db/migrate/20150616080016_create_core_template_input.rb
@@ -1,5 +1,8 @@
 class CreateCoreTemplateInput < ActiveRecord::Migration[4.2]
   def change
+    # This could be the case if upgrading from a previous version with REX
+    return if table_exists? :template_inputs
+
     create_table :template_inputs do |t|
       t.string :name, :null => false, :limit => 255
       t.boolean :required, :null => false, :default => false

--- a/db/migrate/20150827152731_add_options_to_core_template_input.rb
+++ b/db/migrate/20150827152731_add_options_to_core_template_input.rb
@@ -1,5 +1,6 @@
 class AddOptionsToCoreTemplateInput < ActiveRecord::Migration[4.2]
   def change
+    return if column_exists?(:template_inputs, :options)
     add_column :template_inputs, :options, :text
   end
 end

--- a/db/migrate/20160127134032_add_advanced_to_core_template_input.rb
+++ b/db/migrate/20160127134032_add_advanced_to_core_template_input.rb
@@ -1,5 +1,6 @@
 class AddAdvancedToCoreTemplateInput < ActiveRecord::Migration[4.2]
   def up
+    return if column_exists?(:template_inputs, :advanced)
     add_column :template_inputs, :advanced, :boolean, :default => false, :null => false
   end
 


### PR DESCRIPTION
the exact same timestamp as some previously existing migrations in REX.

This causes an error when you upgrade a system where REX was installed
before (db:migrate):

  ActiveRecord::DuplicateMigrationVersionError:

  Multiple migrations have the version number 20150616080015.

I can't see a reason why this wouldn't happen on production too during
an upgrade, even if we remove the migrations from REX, the timestamps
are still saved in memory.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
