### PR TITLE
Fixes #26215 - Autocomplete console warnings

### DIFF
--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -5,7 +5,8 @@ module SearchBarHelper
     url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
     search_query: params[:search],
     use_bookmarks: true,
-    use_key_shortcuts: true
+    use_key_shortcuts: true,
+    autocomplete_id: "searchBar"
   )
     bookmarks = {}
     if use_bookmarks
@@ -15,12 +16,13 @@ module SearchBarHelper
         documentationUrl: documentation_url("4.1.5Searching")
       }
     end
-    mount_react_component('SearchBar', "##{id}", {
+    mount_react_component("SearchBar", "##{id}", {
       controller: controller,
       autocomplete: {
         searchQuery: search_query,
         url: url,
-        useKeyShortcuts: use_key_shortcuts
+        useKeyShortcuts: use_key_shortcuts,
+        id: autocomplete_id
       },
       bookmarks: bookmarks
     }.to_json)
@@ -29,7 +31,8 @@ module SearchBarHelper
   def get_search_props(
     controller: auto_complete_controller_name,
     url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
-    search_query: params[:search]
+    search_query: params[:search],
+    autocomplete_id: "searchBar"
   )
     bookmarks = {
       url: api_bookmarks_path,
@@ -40,7 +43,8 @@ module SearchBarHelper
       controller: controller,
       autocomplete: {
         searchQuery: search_query,
-        url: url
+        url: url,
+        id: autocomplete_id
       },
       bookmarks: bookmarks
     }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "multiselect": "~0.9.12",
     "number_helpers": "^0.1.1",
     "patternfly": "^3.58.0",
-    "patternfly-react": "^2.29.0",
+    "patternfly-react": "^2.30.6",
     "prop-types": "^15.6.0",
     "react": "^16.8.1",
     "react-bootstrap": "0.32.1",

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.fixtures.js
@@ -1,6 +1,7 @@
 import { STATUS } from '../../constants';
 import { TRIGGERS } from './AutoCompleteConstants';
 
+export const id = 'some-id';
 export const url = 'models/auto_complete_search';
 export const status = null;
 export const controller = 'models';
@@ -20,6 +21,7 @@ export const AutoCompleteProps = {
   status,
   results,
   url,
+  id,
 };
 
 export const initialState = {

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
@@ -24,7 +24,6 @@ class AutoComplete extends React.Component {
       'handleInputFocus',
       'getResults',
       'windowKeyPressHandler',
-      'unableHTMLAutocomplete',
       'handleKeyDown',
     ]);
     this._typeahead = React.createRef();
@@ -35,7 +34,6 @@ class AutoComplete extends React.Component {
     window.addEventListener('keypress', this.windowKeyPressHandler);
     const { controller, initialQuery, initialUpdate } = this.props;
     initialUpdate(initialQuery, controller);
-    this.unableHTMLAutocomplete();
   }
 
   windowKeyPressHandler(e) {
@@ -73,17 +71,6 @@ class AutoComplete extends React.Component {
       default: {
         break;
       }
-    }
-  }
-
-  // TODO: remove this HACK when react-bootstrap-typeahead
-  // will support autocomplete = 'off' instead of 'nope' in inputProps prop.
-  unableHTMLAutocomplete() {
-    const input =
-      this._typeahead.current &&
-      this._typeahead.current.getInstance().getInput();
-    if (input) {
-      input.autocomplete = 'off';
     }
   }
 
@@ -156,7 +143,7 @@ class AutoComplete extends React.Component {
 
   render() {
     const {
-      emptyLabel,
+      id,
       error,
       initialQuery,
       inputProps,
@@ -171,6 +158,7 @@ class AutoComplete extends React.Component {
     return (
       <div className="foreman-autocomplete">
         <TypeAheadSelect
+          id={id}
           ref={this._typeahead}
           defaultInputValue={initialQuery}
           options={options}
@@ -179,7 +167,6 @@ class AutoComplete extends React.Component {
           onChange={this.handleResultsChange}
           onFocus={this.handleInputFocus}
           onKeyDown={this.handleKeyDown}
-          emptyLabel={emptyLabel}
           placeholder={__(placeholder)}
           renderMenu={(r, menuProps) => (
             <AutoCompleteMenu {...{ results: r, menuProps }} />
@@ -202,6 +189,7 @@ class AutoComplete extends React.Component {
 }
 
 AutoComplete.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   results: PropTypes.array,
   searchQuery: PropTypes.string,
   initialQuery: PropTypes.string,
@@ -215,7 +203,6 @@ AutoComplete.propTypes = {
   initialUpdate: PropTypes.func,
   useKeyShortcuts: PropTypes.bool,
   placeholder: PropTypes.string,
-  emptyLabel: PropTypes.string,
   url: PropTypes.string,
 };
 
@@ -233,7 +220,6 @@ AutoComplete.defaultProps = {
   initialUpdate: noop,
   useKeyShortcuts: true,
   placeholder: 'Filter ...',
-  emptyLabel: null,
   url: null,
 };
 

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -17,10 +17,11 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
     defaultSelected={Array []}
     disabled={false}
     dropup={false}
-    emptyLabel={null}
+    emptyLabel="No matches found."
     filterBy={Array []}
     flip={false}
     highlightOnlyResult={false}
+    id="some-id"
     ignoreDiacritics={true}
     inputProps={
       Object {

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteMenu.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteMenu.js
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import groupBy from 'lodash/groupBy';
 import { TypeAheadSelect } from 'patternfly-react';
 import SubstringWrapper from '../../common/SubstringWrapper';
 
 const { Menu, MenuItem } = TypeAheadSelect;
+const { Divider, Header } = Menu;
 
 const AutoCompleteMenu = ({ results, menuProps }) => {
+  if (results && results.length === 0) {
+    return null;
+  }
+
   let itemIndex = 0;
   const grouped = groupBy(results, r => r.category);
   const getMenuItemsByCategory = category =>
@@ -24,11 +29,11 @@ const AutoCompleteMenu = ({ results, menuProps }) => {
   const items = Object.keys(grouped)
     .sort()
     .map(category => (
-      <React.Fragment key={`${category}-fragment`}>
-        {!!itemIndex && <Menu.Divider key={`${category}-divider`} />}
-        <Menu.Header key={`${category}-header`}>{category}</Menu.Header>
+      <Fragment key={`${category}-fragment`}>
+        {!!itemIndex && <Divider key={`${category}-divider`} />}
+        <Header key={`${category}-header`}>{category}</Header>
         {getMenuItemsByCategory(category)}
-      </React.Fragment>
+      </Fragment>
     ));
   return <Menu {...menuProps}>{items}</Menu>;
 };

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
@@ -3,6 +3,7 @@ export const SearchBarProps = {
     autocomplete: {
       searchQuery: null,
       url: 'model/auto_complete_search',
+      id: 'some-id',
     },
     bookmarks: {
       url: '/api/bookmarks',

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
@@ -16,6 +16,7 @@ const SearchBar = ({
   return (
     <div className="search-bar input-group">
       <AutoComplete
+        id={autocomplete.id}
         handleSearch={() => resolveSearchQuery(searchQuery)}
         initialQuery={autocomplete.searchQuery || ''}
         useKeyShortcuts={autocomplete.useKeyShortcuts}
@@ -40,6 +41,7 @@ SearchBar.propTypes = {
       searchQuery: PropTypes.string,
       url: PropTypes.string,
       useKeyShortcuts: PropTypes.bool,
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     }),
     controller: PropTypes.string,
     bookmarks: PropTypes.shape({ ...Bookmarks.propTypes }),

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -7,6 +7,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
   <Connect(AutoComplete)
     controller="models"
     handleSearch={[Function]}
+    id="some-id"
     initialQuery=""
     url="model/auto_complete_search"
   />

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -56,6 +56,7 @@ exports[`render pageLayout w/search 1`] = `
               Object {
                 "data": Object {
                   "autocomplete": Object {
+                    "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
                   },
@@ -149,6 +150,7 @@ exports[`render pageLayout w/toastNotifications 1`] = `
               Object {
                 "data": Object {
                   "autocomplete": Object {
+                    "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
                   },
@@ -236,6 +238,7 @@ exports[`render pageLayout w/toolBar 1`] = `
               Object {
                 "data": Object {
                   "autocomplete": Object {
+                    "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
                   },
@@ -299,6 +302,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
               Object {
                 "data": Object {
                   "autocomplete": Object {
+                    "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
                   },
@@ -368,6 +372,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
               Object {
                 "data": Object {
                   "autocomplete": Object {
+                    "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
                   },


### PR DESCRIPTION
After `Patternfly-React` has updated `React-Bootstrap-Typeahead` version,
some console warnings were visible:


![selection_026](https://user-images.githubusercontent.com/26363699/53741913-1b95c380-3ea0-11e9-9540-bdf62595c227.png)

