### PR TITLE
Fixes #25346 - Correctly render menu for non-admin users

### DIFF
--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -23,7 +23,7 @@ module Menu
     end
 
     def to_hash
-      {type: :item, name: @caption || @name, url: url}
+      {type: :item, name: @caption || @name, url: url} if authorized?
     end
 
     def url

--- a/app/registries/menu/manager.rb
+++ b/app/registries/menu/manager.rb
@@ -34,7 +34,7 @@ module Menu
       end
 
       def to_hash(menu_name)
-        items(menu_name).children.map(&:to_hash)
+        items(menu_name).authorized_children.map(&:to_hash)
       end
 
       def get_resource_caption(resource)

--- a/app/registries/menu/node.rb
+++ b/app/registries/menu/node.rb
@@ -24,7 +24,7 @@ module Menu
     end
 
     def authorized_children
-      children.map {|sub_item| sub_item if sub_item.authorized?}.compact
+      children.select(&:authorized?)
     end
 
     def children

--- a/app/registries/menu/toggle.rb
+++ b/app/registries/menu/toggle.rb
@@ -8,11 +8,20 @@ module Menu
     end
 
     def to_hash
-      {type: :sub_menu, name: @caption, icon: @icon, children: children.map(&:to_hash)}
+      {type: :sub_menu, name: @caption, icon: @icon, children: children_hash}
+    end
+
+    def children_hash
+      list = authorized_children
+      list.reject! do |child|
+        index = list.index(child)
+        child.is_a?(Menu::Divider) && (index == list.size - 1 || list[index + 1].is_a?(Menu::Divider))
+      end
+      list.map(&:to_hash)
     end
 
     def authorized?
-      true
+      children_hash.any?
     end
   end
 end

--- a/test/unit/menu_manager_test.rb
+++ b/test/unit/menu_manager_test.rb
@@ -34,6 +34,7 @@ class MenuManagerTest < ActiveSupport::TestCase
 
   def test_hashed_menu
     create_nested_menu
+    Menu::Item.any_instance.stubs(:authorized?).returns(true)
     items = Menu::Manager.to_hash(:nested_menu)
     assert_equal menu_hash, items
   end


### PR DESCRIPTION
The new menu implementation in react did not take into account user
permissions as to which menues should be displayed. This also moves the
logic for deciding what to display into the menu classes and removes the
home helper which is no longer used.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
