### PR TITLE
Fixes #25974 - make uptime available

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -280,6 +280,7 @@ module HostsHelper
     fields += [[_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => %{os_title = "#{host.operatingsystem.title}"}))]] if host.operatingsystem.present?
     fields += [[_("PXE Loader"), host.pxe_loader]] if host.operatingsystem.present? && host.pxe_build?
     fields += [[_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))]] if host.hostgroup.present?
+    fields += [[_("Uptime"), time_ago_in_words(host.uptime_seconds.seconds.from_now)]] if host.uptime_seconds.present?
     fields += [[_("Location"), (link_to(host.location.title, hosts_path(:search => %{location = "#{host.location}"})) if host.location)]] if SETTINGS[:locations_enabled]
     fields += [[_("Organization"), (link_to(host.organization.title, hosts_path(:search => %{organization = "#{host.organization}"})) if host.organization)]] if SETTINGS[:organizations_enabled]
     if host.owner_type == _("User")

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -1,6 +1,7 @@
 module Host
   class Base < ApplicationRecord
     KERNEL_RELEASE_FACTS = [ 'kernelrelease', 'ansible_kernel', 'kernel::release' ]
+    UPTIME_FACTS = [ 'system_uptime::seconds', 'ansible_uptime_seconds', 'uptime_seconds' ]
 
     prepend Foreman::STI
     include Authorizable
@@ -28,6 +29,7 @@ module Host
     has_one :subnet, :through => :primary_interface
     has_one :subnet6, :through => :primary_interface
     has_one :kernel_release, -> { joins(:fact_name).where({ 'fact_names.name' => KERNEL_RELEASE_FACTS }).order('fact_names.type') }, :class_name => '::FactValue', :foreign_key => 'host_id'
+    has_one :uptime_fact, -> { joins(:fact_name).where({ 'fact_names.name' => UPTIME_FACTS }).order('fact_names.type') }, :class_name => '::FactValue', :foreign_key => 'host_id'
     accepts_nested_attributes_for :interfaces, :allow_destroy => true
 
     belongs_to :location
@@ -361,6 +363,10 @@ module Host
 
     def render_template(template:, **params)
       template.render(host: self, **params)
+    end
+
+    def uptime_seconds
+      self.uptime_fact&.value&.to_i
     end
 
     private

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -16,7 +16,7 @@ attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :r
            :compute_resource_id, :compute_resource_name,
            :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
            :certname, :image_id, :image_name, :created_at, :updated_at,
-           :last_compile, :global_status, :global_status_label
+           :last_compile, :global_status, :global_status_label, :uptime_seconds
 attributes :organization_id, :organization_name if SETTINGS[:organizations_enabled]
 attributes :location_id, :location_name         if SETTINGS[:locations_enabled]
 

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -27,7 +27,8 @@ module Foreman
         :rand_hex,
         :rand_name,
         :mac_name,
-        :host_kernel_release
+        :host_kernel_release,
+        :host_uptime_seconds
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -117,6 +117,10 @@ module Foreman
             host&.kernel_release&.value
           end
 
+          def host_uptime_seconds(host)
+            host&.uptime_seconds
+          end
+
           private
 
           def validate_subnet(subnet)
@@ -127,14 +131,17 @@ module Foreman
           #   .each { |batch| batch.each { |record| record.name }}
           # or
           #   .each_record { |record| record.name }
-          def load_resource(klass:, search:, permission:, batch: 1_000, includes: nil, limit: nil)
+          def load_resource(klass:, search:, permission:, batch: 1_000, includes: nil, limit: nil, select: nil, joins: nil, where: nil)
             limit ||= 10 if preview?
 
             base = klass
             base = base.search_for(search)
             base = base.includes(includes) unless includes.nil?
+            base = base.joins(joins) unless joins.nil?
             base = base.authorized(permission) unless permission.nil?
             base = base.limit(limit) unless limit.nil?
+            base = base.where(where) unless where.nil?
+            base = base.select(select) unless select.nil?
             base.in_batches(of: batch)
           end
         end

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -59,6 +59,15 @@ class BaseMacrosTest < ActiveSupport::TestCase
     assert_equal '', @scope.pxe_kernel_options
   end
 
+  describe '#host_uptime_seconds' do
+    test 'should return host uptime in seconds' do
+      host = FactoryBot.create(:host)
+      fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds')
+      FactoryBot.create(:fact_value, fact_name: fact, host: host, :value => '123')
+      assert_equal 123, @scope.host_uptime_seconds(host)
+    end
+  end
+
   describe '#host_kernel_release' do
     test 'should return kernel release' do
       host = FactoryBot.create(:host)


### PR DESCRIPTION
This adds uptime information based on facts available on host detail page in properties table, host info API endpoint and also in templates (also available in safe mode). It is also needed for new report that generates applied errata. I'll reference related PRs in community templates and katello once I open them.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
