### PR TITLE
Fixes #25908 - Fix new setting creation shortcut

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -108,7 +108,7 @@ class Setting < ApplicationRecord
 
   def self.[]=(name, value)
     name   = name.to_s
-    record = where(:name => name).first_or_create
+    record = where(:name => name).first!
     record.value = value
     record.save!
   end


### PR DESCRIPTION
I had a problem running `rake db:seed` and I found out it's impossible to create a new setting with this shortcut `Setting[:some_key] = "some-value"` because `description` and `default` are mandatory fields.

Would you see this solution exceptable?