### PR TITLE
Fixes #24835 - Non-default Settings Bolded

### DIFF
--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -27,7 +27,11 @@ first_category = ordered_settings.values.flatten.first.try(:category)
           <% setting.each do |item| %>
             <tr>
               <td ><%= translate_full_name(item) %></td>
-              <td class="setting_value"><%= value(item) %></td>
+              <% if ((item.value != item.default) && (item.has_default?)) %>
+                  <td class="setting_value"><strong><%= value(item) %></strong></td>
+              <% else %>
+                  <td class="setting_value"><%= value(item) %></td>
+              <% end %>
               <td><%= _(item.description) %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
The non-default settings will appear as bold if they are changed from their default value.