### PR TITLE
Fixes #16591 - Correct parameter value order for complex matcher

### DIFF
--- a/app/services/classification/values_hash_query.rb
+++ b/app/services/classification/values_hash_query.rb
@@ -61,7 +61,7 @@ module Classification
         lookup_values.sort_by do |lv|
           matcher_key, matcher_value = split_matcher(lv)
           # prefer matchers in order of the path, then more specific matches (i.e. hostgroup children)
-          [key.path.index(matcher_key.chomp(',')), -1 * matcher_value.length]
+          [key.path.split.index(matcher_key.chomp(',')), -1 * matcher_value.length]
         end
       end
 


### PR DESCRIPTION
If the order includes more specific complex matchers before less
specific one (e.g., "organization,location" before "organization"), the
order of resolution is incorrect, because the classification service
will check for the index of the matcher in the path which is serialized
as a string - "organization,location\norganization" leading to incorrect
order.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
