### PR TITLE
Fixes #25941 - fix autocomplete snapshot

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -2,27 +2,44 @@
 
 exports[`AutoComplete rendering renders AutoComplete 1`] = `
 <div>
-  <OnClickOutside(TypeaheadContainer(WrappedTypeahead))
+  <TypeaheadContainer(WrappedTypeahead)
+    a11yNumResults={[Function]}
+    a11yNumSelected={[Function]}
+    align="justify"
+    allowNew={false}
+    autoFocus={false}
+    bodyContainer={false}
+    caseSensitive={false}
+    clearButton={false}
     defaultInputValue=""
+    defaultOpen={false}
+    defaultSelected={Array []}
+    disabled={false}
+    dropup={false}
     emptyLabel={null}
-    eventTypes={
-      Array [
-        "mousedown",
-        "touchstart",
-      ]
-    }
-    excludeScrollbar={false}
+    filterBy={Array []}
+    flip={false}
+    highlightOnlyResult={false}
+    ignoreDiacritics={true}
     inputProps={
       Object {
         "className": "search-input use-shortcuts",
         "spellCheck": "false",
       }
     }
+    isInvalid={false}
     isLoading={false}
+    isValid={false}
+    labelKey="label"
+    maxResults={100}
+    minLength={0}
+    multiple={false}
+    onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
     onInputChange={[Function]}
     onKeyDown={[Function]}
+    onPaginate={[Function]}
     options={
       Array [
         Object {
@@ -31,11 +48,11 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
         },
       ]
     }
-    outsideClickIgnoreClass="ignore-react-onclickoutside"
+    paginate={true}
+    paginationText="Display additional results..."
     placeholder="Filter ..."
-    preventDefault={false}
     renderMenu={[Function]}
-    stopPropagation={false}
+    selectHintOnEnter={false}
   />
   <AutoCompleteAux
     onClear={[Function]}


### PR DESCRIPTION
`react-bootstrap-typeahead` removed `react-onclickoutside` on [3.3.0](https://github.com/ericgio/react-bootstrap-typeahead/commit/5ed529e335c7302ba2f7444d03c8b773874205bc) , which affect the snapshot.

no regression has been found.
