### PR TITLE
Refs #4127 - Toggle key type select based on override

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -140,7 +140,7 @@ function undo_remove_child_node(item){
 function toggleOverrideValue(item) {
   var override = $(item).is(':checked');
   var fields = $(item).closest('.fields');
-  var fields_to_disable = fields.find("[name$='[required]'],[id$='_key_type'],[id$='_validator_type'],[name$='[omit]'],[name$='[hidden_value]']");
+  var fields_to_disable = fields.find("[name$='[required]'],[id$='_validator_type'],[name$='[omit]'],[name$='[hidden_value]'],[name$='[parameter_type]']");
   var omit = $(item).closest('fieldset').find("[id$='omit']").is(':checked');
   var default_value_field = fields.find("[id$='_default_value']");
   var pill_icon = $('#pill_' + fields[0].id +' i');

--- a/app/helpers/key_types_helper.rb
+++ b/app/helpers/key_types_helper.rb
@@ -20,7 +20,7 @@ module KeyTypesHelper
 
     send(method_for_select_f, f, :parameter_type,
          options_for_select(LookupKey::KEY_TYPES.map { |e| [_(e), e] }, f.object.parameter_type), {},
-         options.merge(common_extra_options))
+         common_extra_options.merge(options))
   end
 
   def lookup_keys_table?(f)


### PR DESCRIPTION
The 'override' checkbox enables/disables multiple fields in the form, but not the type.

I also flipped the merge order of options in helper to be able to override the defaults and initialize the field properly.

Before:
![before-start](https://user-images.githubusercontent.com/2664090/53342082-7ca42100-390d-11e9-901a-1858f54715bd.png)
![before-end](https://user-images.githubusercontent.com/2664090/53342086-7dd54e00-390d-11e9-9d9e-757c03bb22bb.png)

After:
![after-start](https://user-images.githubusercontent.com/2664090/53342099-829a0200-390d-11e9-85e1-553bf910a819.png)
![after-end](https://user-images.githubusercontent.com/2664090/53342096-8037a800-390d-11e9-89ac-f411fd89a20b.png)


@kgaikwad, what do you think?
