### PR TITLE
Fixes #26423 - update fog-vsphere

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -465,7 +465,7 @@ module Foreman::Model
         vm.firmware = 'bios' if vm.firmware == 'automatic'
         vm.save
       end
-    rescue Fog::Compute::Vsphere::NotFound => e
+    rescue Fog::Vsphere::Compute::NotFound => e
       Foreman::Logging.exception('Caught VMware error', e)
       raise ::Foreman::WrappedException.new(
         e,
@@ -582,7 +582,7 @@ module Foreman::Model
     end
 
     def new_scsi_controller(attr = {})
-      Fog::Compute::Vsphere::SCSIController.new(attr)
+      Fog::Vsphere::Compute::SCSIController.new(attr)
     end
 
     def pubkey_hash

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -53,12 +53,11 @@ end
 
 if Foreman::Model::Vmware.available?
   require 'fog/vsphere'
-  require 'fog/vsphere/compute'
   require 'fog/vsphere/models/compute/server'
-  Fog::Compute::Vsphere::Server.send(:include, FogExtensions::Vsphere::Server)
+  Fog::Vsphere::Compute::Server.send(:include, FogExtensions::Vsphere::Server)
 
   require 'fog/vsphere/models/compute/folder'
-  Fog::Compute::Vsphere::Folder.send(:include, FogExtensions::Vsphere::Folder)
+  Fog::Vsphere::Compute::Folder.send(:include, FogExtensions::Vsphere::Folder)
 end
 
 if Foreman::Model::Rackspace.available?

--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,4 +1,4 @@
 group :vmware do
-  gem 'fog-vsphere', '~> 2.5'
-  gem 'rbvmomi', '~> 1.9'
+  gem 'fog-vsphere', '~> 3.0'
+  gem 'rbvmomi', '~> 2.0'
 end


### PR DESCRIPTION
Updates fog-vsphere to version 3.0, which is ready for fog-core 2.1
To be mergable it needs:
- [x] fog-vsphere 3.0 gem release
- [x] packaging for fog-vsphere
- [x] #6475 merge

In order to test, you need:
* VMware cluster
* Apply #6475 and #6574 first

Tests needed (anticipated impacts):
* VMware VMs manipulation (deletion, creation, listing)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
