### PR TITLE
Fixes #25215 - Support for Debian on aarch64 aka arm64

### DIFF
--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -39,6 +39,6 @@ class Coreos < Operatingsystem
   private
 
   def transform_vars(vars)
-    vars[:arch] = vars[:arch].gsub('x86_64', 'amd64')
+    vars[:arch] = vars[:arch].sub('x86_64', 'amd64')
   end
 end

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -57,5 +57,6 @@ class Debian < Operatingsystem
 
   def transform_vars(vars)
     vars[:arch] = vars[:arch].sub('x86_64', 'amd64')
+    vars[:arch] = vars[:arch].sub('aarch64', 'arm64')
   end
 end

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -56,6 +56,6 @@ class Debian < Operatingsystem
   end
 
   def transform_vars(vars)
-    vars[:arch] = vars[:arch].gsub('x86_64', 'amd64')
+    vars[:arch] = vars[:arch].sub('x86_64', 'amd64')
   end
 end

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -38,6 +38,6 @@ class Freebsd < Operatingsystem
   private
 
   def transform_vars(vars)
-    vars[:arch] = vars[:arch].gsub('x86_64', 'amd64')
+    vars[:arch] = vars[:arch].sub('x86_64', 'amd64')
   end
 end

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -75,6 +75,7 @@ class PuppetFactParser < FactParser
            end
     # ensure that we convert debian legacy to standard
     name = "x86_64" if name == "amd64"
+    name = "aarch64" if name == "arm64"
     Architecture.where(:name => name).first_or_create if name.present?
   end
 


### PR DESCRIPTION
Version 8 of Arm architecture defined 64-bit execution state called
AArch64. RedHat-based distributions (and GNU tools) use "aarch64" name
for it, but Debian went (as Linux kernel) with "arm64" string. This
introduced the same "schism" as happened with "x86_64" and "arm64"
and has to be handled by Debian-related routines.

This change adds handling of the arm64 case in media URL generation
patch, transforming the "arch" variable strings from "aarch64" to
"arm64" and reverses the operation for facts parsing.

Signed-off-by: Pawel Moll <pawel.moll@arm.com>