### PR TITLE
Fixes #25809 - JWT auth for external users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'daemons'
 gem 'bcrypt', '~> 3.1'
 gem 'get_process_mem'
 gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
-gem 'jwt', '~> 2.1.0'
+gem 'jwt', '~> 2.2.1'
 gem 'graphql', '~> 1.8.0'
 gem 'graphql-batch'
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -12,8 +12,8 @@ class Setting < ApplicationRecord
   TYPES = %w{integer boolean hash array string}
   FROZEN_ATTRS = %w{name category full_name}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page max_trend outofsync_interval}
-  BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text
-                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list default_locale default_timezone ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local }
+  BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text oidc_audience oidc_issuer oidc_algorithm
+                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list default_locale default_timezone ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local oidc_jwks_url }
   ARRAY_HOSTNAMES = %w{trusted_hosts}
   URI_ATTRS = %w{foreman_url unattended_url}
   URI_BLANK_ATTRS = %w{login_delegation_logout_url}

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -26,6 +26,10 @@ class Setting::Auth < Setting
       self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60, N_('Idle timeout')),
       self.set('bcrypt_cost', N_("Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."), 4, N_('BCrypt password cost')),
       self.set('bmc_credentials_accessible', N_("Permits access to BMC interface passwords through ENC YAML output and in templates"), true, N_('BMC credentials access')),
+      self.set('oidc_jwks_url', N_("OpenID Connect JSON Web Key Set(JWKS) URL. Typically https://keycloak.example.com/auth/realms/<realm name>/protocol/openid-connect/certs when using Keycloak as an IDP"), nil, N_('OIDC JWKs URL')),
+      self.set('oidc_audience', N_("Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."), nil, N_('OIDC Audience')),
+      self.set('oidc_issuer', N_("The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the IDP's."), nil, N_('OIDC Issuer')),
+      self.set('oidc_algorithm', N_("The algorithm used to encode the JWT in the IDP."), nil, N_('OIDC Algorithm')),
     ]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,10 +299,10 @@ class User < ApplicationRecord
         user.usergroups = new_usergroups.uniq
       end
 
-      return true
+      return user
     # not existing user and creating is disabled by settings
     elsif auth_source_name.nil?
-      return false
+      return nil
     # not existing user and auth source is set, we'll create the user and auth source if needed
     else
       User.as_anonymous_admin do
@@ -315,7 +315,7 @@ class User < ApplicationRecord
         end
         user.post_successful_login
       end
-      return true
+      return user
     end
   end
 

--- a/app/services/jwt_token.rb
+++ b/app/services/jwt_token.rb
@@ -33,6 +33,11 @@ class JwtToken < Struct.new(:token)
     token
   end
 
+  # This method does not verify if the token signature is valid
+  def decoded_payload
+    @decoded_payload ||= JWT.decode(token, nil, false).first
+  end
+
   private
 
   def secret
@@ -42,10 +47,5 @@ class JwtToken < Struct.new(:token)
 
   def user_id
     @user_id ||= decoded_payload['user_id']
-  end
-
-  # This method does not verify if the token signature is valid
-  def decoded_payload
-    @decoded_payload ||= JWT.decode(token, nil, false).first
   end
 end

--- a/app/services/oidc_jwt.rb
+++ b/app/services/oidc_jwt.rb
@@ -1,0 +1,6 @@
+class OidcJwt < JwtToken
+  def decode
+    return if token.blank?
+    OidcJwtValidate.new(token).decoded_payload
+  end
+end

--- a/app/services/oidc_jwt_validate.rb
+++ b/app/services/oidc_jwt_validate.rb
@@ -1,0 +1,50 @@
+class OidcJwtValidate
+  attr_reader :decoded_token
+  delegate :logger, to: :Rails
+
+  def initialize(jwt_token)
+    @jwt_token = jwt_token
+  end
+
+  def decoded_payload
+    # OpenSSL#set_key method does not support ruby version < 2.4.0, apparently the JWT gem uses
+    # OpenSSL#set_key method for all ruby version. We must remove this condition once new version
+    # of the JWT(2.2.2) is released.
+    unless OpenSSL::PKey::RSA.new.respond_to?(:set_key)
+      Foreman::Logging.logger('app').error "SSO feature is not available for Ruby < 2.4.0"
+      return nil
+    end
+    JWT.decode(@jwt_token, nil, true,
+      { aud: Setting['oidc_audience'],
+        verify_aud: true,
+        iss: Setting['oidc_issuer'],
+        verify_iss: true,
+        algorithms: [Setting['oidc_algorithm']],
+        jwks: jwks_loader }
+    ).first
+  rescue JWT::DecodeError => e
+    Foreman::Logging.exception('Failed to decode JWT', e)
+    nil
+  end
+
+  private
+
+  def jwks_loader(options = {})
+    response = RestClient::Request.execute(
+      :url => Setting['oidc_jwks_url'],
+      :method => :get,
+      :verify_ssl => true
+    )
+    json_response = JSON.parse(response)
+    if json_response.is_a?(Hash)
+      jwks_keys = json_response['keys']
+      { keys: jwks_keys.map(&:symbolize_keys) }
+    else
+      Foreman::Logging.logger('app').error "Invalid JWKS response."
+      {}
+    end
+  rescue RestClient::Exception, SocketError, JSON::ParserError => e
+    Foreman::Logging.exception('Failed to load the JWKS', e)
+    {}
+  end
+end

--- a/app/services/sso.rb
+++ b/app/services/sso.rb
@@ -1,5 +1,5 @@
 module SSO
-  METHODS = [Apache, Basic, Jwt, Oauth]
+  METHODS = [Apache, Basic, Jwt, Oauth, OpenidConnect]
 
   def self.get_available(controller)
     all_methods = all.map { |method| method.new(controller) }

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -3,7 +3,7 @@ module SSO
     attr_reader :current_user
 
     def available?
-      controller.api_request? && bearer_token_set?
+      controller.api_request? && bearer_token_set? && no_issuer?
     end
 
     def authenticate!
@@ -34,6 +34,10 @@ module SSO
 
     def bearer_token_set?
       request.authorization.present? && request.authorization.start_with?('Bearer')
+    end
+
+    def no_issuer?
+      !jwt_token.decoded_payload.key?('iss')
     end
   end
 end

--- a/app/services/sso/openid_connect.rb
+++ b/app/services/sso/openid_connect.rb
@@ -1,0 +1,58 @@
+module SSO
+  class OpenidConnect < Base
+    delegate :session, :to => :controller
+    attr_reader :current_user
+
+    def available?
+      controller.api_request? && bearer_token_set? && valid_issuer?
+    end
+
+    def authenticate!
+      payload = jwt_token.decode
+      return nil if payload.nil?
+      user = find_or_create_user_from_jwt(payload)
+      @current_user = user
+      update_session(payload)
+      user&.login
+    end
+
+    def authenticated?
+      self.user = User.current.presence || authenticate!
+    end
+
+    private
+
+    def jwt_token
+      @jwt_token ||= jwt_token_from_request
+    end
+
+    def jwt_token_from_request
+      token = request.authorization.split(' ')[1]
+      OidcJwt.new(token)
+    end
+
+    def bearer_token_set?
+      request.authorization.present? && request.authorization.start_with?('Bearer')
+    end
+
+    def valid_issuer?
+      payload = jwt_token.decoded_payload
+      payload.key?('iss') && (payload['iss'] == Setting['oidc_issuer'])
+    end
+
+    def update_session(payload)
+      session[:sso_method] = self.class.to_s
+      session[:expires_at] = payload['exp']
+    end
+
+    def find_or_create_user_from_jwt(payload)
+      User.find_or_create_external_user(
+        { login: payload['preferred_username'],
+          mail: payload['email'],
+          firstname: payload['given_name'],
+          lastname: payload['family_name']},
+        Setting['authorize_login_delegation_auth_source_user_autocreate']
+      )
+    end
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -404,3 +404,28 @@ attribute87:
   category: Setting::General
   default: '2abbbe02-4ace-4269-9e20-2753f3206cc2'
   description: 'Foreman UUID'
+attribute88:
+  name: oidc_jwks_url
+  category: Setting::Auth
+  default: 'https://keycloak.example.com/auth/realms/foreman/protocol/openid-connect/certs'
+  description: 'OpenID Connect JSON Web Key Set(JWKS) URL. Typically https://keycloak.example.com/auth/realms/<realm name>/protocol/openid-connect/certs if you are using Keycloak as an IDP'
+attribute89:
+  name: oidc_audience
+  category: Setting::Auth
+  default: 'rest-client'
+  description: 'Name of the OpenID Connect Audience that is being used for Authentication. For example in case of Keycloak this is the Client ID.'
+attribute90:
+  name: oidc_issuer
+  category: Setting::Auth
+  default: 127.0.0.1
+  description: "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the IDP's."
+attribute91:
+  name: oidc_algorithm
+  category: Setting::Auth
+  default: 'RS512'
+  description: 'The algorithm used to encode the JWT in the IDP.'
+attribute92:
+  name: authorize_login_delegation_auth_source_user_autocreate
+  category: Setting::Auth
+  default: 'External'
+  description: 'Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'

--- a/test/unit/oidc_jwt_validate_test.rb
+++ b/test/unit/oidc_jwt_validate_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+require 'ostruct'
+require 'openssl'
+require 'jwt'
+
+class OidcJwtValidateTest < ActiveSupport::TestCase
+  context '#decoded_payload?' do
+    def setup
+      skip "SSO feature is not available for Ruby < 2.4.0" unless RUBY_VERSION >= '2.4'
+      @jwk ||= JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+      exp = Time.now.to_i + 4 * 3600
+      payload, headers = { "name": "jwt token", "iat": 1557224758, "exp": exp, "typ": "Bearer", "aud": "rest-client", "iss": "127.0.0.1"}, { kid: @jwk.kid }
+
+      @token = JWT.encode(payload, @jwk.keypair, 'RS512', headers)
+      @decoded_payload = payload.with_indifferent_access
+    end
+
+    test 'if valid jwk json is passed' do
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [@jwk.export]}.to_json)
+      actual = OidcJwtValidate.new(@token).decoded_payload
+      expected = @decoded_payload
+      assert_equal expected, actual
+    end
+
+    test 'must decode with valid signature and claims' do
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [@jwk.export]}.to_json)
+      actual = OidcJwtValidate.new(@token).decoded_payload
+      expected = @decoded_payload
+      assert_equal expected, actual
+    end
+
+    test 'if signature is not valid' do
+      other_jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [other_jwk.export]}.to_json)
+      actual = OidcJwtValidate.new(@token).decoded_payload
+      expected = nil
+      assert_nil expected, actual
+    end
+
+    test 'if audience is not valid' do
+      Setting['oidc_audience'] = "no-client"
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [@jwk.export]}.to_json)
+      actual = OidcJwtValidate.new(@token).decoded_payload
+      expected = nil
+      assert_nil expected, actual
+      Setting['oidc_audience'] = "rest-client"
+    end
+
+    test 'if token has expired' do
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [@jwk.export]}.to_json)
+      actual = travel 1.day do
+        OidcJwtValidate.new(@token).decoded_payload
+      end
+      expected = nil
+      assert_nil expected, actual
+    end
+
+    test 'with invalid token' do
+      other_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjMsImlhdCI6MTUxNDgwNDQwMCwianRpIjoiM2U4Mjg2OTQwZWIxNjJlYzczNWY4YTVhYWM1OTI2MDM3ZmRjN2YwNWU1MjFhNzQyMzFhNjVmMjU1N2E4YWY5NCJ9.TSM2xMnMuMEWwAVoIidyLIwJElJQZVQvcfaxyVA7cDI'
+      stub_request(:get, Setting['oidc_jwks_url'])
+        .to_return(body: {"keys": [@jwk.export]}.to_json)
+      actual = OidcJwtValidate.new(other_token).decoded_payload
+      expected = nil
+      assert_nil expected, actual
+    end
+  end
+end

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -53,7 +53,7 @@ class ApacheTest < ActiveSupport::TestCase
     apache.controller.request.env['REMOTE_USER_LASTNAME']  = 'Bar'
     User.expects(:find_or_create_external_user).
         with({:login => 'ares', :mail => 'foobar@example.com', :firstname => 'Foo', :lastname => 'Bar'}, 'apache').
-        returns(true)
+        returns(User.new)
     assert apache.authenticated?
   end
 
@@ -68,7 +68,7 @@ class ApacheTest < ActiveSupport::TestCase
     apache.controller.request.env['REMOTE_USER_GROUP_2']     = 'does-not-exist-for-sure'
     User.expects(:find_or_create_external_user).
         with({:login => 'ares', :groups => [existing.name, 'does-not-exist-for-sure']}, 'apache').
-        returns(true)
+        returns(User.new)
     assert apache.authenticated?
   end
 

--- a/test/unit/sso/jwt_test.rb
+++ b/test/unit/sso/jwt_test.rb
@@ -6,7 +6,7 @@ class JwtTest < ActiveSupport::TestCase
   end
 
   context 'api request' do
-    let(:token) { 'invalid' }
+    let(:token) { users(:one).jwt_token! }
     let(:controller) { get_controller(true, token) }
     let(:sso) { SSO::Jwt.new(controller) }
 
@@ -22,8 +22,6 @@ class JwtTest < ActiveSupport::TestCase
     end
 
     context 'with valid token' do
-      let(:token) { users(:one).jwt_token! }
-
       test '#authenticate! authenticates a user' do
         assert_equal users(:one).login, sso.authenticated?
         assert_equal users(:one).login, sso.user
@@ -32,6 +30,7 @@ class JwtTest < ActiveSupport::TestCase
     end
 
     context 'with invalid token' do
+      let(:token) { 'invalid' }
       test '#authenticate! does not set user' do
         assert_nil sso.authenticated?
         assert_nil sso.user
@@ -64,6 +63,7 @@ class JwtTest < ActiveSupport::TestCase
   def get_controller(api_request, jwt_token = 'invalid', headers = {})
     controller = Struct.new(:request).new(Struct.new(:authorization, :headers).new("Bearer #{jwt_token}", headers))
     controller.stubs(:api_request?).returns(api_request)
+    controller.stubs(:session).returns(ActionController::TestSession.new)
     controller
   end
 end

--- a/test/unit/sso/openid_connect_test.rb
+++ b/test/unit/sso/openid_connect_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+require 'securerandom'
+
+class OpenidConnectTest < ActiveSupport::TestCase
+  # Generates token: "eyJhbGciOiJub25lIn0.eyJuYW1lIjoiand0IHRva2VuIiwiaWF0IjoxNTU3MjI0NzU4LCJleHAiOjE1NjgyMzc4NzcsInR5cCI6IkJlYXJlciIsImF1ZCI6InJlc3QtY2xpZW50IiwiaXNzIjoiMTI3LjAuMC4xIn0."
+  let(:payload) do
+    { "name": "jwt token",
+      "iat": 1557224758,
+      "exp": Time.now.to_i + 4 * 3600,
+      "typ": "Bearer",
+      "aud": "rest-client",
+      "iss": "127.0.0.1",
+      "preferred_username": "jwt",
+      "email": "jwt@test.com",
+      "given_name": "jwt",
+      "family_name": "family" }
+  end
+
+  let(:decoded_payload) do
+    payload.with_indifferent_access
+  end
+
+  describe '#available?' do
+    test 'returns false when not a api_request' do
+      subject = SSO::OpenidConnect.new(non_api_controller)
+      assert_equal subject.available?, false
+    end
+
+    test "returns true when api request contain valid JWT token" do
+      token = JWT.encode(payload, nil, 'none')
+      controller = api_controller({:authorization => "Bearer #{token}"})
+      subject = SSO::OpenidConnect.new(controller)
+      assert_equal subject.available?, true
+    end
+
+    test "returns true when api request contain invalid JWT token" do
+      invalid_payload = payload
+      invalid_payload['iss'] = "random_value"
+      token = JWT.encode(invalid_payload, nil, 'none')
+      controller = api_controller({:authorization => "Bearer #{token}"})
+      subject = SSO::OpenidConnect.new(controller)
+      assert_equal subject.available?, false
+    end
+
+    test "returns false if api request does not contain JWT token" do
+      controller = api_controller()
+      subject = SSO::OpenidConnect.new(controller)
+      assert_equal subject.available?, false
+    end
+  end
+
+  describe "#authenticated?" do
+    let(:subject) do
+      token = JWT.encode(payload, nil, 'none')
+      SSO::OpenidConnect.new api_controller({:authorization => "Bearer #{token}"})
+    end
+
+    test "it returns nil for Ruby < 2.4.0" do
+      skip if RUBY_VERSION >= '2.4'
+      User.current = nil
+      assert_equal subject.authenticated?, nil
+    end
+
+    test "it authenticates and sets user when currect user does not exists" do
+      skip "SSO feature is not available for Ruby < 2.4.0" unless RUBY_VERSION >= '2.4'
+      User.current = nil
+      OidcJwt.any_instance.stubs(:decode).returns(decoded_payload)
+      assert_equal subject.authenticated?, decoded_payload['preferred_username']
+      assert subject.current_user.is_a?(User)
+      assert_equal subject.current_user.login, decoded_payload['preferred_username']
+    end
+
+    test "it sets user to current_user when currrent_user exists" do
+      as_user(:one) do
+        subject.expects(:authenticate!).never
+        assert_equal users(:one), subject.authenticated?
+      end
+    end
+  end
+
+  private
+
+  def non_api_controller
+    controller = Struct.new(:request) do
+      def api_request?
+        false
+      end
+    end
+    controller.new(ActionDispatch::TestRequest.new({}))
+  end
+
+  def api_controller(headers = {})
+    controller = Struct.new(:request, :session) do
+      def api_request?
+        true
+      end
+    end
+    request = ActionDispatch::TestRequest.new({})
+    request.headers.merge! headers
+    session = {}
+    controller.new(request, session)
+  end
+end


### PR DESCRIPTION
This pr enables Foreman to act as a consumer of the JWT token. It makes sure that an external user, authenticated via a third party application(in my case keycloak), can be created using the JWT token(without the need of a password).