### PR TITLE
Fixes #25850 - Topbar is shortly white after refresh

### DIFF
--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -28,3 +28,5 @@ $dropdown-link-hover-bg: #08c;
 
 $login-bg-color: $primary_color;
 $login-container-bg-color-rgba: rgba(0, 0, 0, 0.3);
+
+$topbar-default-color: #01749d;

--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -1,3 +1,5 @@
+@import './colors.scss';
+
 .navbar {
   .nav a {
     font-size: 13px;
@@ -64,7 +66,7 @@
 }
 
 .navbar-pf-vertical {
-  background: image-url('navbar.png');
+  background: $topbar-default-color image-url('navbar.png');
   background-repeat: no-repeat;
   background-size: cover;
   width: 100%;


### PR DESCRIPTION
Thought we can merge this until all the dynamic-imports/react-loadable discussions complete
This happens after every full page reload, top bar is blank until `navbar.png` arrives.
The change just fills the Topbar until the image arrives

Before
<img width="519" alt="screenshot 2019-01-14 16 21 25" src="https://user-images.githubusercontent.com/24938324/51118559-5fae0580-1819-11e9-9cf9-ddc1c794ec55.png">

After
<img width="517" alt="screenshot 2019-01-14 16 22 23" src="https://user-images.githubusercontent.com/24938324/51118601-718fa880-1819-11e9-9ba7-3bc884cfda6d.png">

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
