### PR TITLE
Fixes #21964 - Reduce calls to external API

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -360,7 +360,8 @@ module Orchestration::Compute
   end
 
   def vm_exists?
-    return false unless compute_object
-    compute_object.persisted?
+    vm = compute_object
+    return false unless vm
+    vm.persisted?
   end
 end

--- a/app/views/hosts/_compute.html.erb
+++ b/app/views/hosts/_compute.html.erb
@@ -1,4 +1,4 @@
-<%= fields_for "#{type}[compute_attributes]", @host ? @host.compute_object : compute_resource.new_vm(vm_attrs) do |compute| %>
+<%= fields_for "#{type}[compute_attributes]", @host ? (@vm || @host.compute_object) : compute_resource.new_vm(vm_attrs) do |compute| %>
   <% if compute.object %>
     <%= alert(:header => _('Notice'),
               :class => 'alert-info hide',

--- a/app/views/hosts/_compute_detail.html.erb
+++ b/app/views/hosts/_compute_detail.html.erb
@@ -1,6 +1,4 @@
 
-<% new_vm = @host.nil? || new_vm?(@host) %>
-
 <%= render :partial => provider_partial(compute_resource, 'base'),
             :locals => { :f => f, :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm }.merge(args_for_compute_resource_partial(@host)) %>
 

--- a/app/views/nic/_provider_specific_form.html.erb
+++ b/app/views/nic/_provider_specific_form.html.erb
@@ -7,8 +7,11 @@
         <span class="profile">( <%= _("from profile %s") % f.object.compute_attributes["from_profile"] %> )</span>
       <% end %>
     </h3>
+
+    <% new_vm = !(@vm && @vm.persisted?) || new_vm?(@host) %>
+
     <%= f.fields_for 'compute_attributes', OpenStruct.new(f.object.compute_attributes) do |f| %>
-      <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm?(@host), :new_vm => new_vm?(@host) %>
+      <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm, :new_vm => new_vm %>
     <% end %>
   </fieldset>
 <% end %>


### PR DESCRIPTION
During a performance analysis of the host edit view rendering, a few redundant API calls were made in some cases. This PR minimizes the number of calls made to [ComputeResource#find_vm_by_uuid](https://github.com/theforeman/foreman/blob/75501405757f3bab8a370c64e8612b331014a89d/app/models/compute_resource.rb#L180), e.g. called by functions [Orchestration::Compute#compute_object](https://github.com/theforeman/foreman/blob/75501405757f3bab8a370c64e8612b331014a89d/app/models/concerns/orchestration/compute.rb#L18-L27) or [ComputeResourcesVmsHelper#new_vm?](https://github.com/theforeman/foreman/blob/75501405757f3bab8a370c64e8612b331014a89d/app/helpers/compute_resources_vms_helper.rb#L221-L226).

The host edit template may send multiple redundant HTTP requests to an external API. Reducing the number of calls should improve overall performance.

* use `@vm` variable when set in `ComputeResourcesVmsController#import`
* reduce number of calls to `ComputeResourcesVmsHelper#new_vm?`
* reduce number of calls to `Orchestration::Compute#compute_object`
* re-use variable `new_vm` passed to partial

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
