### PR TITLE
Refs #25398 - disabled FactValuesControllerTest failing tests

### DIFF
--- a/test/controllers/api/v2/fact_values_controller_test.rb
+++ b/test/controllers/api/v2/fact_values_controller_test.rb
@@ -60,6 +60,7 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
   end
 
   test "should search facts by location" do
+    skip "Randomly fails: https://projects.theforeman.org/issues/25398"
     get :index, params: { "location_id" => @host.location_id }
     assert_response :success
     fact_values = ActiveSupport::JSON.decode(@response.body)['results']
@@ -68,6 +69,7 @@ class Api::V2::FactValuesControllerTest < ActionController::TestCase
   end
 
   test "should search facts by organiztion" do
+    skip "Randomly fails: https://projects.theforeman.org/issues/25398"
     get :index, params: { "organization_id" => @host.organization_id }
     assert_response :success
     fact_values = ActiveSupport::JSON.decode(@response.body)['results']


### PR DESCRIPTION
The two tests are randomly broken for a very long time, we've suffered enough. This is a tracking ticket to fix this, but first let's disable it so Jenkins does return reasonable results. I urge to take a look, I did my homework and I don't know what is causing this.