### PR TITLE
Fixes #26382 - graphql: add Organization queries

### DIFF
--- a/app/graphql/resolvers/host.rb
+++ b/app/graphql/resolvers/host.rb
@@ -1,7 +1,0 @@
-module Resolvers
-  class Host < BaseResolver
-    MODEL_CLASS = ::Host
-
-    include Concerns::Record
-  end
-end

--- a/app/graphql/resolvers/hosts.rb
+++ b/app/graphql/resolvers/hosts.rb
@@ -1,7 +1,0 @@
-module Resolvers
-  class Hosts < BaseResolver
-    MODEL_CLASS = ::Host
-
-    include Concerns::Collection
-  end
-end

--- a/app/graphql/types/organization.rb
+++ b/app/graphql/types/organization.rb
@@ -1,0 +1,10 @@
+module Types
+  class Organization < BaseObject
+    description 'A Organization'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: true
+    field :title, String, null: true
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -23,6 +23,9 @@ module Types
     record_field :location, ::Location
     collection_field :locations, ::Location
 
+    record_field :organization, ::Organization
+    collection_field :organizations, ::Organization
+
     record_field :operatingsystem, ::Operatingsystem
     collection_field :operatingsystems, ::Operatingsystem
 

--- a/test/graphql/queries/organization_query_test.rb
+++ b/test/graphql/queries/organization_query_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class Queries::OrganizationQueryTest < ActiveSupport::TestCase
+  test 'fetching organization attributes' do
+    organization = FactoryBot.create(:organization)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        organization(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          title
+        }
+      }
+    GRAPHQL
+
+    organization_global_id = Foreman::GlobalId.for(organization)
+    variables = { id: organization_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'organization' => {
+        'id' => organization_global_id,
+        'createdAt' => organization.created_at.utc.iso8601,
+        'updatedAt' => organization.updated_at.utc.iso8601,
+        'name' => organization.name,
+        'title' => organization.title
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/organizations_query_test.rb
+++ b/test/graphql/queries/organizations_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::OrganizationsQueryTest < ActiveSupport::TestCase
+  test 'fetching organizations attributes' do
+    FactoryBot.create_list(:organization, 2)
+
+    query = <<-GRAPHQL
+      query {
+        organizations {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = Organization.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['organizations']['totalCount']
+    assert_equal expected_count, result['data']['organizations']['edges'].count
+  end
+end


### PR DESCRIPTION
This patch adds Organization queries to the GraphQL api
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
