### PR TITLE
Fixes #25819 - Show facts for single host API call

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -16,7 +16,7 @@ attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :r
            :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
            :certname, :image_id, :image_name, :created_at, :updated_at,
-           :last_compile, :global_status, :global_status_label
+           :last_compile, :global_status, :global_status_label, :facts
 attributes :organization_id, :organization_name if SETTINGS[:organizations_enabled]
 attributes :location_id, :location_name         if SETTINGS[:locations_enabled]
 


### PR DESCRIPTION
I could be missing the reason this isn't working as expected,
but for some hosts like virt-who hypervisors, I am not seeing
facts showing for GET /hosts/\<id\>. On other hosts, I see the
facts showing up. I'll provide more examples to illustrate this
point.
