### PR TITLE
Fixes #26360 - Usergroup cannot be added to themself

### DIFF
--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -21,7 +21,7 @@
         <hr>
       <% end %>
       <%= text_f f, :name %>
-      <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup,
+      <%= multiple_checkboxes f, :usergroups, @usergroup, Usergroup.where.not(id: @usergroup.id),
         { :label => _("User Groups") } %>
       <%= multiple_checkboxes f, :users, @usergroup, User.except_hidden,
         :label => _("Users"), :object_label_method => :select_title %>


### PR DESCRIPTION
Now when you editing usergroup you cannot add edited usergroup to themselves which prevents error with too deep stack.