### PR TITLE
Fixes #25227 - facts:cleanup batch support

### DIFF
--- a/app/services/fact_cleaner.rb
+++ b/app/services/fact_cleaner.rb
@@ -1,80 +1,58 @@
 class FactCleaner
   delegate :logger, :to => :Rails
 
+  def initialize(batch_size: 500)
+    @batch_size = batch_size
+  end
+
   def clean!
-    @deleted_count = delete_excluded_facts + delete_orphaned_facts
+    @deleted_count = 0
+    delete_excluded_facts
+    delete_orphaned_facts
     self
   end
 
   def deleted_count
     raise 'cleaner has not cleaned anything yet, run #clean! first' if @deleted_count.nil?
+
     @deleted_count
   end
 
   private
 
+  def log_removed(records, message)
+    logger.debug("Removed #{records} #{message} records") if records > 0
+    records
+  end
+
+  def delete_facts_names_values(fact_name_ids)
+    log_removed(FactValue.unscoped.where(:fact_name_id => fact_name_ids).delete_all, "associated fact value")
+    log_removed(FactName.unscoped.where(:id => fact_name_ids).delete_all, "fact name")
+  end
+
   def delete_orphaned_facts
-    to_delete = find_leaf_orphaned_facts
-    # we also delete all composes that either don't have any descendant or all of them are to be deleted
-    to_delete += find_compose_orphaned_facts(to_delete)
-    delete!(to_delete)
-    to_delete.uniq.count
-  end
-
-  def find_leaf_orphaned_facts
-    result = []
-    logger.debug "Searching for leaf orphaned facts..."
-    FactName.leaves.includes(:fact_values).find_in_batches do |batch|
-      result += batch.select do |fact|
-        fact.fact_values.empty?
-      end
-    end
-    result
-  end
-
-  def find_compose_orphaned_facts(found)
-    logger.debug "Searching for compose orphaned facts..."
-    FactName.composes.find_in_batches do |batch|
-      found += batch.select do |compose|
-        compose.descendants.all? { |fact| found.include?(fact) }
-      end
-    end
-    found
-  end
-
-  def delete!(to_delete)
-    logger.debug "#{to_delete.size} facts will be removed"
-    to_delete.each do |fact|
-      logger.debug { "Removing fact #{fact}" }
-      fact.destroy
-    end
-    logger.debug "Cleanup of facts finished!"
-  end
-
-  def find_excluded_facts
-    logger.debug "Searching for facts that match excluded pattern..."
-    fact_name_ids = []
-
-    excluded_facts_regex = FactImporter.excluded_facts_regex
-
-    FactName.unscoped.find_in_batches(:batch_size => 100) do |names_batch|
-      names_batch.select! { |fact_name| fact_name.name.match(excluded_facts_regex) }
-      fact_name_ids += names_batch.map(&:id)
+    logger.debug "Cleaning leaf orphaned facts"
+    leaf_ids = []
+    FactName.leaves.includes(:fact_values).reorder(nil).find_in_batches(:batch_size => @batch_size) do |batch|
+      fact_name_ids = batch.select { |fact| fact.fact_values.empty? }
+      @deleted_count += delete_facts_names_values(fact_name_ids)
+      leaf_ids += fact_name_ids
     end
 
-    fact_name_ids.uniq
+    logger.debug "Cleaning compose orphaned facts"
+    FactName.composes.reorder(nil).find_in_batches(:batch_size => @batch_size) do |batch|
+      fact_name_ids = batch.select { |compose| compose.descendants.all? { |fact| leaf_ids.include?(fact.id) } }.map(&:id)
+      @deleted_count += delete_facts_names_values(fact_name_ids)
+    end
   end
 
   def delete_excluded_facts
-    fact_names = find_excluded_facts
+    excluded_facts_regex = FactImporter.excluded_facts_regex
+    logger.debug "Cleaning facts mathing excluded pattern: #{excluded_facts_regex}"
 
-    # delete related fact values first
-    logger.debug "Removing values of excluded facts..."
-    deleted_values = FactValue.unscoped.where(:fact_name_id => fact_names).delete_all
-    logger.debug "Removed #{deleted_values} associated fact value records."
-    logger.debug "Removing excluded fact names..."
-    deleted_names = FactName.unscoped.where(:id => fact_names).delete_all
-    logger.debug "Removed #{deleted_names} fact name records."
-    deleted_names
+    FactName.unscoped.reorder(nil).find_in_batches(:batch_size => @batch_size) do |names_batch|
+      fact_name_ids = names_batch.select! { |fact_name| fact_name.name.match(excluded_facts_regex) }.map(&:id)
+      @deleted_count += delete_facts_names_values(fact_name_ids)
+    end
   end
 end

--- a/lib/tasks/facts.rake
+++ b/lib/tasks/facts.rake
@@ -6,12 +6,13 @@ This is useful when you used custom facts of different facts sourcers that you d
 After cleaning of such facts they should no longer appear in auto-completion suggestions.
 
 Examples:
-  # foreman-rake facts:clean
+  # foreman-rake facts:clean [batch_size=500]
 END_DESC
 
   task :clean => :environment do
-    puts 'Starting orphaned facts clean up...'
-    count = FactCleaner.new.clean!.deleted_count
+    batch_size = ENV['batch_size'] ? ENV['batch_size'].to_i : 500
+    puts 'Starting orphaned facts clean up'
+    count = FactCleaner.new(batch_size: batch_size).clean!.deleted_count
     puts "Finished, cleaned #{count} facts"
   end
 end


### PR DESCRIPTION
Implementation of slower-paced facts cleanup which is more concurrent-friendly as we did for reports expiration.

https://community.theforeman.org/t/foreman-rake-facts-cleanup-batch-rolling-support/11425