### PR TITLE
Fixes #25204 - fix fact chart modal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/factCharts/index.js
+++ b/webpack/assets/javascripts/react_app/components/factCharts/index.js
@@ -75,12 +75,13 @@ class FactChart extends React.Component {
                 <b>
                   {sprintf(__('Fact distribution chart - %s '), title)}
                 </b>
-                <small>
-                  {sprintf(
-                    n__('(%s host)', '(%s hosts)', factChart.hostsCount),
-                    factChart.hostsCount,
-                  )}
-                </small>
+                {typeof factChart.hostsCount === 'number' &&
+                  <small>
+                    {sprintf(
+                      n__('(%s host)', '(%s hosts)', factChart.hostsCount),
+                      factChart.hostsCount,
+                    )}
+                </small>}
               </Modal.Title>
             </Modal.Header>
             <Modal.Body>


### PR DESCRIPTION
Fact chart modal triggers an error 
`Uncaught Error: The number that was passed in is not a number.`
 caused by `hostCounts` value, which initialize to a null.

This pr fixes the sotrybook as well.