### PR TITLE
Fixes #26076 - modify SearchBar's key-shortcuts.

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
@@ -51,8 +51,24 @@ describe('AutoComplete', () => {
       instance.windowKeyPressHandler({
         charCode: KEYCODES.FWD_SLASH,
         preventDefault: noop,
+        target: { tagName: 'BODY' },
       });
       expect(typeahead.focus.mock.calls).toHaveLength(1);
+    });
+
+    it('pressing "forward-slash" inside an input should not trigger focus', () => {
+      const props = getProps();
+      const component = mount(<AutoComplete {...props} />);
+      const instance = component.instance();
+      const typeahead = instance._typeahead.current.getInstance();
+      typeahead.focus = jest.fn();
+      expect(typeahead.focus.mock.calls).toHaveLength(0);
+      instance.windowKeyPressHandler({
+        charCode: KEYCODES.FWD_SLASH,
+        preventDefault: noop,
+        target: { tagName: 'INPUT' },
+      });
+      expect(typeahead.focus.mock.calls).toHaveLength(0);
     });
 
     it('pressing "ESC" should trigger blur', () => {

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
@@ -39,20 +39,34 @@ class AutoComplete extends React.Component {
   }
 
   windowKeyPressHandler(e) {
-    if (!this.props.useKeyShortcuts) {
+    const { useKeyShortcuts, handleSearch } = this.props;
+    const instance = this._typeahead.current.getInstance();
+    const { ENTER, FWD_SLASH, BACK_SLASH } = KEYCODES;
+    const didEventCameFromInput = e.target.tagName === 'INPUT';
+
+    /**
+     Disable this functionality if the event came from an input,
+     or if the 'useKeyShortcuts' is falsy.
+    */
+    if (didEventCameFromInput || !useKeyShortcuts) {
       return;
     }
-    const instance = this._typeahead.current.getInstance();
+
     switch (e.charCode) {
-      case KEYCODES.ENTER: {
-        this.props.handleSearch();
+      case ENTER: {
+        handleSearch();
         break;
       }
-      case KEYCODES.FWD_SLASH:
-      case KEYCODES.BACK_SLASH: {
-        if (!instance.state.showMenu) {
+      case FWD_SLASH:
+      case BACK_SLASH: {
+        const {
+          focus,
+          state: { showMenu },
+        } = instance;
+        const isMenuHidden = !showMenu;
+        if (isMenuHidden) {
           e.preventDefault();
-          instance.focus();
+          focus();
         }
         break;
       }


### PR DESCRIPTION
Currently, pressing `FWD-SLASH` from any input can cause Search-bar to focus.
This PR fixes that issue, and allow the focused to be triggered from anywhere but inputs.

![hosts](https://user-images.githubusercontent.com/26363699/52973692-8c7cac00-33c7-11e9-8f8d-fc948240118e.gif)
