### PR TITLE
Fixes #26285 - Display IPv6 subnet in NIC overview

### DIFF
--- a/app/views/hosts/_nics.html.erb
+++ b/app/views/hosts/_nics.html.erb
@@ -36,6 +36,12 @@
         <td><%= link_to_if_authorized nic.subnet.to_label, hash_for_edit_subnet_path(:id => nic.subnet).merge(:auth_object => nic.subnet, :authorizer => authorizer) %></td>
       </tr>
     <% end %>
+    <% if nic.subnet6 %>
+      <tr>
+        <td><%= _('IPv6 Subnet') %></td>
+        <td><%= link_to_if_authorized nic.subnet6.to_label, hash_for_edit_subnet_path(:id => nic.subnet6).merge(:auth_object => nic.subnet6, :authorizer => authorizer) %></td>
+      </tr>
+    <% end %>
   </table>
   <br>
 <% end %>


### PR DESCRIPTION
This adds the IPv6 subnet to the NIC overview
![image](https://user-images.githubusercontent.com/15357734/54083710-b4f12980-4327-11e9-871a-b412e17d5023.png)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
