### PR TITLE
Fixes #25969 - Use a default action prop for DefaultEmptyState

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
@@ -37,7 +37,7 @@ const DefaultEmptyState = props => {
       header={header}
       description={description}
       documentation={documentation ? documentationBlock(documentation) : null}
-      action={<PrimaryActionButton action={action} />}
+      action={action ? <PrimaryActionButton action={action} /> : null}
       secondaryActions={<SecondaryActionButtons actions={secondaryActions} />}
     />
   );


### PR DESCRIPTION
This was causing errors in the console if the action prop is not passed in, I changed this to use null if no action prop is passed in
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
