### PR TITLE
Fixes #25524 - allow matching prerelease versions

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -186,10 +186,12 @@ module Foreman #:nodoc:
     # Sets a requirement on a Foreman plugin version
     # Raises a PluginRequirementError exception if the requirement is not met
     # matcher format is gem dependency format
-    def requires_foreman_plugin(plugin_name, matcher)
+    def requires_foreman_plugin(plugin_name, matcher, allow_prerelease: true)
       plugin = Plugin.find(plugin_name)
       raise PluginNotFound.new(N_("%{id} plugin requires the %{plugin_name} plugin, not found") % {:id => id, :plugin_name => plugin_name}) unless plugin
-      unless Gem::Dependency.new('', matcher).match?('', plugin.version)
+      dep_checker = Gem::Dependency.new('', matcher)
+      dep_checker.prerelease = true if allow_prerelease
+      unless dep_checker.match?('', plugin.version)
         raise PluginRequirementError.new(N_("%{id} plugin requires the %{plugin_name} plugin %{matcher} but current is %{plugin_version}" % {:id => id, :plugin_name => plugin_name, :matcher => matcher, :plugin_version => plugin.version}))
       end
       true

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -184,6 +184,11 @@ class PluginTest < ActiveSupport::TestCase
       name 'Other'
       version other_version
     end
+    other_version_pre = '0.5.0.pre.master'
+    @klass.register :other_pre do
+      name 'Other'
+      version other_version_pre
+    end
     @klass.register :foo do
       test.assert requires_foreman_plugin(:other, '>= 0.1.0')
       test.assert requires_foreman_plugin(:other, other_version)
@@ -193,6 +198,11 @@ class PluginTest < ActiveSupport::TestCase
       test.assert_raise Foreman::PluginRequirementError do
         requires_foreman_plugin(:other, '= 99.0.0')
       end
+      test.assert_raise Foreman::PluginRequirementError do
+        requires_foreman_plugin(:other_pre, '>= 0.4.0', allow_prerelease: false)
+      end
+      test.assert requires_foreman_plugin(:other_pre, '>= 0.4.0', allow_prerelease: true)
+      test.assert requires_foreman_plugin(:other_pre, '>= 0.4.0')
 
       # Missing plugin
       test.assert_raise Foreman::PluginNotFound do


### PR DESCRIPTION
Previously, `requires_foreman_plugin` did not account for prerelease
versions, so if you required Katello 3.8 or later, Katello 3.10
prerelease would not satisfy the requirement.

This commit adds a `allow_prerelease` parameter which is disabled by
default. If set to true, prerelease versions are acceptable for
version matching.

For example:

```ruby
requires_foreman_plugin 'katello', '>= 3.8.0'

requires_foreman_plugin 'katello', '>= 3.8.0', true
```



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
