### PR TITLE
Refs #25217 - Add default-props to Alert

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/Alert/AlertBody.js
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/AlertBody.js
@@ -23,4 +23,11 @@ AlertBody.propTypes = {
   children: PropTypes.node,
 };
 
+AlertBody.defaultProps = {
+  message: undefined,
+  children: undefined,
+  link: undefined,
+  title: undefined,
+};
+
 export default AlertBody;

--- a/webpack/assets/javascripts/react_app/components/common/Alert/AlertLink.js
+++ b/webpack/assets/javascripts/react_app/components/common/Alert/AlertLink.js
@@ -13,4 +13,9 @@ AlertLink.propTypes = {
   onClick: PropTypes.func,
 };
 
+AlertLink.defaultProps = {
+  href: undefined,
+  onClick: undefined,
+};
+
 export default AlertLink;


### PR DESCRIPTION
IMO we should start to declare default-props when they should be default undefined.
It will also make `patternfly-react-eslint-plugin` satisfied.