### PR TITLE
Fixes #26080 - Add autocomplete and date inputs to report template

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/template_input.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template_input.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Parameters::TemplateInput
   class_methods do
     def template_input_params_filter
       Foreman::ParameterFilter.new(::TemplateInput).tap do |filter|
-        filter.permit_by_context :id, :_destroy, :name, :required, :input_type, :fact_name,
+        filter.permit_by_context :id, :_destroy, :name, :required, :input_type, :fact_name, :resource_type, :value_type,
                                  :variable_name, :puppet_class_name, :puppet_parameter_name, :description, :template_id,
                                  :options, :advanced, :nested => true
       end

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -53,4 +53,31 @@ module TemplatesHelper
     keys.map!(&:to_s)
     TemplateInput::TYPES.select { |k, _| keys.include?(k.to_s) }.map { |key, name| [ _(name), key ] }
   end
+
+  def hide_resource_type_input(obj)
+    'hide' unless obj.value_type == 'search'
+  end
+
+  def mount_report_template_input(input_value)
+    return if input_value.nil?
+
+    input = input_value.template_input
+    controller = input.resource_type.tableize
+
+    mount_react_component('TemplateInput', "#template-input-#{input.id}", {
+      value: input_value.value.to_s,
+      required: input.required,
+      template: 'report_template_report',
+      description: input.description,
+      supportedTypes: TemplateInput::VALUE_TYPE,
+      resourceType: controller,
+      id: input.id,
+      useKeyShortcuts: false,
+      url: search_path(controller),
+      label: input.name,
+      type: input.value_type,
+      initialError: input_value.errors[:value].join("\n").presence,
+      resourceTypes: Hash[Permission.resources.map { |d| [d.tableize.to_s, d] }]
+    }.to_json)
+  end
 end

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -143,10 +143,9 @@ class ReportComposer
     return inputs if template.nil?
 
     # process values from params (including empty hash)
-    unless input_values.nil?
-      @template.template_inputs.each do |input|
-        inputs[input.id.to_s] = InputValue.new(value: input_values[input.id.to_s].try(:[], 'value'), template_input: input)
-      end
+    template.template_inputs.each do |input|
+      val = input_values[input.id.to_s].try(:[], 'value') unless input_values.nil?
+      inputs[input.id.to_s] = InputValue.new(value: val, template_input: input)
     end
 
     inputs

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -8,6 +8,7 @@ class TemplateInput < ApplicationRecord
 
   TYPES = { :user => N_('User input'), :fact => N_('Fact value'), :variable => N_('Variable'),
             :puppet_parameter => N_('Puppet parameter') }.with_indifferent_access
+  VALUE_TYPE = ['plain', 'search', 'date']
 
   attr_exportable(:name, :required, :input_type, :fact_name, :variable_name, :puppet_class_name,
                   :puppet_parameter_name, :description, :options, :advanced)
@@ -23,6 +24,7 @@ class TemplateInput < ApplicationRecord
   validates :fact_name, :presence => { :if => :fact_template_input? }
   validates :variable_name, :presence => { :if => :variable_template_input? }
   validates :puppet_parameter_name, :puppet_class_name, :presence => { :if => :puppet_parameter_template_input? }
+  validates :value_type, inclusion: { in: VALUE_TYPE }
 
   def user_template_input?
     input_type == 'user'

--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -4,6 +4,8 @@
       <%= text_f f, :name, :disabled => @template.locked? %>
       <%= checkbox_f f, :required, :disabled => @template.locked? %>
       <%= selectable_f f, :input_type, template_input_types_options(@template.acceptable_template_input_types), {}, :class => 'input_type_selector without_select2', :disabled => @template.locked? %>
+      <%= selectable_f f, :value_type, [[_('Plain'), 'plain'], [_("Search"), 'search'], [_('Date'), 'date']], {}, {'data-item': f.object.id, class: 'select-value-type', onchange: "tfm.templateInputs.inputValueOnchange(this)"}  %> 
+      <%= selectable_f f, :resource_type, Permission.resources_with_translations, {}, {wrapper_class: "#{hide_resource_type_input(f.object)} form-group resource-type-#{f.object.id}"} %>
       <div class="fact_input_type custom_input_type_fields" style="<%= f.object.fact_template_input? ? '' : 'display:none' %>">
         <%= text_f f, :fact_name, :class => 'fact_input_type', :required => true, :disabled => @template.locked? %>
       </div>
@@ -17,7 +19,7 @@
       <div class="user_input_type custom_input_type_fields" style="<%= (f.object.user_template_input? || f.object.new_record?) ? '' : 'display:none' %>">
         <%= checkbox_f f, :advanced, :disabled => @template.locked? %>
         <%= textarea_f f, :options, :rows => 3, :class => 'user_input_type', :help_inline => _("A list of options the user can select from. If not provided, the user will be given a free-form field"),
-                                    :disabled => @template.locked? %>
+                                    :disabled => @template.locked?, wrapper_class: "form-group input-options-#{f.object.id}"  %>
       </div>
       <%= textarea_f f, :description, :rows => 3, :disabled => @template.locked? %>
     <% end %>

--- a/app/views/template_inputs/_invocation_form.html.erb
+++ b/app/views/template_inputs/_invocation_form.html.erb
@@ -1,7 +1,12 @@
 <%= input_values_fields.fields_for input.id.to_s, composer.input_value_for(input) do |input_fields| %>
-  <% unless input.options.blank? %>
+  <% if input.options.present? %>
     <%= selectable_f input_fields, :value, input.options_array, { :include_blank => !input.required }, :label_help => input.description, :require => input.required, :label => input.name, :id => input.name, :onchange => local_assigns[:onchange] %>
   <% else %>
-    <%= textarea_f input_fields, :value, :label => input.name, :label_help => input.description, :required => input.required, :rows => 2, :onchange => local_assigns[:onchange], :id => input.name %>
+    <%= content_tag :div, nil, id: "template-input-#{input.id}" %>
+    <% if input.value_type == 'plain' || input.value_type.nil? %>
+      <%= textarea_f input_fields, :value, :label => input.name, :label_help => input.description, :required => input.required, :rows => 2, :onchange => local_assigns[:onchange], :id => input.name %>
+    <% else %>
+      <%= mount_report_template_input(input_fields.object) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/db/migrate/20190228160047_add_value_type_and_resource_type_to_template_input.rb
+++ b/db/migrate/20190228160047_add_value_type_and_resource_type_to_template_input.rb
@@ -1,0 +1,6 @@
+class AddValueTypeAndResourceTypeToTemplateInput < ActiveRecord::Migration[5.2]
+  def change
+    add_column :template_inputs, :value_type, :string, :default => 'plain', :null => false
+    add_column :template_inputs, :resource_type, :string
+  end
+end

--- a/webpack/assets/javascripts/foreman_template_inputs.js
+++ b/webpack/assets/javascripts/foreman_template_inputs.js
@@ -38,3 +38,12 @@ export const generateTemplate = (url, templateInputData) => {
 export const pollReportData = url => {
   store.dispatch(TemplateActions.pollReportData(url));
 };
+
+export const inputValueOnchange = input => {
+  const searchValue = input.value === 'search';
+  const plainValue = input.value === 'plain';
+  const inputId = input.dataset.item;
+
+  $(`.resource-type-${inputId}`).toggle(searchValue);
+  $(`.input-options-${inputId}`).toggle(plainValue);
+};

--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -41,7 +41,7 @@ export const intl = new IntlLoader(langAttr, timezoneAttr);
 const cheveronPrefix = () => (window.I18N_MARK ? '\u00BB' : '');
 const cheveronSuffix = () => (window.I18N_MARK ? '\u00AB' : '');
 
-const documentLocale = () =>
+export const documentLocale = () =>
   document.getElementsByTagName('html')[0].lang.replace(/-/g, '_');
 
 const getLocaleData = () => {

--- a/webpack/assets/javascripts/react_app/components/Template/Inputs/AutoComplete.js
+++ b/webpack/assets/javascripts/react_app/components/Template/Inputs/AutoComplete.js
@@ -1,0 +1,64 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FieldLevelHelp } from 'patternfly-react';
+
+import Form from '../../common/forms/CommonForm';
+import AutoComplete from '../../AutoComplete';
+
+const TemplateAutoComplete = ({
+  label,
+  resourceType,
+  id,
+  initialQuery,
+  initialError,
+  info,
+  isRequired,
+  url,
+  template,
+}) => (
+  <Form
+    touched
+    label={label}
+    error={initialError}
+    required={isRequired}
+    tooltipHelp={
+      info && (
+        <FieldLevelHelp
+          buttonClass="field-help"
+          content={<Fragment>{info}</Fragment>}
+        />
+      )
+    }
+  >
+    <AutoComplete
+      id={`template-autocomplete-input-${id}`}
+      inputProps={{
+        name: `${template}[input_values][${id}][value]`,
+      }}
+      controller={resourceType}
+      url={url}
+      initialQuery={initialQuery}
+    />
+  </Form>
+);
+TemplateAutoComplete.propTypes = {
+  resourceType: PropTypes.string,
+  initialQuery: PropTypes.string,
+  initialError: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  info: PropTypes.string,
+  isRequired: PropTypes.bool,
+  id: PropTypes.number.isRequired,
+  url: PropTypes.string.isRequired,
+  template: PropTypes.string.isRequired,
+};
+
+TemplateAutoComplete.defaultProps = {
+  resourceType: null,
+  initialQuery: '',
+  initialError: null,
+  info: null,
+  isRequired: false,
+};
+
+export default TemplateAutoComplete;

--- a/webpack/assets/javascripts/react_app/components/Template/Inputs/Autocomplete.test.js
+++ b/webpack/assets/javascripts/react_app/components/Template/Inputs/Autocomplete.test.js
@@ -1,0 +1,17 @@
+import Autocomplete from './AutoComplete';
+import {
+  ReportAutocompleteWithRequireAndInfo,
+  ReportAutocompleteProps,
+} from './TemplateInput.fixures';
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+
+const fixtures = {
+  'renders ReportAutoComplete': ReportAutocompleteProps,
+  'With Require and Descriptions': ReportAutocompleteWithRequireAndInfo,
+};
+
+describe('Report Template AutoComplete', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(Autocomplete, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/Template/Inputs/TemplateInput.fixures.js
+++ b/webpack/assets/javascripts/react_app/components/Template/Inputs/TemplateInput.fixures.js
@@ -1,0 +1,51 @@
+const WithRequireAndInfo = {
+  isRequired: true,
+  info: 'some description',
+};
+
+const supportedTypes = ['plain', 'search', 'date'];
+
+export const ReportAutocompleteProps = {
+  url: 'some-url',
+  resourceType: 'some-controller',
+  initailQuery: 'a query',
+  label: 'some label',
+  id: 3,
+  template: 'report_template_report',
+};
+
+export const ReportAutocompleteWithRequireAndInfo = {
+  ...ReportAutocompleteProps,
+  ...WithRequireAndInfo,
+};
+
+export const ReportDateTimePrpos = {
+  id: 4,
+  label: 'some-label',
+  locale: 'EN',
+  template: 'report_template_report',
+  value: '2019-01-04',
+};
+
+export const ReportDateTimeWithRequireAndInfo = {
+  ...ReportDateTimePrpos,
+  ...WithRequireAndInfo,
+};
+
+export const ReportTemplateGenerateSearch = {
+  data: {
+    ...ReportAutocompleteProps,
+    ...WithRequireAndInfo,
+    supportedTypes,
+    type: 'search',
+  },
+};
+
+export const ReportTemplateGenerateDate = {
+  data: {
+    ...ReportDateTimePrpos,
+    ...WithRequireAndInfo,
+    supportedTypes,
+    type: 'date',
+  },
+};

--- a/webpack/assets/javascripts/react_app/components/Template/Inputs/__snapshots__/Autocomplete.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Template/Inputs/__snapshots__/Autocomplete.test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Report Template AutoComplete rendering With Require and Descriptions 1`] = `
+<CommonForm
+  className=""
+  error={null}
+  inputClassName="col-md-4"
+  label="some label"
+  required={true}
+  tooltipHelp={
+    <FieldLevelHelp
+      buttonClass="field-help"
+      content={
+        <React.Fragment>
+          some description
+        </React.Fragment>
+      }
+      placement="top"
+      rootClose={true}
+    />
+  }
+  touched={true}
+>
+  <Connect(AutoComplete)
+    controller="some-controller"
+    id="template-autocomplete-input-3"
+    initialQuery=""
+    inputProps={
+      Object {
+        "name": "report_template_report[input_values][3][value]",
+      }
+    }
+    url="some-url"
+  />
+</CommonForm>
+`;
+
+exports[`Report Template AutoComplete rendering renders ReportAutoComplete 1`] = `
+<CommonForm
+  className=""
+  error={null}
+  inputClassName="col-md-4"
+  label="some label"
+  required={false}
+  tooltipHelp={null}
+  touched={true}
+>
+  <Connect(AutoComplete)
+    controller="some-controller"
+    id="template-autocomplete-input-3"
+    initialQuery=""
+    inputProps={
+      Object {
+        "name": "report_template_report[input_values][3][value]",
+      }
+    }
+    url="some-url"
+  />
+</CommonForm>
+`;

--- a/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
+++ b/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import DateTime from '../common/forms/DateTime/DateTime';
+import Autocomplete from './Inputs/AutoComplete';
+
+const TemplateInput = ({
+  data: {
+    label,
+    resourceType,
+    id,
+    description,
+    required,
+    initialError,
+    type,
+    url,
+    supportedTypes,
+    template,
+    value,
+  },
+}) => {
+  const [plain, search, date] = supportedTypes;
+
+  switch (type) {
+    case plain:
+      return null;
+    case search:
+      return (
+        <Autocomplete
+          label={label}
+          id={id}
+          isRequired={required}
+          info={description}
+          initialError={initialError}
+          resourceType={resourceType}
+          url={url}
+          template={template}
+          initialQuery={value}
+        />
+      );
+    case date:
+      return (
+        <DateTime
+          label={label}
+          id={id}
+          isRequired={required}
+          info={description || 'Format is yyyy-mm-dd HH-mm-ss'}
+          initialError={initialError}
+          url={url}
+          template={template}
+          hideValue={!value.length}
+          value={value || undefined}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+TemplateInput.propTypes = {
+  data: PropTypes.shape({
+    url: PropTypes.string,
+    resourceType: PropTypes.string,
+    initialError: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    required: PropTypes.bool,
+    supportedTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    template: PropTypes.string.isRequired,
+    value: PropTypes.string,
+  }),
+};
+
+TemplateInput.defaultProps = {
+  data: PropTypes.shape({
+    url: null,
+    useKeyShortcuts: false,
+    resourceType: null,
+    initialError: null,
+    description: null,
+    required: false,
+    value: undefined,
+  }),
+};
+
+export default TemplateInput;

--- a/webpack/assets/javascripts/react_app/components/Template/__test__/ReportTemplateInput.test.js
+++ b/webpack/assets/javascripts/react_app/components/Template/__test__/ReportTemplateInput.test.js
@@ -1,0 +1,17 @@
+import TemplateInput from '../TemplateInput';
+import {
+  ReportTemplateGenerateDate,
+  ReportTemplateGenerateSearch,
+} from '../Inputs/TemplateInput.fixures';
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+
+const fixtures = {
+  'renders report template with date input': ReportTemplateGenerateDate,
+  'renders report template with search input': ReportTemplateGenerateSearch,
+};
+
+describe('Report Template AutoComplete', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(TemplateInput, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Report Template AutoComplete rendering renders report template with date input 1`] = `
+<DateTime
+  hideValue={false}
+  id={4}
+  info="Format is yyyy-mm-dd HH-mm-ss"
+  isRequired={false}
+  label="some-label"
+  locale={null}
+  template="report_template_report"
+  value="2019-01-04"
+/>
+`;
+
+exports[`Report Template AutoComplete rendering renders report template with search input 1`] = `
+<TemplateAutoComplete
+  id={3}
+  info={null}
+  initialError={null}
+  initialQuery=""
+  isRequired={false}
+  label="some label"
+  resourceType="some-controller"
+  template="report_template_report"
+  url="some-url"
+/>
+`;

--- a/webpack/assets/javascripts/react_app/components/bookmarks/form/__snapshots__/form.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/form/__snapshots__/form.test.js.snap
@@ -600,7 +600,8 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Name
-                                 *
+                                 
+                                *
                               </label>
                               <div
                                 className="col-md-4"
@@ -988,7 +989,8 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Query
-                                 *
+                                 
+                                *
                               </label>
                               <div
                                 className="col-md-8"
@@ -1345,6 +1347,7 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Public
+                                 
                               </label>
                               <div
                                 className="col-md-4"

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/TodayButton.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/TodayButton.js
@@ -8,6 +8,7 @@ const TodayButton = ({ setSelected }) => (
       <tr>
         <td>
           <button
+            type="button"
             className="today-button"
             onClick={() => {
               if (setSelected) setSelected(new Date());

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/__snapshots__/TodayButton.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/__snapshots__/TodayButton.test.js.snap
@@ -9,6 +9,7 @@ exports[`TodayButton is working properly 1`] = `
       <td>
         <button
           class="today-button"
+          type="button"
         >
           <span
             class="today-button-"

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -14,24 +14,32 @@ import { MONTH } from './DateComponents/DateConstants';
 import './date-time-picker.scss';
 
 class DateTimePicker extends React.Component {
-  state = {
-    value: new Date(this.props.value),
-    typeOfDateInput: MONTH,
-    isTimeTableOpen: false,
-    left: 'auto',
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: new Date(this.props.value),
+      typeOfDateInput: MONTH,
+      isTimeTableOpen: false,
+      hiddenValue: this.props.hiddenValue,
+    };
+  }
+
   formatDate = () => {
-    const { locale } = this.props;
+    const zeroPadding = n => (n < 10 ? `0${n}` : n);
     const { value } = this.state;
-    const options = [
-      { year: 'numeric', month: 'numeric', day: 'numeric' },
-      { hour: '2-digit', minute: '2-digit' },
-    ];
-    return `${value.toLocaleString(locale, options[0])} ${value.toLocaleString(
-      locale,
-      options[1]
-    )}`;
+    const date = {
+      year: value.getFullYear(),
+      month: zeroPadding(value.getMonth() + 1),
+      day: zeroPadding(value.getDate()),
+      hour: zeroPadding(value.getHours()),
+      minutes: zeroPadding(value.getMinutes()),
+    };
+
+    return `${date.year}-${date.month}-${date.day} ${date.hour}:${
+      date.minutes
+    }:00`;
   };
+
   setSelected = date => {
     if (Date.parse(date)) {
       const newDate = new Date(date);
@@ -42,20 +50,14 @@ class DateTimePicker extends React.Component {
       isTimeTableOpen: false,
     });
   };
-  getLeft = () => {
-    const div = document
-      .getElementsByClassName('date-time-picker-pf')[0]
-      .getBoundingClientRect();
-    this.setState({ left: div.left });
-  };
+
   render() {
-    const { locale, weekStartsOn, inputProps } = this.props;
-    const { value, typeOfDateInput, isTimeTableOpen, left } = this.state;
+    const { locale, weekStartsOn, inputProps, id } = this.props;
+    const { value, typeOfDateInput, isTimeTableOpen, hiddenValue } = this.state;
     const popover = (
       <Popover
-        id="popover-date-picker1"
+        id={id}
         className="bootstrap-datetimepicker-widget dropdown-menu timepicker-sbs"
-        style={{ left: `${left} !important` }}
       >
         <div className="row">
           <DateInput
@@ -79,29 +81,38 @@ class DateTimePicker extends React.Component {
     );
     return (
       <div>
-        <OverlayTrigger
-          trigger="click"
-          placement="top"
-          overlay={popover}
-          rootClose
-          shouldUpdatePosition
-        >
-          <InputGroup
-            className="input-group date-time-picker-pf"
-            onClick={this.getLeft}
+        <InputGroup className="input-group date-time-picker-pf">
+          <FormControl
+            {...inputProps}
+            aria-label="date-picker-input"
+            type="text"
+            className="date-time-input"
+            value={hiddenValue ? '' : this.formatDate()}
+            onChange={e => this.setSelected(e.target.value)}
+          />
+
+          <OverlayTrigger
+            trigger="click"
+            placement="top"
+            overlay={popover}
+            rootClose
+            container={this}
+            onEnter={() => this.setState({ hiddenValue: false })}
           >
-            <FormControl
-              {...inputProps}
-              aria-label="date-picker-input"
-              type="text"
-              value={this.formatDate()}
-              onChange={e => this.setSelected(e.target.value)}
-            />
             <InputGroup.Addon className="date-time-picker-pf">
               <Icon type="fa" name="calendar" />
             </InputGroup.Addon>
-          </InputGroup>
-        </OverlayTrigger>
+          </OverlayTrigger>
+          <InputGroup.Addon className="clear-button">
+            <Icon
+              type="fa"
+              name="close"
+              onClick={() =>
+                this.setState({ hiddenValue: true, value: new Date() })
+              }
+            />
+          </InputGroup.Addon>
+        </InputGroup>
       </div>
     );
   }
@@ -112,11 +123,15 @@ DateTimePicker.propTypes = {
   locale: PropTypes.string,
   weekStartsOn: PropTypes.number,
   inputProps: PropTypes.object,
+  id: PropTypes.string,
+  hiddenValue: PropTypes.bool,
 };
 DateTimePicker.defaultProps = {
   value: new Date(),
   locale: 'en-US',
   weekStartsOn: 1,
   inputProps: {},
+  id: 'datetime-picker-popover',
+  hiddenValue: true,
 };
 export default DateTimePicker;

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/PickTimeClock.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/PickTimeClock.js
@@ -70,6 +70,7 @@ class PickTimeClock extends React.Component {
               </td>
               <td>
                 <button
+                  type="button"
                   className="btn btn-primary ampm-toggle"
                   onClick={() => this.toggleAMPM()}
                 >

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/__snapshots__/PickTimeClock.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/__snapshots__/PickTimeClock.test.js.snap
@@ -55,6 +55,7 @@ exports[`Edit hours of PickTimeClock 1`] = `
         <td>
           <button
             class="btn btn-primary ampm-toggle"
+            type="button"
           >
             PM
           </button>
@@ -146,6 +147,7 @@ exports[`Edit minutes of PickTimeClock 1`] = `
         <td>
           <button
             class="btn btn-primary ampm-toggle"
+            type="button"
           >
             PM
           </button>
@@ -237,6 +239,7 @@ exports[`PickTimeClock is working properly 1`] = `
         <td>
           <button
             class="btn btn-primary ampm-toggle"
+            type="button"
           >
             PM
           </button>
@@ -328,6 +331,7 @@ exports[`Toggle hours of PickTimeClock 1`] = `
         <td>
           <button
             class="btn btn-primary ampm-toggle"
+            type="button"
           >
             AM
           </button>

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/__snapshots__/TimeInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimeComponents/__snapshots__/TimeInput.test.js.snap
@@ -58,6 +58,7 @@ exports[`TimeInput is working properly 1`] = `
           <td>
             <button
               class="btn btn-primary ampm-toggle"
+              type="button"
             >
               PM
             </button>

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -7,9 +7,9 @@ exports[`DateTimePicker is working properly 1`] = `
   >
     <input
       aria-label="date-picker-input"
-      class="form-control"
+      class="date-time-input form-control"
       type="text"
-      value="2/21/2019 2:22 PM"
+      value=""
     />
     <span
       class="date-time-picker-pf input-group-addon"
@@ -17,6 +17,14 @@ exports[`DateTimePicker is working properly 1`] = `
       <span
         aria-hidden="true"
         class="fa fa-calendar"
+      />
+    </span>
+    <span
+      class="clear-button input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-close"
       />
     </span>
   </span>
@@ -30,9 +38,9 @@ exports[`Edit form of DateTimePicker 1`] = `
   >
     <input
       aria-label="date-picker-input"
-      class="form-control"
+      class="date-time-input form-control"
       type="text"
-      value="2/21/2019 2:22 PM"
+      value=""
     />
     <span
       class="date-time-picker-pf input-group-addon"
@@ -40,6 +48,14 @@ exports[`Edit form of DateTimePicker 1`] = `
       <span
         aria-hidden="true"
         class="fa fa-calendar"
+      />
+    </span>
+    <span
+      class="clear-button input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-close"
       />
     </span>
   </span>

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/date-time-picker.scss
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/date-time-picker.scss
@@ -33,3 +33,13 @@
     }
   }
 }
+
+span.clear-button {
+  background: none;
+  border-left: none;
+  color: #72767b;
+}
+
+input.date-time-input {
+  border-right: none;
+}

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
@@ -16,8 +16,7 @@ const CommonForm = ({
   >
     <label className="col-md-2 control-label">
       {label}
-      {required && ' *'}
-      {tooltipHelp}
+      {tooltipHelp} {required && '*'}
     </label>
     <div className={inputClassName}>{children}</div>
     {touched && error && (

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
@@ -1,0 +1,73 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FieldLevelHelp } from 'patternfly-react';
+import DateTimePicker from '../../DateTimePicker/DateTimePicker';
+
+import Form from '../CommonForm';
+import { documentLocale } from '../../../../common/I18n';
+import './DateTimeOverrides.scss';
+
+const DateTime = ({
+  label,
+  id,
+  info,
+  isRequired,
+  hideValue,
+  locale,
+  template,
+  value,
+  initialError,
+}) => {
+  const currentLocale = locale || documentLocale();
+
+  return (
+    <Form
+      label={label}
+      touched
+      error={initialError}
+      required={isRequired}
+      tooltipHelp={
+        info && (
+          <FieldLevelHelp
+            buttonClass="field-help"
+            content={<Fragment>{info}</Fragment>}
+          />
+        )
+      }
+    >
+      <DateTimePicker
+        hiddenValue={hideValue && !isRequired}
+        value={value}
+        id={`template-date-input-${id}`}
+        inputProps={{
+          name: `${template}[input_values][${id}][value]`,
+          autoComplete: 'off',
+        }}
+        locale={currentLocale}
+      />
+    </Form>
+  );
+};
+
+DateTime.propTypes = {
+  label: PropTypes.string.isRequired,
+  info: PropTypes.string,
+  isRequired: PropTypes.bool,
+  id: PropTypes.number.isRequired,
+  locale: PropTypes.string,
+  template: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+  initialError: PropTypes.string,
+  hideValue: PropTypes.bool,
+};
+
+DateTime.defaultProps = {
+  info: undefined,
+  isRequired: false,
+  locale: null,
+  value: new Date(),
+  initialError: undefined,
+  hideValue: false,
+};
+
+export default DateTime;

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
@@ -1,0 +1,17 @@
+import DateTime from './DateTime';
+import {
+  ReportDateTimePrpos,
+  ReportDateTimeWithRequireAndInfo,
+} from '../../../Template/Inputs/TemplateInput.fixures';
+import { testComponentSnapshotsWithFixtures } from '../../../../common/testHelpers';
+
+const fixtures = {
+  'renders Report Date input': ReportDateTimePrpos,
+  'With Require and Info': ReportDateTimeWithRequireAndInfo,
+};
+
+describe('Report Template AutoComplete', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(DateTime, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTimeOverrides.scss
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTimeOverrides.scss
@@ -1,0 +1,23 @@
+@import "~patternfly/dist/sass/patternfly/_color-variables.scss";
+@import "~patternfly/dist/sass/patternfly/_variables.scss";
+
+$screen-md:                  992px !default;
+$screen-md-min:              $screen-md !default;
+
+@import "~patternfly/dist/sass/patternfly/_time-picker.scss";
+
+.row > .datepicker > div {
+  display: block;
+}
+
+.bootstrap-datetimepicker-widget table td {
+  vertical-align: inherit;
+}
+
+.timepicker-picker tr:nth-child(2) td {
+  background-color: #def3ff !important;
+}
+
+.field-help {
+  margin-right: -5px;
+}

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Report Template AutoComplete rendering With Require and Info 1`] = `
+<CommonForm
+  className=""
+  inputClassName="col-md-4"
+  label="some-label"
+  required={true}
+  tooltipHelp={
+    <FieldLevelHelp
+      buttonClass="field-help"
+      content={
+        <React.Fragment>
+          some description
+        </React.Fragment>
+      }
+      placement="top"
+      rootClose={true}
+    />
+  }
+  touched={true}
+>
+  <DateTimePicker
+    hiddenValue={false}
+    id="template-date-input-4"
+    inputProps={
+      Object {
+        "autoComplete": "off",
+        "name": "report_template_report[input_values][4][value]",
+      }
+    }
+    locale="EN"
+    value="2019-01-04"
+    weekStartsOn={1}
+  />
+</CommonForm>
+`;
+
+exports[`Report Template AutoComplete rendering renders Report Date input 1`] = `
+<CommonForm
+  className=""
+  inputClassName="col-md-4"
+  label="some-label"
+  required={false}
+  tooltipHelp={null}
+  touched={true}
+>
+  <DateTimePicker
+    hiddenValue={false}
+    id="template-date-input-4"
+    inputProps={
+      Object {
+        "autoComplete": "off",
+        "name": "report_template_report[input_values][4][value]",
+      }
+    }
+    locale="EN"
+    value="2019-01-04"
+    weekStartsOn={1}
+  />
+</CommonForm>
+`;

--- a/webpack/assets/javascripts/react_app/components/common/forms/__snapshots__/CommonForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__snapshots__/CommonForm.test.js.snap
@@ -8,7 +8,8 @@ exports[`common Form should accept a required field 1`] = `
     className="col-md-2 control-label"
   >
     my label
-     *
+     
+    *
   </label>
   <div
     className="col-md-4"
@@ -24,6 +25,7 @@ exports[`common Form should display a label field 1`] = `
     className="col-md-2 control-label"
   >
     my label
+     
   </label>
   <div
     className="col-md-4"
@@ -39,6 +41,7 @@ exports[`common Form should display validation errors if touched 1`] = `
     className="col-md-2 control-label"
   >
     my label
+     
   </label>
   <div
     className="col-md-4"
@@ -63,6 +66,7 @@ exports[`common Form should not display validation errors if not touched 1`] = `
     className="col-md-2 control-label"
   >
     my label
+     
   </label>
   <div
     className="col-md-4"
@@ -78,6 +82,7 @@ exports[`common Form should not display validation errors if there are none 1`] 
     className="col-md-2 control-label"
   >
     my label
+     
   </label>
   <div
     className="col-md-4"
@@ -93,13 +98,14 @@ exports[`common Form should render tooltip help 1`] = `
     className="col-md-2 control-label"
   >
     Required form field
-     *
     <FieldLevelHelp
       buttonClass=""
       content="This is a helpful tooltip"
       placement="top"
       rootClose={true}
     />
+     
+    *
   </label>
   <div
     className="col-md-4"

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -26,6 +26,7 @@ import DiffModal from './ConfigReports/DiffModal';
 import { WrapperFactory } from './wrapperFactory';
 import ModelsTable from './ModelsTable';
 import TemplateGenerator from './TemplateGenerator';
+import TemplateInput from './Template/TemplateInput';
 
 // Pages
 import AuditsPage from '../pages/AuditsPage/AuditsPage';
@@ -116,6 +117,8 @@ const coreComponets = [
   { name: 'ComponentWrapper', type: ComponentWrapper },
   { name: 'ConfigReports', type: ConfigReports },
   { name: 'DiffModal', type: DiffModal },
+  { name: 'TemplateInput', type: TemplateInput },
+
   {
     name: 'RelativeDateTime',
     type: RelativeDateTime,


### PR DESCRIPTION
Blocked by #6500 & #6501 and also by `DateTimePicker` [component](https://github.com/patternfly/patternfly-react/pull/1420)

- [x] Added value type (plain / search / date) and resource type for search input
- [x]  consume autocomplete component
- [x]  consume date-time picker component from patternfly 
- [x] tests
- [x] css customization
- [x] merging #6500 
- [x] merging #6501 
- [x] merging `DateTime` component
- [x]  rebase