### PR TITLE
Fixes #26307 - vmware network guessing

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -749,12 +749,14 @@ function interface_subnet_selected(element, ip_field, skip_mac) {
   });
 }
 
-function selectRelatedNetwork(element) {
-  var subnet_select = $(element);
+function selectRelatedNetwork(subnetElement) {
+  var subnet_select = $(subnetElement);
   var vlanId = subnet_select.find(':selected').attr('data-vlan_id');
   var network_select = subnet_select.closest('fieldset').find('.vmware_network,.ovirt_network');
+  var isVisible = subnet_select.closest('#interfaceModal').length > 0;
+  var isPreSelected = network_select.find("option[selected]").length > 0;
 
-  if (!vlanId || network_select.length == 0) {
+  if ((!isVisible && isPreSelected) || !vlanId || network_select.length == 0) {
     return;
   }
 


### PR DESCRIPTION
There is a guessing of network, which overrides every user selection.
This fix make sure, the guess from subnet vlanid is made only if there was no selection made yet.
So the guessing is just as a last measure.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
