### PR TITLE
Fixes #26402 - VMware scsi_controller type from hammer

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -424,6 +424,10 @@ module Foreman::Model
         args[collection] = nested_attributes_for(collection, nested_attrs) if nested_attrs
       end
 
+      # see #26402 - consume scsi_controller_type from hammer as a default scsi type
+      scsi_type = args.delete(:scsi_controller_type)
+      args[:scsi_controllers] ||= [{ type: scsi_type }] if scsi_type
+
       add_cdrom = args.delete(:add_cdrom)
       args[:cdroms] = [new_cdrom] if add_cdrom == '1'
 

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -368,6 +368,23 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
       @cr.parse_args(attrs_in)
       assert_equal "network-17", attrs_in["interfaces_attributes"]["0"]["network"]
     end
+
+    context 'scsi_controller_type - from hammer' do
+      test 'parse to be a default scsi_controller_type' do
+        attrs_in = HashWithIndifferentAccess.new('scsi_controller_type' => 'ParaVirtualSCSIController')
+        attrs_out = { scsi_controllers: [{ type: 'ParaVirtualSCSIController' }] }
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'do not override scsi_controllers if passed' do
+        attrs_in = HashWithIndifferentAccess.new(
+          'scsi_controller_type' => 'ParaVirtualSCSIController',
+          'scsi_controllers' => [{ 'type' => 'VirtualBusLogicController' }]
+        )
+        attrs_out = { scsi_controllers: [{ type: 'VirtualBusLogicController' }] }
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+    end
   end
 
   describe "#parse_networks" do


### PR DESCRIPTION
Hammer has vmware compute_attribute `scsi_controller_type`, which is not ever parsed by foreman or fog-vsphere so is just uselessly passed on. This is a quick fix to use it as a default controller type.

Prerequisities for testing:
* VMware cluster
* [recomended] Hostgroup with OS and NwrkSetted

Tests needed (anticipated impacts):
* Host creation by UI (with vmware cr, playing with the controller type)
* Host creation by hammer with a scsi_controller_type:

Example of test hammer command:
```shell
hammer host create --name '<somename>' --organization-id <org> --location-id <loc> \
  --compute-resource="<VMwareResource>" \
  --compute-attributes="cpus=1,corespersocket=1,memory_mb=2048,path=<FolderPath>,cluster=<VMwareCluster>,scsi_controller_type=ParaVirtualSCSIController" \
  --interface="managed=true,compute_type=VirtualVmxnet3,compute_network=<ExistingVMwareNetwork>" \
  --hostgroup <OneWithOSandNwrkSetted> --ip 192.168.11.254 \
  --volume="size_gb=10G,datastore=storage1,name=HadDisk,thin=true"
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
