### PR TITLE
Remove tenant as it is part of removed OS Keystone v2 api.

### DIFF
--- a/app/views/compute_resources_vms/index/_openstack.html.erb
+++ b/app/views/compute_resources_vms/index/_openstack.html.erb
@@ -2,7 +2,6 @@
   <tr>
     <th><%= _('Name') %></th>
     <th><%= _('Type') %></th>
-    <th><%= _('Tenant') %></th>
     <th><%= _('State') %></th>
     <th><%= _('Actions') %></th>
   </tr>
@@ -12,7 +11,6 @@
     <tr>
       <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :auth_action => 'view', :authorizer => authorizer) %></td>
       <td><%= vm.flavor_with_object %></td>
-      <td><%= vm.tenant %></td>
       <td>
         <span <%= vm_power_class(vm.ready?) %>>
           <%= vm_state(vm) %></span>


### PR DESCRIPTION
Staring from OpenStack Queens calling v2 endpoint returns HTTP 404 and
this this causes foreman to throw 500. Api v2 was removed in "Queens"
release so tenant should be removed to.

Fixes #25413 - fix error on Opens Stack Compute Resource VM's page.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
