### PR TITLE
Fixes #25871 - timestamps removed from logs

### DIFF
--- a/db/migrate/20190116120705_remove_timestamps_from_logs.rb
+++ b/db/migrate/20190116120705_remove_timestamps_from_logs.rb
@@ -1,0 +1,6 @@
+class RemoveTimestampsFromLogs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :logs, :created_at, :datetime
+    remove_column :logs, :updated_at, :datetime
+  end
+end


### PR DESCRIPTION

Table "logs" can be huge since it joins reports with sources and messages. It currently contains timestamps but we do not appear to make any use of them and it does not make much sense to track creation of individual lines in a report, what is relevant is creation time of a report itself which we already have in table named "reports".

This ticket is to drop the timestamps to save some space.