### PR TITLE
refs #25285 - deprecate @repos variable

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -72,7 +72,7 @@ class Operatingsystem < ApplicationRecord
                'Xenserver' => %r{XenServer}i }
 
   class Jail < Safemode::Jail
-    allow :name, :media_url, :major, :minor, :family, :to_s, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :medium_uri, :boot_files_uri, :password_hash
+    allow :name, :media_url, :major, :minor, :family, :to_s, :repos, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :medium_uri, :boot_files_uri, :password_hash
   end
 
   def self.title_name
@@ -117,6 +117,24 @@ class Operatingsystem < ApplicationRecord
     families.map do |f|
       OpenStruct.new(:name => f.constantize.new.display_family, :value => f)
     end
+  end
+
+  # DEPRECATED - This will be removed in 1.22.
+  #
+  # This method is deprecated in favor of the additional media features of
+  # medium providers.
+  #
+  # Operating system family can override this method to provide an array of
+  # hashes, each describing a repository. For example, to describe a yum repo,
+  # the following structure can be returned by the method:
+  # [{ :baseurl => "https://dl.thesource.com/get/it/here",
+  #    :name => "awesome",
+  #    :description => "awesome product repo"",
+  #    :enabled => 1,
+  #    :gpgcheck => 1
+  #  }]
+  def repos(host)
+    []
   end
 
   # The OS is usually represented as the concatenation of the OS and the revision

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -18,3 +18,7 @@
 # https://projects.theforeman.org/issues/23300
 - message: 'Dangerous query method (method whose arguments are used as raw SQL) called
     with non-attribute argument(s):'
+
+# https://projects.theforeman.org/issues/25285
+- message: 'You are using a deprecated behavior, it will be removed in version 1.22,
+    `repos` is deprecated in favor of providing additional media through a Medium Provider.'

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -53,6 +53,7 @@ module Foreman
         :preseed_path,
         :preseed_server,
         :provisioning_type,
+        :repos,
         :static,
         :template_name,
         :xen

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -75,6 +75,7 @@ module Foreman
             @arch      = architecture_name
             @osver     = major.try(:to_i)
             @mediapath = mediumpath(@medium_provider) if @medium_provider
+            @repos     = repos(host)
           end
 
           def preseed_attributes


### PR DESCRIPTION
During the addition of additional media support, `@repos` was erroneously
removed instead of being deprecated.  I have the deprecation set to 1.21.

If #25285 will not be accepted for 1.20, I'll change it to be 1.22.
