### PR TITLE
Fixes #26039 - disable blob logger by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -224,7 +224,7 @@ module Foreman
       :background => {:enabled => true},
       :dynflow => {:enabled => true},
       :telemetry => {:enabled => false},
-      :blob => {:enabled => true}
+      :blob => {:enabled => false}
     ))
 
     config.logger = Foreman::Logging.logger('app')

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -99,7 +99,7 @@
 #  :telemetry:
 #    :enabled: true
 #  :blob:
-#    :enabled: true
+#    :enabled: false
 
 # Foreman telemetry has three destinations: prometheus, statsd and rails log.
 :telemetry:


### PR DESCRIPTION
Blob is a logger which is used by template renderer to log all rendered
template contents.

This was requested by QA that blob makes logs too large. I was just
about to close the request but I noticed that template content may
contain sensitive data like tokens or root passwords. Therefore it's
good idea to disable it by default.