### PR TITLE
Fixes #25743 - improved OS version help text

### DIFF
--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -17,8 +17,8 @@
     <div class="tab-pane active" id="primary">
 
       <%= text_f f, :name, :help_inline => _("OS name from facter; e.g. RedHat") %>
-      <%= text_f f, :major, :help_inline => _("OS major version from facter; e.g. 6"), :class => "col-md-2" %>
-      <%= text_f f, :minor, :help_inline => _("OS minor version from facter; e.g. 5"), :class => "col-md-2" %>
+      <%= text_f f, :major, :help_inline => _("OS major version from facter; e.g. 7"), :class => "col-md-2" %>
+      <%= text_f f, :minor, :help_inline => _("OS minor version from facter; e.g. 0 or 6.1810 (CentOS scheme)"), :class => "col-md-2" %>
       <%= text_f f, :description, :help_inline => _("OS friendly name; e.g. RHEL 6.5") %>
       <%= select_f f, :family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family") }, { :label => _("Family"), :onchange => 'show_release(this);' } %>
       <div id="release_name" <%= display?(!@operatingsystem.use_release_name?) %>>


### PR DESCRIPTION
It's not obvious that for CentOS you really need to enter minor version
like this, otherwise the Installation Media will not work out of box.