### PR TITLE
Fixes #25727 - remove taxonomy-related helpers

### DIFF
--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -25,15 +25,7 @@ module ProvisioningTemplatesHelper
     if template.locked?
       confirm = [
         _("You are about to unlock a locked template."),
-
-        if locations_only?
-          _("This is for every location that uses it.")
-        elsif organizations_only?
-          _("This is for every organization that uses it.")
-        elsif locations_and_organizations?
-          _("This is for every location and organization that uses it.")
-        end,
-
+        _("This is for every location and organization that uses it."),
         if template.vendor
           _("It is not recommended to unlock this template, as it is provided by %{vendor} and may be overwritten. Please consider cloning it instead.") %
             {:vendor => template.vendor}
@@ -86,19 +78,5 @@ following order:") + '</p>' + '<ul>' +
     '</ul>' +
     (_("The final entry, Operating System default, can be set by editing the %s page.") %
      (link_to _("Operating System"), operatingsystems_path))).html_safe)
-  end
-
-  private
-
-  def locations_only?
-    SETTINGS[:locations_enabled] && !SETTINGS[:organizations_enabled]
-  end
-
-  def organizations_only?
-    SETTINGS[:organizations_enabled] && !SETTINGS[:locations_enabled]
-  end
-
-  def locations_and_organizations?
-    SETTINGS[:locations_enabled] && SETTINGS[:organizations_enabled]
   end
 end

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -6,13 +6,7 @@ module TemplatesHelper
   end
 
   def default_template_description
-    if locations_only?
-      _("Default templates are automatically added to new locations")
-    elsif organizations_only?
-      _("Default templates are automatically added to new organizations")
-    elsif locations_and_organizations?
-      _("Default templates are automatically added to new organizations and locations")
-    end
+    _("Default templates are automatically added to new organizations and locations")
   end
 
   def show_default?


### PR DESCRIPTION
They are no longer needed since locations and organizations are now
always enabled.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
