### PR TITLE
Fixes #25798 - wrong message in select all checkbox in hosts page

### DIFF
--- a/app/assets/javascripts/host_checkbox.js
+++ b/app/assets/javascripts/host_checkbox.js
@@ -214,8 +214,8 @@ function update_counter() {
   if ($.foremanSelectedHosts)
     $(".select_count").text($.foremanSelectedHosts.length);
   var title = "";
-  if (item.prop('checked'))
-    title = pagination_metadata().per_page + " - " + item.attr("uncheck-title");
+  if (item.prop('checked') && $.foremanSelectedHosts)
+    title = $.foremanSelectedHosts.length+ " - " + item.attr("uncheck-title");
   else
     title = item.attr("check-title");
 


### PR DESCRIPTION
In the hosts page, when "select all" checkbox is selected the text is wrong:
actual text: "undefined - items selected. Uncheck to Clear" 
expected text: "20 - items selected. Uncheck to Clear"

