### PR TITLE
Fixes #26379 - allow to reuse SearchBar.updateSearchQuery

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
-import URI from 'urijs';
 import AutoComplete from '../AutoComplete';
 import Bookmarks from '../bookmarks';
+import { resolveSearchQuery } from './SearchBarHelpers';
 import './search-bar.scss';
-
-const handleSearch = searchQuery => {
-  const uri = new URI(window.location.href);
-  const data = { ...uri.query(true), search: searchQuery.trim(), page: 1 };
-  uri.query(URI.buildQuery(data, true));
-  window.Turbolinks.visit(uri.toString());
-};
 
 const SearchBar = ({
   searchQuery,
@@ -23,14 +16,16 @@ const SearchBar = ({
   return (
     <div className="search-bar input-group">
       <AutoComplete
-        handleSearch={() => handleSearch(searchQuery)}
+        handleSearch={() => resolveSearchQuery(searchQuery)}
         initialQuery={autocomplete.searchQuery || ''}
         useKeyShortcuts={autocomplete.useKeyShortcuts}
         url={autocomplete.url}
         controller={controller}
       />
       <div className="input-group-btn">
-        <AutoComplete.SearchButton onClick={() => handleSearch(searchQuery)} />
+        <AutoComplete.SearchButton
+          onClick={() => resolveSearchQuery(searchQuery)}
+        />
         {bookmarksComponent}
       </div>
     </div>

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBarHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBarHelpers.js
@@ -1,0 +1,8 @@
+import URI from 'urijs';
+
+export const resolveSearchQuery = searchQuery => {
+  const uri = new URI(window.location.href);
+  const data = { ...uri.query(true), search: searchQuery.trim(), page: 1 };
+  uri.query(URI.buildQuery(data, true));
+  window.Turbolinks.visit(uri.toString());
+};

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/SearchBarHelpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/SearchBarHelpers.test.js
@@ -1,0 +1,29 @@
+import { resolveSearchQuery } from '../SearchBarHelpers';
+
+const mockWindow = ({ href, visit }) => {
+  const windowLocation = JSON.stringify(window.location);
+  delete window.location;
+  Object.defineProperty(window, 'location', {
+    value: JSON.parse(windowLocation),
+  });
+
+  window.location.href = href;
+  window.Turbolinks = { visit };
+};
+
+describe('SearchBar helpers', () => {
+  test('should resolve search-query', () => {
+    const visit = jest.fn();
+    const baseHref = 'http://some-url.com/';
+    const oldQuery = 'search=some-search&page=3&field=val';
+    const href = `${baseHref}?${oldQuery}`;
+    mockWindow({ href, visit });
+
+    const searchQuery = 'some-new-search';
+    resolveSearchQuery(searchQuery);
+
+    expect(visit).toBeCalledWith(
+      `${baseHref}?search=some-new-search&page=1&field=val`
+    );
+  });
+});


### PR DESCRIPTION
This functionality needed so the new `foreman-tasks#dashboard` can update and resolve the page to a new search-query.
https://community.theforeman.org/t/tasks-redesign-feedback/13268