### PR TITLE
Fixes #25551 - use Rails cache for widgets

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,7 +16,13 @@ class DashboardController < ApplicationController
 
   def show
     if @widget.present? && @widget.user == User.current
-      render(:partial => @widget.template, :locals => @widget.data)
+      cache_key = "#{@widget.cache_key}-#{@widget.user.id}/search-#{params[:search]}"
+      from_cache = Rails.cache.fetch(cache_key)
+      if from_cache
+        render html: from_cache
+      else
+        Rails.cache.write(cache_key, render(:partial => @widget.template, :locals => @widget.data), expires_in: Setting[:widget_cache])
+      end
     else
       render_403 "User #{User.current} attempted to access another user's widget"
     end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -22,7 +22,8 @@ class Setting::General < Setting
       self.set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default.'), [], N_('HTTP(S) proxy except hosts')),
       self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
-      self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 30, N_('Out of sync interval'))
+      self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 30, N_('Out of sync interval')),
+      self.set('widget_cache', N_("Cache for dasboard widgets in seconds, set to 0 to turn it off."), 30 * 60, N_('Widget cache'))
     ]
   end
 


### PR DESCRIPTION
The idea is simple - all widgets gets rendered through a single point
which is the show action in the dashboard controller. Widgets have state
stored in database (mostly data attribute), so this can be taken as the
main cache key (the patch uses Rails built-in `cache_key`). Plus widgets
are per-user (user.id) and users can also alternatively enter a search
query (search). This gives us composed key for accessing Rails cache.

Amount of seconds in the cache is configurable and can be turned off.