### PR TITLE
Fixes #25383 - Enable verbose_query_logs in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,9 @@ Foreman::Application.configure do
   # Raise exception on mass assignment of unfiltered parameters
   config.action_controller.action_on_unpermitted_parameters = :strict
 
+  # include query source line when sql logging is enabled
+  config.active_record.verbose_query_logs = Foreman::Logging.logger('sql')
+
   if defined?(Bullet)
     config.after_initialize do
       Bullet.enable = true


### PR DESCRIPTION
This adds another line to the logs when sql logging is enabled to show
which line of code originated each query.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
