### PR TITLE
Fixes #26164 - Use the proxy configured puppet_url

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -92,15 +92,29 @@ module HostCommon
     !!(puppet_ca_proxy && puppet_ca_proxy.url.present?)
   end
 
-  # no need to store anything in the db if the entry is plain "puppet"
-  # If the system is using smart proxies and the user has run the smartproxy:migrate task
-  # then the puppetmaster functions handle smart proxy objects
-  def puppetmaster
-    puppet_proxy.to_s
+  def puppet_server_uri
+    return unless puppet_proxy
+    url = puppet_proxy.setting('Puppet', 'puppet_url')
+    url ||= "https://#{puppet_proxy}:8140"
+    URI(url)
   end
 
+  # The Puppet server FQDN or an empty string. Exposed as a provisioning macro
+  def puppetmaster
+    puppet_server_uri.try(:host) || ''
+  end
+
+  def puppet_ca_server_uri
+    return unless puppet_ca_proxy
+    url = puppet_ca_proxy.setting('Puppet CA', 'puppet_url')
+    url ||= "https://#{puppet_ca_proxy}:8140"
+    URI(url)
+  end
+
+  # The Puppet CA server FQDN or an empty string. Exposed as a provisioning
+  # macro.
   def puppet_ca_server
-    puppet_ca_proxy.to_s
+    puppet_ca_server_uri.try(:host) || ''
   end
 
   # If the host/hostgroup has a medium then use the path from there

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -47,6 +47,9 @@ FactoryBot.define do
     end
 
     factory :puppet_ca_smart_proxy do
+      before(:create, :build, :build_stubbed) do
+        ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppetca => {'state' => 'running'})
+      end
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppetca, :smart_proxy => smart_proxy)
       end


### PR DESCRIPTION
When the proxy exposes the puppet_url setting for the Puppet or Puppet CA features this can be used to provide multi homing.

WIP for now since it includes https://github.com/theforeman/foreman/pull/6314. Will also need a proxy component.