### PR TITLE
Fixes #25666 - unpin daemons gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'webpack-rails', '~> 0.9.8'
 gem 'mail', '~> 2.7'
 gem 'sshkey', '~> 1.9'
 gem 'dynflow', '>= 1.0.0', '< 2.0.0'
-gem 'daemons', '< 1.3.0'
+gem 'daemons'
 gem 'get_process_mem'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|


### PR DESCRIPTION
This reverts commit db2eae404317e62248b3e7b500c6ade0c4a75cff.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
