### PR TITLE
Fixes #25150 - Check for `#dynamic` with regex

### DIFF
--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -70,7 +70,7 @@ module Foreman
           end
 
           def kickstart_attributes
-            @dynamic   = disk_layout_source_content.start_with?('#Dynamic') if disk_layout_source_content
+            @dynamic   = !!(disk_layout_source_content =~ /^#Dynamic/) if disk_layout_source_content
             @arch      = architecture_name
             @osver     = major.try(:to_i)
             @mediapath = mediumpath(@medium_provider) if medium
@@ -85,7 +85,7 @@ module Foreman
           end
 
           def yast_attributes
-            @dynamic   = disk_layout_source_content.start_with?('#Dynamic') if disk_layout_source_content
+            @dynamic   = !!(disk_layout_source_content =~ /^#Dynamic/) if disk_layout_source_content
             @mediapath = mediumpath(@medium_provider) if medium
           end
 

--- a/test/unit/foreman/renderer/scope/variables/base_test.rb
+++ b/test/unit/foreman/renderer/scope/variables/base_test.rb
@@ -48,6 +48,34 @@ class BaseVariablesTest < ActiveSupport::TestCase
 
       assert_nil scope.instance_variable_get('@mediapath')
     end
+
+    describe "@dynamic" do
+      before do
+        @ptable_template = "%#\n" \
+                           "kind: ptable\n" \
+                           "name: test template\n" \
+                           "oses:\n" \
+                           "- RedHat 7\n" \
+                           "%>\n" \
+                           "#Dynamic\n"
+
+        ptable = FactoryBot.create(:ptable, template: @ptable_template, operatingsystem_ids: [operatingsystems(:redhat).id])
+        @host = FactoryBot.create(:host, :managed, ptable: ptable, operatingsystem: operatingsystems(:redhat))
+      end
+
+      test "is true when '#dynamic' is present in the template" do
+        scope = @scope.new(host: @host, source: @source)
+
+        assert_equal true, scope.instance_variable_get('@dynamic')
+      end
+
+      test "is false when '#dynamic' is not present in the template" do
+        @host.ptable.update(template: @ptable_template.gsub('#Dynamic', ''))
+        scope = @scope.new(host: @host, source: @source)
+
+        assert_equal false, scope.instance_variable_get('@dynamic')
+      end
+    end
   end
 
   test "set kernel and init RAM disk variables" do


### PR DESCRIPTION
This fixes [#25150](https://projects.theforeman.org/issues/25150) where a dynamic template does not always have `#dynamic` as the very first line, but rather often a few lines further down in a given template after the meta data (`<%#\nkind: ptable\n . . . %>`). 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
