### PR TITLE
Fixes #25672 - fix smart class parameter's title

### DIFF
--- a/app/views/puppetclass_lookup_keys/edit.html.erb
+++ b/app/views/puppetclass_lookup_keys/edit.html.erb
@@ -1,3 +1,3 @@
-<% title(_("Edit %s"), @puppetclass_lookup_key.key) %>
+<% title _("Edit %s") % @puppetclass_lookup_key.key %>
 <% lookup_keys_breadcrumbs %>
 <%= render 'lookup_keys/edit', :lookup_key => @puppetclass_lookup_key %>


### PR DESCRIPTION
Page title is changed from `Edit %s` to `Edit <parameter key>`