### PR TITLE
Fixes #25207 - do not instantiate during permission checks

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -9,7 +9,7 @@ module Authorizable
     name = permission_name(creation ? :create : :edit)
 
     Foreman::Logging.logger('permissions').debug { "verifying the transaction by permission #{name} for class #{self.class}" }
-    unless authorizer.can?(name, self)
+    unless authorizer.can?(name, self, false)
       org_loc_string = Taxonomy.enabled_taxonomies.map { |tax| _(tax) }.join(' ' + _('or') + ' ')
       errors.add :base, _("You don't have permission %{name} with attributes that you have specified or you don't have access to specified %{tax_string}") % { :name => name, :tax_string => org_loc_string }
 


### PR DESCRIPTION
Both core and discovery use permission_type "Host" for permissions.
During authorization check, our stack performs a query and then checks
via `include?` call. ActiveRecord then attempts to instantiate all
records to do the comparison as it calls `each` and interates though all
objects.

This patch assumes that subject is always present as well as `id` field.
Then it uses `pluck` call to retrieve array of all IDs and iterates over
it. This solves the problem but it should be also faster in theory since
the ActiveRecord stack appears to iterate through all record instances
while pluck retrieves IDs via a single call.