### PR TITLE
fixes #25248 - build status check without proxy edit

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -57,6 +57,19 @@ class SmartProxy < ApplicationRecord
     errors
   end
 
+  def ping
+    begin
+      reply = ProxyAPI::Features.new(url: url).features
+      unless reply.is_a?(Array)
+        logger.debug("Invalid response from proxy #{name}: Expected Array of features, got #{reply}.")
+        errors.add(:base, _('An invalid response was received while requesting available features from this proxy'))
+      end
+    rescue => e
+      errors.add(:base, _('Unable to communicate with the proxy: %s') % e)
+    end
+    !errors.any?
+  end
+
   def taxonomy_foreign_conditions
     conditions = {}
     if has_feature?('Puppet') && has_feature?('Puppet CA')

--- a/app/services/host_build_status.rb
+++ b/app/services/host_build_status.rb
@@ -47,9 +47,10 @@ class HostBuildStatus
 
     smart_proxies.each do |proxy|
       begin
-        errors = proxy.refresh.messages.any?
+        proxy.ping
+        errors = proxy.errors.messages
         errors = errors.is_a?(Array) ? errors.to_sentence : errors
-        fail!(:proxies, _('Failure deploying via smart proxy %{proxy}: %{error}.') % {:proxy => proxy, :error => errors}, proxy.id) if errors
+        fail!(:proxies, _('Failure deploying via smart proxy %{proxy}: %{error}.') % {:proxy => proxy, :error => errors}, proxy.id) if proxy.errors.any?
       rescue => error
         fail!(:proxies, _('Error connecting to %{proxy}: %{error}.') % {:proxy => proxy, :error => error}, proxy.id)
       end

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -91,4 +91,20 @@ class SmartProxyTest < ActiveSupport::TestCase
     refute proxy.save
     assert_equal('An invalid response was received while requesting available features from this proxy', proxy.errors[:base].first)
   end
+
+  describe '#ping' do
+    let(:proxy) { SmartProxy.new(name: 'Proxy', url: 'https://some.where.net:8443') }
+
+    test 'pings the smart proxy' do
+      ProxyAPI::Features.any_instance.stubs(:features).returns(['logs', 'puppetca', 'templates'])
+      assert proxy.ping
+      assert_empty proxy.errors
+    end
+
+    test 'is false when there are connection errors' do
+      ProxyAPI::Features.any_instance.stubs(:features).raises(Errno::ECONNREFUSED)
+      refute proxy.ping
+      refute_empty proxy.errors
+    end
+  end
 end

--- a/test/unit/host_build_status_test.rb
+++ b/test/unit/host_build_status_test.rb
@@ -5,7 +5,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
 
   setup do
     disable_orchestration
-    ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
+    ProxyAPI::Features.any_instance.stubs(:features).returns(Feature.name_map.keys)
     User.current = users(:admin)
     @host = Host.new(:name => "myfullhost", :mac => "aabbecddeeff", :ip => "2.3.4.03", :ptable => FactoryBot.build(:ptable), :medium => media(:one),
                     :domain => domains(:mydomain), :operatingsystem => operatingsystems(:redhat), :subnet => subnets(:one), :puppet_proxy => smart_proxies(:puppetmaster),
@@ -17,6 +17,7 @@ class HostBuildStatusTest < ActiveSupport::TestCase
   end
 
   test "should be able to render a template" do
+    build.check_all_statuses
     assert build.errors[:templates].blank?
   end
 
@@ -28,7 +29,8 @@ class HostBuildStatusTest < ActiveSupport::TestCase
     refute_empty @build.errors[:templates]
   end
 
-  test "should be able to refresh a smart proxy" do
+  test "should be able to ping a smart proxy" do
+    build.check_all_statuses
     assert_empty build.errors[:proxies]
   end
 end


### PR DESCRIPTION
This fixes this error when the user has the permission to rebuild hosts but not to edit the smart proxies.

![image](https://user-images.githubusercontent.com/4107560/47222621-804ff600-d3b7-11e8-94de-88e12391aaf4.png)
