### PR TITLE
Fixes #24834 - HTML-escape fact name only once

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -6,7 +6,7 @@ module FactValuesHelper
   end
 
   def fact_name(value, parent)
-    value_name = name = h(value.name)
+    value_name = name = value.name
     memo       = ''
     name.split(FactName::SEPARATOR).map do |current_name|
       memo = memo.empty? ? current_name : memo + FactName::SEPARATOR + current_name
@@ -65,5 +65,25 @@ module FactValuesHelper
       switcher_item_url: host_facts_path(':name'),
       switchable: true
     )
+  end
+
+  def is_escaped_value(value)
+    value != CGI.escapeHTML(value)
+  end
+
+  def escaped_warning_title
+    _("contains special characters")
+  end
+
+  def escaped_warning_context
+    _("Search may fail or give you wrong results since it contains special characters that are query keywords such as < and >")
+  end
+
+  def escaped_warning_chart_context
+    _("Fact chart labels may look weird or give the wrong results since the item contains special characters that are query keywords (<,>,&)")
+  end
+
+  def print_escape_warning(column)
+    fact_contains_escaped_values
   end
 end

--- a/app/views/fact_values/_fact.html.erb
+++ b/app/views/fact_values/_fact.html.erb
@@ -9,10 +9,12 @@
       </td>
   <% end %>
   <td>
+    <%= popover("", escaped_warning_context, {:data => {:title => escaped_warning_title, :placement => "top"}, :icon => "warning-triangle-o", :class => "pull-right" }) if is_escaped_value(fact.name) %>
     <%= content_tag(:ol, fact_name(fact, parent), :class => "breadcrumb") %>
   </td>
   <td class="fact-col">
     <% unless fact.compose %>
+      <%= popover("", escaped_warning_context, {:data => {:title => escaped_warning_title, :placement => "top"}, :icon => "warning-triangle-o", :class => "pull-right" }) if is_escaped_value(fact.value) %>
       <% allowed_length = 45 %>
       <%= link_to truncate(fact.value, :length => allowed_length),
                   fact_values_path("search" => "facts.#{fact.name} = \"#{fact.value}\""),
@@ -24,6 +26,7 @@
   <td class='fact-origin'><%= fact_origin_icon(fact.origin) %></td>
   <td><%= fact_from fact %></td>
   <td><% unless fact.compose %>
+        <%= popover("", "the chart can't display special characters and probalby won't be able to redirect you to the right search", {:data => {:title => escaped_warning_title, :placement => "top"}, :icon => "warning-triangle-o", :class => "pull-right" }) if is_escaped_value(fact.value) || is_escaped_value(fact.name) %>
         <span id="view-fact-chart-<%= fact.id %>"></span>
         <%= mount_react_component('FactChart', "#view-fact-chart-#{fact.id}", {
             path: fact_path(fact.fact_name_id),

--- a/test/helpers/fact_values_helper_test.rb
+++ b/test/helpers/fact_values_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class FactValuesHelperTest < ActionView::TestCase
+  include FactValuesHelper
+  include ERB::Util
+
+  def test_fact_name_with_escaped_HTML
+    fact_name = FactName.create(:name => "<s></s>")
+    host = Host.create(:name => "host-with-facts")
+    fact_value = FactValue.create(:value => "\"h\"", :fact_name_id => fact_name.id, :host_id => host.id)
+    assert_equal "<li><a title=\"Show &lt;s&gt;&lt;/s&gt; fact values for all hosts\" href=\"/fact_values?search=name+%3D+%3Cs%3E%3C%2Fs%3E\">&lt;s&gt;&lt;/s&gt;</a></li>", fact_name(fact_value, '')
+  end
+end


### PR DESCRIPTION
In https://github.com/theforeman/foreman/pull/4967 @tbrisker `HTML-escaped` both the fact's value and name.
Nevertheless, when displaying the fact name, it's being `HTML-escaped` again.

In this PR, I removed the [`h`](https://apidock.com/rails/v4.2.7/ERB/Util/h) method and added a unit-test.

The only problem I have is with the link. Although, it didn't work before.
