### PR TITLE
Fixes #25896 - syslog pattern default is short

### DIFF
--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -91,7 +91,7 @@
     - mdc
     - ndc
   :pattern: "%d [%.1l|%.3c|%.8X{request}] %m\n"
-  :sys_pattern: "[%.1l|%.3c|%.8X{request}] %m\n"
+  :sys_pattern: "%m\n"
   :facility: LOG_LOCAL6
 
 :production:


### PR DESCRIPTION
Just improving user experience, when logging to journald/syslog not
time/request id is needed as user can display or configure those fields
as needed. This was actually the purpose of `sys_pattern` configuration
option.