### PR TITLE
Fixes #26124 - WIP: Fix incorrect or missing build durations

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -248,8 +248,8 @@ module HostsHelper
   end
 
   def build_duration(host)
-    return _('N/A') if host.initiated_at.nil? || host.installed_at.nil?
-    if host.installed_at.nil?
+    return _('N/A') if host.initiated_at.nil?
+    if host.installed_at.nil? || host.installed_at < host.initiated_at
       time_ago_in_words(host.initiated_at, include_seconds: true) + " (in progress)"
     else
       distance_of_time_in_words(host.initiated_at, host.installed_at, include_seconds: true)

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -49,6 +49,7 @@ class Host::Managed < Host::Base
   # Custom hooks will be executed after_commit
   after_commit :build_hooks
   before_save :clear_data_on_build
+  before_save :set_initiated_at
   before_save :clear_puppetinfo, :if => :environment_id_changed?
 
   include PxeLoaderValidator
@@ -293,6 +294,11 @@ class Host::Managed < Host::Base
     clear_facts
     clear_reports
     self.build_errors = nil
+  end
+
+  def set_initiated_at
+    return unless build? && self.initiated_at.nil?
+    self.initiated_at = Time.now.utc
   end
 
   # Called from the host build post install process to indicate that the base build has completed


### PR DESCRIPTION
`host.initiated_at` was `nil` for new hosts.

```
time_ago_in_words(host.initiated_at, include_seconds: true) + " (inprogress)"
```

was unreachable.