### PR TITLE
Fixes #24396 - Wrong search on alert-disabled hosts

### DIFF
--- a/app/views/dashboard/_status_links.html.erb
+++ b/app/views/dashboard/_status_links.html.erb
@@ -57,7 +57,9 @@
 <%= searchable_links _('Hosts with alerts disabled'),
                      search_filter_with_origin(
                        "status.enabled = false",
-                       origin
+                       origin,
+                       true,
+                       true
                      ),
                      :disabled_hosts
 %>


### PR DESCRIPTION
Fixes the "Hosts with alerts disabled" link in the status link widget.

The search query now doesn't contain the "out of sync" query anymore. So it matches the search query in the dashboard.