### PR TITLE
Fixes #25384 - expire count cache on switching taxonomy

### DIFF
--- a/app/services/topbar_sweeper.rb
+++ b/app/services/topbar_sweeper.rb
@@ -3,7 +3,14 @@ class TopbarSweeper
   attr_accessor :controller
 
   def expire_cache(user = User.current)
-    controller.expire_fragment(self.class.fragment_name(user.id)) if controller.present? && user.present?
+    if controller.present? && user.present?
+      controller.expire_fragment(self.class.fragment_name(user.id))
+      expire_count_cache(user)
+    end
+  end
+
+  def expire_count_cache(user)
+    Rails.cache.delete("hosts_count/#{controller.resource_name}/#{user.id}")
   end
 
   class << self


### PR DESCRIPTION
Expire hostgroup count cache on switching of taxonomies.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
