### PR TITLE
Fixes #25312 - skip add_*permissions_to_default_roles in rake

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -294,6 +294,7 @@ module Foreman #:nodoc:
     # Usage:
     # add_resource_permissions_to_default_roles ['MyPlugin::FirstResource', 'MyPlugin::SecondResource'], :except => [:skip_this_permission]
     def add_resource_permissions_to_default_roles(resources, opts = {})
+      return if Foreman.in_setup_db_rake? || !permission_table_exists?
       Role.without_auditing do
         Filter.without_auditing do
           Plugin::RbacSupport.new.add_resource_permissions_to_default_roles resources, opts
@@ -305,6 +306,7 @@ module Foreman #:nodoc:
     # Usage:
     # add_permissions_to_default_roles 'Role Name' => [:first_permission, :second_permission]
     def add_permissions_to_default_roles(args)
+      return if Foreman.in_setup_db_rake? || !permission_table_exists?
       Role.without_auditing do
         Filter.without_auditing do
           Plugin::RbacSupport.new.add_permissions_to_default_roles args


### PR DESCRIPTION
(cherry picked from commit 5608af19b4c99fb94421d241a0c31fdf6efe4932)

Without this, katello cannot extend the permissions for Canned admin which means the role will not be able to create organizations because it will not have permissions to create library lifecycle env and default content view for the newly created org.