### PR TITLE
Fixes #21592 - Add chromedriver as alternative JS debugging

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -13,6 +13,7 @@ group :test do
   gem 'factory_bot_rails', '~> 4.5', :require => false
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem 'poltergeist', '>= 1.18.0', :require => false
+  gem 'selenium-webdriver', :require => false
   gem 'shoulda-matchers', '~> 3.0'
   gem 'shoulda-context', '~> 1.2'
   gem 'as_deprecation_tracker', '~> 1.4'

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "optionalDependencies": {
-    "phantomjs-prebuilt": "^2.1.0"
+    "phantomjs-prebuilt": "^2.1.0",
+    "chromedriver": "2.43.0"
   },
   "dependencies": {
     "@novnc/novnc": "^1.0.0",


### PR DESCRIPTION
Adding chromedriver as a debugging tool for JS integration tests.
Need to add documentation : `JS_TEST_DRIVER=selenium_chrome` for it to run chromedriver
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
