### PR TITLE
Fixes #25356 - OS parameter to override PXE Loader

### DIFF
--- a/app/models/concerns/pxe_loader_suggestion.rb
+++ b/app/models/concerns/pxe_loader_suggestion.rb
@@ -1,6 +1,7 @@
 module PxeLoaderSuggestion
   extend ActiveSupport::Concern
   def suggest_default_pxe_loader
+    self.pxe_loader ||= self.try(:operatingsystem).try(:parameters).try(:find_by_name, "pxe-loader").try(:value)
     self.pxe_loader ||= self.try(:operatingsystem).try(:preferred_loader) if self.respond_to?(:pxe_loader)
   end
 end

--- a/app/views/common/os_selection/_pxe_loader.html.erb
+++ b/app/views/common/os_selection/_pxe_loader.html.erb
@@ -10,7 +10,7 @@
         :selected => pxe_loader_selected == true ? f.object.pxe_loader : pxe_loader_selected
       },
       :label => _('PXE loader'),
-      :label_help =>  _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE)"),
+      :label_help =>  _("DHCP filename option to use. Set to None for non-PXE method (e.g. iPXE). Auto-suggested, use OS parameter 'pxe-loader' to override."),
       :label_help_options => { :data => { :placement => 'top' } } %>
   <% end -%>
 <% end -%>

--- a/test/models/concerns/pxe_loader_suggestion_test.rb
+++ b/test/models/concerns/pxe_loader_suggestion_test.rb
@@ -20,6 +20,33 @@ class PxeLoaderSuggestionTest < ActiveSupport::TestCase
     end
   end
 
+  context 'host with os param' do
+    def setup
+      @os = FactoryBot.create(:operatingsystem)
+      @os.os_parameters.create!(:name => "pxe-loader", :value => "PXELinux A")
+      @host = FactoryBot.create(:host, operatingsystem: @os)
+    end
+
+    test 'host suggests default PXEloader for OS' do
+      @host.suggest_default_pxe_loader
+      assert_equal 'PXELinux A', @host.pxe_loader
+    end
+  end
+
+  context 'host with model param' do
+    def setup
+      @host = FactoryBot.create(:host)
+      @os = FactoryBot.create(:operatingsystem)
+      @os.os_parameters.create!(:name => "pxe-loader", :value => "PXELinux A")
+    end
+
+    test 'host suggests default PXEloader for OS' do
+      @host.operatingsystem = @os
+      @host.suggest_default_pxe_loader
+      assert_equal 'PXELinux A', @host.pxe_loader
+    end
+  end
+
   context 'hostgroup' do
     def setup
       @hostgroup = FactoryBot.create(:hostgroup)


### PR DESCRIPTION
A customer requested PXE loader overriding via a global option, I think that OS-level parameter named "pxe-loader" is better fit. We need an OS to be present for auto-suggestion anyway, but the suggestion might not be always good and some users prefer not to use host groups.