### PR TITLE
Fixes #26289 - graphql: add Usergroup queries

### DIFF
--- a/app/graphql/resolvers/usergroup.rb
+++ b/app/graphql/resolvers/usergroup.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Usergroup < BaseResolver
+    MODEL_CLASS = ::Usergroup
+
+    include Concerns::Record
+  end
+end

--- a/app/graphql/resolvers/usergroups.rb
+++ b/app/graphql/resolvers/usergroups.rb
@@ -1,0 +1,7 @@
+module Resolvers
+  class Usergroups < BaseResolver
+    MODEL_CLASS = ::Usergroup
+
+    include Concerns::Collection
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -16,5 +16,8 @@ module Types
 
     field :subnet, Types::Subnet, resolver: Resolvers::Subnet
     field :subnets, Types::Subnet.connection_type, resolver: Resolvers::Subnets
+
+    field :usergroup, Types::Usergroup, resolver: Resolvers::Usergroup
+    field :usergroups, Types::Usergroup.connection_type, resolver: Resolvers::Usergroups
   end
 end

--- a/app/graphql/types/usergroup.rb
+++ b/app/graphql/types/usergroup.rb
@@ -1,0 +1,10 @@
+module Types
+  class Usergroup < BaseObject
+    description 'A Usergroup'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: false
+    field :admin, Boolean, null: false
+  end
+end

--- a/test/graphql/queries/usergroup_query_test.rb
+++ b/test/graphql/queries/usergroup_query_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class Queries::UsergroupQueryTest < ActiveSupport::TestCase
+  test 'fetching usergroup attributes' do
+    usergroup = FactoryBot.create(:usergroup)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        usergroup(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          admin
+        }
+      }
+    GRAPHQL
+
+    usergroup_global_id = Foreman::GlobalId.for(usergroup)
+    variables = { id: usergroup_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'usergroup' => {
+        'id' => usergroup_global_id,
+        'createdAt' => usergroup.created_at.utc.iso8601,
+        'updatedAt' => usergroup.updated_at.utc.iso8601,
+        'name' => usergroup.name,
+        'admin' => usergroup.admin
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/usergroups_query_test.rb
+++ b/test/graphql/queries/usergroups_query_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Queries::UsergroupsQueryTest < ActiveSupport::TestCase
+  test 'fetching usergroups attributes' do
+    FactoryBot.create_list(:usergroup, 2)
+
+    query = <<-GRAPHQL
+      query {
+        usergroups {
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    assert_empty result['errors']
+    assert_equal Usergroup.count, result['data']['usergroups']['edges'].count
+  end
+end


### PR DESCRIPTION
This patch adds Usergroup queries to the GraphQL api
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
