### PR TITLE
Fixes #25487 - Fix subtotal in API response

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -61,12 +61,12 @@ module Api
       end
 
       def metadata_total
-        @total ||= resource_scope.try(:size).to_i
+        @total ||= resource_scope.try(:count).to_i
       end
 
       def metadata_subtotal
         if params[:search].present?
-          @subtotal ||= instance_variable_get("@#{controller_name}").try(:size).to_i
+          @subtotal ||= instance_variable_get("@#{controller_name}").try(:count).to_i
         else
           @subtotal ||= metadata_total
         end

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -61,7 +61,7 @@ module Api
       end
 
       def metadata_total
-        @total ||= resource_scope.try(:count).to_i
+        @total ||= resource_scope.try(:size).to_i
       end
 
       def metadata_subtotal

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -1230,4 +1230,33 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal puppet_proxy['name'], JSON.parse(@response.body)['puppet_proxy']['name'], "Can't update host with puppet proxy #{puppet_proxy}"
   end
+
+  # This is a test of the base_controller functionality, but we need to use a real endpoint
+  # to test the API response metadata is returned correctly
+  describe 'should create correct subtotals' do
+    before do
+      as_admin do
+        100.times { |_| FactoryBot.create(:host) }
+      end
+    end
+
+    it 'with no search parameter' do
+      get :index
+      hosts_response = ActiveSupport::JSON.decode(@response.body)
+
+      assert_response :success
+      assert_equal hosts_response["subtotal"], ::Host.all.count
+      assert hosts_response["subtotal"] > hosts_response["per_page"]
+    end
+
+    it 'with search parameter' do
+      org1 = Organization.find_by_name('Organization 1')
+      get :index, params: { search: "organization = \"#{org1.name}\""}
+      hosts_response = ActiveSupport::JSON.decode(@response.body)
+
+      assert_response :success
+      assert_equal hosts_response["subtotal"], org1.hosts.count
+      assert hosts_response["subtotal"] > hosts_response["per_page"]
+    end
+  end
 end


### PR DESCRIPTION
When requesting an endpoint with a search parameter, the subtotal
shows the results returned, rather than responses found. i.e. even
if 200 results were found, if 20 are being returned because of
pagination, the subtotal will be 20.

This changes back to using `count`, which sends another SQL query
and returns the correct subtotal.

It looks like this was updated (with good intention) for performance reasons https://github.com/theforeman/foreman/pull/5993/files#r213566553


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
