### PR TITLE
Fixes #26194 - Silence ruby warnings for foreman-rake

### DIFF
--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -13,7 +13,7 @@ CMD="$BUNDLER_CMD $RAKE_CMD"
 if [ $# -eq 0 ]; then
   $RAKE_CMD -h; exit 0;
 elif [ "$USERNAME" = foreman ]; then
-  RAILS_ENV=production $CMD "$@"
+  RUBYOPT=-W0 RAILS_ENV=production $CMD "$@"
 else
-  su foreman -s /bin/bash -c 'RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
+  su foreman -s /bin/bash -c 'RUBYOPT=-W0 RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
 fi


### PR DESCRIPTION
This commit adds `-W 0` to ruby for foreman-rake

This will silence warnings for ruby. We already use the production
rails environment, which prevents rails warnings, but we don't alter
the logging for ruby, so ruby warnings are still visible

Here is the option in the ruby help menu:
```
  -W[level=2]     set warning level; 0=silence, 1=medium, 2=verbose
```

This can be reproduced in Katello production environments, where
there are currently ruby warnings.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
