### PR TITLE
Fixes #25150 - Check for `#Dynamic` with regex [CP 1.19]

### DIFF
--- a/lib/foreman/renderer.rb
+++ b/lib/foreman/renderer.rb
@@ -330,7 +330,7 @@ module Foreman
     end
 
     def kickstart_attributes
-      @dynamic   = @host.disk_layout_template[:template] =~ /^#Dynamic/ if @host.disk_layout_template
+      @dynamic   = !!(@host.disk_layout_template[:template] =~ /^#Dynamic/) if @host.disk_layout_template
       @arch      = @host.architecture.name
       @osver     = @host.operatingsystem.major.to_i
       @mediapath = @host.operatingsystem.mediumpath @host if @host.medium
@@ -345,7 +345,7 @@ module Foreman
     end
 
     def yast_attributes
-      @dynamic   = @host.disk_layout_template[:template] =~ /^#Dynamic/ if @host.disk_layout_template
+      @dynamic   = !!(@host.disk_layout_template[:template] =~ /^#Dynamic/) if @host.disk_layout_template
       @mediapath = @host.operatingsystem.mediumpath @host if @host.medium
     end
 


### PR DESCRIPTION
Back ported bug fix for [25150](https://projects.theforeman.org/issues/25150) from https://github.com/theforeman/foreman/pull/6124
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
