### PR TITLE
 fixes #26151 - graphql: add base classes

### DIFF
--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+  end
+end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,5 @@
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+  end
+end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+  end
+end


### PR DESCRIPTION
This is part six of the journey to graphql. 🚀 

This requires #5680.

It's recommended to create our own base classes instead of inheriting from graphql library classes directly. (similar to application record vs inheriting from ActiveRecord::Base)
We should introduce this as early as possible so plugins don't require changes later.

---
Other parts:
Part 1 - JWT Auth: #5596
Part 2 - Graphql Scaffolding: #5680
Part 3 - Relay Global ID #5681
Part 4 - Connections with totalCount #5733
Part 5 - Basic mutations for model #5736