### PR TITLE
Fixes #25610 - Allow DHCP orchestration on NIC alias

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -209,6 +209,10 @@ module Nic
       [mac, name, identifier, _('Unnamed')].detect(&:present?)
     end
 
+    def to_s
+      identifier || mac
+    end
+
     protected
 
     def normalize_mac


### PR DESCRIPTION
Our orchestration queue has a mechanism to prevent multiple DHCP orchestration calls. It uses MAC address to identify duplicates however for NIC alias there are actually two NICs with same MAC address. Adding an extra information to the orchestration name allows orchestrating those.

Repro steps in the issue.