### PR TITLE
Fixes #26128 - pin highlight.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",
-    "highlight.js": "^9.12.0",
+    "highlight.js": "~9.14.0",
     "identity-obj-proxy": "^3.0.0",
     "jest-cli": "^23.6.0",
     "jest-prop-type-error": "^1.1.0",


### PR DESCRIPTION
npm install ends with an error:
```
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/home/afeferku/git/foreman/node_modules/highlight.js/tools/build.js'
```

caused by hightlight.js package:
https://github.com/highlightjs/highlight.js/issues/1984

it seems that version`9.14` is the latest stable