### PR TITLE
Fixes #25752 - fix console error in js test

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/Layout.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/Layout.test.js
@@ -5,7 +5,7 @@ import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers'
 import Layout from '../Layout';
 import { layoutMock, noItemsMock, hasTaxonomiesMock } from '../Layout.fixtures';
 
-jest.mock('../../notifications/index', () => 'notification');
+jest.mock('../../notifications', () => 'span');
 
 const didMountStubs = () => ({
   fetchMenuItems: jest.fn(),

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/integration.test.js
@@ -5,8 +5,7 @@ import IntegrationTestHelper from '../../../common/IntegrationTestHelper';
 import { hasTaxonomiesMock } from '../Layout.fixtures';
 import Layout, { reducers } from '../index';
 
-jest.mock('../../notifications/index', () => 'notification');
-
+jest.mock('../../notifications', () => 'span');
 describe('Layout integration test', () => {
   it('should flow', async () => {
     const integrationTestHelper = new IntegrationTestHelper(reducers);


### PR DESCRIPTION
When running `npm test` a console error appears:
```
console.error node_modules/jest-prop-type-error/index.js:8
    Warning: The tag <notification> is unrecognized in this browser. If you meant to render a React component, start its name with an uppercase letter.
        in notification (created by UserDropdowns)
        in li (created by NavItem)
        in NavItem (created by UserDropdowns)
        in ul (created by Nav)
        in Nav (created by VerticalNav.IconBar)
        in nav (created by VerticalNav.IconBar)
        in VerticalNav.IconBar (created by UserDropdowns)
        in UserDropdowns (created by Layout)
        in BaseVerticalNavMasthead (created by VerticalNav.Masthead)
        in VerticalNav.Masthead (created by Layout)
        in nav (created by BaseVerticalNav)
        in Unknown (created by withContext(Component))
```