### PR TITLE
Fixes #25826 - fix invalid date in dashboard

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,7 +82,7 @@ module ApplicationHelper
     date_id = generate_date_id
 
     content_tag(:span, '', :id => date_id).html_safe +
-    mount_react_component(component, "##{date_id}", { date: time.to_s, default: _('N/A'), seconds: seconds }.to_json, { :flatten_data => true })
+    mount_react_component(component, "##{date_id}", { date: time.iso8601, default: _('N/A'), seconds: seconds }.to_json, { :flatten_data => true })
   end
 
   def contract(model)


### PR DESCRIPTION
React international uses `new Date(dateString)`, which works only on chorme.
Sending an ISO formatted time string fix it under firefox.

![date-good](https://user-images.githubusercontent.com/11807069/51191586-660db180-18ed-11e9-9b0e-95531b47a44f.png)

vs 
![screenshot from 2019-01-15 17-34-51](https://user-images.githubusercontent.com/11807069/51191600-6a39cf00-18ed-11e9-9fc9-47ca00e1aa92.png)
