### PR TITLE
Fixes #26038 - taxonomy import puppet order

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -159,6 +159,9 @@ module Host
       time = time.to_time if time.is_a?(String)
       self.last_compile = time if time
 
+      # taxonomy must be set before populate_fields_from_facts call
+      set_taxonomies(facts)
+
       unless build?
         parser = FactParser.parser_for(type).new(facts)
 
@@ -166,8 +169,6 @@ module Host
           populate_fields_from_facts(parser, type, source_proxy)
         end
       end
-
-      set_taxonomies(facts)
 
       # we are saving here with no validations, as we want this process to be as fast
       # as possible, assuming we already have all the right settings in Foreman.
@@ -251,7 +252,6 @@ module Host
 
     def set_taxonomies(facts)
       ['location', 'organization'].each do |taxonomy|
-        next unless SETTINGS["#{taxonomy.pluralize}_enabled".to_sym]
         taxonomy_class = taxonomy.classify.constantize
         taxonomy_fact = Setting["#{taxonomy}_fact"]
 


### PR DESCRIPTION
There was a problem with order of taxonomy import in discovery described and fixed in #16449. But refactoring done in #15409 changed the order back. Since there was no comment or description of the change, this was likely done by accident. This ticket puts the order back.

I need to write a test and reproduce, I am currently unable to reproduce however I've spent some time with a customer who was hitting this on 6.4. Symptoms are (no matter if subnet is or is not in the correct taxonomy):

```

2019-02-11T19:44:28 [I|app|71250] Processing by Api::V2::DiscoveredHostsController#facts as JSON
2019-02-11T19:44:28 [I|app|71250]   Parameters: {"facts"=>"[FILTERED]", "apiv"=>"v2", "discovered_host"=>{"facts"=>"[FILTERED]"}}
2019-02-11T19:44:28 [I|app|71250] Current user: foreman_admin (administrator)
2019-02-11T19:44:28 [W|app|71250] One or more existing managed hosts found: xxxxxxx.ug/00:aa:aa:aa:aa:82
2019-02-11T19:44:29 [I|aud|71250] create event for Nic::Managed with id 680
2019-02-11T19:44:29 [I|aud|71250] create event for Host::Base with id 332
2019-02-11T19:44:30 [I|app|71250] Import facts for 'mac00XXXXXXXX' completed. Added: 123, Updated: 0, Deleted 0 facts
2019-02-11T19:44:30 [I|aud|71250] update event for Nic::Managed with id 680
2019-02-11T19:44:30 [I|aud|71250] update event for Nic::Managed with id 680
2019-02-11T19:44:30 [W|app|71250] Not queueing Nic::Managed: ["Subnet is not defined for host's location", "Subnet is not defined for host's organization"]
2019-02-11T19:44:30 [W|app|71250] Not queueing Nic::Managed: ["Subnet is not defined for host's location", "Subnet is not defined for host's organization"]
2019-02-11T19:44:30 [W|app|71250] Not queueing Nic::Managed: ["Subnet is not defined for host's location", "Subnet is not defined for host's organization"]
2019-02-11T19:44:30 [W|app|71250] Saving eth0 NIC for host mac00XXXXXXXXX failed, skipping because:
2019-02-11T19:44:30 [W|app|71250]  Subnet is not defined for host's location
2019-02-11T19:44:30 [W|app|71250]  Subnet is not defined for host's organization
2019-02-11T19:44:30 [W|app|71250] Unable to assign subnet - reboot trigger may not be possible, primary interface is missing IP address
2019-02-11T19:44:30 [I|aud|71250] update event for Host::Base with id 332
2019-02-11T19:44:31 [I|app|71250] Completed 201 Created in 2354ms (Views: 4.0ms | ActiveRecord: 489.4ms)
```