### PR TITLE
fixes #25198 - Fix SearchBar keyboard navigation.

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteMenu.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteMenu.js
@@ -11,12 +11,13 @@ const AutoCompleteMenu = ({ results, menuProps }) => {
   const grouped = groupBy(results, r => r.category);
   const getMenuItemsByCategory = category =>
     grouped[category].map((result) => {
-      itemIndex += 1;
-      return (
+      const item = (
         <MenuItem key={itemIndex} option={result.label} position={itemIndex}>
           <SubstringWrapper substring={menuProps.text}>{result.label}</SubstringWrapper>
         </MenuItem>
       );
+      itemIndex += 1;
+      return item;
     });
   const items = Object.keys(grouped)
     .sort()


### PR DESCRIPTION
Seems that the keyboard navigation doesn't work as expected:
- instead of first down-arrow click, the first list item is being selected only after two clicks.
- can't reach the last list element.

The problem was the items positions count.