### PR TITLE
Fixes #25809 - Api implementation for SSO via Keycloak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'sshkey', '~> 1.9'
 gem 'dynflow', '>= 1.0.0', '< 2.0.0'
 gem 'daemons'
 gem 'get_process_mem'
+gem 'jwt'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/services/sso.rb
+++ b/app/services/sso.rb
@@ -1,5 +1,5 @@
 module SSO
-  METHODS = [Apache, Basic, Oauth]
+  METHODS = [Apache, Basic, Oauth, Jwt]
 
   def self.get_available(controller)
     all_methods = all.map { |method| method.new(controller) }

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -1,0 +1,32 @@
+require 'jwt'
+
+module SSO
+  class Jwt < Base
+    def available?
+      controller.api_request? && http_auth_set?
+    end
+
+    def authenticate!
+      token = request.env["HTTP_AUTHORIZATION"].split(' ')
+      @jwt = JWT.decode(token[1], nil, false)
+      User.find_or_create_external_user({ login: @jwt.first["preferred_username"],
+                                          mail: @jwt.first["email"],
+                                          firstname: @jwt.first["given_name"],
+                                          lastname: @jwt.first["family_name"]
+                                        }, Setting['authorize_login_delegation_auth_source_user_autocreate'])
+    rescue JWT::DecodeError
+    end
+
+    def authenticated?
+      User.current.present? ? User.current.login : authenticate!
+    end
+
+    def http_auth_set?
+      request.authorization.present? && request.authorization.start_with?('Bearer')
+    end
+
+    def current_user
+      User.unscoped.except_hidden.find_by_login(@jwt.first["preferred_username"])
+    end
+  end
+end


### PR DESCRIPTION
My attempt is to use keycloak for authenticating the user
and fetching the token, once we have the token we can send this
token to the foreman api, where we can use the JWT gem to
validate the token and then create a session for the user.

In this pr, I have attempted to create a user which is unknown to 
foreman. I have created a keycloak controller, which will be reponsible
for:
1. validating the token.
2. decoding the token and fetch the relevant information from the token.
3. create a passwordless external user.