### PR TITLE
Fixes #25260 - Throw error on jest when prop-type warning appears

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "highlight.js": "^9.12.0",
     "identity-obj-proxy": "^3.0.0",
     "jest-cli": "^20.0.0",
+    "jest-prop-type-error": "^1.1.0",
     "jsdom": "^9.5.0",
     "lodash-webpack-plugin": "^0.11.4",
     "node-sass": "^4.5.0",
@@ -153,6 +154,7 @@
     ],
     "setupFiles": [
       "raf/polyfill",
+      "jest-prop-type-error",
       "./webpack/test_setup.js"
     ]
   }

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
@@ -96,6 +96,7 @@ const BreadcrumbSwitcherPopover = ({
 
 BreadcrumbSwitcherPopover.propTypes = {
   ...Popover.propTypes,
+  searchValue: PropTypes.string,
   loading: PropTypes.bool,
   hasError: PropTypes.bool,
   currentPage: PropTypes.number,
@@ -107,11 +108,11 @@ BreadcrumbSwitcherPopover.propTypes = {
     onClick: PropTypes.func,
   })),
   onSearchChange: PropTypes.func,
-  searchValue: PropTypes.string,
   onResourceClick: PropTypes.func,
 };
 
 BreadcrumbSwitcherPopover.defaultProps = {
+  searchValue: '',
   loading: false,
   hasError: false,
   currentPage: 1,

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/BreadcrumbSwitcher.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/BreadcrumbSwitcher.test.js.snap
@@ -30,6 +30,7 @@ exports[`BreadcrumbSwitcher rendering render closed 1`] = `
       onPrevPageClick={[Function]}
       onResourceClick={[Function]}
       resources={Array []}
+      searchValue=""
       totalPages={1}
     />
   </Overlay>
@@ -66,6 +67,7 @@ exports[`BreadcrumbSwitcher rendering render loading state 1`] = `
       onPrevPageClick={[Function]}
       onResourceClick={[Function]}
       resources={Array []}
+      searchValue=""
       totalPages={1}
     />
   </Overlay>
@@ -132,6 +134,7 @@ exports[`BreadcrumbSwitcher rendering render resources list 1`] = `
           },
         ]
       }
+      searchValue=""
       totalPages={1}
     />
   </Overlay>
@@ -198,6 +201,7 @@ exports[`BreadcrumbSwitcher rendering render resources list with pagination 1`] 
           },
         ]
       }
+      searchValue=""
       totalPages={3}
     />
   </Overlay>

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/BreadcrumbSwitcherPopover.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/BreadcrumbSwitcherPopover.test.js.snap
@@ -9,6 +9,7 @@ exports[`BreadcrumbSwitcherPopover render loading state 1`] = `
 >
   <SearchInput
     focus={true}
+    searchValue=""
   />
   <div
     className="breadcrumb-switcher-popover-loading text-center"
@@ -32,6 +33,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
 >
   <SearchInput
     focus={true}
+    searchValue=""
   />
   <ListGroup
     bsClass="list-group"
@@ -50,6 +52,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 1
         </SubstringWrapper>
@@ -68,6 +71,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 2
         </SubstringWrapper>
@@ -86,6 +90,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 3 with a very long name
         </SubstringWrapper>
@@ -103,6 +108,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 4
         </SubstringWrapper>
@@ -121,6 +127,7 @@ exports[`BreadcrumbSwitcherPopover render resources list 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 5
         </SubstringWrapper>
@@ -153,6 +160,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
 >
   <SearchInput
     focus={true}
+    searchValue=""
   />
   <ListGroup
     bsClass="list-group"
@@ -171,6 +179,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 1
         </SubstringWrapper>
@@ -189,6 +198,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 2
         </SubstringWrapper>
@@ -207,6 +217,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 3 with a very long name
         </SubstringWrapper>
@@ -224,6 +235,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 4
         </SubstringWrapper>
@@ -242,6 +254,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with a search query 1`]
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 5
         </SubstringWrapper>
@@ -274,6 +287,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
 >
   <SearchInput
     focus={true}
+    searchValue=""
   />
   <ListGroup
     bsClass="list-group"
@@ -292,6 +306,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 1
         </SubstringWrapper>
@@ -310,6 +325,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 2
         </SubstringWrapper>
@@ -328,6 +344,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 3 with a very long name
         </SubstringWrapper>
@@ -345,6 +362,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 4
         </SubstringWrapper>
@@ -363,6 +381,7 @@ exports[`BreadcrumbSwitcherPopover render resources list with pagination 1`] = `
       <EllipisWithTooltip>
         <SubstringWrapper
           Element="b"
+          substring=""
         >
           Host 5
         </SubstringWrapper>


### PR DESCRIPTION
After this change, Jest will throw errors and will fail the test once it got prop-type warning.

Example of failing:
![screenshot from 2018-10-21 18-32-54](https://user-images.githubusercontent.com/1262502/47268953-e1b2c900-d55f-11e8-9413-d8f4911fb852.png)
