### PR TITLE
Fixes #25717 - use string in `add_controller_action_scope`

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -466,12 +466,16 @@ module Foreman #:nodoc:
       @smart_proxies.fetch(klass.name, {})
     end
 
-    def add_controller_action_scope(controller_class, action, &block)
-      controller_actions = @controller_action_scopes[controller_class.name] || {}
+    def add_controller_action_scope(controller_name, action, &block)
+      if controller_name.is_a? Class
+        Foreman::Deprecation.deprecation_warning('1.22', "Passing class to add_controller_action_scope is deprecated. Use string instead.")
+        controller_name = controller_name.name
+      end
+      controller_actions = @controller_action_scopes[controller_name] || {}
       actions_list = controller_actions[action] || []
       actions_list << block
       controller_actions[action] = actions_list
-      @controller_action_scopes[controller_class.name] = controller_actions
+      @controller_action_scopes[controller_name] = controller_actions
     end
 
     def action_scopes_hash_for(controller_class)

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -417,7 +417,7 @@ class PluginTest < ActiveSupport::TestCase
   def test_hosts_controller_action_scope
     mock_scope = ->(scope) { scope }
     Foreman::Plugin.register :test_hosts_controller_action_scope do
-      add_controller_action_scope HostsController, :test_action, &mock_scope
+      add_controller_action_scope 'HostsController', :test_action, &mock_scope
     end
     scopes = HostsController.scopes_for(:test_action)
     assert_equal mock_scope, scopes.last
@@ -429,7 +429,7 @@ class PluginTest < ActiveSupport::TestCase
       scope
     end
     Foreman::Plugin.register :test_hosts_controller_action_scope_added_to_local do
-      add_controller_action_scope HostsController, :test_action, &mock_scope
+      add_controller_action_scope 'HostsController', :test_action, &mock_scope
     end
     scopes = HostsController.scopes_for(:test_action)
     assert_equal 2, scopes.count


### PR DESCRIPTION
Using class causes preliminary evaluation of api docs, so that plugin
updates are not visible in docs.

AFAIK Katello and openscap need to be updated to use the string version.

I strongly recommend getting this to 1.21, so that we can fix the plugins still in this versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->