### PR TITLE
Fixes #23699 - Remediation Support for Host Status

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -302,8 +302,10 @@ module HostsHelper
       next unless status.relevant? && !status.substatus?
       [
         _(status.name),
-        content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +
+        content_tag(:span, (
+          content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +
           content_tag(:span, _(status.to_label), :class => host_global_status_class(status.to_global))
+        ), { :'data-original-title' => _(status.remediation_help_text), :rel => 'twipsy' })
       ]
     end.compact
   end

--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -64,6 +64,21 @@ module HostStatus
     def build_errors?
       host && host.build_errors.present?
     end
+
+    def remediation_help_text
+      case host.build_status
+        when PENDING
+          N_("Installation haven't started yet or in progress")
+        when TOKEN_EXPIRED
+          N_("Build token is no longer valid, cancel build mode and enter it again to generate new token")
+        when BUILT
+          N_("OS installer reported end of installation and rebooted the system")
+        when BUILD_FAILED
+          N_("OS installer post script reported failure, check logs")
+        else
+          N_("The host was not scheduled for build yet")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Hello, I am just confused about what text should we display when the status is "pending installation" or "installation error", as the case may have variety of solutions. Also in case of "Token expired", we can show cancel build and regenerate token again but if same host renders Token expired for many times, then we can tell user to create a new host instead, isn't it?