### PR TITLE
Fixes #25624 - add explicit kernel release fact loader

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -1,5 +1,7 @@
 module Host
   class Base < ApplicationRecord
+    KERNEL_RELEASE_FACTS = [ 'kernelrelease', 'ansible_kernel', 'kernel::release' ]
+
     prepend Foreman::STI
     include Authorizable
     include Parameterizable::ByName
@@ -25,6 +27,7 @@ module Host
     has_one :domain, :through => :primary_interface
     has_one :subnet, :through => :primary_interface
     has_one :subnet6, :through => :primary_interface
+    has_one :kernel_release, -> { joins(:fact_name).where({ 'fact_names.name' => KERNEL_RELEASE_FACTS }).order('fact_names.type') }, :class_name => '::FactValue', :foreign_key => 'host_id'
     accepts_nested_attributes_for :interfaces, :allow_destroy => true
 
     belongs_to :location

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -26,7 +26,8 @@ module Foreman
         :input,
         :rand_hex,
         :rand_name,
-        :mac_name
+        :mac_name,
+        :host_kernel_release
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -113,6 +113,10 @@ module Foreman
             NameGenerator.new.generate_next_mac_name(mac_address)
           end
 
+          def host_kernel_release(host)
+            host&.kernel_release&.value
+          end
+
           private
 
           def validate_subnet(subnet)


### PR DESCRIPTION
The problem with registered hosts report is that for each host we load all host facts just in order to display kernelrelease fact value. We can define explicit association for this fact so we can `:include` it. To use it in templates a new macro `host_kernel_release` is introduced.

To reproduce: 
1) have at least 1 host with a lot of facts, puppet facts will do but chef or ansible facts from ohai make it more visible
2) go to Monitor -> Report Templates -> click generate for Registered hosts
3) Submit the form, it will take a long time to render the report
4) in logs with SQL logger enabled, you can see that we load facts very inefficiently

After applying:
1) not much will change as this is just introducing the macro and relation, you need https://github.com/theforeman/community-templates/pull/542
2) once applied the patch from step 1, run rake db:seed in order to get the new version of the template (or update the template manually)
3) repeat steps from reproduce and see that SQL logs are much more efficient and the rendering is instant

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
