### PR TITLE
Fixes #25990 - no reverse DNS search for bootserver

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -78,7 +78,6 @@ module Orchestration::DHCP
     end
   end
 
-  # where are we booting from
   def boot_server
     # if we don't manage tftp for IPv4 at all, we dont create a next-server entry.
     return unless tftp?
@@ -87,13 +86,21 @@ module Orchestration::DHCP
     bs = tftp.bootServer
     # if that failed, trying to guess out tftp next server based on the smart proxy hostname
     bs ||= URI.parse(subnet.tftp.url).host
-    # now convert it into an ip address (see http://theforeman.org/issues/show/1381)
-    ip = NicIpResolver.new(:nic => self).to_ip_address(bs) if bs.present?
-    return ip unless ip.nil?
 
-    failure _("Unable to determine the host's boot server. The DHCP smart proxy failed to provide this information and this subnet is not provided with TFTP services.")
-  rescue => e
-    failure _("failed to detect boot server: %s") % e, e
+    # only smart proxies with V2 API are supported
+    if subnet.dhcp.has_capability?(:DHCP, :dhcp_filename_hostname)
+      # we no longer convert the boot server to IPv4 - smart proxy modules are required to do so if they don't support hostname
+      return bs
+    else
+      begin
+        Foreman::Deprecation.deprecation_warning('1.25', "DHCP proxy does not report dhcp_filename_* capability and reverse DNS search in Foreman will be removed.")
+        ip = NicIpResolver.new(:nic => self).to_ip_address(bs) if bs.present?
+        return ip unless ip.nil?
+        failure _("Unable to determine the host's boot server. The DHCP smart proxy failed to provide this information and this subnet is not provided with TFTP services.")
+      rescue => e
+        failure _("failed to detect boot server: %s") % e, e
+      end
+    end
   end
 
   private

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -92,6 +92,10 @@ class SmartProxy < ApplicationRecord
     self.smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => feature)).try(:capabilities)
   end
 
+  def has_capability?(feature, capability)
+    capabilities(feature)&.include?(capability.to_s)
+  end
+
   def setting(feature, setting)
     self.smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => feature)).try(:settings).try(:[], setting)
   end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -423,6 +423,10 @@ FactoryBot.define do
       subnet { FactoryBot.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]) }
     end
 
+    trait :with_tftp_and_dhcp_subnet do
+      subnet { FactoryBot.build(:subnet_ipv4, :tftp, :dhcp, locations: [location], organizations: [organization]) }
+    end
+
     trait :with_tftp_and_httpboot_subnet do
       subnet { FactoryBot.build(:subnet_ipv4, :tftp, :httpboot, locations: [location], organizations: [organization]) }
     end
@@ -451,7 +455,7 @@ FactoryBot.define do
 
     trait :with_tftp_orchestration do
       managed
-      with_tftp_subnet
+      with_tftp_and_dhcp_subnet
       interfaces do
         [FactoryBot.build(:nic_managed, :primary => true,
                                          :provision => true,

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -6,7 +6,13 @@ FactoryBot.define do
     locations { [Location.find_by_name('Location 1')] }
 
     before(:create, :build, :build_stubbed) do
-      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(Hash[Feature.name_map.keys.collect {|f| [f, {'state' => 'running'}]}])
+      default_features = {
+        "dhcp" => {
+          "capabilities" => ["dhcp_filename_hostname", "dhcp_filename_ipv4"],
+        },
+      }
+      result = Hash[Feature.name_map.keys.collect {|f| [f, {'state' => 'running'}.merge(default_features[f] || {})]}]
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(result)
     end
 
     after(:create) do |proxy|
@@ -27,7 +33,7 @@ FactoryBot.define do
 
     factory :dhcp_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dhcp, :smart_proxy => smart_proxy)
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dhcp, :smart_proxy => smart_proxy, :capabilities => ["dhcp_filename_ipv4"])
       end
     end
 


### PR DESCRIPTION
This moves bootserver DNS PTR resolution from orchestration and NIC
classes to proxy API. This allows reporting TFTP servername correctly in
Proxy status pages and API.

@xprazak2 