### PR TITLE
Fixes #25397 - reimplement indent macro

### DIFF
--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -46,10 +46,18 @@ module Foreman
             "cat << EOF > #{filename}\n#{content}EOF"
           end
 
-          def indent(count)
+          def indent(count, skip1: false)
             return unless block_given? && (text = yield.to_s)
-            prefix = " " * count
-            prefix + text.gsub(/\n/, "\n#{prefix}")
+            prefix = ' ' * count
+            result = []
+            text.each_line.with_index do |line, line_no|
+              if line_no == 0 && skip1
+                result << line
+              else
+                result << prefix + line
+              end
+            end
+            result.join('')
           end
 
           def dns_lookup(name_or_ip)

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -29,6 +29,13 @@ class BaseMacrosTest < ActiveSupport::TestCase
     assert_equal indented, "    foo\n    bar\n    baz"
   end
 
+  test "should indent a string ignoring the first line" do
+    indented = @scope.indent(4, skip1: true) do
+      "foo\nbar\nbaz"
+    end
+    assert_equal indented, "foo\n    bar\n    baz"
+  end
+
   test '#foreman_url can be rendered even outside of controller context' do
     assert_nothing_raised do
       assert_match /\/unattended\/built/, @scope.foreman_url('built')

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
@@ -44,7 +44,7 @@ runcmd:
   
   
   
-  
+
 
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built


### PR DESCRIPTION
It was leaving some garbage whitespace on the last indented line.