### PR TITLE
Remove tenant as it is OpenStack Keystone v2 and it was removed in Queens

### DIFF
--- a/app/views/compute_resources_vms/index/_openstack.html.erb
+++ b/app/views/compute_resources_vms/index/_openstack.html.erb
@@ -2,7 +2,6 @@
   <tr>
     <th><%= _('Name') %></th>
     <th><%= _('Type') %></th>
-    <th><%= _('Tenant') %></th>
     <th><%= _('State') %></th>
     <th><%= _('Actions') %></th>
   </tr>
@@ -12,7 +11,6 @@
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :auth_action => 'view', :authorizer => authorizer) %></td>
       <td><%= vm.flavor_with_object %></td>
-      <td><%= vm.tenant %></td>
       <td>
         <span <%= vm_power_class(vm.ready?) %>>
           <%= vm_state(vm) %></span>


### PR DESCRIPTION
This error cause foreman to throw 500 when viewing Virtual Machines in Compute Resources.

Fixes #25413

Since Compute Resource is connected with single project there is nothing lost as every VM in compute resource will have always the same project name. 