### PR TITLE
Fixes #26405 - Disable implicit puppetclass taxonomy search

### DIFF
--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -38,8 +38,8 @@ class Puppetclass < ApplicationRecord
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :relation => :environments, :on => :name, :complete_value => :true, :rename => "environment"
-  scoped_search :relation => :organizations, :on => :name, :complete_value => :true, :rename => "organization"
-  scoped_search :relation => :locations, :on => :name, :complete_value => :true, :rename => "location"
+  scoped_search :relation => :organizations, :on => :name, :complete_value => :true, :rename => "organization", :only_explicit => true
+  scoped_search :relation => :locations, :on => :name, :complete_value => :true, :rename => "location", :only_explicit => true
   scoped_search :relation => :hostgroups, :on => :name, :complete_value => :true, :rename => "hostgroup", :only_explicit => true
   scoped_search :relation => :config_groups, :on => :name, :complete_value => :true, :rename => "config_group", :only_explicit => true
   scoped_search :relation => :hosts, :on => :name, :complete_value => :true, :rename => "host", :ext_method => :search_by_host, :only_explicit => true


### PR DESCRIPTION
Otherwise, every search not specifing the field causes a double left
join of the taxable_taxonomies table.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
