### PR TITLE
Refs #21312 - Configure webpack devserver for dynamic requests

### DIFF
--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -4,13 +4,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/extensions */
 /* eslint-disable import/first */
-
-// Set the public path for dynamic imports
-if (process.env.NODE_ENV !== 'production') {
-  /* eslint-disable-next-line */
-  __webpack_public_path__ =`${window.location.protocol}//${window.location.hostname}:3808/webpack/`;
-}
-
 import 'babel-polyfill';
 
 require('expose-loader?$!expose-loader?jQuery!jquery');


### PR DESCRIPTION
This reverts commit 3b829980fa77a2a4fa441e4be469ca794ffb05b3 and adds the needed fixes.

This enforces setting the webpack port which actually fixes the sockjs connection in reverse proxy setups where users forgot to pass it in. It looks like this never worked in our centos7-devel box.