### PR TITLE
Fixes #25295 - ignore broken vmware machines

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -19,7 +19,7 @@ module FogExtensions
 
         folder_inventory = generate_folder_inventory(folders)
 
-        vms = results.select { |result| result.obj.is_a?(RbVmomi::VIM::VirtualMachine) && result['config.template'] == templates }
+        vms = results.select { |result| result.obj.is_a?(RbVmomi::VIM::VirtualMachine) && result['config.template'] == templates && !result['config.instanceUuid'].nil? }
 
         vms.map do |vm|
           attrs = attribute_mapping.map do |key, value|


### PR DESCRIPTION
VMWare Machine Listing in ComputeResource, needs to filter virtual-machines with `id==nil`
Otherwise the template fails and the page shows:

`There was an error listing VMs: 500 Internal Server Error`

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
