### PR TITLE
Fixes #24345 - fix breadcrumbs item url

### DIFF
--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -37,6 +37,15 @@ export const bindMethods = (context, methods) => {
 };
 
 /**
+ * Removes slashes from the beggining and end of the path
+ * @param {String} path - the path that should be removed of slashes
+ */
+export const removeLastSlashFromPath = path => {
+  if (!path || path.length < 2) return path;
+  const lastCharIndex = path.length - 1;
+  return path[lastCharIndex] === '/' ? path.slice(0, -1) : path;
+};
+/**
  * An empty function which is usually used as a default function.
  */
 export const noop = Function.prototype;

--- a/webpack/assets/javascripts/react_app/common/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.test.js
@@ -3,6 +3,7 @@ import {
   translateObject,
   propsToSnakeCase,
   propsToCamelCase,
+  removeLastSlashFromPath,
 } from './helpers';
 
 describe('translateArray, translateObject', () => {
@@ -26,5 +27,16 @@ describe('propsToCamelCase, propsToSnakeCase', () => {
 
   it('should transform keys to snake case', () => {
     expect(propsToSnakeCase(camelObj)).toEqual(snakeObj);
+  });
+});
+
+describe('removeLastSlashFromPath', () => {
+  const pathWithSlash = 'example.com/';
+  const pathWithoutSlash = 'example.com';
+  it('should remove the last Slash', () => {
+    expect(removeLastSlashFromPath(pathWithSlash)).toBe('example.com');
+  });
+  it('should not change the path', () => {
+    expect(removeLastSlashFromPath(pathWithoutSlash)).toBe('example.com');
   });
 });

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -12,9 +12,17 @@ class BreadcrumbBar extends React.Component {
       loadSwitcherResourcesByResource,
       currentPage,
       resourceUrl,
+      resourceSwitcherItems,
     } = this.props;
-
-    if (!currentPage || resourceUrl !== resource.resourceUrl) {
+    const isUrlFormatValid = resourceSwitcherItems.length
+      ? resourceSwitcherItems[0].url ===
+        resource.switcherItemUrl.replace(':id', resourceSwitcherItems[0].id)
+      : true;
+    if (
+      !currentPage ||
+      resourceUrl !== resource.resourceUrl ||
+      !isUrlFormatValid
+    ) {
       loadSwitcherResourcesByResource(resource);
     }
   }

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarSelector.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarSelector.js
@@ -1,0 +1,20 @@
+export const selectBreadcrumbBar = state => state.breadcrumbBar;
+export const selectResourceSwitcherItems = state =>
+  selectBreadcrumbBar(state).resourceSwitcherItems;
+export const selectResourceUrl = state =>
+  selectBreadcrumbBar(state).resourceUrl;
+export const selectIsSwitcherOpen = state =>
+  selectBreadcrumbBar(state).isSwitcherOpen;
+export const selectIsLoadingResources = state =>
+  selectBreadcrumbBar(state).isLoadingResources;
+export const selectHasError = state =>
+  selectBreadcrumbBar(state).requestError != null;
+export const selectCurrentPage = state =>
+  selectBreadcrumbBar(state).currentPage;
+export const selectTotalPages = state => selectBreadcrumbBar(state).pages;
+export const selectSearchQuery = state =>
+  selectBreadcrumbBar(state).searchQuery;
+export const selectRemoveSearchQuery = state =>
+  selectBreadcrumbBar(state).removeSearchQuery;
+export const selectTitleReplacement = state =>
+  selectBreadcrumbBar(state).titleReplacement;

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
@@ -58,6 +58,7 @@ describe('BreadcrumbBar', () => {
     });
 
     it('onclick callbacks should work', () => {
+      window.history.pushState({}, 'Test Title', '/hosts/1');
       const props = {
         ...breadcrumbBarSwithcable,
         ...createStubs(),

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
@@ -10,9 +10,10 @@ import {
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import SearchInput from '../../common/SearchInput';
 import SubstringWrapper from '../../common/SubstringWrapper';
-import { noop } from '../../../common/helpers';
+import { noop, removeLastSlashFromPath } from '../../../common/helpers';
 import { translate as __ } from '../../../../react_app/common/I18n';
 import './BreadcrumbSwitcherPopover.scss';
+import { getCurrentPath } from '../../Layout/LayoutHelper';
 
 const BreadcrumbSwitcherPopover = ({
   resources,
@@ -47,12 +48,15 @@ const BreadcrumbSwitcherPopover = ({
     const createItemProps = item => {
       const { id, url, name } = item;
       const key = `${id}-${name}`;
-
+      const urlWithName = url
+        ? removeLastSlashFromPath(url.replace(id, name))
+        : url;
+      const pathname = getCurrentPath();
       const itemProps = {
         key,
         id: key,
         className: 'no-border',
-        active: url === window.location.pathname,
+        active: url === pathname || urlWithName === pathname,
       };
 
       if (itemProps.active) {

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/index.js
@@ -4,20 +4,33 @@ import { connect } from 'react-redux';
 import * as actions from './BreadcrumbBarActions';
 import reducer from './BreadcrumbBarReducer';
 
+import {
+  selectResourceSwitcherItems,
+  selectIsSwitcherOpen,
+  selectResourceUrl,
+  selectIsLoadingResources,
+  selectHasError,
+  selectCurrentPage,
+  selectTotalPages,
+  selectSearchQuery,
+  selectRemoveSearchQuery,
+  selectTitleReplacement,
+} from './BreadcrumbBarSelector';
+
 import BreadcrumbBar from './BreadcrumbBar';
 
 // map state to props
-const mapStateToProps = ({ breadcrumbBar }) => ({
-  resourceSwitcherItems: breadcrumbBar.resourceSwitcherItems,
-  isSwitcherOpen: breadcrumbBar.isSwitcherOpen,
-  resourceUrl: breadcrumbBar.resourceUrl,
-  isLoadingResources: breadcrumbBar.isLoadingResources,
-  hasError: breadcrumbBar.requestError !== null,
-  currentPage: breadcrumbBar.currentPage,
-  totalPages: breadcrumbBar.pages,
-  searchQuery: breadcrumbBar.searchQuery,
-  removeSearchQuery: breadcrumbBar.removeSearchQuery,
-  titleReplacement: breadcrumbBar.titleReplacement,
+const mapStateToProps = state => ({
+  resourceSwitcherItems: selectResourceSwitcherItems(state),
+  isSwitcherOpen: selectIsSwitcherOpen(state),
+  resourceUrl: selectResourceUrl(state),
+  isLoadingResources: selectIsLoadingResources(state),
+  hasError: selectHasError(state),
+  currentPage: selectCurrentPage(state),
+  totalPages: selectTotalPages(state),
+  searchQuery: selectSearchQuery(state),
+  removeSearchQuery: selectRemoveSearchQuery(state),
+  titleReplacement: selectTitleReplacement(state),
 });
 
 // map action dispatchers to props

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -4,8 +4,10 @@ import {
   changeLocation,
 } from '../../../foreman_navigation';
 import { translate as __ } from '../../common/I18n';
+import { removeLastSlashFromPath } from '../../common/helpers';
 
-export const getCurrentPath = () => window.location.pathname;
+export const getCurrentPath = () =>
+  removeLastSlashFromPath(window.location.pathname);
 
 export const getActive = (data, path) => {
   let activeItem = '';


### PR DESCRIPTION
When switching between show to edit host page, the breadcrumb's switcher doesn't reload the right page 

How to reproduce:
go to hosts > click edit > open a resource switcher, close it > click submit > click the breadcrumb sibling selector and pick another host, you end up in host instead of show.
 
And make active popover item more reliable 