### PR TITLE
Fixes #25609 - Move Audits page to React

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,4 +1,4 @@
-class AuditsController < ApplicationController
+class AuditsController < ReactController
   include Foreman::Controller::AutoCompleteSearch
 
   before_action :setup_search_options, :only => :index
@@ -6,11 +6,6 @@ class AuditsController < ApplicationController
   def index
     @audits = resource_base_search_and_page.preload(:user)
     @host = resource_finder(Host.authorized(:view_hosts), params[:host_id]) if params[:host_id]
-  end
-
-  def show
-    @audit = resource_base.find(params[:id])
-    @history = resource_base.includes(:user).descending.where(:auditable_id => @audit.auditable_id, :auditable_type => @audit.auditable_type)
   end
 
   private

--- a/app/controllers/react_controller.rb
+++ b/app/controllers/react_controller.rb
@@ -1,0 +1,3 @@
+class ReactController < ApplicationController
+  layout 'layouts/react_application'
+end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -12,4 +12,14 @@ module PaginationHelper
     options << params[:per_page].to_i if params[:per_page].present?
     options.uniq.sort
   end
+
+  def react_pagination_props(collection = nil, classname = nil)
+    {
+      viewType: 'table',
+      itemCount: collection.total_entries,
+      perPageOptions: per_page_options,
+      perPage: Setting[:entries_per_page],
+      classNames: {pagination_classes: classname}
+    }
+  end
 end

--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -25,4 +25,24 @@ module SearchBarHelper
       bookmarks: bookmarks
     }.to_json)
   end
+
+  def get_search_props(
+    controller: auto_complete_controller_name,
+    url: "#{auto_complete_controller_name}/auto_complete_search",
+    search_query: params[:search]
+  )
+    bookmarks = {
+      url: api_bookmarks_path,
+      canCreate: authorizer.can?(:create_bookmarks),
+      documentationUrl: documentation_url("4.1.5Searching")
+    }
+    {
+      controller: controller,
+      autocomplete: {
+        searchQuery: search_query,
+        url: url
+      },
+      bookmarks: bookmarks
+    }
+  end
 end

--- a/app/views/audits/_list.html.erb
+++ b/app/views/audits/_list.html.erb
@@ -1,2 +1,0 @@
-<div id='audit-list'></div>
-<%= mount_react_component('AuditsList','#audit-list', {audits: construct_additional_info(audits)}.to_json) %>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,6 +1,8 @@
-<%= nested_host_audit_breadcrumbs %>
-<% title _("Audits") %>
-<% title_actions documentation_button('4.1.4Auditing') %>
-<%= render :partial => 'list', :locals =>{:audits => @audits}%>
-
-<%= will_paginate_with_info @audits, {:pagination_classes => "audits-pagination"}%>
+<div id="audits_page"></div>
+<%= mount_react_component('AuditsPage', '#audits_page', {
+    searchProps: get_search_props,
+    docURL: documentation_url('4.1.4Auditing'),
+    audits: {audits: construct_additional_info(@audits)},
+    pagination: react_pagination_props(@audits, "audits-pagination"),
+    searchable: true
+}.to_json) %>

--- a/app/views/layouts/react_application.html.erb
+++ b/app/views/layouts/react_application.html.erb
@@ -1,0 +1,4 @@
+<%= content_for(:content) do %>
+  <%= yield %>
+<% end %>
+<%= render :template => 'layouts/base' %>

--- a/test/controllers/audits_controller_test.rb
+++ b/test/controllers/audits_controller_test.rb
@@ -6,7 +6,6 @@ class AuditsControllerTest < ActionController::TestCase
   end
 
   basic_pagination_per_page_test
-  basic_pagination_rendered_test
 
   def test_index
     get :index, session: set_session_user

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
@@ -7,8 +7,7 @@ export const SearchBarProps = {
     bookmarks: {
       url: '/api/bookmarks',
       canCreate: true,
-      documentationUrl:
-        'http://www.theforeman.org/manuals/1.19/index.html#4.1.5Searching',
+      documentationUrl: '/doc/url',
     },
     controller: 'models',
   },

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -35,7 +35,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
         Object {
           "canCreate": true,
           "controller": "models",
-          "documentationUrl": "http://www.theforeman.org/manuals/1.19/index.html#4.1.5Searching",
+          "documentationUrl": "/doc/url",
           "searchQuery": "",
           "url": "/api/bookmarks",
         }

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -15,7 +15,6 @@ import PasswordStrength from './PasswordStrength';
 import BreadcrumbBar from './BreadcrumbBar';
 import FactChart from './factCharts';
 import Pagination from './Pagination/Pagination';
-import AuditsList from './AuditsList';
 import SearchBar from './SearchBar';
 import Layout from './Layout';
 import EmptyState from './common/EmptyState';
@@ -24,6 +23,9 @@ import ChartBox from './statistics/ChartBox';
 import ConfigReports from './ConfigReports/ConfigReports';
 import DiffModal from './ConfigReports/DiffModal';
 import { WrapperFactory } from './wrapperFactory';
+
+// Pages
+import AuditsPage from '../pages/AuditsPage/AuditsPage';
 
 const componentRegistry = {
   registry: {},
@@ -103,7 +105,6 @@ const coreComponets = [
   { name: 'BreadcrumbBar', type: BreadcrumbBar },
   { name: 'FactChart', type: FactChart },
   { name: 'Pagination', type: Pagination },
-  { name: 'AuditsList', type: AuditsList },
   { name: 'Layout', type: Layout },
   { name: 'EmptyState', type: EmptyState },
   { name: 'BarChart', type: BarChart },
@@ -135,6 +136,9 @@ const coreComponets = [
     data: true,
     store: false,
   },
+
+  // Pages
+  { name: 'AuditsPage', type: AuditsPage },
 ];
 
 componentRegistry.registerMultiple(coreComponets);

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Icon } from 'patternfly-react';
+import { translate as __ } from '../../common/I18n';
+
+import PageLayout from '../common/PageLayout/PageLayout';
+import AuditsList from '../../components/AuditsList';
+import Pagination from '../../components/Pagination/Pagination';
+
+const AuditsPage = ({
+  data: { searchProps, docURL, audits, pagination, searchable },
+}) => (
+  <PageLayout
+    header={__('Audits')}
+    searchable={searchable}
+    searchProps={searchProps}
+    toolbarButtons={
+      <Button href={docURL} className="btn-docs">
+        <Icon type="pf" name="help" />
+        {__(' Documentation')}
+      </Button>
+    }
+  >
+    <div id="audit-list">
+      <AuditsList data={audits} />
+    </div>
+    <div id="pagination">
+      <Pagination data={pagination} />
+    </div>
+  </PageLayout>
+);
+
+AuditsPage.propTypes = {
+  data: PropTypes.shape({
+    searchProps: PropTypes.shape({
+      autocomplete: PropTypes.shape({
+        results: PropTypes.array,
+        searchQuery: PropTypes.string,
+        url: PropTypes.string,
+        useKeyShortcuts: PropTypes.bool,
+      }),
+      controller: PropTypes.string,
+      bookmarks: PropTypes.shape({
+        text: PropTypes.string,
+        query: PropTypes.string,
+      }),
+    }),
+    docURL: PropTypes.string,
+    audits: PropTypes.shape({
+      audits: PropTypes.array.isRequired,
+    }).isRequired,
+    pagination: PropTypes.shape({
+      viewType: PropTypes.string,
+      perPageOptions: PropTypes.arrayOf(PropTypes.number),
+      itemCount: PropTypes.number,
+      perPage: PropTypes.number,
+    }).isRequired,
+    searchable: PropTypes.bool,
+  }).isRequired,
+};
+
+export default AuditsPage;

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.test.js
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { testComponentSnapshotsWithFixtures } from '../../common/testHelpers';
+import AuditsPage from './AuditsPage';
+import { AuditsProps } from '../../components/AuditsList/__tests__/AuditsList.fixtures';
+import { paginationMock } from '../../components/Pagination/Pagination.fixtures';
+import { SearchBarProps } from '../../components/SearchBar/SearchBar.fixtures';
+
+const auditsPageFixtures = {
+  'render audits page': {
+    data: {
+      audits: AuditsProps,
+      pagination: paginationMock.data,
+      docURL: '/url',
+      searchable: true,
+    },
+  },
+};
+
+describe('AuditsPage', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(AuditsPage, auditsPageFixtures));
+
+  describe('pagination is rendered', () => {
+    const component = shallow(
+      <AuditsPage
+        data={{
+          audits: AuditsProps,
+          pagination: paginationMock.data,
+          searchProps: SearchBarProps,
+          searchable: false,
+        }}
+      />
+    ).dive();
+
+    expect(component.exists('#pagination')).toBeTruthy();
+  });
+});

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuditsPage rendering render audits page 1`] = `
+<PageLayout
+  breadcrumbOptions={null}
+  customBreadcrumbs={null}
+  header="Audits"
+  searchProps={Object {}}
+  searchable={true}
+  toastNotifications={null}
+  toolbarButtons={
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="btn-docs"
+      disabled={false}
+      href="/url"
+    >
+      <Icon
+        name="help"
+        type="pf"
+      />
+       Documentation
+    </Button>
+  }
+>
+  <div
+    id="audit-list"
+  >
+    <AuditsList
+      data={
+        Object {
+          "audits": Array [
+            Object {
+              "action": "update",
+              "action_display_name": "updated",
+              "affected_locations": Array [
+                Object {
+                  "name": "test_loc1",
+                  "url": "/locations/2-test_loc1/edit",
+                },
+                Object {
+                  "name": "test_loc2",
+                  "url": "/locations/6-test_loc2/edit",
+                },
+                Object {
+                  "name": "test_loc3",
+                  "url": "/locations/9-test_loc3/edit",
+                },
+              ],
+              "affected_organizations": Array [
+                Object {
+                  "name": "test_org1",
+                  "url": "/organizations/1-test_org1/edit",
+                },
+                Object {
+                  "name": "test_org2",
+                  "url": "/organizations/3-test_org2/edit",
+                },
+                Object {
+                  "name": "test_org3",
+                  "url": "/organizations/5-test_org3/edit",
+                },
+              ],
+              "allowed_actions": Array [
+                Object {
+                  "css_class": "btn btn-default",
+                  "title": "Host details",
+                  "url": "/hosts/host-foo.example.com",
+                },
+              ],
+              "associated_id": null,
+              "associated_name": null,
+              "associated_type": null,
+              "audit_title": "host-foo.example.com",
+              "audit_title_url": "/audits?search=type+%3D+host+and+auditable_id+%3D+9",
+              "auditable_id": 9,
+              "auditable_name": "host-foo.example.com",
+              "auditable_type": "Host::Base",
+              "audited_changes": Object {
+                "comment": Array [
+                  "",
+                  "This is info about host for audit",
+                ],
+                "root_pass": Array [
+                  "[redacted]",
+                  "[redacted]",
+                ],
+              },
+              "audited_changes_with_id_to_label": Array [
+                Object {
+                  "change": Array [
+                    Object {
+                      "css_class": "show-old",
+                      "id_to_label": "[redacted]",
+                    },
+                    Object {
+                      "css_class": "show-new",
+                      "id_to_label": "[redacted]",
+                    },
+                  ],
+                  "name": "Root pass",
+                },
+                Object {
+                  "change": Array [
+                    Object {
+                      "css_class": "show-old",
+                      "id_to_label": "[empty]",
+                    },
+                    Object {
+                      "css_class": "show-new",
+                      "id_to_label": "This is info about host for audit",
+                    },
+                  ],
+                  "name": "Comment",
+                },
+              ],
+              "audited_type_name": "Host",
+              "comment": null,
+              "created_at": "2018-08-13 00:34:55 -1100",
+              "id": 234,
+              "remote_address": "127.0.0.1",
+              "request_uuid": "c134239d-8ac3-494b-9962-35133fe153ba",
+              "user_id": 4,
+              "user_info": Object {
+                "audit_path": "/audits?search=id+%3D+234",
+                "display_name": "Admin ",
+                "login": "admin",
+                "search_path": "/audits?search=user+%3D+admin",
+              },
+              "user_type": null,
+              "username": "Admin User",
+              "version": 2,
+            },
+          ],
+        }
+      }
+    />
+  </div>
+  <div
+    id="pagination"
+  >
+    <Pagination
+      data={
+        Object {
+          "itemCount": 21,
+          "perPage": 20,
+          "perPageOptions": Array [
+            5,
+            10,
+            15,
+            20,
+          ],
+          "viewType": "table",
+        }
+      }
+      dropdownButtonId="pagination-row-dropdown"
+      onPageSet={[Function]}
+      onPerPageSelect={[Function]}
+      pagination={null}
+    />
+  </div>
+</PageLayout>
+`;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.fixtures.js
@@ -1,0 +1,13 @@
+import { breadcrumbBar } from '../../../components/BreadcrumbBar/BreadcrumbBar.fixtures';
+import { SearchBarProps } from '../../../components/SearchBar/SearchBar.fixtures';
+
+export const pageLayoutMock = {
+  header: 'Page',
+  searchable: true,
+  searchProps: SearchBarProps,
+  customBreadcrumbs: null,
+  breadcrumbOptions: breadcrumbBar,
+  toolbarButtons: null,
+  toastNotifications: null,
+  children: 'body',
+};

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'patternfly-react';
+
+import ToastsList from '../../../components/toastNotifications';
+import BreadcrumbBar from '../../../components/BreadcrumbBar';
+import SearchBar from '../../../components/SearchBar';
+
+const PageLayout = ({
+  header,
+  searchable,
+  searchProps,
+  customBreadcrumbs,
+  breadcrumbOptions,
+  toolbarButtons,
+  toastNotifications,
+  children,
+}) => (
+  <div id="main">
+    <div id="content">
+      {toastNotifications && (
+        <div
+          id="toast-notifications-container"
+          data-notifications={toastNotifications}
+        >
+          <ToastsList />
+        </div>
+      )}
+      <div id="breadcrumb">
+        {!breadcrumbOptions && (
+          <div className="row form-group">
+            <h1 className="col-md-8">{header}</h1>
+          </div>
+        )}
+        {customBreadcrumbs
+          ? { customBreadcrumbs }
+          : breadcrumbOptions && <BreadcrumbBar data={breadcrumbOptions} />}
+      </div>
+      <Row>
+        <Col className="title_filter" md={searchable ? 6 : 4}>
+          {searchable && (
+            <div id="search-bar">{<SearchBar data={searchProps} />}</div>
+          )}
+        </Col>
+        <Col id="title_action" md={searchable ? 6 : 8}>
+          <div className="btn-toolbar pull-right">{toolbarButtons}</div>
+        </Col>
+      </Row>
+      {children}
+    </div>
+  </div>
+);
+
+PageLayout.propTypes = {
+  children: PropTypes.node.isRequired,
+  searchable: PropTypes.bool.isRequired,
+  header: PropTypes.string,
+  searchProps: PropTypes.shape({
+    autocomplete: PropTypes.shape({
+      results: PropTypes.array,
+      searchQuery: PropTypes.string,
+      url: PropTypes.string,
+      useKeyShortcuts: PropTypes.bool,
+    }),
+    controller: PropTypes.string,
+    bookmarks: PropTypes.shape({
+      text: PropTypes.string,
+      query: PropTypes.string,
+    }),
+  }),
+  customBreadcrumbs: PropTypes.node,
+  breadcrumbOptions: PropTypes.shape({
+    isSwitchable: PropTypes.bool,
+    resource: PropTypes.shape({
+      nameField: PropTypes.string,
+      resourceUrl: PropTypes.string,
+      switcherItemUrl: PropTypes.string,
+      resourceFilter: PropTypes.string,
+    }),
+    breadcrumbItems: PropTypes.arrayOf(
+      PropTypes.shape({
+        caption: PropTypes.oneOfType([
+          PropTypes.string.isRequired,
+          PropTypes.shape({
+            icon: PropTypes.shape({
+              url: PropTypes.string,
+              alt: PropTypes.string,
+            }),
+            text: PropTypes.string,
+          }),
+        ]),
+        url: PropTypes.string,
+      })
+    ),
+  }),
+  toolbarButtons: PropTypes.node,
+  toastNotifications: PropTypes.string,
+};
+
+PageLayout.defaultProps = {
+  searchProps: {},
+  header: '',
+  toastNotifications: null,
+  customBreadcrumbs: null,
+  toolbarButtons: null,
+  breadcrumbOptions: null,
+};
+
+export default PageLayout;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
@@ -1,0 +1,26 @@
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+import PageLayout from './PageLayout';
+import { pageLayoutMock } from './PageLayout.fixtures';
+
+const pageLayoutFixtures = {
+  'render pageLayout w/search': pageLayoutMock,
+  'render pageLayout without search': { ...pageLayoutMock, searchable: false },
+  'render pageLayout with custom breadcrumbs': {
+    ...pageLayoutMock,
+    customBreadcrumbs: 'customBreadcrumbs',
+  },
+  'render pageLayout without breadcrumbs': {
+    ...pageLayoutMock,
+    breadcrumbOptions: null,
+  },
+  'render pageLayout w/toastNotifications': {
+    ...pageLayoutMock,
+    toastNotifications: 'notification',
+  },
+  'render pageLayout w/toolBar': {
+    ...pageLayoutMock,
+    toolbarButtons: 'toolbarButton',
+  },
+};
+
+testComponentSnapshotsWithFixtures(PageLayout, pageLayoutFixtures);

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -1,0 +1,464 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render pageLayout w/search 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout w/toastNotifications 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      data-notifications="notification"
+      id="toast-notifications-container"
+    >
+      <Connect(ToastsList) />
+    </div>
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout w/toolBar 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        >
+          toolbarButton
+        </div>
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout with custom breadcrumbs 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Component />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout without breadcrumbs 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <div
+        className="row form-group"
+      >
+        <h1
+          className="col-md-8"
+        >
+          Page
+        </h1>
+      </div>
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout without search 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={4}
+      />
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={8}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;


### PR DESCRIPTION
Merging all the React components into one Page component for the Audits view.

- Created a generic `PageLayout` component.
- Created a `AuditsPage` component.
- Created a ReactController to disable the erb PageLayout

File structure:
![filestructure](https://user-images.githubusercontent.com/24938324/49373571-3e7cd400-f707-11e8-9560-ad8d0ee86875.png)
 
Also separated the components from pages in the `componentRegistry`:
<img width="395" alt="screenshot 2018-12-03 13 46 52" src="https://user-images.githubusercontent.com/24938324/49373635-74ba5380-f707-11e8-966d-31ded0c2c570.png">

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
