### PR TITLE
Refs #25882 - Load additional plugin chunks

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -104,7 +104,12 @@ Foreman::Application.configure do |app|
           Rails.logger.debug { "Loading #{plugin.id} webpack asset manifest from #{manifest_path}" }
           assets = JSON.parse(File.read(manifest_path))
 
-          webpack_manifest['assetsByChunkName'][plugin.id.to_s] = assets['assetsByChunkName'][plugin.id.to_s] if assets['assetsByChunkName'].key?(plugin.id.to_s)
+          plugin_id = plugin.id.to_s
+          assets['assetsByChunkName'].each do |chunk, filename|
+            if chunk == plugin_id || chunk.start_with?("#{plugin_id}:")
+              webpack_manifest['assetsByChunkName'][chunk] = filename
+            end
+          end
         end
 
         Webpack::Rails::Manifest.manifest = webpack_manifest


### PR DESCRIPTION
When loading the manifest.json from a plugin we need to include plugin and plugin:*.

bc486dd62734be908cd3f95da1352cc1944eb34b attempted to make it possible to create additional bundles.  202c65d0efc0345b883ba6d1e70aedc90b3d5294 then configured webpack to actually compile the bundle during build. This completes the chain by loading it in the actual manifest so you can use it in a production build where the development server isn't present.