### PR TITLE
fixes #25366 - make http_proxy monkey patch work multithreaded

### DIFF
--- a/lib/foreman/http_proxy.rb
+++ b/lib/foreman/http_proxy.rb
@@ -1,11 +1,15 @@
 module Foreman
   module HTTPProxy
     def http_proxy
-      Setting[:http_proxy]
+      ActiveRecord::Base.connection_pool.with_connection do
+        Setting[:http_proxy]
+      end
     end
 
     def http_proxy_except_list
-      Setting[:http_proxy_except_list]
+      ActiveRecord::Base.connection_pool.with_connection do
+        Setting[:http_proxy_except_list]
+      end
     end
 
     # Answers if this request should be proxied


### PR DESCRIPTION
In Katello, we use concurrent-ruby to kick off a bunch of Net::HTTP requests, but unfortunately what happens is we quickly run out of connections from the database pool due to the setting reads in the http_proxy monkey patch.

After banging my head against this for a while, and trying all kinds of crazy things like wrapping the
Setting accesses in a mutex - it occured to me that this code isn't causing the connection to be returned to the pool automationally since we're outside of ActiveRecord. It takes some time for connection to be reclaimed.

By wrapping this in a with_connection block, the connection is returned to the pool immediately when done and allows Foremans' monkey patching to work with multiple threads in Katello.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
