### PR TITLE
Fixes #25214 - update template snapshots, seeds test

### DIFF
--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -12,7 +12,7 @@ zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --a
 bootloader --timeout=3
 text
 
-ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host --url=file:///install/ostree --ref=rhel-atomic-host/7/x86_64/standard
+ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host-ostree --url=file:///install/ostree --ref=rhel-atomic-host/7/x86_64/standard
 services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local
 rootpw --iscrypted xybxa6JUkz63w
 
@@ -27,6 +27,7 @@ reboot
 
 
 
+rm -f /etc/ostree/remotes.d/*.conf
 
 # SSH keys setup snippet for Remote Execution plugin
 #

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -45,12 +45,16 @@ class SeedsTest < ActiveSupport::TestCase
     refute Ptable.unscoped.where(:os_family => nil).any?
     refute Medium.unscoped.where(:os_family => nil).any?
     Dir["#{Rails.root}/app/views/unattended/**/*.erb"].each do |tmpl|
+      template = File.read(tmpl)
+      requirements = Template.parse_metadata(template)['require'] || []
+      # skip templates that require plugins that aren't available
+      next unless SeedHelper.send(:test_template_requirements, tmpl, requirements)
       if tmpl =~ /partition_tables_templates/
-        assert Ptable.unscoped.where(:template => File.read(tmpl)).any?, "No partition table containing #{tmpl}"
+        assert Ptable.unscoped.where(:template => template).any?, "No partition table containing #{tmpl}"
       elsif tmpl =~ /report_templates/
-        assert ReportTemplate.unscoped.where(:template => File.read(tmpl)).any?, "No report template containing #{tmpl}"
+        assert ReportTemplate.unscoped.where(:template => template).any?, "No report template containing #{tmpl}"
       else
-        assert ProvisioningTemplate.unscoped.where(:template => File.read(tmpl)).any?, "No template containing #{tmpl}"
+        assert ProvisioningTemplate.unscoped.where(:template => template).any?, "No template containing #{tmpl}"
       end
     end
   end


### PR DESCRIPTION
Seeds test expects all templates to be seeded, but new `requires`
metadata prevents seeding of templates requiring plugins that aren't
installed.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
