### PR TITLE
Fixes #25854 - fix the display type field

### DIFF
--- a/app/views/compute_resources/form/_libvirt.html.erb
+++ b/app/views/compute_resources/form/_libvirt.html.erb
@@ -1,6 +1,6 @@
 <%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. qemu://host.example.com/system"), :help_inline => documentation_button('5.2.5LibvirtNotes') %>
 
-<%= select_f f,   :display_type, %w[VNC SPICE],:upcase, :to_s, { }, :label => _("Display Type") %>
+<%= select_f f,   :display_type, %w[VNC SPICE], :downcase, :to_s, { }, :label => _("Display Type") %>
 <%= checkbox_f f, :set_console_password, :checked => f.object.set_console_password?,
                   :label => _("Console Passwords"),
                   :help_inline => _("Set a randomly generated password on the display connection") %>


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->

extremely easy to review, just go and edit libvirt compute resource, change the display type, while it's reflected in DB, we always display wrong (first) value in the form, because values in DB are in fact downcased string so rails won't match it