### PR TITLE
Fixes #26260 - Mass assign discovered hosts to seeded taxonomies

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -1,5 +1,5 @@
 # some associations shouldn't be set or require special handling.
-skip_associations = [:associated_audits, :audits, :default_users, :hosts,
+skip_associations = [:associated_audits, :audits, :default_users, :hosts, :discovered_hosts,
                      :location_parameters, :organization_parameters,
                      :taxable_taxonomies, :reports ] + Template.descendants.map {|type| type.to_s.tableize.to_sym}
 
@@ -19,12 +19,14 @@ User.as_anonymous_admin do
 
       # Only default templates are assigned during taxonomy creation
       Template.where(default: false).each do |template|
-        template.send("#{taxonomy.to_s.parameterize.pluralize}=", [tax])
+        template.without_auditing do
+          template.send("#{taxonomy.to_s.parameterize.pluralize}=", [tax])
+        end
       end
 
       # Mass update when we can
       tax_id = "#{taxonomy.to_s.parameterize}_id"
-      Host::Managed.update_all(tax_id => tax.id)
+      Host::Base.update_all(tax_id => tax.id)
       User.update_all("default_#{tax_id}": tax.id)
 
       Setting[:"default_#{taxonomy.to_s.parameterize}"] = tax_name


### PR DESCRIPTION
Otherwise, assignment triggers callbacks and audits for each discobered
host, leading to very long seed time when upgrading with many discovered
hosts and taxonomies disabled.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
