### PR TITLE
Fixes #25822 - ensure plugin registration and code loading order

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -102,6 +102,13 @@ module Api
       true
     end
 
+    def self.inherited(base)
+      if !Rails.env.test? && !Foreman::Plugin.finished_registration?
+        Foreman::Deprecation.deprecation_warning('1.23', "Plugins registration has not finished yet. "\
+                                                         "Ensure not loading API controllers before to_prepare phase")
+      end
+    end
+
     protected
 
     def not_found(options = nil)

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -61,6 +61,10 @@ module Foreman #:nodoc:
 
       # Plugin constructor
       def register(id, &block)
+        if finished_registration?
+          Foreman::Deprecation.deprecation_warning('1.23', "Plugins registration already finished. "\
+                                                           "Ensure registering plugin before: :finisher_hook")
+        end
         plugin = new(id)
         if (gem = Gem.loaded_specs[id.to_s])
           plugin.name gem.name
@@ -114,6 +118,18 @@ module Foreman #:nodoc:
 
       def with_global_js
         with_webpack.select { |plugin| plugin.global_js_files.present? }
+      end
+
+      def mark_finished_registration!
+        @finished_registration = true
+      end
+
+      def reset_finished_registration!
+        @finished_registration = false
+      end
+
+      def finished_registration?
+        @finished_registration
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -292,6 +292,12 @@ module Foreman
       routes_reloader.execute_if_updated
     end
 
+    # First to_prepare block to run to mark the pre-initialization phase.
+    before_to_prepare_block = lambda do
+      Foreman::Plugin.mark_finished_registration!
+    end
+    config.to_prepare_blocks.unshift(before_to_prepare_block)
+
     config.after_initialize do
       init_dynflow unless Foreman.in_rake?('db:create') || Foreman.in_rake?('db:drop')
       setup_auditing

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+Foreman::Plugin.reset_finished_registration!
 # Use our custom test runner, and register a fake plugin to skip a specific test
 Foreman::Plugin.register :skip_test do
   tests_to_skip "CustomRunnerTest" => [ "custom runner is working" ]

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -71,6 +71,16 @@ class PluginTest < ActiveSupport::TestCase
     assert_equal '/some/path/on/disk', plugin.path
   end
 
+  def test_register_finished
+    Foreman::Deprecation.expects(:deprecation_warning).once
+    @klass.mark_finished_registration!
+    @klass.register :foo do
+      name 'Foo plugin'
+    end
+  ensure
+    @klass.reset_finished_registration!
+  end
+
   def test_installed
     @klass.register(:foo) {}
     assert_equal true, @klass.installed?(:foo)


### PR DESCRIPTION
- [x] https://github.com/theforeman/foreman/pull/6399

Make sure that

1. all plugins are registered before to_prepare block
2. no API controllers are loaded before all plugins are registered

Otherwise, REST API docs might not get updated.

This patch introduces deprecation warnings: by 1.22, it should be changed
to raise errors in those cases.




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->