### PR TITLE
fixes #2308 - add option to select cpumode in libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -3,6 +3,9 @@ module Foreman::Model
     include ComputeResourceConsoleCommon
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
+    
+    #'custom' is not implemented. This needs extra UI.
+    CPU_MODES = %w(default host-model host-passthrough)
 
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true
     validates :display_type, :inclusion => { :in => ALLOWED_DISPLAY_TYPES }

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -3,8 +3,8 @@ module Foreman::Model
     include ComputeResourceConsoleCommon
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
-    
-    #'custom' is not implemented. This needs extra UI.
+
+    # 'custom' is not implemented. This needs extra UI.
     CPU_MODES = %w(default host-model host-passthrough)
 
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true

--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -11,6 +11,14 @@ module FogExtensions
         name
       end
 
+      def cpu_mode
+        attributes[:cpu][:mode].nil? ? Setting[:libvirt_default_cpu_mode] : attributes[:cpu][:mode]
+      end
+
+      def cpu_mode=(cpumode)
+        attributes[:cpu][:mode]= cpumode == 'default' ? nil : cpumode
+      end
+
       def nics_attributes=(attrs)
       end
 

--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -16,7 +16,7 @@ module FogExtensions
       end
 
       def cpu_mode=(cpumode)
-        attributes[:cpu][:mode]= cpumode == 'default' ? nil : cpumode
+        attributes[:cpu][:mode] = (cpumode == 'default') ? nil : cpumode
       end
 
       def nics_attributes=(attrs)

--- a/app/models/concerns/fog_extensions/libvirt/server.rb
+++ b/app/models/concerns/fog_extensions/libvirt/server.rb
@@ -12,7 +12,7 @@ module FogExtensions
       end
 
       def cpu_mode
-        attributes[:cpu][:mode].nil? ? Setting[:libvirt_default_cpu_mode] : attributes[:cpu][:mode]
+        attributes[:cpu][:mode]
       end
 
       def cpu_mode=(cpumode)

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -33,13 +33,6 @@ class Setting::Provisioning < Setting
     'vovsbr*'
   ]
 
-  CPU_MODES = {
-    'default' => 'default',
-    # 'custom' => 'custom' # custom is not implemented. This needs extra UI.
-    'host-model' => 'host-model',
-    'host-passthrough' => 'host-passthrough'
-  }
-
   def self.default_settings
     fqdn = SETTINGS[:fqdn]
     unattended_url = "http://#{fqdn}"
@@ -82,8 +75,7 @@ class Setting::Provisioning < Setting
         N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),
         default_excluded_facts,
         N_('Exclude pattern for facts stored in foreman')
-      ),
-      self.set('libvirt_default_cpu_mode', N_("Default cpu mode for libvirt."), 'custom', N_("Default Libvirt CPU mode."), nil, {:collection => Proc.new {CPU_MODES} })
+      )
     ] + default_global_templates + default_local_boot_templates
   end
 

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -35,9 +35,9 @@ class Setting::Provisioning < Setting
 
   CPU_MODES = {
     'default' => 'default',
-    #'custom' => 'custom' # custom is not implemented. This needs extra UI.
+    # 'custom' => 'custom' # custom is not implemented. This needs extra UI.
     'host-model' => 'host-model',
-    'host-passthrough' => 'host-passthrough',
+    'host-passthrough' => 'host-passthrough'
   }
 
   def self.default_settings

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -32,6 +32,14 @@ class Setting::Provisioning < Setting
     'vlinuxbr*',
     'vovsbr*'
   ]
+
+  CPU_MODES = {
+    'default' => 'default',
+    #'custom' => 'custom' # custom is not implemented. This needs extra UI.
+    'host-model' => 'host-model',
+    'host-passthrough' => 'host-passthrough',
+  }
+
   def self.default_settings
     fqdn = SETTINGS[:fqdn]
     unattended_url = "http://#{fqdn}"
@@ -74,7 +82,8 @@ class Setting::Provisioning < Setting
         N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),
         default_excluded_facts,
         N_('Exclude pattern for facts stored in foreman')
-      )
+      ),
+      self.set('libvirt_default_cpu_mode', N_("Default cpu mode for libvirt."), 'custom', N_("Default Libvirt CPU mode."), nil, {:collection => Proc.new {CPU_MODES} })
     ] + default_global_templates + default_local_boot_templates
   end
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -4,7 +4,7 @@
 
 <%= counter_f f, :cpus, :disabled => !new_vm, :label => _('CPUs'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
 
-<%= select_f f, :cpu_mode, Setting::Provisioning::CPU_MODES.keys, :to_s, :to_s, { }, :label => _("CPU mode"), :label_size => "col-md-2" %>
+<%= select_f f, :cpu_mode, Foreman::Model::Libvirt::CPU_MODES, :to_s, :to_s, { }, :label => _("CPU mode"), :label_size => "col-md-2" %>
 
 <%= byte_size_f f, :memory, :disabled => !new_vm, :label => _('Memory'), :label_size => "col-md-2", :'data-soft-max' => compute_resource.max_memory %>
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -4,6 +4,8 @@
 
 <%= counter_f f, :cpus, :disabled => !new_vm, :label => _('CPUs'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>
 
+<%= select_f f, :cpu_mode, Setting::Provisioning::CPU_MODES.keys, :to_s, :to_s, { }, :label => _("CPU mode"), :label_size => "col-md-2" %>
+
 <%= byte_size_f f, :memory, :disabled => !new_vm, :label => _('Memory'), :label_size => "col-md-2", :'data-soft-max' => compute_resource.max_memory %>
 
 <!--TODO # Move to a helper-->


### PR DESCRIPTION
Hi,

this is my first try in exposing cpu mode in libvirt fog. 
I would be glad if this could be include in mainline oder you would point out some mistakes that I made.

I know of one bug that I Don't know how to fix:
If you select something other than 'default' as the default cpu mode in the settings. Then set the mode to 'default' while creating the Host. If you then edit the host the default from the settings will be shown and submitted. 