### PR TITLE
Fixes #25795 - Improves external usergroups sync :racehorse:

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -79,6 +79,9 @@ class AuthSource < ApplicationRecord
   def update_usergroups(login)
   end
 
+  def refresh_usergroup_members(usergroup)
+  end
+
   # Does the user exist?
   def valid_user?(name)
     false

--- a/app/models/external_usergroup.rb
+++ b/app/models/external_usergroup.rb
@@ -13,30 +13,7 @@ class ExternalUsergroup < ApplicationRecord
   validate :domain_users_forbidden
 
   def refresh
-    return false unless auth_source.respond_to?(:users_in_group)
-
-    current_users = usergroup.users.map(&:login)
-    internal_users = usergroup.users.
-      where(:auth_source => AuthSourceInternal.first).map(&:login)
-    my_users = users
-    return false unless my_users
-
-    all_other_users = (usergroup.external_usergroups - [self]).map(&:users)
-    all_users = (all_other_users + my_users).flatten.uniq
-
-    # We need to make sure when we refresh a external_usergroup
-    # other external_usergroup users remain in. Otherwise refreshing
-    # a external user group with no users in will empty the user group.
-    old_users = current_users - all_users - internal_users
-    new_users = my_users - current_users
-
-    remaining_user_ids = usergroup.user_ids - User.fetch_ids_by_list(old_users)
-    new_user_ids = User.fetch_ids_by_list(new_users)
-
-    # To make changes auditable called update
-    usergroup.user_ids = remaining_user_ids.concat(new_user_ids)
-    usergroup.save
-    true
+    auth_source.refresh_usergroup_members(usergroup)
   end
 
   def users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -320,7 +320,7 @@ class User < ApplicationRecord
   end
 
   def self.fetch_ids_by_list(userlist)
-    User.where(:lower_login => userlist.map(&:downcase)).pluck(:id)
+    self.where(:lower_login => userlist.map(&:downcase)).pluck(:id)
   end
 
   def matching_password?(pass)
@@ -488,6 +488,9 @@ class User < ApplicationRecord
     TopbarSweeper.expire_cache(self)
   end
 
+  # Returns aproximated list of users external groups, without contacting LDAP.
+  # Known issue:
+  #   If usergroup have two associated external groups, we don't know which one the user is in.
   def external_usergroups
     usergroups.flat_map(&:external_usergroups).select { |group| group.auth_source == self.auth_source }
   end

--- a/test/models/external_usergroup_test.rb
+++ b/test/models/external_usergroup_test.rb
@@ -14,4 +14,30 @@ class ExternalUsergroupTest < ActiveSupport::TestCase
     eug.valid?
     assert_match(/special/, eug.errors[:name].first)
   end
+
+  test 'update_usergroups matches LDAP gids with external user groups case insensitively' do
+    setup_ldap_stubs
+
+    @auth_source_ldap.expects(:valid_group?).with('IPAUSERS').returns(true)
+    external = FactoryBot.create(:external_usergroup, :auth_source => @auth_source_ldap, :name => 'IPAUSERS')
+    ldap_user = FactoryBot.create(:user, :login => 'JohnSmith', :mail => 'a@b.com', :auth_source => @auth_source_ldap)
+    AuthSourceLdap.any_instance.expects(:users_in_group).with('IPAUSERS').returns(['JohnSmith'])
+    external.send(:refresh)
+    assert_include ldap_user.usergroups, external.usergroup
+  end
+
+  private
+
+  def setup_ldap_stubs
+    @auth_source_ldap = FactoryBot.create(:auth_source_ldap)
+    User.current = users(:admin)
+
+    # stub out all the LDAP connectivity
+    entry = Net::LDAP::Entry.new
+    {:givenname => ['test'], :dn => ["uid=test123,cn=users,cn=accounts,dc=example,dc=com"], :mail => ["test123@example.com"], :sn => ["test"]}.each do |k, v|
+      entry[k] = v.map { |e| e.encode('UTF-8').force_encoding('ASCII-8BIT') }
+    end
+    LdapFluff.any_instance.stubs(:valid_user?).returns(true)
+    LdapFluff.any_instance.stubs(:find_user).returns([entry])
+  end
 end


### PR DESCRIPTION

Please tak a look, I am trying to address the issue of performance for external groups synchronization on login.

I got two mental blocks though:
- It is going to be on two places (not DRY)
- Not sure, if the complete synchronization will take place at other time.

Proposal:
1. I can make sure it is going to be done for all `AuthSource`s
2. The `refresh` method can be taken out and synchronization of groups on login made mandatory.

It would make sure every user has right groups on login and that's the point i guess :)