### PR TITLE
Fixes #25829 - Remove notification for removed settings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -286,7 +286,6 @@ module Foreman
     config.after_initialize do
       init_dynflow unless Foreman.in_rake?('db:create') || Foreman.in_rake?('db:drop')
       setup_auditing
-      notify_deprecations unless Foreman.in_rake?
     end
 
     def dynflow
@@ -317,31 +316,6 @@ module Foreman
 
     def setup_auditing
       Audit.send(:include, AuditSearch)
-    end
-
-    def notify_deprecations
-      blueprint = NotificationBlueprint.find_by_name('setting_deprecation')
-      [:locations_enabled, :organizations_enabled].each do |setting|
-        next if SETTINGS[setting]
-        Foreman::Deprecation.deprecation_warning('1.21', "The #{setting} setting is deprecated")
-        message = UINotifications::StringParser.new(blueprint.message, {setting: setting, version: '1.21'}).to_s
-        next if blueprint.notifications.where(message: message).any?
-        Notification.create!(
-          audience: Notification::AUDIENCE_ADMIN,
-          message: message,
-          notification_blueprint: blueprint,
-          initiator: User.anonymous_admin,
-          :actions => {
-            :links => [
-              {
-                :href => 'https://community.theforeman.org/t/proposal-remove-support-for-disabling-taxonomies-or-login/10972',
-                :title => _('Further Information'),
-                :external => true
-              }
-            ]
-          }
-        )
-      end
     end
   end
 


### PR DESCRIPTION
The deprecated settings have been removed, so these notifications will
never be displayed anymore. Keeping the blueprint in place so we can
reuse it in the future if needed.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
