### PR TITLE
Refs #25733 - Fix medium_provider test for ubuntu

### DIFF
--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -29,7 +29,7 @@ class DefaultMediumProviderTest < ActiveSupport::TestCase
   end
 
   [["Redhat", "http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot"],
-   ["Ubuntu", "http://sg.archive.ubuntu.com/dists//main/installer-x86_64/current/images/netboot/ubuntu-installer/x86_64"],
+   ["Ubuntu", "http://sg.archive.ubuntu.com/dists/rn10/main/installer-x86_64/current/images/netboot/ubuntu-installer/x86_64"],
    ["OpenSuse", "http://download.opensuse.org/distribution/12.3/repo/oss/boot/x86_64/loader"],
    ["Solaris", "http://brsla01/vol/solgi_5.10/sol10_hw0910_sparc/Solaris_10/Tools/Boot"]].each do |osname, expected_uri|
     test "generates unique ID based on base and pxedir for #{osname}" do


### PR DESCRIPTION
Debain-based distros now require relname property, os fixtures were
updated with them while the test wasn't because the PR wasn't rebased
prior to merging.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
