### PR TITLE
Fix #25137 - webpack-analyze script fails if there is no public/webpack folder

### DIFF
--- a/script/webpack-analyze
+++ b/script/webpack-analyze
@@ -8,5 +8,6 @@ WEBPACK="webpack --config $FOREMAN_PATH/config/webpack.config.js"
 WEBPACK_DIR="$FOREMAN_PATH/public/webpack"
 REPORT="${WEBPACK_DIR}/report.html"
 
+mkdir -p $WEBPACK_DIR
 $WEBPACK --profile --json > $WEBPACK_DIR/stats.json && \
 webpack-bundle-analyzer --mode static -r $REPORT $WEBPACK_DIR/stats.json


### PR DESCRIPTION




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
