### PR TITLE
Fixes #25745 - fix permission lookup on custom actions

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -365,6 +365,17 @@ Return the host's compute attributes that can be used to create a clone of this 
         end
       end
 
+      def parent_permission(child_permission)
+        case child_permission.to_s
+          when 'power', 'boot', 'console', 'vm_compute_attributes', 'get_status', 'template', 'enc', 'rebuild_config'
+            'view'
+          when 'disassociate'
+            'edit'
+          else
+            super
+        end
+      end
+
       # this is required for template generation (such as pxelinux) which is not done via a web request
       def forward_request_url
         @host.request_url = request.host_with_port if @host.respond_to?(:request_url)


### PR DESCRIPTION
To reproduce:

1) setup org, user who's not admin but has permisson in this org (e.g. assign him to org and assign Manager role
2) have a VM on any compute resource so you can call power on and power off the host
3) run this command `hammer host stop --id 1 --organization-id 1` where 1 is id of that VM

you'll get the error of parent permission, the problem is that if we specify organization, since the route is /organization/1/host/1/, we try to verify permission for the organization. But we don't know what permission.

So this adds the missing mapping between parent resource permission and custom host actions. For powering host, view organization permission is required.

I don't think we should add a test that verifies this definition. The logic for checking parent permission is being tested already.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
