### PR TITLE
Fixes #26123 - removed hardcoded value of main_objects for audit

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -1,7 +1,4 @@
 module AuditsHelper
-  MAIN_OBJECTS = %w(Host::Base Hostgroup User Operatingsystem Environment Puppetclass Parameter Architecture ComputeResource ProvisioningTemplate ComputeProfile ComputeAttribute
-                    Location Organization Domain Subnet SmartProxy AuthSource Image Role Usergroup Bookmark ConfigGroup Ptable ReportTemplate)
-
   # lookup the Model representing the numerical id and return its label
   def id_to_label(name, change, audit: @audit, truncate: true)
     return _("N/A") if change.nil?
@@ -235,9 +232,10 @@ module AuditsHelper
   end
 
   def main_object?(audit)
-    return true if MAIN_OBJECTS.include?(audit.auditable_type)
+    main_objects_names = Audit.main_object_names
+    return true if main_objects_names.include?(audit.auditable_type)
     type = audit.auditable_type.split("::").last rescue ''
-    MAIN_OBJECTS.include?(type)
+    main_objects_names.include?(type)
   end
 
   def key_to_class(key, audit)

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -119,6 +119,16 @@ module AuditExtensions
     end
   end
 
+  module ClassMethods
+    def main_objects
+      audited_classes.reject { |cl| cl.audited_options.key?(:associated_with) }
+    end
+
+    def main_object_names
+      main_objects.map(&:name)
+    end
+  end
+
   private
 
   def log_audit


### PR DESCRIPTION
Calculated value of main_objects using audited_classes & option :associated_with. 
Consider resource class as main_object when there is no :associated_with option mentioned in audited.
