### PR TITLE
Fixes #25543 - Breadcrumb switcher doesn't work for filters

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -105,6 +105,10 @@ class Filter < ApplicationRecord
     type.presence
   end
 
+  def resource_type_label
+    resource_class.try(:humanize_class_name) || resource_type || N_('(Miscellaneous)')
+  end
+
   def resource_class
     @resource_class ||= self.class.get_resource_class(resource_type)
   end

--- a/app/views/api/v2/filters/main.json.rabl
+++ b/app/views/api/v2/filters/main.json.rabl
@@ -2,7 +2,7 @@ object @filter
 
 extends "api/v2/filters/base"
 
-attributes :search, :resource_type, :unlimited?, :created_at, :updated_at, :override?
+attributes :search, :resource_type, :resource_type_label, :unlimited?, :created_at, :updated_at, :override?
 
 child :role do
   extends "api/v2/roles/base"

--- a/app/views/filters/edit.html.erb
+++ b/app/views/filters/edit.html.erb
@@ -1,9 +1,20 @@
 <%=
 breadcrumbs(
+  resource_url: api_filters_path(),
+  resource_filter: 'role_id=%s' % @filter.role.id,
+  name_field: "resource_type_label",
   items: [
-    (@role.present? ? { caption: _('Roles'), url: (url_for(roles_path) if authorized_for(hash_for_roles_path)) } : { caption: _("Filters"), url: filters_path }),
-    ({ caption: _("%s filters") % @role.to_s, url: filters_path(role_id: @role.id) } if @role.present?),
-    { caption: _('Edit %s') % @filter.to_s },
+    {
+      caption: _("Roles"),
+      url: (url_for(roles_path) if authorized_for(hash_for_roles_path))
+    },
+    {
+      caption: _('%s Filters') % @filter.role.name,
+      url: (filters_path(:role_id => @filter.role) if authorized_for(hash_for_filters_path))
+    },
+    {
+      caption: _('Edit %s Resource Filter' ) % _(@filter.resource_type_label)
+    },
   ].compact
 )
 %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -43,7 +43,7 @@ end %>
           </td>
         <% end %>
         <td>
-          <%= _(filter.resource_class.try(:humanize_class_name) || filter.resource_type || '(Miscellaneous)') %>
+          <%= _( filter.resource_type_label ) %>
         </td>
         <td><%= filter.permissions.map(&:name).join(', ') %></td>
         <td><%= checked_icon filter.unlimited? %></td>

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/BreadcrumbSwitcherPopover.js
@@ -74,10 +74,10 @@ const BreadcrumbSwitcherPopover = ({
               <EllipsisWithTooltip>
                 {searchValue && searchValue.length ? (
                   <SubstringWrapper substring={searchValue}>
-                    {resource.name}
+                    {__(resource.name)}
                   </SubstringWrapper>
                 ) : (
-                  resource.name
+                  __(resource.name)
                 )}
               </EllipsisWithTooltip>
             </ListGroupItem>


### PR DESCRIPTION
When editing a filter `/filters/<id>/edit`, the breadcrumb-switcher showed blank lines in the results box.
Also changed breadcrumbs in filters from "filters > _filter_" to "Roles > _role_ Filters
Edit _filter_ Filter" since filters are a part of roles and aren't a standalone.

