### PR TITLE
fixes #25331 - do not audit fact import

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -473,7 +473,7 @@ module Host
 
       if iface.new_record? || iface.changed?
         logger.debug "Saving #{name} NIC for host #{self.name}"
-        result = iface.save
+        result = iface.save_without_auditing
 
         unless result
           logger.warn "Saving #{name} NIC for host #{self.name} failed, skipping because:"


### PR DESCRIPTION
A slightly less intrusive version of #6178 for backports.

cc: @lzap 

I'm running our production cluster successfully with this.

___

Some side nodes.

This are the records that piled up during a couple of hours.

```ruby
audits = Audit.where(auditable_type: ['Nic::Managed', 'Nic::Bridge', 'Nic::Bond'])
TaxableTaxonomy.where(taxable_type: "Audited::Audit", taxable: audits).delete_all
# -> 191384
audits.delete_all
# -> 95692
```

This leads to `TaxableTaxonomy` being huge and slows down the whole app.


```sql
foreman=# SELECT DISTINCT "taxable_taxonomies"."taxable_id" FROM "taxable_taxonomies" WHERE "taxable_taxonomies"."taxable_type" = 'ComputeResource' AND "taxable_taxonomies"."taxonomy_id" = 3;
 taxable_id
------------
          4
          5
         12
         15
         21
         24
         27
         30
         33
         36
         37
         38
         39
         40
(14 rows)

Time: 253.721 ms
```