### PR TITLE
Refs #25493 - Don't warn on setting cache miss

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -354,8 +354,8 @@ class Setting < ApplicationRecord
   end
 
   def clear_cache
-    # ensures we don't have cache left overs in settings
-    unless Setting.cache.delete(cache_key)
+    # Rails cache returns false if the delete failed and nil if the key is missing
+    if Setting.cache.delete(cache_key) == false
       Rails.logger.warn "Failed to remove #{name} from cache"
     end
   end


### PR DESCRIPTION
Deleting a key from the cache will return `false` if it fails to delete
it or `nil` if the key is missing so we have to explicitly check for
false value.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
