### PR TITLE
Fixes #25577 - updated puppetclass_lookup_keys_controller queries

### DIFF
--- a/app/controllers/puppetclass_lookup_keys_controller.rb
+++ b/app/controllers/puppetclass_lookup_keys_controller.rb
@@ -4,8 +4,11 @@ class PuppetclassLookupKeysController < LookupKeysController
   before_action :setup_search_options, :only => :index
 
   def index
-    @lookup_keys = resource_base_search_and_page(:param_classes).smart_class_parameters
-    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map {|key| key.param_class.try(:id)}.compact.uniq)
+    @lookup_keys = resource_base_search_and_page.distinct.preload(:lookup_values)
+    environment_classes = EnvironmentClass.where(puppetclass_lookup_key_id: @lookup_keys.map(&:id)).select(:puppetclass_id, :puppetclass_lookup_key_id).distinct.preload(:puppetclass)
+    puppetclass_ids = environment_classes.map(&:puppetclass_id).uniq
+    @puppetclass_authorizer = Authorizer.new(User.current, :collection => puppetclass_ids)
+    @lookup_keys_to_class = Hash[environment_classes.map { |environment_class| [environment_class.puppetclass_lookup_key_id, environment_class.puppetclass]}]
   end
 
   private

--- a/app/models/environment_class.rb
+++ b/app/models/environment_class.rb
@@ -1,7 +1,7 @@
 class EnvironmentClass < ApplicationRecord
   belongs_to :environment
-  belongs_to :puppetclass
-  belongs_to :puppetclass_lookup_key
+  belongs_to :puppetclass, :inverse_of => :environment_classes
+  belongs_to :puppetclass_lookup_key, :inverse_of => :environment_classes
   validates :puppetclass_lookup_key_id, :uniqueness => {:scope => [:environment_id, :puppetclass_id]}
   validates :puppetclass_id, :environment_id, :presence => true
   after_destroy :delete_orphaned_lookup_keys

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -1,5 +1,5 @@
 class PuppetclassLookupKey < LookupKey
-  has_many :environment_classes, :dependent => :destroy
+  has_many :environment_classes, :dependent => :destroy, :inverse_of => :puppetclass_lookup_key
   has_many :environments, -> { distinct }, :through => :environment_classes
   has_many :param_classes, :through => :environment_classes, :source => :puppetclass
 

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -8,7 +8,7 @@ class Puppetclass < ApplicationRecord
 
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
-  has_many :environment_classes, :dependent => :destroy
+  has_many :environment_classes, :dependent => :destroy, :inverse_of => :puppetclass
   has_many :environments, -> { distinct }, :through => :environment_classes
   has_and_belongs_to_many :operatingsystems
   has_many :hostgroup_classes

--- a/app/views/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/puppetclass_lookup_keys/index.html.erb
@@ -12,7 +12,7 @@
     <% @lookup_keys.each do |lookup_key| %>
       <tr>
         <td class="ellipsis"><%= link_to_if_authorized lookup_key.key, hash_for_edit_puppetclass_lookup_key_path(:id => lookup_key).merge(:auth_object => lookup_key, :permission => 'edit_external_parameters', :authorizer => authorizer) %></td>
-        <% puppet_class = lookup_key.param_class %>
+        <% puppet_class = @lookup_keys_to_class[lookup_key.id] %>
         <td class="ellipsis"><%= link_to_if_authorized puppet_class, hash_for_edit_puppetclass_path(:id => puppet_class).merge(:auth_object => puppet_class, :authorizer => @puppetclass_authorizer) if puppet_class %></td>
         <td><%= lookup_key.lookup_values.size %></td>
       </tr>

--- a/db/migrate/20181224174419_add_index_to_environment_class_by_lookup_key_and_puppetclass.rb
+++ b/db/migrate/20181224174419_add_index_to_environment_class_by_lookup_key_and_puppetclass.rb
@@ -1,0 +1,5 @@
+class AddIndexToEnvironmentClassByLookupKeyAndPuppetclass < ActiveRecord::Migration[5.2]
+  def change
+    add_index :environment_classes, [:puppetclass_lookup_key_id, :puppetclass_id], name: 'index_env_classes_on_lookup_key_and_class'
+  end
+end

--- a/test/controllers/puppetclass_lookup_keys_controller_test.rb
+++ b/test/controllers/puppetclass_lookup_keys_controller_test.rb
@@ -49,13 +49,4 @@ class PuppetclassLookupKeysControllerTest < ActionController::TestCase
     get :index, session: set_session_user.merge(:user => users(:one).id)
     assert_response :success
   end
-
-  test "smart class parameters that aren't connected to an environment class shouldn't appear in the index" do
-    lkey1 = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :puppetclass => puppetclasses(:one), :override => true, :default_value => 'test')
-    lkey2 = FactoryBot.create(:puppetclass_lookup_key)
-    get :index, params: { :search => "key=#{lkey1.key}" }, session: set_session_user
-    refute_empty assigns(:lookup_keys)
-    get :index, params: { :search => "key=#{lkey2.key}" }, session: set_session_user
-    assert_empty assigns(:lookup_keys)
-  end
 end


### PR DESCRIPTION
1. Added `:inverse_of` to relevant objects
2. Changed queries to use less resources.
