### PR TITLE
Fixes #26113 - Show timestamp in proxy log pane

### DIFF
--- a/app/assets/javascripts/proxy_status/logs.js
+++ b/app/assets/javascripts/proxy_status/logs.js
@@ -29,9 +29,6 @@ function activateLogsDataTable() {
     dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>>",
     autoWidth: false,
     columnDefs: [{
-      render: function ( data, type, row ) {
-        return data;
-      },
       width: "15%",
       targets: 0
     },{

--- a/app/views/smart_proxies/logs/_list.html.erb
+++ b/app/views/smart_proxies/logs/_list.html.erb
@@ -21,7 +21,7 @@
     <% log_entries.each do |log| %>
       <tr class="<%= logs_color_map[log['level']] || '' %>">
         <% timestamp = Time.at(log['timestamp']) %>
-        <td class="ca col-md-2 hidden-xs nbsp"><%= date_time_absolute(timestamp) %></td>
+        <td class="ca col-md-2 hidden-xs nbsp"><%= date_time_absolute(timestamp, :short, true) %></td>
         <td class="ca col-md-1 hidden-sm hidden-xs nbsp">
           <a href="#"
             data-toggle="modal"


### PR DESCRIPTION
When unifing the date time columns, the datatables initializer for the
logs table was changes to render the time column as it is. This does not
work properly with the new react date component, causing the column to
be empty. This commit removes the unneeded render function for this
column and corrects the helper to also display seconds for the
timestamps.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
