### PR TITLE
Fixes #25203 - set hosts count to 0 if null

### DIFF
--- a/webpack/assets/javascripts/react_app/components/factCharts/index.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/index.js
@@ -75,12 +75,9 @@ class FactChart extends React.Component {
                 <b>
                   {sprintf(__('Fact distribution chart - %s '), title)}
                 </b>
-                <small>
-                  {sprintf(
-                    n__('(%s host)', '(%s hosts)', factChart.hostsCount),
-                    factChart.hostsCount,
-                  )}
-                </small>
+                {factChart.hostsCount && (<small>
+                  {sprintf(n__('(%s host)', '(%s hosts)', factChart.hostsCount), factChart.hostsCount)}
+                </small>)}
               </Modal.Title>
             </Modal.Header>
             <Modal.Body>


### PR DESCRIPTION
`ngettext` expects the last argument to be a number while `factCharts.hostsCount` is initialized to null in Redux.

When rendering the `factChart` modal the number of hosts is translated using `ngettext`.

However, if `factChart` is rendered before the data arrives the component will fail printing the error below in the console:

> The number that was passed in is not a number

To fix this if `factCharts.hostsCount` is null pass to `ngettext` 0 in the last argument instead of `factCharts.hostsCount`.


