### PR TITLE
Fixes #25802 - Add disk usage info on storage domain select for oVirt

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -193,6 +193,10 @@ module ComputeResourcesVmsHelper
     params['start'].to_i + 1 + [@vms.length, params['length'].to_i].min
   end
 
+  def ovirt_storage_domains_for_select(compute_resource)
+    compute_resource.storage_domains.map { |sd| OpenStruct.new({ id: sd.id, label: "#{sd.name} (" + _("Available") + ": #{sd.available.to_i / 1.gigabyte} GiB, " + _("Used") + ": #{sd.used.to_i / 1.gigabyte} GiB)" }) }
+  end
+
   def ovirt_vms_data
     data = @vms.map do |vm|
       [

--- a/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_volume.html.erb
@@ -1,7 +1,7 @@
 
 <%= text_f f,:size_gb, :label => _('Size (GB)'), :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2" %>
 <%= f.hidden_field :size_gb if !new_vm %>
-<%= select_f f, :storage_domain, compute_resource.storage_domains, :id, :name,
+<%= select_f f, :storage_domain, ovirt_storage_domains_for_select(compute_resource), :id, :label,
              { }, :label => _('Storage domain'), :label_size => "col-md-2", :disabled => !new_vm, :class => "col-md-2" %>
 <%= f.hidden_field :storage_domain if !new_vm %>
 <%= f.hidden_field :id %>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
Print info on storage space for oVirt Storage domains in select box.


Before:

![screenshot_foreman_ovirt1](https://user-images.githubusercontent.com/2952632/50834347-1b6fc080-1354-11e9-8da9-8d2d391c62d6.png)

After:

![screenshot_foreman_ovirt2](https://user-images.githubusercontent.com/2952632/50834354-1f034780-1354-11e9-92ae-c28a6d9e6a75.png)
