### PR TITLE
fixes #22011 - add unique constraint for trends counter

### DIFF
--- a/db/migrate/20181031155025_add_trend_counter_created_at_unique_constraint.rb
+++ b/db/migrate/20181031155025_add_trend_counter_created_at_unique_constraint.rb
@@ -1,0 +1,22 @@
+class AddTrendCounterCreatedAtUniqueConstraint < ActiveRecord::Migration[5.1]
+  def up
+    fields = [:trend_id, :created_at]
+    duplicates = TrendCounter.order(created_at: :asc).select(fields)
+      .group(*fields).
+    having(TrendCounter.arel_table[:created_at].count.gt(1))
+      .pluck(*fields)
+
+    duplicates.each do |duplicate|
+      trend_id, created_at = duplicate
+      to_delete = TrendCounter.where(trend_id: trend_id, created_at: created_at).pluck(:id)[1..-1]
+      say "Removing duplicate TrendCounters for Trend #{trend_id} with IDs: #{to_delete.to_sentence}"
+      TrendCounter.where(id: to_delete).delete_all
+    end
+
+    add_index :trend_counters, [:trend_id, :created_at], unique: true
+  end
+
+  def down
+    remove_index :trend_counters, [:trend_id, :created_at]
+  end
+end

--- a/test/factories/trends.rb
+++ b/test/factories/trends.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
     after(:create) do |trend, evaluator|
       if trend.fact_value.present? # only trends for a certain value have counters
-        trend.trend_counters = (0...evaluator.counter_count).map { FactoryBot.build(:trend_counter) }
+        trend.trend_counters = (0...evaluator.counter_count).map { |idx| FactoryBot.build(:trend_counter, trend: trend, created_at: Time.now - idx.minutes) }
       end
     end
   end


### PR DESCRIPTION
`TrendCounter` has a unique validation in rails. If for some mysterious reason (it's Halloween after all 🎃) duplicate records are created all fact import fail from this time on.
I think it's best du dedupe the existing records and add a unique constraint so the db takes care of keeping the data consistent.