### PR TITLE
Fixes #26209 - undefined method 'e' in compute

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -82,7 +82,7 @@ module Orchestration::Compute
   def setCompute
     logger.info "Adding Compute instance for #{name}"
     if compute_attributes.nil?
-      failure _("Failed to find compute attributes, please check if VM %{name} was deleted: %{message}") % { name: name, message: e.message }, e
+      failure _("Failed to find compute attributes, please check if VM %s was deleted") % name
       return false
     end
     # TODO: extract the merging into separate class in combination


### PR DESCRIPTION
While working on GCE I noticed that `e` is not defined and it will raise an undefined exception for 'e'.
I think, it would be ok to display only "Failed to find compute attributes, please check if VM #{name} was deleted" message.

Adding @justahero into @cc as the [original change](https://github.com/theforeman/foreman/pull/6332) submitted by you. 
Please correct me if I am missing any scenario. 