### PR TITLE
Fixes #22898 - Preview fails on /clone_template

### DIFF
--- a/app/helpers/template_paths_helper.rb
+++ b/app/helpers/template_paths_helper.rb
@@ -19,9 +19,14 @@ module TemplatePathsHelper
   end
 
   def template_hash_for_member(template, member = nil)
+    return {} unless member.present?
     member = "#{member}_" if member.present?
     # hash_for is protected method
-    send("hash_for_#{member}#{template_route_prefix(template.class).singularize}_path", :id => template)
+    if template.id.present?
+      send("hash_for_#{member}#{template_route_prefix(template.class).singularize}_path", :id => template)
+    else
+      send("hash_for_#{member}#{template_route_prefix(template.class)}_path")
+    end
   end
 
   def render_if_exists(partial)


### PR DESCRIPTION
Since we are using `dup` method to get a cloned template, but `dup` typically uses the class of the existing template object to create the new instance and since it is a new instance, id that it gets is nil. So, I have tried here, to store the id of the template before cloning it and later, using it when the template is cloned.