### PR TITLE
fixes #25382 - Autocomplete test fails when trying to upgrade Jest.

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
@@ -4,6 +4,7 @@ import AutoComplete from '../index';
 import { AutoCompleteProps } from '../AutoComplete.fixtures.js';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 import { KEYCODES } from '../AutoCompleteConstants';
+import { noop } from '../../../common/helpers';
 
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 jest.mock('uuid/v1', () => jest.fn(fn => '1234'));
@@ -45,11 +46,11 @@ describe('AutoComplete', () => {
     it('pressing "forward-slash" should trigger focus', () => {
       const props = getProps();
       const component = mount(<AutoComplete {...props} />);
-      const typeahead = component.instance()._typeahead.current.getInstance();
+      const instance = component.instance();
+      const typeahead = instance._typeahead.current.getInstance();
       typeahead.focus = jest.fn();
       expect(typeahead.focus.mock.calls.length).toBe(0);
-      const event = new KeyboardEvent('keypress', { keyCode: KEYCODES.FWD_SLASH });
-      global.dispatchEvent(event);
+      instance.windowKeyPressHandler({ keyCode: KEYCODES.FWD_SLASH, preventDefault: noop });
       expect(typeahead.focus.mock.calls.length).toBe(1);
     });
 


### PR DESCRIPTION
Jest global/window object seem to change through the update to Jest 23.6.0,
in my opinion, simulate shouldn't be used on the window object as it isn't 
working as the DOM window, calling the function which is triggered by window's key press
is really what we want to test, and almost sure not to fail in future Jest/Enzyme upgrades.

Coverage remains the same.
