### PR TITLE
Fixes #26174 - Webpack skip plugins cores

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -40,7 +40,7 @@ specs.each do |dep|
   # skip other rails engines that are not plugins
   # TODO: Consider using the plugin registration api?
   next unless dep.name =~ plugin_name_regexp
-  next if dep.name =~ /.*_core$/
+  next if dep.name =~ /.*[_-]core$/
   dep = dep.to_spec if gemfile_in
 
   path = "#{dep.to_spec.full_gem_path}/webpack"


### PR DESCRIPTION
It currently skipping `_core` and should skip `-core` as well so `foreman-tasks` won't produce `foreman-tasks-core` bundle.

