### PR TITLE
Fixes #25755 - log when unpermitted params are used in all envs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,8 +38,8 @@ Foreman::Application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  # Raise exception on mass assignment of unfiltered parameters
-  config.action_controller.action_on_unpermitted_parameters = :strict
+  # log on mass assignment of unfiltered parameters
+  config.action_controller.action_on_unpermitted_parameters = :log
 
   # include query source line when sql logging is enabled
   config.active_record.verbose_query_logs = Foreman::Logging.logger('sql')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,8 +54,8 @@ Foreman::Application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raise exception on mass assignment of unfiltered parameters
-  config.action_controller.action_on_unpermitted_parameters = :strict
+  # log on mass assignment of unfiltered parameters
+  config.action_controller.action_on_unpermitted_parameters = :log
 
   # Use default memory cache (32 MB top)
   config.cache_store = :memory_store


### PR DESCRIPTION
:strict option is a leftover from protected attributes and is ignored.
Only :log, :raise or false are valid options.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
