### PR TITLE
fixes #26189 - remove node 6 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6.14' # previous LTS, currently in EPEL
   - '8' # current LTS
   - '10' # future LTS
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
As tests are always red on node 6 for about a month now, I don't see
any value in keeping it.