### PR TITLE
Fixes #25640 - keep breadcrumb's title after invalid editing

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -63,6 +63,17 @@ module LayoutHelper
     @page_header ||= page_header || page_title.to_s
   end
 
+  def edit_title(obj, page_header: nil, attribute: :to_s)
+    valid_obj = obj
+    unless obj.valid?
+      # we need to override changed values with previous ones,
+      # in order to show the valid name in the page title after an unsuccessful editing
+      old_attributes = obj.attributes.merge(obj.changed_attributes)
+      valid_obj = obj.class.new(old_attributes)
+    end
+    title(_('Edit %s') % valid_obj.public_send(attribute), page_header)
+  end
+
   def title_actions(*elements)
     content_for(:title_actions) { elements.join(" ").html_safe }
   end

--- a/app/views/architectures/edit.html.erb
+++ b/app/views/architectures/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @architecture.to_s %>
+<% edit_title @architecture %>
 
 <%= render :partial => 'form' %>

--- a/app/views/bookmarks/edit.html.erb
+++ b/app/views/bookmarks/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @bookmark.to_s %>
+<% edit_title @bookmark %>
 
 <%= render :partial => 'form' %>

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @domain.to_s %>
+<% edit_title @domain %>
 
 <%= render :partial => 'form' %>

--- a/app/views/environments/edit.html.erb
+++ b/app/views/environments/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @environment.to_s %>
+<% edit_title @environment %>
 
 <%= render :partial => 'form' %>

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -1,4 +1,4 @@
-<% title(_("Edit %s") % @host) %>
+<% edit_title @host %>
 <% host_breadcrumb %>
 
 <% if SETTINGS[:unattended] %>

--- a/app/views/http_proxies/edit.html.erb
+++ b/app/views/http_proxies/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @http_proxy.to_s %>
+<% edit_title @http_proxy %>
 
 <%= render :partial => 'form' %>

--- a/app/views/media/edit.html.erb
+++ b/app/views/media/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @medium.to_s %>
+<% edit_title @medium %>
 
 <%= render :partial => 'form' %>

--- a/app/views/models/edit.html.erb
+++ b/app/views/models/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @model.to_s %>
+<% edit_title @model %>
 
 <%= render :partial => 'form' %>

--- a/app/views/ptables/edit.html.erb
+++ b/app/views/ptables/edit.html.erb
@@ -1,3 +1,4 @@
-<% title _("Edit %s") % @template.to_s %>
+<% edit_title @template %>
+
 <%= breadcrumbs(switcher_item_url: edit_ptable_path(':id')) %>
 <%= render :partial => 'form' %>

--- a/app/views/realms/edit.html.erb
+++ b/app/views/realms/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @realm.to_s %>
+<% edit_title @realm %>
 
 <%= render :partial => 'form' %>

--- a/app/views/report_templates/edit.html.erb
+++ b/app/views/report_templates/edit.html.erb
@@ -1,3 +1,4 @@
-<% title _("Edit %s") % @template.to_s %>
+<% edit_title @template %>
+
 <%= breadcrumbs(switcher_item_url: edit_report_template_path(':id')) %>
 <%= render :partial => 'form' %>

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,4 +1,4 @@
-<% title _("Edit %s") % @role.to_s %>
+<% edit_title @role %>
 <% breadcrumbs(switchable: false) %>
 
 <%= render 'form' %>

--- a/app/views/subnets/edit.html.erb
+++ b/app/views/subnets/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @subnet.to_label %>
+<% edit_title @subnet %>
 
 <%= render :partial => 'form' %>

--- a/app/views/taxonomies/edit.html.erb
+++ b/app/views/taxonomies/edit.html.erb
@@ -1,4 +1,4 @@
-<% title _("Edit %s") % @taxonomy.title %>
+<% edit_title @taxonomy, page_header: nil, attrbiture: :title %>
 
 <%= title_actions(link_to(_("Fix Mismatches"), import_mismatches_taxonomy_path(@taxonomy), :class => 'btn btn-success', :method => :post)) unless @taxonomy.valid? %>
 <%= render 'taxonomies/form' , :taxonomy => @taxonomy %>

--- a/app/views/usergroups/edit.html.erb
+++ b/app/views/usergroups/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @usergroup.to_label %>
+<% edit_title @usergroup, page_header: nil, attrbiture: :to_label %>
 
 <%= render :partial => 'form' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,3 @@
-<% title _("Edit %s") % @user.to_s %>
+<% edit_title @user %>
 
 <%= render :partial => 'form' %>

--- a/test/helpers/layout_helper_test.rb
+++ b/test/helpers/layout_helper_test.rb
@@ -35,4 +35,12 @@ class LayoutHelperTest < ActionView::TestCase
 
     mount_breadcrumbs
   end
+
+  test "edit title should return valid name" do
+    valid = FactoryBot.create(:architecture)
+    valid_name = valid.name
+    valid.name = 'name with spaces'
+
+    assert_equal edit_title(valid), "Edit #{valid_name}"
+  end
 end


### PR DESCRIPTION
Before:
![with_spaces-2](https://user-images.githubusercontent.com/11807069/49598591-a5a8bb80-f987-11e8-9751-e406b890817c.png)

After:
![with_spaces-1](https://user-images.githubusercontent.com/11807069/49598582-a04b7100-f987-11e8-8c35-348acf4aa6aa.png)
