### PR TITLE
Refs #25285 - medium provider test fixes

### DIFF
--- a/test/unit/foreman/renderer/scope/variables/base_test.rb
+++ b/test/unit/foreman/renderer/scope/variables/base_test.rb
@@ -35,7 +35,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
       MediumProviders::Default.any_instance.stubs(:additional_media).returns(additional_media)
 
       scope = @scope.new(host: host, source: @source)
-      assert_equal scope.instance_variable_get('@additional_media'), additional_media
+      assert_equal additional_media.map(&:with_indifferent_access), scope.instance_variable_get('@additional_media')
     end
   end
 
@@ -111,7 +111,7 @@ class BaseVariablesTest < ActiveSupport::TestCase
       MediumProviders::Default.any_instance.stubs(:additional_media).returns(additional_media)
 
       scope = @scope.new(host: host, source: @source)
-      assert_equal scope.instance_variable_get('@additional_media'), additional_media
+      assert_equal additional_media.map(&:with_indifferent_access), scope.instance_variable_get('@additional_media')
     end
 
     describe "@dynamic" do


### PR DESCRIPTION
Fixes develop tests, sorry about that. @stbenjam

I also noticed some of the tests have `assert_equal` parameters swapped,
expected value comes always first. I am swapping this only for the
failed tests tho, no big deal.