### PR TITLE
Fixes #19701 - use friendly vmware network name, not its id

### DIFF
--- a/app/assets/javascripts/compute_resources/vmware/nic_info.js
+++ b/app/assets/javascripts/compute_resources/vmware/nic_info.js
@@ -1,3 +1,3 @@
 providerSpecificNICInfo = function(form) {
-  return form.find('.vmware_type').val() + ' @ ' + form.find('.vmware_network').val();
+  return form.find('.vmware_type').val() + ' @ ' + form.find('.vmware_network option:selected').text();
 }

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -2,11 +2,7 @@
   :class => "col-md-3 vmware_type",
   :label => _('NIC type'), :label_size => "col-md-3", :disabled => !new_vm
 %>
-<% if new_vm %>
-  <%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
-    :class => "col-md-3 vmware_network",
-    :label => _('Network'), :label_size => "col-md-3"
-  %>
-<% else %>
-  <%= text_f f, :network, :class => 'col-md-3 vmware_network', :label => _("Network"), :label_size => "col-md-3", :readonly => true %>
-<% end %>
+<%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
+  :class => "col-md-3 vmware_network",
+  :label => _('Network'), :label_size => "col-md-3", :disabled => !new_vm
+%>

--- a/app/views/nic/_provider_specific_form.html.erb
+++ b/app/views/nic/_provider_specific_form.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </h3>
 
-    <% new_vm = !(@vm && @vm.persisted?) || new_vm?(@host) %>
+    <% new_vm = @vm ? @vm.persisted? : new_vm?(@host) %>
 
     <%= f.fields_for 'compute_attributes', OpenStruct.new(f.object.compute_attributes) do |f| %>
       <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm, :new_vm => new_vm %>


### PR DESCRIPTION
Addressing the issue of showing network id instead of its human readable value.
Before:
![Before - unfriendly_id](https://user-images.githubusercontent.com/2884324/52069855-dff59a00-257f-11e9-8d51-c0acdf3b8bf5.png)
After:
![After - friendly_name](https://user-images.githubusercontent.com/2884324/52069862-e421b780-257f-11e9-9525-35bf03765838.png)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
