### PR TITLE
Fixes #26265 - graphql: add Operatingsystem queries

### DIFF
--- a/app/graphql/resolvers/concerns/collection.rb
+++ b/app/graphql/resolvers/concerns/collection.rb
@@ -4,7 +4,7 @@ module Resolvers
       extend ActiveSupport::Concern
 
       included do
-        type ["Types::#{self::MODEL_CLASS}".constantize], null: false
+        type ["Types::#{self::MODEL_CLASS}".safe_constantize], null: false
 
         argument :search, String, 'Search query', required: false
         argument :order_by, String, 'Order by this field', required: false

--- a/app/graphql/resolvers/concerns/record.rb
+++ b/app/graphql/resolvers/concerns/record.rb
@@ -4,7 +4,7 @@ module Resolvers
       extend ActiveSupport::Concern
 
       included do
-        type "Types::#{self::MODEL_CLASS}".constantize, null: false
+        type "Types::#{self::MODEL_CLASS}".safe_constantize, null: false
 
         argument :id, String, 'Global ID for Record', required: true
       end

--- a/app/graphql/resolvers/operatingsystem.rb
+++ b/app/graphql/resolvers/operatingsystem.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Operatingsystem < BaseResolver
+    MODEL_CLASS = ::Operatingsystem
+
+    include Concerns::Record
+  end
+end

--- a/app/graphql/resolvers/operatingsystems.rb
+++ b/app/graphql/resolvers/operatingsystems.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Operatingsystems < BaseResolver
+    MODEL_CLASS = ::Operatingsystem
+
+    include Concerns::Collection
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,4 +1,8 @@
 module Types
   class BaseObject < GraphQL::Types::Relay::BaseObject
+    def self.timestamps
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+    end
   end
 end

--- a/app/graphql/types/location.rb
+++ b/app/graphql/types/location.rb
@@ -3,6 +3,7 @@ module Types
     description 'A Location'
 
     global_id_field :id
+    timestamps
     field :name, String, null: true
     field :title, String, null: true
   end

--- a/app/graphql/types/model.rb
+++ b/app/graphql/types/model.rb
@@ -2,10 +2,8 @@ module Types
   class Model < BaseObject
     description 'A Model'
 
-    implements GraphQL::Relay::Node.interface
-
     global_id_field :id
-
+    timestamps
     field :name, String, null: false
     field :info, String, null: true
     field :vendorClass, String, null: true

--- a/app/graphql/types/operatingsystem.rb
+++ b/app/graphql/types/operatingsystem.rb
@@ -1,0 +1,12 @@
+module Types
+  class Operatingsystem < BaseObject
+    description 'An Operatingsystem'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: true
+    field :title, String, null: true
+    field :type, String, null: true
+    field :fullname, String, null: true
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -10,5 +10,8 @@ module Types
 
     field :location, Types::Location, resolver: Resolvers::Location
     field :locations, Types::Location.connection_type, resolver: Resolvers::Locations
+
+    field :operatingsystem, Types::Operatingsystem, resolver: Resolvers::Operatingsystem
+    field :operatingsystems, Types::Operatingsystem.connection_type, resolver: Resolvers::Operatingsystems
   end
 end

--- a/test/graphql/queries/location_query_test.rb
+++ b/test/graphql/queries/location_query_test.rb
@@ -10,6 +10,8 @@ class Queries::LocationQueryTest < ActiveSupport::TestCase
       ) {
         location(id: $id) {
           id
+          createdAt
+          updatedAt
           name
           title
         }
@@ -24,6 +26,8 @@ class Queries::LocationQueryTest < ActiveSupport::TestCase
     expected = {
       'location' => {
         'id' => location_global_id,
+        'createdAt' => location.created_at.utc.iso8601,
+        'updatedAt' => location.updated_at.utc.iso8601,
         'name' => location.name,
         'title' => location.title
       }

--- a/test/graphql/queries/model_query_test.rb
+++ b/test/graphql/queries/model_query_test.rb
@@ -10,6 +10,8 @@ class Queries::ModelQueryTest < ActiveSupport::TestCase
       ) {
         model(id: $id) {
           id
+          createdAt
+          updatedAt
           name
           info
           vendorClass
@@ -27,6 +29,8 @@ class Queries::ModelQueryTest < ActiveSupport::TestCase
     expected = {
       'model' => {
         'id' => model_global_id,
+        'createdAt' => model.created_at.utc.iso8601,
+        'updatedAt' => model.updated_at.utc.iso8601,
         'name' => model.name,
         'info' => model.info,
         'vendorClass' => model.vendor_class,

--- a/test/graphql/queries/nodes_query_test.rb
+++ b/test/graphql/queries/nodes_query_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Queries::NodesQueryTest < ActiveSupport::TestCase
   test 'fetching node by relay global id' do
     model = FactoryBot.create(:model)
-    global_id = Foreman::GlobalId.encode('Model', model.id)
+    global_id = Foreman::GlobalId.for(model)
 
     query = <<-GRAPHQL
       query getNode {
@@ -31,7 +31,7 @@ class Queries::NodesQueryTest < ActiveSupport::TestCase
 
   test 'fetching multiple nodes by relay global id' do
     model = FactoryBot.create(:model)
-    global_id = Foreman::GlobalId.encode('Model', model.id)
+    global_id = Foreman::GlobalId.for(model)
 
     query = <<-GRAPHQL
       query getNodes {

--- a/test/graphql/queries/operatingsystem_query_test.rb
+++ b/test/graphql/queries/operatingsystem_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Queries::OperatingsystemQueryTest < ActiveSupport::TestCase
+  test 'fetching operatingsystem attributes' do
+    operatingsystem = FactoryBot.create(:operatingsystem)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        operatingsystem(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          title
+          type
+          fullname
+        }
+      }
+    GRAPHQL
+
+    operatingsystem_global_id = Foreman::GlobalId.for(operatingsystem)
+    variables = { id: operatingsystem_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'operatingsystem' => {
+        'id' => operatingsystem_global_id,
+        'createdAt' => operatingsystem.created_at.utc.iso8601,
+        'updatedAt' => operatingsystem.updated_at.utc.iso8601,
+        'name' => operatingsystem.name,
+        'title' => operatingsystem.title,
+        'type' => operatingsystem.type,
+        'fullname' => operatingsystem.fullname
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/operatingsystems_query_test.rb
+++ b/test/graphql/queries/operatingsystems_query_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Queries::OperatingsystemsQueryTest < ActiveSupport::TestCase
+  test 'fetching operatingsystems attributes' do
+    FactoryBot.create_list(:operatingsystem, 2)
+
+    query = <<-GRAPHQL
+      query {
+        operatingsystems {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    assert_empty result['errors']
+    assert_equal Operatingsystem.count, result['data']['operatingsystems']['edges'].count
+  end
+end


### PR DESCRIPTION
This patch adds Operatingsystem queries to the GraphQL api

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
