### PR TITLE
Fixes #25241 - Add the ability to pass in include=[facts] to /api/v2/hosts

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -57,6 +57,7 @@ module Api
         if params[:include].present?
           @parameters = params[:include].include?('parameters')
           @all_parameters = params[:include].include?('all_parameters')
+          @facts = params[:include].include?('facts')
         end
       end
 

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -68,6 +68,7 @@ module Api
       def show
         @parameters = true
         @all_parameters = true
+        @facts = true
       end
 
       def_param_group :host do

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -41,6 +41,12 @@ node :hostgroup_title do |host|
   host.hostgroup.title if host.hostgroup.present?
 end
 
+if @facts
+  node do |host|
+    { :facts => host.facts } if host.facts.present?
+  end
+end
+
 if @parameters
   node do |host|
     { :parameters => partial("api/v2/parameters/index", :object => host.host_parameters.authorized) }


### PR DESCRIPTION
This helps to speed things up for things such as the Ansible Dynamic Inventory Script.  Currently, the Ansible Dynamic Inventory Script makes one API call per host to pull this information back.  This will allow a single call to be made, and the rest to be parsed in memory.

This will allow us to do the same thing as this PR (https://github.com/ansible/ansible/pull/47257) for the Foreman inventory for Ansible.

Sample API call.  Notice the new 'facts' key in the body of the response:

```
[root@satmlmv001 hosts]# curl -k -u 'admin:redacted' 'https://localhost/api/v2/hosts?include=\[all_parameters,facts\]' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 18163    0 18163    0     0  51967      0 --:--:-- --:--:-- --:--:-- 51894
{
    "page": 1,
    "per_page": 20,
    "results": [
        {
            "all_parameters": [
                {
                    "created_at": "2018-10-18 18:51:15 UTC",
                    "id": 4,
                    "name": "new_param",
                    "priority": 0,
                    "updated_at": "2018-10-18 18:51:15 UTC",
                    "value": "new"
                },
                {
                    "created_at": "2018-10-17 15:38:10 UTC",
                    "id": 2,
                    "name": "global_param",
                    "priority": 0,
                    "updated_at": "2018-10-17 15:38:10 UTC",
                    "value": "test"
                }
            ],
            "architecture_id": 1,
            "architecture_name": "x86_64",
            "build": false,
            "capabilities": [
                "build"
            ],
            "certname": "satmlmv001.laptop.scott.lab",
            "comment": null,
            "compute_profile_id": null,
            "compute_profile_name": null,
            "compute_resource_id": null,
            "compute_resource_name": null,
            "configuration_status": 0,
            "configuration_status_label": "No changes",
            "created_at": "2018-10-17 14:25:58 UTC",
            "disk": null,
            "domain_id": 1,
            "domain_name": "laptop.scott.lab",
            "enabled": true,
            "environment_id": 1,
            "environment_name": "production",
            "facts": {
                "agent_specified_environment": "production",
                "aio_agent_version": "1.10.9",
                "architecture": "x86_64",
                "augeas": null,
                "augeas::version": "1.4.0",
                "augeasversion": "1.4.0",
                "bios_release_date": "05/19/2017",
                "bios_vendor": "Phoenix Technologies LTD",
                "bios_version": "6.00",
                "blockdevice_sda_model": "VMware Virtual S",
```

......etc etc

