### PR TITLE
Fixes #25950 - Don't try to assign seeded taxonomies to reports

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -1,7 +1,7 @@
 # some associations shouldn't be set or require special handling.
 skip_associations = [:associated_audits, :audits, :default_users, :hosts,
                      :location_parameters, :organization_parameters,
-                     :taxable_taxonomies ] + Template.descendants.map {|type| type.to_s.tableize.to_sym}
+                     :taxable_taxonomies, :reports ] + Template.descendants.map {|type| type.to_s.tableize.to_sym}
 
 User.as_anonymous_admin do
   [Location, Organization].select(&:none?).each do |taxonomy|


### PR DESCRIPTION
Reports have one taxonomy via host, no need to assign them when
seeding default taxonomies.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
