### PR TITLE
Fixes #24276 - add resource switcher to facts page

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -49,4 +49,21 @@ module FactValuesHelper
     return origin if origin == 'N/A'
     image_tag(origin + ".png", :title => origin)
   end
+
+  def fact_breadcrumbs
+    breadcrumbs(
+      items: [
+        {
+          caption: _("Facts Values"),
+          url: (url_for(fact_values_path) if authorized_for(hash_for_fact_values_path))
+        },
+        {
+          caption: params[:host_id]
+        }
+      ],
+      resource_url: api_hosts_path(thin: true),
+      switcher_item_url: host_facts_path(':name'),
+      switchable: true
+    )
+  end
 end

--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -1,20 +1,6 @@
 <%
 if params[:host_id].present?
-  breadcrumbs(
-    items: [
-      {
-        caption: _("Facts"),
-        url: (url_for(fact_values_path) if authorized_for(hash_for_fact_values_path))
-      },
-      {
-        caption: params[:host_id],
-        url: (host_path(params[:host_id]) if authorized_for(hash_for_host_path(params[:host_id])))
-      },
-      {
-        caption: _('values')
-      }
-    ]
-  )
+  fact_breadcrumbs
 else
   title(_("Fact Values"))
 end


### PR DESCRIPTION
we were thinking (@theforeman/ui-ux) that it would be better to include the breadcrumb switcher on pages where the host is the value being filtered by. 
