### PR TITLE
Fixes #25278 - add index environment-puppetclass

### DIFF
--- a/db/migrate/20181023112532_add_environment_puppetclass_id.rb
+++ b/db/migrate/20181023112532_add_environment_puppetclass_id.rb
@@ -1,0 +1,6 @@
+class AddEnvironmentPuppetclassId < ActiveRecord::Migration[5.2]
+  def change
+    add_index :environment_classes, [:environment_id, :puppetclass_id]
+    remove_index :environment_classes, :environment_id
+  end
+end


### PR DESCRIPTION
Looks like PostgreSQL optimizer would benefit from this one during
condition recheck: https://explain.depesz.com/s/5zZi

Environments - Puppetclass join table is not huge usually, no risk.

This is how the table looks like after the migration:

```ruby
  create_table "environment_classes", force: :cascade do |t|
    t.integer "puppetclass_id", null: false
    t.integer "environment_id", null: false
    t.integer "puppetclass_lookup_key_id"
    t.index ["environment_id", "puppetclass_id"], name: "index_environment_classes_on_environment_id_and_puppetclass_id"
    t.index ["environment_id"], name: "index_environment_classes_on_environment_id"
    t.index ["puppetclass_id"], name: "index_environment_classes_on_puppetclass_id"
    t.index ["puppetclass_lookup_key_id"], name: "index_environment_classes_on_puppetclass_lookup_key_id"
  end
```