### PR TITLE
Fixes #25985 - listen on IPv6 for dev setup

### DIFF
--- a/script/foreman-start-dev
+++ b/script/foreman-start-dev
@@ -1,3 +1,3 @@
 #!/bin/sh
-./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host 0.0.0.0 --disable-host-check $WEBPACK_OPTS &
-./bin/rails server -b 0.0.0.0 "$@"
+./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host "::" --disable-host-check $WEBPACK_OPTS &
+./bin/rails server -b \[::\] "$@"


### PR DESCRIPTION
We currently only listen on IPv4. This is the other option than with Procfile because Foreman (the other project) does not work well with pry.