### PR TITLE
Fixes #25654 - use generator-react-domain for creating React/Redux components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ public/webpack
 package-lock.json
 npm-debug.log
 .vscode
+.yo-rc.json

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prettier": "^1.13.5",
     "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
+    "react-redux-test-utils": "^0.1.1",
     "react-remarkable": "^1.1.3",
     "react-test-renderer": "^16.2.0",
     "redux-mock-store": "^1.2.2",
@@ -118,7 +119,8 @@
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
     "postinstall": "node ./script/npm_install_plugins.js",
-    "analyze": "./script/webpack-analyze"
+    "analyze": "./script/webpack-analyze",
+    "create-react-component": "yo react-domain"
   },
   "jest": {
     "automock": true,

--- a/webpack/stories/docs/addingNewComponent.md
+++ b/webpack/stories/docs/addingNewComponent.md
@@ -1,5 +1,15 @@
 # Adding components
 
+ ## Component Generator
+We are using `generator-react-domain` to help you generate your component easily.
+```sh
+npm i -g yo generator-react-domain       # install the generator globally
+
+npm run create-react-component            # create a component.
+npm run create-react-component -- --redux # create a connected component
+```
+This generator will create all folders and files for you with prewritten templates.
+
 ## Where to put them
 
 Components are stored in `webpack/assets/javascripts/react_app/components/`. Each component should be placed in its own subfolder that respects the following structure:


### PR DESCRIPTION
I created a generator that can help us (After we agreed that the shell script is not the right solution)

[generator-react-domain
](https://github.com/glekner/generator-react-domain)

Any feedback is appreciated. 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
