### PR TITLE
Fixes #25680 - proper overriding of validate_media?

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -730,7 +730,7 @@ class Host::Managed < Host::Base
   end
 
   def validate_media?
-    managed && pxe_build? && build?
+    managed && !image_build? && build?
   end
 
   def build_status_checker


### PR DESCRIPTION
This should allow to add own validator condition for both bootdisk and katello which are now using monkey patching which does not work well. Maybe hash could be better which could make sure we don't insert multiple entries (e.g during development mode code reload).