### PR TITLE
Fixes #26294 - graphql: add Environment queries

### DIFF
--- a/app/graphql/types/environment.rb
+++ b/app/graphql/types/environment.rb
@@ -1,0 +1,9 @@
+module Types
+  class Environment < BaseObject
+    description 'An Environment'
+
+    global_id_field :id
+    timestamps
+    field :name, String, null: true
+  end
+end

--- a/app/graphql/types/host.rb
+++ b/app/graphql/types/host.rb
@@ -6,6 +6,7 @@ module Types
     timestamps
     field :name, String, null: false
 
+    belongs_to :environment, Types::Environment
     belongs_to :model, Types::Model
     has_many :fact_names, Types::FactName
     has_many :fact_values, Types::FactValue

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -50,5 +50,8 @@ module Types
 
     record_field :fact_value, Types::FactValue
     collection_field :fact_values, Types::FactValue
+
+    record_field :environment, Types::Environment
+    collection_field :environments, Types::Environment
   end
 end

--- a/test/graphql/queries/environment_query_test.rb
+++ b/test/graphql/queries/environment_query_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Queries::EnvironmentQueryTest < ActiveSupport::TestCase
+  test 'fetching environment attributes' do
+    environment = FactoryBot.create(:environment)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        environment(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+        }
+      }
+    GRAPHQL
+
+    environment_global_id = Foreman::GlobalId.for(environment)
+    variables = { id: environment_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'environment' => {
+        'id' => environment_global_id,
+        'createdAt' => environment.created_at.utc.iso8601,
+        'updatedAt' => environment.updated_at.utc.iso8601,
+        'name' => environment.name
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/environments_query_test.rb
+++ b/test/graphql/queries/environments_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::EnvironmentsQueryTest < ActiveSupport::TestCase
+  test 'fetching environments attributes' do
+    FactoryBot.create_list(:environment, 2)
+
+    query = <<-GRAPHQL
+      query {
+        environments {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = Environment.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['environments']['totalCount']
+    assert_equal expected_count, result['data']['environments']['edges'].count
+  end
+end

--- a/test/graphql/queries/host_query_test.rb
+++ b/test/graphql/queries/host_query_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Queries::HostQueryTest < ActiveSupport::TestCase
   test 'fetching host attributes' do
-    host = FactoryBot.create(:host, :managed, :with_model, :with_facts)
+    host = FactoryBot.create(:host, :managed, :with_environment, :with_model, :with_facts)
 
     query = <<-GRAPHQL
       query (
@@ -13,6 +13,9 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
           createdAt
           updatedAt
           name
+          environment {
+            id
+          }
           model {
             id
           }
@@ -47,6 +50,9 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
         'createdAt' => host.created_at.utc.iso8601,
         'updatedAt' => host.updated_at.utc.iso8601,
         'name' => host.name,
+        'environment' => {
+          'id' => Foreman::GlobalId.for(host.environment)
+        },
         'model' => {
           'id' => Foreman::GlobalId.for(host.model)
         },


### PR DESCRIPTION
This patch adds Environment queries to the GraphQL api.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
