### PR TITLE
Fixes #24801 - Always seed default taxonomies

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -7,8 +7,6 @@ class Taxonomy < ApplicationRecord
 
   serialize :ignore_types, Array
 
-  belongs_to :user
-
   before_create :assign_default_templates
   after_create :assign_taxonomy_to_user
   before_validation :sanitize_ignored_types

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,9 +13,6 @@ Foreman::Application.configure do |app|
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Eager load all classes pre-fork for performance
-  config.eager_load = true
-
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -18,8 +18,8 @@ Medium.without_auditing do
     next if Medium.unscoped.where(['name = ? OR path = ?', input[:name], input[:path]]).any?
     next if SeedHelper.audit_modified? Medium, input[:name]
     m = Medium.create input
-    m.organizations = organizations if SETTINGS[:organizations_enabled]
-    m.locations = locations if SETTINGS[:locations_enabled]
+    m.organizations = organizations
+    m.locations = locations
     raise "Unable to create medium: #{format_errors m}" if m.nil? || m.errors.any?
   end
 end

--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -122,8 +122,8 @@ class SeedHelper
       t.vendor = vendor
 
       if !t.persisted?
-        t.organizations = Organization.unscoped.all if SETTINGS[:organizations_enabled] && t.respond_to?(:organizations=)
-        t.locations = Location.unscoped.all if SETTINGS[:locations_enabled] && t.respond_to?(:locations=)
+        t.organizations = Organization.unscoped.all if t.respond_to?(:organizations=)
+        t.locations = Location.unscoped.all if t.respond_to?(:locations=)
         raise "Unable to create template #{t.name}: #{format_errors t}" unless t.valid?
       else
         raise "Unable to update template #{t.name}: #{format_errors t}" unless t.valid?

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -145,7 +145,7 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "seed organization when environment SEED_ORGANIZATION specified" do
-    Organization.stubs(:any?).returns(false)
+    Organization.stubs(:none?).returns(true)
     with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed('030-auth_sources.rb', '035-admin.rb', '050-taxonomies.rb')
     end
@@ -153,7 +153,7 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "don't seed organization when an org already exists" do
-    Organization.stubs(:any?).returns(true)
+    Organization.stubs(:none?).returns(false)
     with_env('SEED_ORGANIZATION' => 'seed_test') do
       seed('030-auth_sources.rb', '035-admin.rb', '050-taxonomies.rb')
     end
@@ -161,7 +161,7 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "seed location when environment SEED_LOCATION specified" do
-    Location.stubs(:any?).returns(false)
+    Location.stubs(:none?).returns(true)
     with_env('SEED_LOCATION' => 'seed_test') do
       seed('030-auth_sources.rb', '035-admin.rb', '050-taxonomies.rb')
     end
@@ -169,7 +169,7 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "don't seed location when a location already exists" do
-    Location.stubs(:any?).returns(true)
+    Location.stubs(:none?).returns(false)
     with_env('SEED_LOCATION' => 'seed_test') do
       seed('030-auth_sources.rb', '035-admin.rb', '050-taxonomies.rb')
     end
@@ -177,8 +177,8 @@ class SeedsTest < ActiveSupport::TestCase
   end
 
   test "seeded organization contains seeded location" do
-    Location.stubs(:any?).returns(false)
-    Organization.stubs(:any?).returns(false)
+    Location.stubs(:none?).returns(true)
+    Organization.stubs(:none?).returns(true)
 
     org_name = 'seed_org'
     loc_name = 'seed_loc'


### PR DESCRIPTION
This is needed so we can enforce enabling taxonomies. If this seed is
run on an existing system, all existing objects will be associated to
the default taxonomy. For systems that already have taxonomies this
seed will remain a noop.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
