### PR TITLE
Fixes #25673 - Change smart variable edit page's title

### DIFF
--- a/app/views/variable_lookup_keys/edit.html.erb
+++ b/app/views/variable_lookup_keys/edit.html.erb
@@ -1,4 +1,5 @@
-<% title(_("Edit Smart Variable")) %>
+<% title _("Edit %s") % @variable_lookup_key.to_label %>
+
 <%= breadcrumbs(
     items:
     [
@@ -7,7 +8,7 @@
         url: (url_for(variable_lookup_keys_path) if authorized_for(hash_for_variable_lookup_keys_path))
       },
       {
-        caption: _('Edit Smart Variable')
+        caption: _("Edit %s") % @variable_lookup_key.to_label
       }
     ],
     resource_url: api_smart_variables_path,


### PR DESCRIPTION
Changed from unspecific `Edit Smart Variable` to `Edit <smart variable label>`