### PR TITLE
Fixes #25421 - Allow mapped IPv4 in forwarded address list

### DIFF
--- a/app/services/foreman/unattended_installation/host_finder.rb
+++ b/app/services/foreman/unattended_installation/host_finder.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module Foreman
   module UnattendedInstallation
     class HostFinder
@@ -47,7 +49,9 @@ module Foreman
 
       def find_host_by_ip_or_mac
         # In-case we get back multiple ips (see #1619)
-        ip = query_params[:ip].split(',').first
+        address_parser = IPAddr.new query_params[:ip].split(',').first
+        ip = address_parser.native.to_s
+
         mac_list = query_params[:mac_list]
 
         query = mac_list.empty? ? { :nics => { :ip => ip } } : ["lower(nics.mac) IN (?)", mac_list]

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -58,6 +58,13 @@ class UnattendedControllerTest < ActionController::TestCase
       assert_response :success
     end
 
+    test "should get a kickstart when IPv6 mapped IPv4 address is used" do
+      @request.env["HTTP_X_FORWARDED_FOR"] = "::ffff:" + @rh_host.ip
+      @request.env["REMOTE_ADDR"] = "127.0.0.1"
+      get :host_template, params: { :kind => 'provision' }
+      assert_response :success
+    end
+
     test "should set @static when requested" do
       Setting[:safemode_render] = false
       @request.env["HTTP_X_RHN_PROVISIONING_MAC_0"] = "eth0 #{@rh_host.mac}"


### PR DESCRIPTION
Solves the case in which an IPv4 is mapped to IPv6, if this is the case, it will convert back to an IPv4 if possible. In case it's an IPv6 it will be returned as is.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
