### PR TITLE
Fixes #24824 - Allow UI notifications when login is disabled

### DIFF
--- a/app/controllers/notification_recipients_controller.rb
+++ b/app/controllers/notification_recipients_controller.rb
@@ -1,7 +1,6 @@
 class NotificationRecipientsController < Api::V2::BaseController
   include Foreman::Controller::Parameters::NotificationRecipient
   skip_before_action :update_activity_time, :only => [:index]
-  before_action :require_login
   before_action :find_resource, :only => [:update, :destroy]
 
   def index
@@ -44,10 +43,6 @@ class NotificationRecipientsController < Api::V2::BaseController
   end
 
   private
-
-  def require_login
-    not_found unless SETTINGS[:login]
-  end
 
   def find_resource
     super

--- a/test/controllers/notification_recipients_controller_test.rb
+++ b/test/controllers/notification_recipients_controller_test.rb
@@ -51,13 +51,6 @@ class NotificationRecipientsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
-  test "should not get notifications if settings login is disabled" do
-    SETTINGS[:login] = false
-    get :index, params: { :format => 'json' }
-    SETTINGS[:login] = true
-    assert_response :not_found
-  end
-
   test "should not respond with expired notifications" do
     notification = add_notification
     notification.update_attribute(:expired_at, Time.now.utc - 48.hours)

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -14,14 +14,12 @@ const UserDropdowns = ({
   ...props
 }) => (
   <VerticalNav.IconBar {...props}>
-    {!!user && (
-      <NavItem
-        className="drawer-pf-trigger dropdown notification-dropdown"
-        id="notifications_container"
-      >
-        <NotificationContainer data={{ url: notificationUrl }} />
-      </NavItem>
-    )}
+    <NavItem
+      className="drawer-pf-trigger dropdown notification-dropdown"
+      id="notifications_container"
+    >
+      <NotificationContainer data={{ url: notificationUrl }} />
+    </NavItem>
     {!!user &&
       !!user.current_user && (
         <NavDropdown componentClass="li" id="account_menu">


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
