### PR TITLE
Fixes #26268, #26269 - graphql: add FactName and FactValue queries

### DIFF
--- a/app/graphql/resolvers/generic.rb
+++ b/app/graphql/resolvers/generic.rb
@@ -1,30 +1,31 @@
 module Resolvers
   class Generic
-    def initialize(model)
-      @model = model
+    def initialize(type)
+      @type = type
     end
 
-    def self.for(model)
-      new(model)
+    def self.for(type)
+      new(type)
     end
 
     def record
-      return unless model
+      return unless model_class
       base_class.include(Resolvers::Concerns::Record)
     end
 
     def collection
-      return unless model
+      return unless model_class
       base_class.include(Resolvers::Concerns::Collection)
     end
 
     private
 
-    attr_reader :model
+    attr_reader :type
+    delegate :model_class, to: :type
 
     def base_class
       Class.new(Resolvers::BaseResolver).tap do |c|
-        c.const_set('MODEL_CLASS', model)
+        c.const_set('MODEL_CLASS', model_class)
       end
     end
   end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -4,9 +4,28 @@ module Types
 
     connection_type_class Connections::BaseConnection
 
-    def self.timestamps
-      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+    class << self
+      def timestamps
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      end
+
+      def has_many(name, type, null: true)
+        field name, type.connection_type, null: null,
+          resolve: proc { |object| CollectionLoader.for(object.class, name).load(object) }
+      end
+
+      def belongs_to(name, type, null: true)
+        field name, type, null: null,
+          resolve: (proc do |object|
+            foreign_key = object.class.reflect_on_association(name).foreign_key
+            RecordLoader.for(type.model_class).load(object.send(foreign_key))
+          end)
+      end
+
+      def model_class
+        "::#{self.to_s.demodulize}".safe_constantize
+      end
     end
   end
 end

--- a/app/graphql/types/domain.rb
+++ b/app/graphql/types/domain.rb
@@ -7,7 +7,6 @@ module Types
     field :name, String, null: true
     field :fullname, String, null: true
 
-    field :subnets, Types::Subnet.connection_type, null: true,
-      resolve: proc { |object| CollectionLoader.for(object.class, :subnets).load(object) }
+    has_many :subnets, Types::Subnet
   end
 end

--- a/app/graphql/types/fact_name.rb
+++ b/app/graphql/types/fact_name.rb
@@ -1,0 +1,13 @@
+module Types
+  class FactName < BaseObject
+    description 'A FactName'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: true
+    field :short_name, String, null: true
+    field :type, String, null: true
+
+    has_many :fact_values, Types::FactValue
+  end
+end

--- a/app/graphql/types/fact_value.rb
+++ b/app/graphql/types/fact_value.rb
@@ -1,0 +1,12 @@
+module Types
+  class FactValue < BaseObject
+    description 'A FactValue'
+
+    global_id_field :id
+    timestamps
+    field :value, String, null: true
+
+    belongs_to :fact_name, Types::FactName
+    belongs_to :host, Types::Host
+  end
+end

--- a/app/graphql/types/host.rb
+++ b/app/graphql/types/host.rb
@@ -5,7 +5,9 @@ module Types
     global_id_field :id
     timestamps
     field :name, String, null: false
-    field :model, Types::Model, null: true,
-      resolve: proc { |object| RecordLoader.for(::Model).load(object.model_id) }
+
+    belongs_to :model, Types::Model
+    has_many :fact_names, Types::FactName
+    has_many :fact_values, Types::FactValue
   end
 end

--- a/app/graphql/types/model.rb
+++ b/app/graphql/types/model.rb
@@ -9,7 +9,6 @@ module Types
     field :vendorClass, String, null: true
     field :hardwareModel, String, null: true
 
-    field :hosts, Types::Host.connection_type, null: false,
-      resolve: proc { |object| CollectionLoader.for(object.class, :hosts).load(object) }
+    has_many :hosts, Types::Host
   end
 end

--- a/app/graphql/types/organization.rb
+++ b/app/graphql/types/organization.rb
@@ -1,6 +1,6 @@
 module Types
   class Organization < BaseObject
-    description 'A Organization'
+    description 'An Organization'
 
     global_id_field :id
     timestamps

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -3,48 +3,52 @@ module Types
     graphql_name 'Query'
 
     class << self
-      def record_field(name, model)
-        field name, "Types::#{model}".safe_constantize,
-          resolver: Resolvers::Generic.for(model).record
+      def record_field(name, type)
+        field name, type, resolver: Resolvers::Generic.for(type).record
       end
 
-      def collection_field(name, model)
-        field name, "Types::#{model}".safe_constantize.connection_type,
-          resolver: Resolvers::Generic.for(model).collection
+      def collection_field(name, type)
+        field name, type.connection_type, resolver: Resolvers::Generic.for(type).collection
       end
     end
 
     field :node, field: GraphQL::Relay::Node.field
     field :nodes, field: GraphQL::Relay::Node.plural_field
 
-    record_field :model, ::Model
-    collection_field :models, ::Model
+    record_field :model, Types::Model
+    collection_field :models, Types::Model
 
-    record_field :location, ::Location
-    collection_field :locations, ::Location
+    record_field :location, Types::Location
+    collection_field :locations, Types::Location
 
-    record_field :organization, ::Organization
-    collection_field :organizations, ::Organization
+    record_field :organization, Types::Organization
+    collection_field :organizations, Types::Organization
 
-    record_field :operatingsystem, ::Operatingsystem
-    collection_field :operatingsystems, ::Operatingsystem
+    record_field :operatingsystem, Types::Operatingsystem
+    collection_field :operatingsystems, Types::Operatingsystem
 
-    record_field :subnet, ::Subnet
-    collection_field :subnets, ::Subnet
+    record_field :subnet, Types::Subnet
+    collection_field :subnets, Types::Subnet
 
-    record_field :usergroup, ::Usergroup
-    collection_field :usergroups, ::Usergroup
+    record_field :usergroup, Types::Usergroup
+    collection_field :usergroups, Types::Usergroup
 
-    record_field :host, ::Host
-    collection_field :hosts, ::Host
+    record_field :host, Types::Host
+    collection_field :hosts, Types::Host
 
-    record_field :architecture, ::Architecture
-    collection_field :architectures, ::Architecture
+    record_field :architecture, Types::Architecture
+    collection_field :architectures, Types::Architecture
 
-    record_field :smart_proxy, ::SmartProxy
-    collection_field :smart_proxies, ::SmartProxy
+    record_field :domain, Types::Domain
+    collection_field :domains, Types::Domain
 
-    record_field :domain, ::Domain
-    collection_field :domains, ::Domain
+    record_field :smart_proxy, Types::SmartProxy
+    collection_field :smart_proxies, Types::SmartProxy
+
+    record_field :fact_name, Types::FactName
+    collection_field :fact_names, Types::FactName
+
+    record_field :fact_value, Types::FactValue
+    collection_field :fact_values, Types::FactValue
   end
 end

--- a/app/graphql/types/subnet.rb
+++ b/app/graphql/types/subnet.rb
@@ -21,7 +21,6 @@ module Types
     field :network_type, String, null: true
     field :cidr, Int, null: true
 
-    field :domains, Types::Domain.connection_type, null: true,
-      resolve: proc { |object| CollectionLoader.for(object.class, :domains).load(object) }
+    has_many :domains, Types::Domain
   end
 end

--- a/test/graphql/queries/fact_name_query_test.rb
+++ b/test/graphql/queries/fact_name_query_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class Queries::FactNameQueryTest < ActiveSupport::TestCase
+  test 'fetching fact name attributes' do
+    fact_value = FactoryBot.create(:fact_value)
+    fact_name = fact_value.fact_name
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        factName(id: $id) {
+          id
+          createdAt
+          updatedAt
+          shortName
+          type
+          factValues {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    fact_name_global_id = Foreman::GlobalId.for(fact_name)
+    variables = { id: fact_name_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'factName' => {
+        'id' => fact_name_global_id,
+        'createdAt' => fact_name.created_at.utc.iso8601,
+        'updatedAt' => fact_name.updated_at.utc.iso8601,
+        'shortName' => fact_name.short_name,
+        'type' => fact_name.type,
+        'factValues' => {
+          'totalCount' => fact_name.fact_values.count,
+          'edges' => fact_name.fact_values.map do |fv|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.for(fact_value)
+              }
+            }
+          end
+        }
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/fact_names_query_test.rb
+++ b/test/graphql/queries/fact_names_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::FactNamesQueryTest < ActiveSupport::TestCase
+  test 'fetching fact names attributes' do
+    FactoryBot.create_list(:fact_name, 2)
+
+    query = <<-GRAPHQL
+      query {
+        factNames {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = FactName.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['factNames']['totalCount']
+    assert_equal expected_count, result['data']['factNames']['edges'].count
+  end
+end

--- a/test/graphql/queries/fact_value_query_test.rb
+++ b/test/graphql/queries/fact_value_query_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class Queries::FactValueQueryTest < ActiveSupport::TestCase
+  test 'fetching fact value attributes' do
+    fact_value = FactoryBot.create(:fact_value)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        factValue(id: $id) {
+          id
+          createdAt
+          updatedAt
+          value
+          factName {
+            id
+          }
+          host {
+            id
+          }
+        }
+      }
+    GRAPHQL
+
+    fact_value_global_id = Foreman::GlobalId.for(fact_value)
+    variables = { id: fact_value_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'factValue' => {
+        'id' => fact_value_global_id,
+        'createdAt' => fact_value.created_at.utc.iso8601,
+        'updatedAt' => fact_value.updated_at.utc.iso8601,
+        'value' => fact_value.value,
+        'factName' => {
+          'id' => Foreman::GlobalId.for(fact_value.fact_name)
+        },
+        'host' => {
+          'id' => Foreman::GlobalId.encode('Host', fact_value.host.id)
+        }
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/fact_values_query_test.rb
+++ b/test/graphql/queries/fact_values_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::FactValuesQueryTest < ActiveSupport::TestCase
+  test 'fetching fact values attributes' do
+    FactoryBot.create_list(:fact_value, 2)
+
+    query = <<-GRAPHQL
+      query {
+        factValues {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = FactValue.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['factValues']['totalCount']
+    assert_equal expected_count, result['data']['factValues']['edges'].count
+  end
+end

--- a/test/graphql/queries/host_query_test.rb
+++ b/test/graphql/queries/host_query_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Queries::HostQueryTest < ActiveSupport::TestCase
   test 'fetching host attributes' do
-    host = FactoryBot.create(:host, :managed, :with_model)
+    host = FactoryBot.create(:host, :managed, :with_model, :with_facts)
 
     query = <<-GRAPHQL
       query (
@@ -15,6 +15,22 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
           name
           model {
             id
+          }
+          factNames {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+          factValues {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
           }
         }
       }
@@ -33,6 +49,26 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
         'name' => host.name,
         'model' => {
           'id' => Foreman::GlobalId.for(host.model)
+        },
+        'factNames' => {
+          'totalCount' => host.fact_names.count,
+          'edges' => host.fact_names.sort_by(&:id).map do |fact_name|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.for(fact_name)
+              }
+            }
+          end
+        },
+        'factValues' => {
+          'totalCount' => host.fact_values.count,
+          'edges' => host.fact_values.map do |fact_value|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.for(fact_value)
+              }
+            }
+          end
         }
       }
     }

--- a/test/graphql/resolvers/generic_test.rb
+++ b/test/graphql/resolvers/generic_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class GenericResolverTest < ActiveSupport::TestCase
   test 'record resolver' do
-    resolver = Resolvers::Generic.for(::Model).record
+    resolver = Resolvers::Generic.for(Types::Model).record
 
     assert_equal Resolvers::BaseResolver, resolver.superclass
     assert_includes resolver.ancestors, Resolvers::Concerns::Record
@@ -10,7 +10,7 @@ class GenericResolverTest < ActiveSupport::TestCase
   end
 
   test 'collection resolver' do
-    resolver = Resolvers::Generic.for(::Model).collection
+    resolver = Resolvers::Generic.for(Types::Model).collection
 
     assert_equal Resolvers::BaseResolver, resolver.superclass
     assert_includes resolver.ancestors, Resolvers::Concerns::Collection


### PR DESCRIPTION
This patch adds FactName and FactValue queries to the GraphQL api.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
