### PR TITLE
Fixes #26158 - missing<id> in old/new changes of audit_record

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -242,7 +242,9 @@ module AuditsHelper
 
   def key_to_class(key, audit)
     auditable_type = (audit.auditable_type == 'Host::Base') ? 'Host::Managed' : audit.auditable_type
-    auditable_type.constantize.reflect_on_association(key.sub(/_id(s?)$/, '\1'))&.klass
+    association_name = key.gsub(/_id(s?)$/, '')
+    association_name = association_name.pluralize if key =~ /_ids$/
+    auditable_type.constantize.reflect_on_association(association_name)&.klass
   end
 
   def rebuild_audit_changes(audit)

--- a/test/helpers/audits_helper_test.rb
+++ b/test/helpers/audits_helper_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class DummyHostContent < ApplicationRecord
+  has_many :dummy_repositories
+  has_many :dummy_orgs
+  has_one :dummy_environment
+end
+
+class DummyOrg < ApplicationRecord
+  belongs_to :dummy_host_content
+end
+
+class DummyEnvironment < ApplicationRecord
+  belongs_to :dummy_host_content
+end
+
+class DummyRepository < ApplicationRecord
+  belongs_to :dummy_host_content
+end
+
+class AuditsHelperTest < ActionView::TestCase
+  include AuditsHelper
+
+  describe ":key_to_class" do
+    test "with association_name '*y' and :has_many, :key_to_class should return correct klass" do
+      audit_rec = FactoryBot.build(
+        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
+        :auditable_id => "272", :version => "1",
+        :audited_changes => { "dummy_repository_ids" => [[12], [12, 3]] })
+      output = key_to_class('dummy_repository_ids', audit_rec)
+      assert_equal output, DummyRepository
+    end
+
+    test "with :has_many, :key_to_class should return correct klass" do
+      audit_rec = FactoryBot.build(
+        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
+        :auditable_id => "272", :version => "2",
+        :audited_changes => { "dummy_org_ids" => [[1], [1, 3]] })
+      output = key_to_class('dummy_org_ids', audit_rec)
+      assert_equal output, DummyOrg
+    end
+
+    test 'with :has_one, :key_to_class should return correct association' do
+      audit_rec = FactoryBot.build(
+        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
+        :auditable_id => "272", :version => "3",
+        :audited_changes => { "dummy_environment_id" => [1, 2] })
+      output = key_to_class('dummy_environment_id', audit_rec)
+      assert_equal output, DummyEnvironment
+    end
+  end
+end


### PR DESCRIPTION
Example - for *y_ids,
has_many association_name should be '*ies' not '*ys'
