### PR TITLE
refs #19067 - adds react-diff-view to vendor file

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -7,6 +7,7 @@ module.exports = [
   'react-dom',
   'react-bootstrap',
   'react-debounce-input',
+  'react-diff-view',
   'react-ellipsis-with-tooltip',
   'react-numeric-input',
   'react-onclickoutside',


### PR DESCRIPTION
this avoids the package to being duplicated when used by plugins.

before (on foreman + rex + ansible plugins)

```
￼All (5.3 MB)
￼vendor-1c326de93e364f3d92c2.js (4.07 MB)
￼foreman_ansible-824cba753b2f8e3afd08.js (445.93 KB)
￼bundle-96cce9ae71e71f78eb9f.js (424.3 KB)
￼foreman_remote_execution-3f8355b3cc3b3cc399b8.js (393.61 KB)
```

after:
```
￼All (5 MB)
￼vendor-ea25bb4408e14b8aa07a.js (4.21 MB)
￼foreman_ansible-37e250519f35a92fa4c0.js (294.93 KB)
￼bundle-135f6abcfbdd882efd78.js (273.29 KB)
￼foreman_remote_execution-459ed3afbe82bf66388e.js (242.61 KB)
```