### PR TITLE
Fixes #25913 - Add helpers for snake and camel case

### DIFF
--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -1,4 +1,5 @@
 import debounce from 'lodash/debounce';
+import { snakeCase, camelCase } from 'lodash';
 import { translate as __ } from './I18n';
 
 /**
@@ -72,6 +73,27 @@ export const translateObject = obj =>
  */
 export const translateArray = arr => arr.map(str => __(str));
 
+/**
+ * Transform object keys to snake case
+ */
+export const propsToSnakeCase = ob =>
+  propsToCase(snakeCase, 'propsToSnakeCase only takes objects', ob);
+
+/**
+ * Transform object keys to camel case
+ */
+export const propsToCamelCase = ob =>
+  propsToCase(camelCase, 'propsToCamelCase only takes objects', ob);
+
+const propsToCase = (casingFn, errorMsg, ob) => {
+  if (typeof ob !== 'object') throw Error(errorMsg);
+
+  return Object.keys(ob).reduce((memo, key) => {
+    memo[casingFn(key)] = ob[key];
+    return memo;
+  }, {});
+};
+
 export default {
   bindMethods,
   noop,
@@ -81,4 +103,6 @@ export default {
   getDisplayName,
   translateObject,
   translateArray,
+  propsToCamelCase,
+  propsToSnakeCase,
 };

--- a/webpack/assets/javascripts/react_app/common/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.test.js
@@ -1,4 +1,9 @@
-import { translateArray, translateObject } from './helpers';
+import {
+  translateArray,
+  translateObject,
+  propsToSnakeCase,
+  propsToCamelCase,
+} from './helpers';
 
 describe('translateArray, translateObject', () => {
   const arr = ['Hello', 'There'];
@@ -8,5 +13,18 @@ describe('translateArray, translateObject', () => {
   });
   it('should translate Object', () => {
     expect(translateObject(obj)).toMatchSnapshot();
+  });
+});
+
+describe('propsToCamelCase, propsToSnakeCase', () => {
+  const snakeObj = { hello_world: 'hello', test_obj: 'test' };
+  const camelObj = { helloWorld: 'hello', testObj: 'test' };
+
+  it('should transform keys to camel case', () => {
+    expect(propsToCamelCase(snakeObj)).toEqual(camelObj);
+  });
+
+  it('should transform keys to snake case', () => {
+    expect(propsToSnakeCase(camelObj)).toEqual(snakeObj);
   });
 });


### PR DESCRIPTION
Taken from katello/webpack/services/index.js and slightly modified. Note the transformation is shallow, so I wonder if recursive calls make sense when `typeof ob[key] === 'object'`