### PR TITLE
Fixes #26290 - graphql: query objects by global id

### DIFF
--- a/app/graphql/queries/authorized_model_query.rb
+++ b/app/graphql/queries/authorized_model_query.rb
@@ -17,6 +17,11 @@ module Queries
       end
     end
 
+    def find_by_global_id(global_id)
+      id = Foreman::GlobalId.decode(global_id).last
+      find_by(id: id)
+    end
+
     private
 
     attr_reader :model_class, :user

--- a/app/graphql/queries/fetch_field.rb
+++ b/app/graphql/queries/fetch_field.rb
@@ -2,7 +2,7 @@ module Queries
   class FetchField < GraphQL::Function
     attr_reader :type
 
-    argument(:id, !types.Int, 'ID for Record')
+    argument(:id, !types.String, 'ID for Record')
 
     def initialize(model_class:, type:)
       @model_class = model_class
@@ -11,7 +11,7 @@ module Queries
 
     def call(_, args, ctx)
       Queries::AuthorizedModelQuery.new(model_class: @model_class, user: ctx[:current_user])
-                                   .find_by(id: args['id'])
+                                   .find_by_global_id(args['id'])
     end
   end
 end

--- a/app/services/foreman/global_id.rb
+++ b/app/services/foreman/global_id.rb
@@ -21,5 +21,9 @@ module Foreman
       type_name, object_value = payload.split(ID_SEPARATOR, 2)
       [version.to_i, type_name, object_value]
     end
+
+    def self.for(obj)
+      encode(obj.class.name, obj.id)
+    end
   end
 end

--- a/test/graphql/queries/model_query_test.rb
+++ b/test/graphql/queries/model_query_test.rb
@@ -6,9 +6,9 @@ class Queries::ModelQueryTest < ActiveSupport::TestCase
 
     query = <<-GRAPHQL
       query modelQuery (
-        $modelId: Int!
+        $id: String!
       ) {
-        model(id: $modelId) {
+        model(id: $id) {
           id
           name
           info
@@ -18,15 +18,14 @@ class Queries::ModelQueryTest < ActiveSupport::TestCase
       }
     GRAPHQL
 
+    model_global_id = Foreman::GlobalId.for(model)
     context = { current_user: FactoryBot.create(:user, :admin) }
-    variables = { modelId: model.id }
+    variables = { id: model_global_id }
 
     result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
 
-    expected_id = Foreman::GlobalId.encode('Model', model.id)
-
     expected_model_attributes = {
-      'id' => expected_id,
+      'id' => model_global_id,
       'name' => model.name,
       'info' => model.info,
       'vendorClass' => model.vendor_class,

--- a/test/graphql/queries/models_query_test.rb
+++ b/test/graphql/queries/models_query_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Queries::ModelsQueryTest < ActiveSupport::TestCase
   test 'fetching models attributes and relations' do
-    model = FactoryBot.create(:model)
+    FactoryBot.create_list(:model, 2)
 
     query = <<-GRAPHQL
       query modelsQuery {
@@ -17,10 +17,6 @@ class Queries::ModelsQueryTest < ActiveSupport::TestCase
             cursor
             node {
               id
-              name
-              info
-              vendorClass
-              hardwareModel
             }
           }
         }
@@ -31,17 +27,7 @@ class Queries::ModelsQueryTest < ActiveSupport::TestCase
 
     result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
 
-    expected_id = Foreman::GlobalId.encode('Model', model.id)
-
-    expected_model_attributes = {
-      'id' => expected_id,
-      'name' => model.name,
-      'info' => model.info,
-      'vendorClass' => model.vendor_class,
-      'hardwareModel' => model.hardware_model
-    }
-
     assert_empty result['errors']
-    assert_includes result['data']['models']['edges'].map { |e| e['node'] }, expected_model_attributes
+    assert_equal Model.count, result['data']['models']['edges'].count
   end
 end


### PR DESCRIPTION
This patch allows querying for a specific object by its global id

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
