### PR TITLE
Fixes #26253 - Migration to fix the format of vm attributes

### DIFF
--- a/db/migrate/20190305150816_drop_elements_from_vm_attrs_hash.rb
+++ b/db/migrate/20190305150816_drop_elements_from_vm_attrs_hash.rb
@@ -1,0 +1,83 @@
+class DropElementsFromVmAttrsHash < ActiveRecord::Migration[5.1]
+  def up
+    nics = FakeNic.unscoped.where("attrs like ? or compute_attributes like ?", "%elements:%", "%elements:%")
+    if nics.count > 0
+      say "Correcting serialized nics attributes, total #{nics.count}"
+      nics.find_each do |nic|
+        nic.attrs = drop_elements(compute_attribute.attrs)
+        nic.compute_attributes = drop_elements(compute_attribute.compute_attributes)
+        nic.save!(validate: false)
+      end
+    end
+
+    attributes = FakeComputeAttribute.unscoped.where("vm_attrs like ?", "%elements:%")
+    if attributes.count > 0
+      say "Correcting serialized  vm attributes, total #{attributes.count}"
+      attributes.find_each do |compute_attribute|
+        compute_attribute.vm_attrs = drop_elements(compute_attribute.vm_attrs)
+        compute_attribute.save!(validate: false)
+      end
+    end
+
+    compute_resources = FakeComputeResource.unscoped.where("attrs like ?", "%elements:%")
+    if compute_resources.count > 0
+      say "Correcting serialized Compute Resources attributes, total #{compute_resources.count}"
+      compute_resources.find_each do |compute_attribute|
+        compute_attribute.attrs = drop_elements(compute_attribute.attrs)
+        compute_attribute.save!(validate: false)
+      end
+    end
+
+    lookup_keys = FakeLookupKey.unscoped.where("default_value like ?", "%elements:%")
+    if lookup_keys.count > 0
+      say "Correcting serialized Lookup Keys default values, total #{lookup_keys.count}"
+      lookup_keys.find_each do |lk|
+        lk.default_value = drop_elements(compute_attribute.default_value)
+        lk.save!(validate: false)
+      end
+    end
+
+    lookup_key_values = FakeLookupValue.unscoped.where("value like ?", "%elements:%")
+    if lookup_key_values.count > 0
+      say "Correcting serialized Lookup Keys value, total #{lookup_key_values.count}"
+      lookup_key_values.find_each do |lv|
+        lv.value = drop_elements(compute_attribute.value)
+        lv.save!(validate: false)
+      end
+    end
+  end
+
+  def drop_elements(h)
+    h = h['elements'] if h.key? 'elements'
+    h.transform_values! { |v| v.is_a?(Hash) ? drop_elements(v) : v}
+  end
+
+  class FakeNic < ApplicationRecord
+    self.table_name = 'nics'
+    self.inheritance_column = nil
+    serialize :compute_attributes, Hash
+    serialize :attrs, Hash
+  end
+
+  class FakeComputeAttribute < ApplicationRecord
+    self.table_name = 'compute_attributes'
+    serialize :vm_attrs, Hash
+  end
+
+  class FakeComputeResource < ApplicationRecord
+    self.table_name = 'compute_resources'
+    self.inheritance_column = nil
+    serialize :attrs, Hash
+  end
+
+  class FakeLookupValue < ApplicationRecord
+    self.table_name = 'lookup_values'
+    serialize :default_value, Hash
+  end
+
+  class FakeLookupKey < ApplicationRecord
+    self.table_name = 'lookup_keys'
+    self.inheritance_column = nil
+    serialize :value, Hash
+  end
+end


### PR DESCRIPTION
In foreman 1.17 we moved from rails 4.2 to rails 5. 
In Rails 5 ActionController::Parameters no longer inherits from Ruby’s Hash. This broke loading YAML serialized from older Rails version.
and cause the following format:

{"elements"=>
  {"cluster"=>"9222ec39-6ce6-40ea-8c52-782fe8bdaadb",
   "template"=>"",
   "cores"=>"4",
   "memory"=>"3221225472",
   "interfaces_attributes"=>{"elements"=>{"1551688104348"=>{"elements"=>{"name"=>"a", "network"=>"e522e1bf-e3b0-496f-bc6e-952122fb38b3"}, "ivars"=>{"@permitted"=>true}}}, "ivars"=>{"@permitted"=>true}},
   "volumes_attributes"=>
    {"elements"=>{"1551688108883"=>{"elements"=>{"size_gb"=>"1", "storage_domain"=>"cba471b0-7fb1-4fb9-b97a-18afac346368", "id"=>"", "preallocate"=>"1", "bootable"=>"true"}, "ivars"=>{"@permitted"=>true}}},
     "ivars"=>{"@permitted"=>true}}},
 "ivars"=>{"@permitted"=>true}}

