### PR TITLE
Fixes #25629: Fix changing disc size

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -475,10 +475,11 @@ module Foreman::Model
       # volumes are not part of vm.attributes so we have to set them seperately if needed
       if attr.has_key?(:volumes_attributes)
         vm.volumes.each do |vm_volume|
-          volume_attrs = attr[:volumes_attributes].values.detect {|vol| vol[:id] == vm_volume.id}
-          if volume_attrs.class == Hash && volume_attrs.key?(:size_gb)
-            vm_volume.size_gb = volume_attrs[:size_gb]
-          end
+          volume_attrs = attr[:volumes_attributes].values.detect { |vol| vol[:id] == vm_volume.id }
+
+          next unless volume_attrs.present?
+
+          vm_volume.size_gb = volume_attrs[:size_gb] if volume_attrs[:size_gb].present?
         end
       end
       vm.save

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -518,6 +518,39 @@ class HostJSTest < IntegrationTestWithJavascript
       assert page.has_no_selector?("#inherited_parameters #name_#{hostgroup1.group_parameters.first.name}")
       assert page.has_selector?("#inherited_parameters #name_#{hostgroup2.group_parameters.first.name}")
     end
+
+    # At this point in time this only tests the UI. Since Fog mocks all requests the Hard drive change is ignored as it
+    # will always return the mocked values. Not a total waste however as the UI is still tested with this.
+    test 'enables changing vm disk size' do
+      Fog.mock!
+
+      organization = Organization.find_by_name('Organization 1')
+      location = Location.find_by_name('Location 1')
+      uuid = '5032c8a5-9c5e-ba7a-3804-832a03e16381'
+      compute_resource = FactoryBot.create(:compute_resource, :vmware, organizations: [organization], locations: [location], uuid: 'Solutions')
+      compute_resource = ComputeResource.find_by_id(compute_resource.id)
+
+      host = FactoryBot.create(:host, :managed, compute_resource: compute_resource,
+                                                uuid: uuid,
+                                                location: location,
+                                                organization: organization,
+                                                provision_method: 'image')
+
+      visit edit_host_path(host)
+
+      wait_for_ajax
+
+      click_link('Virtual Machine')
+      within('.text-vmware-size') do
+        # Unusual here that the volume size input field has no name or id.
+        first('input').set('10 GB')
+      end
+
+      click_on('Submit')
+
+      assert_content("Successfully updated #{host.name}")
+      Fog.unmock!
+    end
   end
 
   describe "NIC modal window" do


### PR DESCRIPTION
Problem here was the type check for `volume_attrs` against `Hash` when its actually a `HashWithIndifferentAccess`. I made this more solid with `vm_volume.size_gb = volume_attrs[:size_gb] if volume_attrs[:size_gb].present?`. After testing this seems to be fine. We need to implement some happy path feature tests then things like this would be caught much earlier.
