### PR TITLE
Fixes #25197- SearchBar's onChange debounce too slow

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteActions.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteActions.js
@@ -1,4 +1,5 @@
 import URI from 'urijs';
+import debounce from 'lodash/debounce';
 import API from '../../API';
 import { STATUS } from '../../constants';
 import { clearSpaces } from '../../common/helpers';
@@ -20,17 +21,35 @@ export const getResults = ({
     dispatch,
   });
 
-  return API.get(getAPIPath({ trigger, searchQuery, url }))
-    .then(({ data }) =>
-      requestSuccess({
-        data,
-        controller,
-        dispatch,
-        searchQuery,
-        trigger,
-      }))
-    .catch(error => requestFailure({ error, dispatch }));
+  const path = getAPIPath({ trigger, searchQuery, url });
+  return createAPIRequest({
+    controller,
+    path,
+    searchQuery,
+    trigger,
+    dispatch,
+  });
 };
+
+let createAPIRequest = ({
+  controller,
+  path,
+  searchQuery,
+  trigger,
+  dispatch,
+}) => API.get(path)
+  .then(({
+    data,
+  }) => requestSuccess({
+    data,
+    controller,
+    dispatch,
+    searchQuery,
+    trigger,
+  }))
+  .catch(error => requestFailure({ error, dispatch }));
+
+createAPIRequest = debounce(createAPIRequest, 250);
 
 const startRequest = ({
   controller, searchQuery, trigger, dispatch,

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteActions.test.js
@@ -10,6 +10,7 @@ import {
   url,
 } from '../AutoComplete.fixtures';
 
+jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('../../../API');
 
 const loadResults = (requestParams, serverMock) => {

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
@@ -26,9 +26,8 @@ class AutoComplete extends React.Component {
       'unableHTMLAutocomplete',
       'handleKeyDown',
     ]);
-    debounceMethods(this, 250, ['handleInputChange', 'handleLoading']);
-    debounceMethods(this, 125, ['handleInputFocus']);
     this._typeahead = React.createRef();
+    debounceMethods(this, 500, ['handleLoading']);
   }
 
   componentDidMount() {


### PR DESCRIPTION
While typing something very quickly and pressing 'Enter' to search,
the onChange function is not fast enough to update the current `searchQuery`.
Removing the debounce on the onChange  fix this problem.