### PR TITLE
Fixes #22766 - Puppet classes are not removed by non-admin user

### DIFF
--- a/app/views/puppetclasses/_class_selection.html.erb
+++ b/app/views/puppetclasses/_class_selection.html.erb
@@ -9,10 +9,9 @@
   <div class="col-md-4 classes">
     <h3><%= _('Included Classes') %></h3>
 
-    <%= hidden_field_tag "#{obj_type(obj)}[puppetclass_ids][]" %>
-
     <ul id="selected_classes">
       <% if authorized_for(:controller => :host_editing, :action => :edit_classes) %>
+        <%= hidden_field_tag "#{obj_type(obj)}[puppetclass_ids][]" %>
         <%= render :partial => "puppetclasses/selectedClasses",
           :collection => obj.individual_puppetclasses,:as => :klass, :locals => { :type => obj_type(obj), :host => obj } %>
         <% unless controller_name == 'config_groups' %>


### PR DESCRIPTION
Edit: a user without permissions to edit puppet classes would always send an empty array of puppet class ids which would remove all the puppet classes from the host.