### PR TITLE
Refs #25503 - fix breadcrumbs alignment

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -46,6 +46,7 @@ const Breadcrumb = ({
             onClick={item.onClick}
             href={item.url}
             title={itemTitle}
+            className={icon && active && 'breadcrumb-item-with-icon'}
           >
             {icon && <img src={icon.url} alt={icon.alt} title={icon.alt} />}{' '}
             {inner}

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumbs.scss
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumbs.scss
@@ -2,3 +2,11 @@
   display: inline-flex;
   max-width: 50%;
 }
+
+.breadcrumbs-pf-title li.breadcrumb-item-with-icon span {
+  vertical-align: middle;
+
+  img {
+    align-self: center;
+  }
+}


### PR DESCRIPTION
The icon on a breadcrumb item breaks the alignment.

before: 
![breadcrumb-with-icon-1](https://user-images.githubusercontent.com/11807069/50167747-877d7c80-02f2-11e9-969a-2b4ad802b56f.png)


after:
![breadcrumb-with-icon-2](https://user-images.githubusercontent.com/11807069/50167765-8ea48a80-02f2-11e9-9c5c-dbb2a0b11a5c.png)
