### PR TITLE
Fixes #25894 - rename the host statuses report

### DIFF
--- a/app/views/unattended/report_templates/host_statuses.erb
+++ b/app/views/unattended/report_templates/host_statuses.erb
@@ -1,5 +1,5 @@
 <%#
-name: Host statuses CSV
+name: Host statuses
 snippet: false
 template_inputs:
 - name: hosts

--- a/db/migrate/20190122115421_rename_host_statuses_report.rb
+++ b/db/migrate/20190122115421_rename_host_statuses_report.rb
@@ -1,0 +1,13 @@
+class RenameHostStatusesReport < ActiveRecord::Migration[5.2]
+  def up
+    ReportTemplate.skip_permission_check do
+      ReportTemplate.unscoped.where(:name => 'Host statuses CSV').update_all(:name => 'Host statuses')
+    end
+  end
+
+  def down
+    ReportTemplate.skip_permission_check do
+      ReportTemplate.unscoped.where(:name => 'Host statuses').update_all(:name => 'Host statuses CSV')
+    end
+  end
+end


### PR DESCRIPTION
Reproducing steps:

1) go to monitor -> report templates
2) host statuses contains format in name, see "CSV"

this is no longer needed, we use rendering DSL which can modify the type, this is a leftover

to review:

3) apply the patch, run `rake db:migrate`
4) run `rake db:seed`
5) go to page from 2) see the name has changed, metadata also changed (thanks to seed) so the name is correct there
6) the template id hasn't changed, no audit was created for this internal change

Best with https://github.com/theforeman/community-templates/pull/548 which should be merged at the same time so next sync won't restore original template name.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
