### PR TITLE
fixes #25154 - do not join reports when searching

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -19,7 +19,7 @@ module Hostext
       scoped_search :on => :owner_type,    :complete_value => true, :only_explicit => true
       scoped_search :on => :owner_id,      :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
-      scoped_search :relation => :last_report_object, :on => :origin
+      scoped_search :relation => :last_report_object, :on => :origin, :only_explicit => true
 
       scoped_search :relation => :configuration_status_object, :on => :status, :offset => 0, :word_size => ConfigReport::BIT_NUM * 4, :rename => :'status.interesting', :complete_value => {:true => true, :false => false}, :only_explicit => true
       scoped_search_status "applied",         :relation => :configuration_status_object, :on => :status, :rename => :'status.applied'


### PR DESCRIPTION
This might not be a proper fix. We might need to optimize the generated SQL or add indices.