### PR TITLE
[CP 1.20] Fixes #25487 - Fix subtotal in API response

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -66,7 +66,7 @@ module Api
 
       def metadata_subtotal
         if params[:search].present?
-          @subtotal ||= instance_variable_get("@#{controller_name}").try(:size).to_i
+          @subtotal ||= instance_variable_get("@#{controller_name}").try(:count).to_i
         else
           @subtotal ||= metadata_total
         end


### PR DESCRIPTION
When requesting an endpoint with a search parameter, the subtotal
shows the results returned, rather than responses found. i.e. even
if 200 results were found, if 20 are being returned because of
pagination, the subtotal will be 20.

This changes back to using `count`, which sends another SQL query
and returns the correct subtotal.

(cherry picked from commit 660e9794af46b3f614b54fe0f2c9375a169f3613)




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->