### PR TITLE
Fixes #25637 - Default dashboard auto-refresh to off

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -16,7 +16,7 @@ module DashboardHelper
           widgets_to_add
         end
       ),
-      auto_refresh_button(:defaults_to => true),
+      auto_refresh_button(:defaults_to => false),
       documentation_button
     ]
   end


### PR DESCRIPTION
Leaving auto-refresh on can lead to siginificant slowdowns and load on
the web server process, especially when using many widgets.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
