### PR TITLE
Fixes #25466 - user inputs should be previewed as empty strings

### DIFF
--- a/app/services/input_resolver/user_input_resolver.rb
+++ b/app/services/input_resolver/user_input_resolver.rb
@@ -13,6 +13,10 @@ module InputResolver
       input_value
     end
 
+    def preview_value
+      @input.template.is_a?(ReportTemplate) ? "" : super
+    end
+
     private
 
     def required_value_needed?


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->

Turns out empty value is better value for seeing the output in preview mode. cc @iNecas any concerns about REX? Longer term, it would be good to have input's default value or let user specify custom value for previewing.