### PR TITLE
Refs #25217 - ConfigReport data should be required

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ConfigReports/ConfigReports.js
+++ b/webpack/assets/javascripts/react_app/components/ConfigReports/ConfigReports.js
@@ -70,7 +70,7 @@ ConfigReports.propTypes = {
       total: PropTypes.number,
       tableClasses: PropTypes.string,
     }),
-  }),
+  }).isRequired,
 };
 
 export default ConfigReports;


### PR DESCRIPTION
Update the ConfigReport prop-types so `data` is a required prop
