### PR TITLE
Fixes #26419 - allow setting custom recipients on notification

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -60,6 +60,7 @@ class Notification < ApplicationRecord
   end
 
   def set_notification_recipients
+    return unless notification_recipients.empty?
     subscribers = User.unscoped.where(:id => subscriber_ids)
     notification_recipients.build subscribers.map {|user| { :user => user}}
   end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -24,6 +24,13 @@ class NotificationTest < ActiveSupport::TestCase
     assert_equal User.all, notice.recipients
   end
 
+  test 'should allow setting custom recipients' do
+    notice = FactoryBot.build(:notification, :audience => 'global')
+    notice.notification_recipients.build(user: User.current)
+    notice.save!
+    assert_equal [User.current], notice.recipients, 'the custom notification recipient should not be overridden'
+  end
+
   test 'should return active notifications' do
     blueprint = FactoryBot.create(
       :notification_blueprint,


### PR DESCRIPTION
First step for enabling aggregated notifications, that can be updated
until marked as seen.




<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->