### PR TITLE
Fixes #16520 - Associating VM-mac is case sensitive

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -423,6 +423,7 @@ class ComputeResource < ApplicationRecord
   end
 
   def associate_by(name, attributes)
+    attributes = Array.wrap(attributes).map { |mac| Net::Validations.normalize_mac(mac) } if name == 'mac'
     Host.authorized(:view_hosts, Host).joins(:primary_interface).
       where(:nics => {:primary => true}).
       where("nics.#{name}" => attributes).

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -186,7 +186,7 @@ module Foreman::Model
     end
 
     def associated_host(vm)
-      associate_by("mac", vm.mac)
+      associate_by("mac", vm.interfaces.map(&:mac))
     end
 
     def vm_compute_attributes_for(uuid)

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -224,6 +224,12 @@ class ComputeResourceTest < ActiveSupport::TestCase
     assert_equal host, as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }
   end
 
+  test "#associate_by returns host by MAC attribute with upper case MAC" do
+    host = FactoryBot.create(:host, :mac => '00:22:33:44:C8:1A')
+    cr = FactoryBot.build_stubbed(:compute_resource)
+    assert_equal host, as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:c8:1a') }
+  end
+
   test "#associated_by returns read/write host" do
     FactoryBot.create(:host, :mac => '00:22:33:44:55:1a')
     cr = FactoryBot.build_stubbed(:compute_resource)

--- a/test/models/compute_resources/libvirt_test.rb
+++ b/test/models/compute_resources/libvirt_test.rb
@@ -11,9 +11,22 @@ class Foreman::Model::LibvirtTest < ActiveSupport::TestCase
 
   test "#associated_host matches any NIC" do
     host = FactoryBot.create(:host, :mac => 'ca:d0:e6:32:16:97')
+    Nic::Base.create! :mac => "ca:d0:e6:32:16:99", :host => host
+    host.reload
     cr = FactoryBot.build_stubbed(:libvirt_cr)
     iface = mock('iface1', :mac => 'ca:d0:e6:32:16:97')
-    assert_equal host, as_admin { cr.associated_host(iface) }
+    vm = mock('vm', :interfaces => [iface])
+    assert_equal host, as_admin { cr.associated_host(vm) }
+  end
+
+  test "#associated_host matches any NIC with upper case MAC" do
+    host = FactoryBot.create(:host, :mac => 'ca:d0:e6:32:16:97')
+    Nic::Base.create! :mac => "ca:d0:e6:32:16:99", :host => host
+    host.reload
+    cr = FactoryBot.build_stubbed(:libvirt_cr)
+    iface = mock('iface1', :mac => 'CA:D0:E6:32:16:97')
+    vm = mock('vm', :interfaces => [iface])
+    assert_equal host, as_admin { cr.associated_host(vm) }
   end
 
   test 'should update with multiple valid names' do

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -19,6 +19,15 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
     assert_equal host, as_admin { cr.associated_host(vm) }
   end
 
+  test "#associated_host matches NIC mac with uppercase letters" do
+    host = FactoryBot.create(:host, :mac => 'ca:d0:e6:32:16:97')
+    cr = FactoryBot.build_stubbed(:ovirt_cr)
+    iface1 = mock('iface1', :mac => '36:48:c5:c9:86:f2')
+    iface2 = mock('iface2', :mac => 'CA:D0:E6:32:16:97')
+    vm = mock('vm', :interfaces => [iface1, iface2])
+    assert_equal host, as_admin { cr.associated_host(vm) }
+  end
+
   describe "destroy_vm" do
     it "handles situation when vm is not present" do
       cr = mock_cr_servers(Foreman::Model::Ovirt.new, empty_servers)

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -482,6 +482,17 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
     assert_equal host, as_admin { cr.associated_host(vm) }
   end
 
+  test "#associated_host matches NIC mac with uppercase letters" do
+    host = FactoryBot.create(:host, :mac => 'ca:d0:e6:32:16:98')
+    Nic::Base.create! :mac => "ca:d0:e6:32:16:99", :host => host
+    host.reload
+    cr = FactoryBot.build_stubbed(:vmware_cr)
+    iface1 = mock('iface1', :mac => 'CA:D0:E6:32:16:98')
+    iface2 = mock('iface1', :mac => 'ca:d0:e6:32:16:99')
+    vm = mock('vm', :interfaces => [iface1, iface2])
+    assert_equal host, as_admin { cr.associated_host(vm) }
+  end
+
   describe "vm_compute_attributes_for" do
     before do
       plain_attrs = {


### PR DESCRIPTION
If mac address from VMware or ovirt is uppercase, it should now can be associated with foreman host mac(case insensitive).
