### PR TITLE
Fixes #25914 - fix user deletion

### DIFF
--- a/app/models/usergroup_member.rb
+++ b/app/models/usergroup_member.rb
@@ -86,7 +86,9 @@ class UsergroupMember < ApplicationRecord
   end
 
   def recache_memberships
-    find_all_affected_memberships.each(&:save!)
+    memberships = find_all_affected_memberships
+    memberships = memberships.without(self) if self.destroyed?
+    memberships.each(&:save!)
   end
 
   def drop_role_cache(users, user_roles)

--- a/test/models/usergroup_member_test.rb
+++ b/test/models/usergroup_member_test.rb
@@ -315,6 +315,14 @@ class UsergroupMemberTest < ActiveSupport::TestCase
     assert_includes @semiadmin_user.cached_user_roles.map(&:role), @admin_role
   end
 
+  # before destroy callback could fail, covers #25914
+  test "user can be destroyed and it destroys also user group members correctly" do
+    user = FactoryBot.create :user
+    group = FactoryBot.create :usergroup
+    group.users = [ user ]
+    assert user.destroy
+  end
+
   def setup_redundant_scenario
     as_admin do
       @semiadmins = FactoryBot.create :usergroup, :name => 'um_semiadmins'


### PR DESCRIPTION
destroyed objects are now still listed during the transaction (some rails update I guess) so we need to skip it

to reproduce:
1) create user
2) create usergroup and assign user from 1)
3) try deleting this user, error can be observed

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
