### PR TITLE
Fixes #26291 - graphql: add ComputeResource queries

### DIFF
--- a/app/graphql/types/compute_attribute.rb
+++ b/app/graphql/types/compute_attribute.rb
@@ -1,0 +1,11 @@
+module Types
+  class ComputeAttribute < BaseObject
+    description 'A ComputeAttribute'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+
+    belongs_to :compute_resource, Types::ComputeResource
+  end
+end

--- a/app/graphql/types/compute_resource.rb
+++ b/app/graphql/types/compute_resource.rb
@@ -1,0 +1,16 @@
+module Types
+  class ComputeResource < BaseObject
+    description 'A ComputeResource'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+    field :description, String
+    field :url, String
+    field :provider, Types::ProviderEnum
+    field :provider_friendly_name, Types::ProviderFriendlyNameEnum
+
+    has_many :compute_attributes, Types::ComputeAttribute
+    has_many :hosts, Types::Host
+  end
+end

--- a/app/graphql/types/fact_name.rb
+++ b/app/graphql/types/fact_name.rb
@@ -9,5 +9,6 @@ module Types
     field :type, String
 
     has_many :fact_values, Types::FactValue
+    has_many :hosts, Types::Host
   end
 end

--- a/app/graphql/types/host.rb
+++ b/app/graphql/types/host.rb
@@ -6,6 +6,7 @@ module Types
     timestamps
     field :name, String
 
+    belongs_to :compute_resource, Types::ComputeResource
     belongs_to :environment, Types::Environment
     belongs_to :model, Types::Model
     has_many :fact_names, Types::FactName

--- a/app/graphql/types/provider_enum.rb
+++ b/app/graphql/types/provider_enum.rb
@@ -1,0 +1,7 @@
+module Types
+  class ProviderEnum < Types::BaseEnum
+    ::ComputeResource.supported_providers.keys.each do |provider|
+      value provider
+    end
+  end
+end

--- a/app/graphql/types/provider_friendly_name_enum.rb
+++ b/app/graphql/types/provider_friendly_name_enum.rb
@@ -1,0 +1,7 @@
+module Types
+  class ProviderFriendlyNameEnum < Types::BaseEnum
+    ::ComputeResource.supported_providers.values.each do |class_name|
+      value class_name.constantize.provider_friendly_name
+    end
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -62,5 +62,11 @@ module Types
 
     record_field :puppetclass, Types::Puppetclass
     collection_field :puppetclasses, Types::Puppetclass
+
+    record_field :compute_resource, Types::ComputeResource
+    collection_field :compute_resources, Types::ComputeResource
+
+    record_field :compute_attribute, Types::ComputeAttribute
+    collection_field :compute_attributes, Types::ComputeAttribute
   end
 end

--- a/test/graphql/queries/compute_attribute_query_test.rb
+++ b/test/graphql/queries/compute_attribute_query_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class Queries::ComputeAttributeQueryTest < ActiveSupport::TestCase
+  test 'fetching compute attribute attributes' do
+    compute_resource = FactoryBot.create(:compute_resource, :vmware, uuid: 'Solutions')
+    FactoryBot.create(:compute_profile, :with_compute_attribute, compute_resource: compute_resource)
+    compute_attribute = compute_resource.compute_attributes.first
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        computeAttribute(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          computeResource {
+            id
+          }
+        }
+      }
+    GRAPHQL
+
+    compute_attribute_global_id = Foreman::GlobalId.for(compute_attribute)
+    variables = { id: compute_attribute_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'computeAttribute' => {
+        'id' => compute_attribute_global_id,
+        'createdAt' => compute_attribute.created_at.utc.iso8601,
+        'updatedAt' => compute_attribute.updated_at.utc.iso8601,
+        'name' => compute_attribute.name,
+        'computeResource' => {
+          'id' => Foreman::GlobalId.for(compute_attribute.compute_resource)
+        }
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/compute_attributes_query_test.rb
+++ b/test/graphql/queries/compute_attributes_query_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Queries::ComputeAttributesQueryTest < ActiveSupport::TestCase
+  test 'fetching compute resources attributes' do
+    compute_resource = FactoryBot.create(:compute_resource, :vmware, uuid: 'Solutions')
+    FactoryBot.create(:compute_profile, :with_compute_attribute, compute_resource: compute_resource)
+
+    query = <<-GRAPHQL
+      query {
+        computeAttributes {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = ComputeAttribute.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['computeAttributes']['totalCount']
+    assert_equal expected_count, result['data']['computeAttributes']['edges'].count
+  end
+end

--- a/test/graphql/queries/compute_resource_query_test.rb
+++ b/test/graphql/queries/compute_resource_query_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+class Queries::ComputeResourceQueryTest < ActiveSupport::TestCase
+  test 'fetching compute resource attributes' do
+    hosts = FactoryBot.create_list(:host, 2)
+    compute_resource = FactoryBot.create(:vmware_cr, uuid: 'Solutions', hosts: hosts)
+    FactoryBot.create(:compute_profile, :with_compute_attribute, compute_resource: compute_resource)
+    Queries::AuthorizedModelQuery.any_instance.expects(:find_by_global_id).returns(compute_resource)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        computeResource(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          description
+          url
+          provider
+          providerFriendlyName
+          computeAttributes {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+          hosts {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    compute_resource_global_id = Foreman::GlobalId.encode('ComputeResource', compute_resource.id)
+    variables = { id: compute_resource_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected = {
+      'computeResource' => {
+        'id' => compute_resource_global_id,
+        'createdAt' => compute_resource.created_at.utc.iso8601,
+        'updatedAt' => compute_resource.updated_at.utc.iso8601,
+        'name' => compute_resource.name,
+        'description' => compute_resource.description,
+        'url' => compute_resource.url,
+        'provider' => compute_resource.provider,
+        'providerFriendlyName' => compute_resource.provider_friendly_name,
+        'computeAttributes' => {
+          'totalCount' => compute_resource.compute_attributes.count,
+          'edges' => compute_resource.compute_attributes.sort_by(&:id).map do |ca|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.for(ca)
+              }
+            }
+          end
+        },
+        'hosts' => {
+          'totalCount' => compute_resource.hosts.count,
+          'edges' => compute_resource.hosts.sort_by(&:id).map do |host|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.encode('Host', host.id)
+              }
+            }
+          end
+        }
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected, result['data']
+  end
+end

--- a/test/graphql/queries/compute_resources_query_test.rb
+++ b/test/graphql/queries/compute_resources_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::ComputeResourcesQueryTest < ActiveSupport::TestCase
+  test 'fetching compute resources attributes' do
+    FactoryBot.create_list(:compute_resource, 2, :vmware, uuid: 'Solutions')
+
+    query = <<-GRAPHQL
+      query {
+        computeResources {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = ComputeResource.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['computeResources']['totalCount']
+    assert_equal expected_count, result['data']['computeResources']['edges'].count
+  end
+end

--- a/test/graphql/queries/fact_name_query_test.rb
+++ b/test/graphql/queries/fact_name_query_test.rb
@@ -23,6 +23,14 @@ class Queries::FactNameQueryTest < ActiveSupport::TestCase
               }
             }
           }
+          hosts {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
         }
       }
     GRAPHQL
@@ -45,6 +53,16 @@ class Queries::FactNameQueryTest < ActiveSupport::TestCase
             {
               'node' => {
                 'id' => Foreman::GlobalId.for(fv)
+              }
+            }
+          end
+        },
+        'hosts' => {
+          'totalCount' => fact_name.hosts.count,
+          'edges' => fact_name.hosts.sort_by(&:id).map do |host|
+            {
+              'node' => {
+                'id' => Foreman::GlobalId.encode('Host', host.id)
               }
             }
           end

--- a/test/graphql/queries/host_query_test.rb
+++ b/test/graphql/queries/host_query_test.rb
@@ -2,7 +2,12 @@ require 'test_helper'
 
 class Queries::HostQueryTest < ActiveSupport::TestCase
   test 'fetching host attributes' do
-    host = FactoryBot.create(:host, :managed, :with_environment, :with_model, :with_facts)
+    hostgroup = FactoryBot.create(:hostgroup, :with_compute_resource)
+    host = FactoryBot.create(:host, :managed,
+                                    :with_environment,
+                                    :with_model,
+                                    :with_facts,
+                                    hostgroup: hostgroup)
 
     query = <<-GRAPHQL
       query (
@@ -14,6 +19,9 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
           updatedAt
           name
           environment {
+            id
+          }
+          computeResource {
             id
           }
           model {
@@ -52,6 +60,9 @@ class Queries::HostQueryTest < ActiveSupport::TestCase
         'name' => host.name,
         'environment' => {
           'id' => Foreman::GlobalId.for(host.environment)
+        },
+        'computeResource' => {
+          'id' => Foreman::GlobalId.encode('ComputeResource', host.compute_resource.id)
         },
         'model' => {
           'id' => Foreman::GlobalId.for(host.model)


### PR DESCRIPTION
This patch adds ComputeResource queries to the GraphQL api.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
