### PR TITLE
Fixes #26173 - added config_report_metric_count metric

### DIFF
--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -28,3 +28,4 @@ telemetry.add_histogram(:report_importer_create, 'Total duration of report impor
 telemetry.add_histogram(:report_importer_refresh, 'Total duration of report status refresh', [:type])
 telemetry.add_counter(:audit_records_created, 'Number of audit records created in the DB', [:type])
 telemetry.add_counter(:audit_records_logged, 'Number of audit records sent into logger', [:type])
+telemetry.add_counter(:config_report_metric_count, 'Number of config report status metrics', [:metric])

--- a/test/unit/config_report_status_calculator_test.rb
+++ b/test/unit/config_report_status_calculator_test.rb
@@ -1,5 +1,11 @@
 require 'test_helper'
 class ConfigReportStatusCalculatorTest < ActiveSupport::TestCase
+  test 'it should return status' do
+    r = ConfigReportStatusCalculator.new(:counters => {'applied' => 0, 'restarted' => 0, 'failed' => 0, 'failed_restarts' => 0, 'skipped' => 1, 'pending' => 0})
+    expected = {"applied" => 0, "restarted" => 0, "failed" => 0, "failed_restarts" => 0, "skipped" => 1, "pending" => 0}
+    assert_equal expected, r.status
+  end
+
   test 'it should not change host report status when we have skipped reports but there are no log entries' do
     r = ConfigReportStatusCalculator.new(:counters => {'applied' => 0, 'restarted' => 0, 'failed' => 0, 'failed_restarts' => 0, 'skipped' => 1, 'pending' => 0})
     assert_equal 0, r.status['failed']


### PR DESCRIPTION
Adds a new metric - count of status report metrics, e.g. failed,
applied, restarted etc.

This will help to correlate with other monitoring data.

To test, enable monitoring and upload a puppet report. This should work
with any report basically if plugin provides the report metric
capability.