### PR TITLE
Fixes #26280 - preserving selection of related network

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -768,6 +768,8 @@ function selectRelatedNetwork(element) {
 
   if (selected !== null) {
     network_select.val(selected).trigger('change');
+    preserve_selected_options(network_select);
+    update_interface_table();
   }
 }
 


### PR DESCRIPTION
Fixes this behaviour, which is caused by hostgroup selection with subnet setted on one with vlanid, which preselects a vmware network, but only in the hidden interface form, not in the table.

This is happening:
![Before](https://user-images.githubusercontent.com/2884324/54002413-c9c69500-414e-11e9-8bee-225b4c6d25a9.gif)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
