### PR TITLE
Refs #23369 - Correctly correct string extraction

### DIFF
--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
@@ -86,7 +86,7 @@ exports[`StorageContainer should render controller 1`] = `
       datastore=""
       datastores={
         Object {
-          "FC0001_LX_DC1_EXAMPLE_PROD_01": "%(name) (free: %(free), prov: %(prov), total: %(total))",
+          "FC0001_LX_DC1_EXAMPLE_PROD_01": "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)",
         }
       }
       eagerzero={false}
@@ -99,7 +99,7 @@ exports[`StorageContainer should render controller 1`] = `
       storagePod=""
       storagePods={
         Object {
-          "LX-DC1-EXAMPLE": "%(name) (free: %(free), prov: %(prov), total: %(total))",
+          "LX-DC1-EXAMPLE": "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)",
         }
       }
       thin={true}

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
@@ -54,7 +54,7 @@ const Controller = ({
     }
     return datastores.reduce((obj, d) => {
       obj[d.name] = sprintf(
-        __('%(name) (free: %(free), prov: %(prov), total: %(total))'),
+        __('%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)'),
         {
           name: d.name,
           free: humanSize(d.freespace),
@@ -72,7 +72,7 @@ const Controller = ({
     }
     return storagePods.reduce((obj, s) => {
       obj[s.name] = sprintf(
-        __('%(name) (free: %(free), prov: %(prov), total: %(total))'),
+        __('%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)'),
         {
           name: s.name,
           free: humanSize(s.freespace),


### PR DESCRIPTION
Missing `s` at the end of the named parameters led to failing tests.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
