### PR TITLE
Fixes #25975 - Add ability to read compute_attributes via foreman API

### DIFF
--- a/app/controllers/api/v2/compute_attributes_controller.rb
+++ b/app/controllers/api/v2/compute_attributes_controller.rb
@@ -1,14 +1,39 @@
 module Api
   module V2
     class ComputeAttributesController < V2::BaseController
+      include Api::Version2
       include Foreman::Controller::Parameters::ComputeAttribute
 
-      before_action :find_resource, :only => :update
+      before_action :find_optional_nested_object
+      before_action :find_resource, :only => [:show, :update]
 
       def_param_group :compute_attribute do
         param :compute_attribute, Hash, :required => true, :action_aware => true do
           param :vm_attrs, Hash, :required => true
         end
+      end
+
+      api :GET, "/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/", N_("List of compute attributes for provided compute profile and compute resource")
+      api :GET, "/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes/", N_("List of compute attributes for provided compute profile and compute resource")
+      api :GET, "/compute_resources/:compute_resource_id/compute_attributes/", N_("List of compute attributes for compute resource")
+      api :GET, "/compute_profiles/:compute_profile_id/compute_attributes/", N_("List of compute attributes for compute profile")
+      api :GET, "/compute_attributes/:id", N_("List of compute attributes")
+      param :compute_profile_id, String, :desc => N_("ID of compute profile")
+      param :compute_resource_id, String, :desc => N_("ID of compute_resource")
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      add_scoped_search_description_for(ComputeAttribute)
+
+      def index
+        @compute_attributes = resource_scope_for_index
+      end
+
+      api :GET, "/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id", N_("Show a compute attributes set")
+      api :GET, "/compute_profiles/:compute_profile_id/compute_resources/:compute_resource_id/compute_attributes/:id", N_("Show a compute attributes set")
+      api :GET, "/compute_resources/:compute_resource_id/compute_attributes/:id", N_("Show a compute attributes set")
+      api :GET, "/compute_profiles/:compute_profile_id/compute_attributes/:id", N_("Show a compute attributes set")
+      api :GET, "/compute_attributes/:id", N_("Show a compute attributes set")
+
+      def show
       end
 
       api :POST, "/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes", N_("Create a compute attributes set")
@@ -40,6 +65,12 @@ module Api
 
       def update
         process_response @compute_attribute.update(compute_attribute_params)
+      end
+
+      private
+
+      def allowed_nested_id
+        %w(compute_resource_id compute_profile_id)
       end
     end
   end

--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -11,6 +11,10 @@ class ComputeAttribute < ApplicationRecord
   before_save :update_name
 
   delegate :provider_friendly_name, :to => :compute_resource
+  scoped_search :on => [:name], :complete_value => true
+
+  scoped_search :relation => :compute_resource, :on => :name, :rename => :compute_resource, :complete_value => true
+  scoped_search :relation => :compute_profile, :on => :name, :rename => :compute_profile, :complete_value => true
 
   def method_missing(method, *args, &block)
     method = method.to_s

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -85,7 +85,7 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :edit_compute_resources, {:compute_resources => [:edit, :update].push(*ajax_actions),
                                                 :compute_attributes => [:new, :create, :edit, :update],
                                                 :"api/v2/compute_resources" => [:update],
-                                                :"api/v2/compute_attributes" => [:create, :update]
+                                                :"api/v2/compute_attributes" => [:index, :show, :create, :update]
     }
     map.permission :destroy_compute_resources, {:compute_resources => [:destroy],
                                                 :"api/v2/compute_resources" => [:destroy]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -292,12 +292,12 @@ Foreman::Application.routes.draw do
       resources :template_combinations, :only => [:show, :destroy]
       resources :config_groups, :except => [:new, :edit]
 
-      resources :compute_attributes, :only => [:create, :update]
+      resources :compute_attributes, :only => [:index, :show, :create, :update]
 
       resources :compute_profiles, :except => [:new, :edit] do
-        resources :compute_attributes, :only => [:create, :update]
+        resources :compute_attributes, :only => [:index, :show, :create, :update]
         resources :compute_resources, :except => [:new, :edit] do
-          resources :compute_attributes, :only => [:create, :update]
+          resources :compute_attributes, :only => [:index, :show, :create, :update]
         end
       end
 
@@ -322,9 +322,9 @@ Foreman::Application.routes.draw do
           put :refresh_cache, :on => :member
           (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
           (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
-          resources :compute_attributes, :only => [:create, :update]
+          resources :compute_attributes, :only => [:index, :show, :create, :update]
           resources :compute_profiles, :except => [:new, :edit] do
-            resources :compute_attributes, :only => [:create, :update]
+            resources :compute_attributes, :only => [:index, :show, :create, :update]
           end
         end
 

--- a/test/controllers/api/v2/compute_attributes_controller_test.rb
+++ b/test/controllers/api/v2/compute_attributes_controller_test.rb
@@ -1,6 +1,22 @@
 require 'test_helper'
 
 class Api::V2::ComputeAttributesControllerTest < ActionController::TestCase
+  def setup
+    Fog.mock!
+  end
+
+  def teardown
+    Fog.unmock!
+  end
+
+  test "index content is a JSON array" do
+    get :index
+    compute_attributes = ActiveSupport::JSON.decode(@response.body)
+    assert compute_attributes['results'].is_a?(Array)
+    assert_response :success
+    assert !compute_attributes.empty?
+  end
+
   test "should create compute attribute" do
     assert_difference('ComputeAttribute.count') do
       ComputeAttribute.any_instance.stubs(:new_vm).returns(nil)
@@ -10,6 +26,13 @@ class Api::V2::ComputeAttributesControllerTest < ActionController::TestCase
                               :compute_resource_id => compute_resources(:one).id }
     end
     assert_response :created
+  end
+
+  test "should show compute attribute" do
+    get :show, params: { :id => compute_attributes(:two).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert !show_response.empty?
   end
 
   test "should update compute attribute" do


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
Add ability to read compute_attribute to foreman API.

This is needed for [compute attribute foreman-ansible-modules support](https://github.com/theforeman/foreman-ansible-modules/issues/222)