### PR TITLE
Fixes #20118 - return error message

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -165,7 +165,7 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 754
+  Max: 755
 
 # Offense count: 161
 Metrics/CyclomaticComplexity:

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -153,6 +153,7 @@ class HostsController < ApplicationController
       return not_found if compute_resource_id.blank?
       compute_profile_id = params[:host][:compute_profile_id] || hostgroup.try(:inherited_compute_profile_id)
       compute_resource = ComputeResource.authorized(:view_compute_resources).find_by_id(compute_resource_id)
+      return not_found if compute_resource.blank?
       render :partial => "compute", :locals => { :compute_resource => compute_resource,
                                                  :vm_attrs         => compute_resource.compute_profile_attributes_for(compute_profile_id) }
     end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -80,6 +80,10 @@ module Orchestration::Compute
 
   def setCompute
     logger.info "Adding Compute instance for #{name}"
+    if compute_attributes.nil?
+      failure _("Failed to find compute attributes, please check if VM #{name} was deleted: %{message}") % { name: name, message: e.message }, e
+      return false
+    end
     # TODO: extract the merging into separate class in combination
     # with ComputeAttributesMerge and InterfacesMerge http://projects.theforeman.org/issues/14536
     final_compute_attrs = compute_attributes.merge(compute_resource.host_compute_attrs(self))

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1596,6 +1596,18 @@ class HostsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test '#compute_resource_selected returns 404 without valid compute resource' do
+    user = FactoryBot.build(:user, :with_mail, :admin => false)
+    FactoryBot.create(:filter, :role => roles(:create_hosts), :permissions => Permission.where(:name => [ 'edit_hosts', 'view_hosts' ]))
+    user.roles << roles(:create_hosts)
+    user.save!
+
+    parent = FactoryBot.create(:hostgroup, :compute_profile => compute_profiles(:two))
+    group = FactoryBot.build(:hostgroup, :parent => parent)
+    get :compute_resource_selected, params: { :host => {:compute_resource_id => compute_resources(:one).id, :hostgroup_id => group.id}}, session: set_session_user(user), xhr: true
+    assert_response :not_found
+  end
+
   test '#interfaces applies compute profile and returns interfaces partial' do
     modifier = mock('InterfaceMerge')
     InterfaceMerge.expects(:new).with().returns(modifier)

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -67,6 +67,21 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
       click_link 'Parameters'
       assert_equal class_params.find("textarea").value, "a: c\n"
     end
+
+    test 'displays warning when vm not found by uuid' do
+      ComputeResource.any_instance.stubs(:find_vm_by_uuid).raises(ActiveRecord::RecordNotFound)
+      host = FactoryBot.create(:host, :with_hostgroup, :with_environment, :on_compute_resource, :managed)
+
+      visit edit_host_path(host)
+      assert page.has_link?('Operating System')
+      click_link 'Operating System'
+
+      alert_header = page.find('#compute_resource div.alert strong')
+      alert_body = page.find('#compute_resource div.alert span.text')
+
+      assert_equal "'#{host.name}' not found on '#{host.compute_resource}'", alert_header.text
+      assert_equal "'#{host.name}' could be deleted or '#{host.compute_resource}' is not responding.", alert_body.text
+    end
   end
 
   describe 'clone page' do


### PR DESCRIPTION
In some scenarios when editing a host in Foreman, the VM may not
exist in VMware anymore, e.g. was deleted. In this case the `setCompute` method will return an error message instead of raising a `NilClass` error.

* return failure message in case `compute_attributes` are missing
* add unit tests to check `setCompute`
* add integration test to check alert is displayed


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
