### PR TITLE
Fixes #25733 - PXE uid generated from pxedir

### DIFF
--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -26,8 +26,9 @@ module MediumProviders
 
     def unique_id
       @unique_id ||= begin
-        full_uniq = super
-        "#{entity.medium.name.parameterize}-#{full_uniq[1..10]}"
+        digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri(entity.operatingsystem.pxedir).to_s), padding: false)
+        # return first 12 characters of encoded digest stripped down of non-alphanums for better readability
+        "#{entity.medium.name.parameterize}-#{digest.gsub(/[-_]/, '')[1..12]}"
       end
     end
 

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -41,9 +41,11 @@ module MediumProviders
       parse_media(media) || []
     end
 
-    # Returns unique string representing current installation medium.
+    # Returns unique string representing current installation medium. PXE prefix path is passed as a parameter
+    # and it is important to take it into account when generating unique string as some operating systems (e.g.
+    # Debian/Ubuntu) has a constant base URL for all versions.
     def unique_id
-      @unique_id ||= Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri.to_s), padding: false)
+      raise "unique_id is not implemented for #{self.class.name}"
     end
 
     def valid?

--- a/test/models/operatingsystems/operatingsystems_test.rb
+++ b/test/models/operatingsystems/operatingsystems_test.rb
@@ -30,10 +30,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-coreos_production_pxe.vmlinuz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-linux' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw-linux' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y-linux' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr-coreos_production_pxe.vmlinuz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb-linux' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3-linux' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW-linux' } }.
   each do |os, config|
     test "kernel location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -50,10 +50,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-coreos_production_pxe_image.cpio.gz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_-initrd.gz' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw-initrd.gz' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y-initrd' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr-coreos_production_pxe_image.cpio.gz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb-initrd.gz' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3-initrd.gz' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW-initrd' } }.
   each do |os, config|
     test "initrd location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -70,10 +70,10 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_'},
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-EClLgEZtX_'},
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-_3yVUzKcKw'},
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-gyHZQuKN-y' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr'},
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb'},
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3'},
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW' } }.
   each do |os, config|
     test "pxe prefix for #{os}" do
       arch = architectures(config['arch'])

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -198,8 +198,8 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     expected = <<-EXPECTED
 default linux
 label linux
-kernel boot/centos-5-4-hZvopwDGZA-vmlinuz
-append initrd=boot/centos-5-4-hZvopwDGZA-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
+kernel boot/centos-5-4-0hJnFEYDTkXX-vmlinuz
+append initrd=boot/centos-5-4-0hJnFEYDTkXX-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
 EXPECTED
     assert_equal expected.strip, template
     assert h.build
@@ -372,8 +372,8 @@ EXPECTED
     expected = <<-EXPECTED
 DEFAULT linux
 LABEL linux
-KERNEL boot/opensuse-vEX5RaXkI7-linux
-APPEND initrd=boot/opensuse-vEX5RaXkI7-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
+KERNEL boot/opensuse-kAwuzwT2nvld-linux
+APPEND initrd=boot/opensuse-kAwuzwT2nvld-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
 EXPECTED
     assert_equal expected.strip, template
     assert h.build


### PR DESCRIPTION
@ShimStein we are generating UIDs incorrectly for Debian-based distros.
This should fix it.