### PR TITLE
Fixes #26051 - added grub2 pc/bios and elf options

### DIFF
--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -5,7 +5,7 @@ module PxeLoaderSupport
   PXE_KINDS = {
     :PXELinux => /^(pxelinux.*|PXELinux (BIOS|UEFI))$/,
     :PXEGrub => /^(grub\/|Grub UEFI).*/,
-    :PXEGrub2 => /^(grub2\/|Grub2 UEFI|http.*grub2\/).*/,
+    :PXEGrub2 => /^(grub2\/|Grub2 (BIOS|UEFI|ELF)|http.*grub2\/).*/,
     :iPXE => /^((iPXE|http.*\/ipxe-).*|ipxe\.efi|undionly\.kpxe)$/
   }.with_indifferent_access.freeze
 
@@ -24,6 +24,8 @@ module PxeLoaderSupport
         "PXELinux BIOS" => "pxelinux.0",
         "PXELinux UEFI" => "pxelinux.efi",
         "Grub UEFI" => "grub/grub#{precision}.efi",
+        "Grub2 BIOS" => "grub2/grub#{precision}.0",
+        "Grub2 ELF" => "grub2/grub#{precision}.elf",
         "Grub2 UEFI" => "grub2/grub#{precision}.efi",
         "Grub2 UEFI SecureBoot" => "grub2/shim#{precision}.efi",
         "Grub2 UEFI HTTP" => "http://#{httpboot_host}/httpboot/grub2/grub#{precision}.efi",

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -57,8 +57,18 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
       assert_equal :PXEGrub, @subject.pxe_loader_kind(@host)
     end
 
-    test "PXEGrub2 is found for given loader name" do
+    test "PXEGrub2 is found for EFI loader name" do
       @host.pxe_loader = "Grub2 UEFI"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for ELF loader name" do
+      @host.pxe_loader = "Grub2 ELF"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for PC loader name" do
+      @host.pxe_loader = "Grub2 BIOS"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 


### PR DESCRIPTION
These will be useful for IBM POWER users and PC users wanting to use Grub2 on i386.