### PR TITLE
Fixes #26083 - rename default in search definition

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -41,7 +41,7 @@ class ProvisioningTemplate < Template
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
   scoped_search :on => :template
   scoped_search :on => :vendor, :only_explicit => true, :complete_value => true
-  scoped_search :on => :default, :only_explicit => true, :complete_value => {:true => true, :false => false}
+  scoped_search :on => :default, :only_explicit => true, :complete_value => {:true => true, :false => false}, :rename => 'default_template'
 
   scoped_search :relation => :operatingsystems, :on => :name, :rename => :operatingsystem, :complete_value => true
   scoped_search :relation => :environments,     :on => :name, :rename => :environment,     :complete_value => true


### PR DESCRIPTION
@ranjan would you like to test and confirm this fixes your issue?

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
