### PR TITLE
Fixes #25482 - parameters are logged via params logger

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -214,6 +214,7 @@ module Foreman
     # Check that the loggers setting exist to configure the app and sql loggers
     Foreman::Logging.add_loggers((SETTINGS[:loggers] || {}).reverse_merge(
       :app => {:enabled => true},
+      :params => {:enabled => true},
       :audit => {:enabled => true},
       :ldap => {:enabled => false},
       :permissions => {:enabled => false},

--- a/config/initializers/0_custom_logging.rb
+++ b/config/initializers/0_custom_logging.rb
@@ -1,0 +1,13 @@
+# Override "Processing by" logging method because Rails devs are opinionated
+# about this: https://github.com/rails/rails/pull/26025 and we can't simply
+# send "Parameters" line into INFO log level because of Katello and OpenSCAP
+# very noisy endpoints leading to tens of gigabytes log file per day.
+#
+# Our own customized log subscriber logs all "Parameters" via DEBUG log level
+# so users can decide when they want to see them. Prior attaching we need
+# to unsubscribe all from start_processing.action_controller event as Rails
+# API does not provide a way of unsubscribing an event for a particular subscriber.
+#
+ActiveSupport::Notifications.unsubscribe "start_processing.action_controller"
+ActiveSupport::LogSubscriber.log_subscribers.select { |ls| ls.instance_of? ActionController::LogSubscriber }.first.patterns.delete("start_processing.action_controller")
+Foreman::CustomizedLogSubscriber.attach_to :action_controller

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -78,6 +78,8 @@
 #:loggers:
 #  :app:
 #    :enabled: true
+#  :params:
+#    :enabled: true
 #  :audit:
 #    :enabled: true
 #  :ldap:

--- a/lib/foreman/customized_log_subscriber.rb
+++ b/lib/foreman/customized_log_subscriber.rb
@@ -1,0 +1,21 @@
+module Foreman
+  class CustomizedLogSubscriber < ActiveSupport::LogSubscriber
+    def params_logger
+      ::Foreman::Logging.logger('params')
+    end
+
+    # See config/initializers/0_custom_logging.rb for more details
+    def start_processing(event)
+      return unless logger.info?
+
+      payload = event.payload
+      format  = payload[:format]
+      format  = format.to_s.upcase if format.is_a?(Symbol)
+
+      info "Processing by #{payload[:controller]}##{payload[:action]} as #{format}"
+
+      params = payload[:params].except(*ActionController::LogSubscriber::INTERNAL_PARAMS)
+      params_logger.info "  Parameters: #{params.inspect}" unless params.empty?
+    end
+  end
+end


### PR DESCRIPTION
Rails log contains excessive amount of JSON for one of the OpenScap endpoints. Rails unfortunately doesn't provide a way to turn off logging of "Parameters" via INFO logging line. I've attempted to create patch in upstream Rails, but the community seems to be very opinionated about this: https://github.com/rails/rails/pull/26025

Rails provides a simple "filtering" mechanism for keys (e.g. passwords) and Katello plugin has a workaround to avoid logging of some larger requests:

    app.config.filter_parameters += [:_json] #package profile parameter

But this approach cannot be done for OpenSCAP as it does not have a common root JSON element and we'd need to add filters for generic fields like "logs" or "name" etc.

The only reasonable way is to create our own logging subscriber and turn
off the Rails default one then. That's what this patch does. The code is
a bit clunky as I don't want to unsubscribe whole
ActionController::LogSubscriber as it provides many other event listener
and future versions of Rails will definitely add more. Thus the patch
simply unregisters the event, removes it from the registry (this is just
for record) and adds new subscriber.

Before the patch:

```
[app|I||] Started GET "/domains/1-home-lan/edit" for 127.0.0.1 at 2018-11-16 14:49:12 +0100
[app|I|7f0|675] Processing by DomainsController#edit as HTML
[app|I|7f0|675]   Parameters: {"id"=>"1-home-lan"}
...

```

After (note the level change):

```
[app|I||] Started GET "/domains/1-home-lan/edit" for 127.0.0.1 at 2018-11-16 14:49:12 +0100
[app|I|7f0|675] Processing by DomainsController#edit as HTML
[app|D|7f0|675]   Parameters: {"id"=>"1-home-lan"}
...

```