### PR TITLE
Fixes #26122 - fix layout rendering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,7 @@ $(function() {
 });
 
 function onContentLoad(){
+  tfm.store.observeStore('layout', tfm.nav.showContent);
   uninitialized_autocompletes = $.grep($('.autocomplete-input'), function(i){ return !$(i).next().hasClass('autocomplete-clear'); });
   if (uninitialized_autocompletes.length > 0) {
     $.each(uninitialized_autocompletes, function(i, input) {$(input).scopedSearch({'delay': 250})});

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -153,6 +153,10 @@ select {
   cursor: auto;
 }
 
+#content {
+  display: none;
+}
+
 .used_by_hosts {
   color: #000 !important;
   cursor: auto;

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -30,6 +30,7 @@ import compute from './foreman_compute_resource';
 import componentRegistry from './react_app/components/componentRegistry';
 import i18n from './react_app/common/I18n';
 import * as foremanDocument from './react_app/common/document';
+import * as foremanStore from './foreman_store';
 
 window.tfm = Object.assign(window.tfm || {}, {
   authSource: require('./foreman_auth_source'),
@@ -54,4 +55,5 @@ window.tfm = Object.assign(window.tfm || {}, {
   i18n,
   document: foremanDocument,
   componentRegistry,
+  store: foremanStore,
 });

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -20,3 +20,14 @@ export const changeOrganization = org => {
 export const changeActive = active => {
   store.dispatch(LayoutActions.changeActiveMenu({ title: active }));
 };
+
+export function showContent(layout, unsubscribe) {
+  const content = () => {
+    $('#content').show();
+    unsubscribe();
+  };
+  // workaround for pages with no layout object
+  if (layout.items.length && !layout.isLoading) {
+    content();
+  } else if ($('#layout').length === 0) content();
+}

--- a/webpack/assets/javascripts/foreman_store.js
+++ b/webpack/assets/javascripts/foreman_store.js
@@ -1,0 +1,34 @@
+import { get } from 'lodash';
+import store from './react_app/redux';
+
+/**
+ * Observe a state from the store for changes
+ * @param  {String}   state a sub object of the store
+ * @param  {Function} onChange  a callback to run when the store has been changed
+ * @return {Function}           unsubscribe function
+ */
+export function observeStore(state, onChange) {
+  let currentState;
+
+  function handleChange() {
+    const nextState = select(state);
+    if (nextState !== currentState) {
+      currentState = nextState;
+      onChange(currentState, unsubscribe);
+    }
+  }
+
+  const unsubscribe = store.subscribe(handleChange);
+  handleChange();
+  return unsubscribe;
+}
+
+function select(state) {
+  const stateObj = get(store.getState(), state);
+
+  if (stateObj === undefined) {
+    throw new Error(`State ${state} does not exist`);
+  }
+
+  return stateObj;
+}


### PR DESCRIPTION
When a  full page loading occurs, the layout (vertical nav and topbar menu) are rendered after the main content, which might cause a flickering effect.

these videos captured with chrome’s slow network mimicking 

before:
https://drive.google.com/open?id=1z-ggdKgzbdjhYZ1lOr-AaROwnkF4nOFf

after:
https://drive.google.com/open?id=1lwhXJ84ZbupLcpu3uYSG_CEYPog0DvXJ