### PR TITLE
Fixes #26055 - select bind on change just once

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -12,21 +12,31 @@ import MessageBox from '../MessageBox';
 
 class Select extends React.Component {
   initializeSelect2() {
-    const { allowClear, onChange } = this.props;
+    const { allowClear } = this.props;
 
     if ($.fn.select2) {
-      $(this.select)
-        .select2({ allowClear })
-        .on('change', onChange);
+      $(this.select).select2({ allowClear });
     }
+  }
+
+  attachEvent() {
+    const { onChange } = this.props;
+    $(this.select)
+      .off('change', onChange)
+      .on('change', onChange);
   }
 
   componentDidMount() {
     this.initializeSelect2();
+    this.attachEvent();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     this.initializeSelect2();
+
+    if (this.props.status !== prevProps.status) {
+      this.attachEvent();
+    }
   }
 
   render() {

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.test.js
@@ -1,0 +1,31 @@
+import $ from 'jquery';
+import 'select2';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import Select from './Select';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div>\n  <span id="select" />\n</div>';
+});
+
+describe('Select', () => {
+  it('onChange called exactly once even after update', () => {
+    const options = { one: '1', two: '2' };
+    const onChangeMock = jest.fn();
+    const wrapper = mount(
+      <Select options={options} onChange={onChangeMock} />,
+      { attachTo: document.getElementById('select') }
+    );
+
+    $('#select select').trigger('change');
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+
+    options.three = '3';
+    wrapper.setProps(Object.assign({}, wrapper.props(), { options }));
+
+    onChangeMock.mockClear();
+    $('#select select').trigger('change');
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Select is binding the change event handler multiple times.
It needs to be detached before component update to ensure single evocation.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
