### PR TITLE
Fixes #25497 - Fix backslash shortcut on firefox

### DIFF
--- a/test/integration/search_bar_js_test.rb
+++ b/test/integration/search_bar_js_test.rb
@@ -1,0 +1,9 @@
+require 'integration_test_helper'
+
+class SearchBarTest < IntegrationTestWithJavascript
+  test "backslash key clicked should opens the search" do
+    visit bookmarks_path
+    find('table').send_keys "/"
+    assert find('.search-input.focus')
+  end
+end

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
@@ -51,7 +51,7 @@ describe('AutoComplete', () => {
       typeahead.focus = jest.fn();
       expect(typeahead.focus.mock.calls).toHaveLength(0);
       instance.windowKeyPressHandler({
-        keyCode: KEYCODES.FWD_SLASH,
+        charCode: KEYCODES.FWD_SLASH,
         preventDefault: noop,
       });
       expect(typeahead.focus.mock.calls).toHaveLength(1);

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
@@ -43,7 +43,7 @@ class AutoComplete extends React.Component {
       return;
     }
     const instance = this._typeahead.current.getInstance();
-    switch (e.keyCode) {
+    switch (e.charCode) {
       case KEYCODES.ENTER: {
         this.props.handleSearch();
         break;

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/integration.test.js
@@ -103,7 +103,7 @@ describe('SearchBar integration test', () => {
     );
     // expect it to call Turbolinks.
     expect(global.Turbolinks.visit.mock.calls).toHaveLength(1);
-    const event = new KeyboardEvent('keypress', { keyCode: 13 });
+    const event = new KeyboardEvent('keypress', { charCode: 13 });
     global.dispatchEvent(event);
     expect(global.Turbolinks.visit.mock.calls).toHaveLength(2);
     // bookmark this page:


### PR DESCRIPTION
The search's backslash shortcut doesn't work on firefox because `keyCode` value is different.