### PR TITLE
Fixes #22684 - host creation is bootdisk method friendly

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -278,7 +278,7 @@ module HostsHelper
     fields += [[_("Puppet Environment"), link_to(host.environment, hosts_path(:search => %{environment = "#{host.environment}"}))]] if host.environment.present?
     fields += [[_("Architecture"), link_to(host.arch, hosts_path(:search => %{architecture = "#{host.arch}"}))]] if host.arch.present?
     fields += [[_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => %{os_title = "#{host.operatingsystem.title}"}))]] if host.operatingsystem.present?
-    fields += [[_("PXE Loader"), host.pxe_loader]] if host.operatingsystem.present? && host.pxe_build?
+    fields += [[_("PXE Loader"), host.pxe_loader]] if host.operatingsystem.present? && !host.image_build?
     fields += [[_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))]] if host.hostgroup.present?
     fields += [[_("Uptime"), time_ago_in_words(host.uptime_seconds.seconds.from_now)]] if host.uptime_seconds.present?
     fields += [[_("Location"), (link_to(host.location.title, hosts_path(:search => %{location = "#{host.location}"})) if host.location)]] if SETTINGS[:locations_enabled]

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -15,7 +15,7 @@ module Orchestration::TFTP
   def tftp_ready?
     # host.managed? and managed? should always come first so that orchestration doesn't
     # even get tested for such objects
-    (host.nil? || host&.managed?) && managed && provision? && (host&.operatingsystem && host.pxe_loader.present?) && pxe_build? && SETTINGS[:unattended]
+    (host.nil? || host&.managed?) && managed && provision? && (host&.operatingsystem && host.pxe_loader.present?) && !image_build? && SETTINGS[:unattended]
   end
 
   def tftp?

--- a/app/services/nic_ip_required/base.rb
+++ b/app/services/nic_ip_required/base.rb
@@ -51,7 +51,7 @@ module NicIpRequired
     end
 
     def unattended_controller_used?
-      host.pxe_build? || (host.image_build? && host.image.try(:user_data?))
+      !host.image_build? || (host.image_build? && host.image.try(:user_data?))
     end
 
     def compute_provides_ip?

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2316,24 +2316,24 @@ class HostTest < ActiveSupport::TestCase
 
   test "with tokens disabled PXE build hosts do require an IPv4 address" do
     host = FactoryBot.build_stubbed(:host, :managed)
-    host.expects(:pxe_build?).twice.returns(true)
-    host.stubs(:image_build?).returns(false)
+    host.stubs(:pxe_build?).returns(true)
+    host.expects(:image_build?).twice.returns(false)
     assert host.require_ip4_validation?
     refute host.require_ip6_validation?
   end
 
   test "with tokens disabled PXE build IPv6 hosts do not require an IPv4 but a IPv6 address" do
     host = FactoryBot.build_stubbed(:host, :managed, :with_ipv6)
-    host.expects(:pxe_build?).twice.returns(true)
-    host.stubs(:image_build?).returns(false)
+    host.stubs(:pxe_build?).returns(true)
+    host.expects(:image_build?).twice.returns(false)
     refute host.require_ip4_validation?
     assert host.require_ip6_validation?
   end
 
   test "tokens disabled doesn't require an IPv4 or IPv6 address for image hosts" do
     host = FactoryBot.build_stubbed(:host, :managed)
-    host.expects(:pxe_build?).twice.returns(false)
-    host.expects(:image_build?).twice.returns(true)
+    host.stubs(:pxe_build?).returns(false)
+    host.expects(:image_build?).times(4).returns(true)
     image = stub()
     image.expects(:user_data?).twice.returns(false)
     host.stubs(:image).returns(image)
@@ -2343,8 +2343,8 @@ class HostTest < ActiveSupport::TestCase
 
   test "tokens disabled requires an IPv4 address for image hosts with user data" do
     host = FactoryBot.build_stubbed(:host, :managed)
-    host.expects(:pxe_build?).twice.returns(false)
-    host.expects(:image_build?).twice.returns(true)
+    host.stubs(:pxe_build?).returns(false)
+    host.expects(:image_build?).times(4).returns(true)
     image = stub()
     image.expects(:user_data?).twice.returns(true)
     host.stubs(:image).returns(image)
@@ -2354,8 +2354,8 @@ class HostTest < ActiveSupport::TestCase
 
   test "tokens disabled requires only an IPv6 address for image hosts with user data and IPv6 address" do
     host = FactoryBot.build_stubbed(:host, :managed, :with_ipv6)
-    host.expects(:pxe_build?).twice.returns(false)
-    host.expects(:image_build?).twice.returns(true)
+    host.stubs(:pxe_build?).returns(false)
+    host.expects(:image_build?).times(4).returns(true)
     image = stub()
     image.expects(:user_data?).twice.returns(true)
     host.stubs(:image).returns(image)


### PR DESCRIPTION
When we introduced bootdisk provision method and provision methods in
general, we haven't refactored our code. We use `pxe_build?` helper on
many places to determine if method is PXE or image. But now with
provisioning methods extendable by plugins, PXE also includes bootdisk
method.

This patch reverts the logic, instead asking for `pxe_build?` the code
asks if the method is not `image_build?`. This unblocks bootdisk method
to work.

Long term, we should probably create some extension points or API for
plugins to be able to specify if a provision method is PXE based or
image based. This however involves bigger changes - we will need to
introduce probably new model ProvisionMethod with some parameters. This
will create the code unnecessary complex, we can live with three methods
for now until that shows up again.

Partially this was already started few months ago in:

https://github.com/theforeman/foreman/pull/6331/files

So this patch is continuation of the previous one.