### PR TITLE
Fixes #25620 - do not log reports to blob logger

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -112,11 +112,6 @@ class Report < ApplicationRecord
     Foreman::Plugin.report_origin_registry.all_origins
   end
 
-  # we don't want to log reports, it can be a lot of data
-  def self.log_render_results?
-    false
-  end
-
   private
 
   def read_metrics

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -47,4 +47,9 @@ class ReportTemplate < Template
   def self.acceptable_template_input_types
     [ :user ]
   end
+
+  # we don't want to log reports, it can be a lot of data
+  def self.log_render_results?
+    false
+  end
 end


### PR DESCRIPTION
This was a stupid mistake when I defined this method in a wrong model in the first commit of report templates. We just need to simply move it to `report_template.rb`.

To reproduce: 
1) make sure you have blob logger enabled and log level set to debug
2) generate any report based of report template
3) see the output of report is logged there

This PR fixes:
1) this is no longer being logged

Additional info:
don't test via template previewing, preview always skips logging

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
