### PR TITLE
Fixes #26327 - Deprecate confirm option in link_to helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,7 @@ module ApplicationHelper
       html_options[:'data-id'] = "aid_#{id}" unless id.empty?
     end
     if html_options[:confirm]
+      Foreman::Deprecation.deprecation_warning('1.24', 'passing :confirm parameter in html_options to link_to is deprecated. Please use `data: {confirm: "confirmation message?"}` instead.')
       html_options[:data] ||= {}
       html_options[:data][:confirm] = html_options.delete(:confirm)
     end

--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -2,7 +2,7 @@ module ComputeResourcesVmsHelper
   def vm_power_actions(host, vm)
     button_group(
       if vm
-        html_opts = vm.ready? ? {:confirm => _('Are you sure?'), :class => "btn btn-danger"} : {:class => "btn btn-success"}
+        html_opts = vm.ready? ? {:data => {:confirm => _('Are you sure?')}, :class => "btn btn-danger"} : {:class => "btn btn-success"}
         link_to_if_authorized _("Power%s") % state(vm.ready?), hash_for_power_host_path(:power_action => vm.ready? ? :stop : :start).merge(:auth_object => host, :permission => 'power_hosts'),
         html_opts.merge(:method => :put)
       else

--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -35,13 +35,13 @@ module ProvisioningTemplatesHelper
       ].compact
 
       actions << display_link_if_authorized(_('Unlock'), template_hash_for_member(template, 'unlock'),
-                                            {:confirm => confirm.join(" "), :style => 'color: red'})
+                                            {:data => {:confirm => confirm.join(" ")}, :style => 'color: red'})
 
     else
       actions << display_link_if_authorized(_('Lock'), template_hash_for_member(template, 'lock'))
       actions << display_delete_if_authorized(template_hash_for_member(template).
          merge(:auth_object => template, :authorizer => authorizer, :permission => "destroy_#{@type_name_plural}"),
-         :confirm => _("Delete %s?") % template)
+         :data => {:confirm => _("Delete %s?") % template})
     end
   end
 

--- a/app/views/config_reports/_list.html.erb
+++ b/app/views/config_reports/_list.html.erb
@@ -35,7 +35,7 @@
         <td><%= report_event_column(report.pending, "label-info") %></td>
         <td>
           <%= action_buttons(display_delete_if_authorized hash_for_config_report_path(:id => report).merge(:auth_object => report, :authorizer => authorizer),
-                                           :confirm => _("Delete report for %s?") % report.host.try(:name)) %>
+                             :data => {:confirm => _("Delete report for %s?") % report.host.try(:name)}) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/provisioning_templates/index.html.erb
+++ b/app/views/provisioning_templates/index.html.erb
@@ -2,7 +2,7 @@
 
 <% title_actions new_link(_("Create Template")),
                  display_link_if_authorized(_("Build PXE Default"), { :controller => 'provisioning_templates', :action => :build_pxe_default },{
-                   :confirm => _("You are about to change the default PXE menu on all configured TFTP servers - continue?"),
+                   :data => {:confirm => _("You are about to change the default PXE menu on all configured TFTP servers - continue?")},
                    :class => "btn btn-default"}),
                 documentation_button('4.4.3ProvisioningTemplates')
 %>


### PR DESCRIPTION
This was introduced as a workaround when upgrading to rails 4 and stayed
around since then. It's about time we stop supporting it and start using
the rails 4+ way.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
