### PR TITLE
Fixes #26259 - Incorect lxcbr0 interface type detection

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,7 +1,7 @@
 class FactParser
   delegate :logger, :to => :Rails
   VIRTUAL = /\A([a-z0-9]+)[_|\.|:]([a-z0-9]+)\Z/
-  BRIDGES = /\A(vir)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
+  BRIDGES = /\A(vir|lxc)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   ALIASES = /(\A[a-z0-9\.]+):([a-z0-9]+)\Z/
   VLANS = /\A([a-z0-9]+)\.([0-9]+)\Z/


### PR DESCRIPTION
Foreman does not detect interface lxcbr0 as a bridge. This interface is automatically pre-configured by LXC-package. Foreman detects this interface as a physical one leading to the wrong network configurations.
