### PR TITLE
Fixes #26344 - Skip nested associations during taxonomy seed

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -10,9 +10,11 @@ User.as_anonymous_admin do
       tax = taxonomy.create!(name: tax_name)
       associations = taxonomy.reflect_on_all_associations.reject do |assoc|
         skip_associations.include?(assoc.name) ||
-        assoc.is_a?(ActiveRecord::Reflection::HasOneReflection) ||
-            assoc.is_a?(ActiveRecord::Reflection::BelongsToReflection)
+          assoc.is_a?(ActiveRecord::Reflection::HasOneReflection) ||
+          assoc.is_a?(ActiveRecord::Reflection::BelongsToReflection) ||
+          assoc.nested?
       end
+
       associations.each do |association|
         tax.send("#{association.name}=", association.klass.all)
       end


### PR DESCRIPTION
Nested associations can't be assigned using `${association}=`.
This causes seed to fail if there are any puppetclasses in the DB and
taxonomies were disabled during upgrade from 1.20 to 1.21.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
