### PR TITLE
Fixes #26429 - Make Breadcrumb links more configurable

### DIFF
--- a/app/services/breadcrumbs_options.rb
+++ b/app/services/breadcrumbs_options.rb
@@ -14,6 +14,7 @@ class BreadcrumbsOptions
       isSwitchable: switchable?,
       breadcrumbItems: items,
       resource: resource,
+      wrapWithReactRouter: true,
     }
   end
 

--- a/app/views/ssh_keys/new.html.erb
+++ b/app/views/ssh_keys/new.html.erb
@@ -3,12 +3,12 @@
     items:
     [
       {
-         caption: _("Users"),
-         url: (users_path if authorized_for(hash_for_users_path))
+        caption: _("Users"),
+        to: (users_path if authorized_for(hash_for_users_path))
       },
       {
         caption: @user.name,
-        url: (edit_user_path(@user) if authorized_for(hash_for_edit_user_path(@user)))
+        to: (edit_user_path(@user) if authorized_for(hash_for_edit_user_path(@user)))
       },
       {
         caption: _('Add SSH Key')}

--- a/test/unit/breadcrumbs_options_test.rb
+++ b/test/unit/breadcrumbs_options_test.rb
@@ -50,6 +50,7 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
         nameField: "name",
         resourceFilter: "",
       },
+      wrapWithReactRouter: true,
     }
   end
 
@@ -80,6 +81,7 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
         nameField: "name",
         resourceFilter: "",
       },
+      wrapWithReactRouter: true,
     }
   end
 

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.fixtures.js
@@ -131,3 +131,15 @@ export const breadcrumbBarSwithcable = {
   searchQuery: 'some value',
   searchDebounceTimeout: 0,
 };
+
+export const breadcrumbBarRouterLinks = {
+  data: {
+    breadcrumbItems: [
+      {
+        caption: 'Import or Export Templates',
+        to: '/template_syncs',
+      },
+      { caption: 'Sync Result' },
+    ],
+  },
+};

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { BreadcrumbSwitcher } from 'patternfly-react';
+import { Router } from 'react-router-dom';
+import history from '../../history';
+import AppSwitcher from '../../routes';
 
 import { noop } from '../../common/helpers';
 import Breadcrumb from './components/Breadcrumb';
@@ -30,7 +33,7 @@ class BreadcrumbBar extends React.Component {
 
   render() {
     const {
-      data: { breadcrumbItems, isSwitchable, resource },
+      data: { breadcrumbItems, isSwitchable, resource, wrapWithReactRouter },
       currentPage,
       totalPages,
       resourceSwitcherItems,
@@ -58,7 +61,7 @@ class BreadcrumbBar extends React.Component {
       onSwitcherItemClick(e, href);
     };
 
-    return (
+    const bar = (
       <div className="breadcrumb-bar">
         <Breadcrumb
           title
@@ -104,6 +107,15 @@ class BreadcrumbBar extends React.Component {
         {!isTitle && <hr className="breadcrumb-line" />}
       </div>
     );
+
+    if (wrapWithReactRouter) {
+      return (
+        <Router history={history}>
+          <AppSwitcher>{bar}</AppSwitcher>
+        </Router>
+      );
+    }
+    return bar;
   }
 }
 
@@ -117,6 +129,7 @@ BreadcrumbBar.propTypes = {
       resourceFilter: PropTypes.string,
     }),
     breadcrumbItems: Breadcrumb.propTypes.items,
+    wrapWithReactRouter: PropTypes.bool,
   }),
   searchDebounceTimeout: PropTypes.number,
   searchQuery: PropTypes.string,
@@ -139,6 +152,7 @@ BreadcrumbBar.defaultProps = {
   data: {
     breadcrumbItems: [],
     isSwitchable: false,
+    wrapWithReactRouter: false,
   },
   searchQuery: '',
   currentPage: null,

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.md
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.md
@@ -1,0 +1,27 @@
+# Using BreadcrumbBar with react-router
+
+To make breadcrumbs navigable using react-router, you need to specify the items:
+
+```js
+const items = [
+    {
+      caption: "Hosts",
+      to: "/hosts"
+    },
+    { caption: "Not a link" },
+  ];
+```
+
+Then pass it as a prop to BreadcrumbBar:
+
+```
+<BreadcrumbBar data={{ breadcrumbItems: items }} />
+```
+
+Since you will probably use the breadcrumbs in the layout, you can pass the items through the PageLayout:
+
+```
+<PageLayout breadcrumbOptions={{ breadcrumbItems: items }}>
+// page content here
+</PageLayout>
+```

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
@@ -4,6 +4,9 @@ import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import BreadcrumbBar from './BreadcrumbBar';
 import Story from '../../../../../stories/components/Story';
+import Markdown from '../../../../../stories/components/Markdown';
+
+import routing from './BreadcrumbBar.md';
 
 storiesOf('Components/BreadcrumbBar', module)
   .addDecorator(withKnobs)
@@ -36,5 +39,10 @@ storiesOf('Components/BreadcrumbBar', module)
           ],
         }}
       />
+    </Story>
+  ))
+  .add('With react-router', () => (
+    <Story>
+      <Markdown source={routing} />
     </Story>
   ));

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
@@ -4,12 +4,15 @@ import { mount } from 'enzyme';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 
 import BreadcrumbBar from '../BreadcrumbBar';
+
 import {
   breadcrumbBar,
   breadcrumbBarSwithcable,
   mockBreadcrumbItemOnClick,
   breadcrumbBarRouterLinks,
 } from '../BreadcrumbBar.fixtures';
+
+jest.mock('../../../routes');
 
 const createStubs = () => ({
   toggleSwitcher: jest.fn(),

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/BreadcrumbBar.test.js
@@ -8,6 +8,7 @@ import {
   breadcrumbBar,
   breadcrumbBarSwithcable,
   mockBreadcrumbItemOnClick,
+  breadcrumbBarRouterLinks,
 } from '../BreadcrumbBar.fixtures';
 
 const createStubs = () => ({
@@ -19,6 +20,7 @@ const createStubs = () => ({
 const fixtures = {
   'renders breadcrumb-bar': breadcrumbBar,
   'renders switchable breadcrumb-bar': breadcrumbBarSwithcable,
+  'renders with links for react-router': breadcrumbBarRouterLinks,
 };
 
 describe('BreadcrumbBar', () => {

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
@@ -81,6 +81,32 @@ exports[`BreadcrumbBar rendering renders switchable breadcrumb-bar 1`] = `
 </div>
 `;
 
+exports[`BreadcrumbBar rendering renders with links for react-router 1`] = `
+<div
+  className="breadcrumb-bar"
+>
+  <Breadcrumb
+    isTitle={false}
+    items={
+      Array [
+        Object {
+          "caption": "Import or Export Templates",
+          "to": "/template_syncs",
+        },
+        Object {
+          "caption": "Sync Result",
+        },
+      ]
+    }
+    title={true}
+    titleReplacement={null}
+  />
+  <hr
+    className="breadcrumb-line"
+  />
+</div>
+`;
+
 exports[`BreadcrumbBar triggering should trigger callbacks: loadSwitcherResourcesByResource calls 1`] = `
 Array [
   Array [

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb as PfBreadcrumb } from 'patternfly-react';
+import { LinkContainer } from 'react-router-bootstrap';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import './Breadcrumbs.scss';
 
@@ -38,7 +39,7 @@ const Breadcrumb = ({
           itemTitle
         );
 
-        return (
+        const crumb = (
           <PfBreadcrumb.Item
             key={index}
             active={active}
@@ -51,6 +52,16 @@ const Breadcrumb = ({
             {inner}
           </PfBreadcrumb.Item>
         );
+
+        if (item.to) {
+          return (
+            <LinkContainer to={item.to} key={index}>
+              {crumb}
+            </LinkContainer>
+          );
+        }
+
+        return crumb;
       })}
       {children}
     </PfBreadcrumb>

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -41,9 +41,11 @@ const PageLayout = ({
               <h1 className="col-md-8">{header}</h1>
             </div>
           )}
-          {customBreadcrumbs
-            ? { customBreadcrumbs }
-            : breadcrumbOptions && <BreadcrumbBar data={breadcrumbOptions} />}
+          {customBreadcrumbs ? (
+            <React.Fragment>{customBreadcrumbs}</React.Fragment>
+          ) : (
+            breadcrumbOptions && <BreadcrumbBar data={breadcrumbOptions} />
+          )}
         </div>
         {beforeToolbarComponent}
         <Row>

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -387,7 +387,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
     <div
       id="breadcrumb"
     >
-      <Component />
+      customBreadcrumbs
     </div>
     <Row
       bsClass="row"

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
 import { routes } from './routes';
 
 let currentLocation = null;
 
-const AppSwitcher = () => (
+const AppSwitcher = props => (
   <Switch>
     {routes.map(({ render, path, ...routeProps }) => (
       <Route
@@ -27,17 +28,26 @@ const AppSwitcher = () => (
           currentLocation.pathname !== child.location.pathname
         ) {
           const useTurbolinks =
-            child.location.state &&
-            child.location.state.useTurbolinks &&
-            !window.history.state.turbolinks; // visit() already called
+            (child.location.state &&
+              child.location.state.useTurbolinks &&
+              !window.history.state.turbolinks) ||
+            !child.location.state;
 
           if (useTurbolinks) window.Turbolinks.visit(child.location.pathname);
         }
         currentLocation = child.location;
-        return null;
+        return props.children ? props.children : null;
       }}
     />
   </Switch>
 );
+
+AppSwitcher.propTypes = {
+  children: PropTypes.object,
+};
+
+AppSwitcher.defaultProps = {
+  children: null,
+};
 
 export default AppSwitcher;


### PR DESCRIPTION
```js
const customItem = (props) => {
    return (
      <li>
        <span { ...props} />
      </li>
    )
  }

  const items = [
    {
      caption: <Link to={'/template_syncs'}>Import or Export Templates</Link>,
      customItem: customItem,
      customTitle: 'Awesome title in tooltip'
    },
    { caption: "Sync Result" },
  ];

<BreadcrumbBar data={{ breadcrumbItems: items }} />
```

I need to use `Link` component for react routing, but breadcrumb bar item adds `a` by default, which leads to nested `a` tags. When caption is a node, it does not look good in tooltip, so I specify what should be there with `customTitle`. 

The change in `PageLayout` is somewhat related, react was complaining about using object as a child when I tried custom bar.

I realize this is not ideal, but I am not sure what would be better.

@amirfefer, any thoughts? 