### PR TITLE
Refs #22898 - delete action broken for provisioning_templates

### DIFF
--- a/app/helpers/template_paths_helper.rb
+++ b/app/helpers/template_paths_helper.rb
@@ -19,7 +19,6 @@ module TemplatePathsHelper
   end
 
   def template_hash_for_member(template, member = nil)
-    return {} unless member.present?
     member = "#{member}_" if member.present?
     # hash_for is protected method
     if template.id.present?


### PR DESCRIPTION
For action "provisioning_templates -> template -> delete" getting an error `ActionController::RoutingError (No route matches [DELETE] "/templates/provisioning_templates")`

@apuntamb,
Adding you into loop as you worked on original fix [PR-6190](https://github.com/theforeman/foreman/pull/6190).
**Edit:** @apuntamb, let me know if I am missing any scenario.