### PR TITLE
Fixes #26029 - correct links to templates on build failure

### DIFF
--- a/app/services/host_build_status.rb
+++ b/app/services/host_build_status.rb
@@ -21,10 +21,10 @@ class HostBuildStatus
   def host_status
     return if host.valid?
     host.errors.full_messages.each do |error|
-      fail!(:host, error.to_s, host.to_label)
+      fail!(:host, error.to_s, host.to_param)
     end
   rescue => error
-    fail!(:host, _('Failed to validate %{host}: %{error}') % {:host => host, :error => error.to_s}, host.to_label)
+    fail!(:host, _('Failed to validate %{host}: %{error}') % {:host => host, :error => error.to_s}, host.to_param)
   end
 
   def templates_status
@@ -34,10 +34,10 @@ class HostBuildStatus
       begin
         Rails.logger.info "Rendering #{template}"
         valid_template = host.render_template(template: template)
-        fail!(:templates, _('Template %s is empty.') % template.name, template.name) if valid_template.blank?
+        fail!(:templates, _('Template %s is empty.') % template.name, template.to_param) if valid_template.blank?
       rescue => exception
         Foreman::Logging.exception("Review template error", exception)
-        fail!(:templates, _('Failure parsing %{template}: %{error}.') % {:template => template.name, :error => exception}, template.name)
+        fail!(:templates, _('Failure parsing %{template}: %{error}.') % {:template => template.name, :error => exception}, template.to_param)
       end
     end
   end
@@ -50,9 +50,9 @@ class HostBuildStatus
         proxy.ping
         errors = proxy.errors.messages
         errors = errors.is_a?(Array) ? errors.to_sentence : errors
-        fail!(:proxies, _('Failure deploying via smart proxy %{proxy}: %{error}.') % {:proxy => proxy, :error => errors}, proxy.id) if proxy.errors.any?
+        fail!(:proxies, _('Failure deploying via smart proxy %{proxy}: %{error}.') % {:proxy => proxy, :error => errors}, proxy.to_param) if proxy.errors.any?
       rescue => error
-        fail!(:proxies, _('Error connecting to %{proxy}: %{error}.') % {:proxy => proxy, :error => error}, proxy.id)
+        fail!(:proxies, _('Error connecting to %{proxy}: %{error}.') % {:proxy => proxy, :error => error}, proxy.to_param)
       end
     end
   end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->