### PR TITLE
Fixes #25367 - Create new object when cloning the report template

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -92,7 +92,7 @@ module Api
       param_group :report_template_clone, :as => :create
 
       def clone
-        @report_template = @report_template.clone
+        @report_template = @report_template.dup
         @report_template.name = params[:report_template][:name]
         process_response @report_template.save
       end

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -170,6 +170,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
     template = ActiveSupport::JSON.decode(@response.body)
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_report_template.template)
+    refute_equal(template['id'], original_report_template.id)
   end
 
   test 'export should export the erb of the template' do


### PR DESCRIPTION
According to ActiveRecord docs objects should be cloned using the dup method https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-clone