### PR TITLE
Fixes #26380 - Only execute webpack:compile task once

### DIFF
--- a/lib/tasks/webpack_compile.rake
+++ b/lib/tasks/webpack_compile.rake
@@ -1,3 +1,6 @@
+# We need to delete the existing task which comes from webpack-rails gem or this task will get executed twice
+Rake::Task['webpack:compile'].clear
+
 namespace :webpack do
   # TODO: remove after migrating away from webpack-rails (after setting the
   # max_old_space_size) in other tool.


### PR DESCRIPTION
webpack-rails gem defines a task with the same name, causing the task to
be registered twice and thus executed twice. The task file in our code
has been renamed so it registers after the gem's task and clears the
previously registered task before registering our version.

This should save about 3 minutes per jenkins run, and also speed up
running tests locally.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
