### PR TITLE
Fixes #25748 - fallback to login in user drop down

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,6 +129,10 @@ class User < ApplicationRecord
 
   attr_exportable :firstname, :lastname, :mail, :description, :fullname, :name => ->(user) { user.login }, :ssh_authorized_keys => ->(user) { user.ssh_keys.map(&:to_export_hash) }
 
+  def as_json(options = {})
+    super.tap { |h| h.key?('user') ? h['user']['name'] = name : h['name'] = name }
+  end
+
   class Jail < ::Safemode::Jail
     allow :login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail
   end

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -158,6 +158,7 @@ const user = {
       login: 'admin',
       firstname: 'Admin',
       lastname: 'User',
+      name: 'Admin User',
     },
   },
   user_dropdown: [
@@ -192,6 +193,7 @@ const serverUser = {
     user: {
       firstname: 'G',
       lastname: 'L',
+      name: 'G L',
     },
   },
   user_dropdown: [

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -136,6 +136,7 @@ exports[`Layout rendering renders layout 1`] = `
             "id": 4,
             "lastname": "User",
             "login": "admin",
+            "name": "Admin User",
           },
         },
         "user_dropdown": Array [
@@ -275,6 +276,7 @@ exports[`Layout rendering renders layout 1`] = `
               "id": 4,
               "lastname": "User",
               "login": "admin",
+              "name": "Admin User",
             },
           },
           "user_dropdown": Array [

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -28,7 +28,7 @@ const UserDropdowns = ({
         <NavDropdown componentClass="li" id="account_menu">
           <Dropdown.Toggle useAnchor className="nav-item-iconic">
             <Icon type="fa" name="user avatar small" />
-            {userInfo.firstname} {userInfo.lastname}
+            {userInfo.name}
           </Dropdown.Toggle>
           <Dropdown.Menu>
             {user.user_dropdown[0].children.map((item, i) =>

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
@@ -38,9 +38,7 @@ exports[`UserDropdown rendering render switcher w/loading 1`] = `
         name="user avatar small"
         type="fa"
       />
-      G
-       
-      L
+      G L
     </DropdownToggle>
     <DropdownMenu
       bsClass="dropdown-menu"


### PR DESCRIPTION
To reproduce:

1) login as a user that does not have first name and last name set
2) look at user dropdown where you normally see the name
3) there's nothing

We used to fall back to login in such case, this was dropped when we moved to new implementation in react for layout. We only print first name and last name now. This PR adds `name` virtual attribute that we use in erb helpers to `user.to_json` so it can be easily reused in JS layer. The other option would be to implement this logic in JS, but I'd need some help there + it would duplicate what we already have on server side. @theforeman/ui-ux what do you think, where does this logic belong to? If you prefer JS, where do I put such a helper (it would be useful in other components too)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
