### PR TITLE
Fixes #26392 - Include "all users" taxonomies in my_taxonomy

### DIFF
--- a/app/views/taxonomies/_loc_org_tabs.html.erb
+++ b/app/views/taxonomies/_loc_org_tabs.html.erb
@@ -10,7 +10,7 @@
             {'data-descendants' => obj.children_of_selected_location_ids.to_json,
              'data-useds' => obj.used_location_ids.to_json }.merge!(html_options[:location]) %>
     <% if SETTINGS[:locations_enabled] && (obj.kind_of? User) %>
-      <%= select_f f, :default_location_id, (obj.admin? ? Location.all : obj.locations), :id, :title,
+      <%= select_f f, :default_location_id, (obj.admin? ? Location.all : obj.my_locations), :id, :title,
                     { :include_blank => true }, { :label => _('Default on login') } %>
     <% end %>
   </div>
@@ -23,7 +23,7 @@
             {'data-descendants' => obj.children_of_selected_organization_ids.to_json,
              'data-useds' => obj.used_organization_ids.to_json }.merge!(html_options[:organization]) %>
     <% if SETTINGS[:organizations_enabled] && (obj.kind_of? User) %>
-      <%= select_f f, :default_organization_id,(obj.admin? ? Organization.all : obj.organizations), :id, :title,
+      <%= select_f f, :default_organization_id,(obj.admin? ? Organization.all : obj.my_organizations), :id, :title,
                     { :include_blank => true }, { :label => _('Default on login') } %>
     <% end %>
   </div>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -888,6 +888,24 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "my_locations includes locations set to 'all users'" do
+    user = FactoryBot.create(:user)
+    location = FactoryBot.create(:location)
+    refute_includes user.my_locations, location
+    location.ignore_types = ['User']
+    location.save!
+    assert_includes user.my_locations, location
+  end
+
+  test "my_organizations includes organizations set to 'all users'" do
+    user = FactoryBot.create(:user)
+    organization = FactoryBot.create(:organization)
+    refute_includes user.my_organizations, organization
+    organization.ignore_types = ['User']
+    organization.save!
+    assert_includes user.my_organizations, organization
+  end
+
   test "chaging hostgroup should update cache" do
     u = FactoryBot.create(:user)
     g1 = FactoryBot.create(:usergroup)
@@ -911,18 +929,16 @@ class UserTest < ActiveSupport::TestCase
     assert_empty u.cached_usergroups
   end
 
-  #  Uncomment after users get access to children taxonomies of their current taxonomies.
-  #
-  #  test 'default taxonomy inclusion validator takes into account inheritance' do
-  #    inherited_location     = Location.create(:parent => Location.first, :name => 'inherited_loc')
-  #    inherited_organization = Organization.create(:parent => Organization.first, :name => 'inherited_org')
-  #    users(:one).update_attribute(:locations, [Location.first])
-  #    users(:one).update_attribute(:organizations, [Organization.first])
-  #    users(:one).default_location     = Location.find_by_name('inherited_loc')
-  #    users(:one).default_organization = Organization.find_by_name('inherited_org')
-  #
-  #    assert users(:one).valid?
-  #  end
+  test 'default taxonomy inclusion validator takes into account inheritance' do
+    Location.create(:parent => Location.first, :name => 'inherited_loc')
+    Organization.create(:parent => Organization.first, :name => 'inherited_org')
+    users(:one).update_attribute(:locations, [Location.first])
+    users(:one).update_attribute(:organizations, [Organization.first])
+    users(:one).default_location     = Location.find_by_name('inherited_loc')
+    users(:one).default_organization = Organization.find_by_name('inherited_org')
+
+    assert users(:one).valid?
+  end
 
   test "#matching_password? succeeds if password matches" do
     u = FactoryBot.build_stubbed(:user)

--- a/test/unit/puppet_class_importer_test.rb
+++ b/test/unit/puppet_class_importer_test.rb
@@ -249,10 +249,10 @@ class PuppetClassImporterTest < ActiveSupport::TestCase
   end
 
   test "should detect correct environments for import" do
-    org_a = FactoryBot.build(:organization, :name => "OrgA")
-    loc_a = FactoryBot.build(:location, :name => "LocA")
-    org_b = FactoryBot.build(:organization, :name => "OrgB")
-    loc_b = FactoryBot.build(:location, :name => "LocB")
+    org_a = FactoryBot.create(:organization, :name => "OrgA")
+    loc_a = FactoryBot.create(:location, :name => "LocA")
+    org_b = FactoryBot.create(:organization, :name => "OrgB")
+    loc_b = FactoryBot.create(:location, :name => "LocB")
     b_role = roles(:manager).clone :name => 'b_role'
     b_role.add_permissions! [:destroy_external_parameters, :edit_external_parameters, :create_external_parameters, :view_external_parameters]
     a_user = FactoryBot.create(:user, :organizations => [org_a], :locations => [loc_a], :roles => [roles(:manager)], :login => 'a_user')


### PR DESCRIPTION
Otherwise, when selecting all users, users will not be able to set the
default taxonomy to such taxonomy, nor will other methods of
authentication would function correctly.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
