### PR TITLE
Fixes #13517 - smart class parameter override values API result

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -7,8 +7,8 @@ module Api
 
       before_action :find_override_values
       before_action :find_override_value, :only => [:show, :update, :destroy]
-      # override return_if_smart_mismatch in LookupKeysCommonController to add :index, :create
-      before_action :return_if_smart_mismatch, :only => [:index, :create, :show, :update, :destroy]
+      # override return_if_smart_mismatch in LookupKeysCommonController to add :create
+      before_action :return_if_smart_mismatch, :only => [:create, :show, :update, :destroy]
       before_action :return_if_override_mismatch, :only => [:show, :update, :destroy]
 
       before_action :rename_use_puppet_default, :only => [:create, :update]


### PR DESCRIPTION
This PR is to fix the 404 error when using API for searching smart class parameter override values.