### PR TITLE
Fixes #25702 - Deprecate Taxonomy-enabled related methods

### DIFF
--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -28,8 +28,6 @@ module ApplicationShared
     return if user.nil?
 
     ['location', 'organization'].each do |taxonomy|
-      next unless Taxonomy.enabled?(taxonomy.to_sym)
-
       available = user.send("my_#{taxonomy.pluralize}")
       determined_taxonomy = nil
 

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -10,8 +10,7 @@ module TemplatesHelper
   end
 
   def show_default?
-    rights = Taxonomy.enabled_taxonomies.select { |taxonomy| User.current.can?("create_#{taxonomy}".to_sym) }
-    rights.all? && rights.present?
+    User.current.can?(:create_oragnizations) && User.current.can?(:create_locations)
   end
 
   def safemode_methods

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -78,7 +78,7 @@ module AuditExtensions
       def fully_taxable
         known_auditable_types.select do |model|
           [:location, :organization].map do |taxable|
-            Taxonomy.enabled?(taxable) && has_any_association_to?(taxable, model)
+            has_any_association_to?(taxable, model)
           end.all?
         end
       end

--- a/app/models/concerns/hostext/ownership.rb
+++ b/app/models/concerns/hostext/ownership.rb
@@ -53,10 +53,10 @@ module Hostext
     def owner_taxonomies_match
       return true if self.owner.admin?
 
-      if Organization.organizations_enabled && self.organization_id && !self.owner.my_organizations.where(:id => self.organization_id).exists?
+      if self.organization_id && !self.owner.my_organizations.where(:id => self.organization_id).exists?
         errors.add :is_owned_by, _("does not belong into host's organization")
       end
-      if Location.locations_enabled && self.location_id && !self.owner.my_locations.where(:id => self.location_id).exists?
+      if self.location_id && !self.owner.my_locations.where(:id => self.location_id).exists?
         errors.add :is_owned_by, _("does not belong into host's location")
       end
     end

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -30,7 +30,6 @@ module Taxonomix
     # default inner_method includes children (subtree_ids)
     def with_taxonomy_scope(loc = Location.current, org = Organization.current, inner_method = :subtree_ids, which_taxonomy_ignored = [])
       scope = block_given? ? yield : where(nil)
-      return scope unless Taxonomy.enabled_taxonomies.present?
       self.which_ancestry_method = inner_method
       self.which_taxonomy_ignored = which_taxonomy_ignored
       if SETTINGS[:locations_enabled] && !which_taxonomy_ignored.include?(:location)
@@ -181,7 +180,7 @@ module Taxonomix
                              raise ArgumentError, "unknown taxonomy #{taxonomy}"
                          end
     current_taxonomy = klass.current
-    Taxonomy.enabled?(taxonomy) && current_taxonomy && !self.send(association).include?(current_taxonomy)
+    current_taxonomy && !self.send(association).include?(current_taxonomy)
   end
 
   def used_location_ids

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -133,7 +133,7 @@ class Filter < ApplicationRecord
 
   def search_condition
     searches = [self.search]
-    searches << self.taxonomy_search if Taxonomy.enabled_taxonomies.any?
+    searches << self.taxonomy_search
     searches.compact!
     searches.map! { |s| parenthesize(s) } if searches.size > 1
     searches.join(' and ')

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -205,7 +205,7 @@ class Host::Managed < Host::Base
   validates :environment_id, :presence => true, :unless => Proc.new { |host| host.puppet_proxy_id.blank? }
   validates :organization_id, :presence => true, :if => Proc.new { |host| host.managed? && SETTINGS[:organizations_enabled] }
   validates :location_id,     :presence => true, :if => Proc.new { |host| host.managed? && SETTINGS[:locations_enabled] }
-  validate :compute_resource_in_taxonomy, :if => Proc.new { |host| Taxonomy.enabled_taxonomies.any? && host.managed? && host.compute_resource_id.present? }
+  validate :compute_resource_in_taxonomy, :if => Proc.new { |host| host.managed? && host.compute_resource_id.present? }
 
   if SETTINGS[:unattended]
     # define before orchestration is included so we can prepare object before VM is tried to be deleted
@@ -967,7 +967,7 @@ class Host::Managed < Host::Base
     association = self.class.reflect_on_association(association_name)
     raise ArgumentError, "Association #{association_name} not found" unless association
     associated_object_id = public_send(association.foreign_key)
-    if Taxonomy.enabled_taxonomies.present? && associated_object_id.present? &&
+    if associated_object_id.present? &&
       association.klass.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
       errors.add(association.foreign_key, _("with id %{object_id} doesn't exist or is not assigned to proper organization and/or location") % { :object_id => associated_object_id })
       false

--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -44,8 +44,7 @@ module HostInfoProviders
     end
 
     def add_taxonomy_params(param)
-      Taxonomy.enabled_taxonomies.each do |taxonomy_type|
-        single_taxonomy = taxonomy_type.singularize
+      ['location', 'organization'].each do |single_taxonomy|
         tax_field = host.send(single_taxonomy)
         next unless tax_field.present?
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -40,10 +40,10 @@ module Nic
     validate :validate_updating_types
 
     # Validate that subnet's taxonomies are defined for nic's host
-    Taxonomy.enabled_taxonomies.map(&:singularize).map(&:to_sym).each do |taxonomy|
-      validates :subnet, :belongs_to_host_taxonomy => {:taxonomy => taxonomy }
-      validates :subnet6, :belongs_to_host_taxonomy => {:taxonomy => taxonomy }
-    end
+    validates :subnet, :belongs_to_host_taxonomy => {:taxonomy => :location }
+    validates :subnet6, :belongs_to_host_taxonomy => {:taxonomy => :location }
+    validates :subnet, :belongs_to_host_taxonomy => {:taxonomy => :organization }
+    validates :subnet6, :belongs_to_host_taxonomy => {:taxonomy => :organization }
 
     scope :bmc, -> { where(:type => "Nic::BMC") }
     scope :bonds, -> { where(:type => "Nic::Bond") }

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -27,12 +27,8 @@ class Parameter < ApplicationRecord
   scoped_search :relation => :subnet, :on => :name, :complete_value => true, :rename => 'subnet_name'
   scoped_search :relation => :host, :on => :name, :complete_value => true, :rename => 'host_name'
   scoped_search :relation => :hostgroup, :on => :name, :complete_value => true, :rename => 'host_group_name'
-  if Taxonomy.locations_enabled
-    scoped_search :relation => :location, :on => :name, :complete_value => true, :rename => 'location_name'
-  end
-  if Taxonomy.organizations_enabled
-    scoped_search :relation => :organization, :on => :name, :complete_value => true, :rename => 'organization_name'
-  end
+  scoped_search :relation => :location, :on => :name, :complete_value => true, :rename => 'location_name'
+  scoped_search :relation => :organization, :on => :name, :complete_value => true, :rename => 'organization_name'
 
   default_scope -> { order("parameters.name") }
 

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -57,11 +57,13 @@ class Taxonomy < ApplicationRecord
   }
 
   def self.locations_enabled
-    enabled?(:location)
+    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.locations_enabled is always true, settings to disable taxonomies has been removed in 1.21.')
+    true
   end
 
   def self.organizations_enabled
-    enabled?(:organization)
+    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.organizations_enabled is always true, settings to disable taxonomies has been removed in 1.21.')
+    true
   end
 
   def self.no_taxonomy_scope
@@ -79,18 +81,14 @@ class Taxonomy < ApplicationRecord
   end
 
   def self.enabled?(taxonomy)
-    case taxonomy
-      when :organization
-        SETTINGS[:organizations_enabled]
-      when :location
-        SETTINGS[:locations_enabled]
-      else
-        raise ArgumentError, "unknown taxonomy #{taxonomy}"
-    end
+    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.enabled? is always true, settings to disable taxonomies has been removed in 1.21.')
+    true
   end
 
   def self.enabled_taxonomies
-    %w(locations organizations).select { |taxonomy| SETTINGS["#{taxonomy}_enabled".to_sym] }
+    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.enabled_taxonomies is always locations and organizations, settings to disable taxonomies has been removed in 1.21.')
+    true
+    %w(locations organizations)
   end
 
   def self.ignore?(taxable_type)

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -34,18 +34,16 @@ class Authorizer
     base = user.filters.joins(:permissions).where(["#{Permission.table_name}.resource_type = ?", resource_name(resource_class)])
     all_filters = permission.nil? ? base : base.where(["#{Permission.table_name}.name = ?", permission])
 
-    if Taxonomy.enabled_taxonomies.any?
-      organization_ids = allowed_organizations(resource_class)
-      Foreman::Logging.logger('permissions').debug "organization_ids: #{organization_ids.inspect}"
-      location_ids = allowed_locations(resource_class)
-      Foreman::Logging.logger('permissions').debug "location_ids: #{location_ids.inspect}"
+    organization_ids = allowed_organizations(resource_class)
+    Foreman::Logging.logger('permissions').debug "organization_ids: #{organization_ids.inspect}"
+    location_ids = allowed_locations(resource_class)
+    Foreman::Logging.logger('permissions').debug "location_ids: #{location_ids.inspect}"
 
-      organizations, locations, values = taxonomy_conditions(organization_ids, location_ids)
-      all_filters = all_filters.joins(taxonomy_join).where(["#{TaxableTaxonomy.table_name}.id IS NULL " +
-                                                                "OR (#{organizations}) " +
-                                                                "OR (#{locations})",
-                                                            *values]).distinct
-    end
+    organizations, locations, values = taxonomy_conditions(organization_ids, location_ids)
+    all_filters = all_filters.joins(taxonomy_join).where(["#{TaxableTaxonomy.table_name}.id IS NULL " +
+                                                              "OR (#{organizations}) " +
+                                                              "OR (#{locations})",
+                                                          *values]).distinct
 
     all_filters = all_filters.reorder(nil).to_a # load all records, so #empty? does not call extra COUNT(*) query
     Foreman::Logging.logger('permissions').debug do

--- a/app/validators/belongs_to_host_taxonomy_validator.rb
+++ b/app/validators/belongs_to_host_taxonomy_validator.rb
@@ -6,7 +6,7 @@ class BelongsToHostTaxonomyValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     taxonomy = @options[:taxonomy]
-    return unless Taxonomy.enabled?(taxonomy) && record.host.present? && value.present?
+    return unless record.host.present? && value.present?
 
     host_taxonomy = record.host.public_send(taxonomy)
     attribute_taxonomies = value.public_send(taxonomy.to_s.pluralize.to_sym)

--- a/app/views/audits/_list.html.erb
+++ b/app/views/audits/_list.html.erb
@@ -1,2 +1,2 @@
 <div id='audit-list'></div>
-<%= mount_react_component('AuditsList','#audit-list', {audits: construct_additional_info(audits), isOrgEnabled: Taxonomy.organizations_enabled, isLocEnabled: Taxonomy.locations_enabled}.to_json) %>
+<%= mount_react_component('AuditsList','#audit-list', {audits: construct_additional_info(audits)}.to_json) %>

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div id="override_taxonomy_form" class="<%= f.object.allows_taxonomies_filtering? && Taxonomy.enabled_taxonomies.any? ? '' : 'hidden' %>">
+      <div id="override_taxonomy_form" class="<%= f.object.allows_taxonomies_filtering? ? '' : 'hidden' %>">
         <%= checkbox_f f, :override?,
                        :label_help => _("Filters inherit organizations and locations associated with the role by default. If override field is enabled, <br> the filter can override the set of its organizations and locations. Later role changes will not affect such filter.<br> After disabling the override field, the role organizations and locations apply again.").html_safe,
                        :id => 'override_taxonomy_checkbox' %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -59,7 +59,7 @@ end %>
             <% buttons.push display_link_if_authorized(_("Edit"), hash_for_edit_filter_path(:id => filter, :role_id => @role).
                               merge(:auth_object => filter, :authorizer => authorizer)) %>
             <% buttons.push display_link_if_authorized(_("Disable overriding"), hash_for_disable_overriding_filter_path(:id => filter, :role_id => @role).
-                              merge(:auth_object => filter, :authorizer => authorizer), :method => :patch) if filter.override? && Taxonomy.enabled_taxonomies.any? %>
+                              merge(:auth_object => filter, :authorizer => authorizer), :method => :patch) if filter.override? %>
             <% buttons.push display_delete_if_authorized(hash_for_filter_path(:id => filter, :role_id => @role).
                                                            merge(:auth_object => filter, :authorizer => authorizer),
                                                            :data => { :confirm => (_("Delete filter?")) } ) %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -52,10 +52,8 @@
         <hr>
         <%= link_to_if_authorized(_("New filter"), hash_for_new_filter_path(:role_id => @role),
                                   { :class => 'btn btn-success pull-right'} ) %>
-        <% if Taxonomy.enabled_taxonomies.any? %>
-          <%= link_to_if_authorized(_('Disable all filters overriding'), hash_for_disable_filters_overriding_role_path(:id => @role),
-                                    :method => :patch, :class => 'btn btn-default pull-right') %>
-        <% end %>
+        <%= link_to_if_authorized(_('Disable all filters overriding'), hash_for_disable_filters_overriding_role_path(:id => @role),
+                                  :method => :patch, :class => 'btn btn-default pull-right') %>
       <% end %>
     </div>
 

--- a/webpack/assets/javascripts/react_app/components/AuditsList/ShowOrgsLocs.js
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/ShowOrgsLocs.js
@@ -4,33 +4,22 @@ import { Col } from 'patternfly-react';
 import ShowTaxonomyInline from './ShowTaxonomyInline';
 import { translate as __ } from '../../common/I18n';
 
-const ShowOrgsLocs = ({ isOrgEnabled, isLocEnabled, orgs, locs }) => (
+const ShowOrgsLocs = ({ orgs, locs }) => (
   <Col sm={10} className="taxonomy-section">
-    {isOrgEnabled && (
-      <ShowTaxonomyInline
-        displayLabel={__('Affected Organizations')}
-        items={orgs}
-      />
-    )}
-    {isLocEnabled && (
-      <ShowTaxonomyInline
-        displayLabel={__('Affected Locations')}
-        items={locs}
-      />
-    )}
+    <ShowTaxonomyInline
+      displayLabel={__('Affected Organizations')}
+      items={orgs}
+    />
+    <ShowTaxonomyInline displayLabel={__('Affected Locations')} items={locs} />
   </Col>
 );
 
 ShowOrgsLocs.propTypes = {
-  isOrgEnabled: PropTypes.bool,
-  isLocEnabled: PropTypes.bool,
   orgs: PropTypes.array,
   locs: PropTypes.array,
 };
 
 ShowOrgsLocs.defaultProps = {
-  isOrgEnabled: false,
-  isLocEnabled: false,
   orgs: [],
   locs: [],
 };

--- a/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/AuditsList.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/AuditsList.fixtures.js
@@ -15,8 +15,6 @@ export const actionsList = [
 ];
 
 export const TaxonomyProps = {
-  isOrgEnabled: true,
-  isLocEnabled: true,
   orgs: [
     {
       name: 'testOrg',
@@ -210,6 +208,4 @@ export const AuditsProps = {
       version: 2,
     },
   ],
-  isLocEnabled: false,
-  isOrgEnabled: true,
 };

--- a/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/__snapshots__/AuditsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/__snapshots__/AuditsList.test.js.snap
@@ -73,8 +73,6 @@ exports[`AuditsList rendering render resources list 1`] = `
       componentClass="div"
     >
       <ShowOrgsLocs
-        isLocEnabled={false}
-        isOrgEnabled={true}
         locs={
           Array [
             Object {

--- a/webpack/assets/javascripts/react_app/components/AuditsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/index.js
@@ -52,7 +52,7 @@ const renderResourceLink = (auditTitle, auditTitleUrl, id) => {
   return auditTitle;
 };
 
-const AuditsList = ({ data: { audits, isOrgEnabled, isLocEnabled } }) => (
+const AuditsList = ({ data: { audits } }) => (
   <ListView>
     {audits.map(
       (
@@ -101,8 +101,6 @@ const AuditsList = ({ data: { audits, isOrgEnabled, isLocEnabled } }) => (
         >
           <Row>
             <ShowOrgsLocs
-              isOrgEnabled={isOrgEnabled}
-              isLocEnabled={isLocEnabled}
               orgs={affectedOrganizations}
               locs={affectedLocations}
             />
@@ -128,8 +126,6 @@ const AuditsList = ({ data: { audits, isOrgEnabled, isLocEnabled } }) => (
 AuditsList.propTypes = {
   data: PropTypes.shape({
     audits: PropTypes.array.isRequired,
-    isOrgEnabled: PropTypes.bool,
-    isLocEnabled: PropTypes.bool,
   }).isRequired,
 };
 


### PR DESCRIPTION
This commit deprecates the following Taxonomy methods:
`Taxonomy.enabled?`, `Taxonomy.enabled_taxonomies`,
`Taxonomy.locations_enabled`, `Taxonomy.organizations_enabled`.
Since both taxonomies are now always enabled, these methods will always
return the same results and can be removed.
All usage of the methods in core has been removed.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
