### PR TITLE
Fixes #25098 - Validate compute resource taxonomy on NIC creation

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -27,6 +27,7 @@ module Orchestration::Compute
   end
 
   def compute_provides?(attr)
+    return false if compute_resource.nil?
     compute? && compute_resource.provided_attributes.key?(attr)
   end
 

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -15,6 +15,11 @@ module Nic
     validates :ip, :belongs_to_subnet => {:subnet => :subnet }, :if => ->(nic) { nic.managed? }
     validates :ip6, :belongs_to_subnet => {:subnet => :subnet6 }, :if => ->(nic) { nic.managed? }
 
+    validates :compute_resource, :belongs_to_host_taxonomy => { :taxonomy => :organization },
+              :if => ->(nic) { nic.host.respond_to?(:compute_resource) }
+    validates :compute_resource, :belongs_to_host_taxonomy => { :taxonomy => :location },
+              :if => ->(nic) { nic.host.respond_to?(:compute_resource) }
+
     # Interface normally are not executed by them self, so we use the host queue and related methods.
     # this ensures our orchestration works on both a host and a managed interface
     delegate :capabilities, :compute_resource, :operatingsystem, :provisioning_template, :jumpstart?, :build, :build?, :os, :arch,

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -169,7 +169,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "can fetch vm compute attributes" do
-    host = FactoryBot.create(:host, :compute_resource => compute_resources(:ec2))
+    host = FactoryBot.create(:host, :on_compute_resource)
     ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:cpus => 4})
     assert_equal host.vm_compute_attributes, :cpus => 4
   end
@@ -2824,7 +2824,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test 'clone should create compute_attributes for VM-based hosts' do
-    host = FactoryBot.create(:host, :compute_resource => compute_resources(:ec2))
+    host = FactoryBot.create(:host, :on_compute_resource)
     ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:foo => 'bar'})
     copy = host.clone
     assert !copy.compute_attributes.nil?

--- a/test/models/nics/managed_test.rb
+++ b/test/models/nics/managed_test.rb
@@ -159,6 +159,23 @@ class ManagedTest < ActiveSupport::TestCase
     end
   end
 
+  context "with computeresource not in taxonomy scope" do
+    let(:managed_host) { FactoryBot.build_stubbed(:host, :managed, :on_compute_resource) }
+    let(:host_cr) { managed_host.compute_resource }
+
+    setup do
+      host_cr.update({ :locations => [taxonomies(:location2)],
+                       :organizations => [taxonomies(:organization2)]
+                    })
+    end
+
+    test 'host should be invalid via the interfaces compute_resource validation' do
+      managed_host.interfaces.build(:name => 'test')
+      refute managed_host.valid?
+      assert managed_host.errors[:"interfaces.compute_resource_id"].present?
+    end
+  end
+
   private
 
   def setup_primary_nic_with_name(name, opts = {})

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -65,8 +65,11 @@ module TaxonomiesBaseTest
                                   :"#{opposite_taxonomy}_ids" => [],
                                   :"#{taxonomy_name.pluralize}" => [taxonomy])
       domain = FactoryBot.build(:domain)
+      cr_one = compute_resources(:one)
+      cr_one.update(:"#{taxonomy_name.pluralize}" => [taxonomy],
+                    :"#{opposite_taxonomy.pluralize}" => [])
       FactoryBot.create(:host,
-                         :compute_resource => compute_resources(:one),
+                         :compute_resource => cr_one,
                          :domain           => domain,
                          :environment      => environments(:production),
                          :medium           => media(:one),


### PR DESCRIPTION
In cases where the compute resource is not in the same taxonomy as
the host, creating NICs is raising an error when trying to get to
the compute resource, which is out of scope, to ask for attributes
provided by it.