### PR TITLE
fixes #26197 - boot_filename for host without subnet

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -251,7 +251,7 @@ class Operatingsystem < ApplicationRecord
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
     return host.foreman_url('iPXE') if host.pxe_loader == 'iPXE Embedded'
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
-    boot_uri = URI.parse(host.subnet.httpboot? ? host.subnet.httpboot.url : Setting[:unattended_url])
+    boot_uri = URI.parse((host.subnet&.httpboot?) ? host.subnet.httpboot.url : Setting[:unattended_url])
     self.class.all_loaders_map(architecture, "#{boot_uri.host}:#{boot_uri.port}")[host.pxe_loader]
   end
 

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -365,5 +365,10 @@ class OperatingsystemTest < ActiveSupport::TestCase
       host = FactoryBot.build(:host, :managed, :with_templates_subnet, pxe_loader: 'iPXE Embedded')
       assert_equal 'https://someproxy:8443/unattended/iPXE', host.operatingsystem.boot_filename(host)
     end
+
+    test 'should be the unattended url for a host without a subnet' do
+      host = FactoryBot.build(:host, :managed, pxe_loader: 'Grub2 UEFI HTTP')
+      assert_equal 'http://foreman.some.host.fqdn:80/httpboot/grub2/grubx64.efi', host.operatingsystem.boot_filename(host)
+    end
   end
 end


### PR DESCRIPTION
When a host has no subnet associated an exception is raised during save:

`undefined method 'httpboot?' for nil:NilClass`