### PR TITLE
Fixes #25503 - Allow truncation of page header in breadcrumbs

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -31,9 +31,11 @@ const Breadcrumb = ({
         } = item;
         const overrideTitle = active && titleReplacement;
         const itemTitle = overrideTitle || text || caption;
-        const inner = (active
-                       ? (<EllipsisWithTooltip>{itemTitle}</EllipsisWithTooltip>)
-                       : itemTitle);
+        const inner = active ? (
+          <EllipsisWithTooltip>{itemTitle}</EllipsisWithTooltip>
+        ) : (
+          itemTitle
+        );
 
         return (
           <PfBreadcrumb.Item

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -32,7 +32,9 @@ const Breadcrumb = ({
         const overrideTitle = active && titleReplacement;
         const itemTitle = overrideTitle || text || caption;
         const inner = active ? (
-          <EllipsisWithTooltip>{itemTitle}</EllipsisWithTooltip>
+          <EllipsisWithTooltip placement="bottom">
+            {itemTitle}
+          </EllipsisWithTooltip>
         ) : (
           itemTitle
         );

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb as PfBreadcrumb } from 'patternfly-react';
 import 'patternfly-react/dist/sass/_breadcrumb.scss';
+import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
+import './Breadcrumbs.scss';
 
 const Breadcrumb = ({
   items,
@@ -29,6 +31,9 @@ const Breadcrumb = ({
         } = item;
         const overrideTitle = active && titleReplacement;
         const itemTitle = overrideTitle || text || caption;
+        const inner = (active
+                       ? (<EllipsisWithTooltip>{itemTitle}</EllipsisWithTooltip>)
+                       : itemTitle);
 
         return (
           <PfBreadcrumb.Item
@@ -39,7 +44,7 @@ const Breadcrumb = ({
             title={itemTitle}
           >
             {icon && <img src={icon.url} alt={icon.alt} title={icon.alt} />}{' '}
-            {itemTitle}
+            {inner}
           </PfBreadcrumb.Item>
         );
       })}

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumbs.scss
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumbs.scss
@@ -1,0 +1,4 @@
+.active span {
+  display: inline-flex;
+  max-width: 50%;
+}

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
@@ -28,7 +28,9 @@ exports[`Breadcrumbs renders breadcrumbs menu 1`] = `
     title="active child"
   >
      
-    <EllipisWithTooltip>
+    <EllipisWithTooltip
+      placement="bottom"
+    >
       active child
     </EllipisWithTooltip>
   </BreadcrumbItem>
@@ -45,7 +47,9 @@ exports[`Breadcrumbs renders h1 title 1`] = `
     title="title"
   >
      
-    <EllipisWithTooltip>
+    <EllipisWithTooltip
+      placement="bottom"
+    >
       title
     </EllipisWithTooltip>
   </BreadcrumbItem>
@@ -71,7 +75,9 @@ exports[`Breadcrumbs renders title override 1`] = `
     title="override title"
   >
      
-    <EllipisWithTooltip>
+    <EllipisWithTooltip
+      placement="bottom"
+    >
       override title
     </EllipisWithTooltip>
   </BreadcrumbItem>

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
@@ -28,7 +28,9 @@ exports[`Breadcrumbs renders breadcrumbs menu 1`] = `
     title="active child"
   >
      
-    active child
+    <EllipisWithTooltip>
+      active child
+    </EllipisWithTooltip>
   </BreadcrumbItem>
 </Breadcrumb>
 `;
@@ -43,7 +45,9 @@ exports[`Breadcrumbs renders h1 title 1`] = `
     title="title"
   >
      
-    title
+    <EllipisWithTooltip>
+      title
+    </EllipisWithTooltip>
   </BreadcrumbItem>
 </Breadcrumb>
 `;
@@ -67,7 +71,9 @@ exports[`Breadcrumbs renders title override 1`] = `
     title="override title"
   >
      
-    override title
+    <EllipisWithTooltip>
+      override title
+    </EllipisWithTooltip>
   </BreadcrumbItem>
 </Breadcrumb>
 `;


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
