### PR TITLE
Fixes #25548 - SearchBar bug on hosts page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteReducer.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteReducer.js
@@ -45,7 +45,7 @@ export default (state = initialState, action) => {
         status,
       });
     case AUTO_COMPLETE_RESET:
-      return state.merge({ ...initialState });
+      return initialState;
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteSelectors.js
@@ -1,0 +1,18 @@
+export const selectAutocomplete = state => state.autocomplete;
+
+export const selectAutocompleteError = state => selectAutocomplete(state).error;
+
+export const selectAutocompleteResults = state =>
+  selectAutocomplete(state).results;
+
+export const selectAutocompleteSearchQuery = state =>
+  selectAutocomplete(state).searchQuery;
+
+export const selectAutocompleteStatus = state =>
+  selectAutocomplete(state).status;
+
+export const selectAutocompleteController = state =>
+  selectAutocomplete(state).controller;
+
+export const selectAutocompleteTrigger = state =>
+  selectAutocomplete(state).trigger;

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteSelectors.test.js
@@ -1,0 +1,43 @@
+import {
+  selectAutocompleteSearchQuery,
+  selectAutocompleteStatus,
+  selectAutocompleteController,
+  selectAutocompleteTrigger,
+} from '../AutoCompleteSelectors';
+import {
+  searchQuery,
+  status,
+  url,
+  isDisabled,
+  controller,
+  trigger,
+} from '../AutoComplete.fixtures';
+
+describe('Autocomplete Selector', () => {
+  const state = {
+    autocomplete: {
+      searchQuery,
+      status,
+      url,
+      isDisabled,
+      controller,
+      trigger,
+    },
+  };
+
+  it('should select searchQuery', () => {
+    expect(selectAutocompleteSearchQuery(state)).toEqual(searchQuery);
+  });
+
+  it('should select status', () => {
+    expect(selectAutocompleteStatus(state)).toEqual(status);
+  });
+
+  it('should select controller', () => {
+    expect(selectAutocompleteController(state)).toEqual(controller);
+  });
+
+  it('should select trigger', () => {
+    expect(selectAutocompleteTrigger(state)).toEqual(trigger);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TypeAheadSelect } from 'patternfly-react';
 import classNames from 'classnames';
+import Immutable from 'seamless-immutable';
 import { bindMethods, debounceMethods, noop } from '../../common/helpers';
 import AutoCompleteMenu from './components/AutoCompleteMenu';
 import AutoCompleteSearchButton from './components/AutoCompleteSearchButton';
@@ -151,12 +152,16 @@ class AutoComplete extends React.Component {
       results,
       useKeyShortcuts,
     } = this.props;
+    /** Using a 3rd party library (react-bootstrap-typeahead) that expects a mutable array. */
+    const options = Immutable.isImmutable(results)
+      ? results.asMutable()
+      : results;
     return (
       <div>
         <TypeAheadSelect
           ref={this._typeahead}
           defaultInputValue={initialQuery}
-          options={results}
+          options={options}
           isLoading={this.handleLoading()}
           onInputChange={this.handleInputChange}
           onChange={this.handleResultsChange}

--- a/webpack/assets/javascripts/react_app/components/SearchBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/index.js
@@ -3,14 +3,18 @@ import { bindActionCreators } from 'redux';
 import * as actions from '../AutoComplete/AutoCompleteActions';
 import reducer from '../AutoComplete/AutoCompleteReducer';
 import SearchBar from './SearchBar';
+import {
+  selectAutocompleteError,
+  selectAutocompleteResults,
+  selectAutocompleteSearchQuery,
+  selectAutocompleteStatus,
+} from '../AutoComplete/AutoCompleteSelectors';
 
-const mapStateToProps = ({
-  autocomplete: { error, results, searchQuery, status },
-}) => ({
-  error,
-  results,
-  searchQuery,
-  status,
+const mapStateToProps = state => ({
+  error: selectAutocompleteError(state),
+  results: selectAutocompleteResults(state),
+  searchQuery: selectAutocompleteSearchQuery(state),
+  status: selectAutocompleteStatus(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);


### PR DESCRIPTION
**Description of problem:**

Unable to search host in search box for all host

**Steps to Reproduce:**
1. Go on all hosts page
2. click on search box and type to search

**Actual results:**
As soon as we try to search, search box is gets disappear with error on browser console.

**Expected results:**
User should able to search from available hosts.