### PR TITLE
Fixes #25364 - disable auditing for some endpoints

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -304,9 +304,11 @@ Return the host's compute attributes that can be used to create a clone of this 
       param :type, String,     :desc => N_("optional: the STI type of host to create")
 
       def facts
-        @host = detect_host_type.import_host params[:name], params[:certname]
-        state = @host.import_facts(params[:facts].to_unsafe_h, detected_proxy)
-        process_response state
+        Audited.without_auditing do
+          @host = detect_host_type.import_host params[:name], params[:certname]
+          state = @host.import_facts(params[:facts].to_unsafe_h, detected_proxy)
+          process_response state
+        end
       rescue ::Foreman::Exception => e
         render_exception(e, :status => :unprocessable_entity)
       end

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -37,8 +37,10 @@ module Api
       param_group :report, :as => :create
 
       def create
-        @report = resource_class.import(params.to_unsafe_h[:report], detected_proxy.try(:id))
-        process_response @report.errors.empty?
+        Audited.without_auditing do
+          @report = resource_class.import(params.to_unsafe_h[:report], detected_proxy.try(:id))
+          process_response @report.errors.empty?
+        end
       rescue ::Foreman::Exception => e
         render_exception(e, :status => :unprocessable_entity)
       end
@@ -47,7 +49,9 @@ module Api
       param :id, String, :required => true
 
       def destroy
-        process_response @report.destroy
+        Audited.without_auditing do
+          process_response @report.destroy
+        end
       end
 
       api :GET, "/hosts/:host_id/reports/last", N_("Show the last report for a host")


### PR DESCRIPTION
Some endpoints are only used by clients not humans and can be put under
heavy stress (reports, facts). It does not make much sense to put all
the changes done by these into the audit.

This disables auditing of these requests completely on the controller
level. It uses new (thread-safe) helper method in audited gem introduced
in: https://github.com/collectiveidea/audited/pull/472

(Bump audited gem packages before merging this.)