### PR TITLE
Fixes #24798 - Host Interface API search

### DIFF
--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -19,7 +19,7 @@ module Api
       param_group :pagination, ::Api::V2::BaseController
 
       def index
-        @interfaces = resource_scope.paginate(paginate_options)
+        @interfaces = resource_scope_for_index
       end
 
       api :GET, '/hosts/:host_id/interfaces/:id', N_("Show an interface for host")

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -64,6 +64,13 @@ module Nic
 
     belongs_to_host :inverse_of => :interfaces, :class_name => "Host::Base"
 
+    scoped_search :on => :mac, :complete_value => true
+    scoped_search :on => :ip, :complete_value => true
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :managed, :complete_value => {:true => true, :false => false}
+    scoped_search :on => :primary, :complete_value => {:true => true, :false => false}
+    scoped_search :on => :domain, :complete_value => true
+
     # keep extra attributes needed for sub classes.
     serialize :attrs, Hash
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -64,12 +64,12 @@ module Nic
 
     belongs_to_host :inverse_of => :interfaces, :class_name => "Host::Base"
 
-    scoped_search :on => :mac, :complete_value => true
-    scoped_search :on => :ip, :complete_value => true
-    scoped_search :on => :name, :complete_value => true
-    scoped_search :on => :managed, :complete_value => {:true => true, :false => false}
-    scoped_search :on => :primary, :complete_value => {:true => true, :false => false}
-    scoped_search :on => :domain, :complete_value => true
+    scoped_search :on => :mac, :complete_value => true, :only_explicit => true
+    scoped_search :on => :ip, :complete_value => true, :only_explicit => true
+    scoped_search :on => :name, :complete_value => true, :only_explicit => true
+    scoped_search :on => :managed, :complete_value => {:true => true, :false => false}, :only_explicit => true
+    scoped_search :on => :primary, :complete_value => {:true => true, :false => false}, :only_explicit => true
+    scoped_search :on => :domain_id, :complete_value => true, :only_explicit => true
 
     # keep extra attributes needed for sub classes.
     serialize :attrs, Hash


### PR DESCRIPTION
The API now supports the search with attribute values. Search not supported for "type" attribute as it is a serialize attribute.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
