### PR TITLE
Fixes #26022 - Fix host test

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -518,39 +518,6 @@ class HostJSTest < IntegrationTestWithJavascript
       assert page.has_no_selector?("#inherited_parameters #name_#{hostgroup1.group_parameters.first.name}")
       assert page.has_selector?("#inherited_parameters #name_#{hostgroup2.group_parameters.first.name}")
     end
-
-    # At this point in time this only tests the UI. Since Fog mocks all requests the Hard drive change is ignored as it
-    # will always return the mocked values. Not a total waste however as the UI is still tested with this.
-    test 'enables changing vm disk size' do
-      Fog.mock!
-
-      organization = Organization.find_by_name('Organization 1')
-      location = Location.find_by_name('Location 1')
-      uuid = '5032c8a5-9c5e-ba7a-3804-832a03e16381'
-      compute_resource = FactoryBot.create(:compute_resource, :vmware, organizations: [organization], locations: [location], uuid: 'Solutions')
-      compute_resource = ComputeResource.find_by_id(compute_resource.id)
-
-      host = FactoryBot.create(:host, :managed, compute_resource: compute_resource,
-                                                uuid: uuid,
-                                                location: location,
-                                                organization: organization,
-                                                provision_method: 'image')
-
-      visit edit_host_path(host)
-
-      wait_for_ajax
-
-      click_link('Virtual Machine')
-      within('.text-vmware-size') do
-        # Unusual here that the volume size input field has no name or id.
-        first('input').set('10 GB')
-      end
-
-      click_on('Submit')
-
-      assert_content("Successfully updated #{host.name}")
-      Fog.unmock!
-    end
   end
 
   describe "NIC modal window" do


### PR DESCRIPTION
Removes the failing host_js test.
It would be really hard to reliably mock the fog on the server side from the test (probably some parameter, or just mock the Fog for all the test suit.
But what is more importat in my opinion, that the test is running a lot of code for really long time, but is not testing anything so useful, we can't test it otherwise.

As @tbrisker and @ekohl already tried and failed to fix this test in https://github.com/theforeman/foreman/pull/6474, I don't think we should put more effort in it.

Opinions are welcome :)

P.S.: Maybe we could just not send it ( delete the submit phase ), for testing really just the UI, but I don't see the point. UI should be tested properly on webpack side.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
