### PR TITLE
Fixes #25128 - Fix variables loader registry when the class is inherited

### DIFF
--- a/lib/foreman/renderer/scope/base.rb
+++ b/lib/foreman/renderer/scope/base.rb
@@ -7,6 +7,11 @@ module Foreman
         include Foreman::Renderer::Scope::Macros::TemplateLogging
         include Foreman::Renderer::Scope::Macros::SnippetRendering
 
+        def self.inherited(child_class)
+          self.loaders.each { |loader| child_class.register_loader(loader) }
+          super
+        end
+
         delegate :template, :to => :source, :allow_nil => true
 
         def initialize(source:, host: nil, params: {}, variables: {}, mode: Foreman::Renderer::REAL_MODE)

--- a/test/unit/foreman/renderer/scope/base_test.rb
+++ b/test/unit/foreman/renderer/scope/base_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class BaseScopeTest < ActiveSupport::TestCase
+  let(:described_class) { ::Foreman::Renderer::Scope::Base }
+
+  describe 'inheritance' do
+    let(:parent_class) { Class.new(described_class).tap { |c| c.include(Foreman::Renderer::Scope::Variables::Base) }}
+    let(:child_class) { Class.new(parent_class) }
+
+    test 'child class should inherit loaders' do
+      assert_not_empty parent_class.loaders
+      assert_same_elements parent_class.loaders, child_class.loaders
+    end
+  end
+end


### PR DESCRIPTION
This is a fix for the variables loader registry when the class is inherited
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
