### PR TITLE
Fixes #25976 - use path helper to determine auto-completion path

### DIFF
--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -2,7 +2,7 @@ module SearchBarHelper
   def mount_search_bar(
     id,
     controller: auto_complete_controller_name,
-    url: "#{auto_complete_controller_name}/auto_complete_search",
+    url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
     search_query: params[:search],
     use_bookmarks: true,
     use_key_shortcuts: true
@@ -28,7 +28,7 @@ module SearchBarHelper
 
   def get_search_props(
     controller: auto_complete_controller_name,
-    url: "#{auto_complete_controller_name}/auto_complete_search",
+    url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
     search_query: params[:search]
   )
     bookmarks = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -473,7 +473,7 @@ Foreman::Application.routes.draw do
 
   root :to => 'dashboard#index'
   get 'dashboard', :to => 'dashboard#index', :as => "dashboard"
-  get 'dashboard/auto_complete_search', :to => 'hosts#auto_complete_search', :as => "auto_complete_search_dashboards"
+  get 'dashboard/auto_complete_search', :to => 'hosts#auto_complete_search', :as => "auto_complete_search_dashboard"
   get 'status', :to => 'home#status', :as => "status"
 
   # get only for alterator unattended scripts


### PR DESCRIPTION
Commit 184f8d5ce2 changed the meaning of the
auto_complete_controller_name and assumed it will always equal to the
path, which is not the case for nested controllers (that we have
for example in foreman-tasks). As a result, this feature has been broken
there.

This commit adds back the original behavior + makes sure the
auto_complete_search is actually defined, so that we detect the missing
path sooner.




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->