### PR TITLE
Fixes #25553 - neutron fixed IP support

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -133,7 +133,7 @@ module Foreman::Model
       network = args.delete(:network)
       # fix internal network format for fog.
       args[:nics].delete_if(&:blank?)
-      args[:nics].map! {|nic| { 'net_id' => nic } }
+      args[:nics].map! {|nic| nic.is_a?(String) ? { 'net_id' => nic } : nic }
       args[:security_groups].delete_if(&:blank?) if args[:security_groups].present?
       format_scheduler_hint_filter(args) if args[:scheduler_hint_filter].present?
       vm = super(args)

--- a/test/models/compute_resources/openstack_test.rb
+++ b/test/models/compute_resources/openstack_test.rb
@@ -136,6 +136,30 @@ module Foreman
           )
         end
 
+        test "passes neutron nics hash" do
+          args = {
+            :nics => [
+              'nic1',
+              {'net_id' => 'nic2', 'v4_fixed_ip' => '10.1.1.1'}
+            ],
+            'flavor_ref' => 'foo_flavor',
+            'image_ref' => 'foo_image'
+          }
+          desired = {
+            :nics => [
+              {'net_id' => 'nic1'},
+              {'net_id' => 'nic2', 'v4_fixed_ip' => '10.1.1.1'}
+            ],
+            'flavor_ref' => 'foo_flavor',
+            'image_ref' => 'foo_image'
+          }
+
+          Fog.mock!
+          @compute_resource.stubs(:key_pair).returns(mocked_key_pair)
+          @compute_resource.create_vm(args)
+          assert_equal(desired, args)
+        end
+
         test 'maps flavor_ref to flavor_id' do
           assert_attrs_mapped(cr, 'flavor_ref', 'flavor_id')
         end


### PR DESCRIPTION
Allows to post nic hash for fog-openstack when creating a host. It's
backward compatible, if a string is posted, it's transformed to a hash
like before. With this change a 'v4_fixed_ip' or 'port_id' can be
used, which enables user to select the desired IP.

https://github.com/fog/fog-openstack/blob/master/lib/fog/openstack/compute/requests/create_server.rb#L50