### PR TITLE
Fixes #24852 - Creating Host with empty allocation fails

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -278,7 +278,9 @@ module Foreman::Model
         (volumes = args[:volumes]).each do |vol|
           vol.name = "#{args[:prefix]}-disk#{volumes.index(vol) + 1}"
           vol.capacity = "#{vol.capacity}G" unless vol.capacity.to_s.end_with?('G')
-          vol.allocation = "#{vol.allocation}G" unless vol.allocation.to_s.end_with?('G')
+          if vol.allocation.match(/^\d+/) && !vol.allocation.to_s.end_with?('G')
+            vol.allocation = "#{vol.allocation}G"
+          end
           vol.save
           vols << vol
         end

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -75,7 +75,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "libvirt: 'G' suffix should be appended to libvirt volume capacity if none was specified" do
-    volume = OpenStruct.new(:capacity => 10)
+    volume = OpenStruct.new(:capacity => 10, :allocation => '10')
     volume.stubs(:save!).returns(true)
 
     result = Foreman::Model::Libvirt.new.send(:create_volumes, {:prefix => 'test', :volumes => [volume]})
@@ -84,7 +84,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "libvirt: no exceptions should be raised if a 'G' suffix was specified for volume capacity" do
-    volume = OpenStruct.new(:capacity => "10G")
+    volume = OpenStruct.new(:capacity => "10G", :allocation => "10G")
     volume.stubs(:save!).returns(true)
 
     assert_nothing_raised { Foreman::Model::Libvirt.new.send(:create_volumes, {:prefix => 'test', :volumes => [volume]}) }

--- a/webpack/assets/javascripts/compute_resource/libvirt.js
+++ b/webpack/assets/javascripts/compute_resource/libvirt.js
@@ -97,7 +97,7 @@ export function allocationSwitcher(element, action) {
       break;
     case 'Size':
       $(allocation).removeAttr('readonly');
-      allocation.value = '';
+      allocation.value = '0G';
       $(allocation).focus();
       break;
     case 'Full':


### PR DESCRIPTION
In case of clicking on Size, the Allocation text field becomes editable and user can give any custom size as per their requirement. But, I think keeping it empty is as good as "0G" for the user. Therefore, I have set the allocation to 0G in case when user selects Size option. 
Any suggestions ?
Also, creating a PR in the fog/fog-libvirt repo to handle when user sends empty allocation.
