### PR TITLE
Fixes #25436 - Add host power state api endpoint

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -356,7 +356,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :"api/v2/hosts" => [:rebuild_config]
                                      }
     map.permission :power_hosts,   {:hosts          => [:power],
-                                    :"api/v2/hosts" => [:power] }
+                                    :"api/v2/hosts" => [:power, :power_status] }
     map.permission :console_hosts, {:hosts => [:console] }
     map.permission :ipmi_boot_hosts, { :hosts          => [:ipmi_boot],
                                        :"api/v2/hosts" => [:boot] }

--- a/app/services/power_manager/power_status.rb
+++ b/app/services/power_manager/power_status.rb
@@ -1,0 +1,40 @@
+module PowerManager
+  class PowerStatus < Base
+    HOST_POWER = {
+      on:  { state: 'on', title: N_('On') },
+      off: { state: 'off', title: N_('Off') },
+      na:  { state: 'na', title: N_('N/A') }
+    }.freeze
+
+    def power_state
+      result = { id: host.id }.merge(HOST_POWER[:na])
+
+      if host.supports_power?
+        result = host_power_ping(result)
+      else
+        result[:statusText] = _('Power operations are not enabled on this host.')
+      end
+
+      result
+    end
+
+    private
+
+    def host_power_ping(result)
+      timeout = 3
+
+      Timeout.timeout(timeout) do
+        result.merge!(HOST_POWER[host.supports_power_and_running? ? :on : :off])
+      end
+
+      result
+    rescue Timeout::Error
+      logger.debug("Failed to retrieve power status for #{host} within #{timeout} seconds.")
+
+      result[:statusText] = n_("Failed to retrieve power status for %{host} within %{timeout} second.",
+                               "Failed to retrieve power status for %{host} within %{timeout} seconds.", timeout) %
+                              {host: host, timeout: timeout}
+      result
+    end
+  end
+end

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -27,7 +27,7 @@
           <td class="ca">
             <% selector = dom_id(host, 'power') %>
             <span id=<%= selector %>></span>
-            <%= mount_react_component('PowerStatus', '#' + selector, {:id => host.id, :url => power_host_path(host.id)}.to_json) %>
+            <%= mount_react_component('PowerStatus', '#' + selector, {:id => host.id, :url => power_api_host_path(host)}.to_json) %>
           </td>
         <% end %>
         <td class="ellipsis"><%= name_column(host) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,6 @@ Foreman::Application.routes.draw do
         put 'toggle_manage'
         post 'environment_selected'
         put 'power'
-        get 'power', :to => 'hosts#get_power_state'
         get 'console'
         get 'overview'
         get 'bmc'

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -370,6 +370,7 @@ Foreman::Application.routes.draw do
           get 'template/:kind', :on => :member, :action => :template
           put :disassociate, :on => :member
           put :boot, :on => :member
+          get :power, :on => :member, :action => :power_status
           put :power, :on => :member
           put :rebuild_config, :on => :member
           post :facts, :on => :collection

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1663,53 +1663,6 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'show power status for a host' do
-    Host.any_instance.stubs(:supports_power?).returns(true)
-    Host.any_instance.stubs(:supports_power_and_running?).returns(true)
-    get :get_power_state, params: { :id => @host.id }, session: set_session_user, xhr: true
-    assert_response :success
-    response = JSON.parse @response.body
-    assert_equal({"id" => @host.id, "state" => "on", "title" => "On"}, response)
-  end
-
-  test 'show power status for a powered off host' do
-    Host.any_instance.stubs(:supports_power?).returns(true)
-    Host.any_instance.stubs(:supports_power_and_running?).returns(false)
-    get :get_power_state, params: { :id => @host.id }, session: set_session_user, xhr: true
-    assert_response :success
-    response = JSON.parse @response.body
-    assert_equal({"id" => @host.id, "state" => "off", "title" => "Off"}, response)
-  end
-
-  test 'show power status for a host that has no power' do
-    Host.any_instance.stubs(:supports_power?).returns(false)
-    get :get_power_state, params: { :id => @host.id }, session: set_session_user, xhr: true
-    assert_response :success
-    response = JSON.parse @response.body
-    assert_equal({"id" => @host.id, "state" => "na", "title" => 'N/A',
-      "statusText" => "Power operations are not enabled on this host."}, response)
-  end
-
-  test 'show power status for a host that has an exception' do
-    Host.any_instance.stubs(:supports_power?).returns(true)
-    Host.any_instance.stubs(:power).raises(::Foreman::Exception.new(N_("Unknown power management support - can't continue")))
-    get :get_power_state, params: { :id => @host.id }, session: set_session_user, xhr: true
-    assert_response :success
-    response = JSON.parse @response.body
-    assert_equal({"id" => @host.id, "state" => "na", "title" => "N/A",
-      "statusText" => "Failed to fetch power status: ERF42-9958 [Foreman::Exception]: Unknown power management support - can't continue"}, response)
-  end
-
-  test 'do not provide power state on an unknown host' do
-    get :get_power_state, params: { :id => 'no-such-host' }, session: set_session_user, xhr: true
-    assert_response :not_found
-  end
-
-  test 'do not provide power state for non ajax requests' do
-    get :get_power_state, params: { :id => @host.id }, session: set_session_user
-    assert_response :method_not_allowed
-  end
-
   describe '#hostgroup_or_environment_selected' do
     test 'choosing only one of hostgroup or environment renders classes' do
       post :hostgroup_or_environment_selected, params: {


### PR DESCRIPTION
This adds a new enpoint to the api `/hosts/:id/power_status` as per [#25436](https://projects.theforeman.org/issues/25436)

To achieve this I also refactored the existing status check in the hosts_controller (non api).

TODO:

- [x] Add endpoint using the new HostPowerStatusService