### PR TITLE
Fixes #25735 - improve the warning on bulk deletion

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -365,9 +365,9 @@ module HostsHelper
   def delete_host_dialog(host)
     if host.compute?
       if Setting[:destroy_vm_on_host_delete]
-        _("Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed in global settings.") % host.name
+        _("Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\".") % host.name
       else
-        _("Are you sure you want to delete host %s? It is irreversible, but VM and its disks will not be deleted. This behavior can be changed in global settings.") % host.name
+        _("Are you sure you want to delete host %s? It is irreversible, but VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\".") % host.name
       end
     else
       _("Are you sure you want to delete host %s? This action is irreversible.") % host.name

--- a/app/views/hosts/multiple_destroy.html.erb
+++ b/app/views/hosts/multiple_destroy.html.erb
@@ -1,7 +1,13 @@
 <%= form_tag submit_multiple_destroy_hosts_path(:host_ids => params[:host_ids]), :onsubmit => "resetSelection()" do %>
+  <% if Setting[:destroy_vm_on_host_delete] %>
+    <% extra_warning = _("This <b>will delete</b> the linked VMs and their disks, and is irreversible.") %>
+  <% else %>
+    <% extra_warning = _("It is irreversible, but VMs and their disks <b>will not be deleted</b>.") %>
+  <% end %>
+
   <%= alert :class => 'alert-warning',
-  :text => _("This might take a while, as all hosts, facts and reports will be destroyed as well"),
-  :header => '' %>
+    :text => (_("This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\".") % extra_warning).html_safe,
+    :header => '' %>
 <% end %>
 
 <%= render 'selected_hosts', :hosts => @hosts %>


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->

![warn](https://user-images.githubusercontent.com/109773/50231253-a3deef00-03ae-11e9-9766-4bb92561b624.png)

@lhellebr any comments to the text?
