### PR TITLE
Fixes #21545 - Unified role cloning via UI and hammer

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -44,9 +44,11 @@ class RolesController < ApplicationController
   end
 
   def clone
-    @cloned_role      = true
-    @original_role_id = @role.id
+    @cloned_role = true
+    @original_role = @role
     @role = Role.new
+    @role.locations = @original_role.locations
+    @role.organizations = @original_role.organizations
     render :action => :new
   end
 

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -25,7 +25,7 @@
       <%= text_f f, :name, :class => @role.builtin? ? "disabled" : ""  %>
       <%= textarea_f f, :description, :rows=> 5, :size => "col-md-4" %>
 
-      <%= hidden_field_tag :original_role_id, @original_role_id if @cloned_role %>
+      <%= hidden_field_tag :original_role_id, @original_role.id if @cloned_role %>
 
       <% tax_help = N_("When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.
                          Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.

--- a/test/controllers/api/v2/roles_controller_test.rb
+++ b/test/controllers/api/v2/roles_controller_test.rb
@@ -74,7 +74,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
     assert_equal loc, r.locations.first
   end
 
-  test "should override attributes when clonning" do
+  test "should override attributes when cloning" do
     new_name = "New Role"
     loc = taxonomies(:location1)
     org = taxonomies(:organization1)
@@ -95,7 +95,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
     assert_equal new_desc, cloned_role.description
   end
 
-  test "should override organizations and leave locations alone when clonning" do
+  test "should override organizations and leave locations alone when cloning" do
     new_name = "New Role"
     loc = taxonomies(:location1)
     org = taxonomies(:organization1)
@@ -115,7 +115,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
     assert_equal new_desc, cloned_role.description
   end
 
-  test "should not have any taxonomies when clonning" do
+  test "should not have any taxonomies when cloning" do
     new_name = "New Role"
     loc = taxonomies(:location1)
     org = taxonomies(:organization1)


### PR DESCRIPTION
Unified role cloning. Now role is cloned via UI and Hammer with original role
taxonomies