### PR TITLE
Fixes #26367 - Fix building sources outside of bundler

### DIFF
--- a/lib/tasks/pkg.rake
+++ b/lib/tasks/pkg.rake
@@ -1,3 +1,4 @@
+require 'English'
 require 'fileutils'
 
 namespace :pkg do


### PR DESCRIPTION
Using `rake -f Rakefile.dist pkg:generate_source` fails because it doesn't require the English module. This means `$CHILD_STATUS` is not set and the task fails. When using it via Rakefile it loads the main application which pulls in the English module somewhere so there the issue doesn't exist.