### PR TITLE
Fixes #25679 - Provide better hostname generator examples

### DIFF
--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -23,7 +23,10 @@ module Foreman
         :host_status,
         :preview?,
         :raise,
-        :input
+        :input,
+        :rand_hex,
+        :rand_name,
+        :mac_name
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -101,6 +101,18 @@ module Foreman
             mode == Renderer::PREVIEW_MODE
           end
 
+          def rand_hex(n)
+            SecureRandom.hex(n)
+          end
+
+          def rand_name
+            NameGenerator.new.generate_next_random_name
+          end
+
+          def mac_name(mac_address)
+            NameGenerator.new.generate_next_mac_name(mac_address)
+          end
+
           private
 
           def validate_subnet(subnet)

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -39,6 +39,21 @@ module RenderersSharedTests
       assert_equal 'http://foreman.some.host.fqdn', renderer.render(source, @scope)
     end
 
+    test "rand_hex helper method" do
+      source = OpenStruct.new(content: '<%= rand_hex(5) %>')
+      assert_not_nil renderer.render(source, @scope)
+    end
+
+    test "rand_name helper method" do
+      source = OpenStruct.new(content: '<%= rand_name %>')
+      assert_not_nil renderer.render(source, @scope)
+    end
+
+    test "mac_name helper method" do
+      source = OpenStruct.new(content: '<%= mac_name("52:54:00:3d:f3:53") %>')
+      assert_equal 'jimmy-alton-danko-deckard', renderer.render(source, @scope)
+    end
+
     test "indent helper method" do
       source = OpenStruct.new(content: '<%= indent(3) { "test" } %>')
       assert_equal '   test', renderer.render(source, @scope)


### PR DESCRIPTION
This feature provides some new helpers (currently for Discovery Rule Hostname example). But keeping in mind the future use, these helpers have been added in Foreman core and to be allowed in safemode. Following are the three helpers provided for hostname generator :

- rand_hex(n) - returns SecureRandom.hex(n)
- rand_name - returns NameGenerator.new.next_random_name
- mac_name(mac_address) - returns NameGenerator.new.generate.next_mac_name(mac_address)