### PR TITLE
Fixes #26362 - update fog-openstack to 1.0.8

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -84,9 +84,9 @@ module ComputeResourcesVmsHelper
   end
 
   def available_actions(vm, authorizer = nil)
-    return default_available_actions(vm, authorizer) unless defined? Fog::Compute::OpenStack::Server
+    return default_available_actions(vm, authorizer) unless defined? Fog::OpenStack::Compute::Server
     case vm
-    when Fog::Compute::OpenStack::Server
+    when Fog::OpenStack::Compute::Server
       openstack_available_actions(vm, authorizer)
     else
       default_available_actions(vm, authorizer)

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -1,6 +1,7 @@
 module FogExtensions
 end
 
+require 'concerns/fog_extensions/model'
 Fog::Model.send(:include, FogExtensions::Model) if defined? Fog::Model
 
 # Fog is required by bundler, and depending on the group configuration,
@@ -43,12 +44,11 @@ end
 
 if Foreman::Model::Openstack.available?
   require 'fog/openstack'
-  require 'fog/compute/openstack'
-  Fog::Compute::OpenStack::Real.send(:include, FogExtensions::Openstack::Core)
-  require 'fog/compute/openstack/models/server'
-  Fog::Compute::OpenStack::Server.send(:prepend, FogExtensions::Openstack::Server)
-  require 'fog/compute/openstack/models/flavor'
-  Fog::Compute::OpenStack::Flavor.send(:include, FogExtensions::Openstack::Flavor)
+  require 'fog/openstack/compute/models/server'
+  require 'fog/openstack/compute/models/flavor'
+  Fog::OpenStack::Compute::Real.send(:include, FogExtensions::Openstack::Core)
+  Fog::OpenStack::Compute::Server.send(:prepend, FogExtensions::Openstack::Server)
+  Fog::OpenStack::Compute::Flavor.send(:include, FogExtensions::Openstack::Flavor)
 end
 
 if Foreman::Model::Vmware.available?

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -1,9 +1,11 @@
 <%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens or http://openstack:5000/v3/auth/tokens"), :help_inline => documentation_button('5.2.6OpenStackNotes') %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
-<%= text_f f, :domain, :help_block => _("Domain for V3 authentication") %>
 
 <% tenants = f.object.tenants rescue [] %>
-<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Tenant'), :disabled => tenants.empty?,
-                 :help_inline_permanent => load_button_f(f, !tenants.empty?, _("Load Tenants")) }) %>
+<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Project (Tenant)'), :help_block => _("Project (v3) or Tenant (v2)"), :disabled => tenants.empty?,
+                 :help_inline_permanent => load_button_f(f, !tenants.empty?, _("Load")) }) %>
+
+<%= text_f f, :domain, :help_block => _("Only for v3 authentication") %>
+
 <%= checkbox_f f, :allow_external_network, {:checked => f.object.allow_external_network, :label => _("Allow external network as main network")} %>

--- a/bundler.d/openstack.rb
+++ b/bundler.d/openstack.rb
@@ -1,3 +1,3 @@
 group :openstack do
-  gem 'fog-openstack', '>= 0.1.25', '< 0.2.0'
+  gem 'fog-openstack', '>= 1.0.8', '< 2.0.0'
 end

--- a/test/controllers/compute_resources_vms_controller_test.rb
+++ b/test/controllers/compute_resources_vms_controller_test.rb
@@ -143,8 +143,8 @@ class ComputeResourcesVmsControllerTest < ActionController::TestCase
     @compute_resource.organizations = User.current.organizations
     @compute_resource.locations = User.current.locations
 
-    Fog::Compute::OpenStack::Server.any_instance.expects(:state).returns('ACTIVE').at_least_once
-    Fog::Compute::OpenStack::Server.any_instance.expects(:pause).returns(true)
+    Fog::OpenStack::Compute::Server.any_instance.expects(:state).returns('ACTIVE').at_least_once
+    Fog::OpenStack::Compute::Server.any_instance.expects(:pause).returns(true)
     get :pause, params: { :format => 'json', :id => @test_vm.id, :compute_resource_id => @compute_resource.to_param }, session: set_session_user
     assert_redirected_to compute_resource_vm_path(:compute_resource_id => @compute_resource.to_param, :id => @test_vm.identity)
     Fog.unmock!


### PR DESCRIPTION
This looks like a smooth upgrade, nothing major changed and everything seem to work. However, there is one slight detail - fog-openstack URL is not versionless, therefore it must not contain any path part (/v2 or /v3) as the API code determines the version from the other fields. This is the upstream change:

* https://github.com/fog/fog-openstack/commit/bfb27375e5590e3f2a462c79a96a7b16ca0c421b

Keystone endpoints are version less. Version 3 is the default as v2.0 is deprecated. Meanwhile Keystone V3 still supports v2.0 for backward compatibility. Therefore passing a tenant instead of a project (along with a domain) makes Keystone provide v2.0 token.

This does not work nicely with Foreman when Tenants are not known (before Load tenants button is pressed), therefore the easiest solution is to enforce users to select V2 or V3. Instead adding new flag, I propose easier approach which will be also upgrade-friendly - Compute Resource model now validates if URL contains /v2 or /v3 and this is used to pick either v2.0 or v3 protocol. Users already have paths so this will work transparently for them.

For the record, this patch was written and tested on top of https://github.com/theforeman/foreman/pull/6475