### PR TITLE
Fixes #26356 - hostgroup combo works with katello

### DIFF
--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
     end
 
     factory :rhel7_5, class: Redhat do
-      sequence(:name) { 'Red Hat Enterprise Linux' }
+      sequence(:name) { |n| "RedHat#{n}" }
       major { '7' }
       minor { '5' }
       type { 'Redhat' }

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -57,7 +57,25 @@ pxe_menu:
 
 pxe_default:
   name: PXELinux global default
-  template: default linux~label linux~kernel <%%= @kernel %>~append initrd=<%%= @initrd %> ksdevice=bootif network kssendmac
+  template: |
+    DEFAULT menu
+    <%% unless @profiles.nil? -%>
+    <%% for profile in @profiles
+      url = default_template_url(profile[:template], profile[:hostgroup])
+      case profile[:pxe_type]
+      when 'kickstart'
+        append = "ks=#{url}"
+      when 'preseed'
+        locale = profile[:hostgroup].params['lang'] || 'en_US'
+        append = "interface=auto url=#{url}"
+      else
+        raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+      end %>
+    LABEL <%%= "#{profile[:hostgroup]} - #{profile[:template]}" %>
+      KERNEL <%%= profile[:kernel] %>
+      APPEND initrd=<%%= profile[:initrd] %> <%%= append %>
+    <%% end -%>
+    <%% end -%>
   template_kind: pxelinux
   operatingsystems: centos5_3, redhat
   locked: false
@@ -89,7 +107,25 @@ pxegrub:
 
 pxegrub_default:
   name: PXEGrub global default
-  template: "FOO"
+  template: |
+    default=0
+    <%% unless @profiles.nil? -%>
+    <%% for profile in @profiles
+      url = default_template_url(profile[:template], profile[:hostgroup])
+      case profile[:pxe_type]
+      when 'kickstart'
+        append = "ks=#{url}"
+      when 'preseed'
+        locale = profile[:hostgroup].params['lang'] || 'en_US'
+        append = "interface=auto url=#{url}"
+      else
+        raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+      end %>
+    title <%%= "#{profile[:hostgroup]} - #{profile[:template]}" %>
+      kernel <%%= profile[:kernel] %> <%%= append %>
+      initrd <%%= profile[:initrd] %>
+    <%% end -%>
+    <%% end -%>
   template_kind: pxegrub
   operatingsystems: centos5_3, redhat
   locked: false
@@ -97,7 +133,26 @@ pxegrub_default:
 
 pxegrub2_default:
   name: PXEGrub2 global default
-  template: "FOO"
+  template: |
+    default=local
+    <%% unless @profiles.nil? -%>
+    <%% for profile in @profiles
+      url = default_template_url(profile[:template], profile[:hostgroup])
+      case profile[:pxe_type]
+      when 'kickstart'
+        append = "ks=#{url}"
+      when 'preseed'
+        locale = profile[:hostgroup].params['lang'] || 'en_US'
+        append = "interface=auto url=#{url}"
+      else
+        raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
+      end %>
+    menuentry '<%%= "#{profile[:hostgroup]} - #{profile[:template]}" %>' {
+      linuxefi <%%= profile[:kernel] %> <%%= append %>
+      initrdefi <%%= profile[:initrd] %>
+    }
+    <%% end -%>
+    <%% end -%>
   template_kind: pxegrub2
   operatingsystems: centos5_3, redhat
   locked: false


### PR DESCRIPTION
There is no medium associated when Katello plugin is installed and
Synced Content is selected. This breaks hostgroup provisioning. To test
this:

* Install Foreman with Katello
* Sync a kickstart repository
* Create hostgroup/environment combination on a "provision" template (Kickstart default for example) with OS synced via Katello
* Build PXE Default template
* Validate the hostgroup combination is present

This patch vastly improves testing of hostgroup combinations, it was
actually not working correctly at all.