### PR TITLE
Refs #26122 - fix audit page rendering

### DIFF
--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
@@ -17,7 +17,7 @@ const PageLayout = ({
   children,
 }) => (
   <div id="main">
-    <div id="content">
+    <div id="react-content">
       {toastNotifications && (
         <div
           id="toast-notifications-container"

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -5,7 +5,7 @@ exports[`render pageLayout w/search 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       id="breadcrumb"
@@ -93,7 +93,7 @@ exports[`render pageLayout w/toastNotifications 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       data-notifications="notification"
@@ -187,7 +187,7 @@ exports[`render pageLayout w/toolBar 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       id="breadcrumb"
@@ -277,7 +277,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       id="breadcrumb"
@@ -339,7 +339,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       id="breadcrumb"
@@ -409,7 +409,7 @@ exports[`render pageLayout without search 1`] = `
   id="main"
 >
   <div
-    id="content"
+    id="react-content"
   >
     <div
       id="breadcrumb"


### PR DESCRIPTION
Audit is now a react page, there are legacy js functions that manipulate `content` div, and it would be risky to use these on react content, therefore it  would be better to distinguish  it from other pages.