### PR TITLE
Fixes #25014 - Remove openscap features easily

### DIFF
--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -50,4 +50,10 @@ module HostsAndHostgroupsHelper
                      "Reminder: <strong> All %{count} hosts are selected </strong> for query filter %{query}", host_count).html_safe % {count: host_count, query: h(params[:search]) }
     params[:search].blank? ? no_filter : with_filter
   end
+  
+  def proxy_openscap_enabled?(proxy_id)
+    return true if proxy_id.nil?
+    all_oscap_proxies = SmartProxy.all.reject {|s| !s.feature_names.include?("Openscap")}
+    all_oscap_proxies.include?(proxy_id)
+  end
 end

--- a/app/helpers/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/hosts_and_hostgroups_helper.rb
@@ -50,10 +50,9 @@ module HostsAndHostgroupsHelper
                      "Reminder: <strong> All %{count} hosts are selected </strong> for query filter %{query}", host_count).html_safe % {count: host_count, query: h(params[:search]) }
     params[:search].blank? ? no_filter : with_filter
   end
-  
+
   def proxy_openscap_enabled?(proxy_id)
     return true if proxy_id.nil?
-    all_oscap_proxies = SmartProxy.all.reject {|s| !s.feature_names.include?("Openscap")}
-    all_oscap_proxies.include?(proxy_id)
+    SmartProxy.find_by!(id: proxy_id).feature_names.include?('Openscap')
   end
 end

--- a/app/views/common/_scap_feature_error.erb
+++ b/app/views/common/_scap_feature_error.erb
@@ -1,0 +1,20 @@
+<div id="host-conflicts-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title"><%= _('OpenScap Proxy is not having Openscap feature enabled !') %></h4>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-warning alert-block base">
+          <%= icon_text("warning-triangle-o", "",:kind => "pficon") %>
+          <% proxy = @host.try(:openscap_proxy) || @hostgroup.try(:openscap_proxy) %>
+          <b><%= ("OpenSCAP Proxy: #{proxy[:name]}") %></b><%=_(' is not having Openscap feature, change to valid proxy or unset it.') %>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= _('OK') %></button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -1,4 +1,5 @@
 <%= javascript 'host_edit', 'host_edit_interfaces', 'class_edit' %>
+<%= render "common/scap_feature_error" if !proxy_openscap_enabled?(@hostgroup.try(:openscap_proxy)) %>
 <%= form_for @hostgroup, :html => {:data => {:id => @hostgroup.try(:id), :submit => 'progress_bar' }} do |f| %>
   <%= base_errors_for @hostgroup %>
 

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -2,7 +2,7 @@
 <%= render "hosts/dhcp_lease_errors" if has_dhcp_lease_errors?(@host.errors) %>
 <%= render "hosts/conflicts" if (!has_dhcp_lease_errors?(@host.errors) && has_conflicts?(@host.errors)) %>
 <%= render "hosts/progress" %>
-
+<%= render "common/scap_feature_error" if !proxy_openscap_enabled?(@host.try(:openscap_proxy)) %>
 <% Taxonomy.as_taxonomy @organization , @location do %>
 
   <%= form_for @host, :url => (@host.new_record? ? hosts_path : host_path(:id => @host.id)), :html => {:data => {:id => @host.try(:id), :type_changed => !!@host.type_changed?, :submit => 'progress_bar'}} do |f| %>


### PR DESCRIPTION
This handles the situation where host or hostgroup has Openscap proxy added but that proxy is not having Openscap feature enabled. In this case when user will edit host or hostgroup there will be notification to unset the proxy or change it to another valid one.