### PR TITLE
Fixes #25940 - react mounter is able to generate a div wrapper

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,7 +1,15 @@
 module ReactjsHelper
   def mount_react_component(name, selector, data = [], opts = {})
-    javascript_tag defer: 'defer' do
-      "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}, #{opts[:flatten_data] || false}));".html_safe
+    selector_id = selector.present? ? selector : "##{opts[:dom_id]}"
+    react_component = javascript_tag defer: 'defer' do
+      "$(tfm.reactMounter.mount('#{name}', '#{selector_id}', #{data}, #{opts[:flatten_data] || false}));".html_safe
+    end
+    if selector.present? 
+      react_component
+    else 
+      content_tag(:div, '', id: opts[:dom_id]) do  
+        react_component
+      end
     end
   end
 

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,5 +1,3 @@
 <% title _("Statistics"), _('Statistics') %>
 
-<div id="statistics"></div>
-
-<%= mount_react_component('StatisticsChartsList', '#statistics', @metadata.to_json)%>
+<%= mount_react_component('StatisticsChartsList', nil, @metadata.to_json, dom_id: 'statistics-charts-list')%>


### PR DESCRIPTION
react mounter generates a div wrapper when no selector is given
