### PR TITLE
Fixes #26287 - Add a loader of global js files for plugins

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -9,6 +9,10 @@ module ReactjsHelper
     js_tags_for(select_requested_plugins(plugin_names)).join.html_safe
   end
 
+  def webpacked_plugins_with_global_js
+    js_tags_for_global_files(Foreman::Plugin.with_global_js.map { |plugin| { id: plugin.id, files: plugin.global_js_files } }).join.html_safe
+  end
+
   def webpacked_plugins_css_for(*plugin_names)
     css_tags_for(select_requested_plugins(plugin_names)).join.html_safe
   end
@@ -26,6 +30,14 @@ module ReactjsHelper
   def js_tags_for(requested_plugins)
     requested_plugins.map do |plugin|
       javascript_include_tag(*webpack_asset_paths(plugin.to_s, :extension => 'js'), "data-turbolinks-track" => true)
+    end
+  end
+
+  def js_tags_for_global_files(requested_plugins)
+    requested_plugins.map do |plugin|
+      plugin[:files].map do |file|
+        javascript_include_tag(*webpack_asset_paths(plugin[:id].to_s + ":#{file}", :extension => 'js'), "data-turbolinks-track" => true, :defer => "defer")
+      end
     end
   end
 

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -111,10 +111,15 @@ module Foreman #:nodoc:
       def with_webpack
         all.select(&:uses_webpack?)
       end
+
+      def with_global_js
+        with_webpack.select { |plugin| plugin.global_js_files.present? }
+      end
     end
 
     prepend Foreman::Plugin::Assets
     prepend Foreman::Plugin::SearchOverrides
+    prepend Foreman::Plugin::GlobalJs
 
     def_field :name, :description, :url, :author, :author_url, :version, :path
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,

--- a/app/registries/foreman/plugin/global_js.rb
+++ b/app/registries/foreman/plugin/global_js.rb
@@ -1,0 +1,16 @@
+module Foreman
+  class Plugin
+    module GlobalJs
+      attr_reader :global_js_files
+
+      def initialize(id)
+        super
+        @global_js_files = []
+      end
+
+      def register_global_js_file(file)
+        @global_js_files << file
+      end
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -33,6 +33,7 @@
     <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>
+    <%= webpacked_plugins_with_global_js %>
     <%= webpack_dev_server %>
     <%= yield(:javascripts) %>
 

--- a/test/helpers/reactjs_helper_test.rb
+++ b/test/helpers/reactjs_helper_test.rb
@@ -39,4 +39,13 @@ class ReactjsHelperTest < ActionView::TestCase
     assert res.include?('webpack/foreman_react.js')
     assert res.include?('webpack/foreman_angular.js')
   end
+
+  test "should be able to load global js in foreman core" do
+    Foreman::Plugin.register :plugin_with_global_js do
+      register_global_js_file 'some_global_file'
+    end
+
+    res = webpacked_plugins_with_global_js
+    assert res.include?('webpack/plugin_with_global_js:some_global_file.js')
+  end
 end


### PR DESCRIPTION
For extendable react components and a global client routing, foreman needs a mechanism for loading  plugin's global js files as described [here](https://community.theforeman.org/t/rfc-expandable-component-architecture/12083/21)

For example, `Katello` would like to add some react content into `host show page` via Slot&Fill
katello just register its global fills file with
```rb
    Foreman::Plugin.register :katello do
     # content...
      register_global_file 'fills'
    end
```

and by that, foreman will load `katello:fills.js` globally.
