### PR TITLE
Fixes #25457 - expose extraConfig from user_data 

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -521,6 +521,7 @@ module Foreman::Model
       opts['volumes'] = vm_model.volumes
       if args[:user_data] && valid_cloudinit_for_customspec?(args[:user_data])
         opts["customization_spec"] = client.cloudinit_to_customspec(args[:user_data])
+        opts["extraConfig"] = opts["customization_spec"]["extraConfig"] if opts["customization_spec"].key?("extraConfig")
       end
       client.servers.get(client.vm_clone(opts)['new_vm']['id'])
     end


### PR DESCRIPTION
This is a pull request for the issue from fog/fog-vsphere#93 (Also see fog/fog-vsphere#172)
Further information from https://projects.theforeman.org/issues/25457

> Two simple line changes allow for the extraConfig from userdata to be passed through to fog-vsphere vm_clone.
> This adds the option to pass through guestinfo network configuration for CoreOS VMs.
> With the use of Omaha or similar tools even building the ignition configuration and passing it to the VM on clone is an option.
> 
> Without this change an additional tool has to be used to supply the guestinfo before the machine is started for the first time.
> 