### PR TITLE
Fixes #26121 - distinguish between Autocompletes

### DIFF
--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -19,6 +19,7 @@ module SearchBarHelper
     mount_react_component("SearchBar", "##{id}", {
       controller: controller,
       autocomplete: {
+        id: autocomplete_id,
         searchQuery: search_query,
         url: url,
         useKeyShortcuts: use_key_shortcuts,

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.fixtures.js
@@ -31,6 +31,7 @@ export const initialState = {
   searchQuery: '',
   status: null,
   trigger: null,
+  id,
 };
 
 export const initialValues = {
@@ -39,6 +40,7 @@ export const initialValues = {
   trigger: TRIGGERS.COMPONENT_DID_MOUNT,
   results,
   status: STATUS.RESOLVED,
+  id,
 };
 
 export const request = {
@@ -47,6 +49,7 @@ export const request = {
   searchQuery,
   status: STATUS.PENDING,
   trigger,
+  id,
 };
 
 export const success = {
@@ -56,12 +59,14 @@ export const success = {
   searchQuery,
   controller,
   trigger,
+  id,
 };
 
 export const failure = {
   error,
   results: [],
   status: STATUS.ERROR,
+  id,
 };
 
 export const API = {

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
@@ -32,8 +32,8 @@ class AutoComplete extends React.Component {
 
   componentDidMount() {
     window.addEventListener('keypress', this.windowKeyPressHandler);
-    const { controller, initialQuery, initialUpdate } = this.props;
-    initialUpdate(initialQuery, controller);
+    const { controller, initialQuery, initialUpdate, id } = this.props;
+    initialUpdate(initialQuery, controller, id);
   }
 
   windowKeyPressHandler(e) {
@@ -74,32 +74,36 @@ class AutoComplete extends React.Component {
     }
   }
 
-  getResults(searchQuery, trigger) {
+  getResults(searchQuery, trigger, id) {
     const { getResults, controller, url } = this.props;
     getResults({
       url,
       searchQuery,
       controller,
       trigger,
+      id,
     });
   }
 
   handleInputFocus({ target: { value } }) {
-    if (this.props.results.length === 0) {
-      this.getResults(value, TRIGGERS.INPUT_FOCUS);
+    const { id, results } = this.props;
+    if (results.length === 0) {
+      this.getResults(value, TRIGGERS.INPUT_FOCUS, id);
     }
   }
 
   handleInputChange(query) {
-    this.getResults(query, TRIGGERS.INPUT_CHANGE);
+    const { id } = this.props;
+    this.getResults(query, TRIGGERS.INPUT_CHANGE, id);
   }
 
   // Gets the first result from an array of selected results.
   handleResultsChange({ 0: result }) {
+    const { id } = this.props;
     if (!result) {
       return;
     }
-    this.getResults(result, TRIGGERS.ITEM_SELECT);
+    this.getResults(result, TRIGGERS.ITEM_SELECT, id);
     /**
      *  HACK: I had no choice but to call to an inner function,
      * due to lack of design in react-bootstrap-typeahead.
@@ -127,8 +131,9 @@ class AutoComplete extends React.Component {
   }
 
   handleClear() {
+    const { id } = this.props;
     this._typeahead.current.getInstance().clear();
-    this.getResults('', TRIGGERS.INPUT_CLEAR);
+    this.getResults('', TRIGGERS.INPUT_CLEAR, id);
   }
 
   handleLoading() {
@@ -137,8 +142,8 @@ class AutoComplete extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('keypress', this.windowKeyPressHandler);
-    const { resetData, controller } = this.props;
-    resetData(controller);
+    const { resetData, controller, id } = this.props;
+    resetData(controller, id);
   }
 
   render() {
@@ -177,6 +182,7 @@ class AutoComplete extends React.Component {
               useKeyShortcuts ? 'use-shortcuts' : ''
             ),
             spellCheck: 'false',
+            'data-autocomplete-id': id,
             ...inputProps,
           }}
         />

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteActions.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteActions.js
@@ -16,12 +16,14 @@ export const getResults = ({
   searchQuery,
   controller,
   trigger,
+  id,
 }) => dispatch => {
   startRequest({
     controller,
     searchQuery,
     trigger,
     dispatch,
+    id,
   });
 
   const path = getAPIPath({ trigger, searchQuery, url });
@@ -30,11 +32,19 @@ export const getResults = ({
     path,
     searchQuery,
     trigger,
+    id,
     dispatch,
   });
 };
 
-let createAPIRequest = ({ controller, path, searchQuery, trigger, dispatch }) =>
+let createAPIRequest = ({
+  controller,
+  path,
+  searchQuery,
+  trigger,
+  id,
+  dispatch,
+}) =>
   API.get(path)
     .then(({ data }) =>
       requestSuccess({
@@ -43,13 +53,14 @@ let createAPIRequest = ({ controller, path, searchQuery, trigger, dispatch }) =>
         dispatch,
         searchQuery,
         trigger,
+        id,
       })
     )
-    .catch(error => requestFailure({ error, dispatch }));
+    .catch(error => requestFailure({ error, id, dispatch }));
 
 createAPIRequest = debounce(createAPIRequest, 250);
 
-const startRequest = ({ controller, searchQuery, trigger, dispatch }) => {
+const startRequest = ({ controller, searchQuery, trigger, dispatch, id }) => {
   dispatch({
     type: AUTO_COMPLETE_REQUEST,
     payload: {
@@ -57,6 +68,7 @@ const startRequest = ({ controller, searchQuery, trigger, dispatch }) => {
       searchQuery,
       status: STATUS.PENDING,
       trigger,
+      id,
     },
   });
 };
@@ -66,6 +78,7 @@ const requestSuccess = ({
   trigger,
   controller,
   searchQuery,
+  id,
   dispatch,
 }) => {
   const { error } = data[0] || {};
@@ -81,17 +94,19 @@ const requestSuccess = ({
       searchQuery,
       status: STATUS.RESOLVED,
       trigger,
+      id,
     },
   });
 };
 
-const requestFailure = ({ error, dispatch }) =>
+const requestFailure = ({ error, id, dispatch }) =>
   dispatch({
     type: AUTO_COMPLETE_FAILURE,
     payload: {
       results: [],
       error: error.message || error,
       status: STATUS.ERROR,
+      id,
     },
   });
 
@@ -108,14 +123,13 @@ const getAPIPath = ({ trigger, searchQuery, url }) => {
   return APIPath.toString();
 };
 
-export const resetData = controller => dispatch =>
+export const resetData = (controller, id) => dispatch =>
   dispatch({
     type: AUTO_COMPLETE_RESET,
-    payload: { controller },
-    error: null,
+    payload: { controller, id },
   });
 
-export const initialUpdate = (searchQuery, controller) => dispatch =>
+export const initialUpdate = (searchQuery, controller, id) => dispatch =>
   dispatch({
     type: AUTO_COMPLETE_SUCCESS,
     payload: {
@@ -124,6 +138,7 @@ export const initialUpdate = (searchQuery, controller) => dispatch =>
       trigger: TRIGGERS.COMPONENT_DID_MOUNT,
       status: STATUS.RESOLVED,
       results: [],
+      id,
     },
   });
 

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteReducer.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteReducer.js
@@ -6,23 +6,32 @@ import {
   AUTO_COMPLETE_RESET,
 } from './AutoCompleteConstants';
 
-const initialState = Immutable({
+const initialAutocompleteState = {
   controller: null,
   error: null,
   results: [],
   searchQuery: '',
   status: null,
   trigger: null,
-});
+};
 
-export default (state = initialState, action) => {
+export default (state = Immutable({}), action) => {
   const {
     type,
-    payload: { controller, error, results, searchQuery, status, trigger } = {},
+    payload: {
+      controller,
+      error,
+      results,
+      searchQuery,
+      status,
+      trigger,
+      id,
+    } = {},
   } = action;
   switch (type) {
     case AUTO_COMPLETE_REQUEST:
-      return state.merge({
+      return state.setIn([id], {
+        ...state[id],
         controller,
         error: null,
         searchQuery,
@@ -30,7 +39,8 @@ export default (state = initialState, action) => {
         trigger,
       });
     case AUTO_COMPLETE_SUCCESS:
-      return state.merge({
+      return state.setIn([id], {
+        ...state[id],
         controller,
         error: null,
         results,
@@ -39,13 +49,17 @@ export default (state = initialState, action) => {
         trigger,
       });
     case AUTO_COMPLETE_FAILURE:
-      return state.merge({
+      return state.setIn([id], {
+        ...state[id],
         error,
         results,
         status,
       });
     case AUTO_COMPLETE_RESET:
-      return initialState;
+      return state.setIn([id], {
+        ...initialAutocompleteState,
+        controller,
+      });
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoCompleteSelectors.js
@@ -1,18 +1,20 @@
-export const selectAutocomplete = state => state.autocomplete;
+export const selectAutocomplete = ({ autocomplete }, id) =>
+  autocomplete[id] || {};
 
-export const selectAutocompleteError = state => selectAutocomplete(state).error;
+export const selectAutocompleteError = (state, id) =>
+  selectAutocomplete(state, id).error;
 
-export const selectAutocompleteResults = state =>
-  selectAutocomplete(state).results;
+export const selectAutocompleteResults = (state, id) =>
+  selectAutocomplete(state, id).results;
 
-export const selectAutocompleteSearchQuery = state =>
-  selectAutocomplete(state).searchQuery;
+export const selectAutocompleteSearchQuery = (state, id) =>
+  selectAutocomplete(state, id).searchQuery;
 
-export const selectAutocompleteStatus = state =>
-  selectAutocomplete(state).status;
+export const selectAutocompleteStatus = (state, id) =>
+  selectAutocomplete(state, id).status;
 
-export const selectAutocompleteController = state =>
-  selectAutocomplete(state).controller;
+export const selectAutocompleteController = (state, id) =>
+  selectAutocomplete(state, id).controller;
 
-export const selectAutocompleteTrigger = state =>
-  selectAutocomplete(state).trigger;
+export const selectAutocompleteTrigger = (state, id) =>
+  selectAutocomplete(state, id).trigger;

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteActions.test.js
@@ -8,6 +8,7 @@ import {
   controller,
   trigger,
   url,
+  id,
 } from '../AutoComplete.fixtures';
 
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
@@ -21,7 +22,7 @@ const loadResults = (requestParams, serverMock) => {
 
 const fixtures = {
   'should update store with initial data': () =>
-    initialUpdate('searchQuery', controller),
+    initialUpdate('searchQuery', controller, id),
 
   'should load results and success': () =>
     loadResults(
@@ -30,6 +31,7 @@ const fixtures = {
         searchQuery,
         controller,
         trigger,
+        id,
       },
       async () => APISuccessMock
     ),
@@ -41,11 +43,12 @@ const fixtures = {
         searchQuery: 'x = y',
         controller,
         trigger,
+        id,
       },
       async () => APIFailMock
     ),
 
-  'should reset-data': () => resetData(controller),
+  'should reset-data': () => resetData(controller, id),
 };
 
 describe('AutoComplete actions', () =>

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoCompleteSelectors.test.js
@@ -11,33 +11,36 @@ import {
   isDisabled,
   controller,
   trigger,
+  id,
 } from '../AutoComplete.fixtures';
 
 describe('Autocomplete Selector', () => {
   const state = {
     autocomplete: {
-      searchQuery,
-      status,
-      url,
-      isDisabled,
-      controller,
-      trigger,
+      [id]: {
+        searchQuery,
+        status,
+        url,
+        isDisabled,
+        controller,
+        trigger,
+      },
     },
   };
 
   it('should select searchQuery', () => {
-    expect(selectAutocompleteSearchQuery(state)).toEqual(searchQuery);
+    expect(selectAutocompleteSearchQuery(state, id)).toEqual(searchQuery);
   });
 
   it('should select status', () => {
-    expect(selectAutocompleteStatus(state)).toEqual(status);
+    expect(selectAutocompleteStatus(state, id)).toEqual(status);
   });
 
   it('should select controller', () => {
-    expect(selectAutocompleteController(state)).toEqual(controller);
+    expect(selectAutocompleteController(state, id)).toEqual(controller);
   });
 
   it('should select trigger', () => {
-    expect(selectAutocompleteTrigger(state)).toEqual(trigger);
+    expect(selectAutocompleteTrigger(state, id)).toEqual(trigger);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -26,6 +26,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
     inputProps={
       Object {
         "className": "search-input use-shortcuts",
+        "data-autocomplete-id": "some-id",
         "spellCheck": "false",
       }
     }

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoCompleteActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoCompleteActions.test.js.snap
@@ -6,6 +6,7 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
+        "id": "some-id",
         "searchQuery": "x = y",
         "status": "PENDING",
         "trigger": "INPUT_CHANGE",
@@ -17,6 +18,7 @@ Array [
     Object {
       "payload": Object {
         "error": "oops",
+        "id": "some-id",
         "results": Array [],
         "status": "ERROR",
       },
@@ -32,6 +34,7 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
+        "id": "some-id",
         "searchQuery": "",
         "status": "PENDING",
         "trigger": "INPUT_CHANGE",
@@ -43,6 +46,7 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
+        "id": "some-id",
         "results": Array [
           Object {
             "category": "category",
@@ -63,9 +67,9 @@ exports[`AutoComplete actions should reset-data 1`] = `
 Array [
   Array [
     Object {
-      "error": null,
       "payload": Object {
         "controller": "models",
+        "id": "some-id",
       },
       "type": "AUTO_COMPLETE_RESET",
     },
@@ -79,6 +83,7 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
+        "id": "some-id",
         "results": Array [],
         "searchQuery": "searchQuery",
         "status": "RESOLVED",

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoCompleteReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoCompleteReducer.test.js.snap
@@ -2,76 +2,73 @@
 
 exports[`AutoComplete reducer should handle AUTO_COMPLETE_FAILURE 1`] = `
 Object {
-  "controller": null,
-  "error": "oops",
-  "results": Array [],
-  "searchQuery": "",
-  "status": "ERROR",
-  "trigger": null,
+  "some-id": Object {
+    "error": "oops",
+    "results": Array [],
+    "status": "ERROR",
+  },
 }
 `;
 
 exports[`AutoComplete reducer should handle AUTO_COMPLETE_REQUEST 1`] = `
 Object {
-  "controller": "models",
-  "error": null,
-  "results": Array [],
-  "searchQuery": "",
-  "status": "PENDING",
-  "trigger": "INPUT_CHANGE",
+  "some-id": Object {
+    "controller": "models",
+    "error": null,
+    "searchQuery": "",
+    "status": "PENDING",
+    "trigger": "INPUT_CHANGE",
+  },
 }
 `;
 
 exports[`AutoComplete reducer should handle AUTO_COMPLETE_RESET 1`] = `
 Object {
-  "controller": null,
-  "error": null,
-  "results": Array [],
-  "searchQuery": "",
-  "status": null,
-  "trigger": null,
+  "some-id": Object {
+    "controller": null,
+    "error": null,
+    "results": Array [],
+    "searchQuery": "",
+    "status": null,
+    "trigger": null,
+  },
 }
 `;
 
 exports[`AutoComplete reducer should handle AUTO_COMPLETE_SUCCESS 1`] = `
 Object {
-  "controller": "models",
-  "error": null,
-  "results": Array [
-    Object {
-      "category": "category",
-      "label": "some results",
-    },
-  ],
-  "searchQuery": "",
-  "status": "RESOLVED",
-  "trigger": "INPUT_CHANGE",
+  "some-id": Object {
+    "controller": "models",
+    "error": null,
+    "results": Array [
+      Object {
+        "category": "category",
+        "label": "some results",
+      },
+    ],
+    "searchQuery": "",
+    "status": "RESOLVED",
+    "trigger": "INPUT_CHANGE",
+  },
 }
 `;
 
-exports[`AutoComplete reducer should return the initial state 1`] = `
-Object {
-  "controller": null,
-  "error": null,
-  "results": Array [],
-  "searchQuery": "",
-  "status": null,
-  "trigger": null,
-}
-`;
+exports[`AutoComplete reducer should return the initial state 1`] = `Object {}`;
 
 exports[`AutoComplete reducer should update state with initial data 1`] = `
 Object {
-  "controller": "models",
-  "error": null,
-  "results": Array [
-    Object {
-      "category": "category",
-      "label": "some results",
-    },
-  ],
-  "searchQuery": "",
-  "status": "RESOLVED",
-  "trigger": "COMPONENT_DID_MOUNT",
+  "some-id": Object {
+    "controller": "models",
+    "error": null,
+    "results": Array [
+      Object {
+        "category": "category",
+        "label": "some results",
+      },
+    ],
+    "searchQuery": "",
+    "status": "RESOLVED",
+    "trigger": "COMPONENT_DID_MOUNT",
+  },
 }
 `;

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/integration.test.js.snap
@@ -7,6 +7,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "searchQuery": "",
           "status": "PENDING",
           "trigger": "INPUT_CLEAR",
@@ -17,21 +18,23 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [
-        Object {
-          "category": "",
-          "label": "results1 ",
-        },
-        Object {
-          "category": "Dolphine",
-          "label": "results2 ",
-        },
-      ],
-      "searchQuery": "",
-      "status": "PENDING",
-      "trigger": "INPUT_CLEAR",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [
+          Object {
+            "category": "",
+            "label": "results1 ",
+          },
+          Object {
+            "category": "Dolphine",
+            "label": "results2 ",
+          },
+        ],
+        "searchQuery": "",
+        "status": "PENDING",
+        "trigger": "INPUT_CLEAR",
+      },
     },
   },
 }
@@ -40,12 +43,14 @@ Object {
 exports[`Autocomplete integration test should flow: initial state 1`] = `
 Object {
   "autocomplete": Object {
-    "controller": "models",
-    "error": null,
-    "results": Array [],
-    "searchQuery": "",
-    "status": "RESOLVED",
-    "trigger": "COMPONENT_DID_MOUNT",
+    "some-id": Object {
+      "controller": "models",
+      "error": null,
+      "results": Array [],
+      "searchQuery": "",
+      "status": "RESOLVED",
+      "trigger": "COMPONENT_DID_MOUNT",
+    },
   },
 }
 `;
@@ -57,6 +62,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "searchQuery": "",
           "status": "PENDING",
           "trigger": "INPUT_FOCUS",
@@ -67,12 +73,14 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [],
-      "searchQuery": "",
-      "status": "PENDING",
-      "trigger": "INPUT_FOCUS",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [],
+        "searchQuery": "",
+        "status": "PENDING",
+        "trigger": "INPUT_FOCUS",
+      },
     },
   },
 }
@@ -85,6 +93,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "searchQuery": "result",
           "status": "PENDING",
           "trigger": "ITEM_SELECT",
@@ -95,17 +104,19 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [
-        Object {
-          "category": "",
-          "label": "result",
-        },
-      ],
-      "searchQuery": "result",
-      "status": "PENDING",
-      "trigger": "ITEM_SELECT",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [
+          Object {
+            "category": "",
+            "label": "result",
+          },
+        ],
+        "searchQuery": "result",
+        "status": "PENDING",
+        "trigger": "ITEM_SELECT",
+      },
     },
   },
 }
@@ -118,6 +129,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "searchQuery": "result",
           "status": "PENDING",
           "trigger": "ITEM_SELECT",
@@ -128,21 +140,23 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [
-        Object {
-          "category": "",
-          "label": "results1 ",
-        },
-        Object {
-          "category": "Dolphine",
-          "label": "results2 ",
-        },
-      ],
-      "searchQuery": "result",
-      "status": "PENDING",
-      "trigger": "ITEM_SELECT",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [
+          Object {
+            "category": "",
+            "label": "results1 ",
+          },
+          Object {
+            "category": "Dolphine",
+            "label": "results2 ",
+          },
+        ],
+        "searchQuery": "result",
+        "status": "PENDING",
+        "trigger": "ITEM_SELECT",
+      },
     },
   },
 }
@@ -155,6 +169,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "results": Array [
             Object {
               "category": "",
@@ -171,17 +186,19 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [
-        Object {
-          "category": "",
-          "label": "result",
-        },
-      ],
-      "searchQuery": "",
-      "status": "RESOLVED",
-      "trigger": "INPUT_FOCUS",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [
+          Object {
+            "category": "",
+            "label": "result",
+          },
+        ],
+        "searchQuery": "",
+        "status": "RESOLVED",
+        "trigger": "INPUT_FOCUS",
+      },
     },
   },
 }
@@ -194,6 +211,7 @@ Object {
       Object {
         "payload": Object {
           "controller": "models",
+          "id": "some-id",
           "results": Array [
             Object {
               "category": "",
@@ -214,21 +232,23 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [
-        Object {
-          "category": "",
-          "label": "results1 ",
-        },
-        Object {
-          "category": "Dolphine",
-          "label": "results2 ",
-        },
-      ],
-      "searchQuery": "result",
-      "status": "RESOLVED",
-      "trigger": "ITEM_SELECT",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [
+          Object {
+            "category": "",
+            "label": "results1 ",
+          },
+          Object {
+            "category": "Dolphine",
+            "label": "results2 ",
+          },
+        ],
+        "searchQuery": "result",
+        "status": "RESOLVED",
+        "trigger": "ITEM_SELECT",
+      },
     },
   },
 }

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/index.js
@@ -10,11 +10,11 @@ import {
   selectAutocompleteStatus,
 } from './AutoCompleteSelectors';
 
-const mapStateToProps = state => ({
-  error: selectAutocompleteError(state),
-  results: selectAutocompleteResults(state),
-  searchQuery: selectAutocompleteSearchQuery(state),
-  status: selectAutocompleteStatus(state),
+const mapStateToProps = (state, { id }) => ({
+  error: selectAutocompleteError(state, id),
+  results: selectAutocompleteResults(state, id),
+  searchQuery: selectAutocompleteSearchQuery(state, id),
+  status: selectAutocompleteStatus(state, id),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -14,12 +14,14 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [],
-      "searchQuery": "result",
-      "status": "PENDING",
-      "trigger": "INPUT_CHANGE",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [],
+        "searchQuery": "result",
+        "status": "PENDING",
+        "trigger": "INPUT_CHANGE",
+      },
     },
     "bookmarks": Object {
       "models": Object {
@@ -47,12 +49,14 @@ Object {
   ],
   "state": Object {
     "autocomplete": Object {
-      "controller": "models",
-      "error": null,
-      "results": Array [],
-      "searchQuery": "result",
-      "status": "PENDING",
-      "trigger": "INPUT_CHANGE",
+      "some-id": Object {
+        "controller": "models",
+        "error": null,
+        "results": Array [],
+        "searchQuery": "result",
+        "status": "PENDING",
+        "trigger": "INPUT_CHANGE",
+      },
     },
     "bookmarks": Object {
       "currentQuery": "result",

--- a/webpack/assets/javascripts/react_app/components/SearchBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/index.js
@@ -2,8 +2,15 @@ import { connect } from 'react-redux';
 import SearchBar from './SearchBar';
 import { selectAutocompleteSearchQuery } from '../AutoComplete/AutoCompleteSelectors';
 
-const mapStateToProps = state => ({
-  searchQuery: selectAutocompleteSearchQuery(state),
+const mapStateToProps = (
+  state,
+  {
+    data: {
+      autocomplete: { id },
+    },
+  }
+) => ({
+  searchQuery: selectAutocompleteSearchQuery(state, id),
 });
 
 export default connect(mapStateToProps)(SearchBar);


### PR DESCRIPTION
In addition to the last Autocomplete refactoring:[ consume the Autocomplete as an independent component](https://github.com/theforeman/foreman/pull/6500),
we need a mechanism to distinguish between the different autocomplete components on a page in the Redux store.
Part of the code that was implemented in [filter's forms Autocomplete](https://github.com/theforeman/foreman/pull/6142)

blocked by: https://github.com/theforeman/foreman/pull/6500
@theforeman/ui-ux could you have a look?