### PR TITLE
Fixes #26298 - graphql: add SshKey queries

### DIFF
--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -39,6 +39,9 @@ module Types
     record_field :personal_access_token, Types::PersonalAccessToken
     collection_field :personal_access_tokens, Types::PersonalAccessToken
 
+    record_field :ssh_key, Types::SshKey
+    collection_field :ssh_keys, Types::SshKey
+
     record_field :host, Types::Host
     collection_field :hosts, Types::Host
 

--- a/app/graphql/types/ssh_key.rb
+++ b/app/graphql/types/ssh_key.rb
@@ -1,0 +1,16 @@
+module Types
+  class SshKey < BaseObject
+    description 'A SSH Key'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+    field :key, String
+    field :fingerprint, String
+    field :length, Integer
+    field :comment, String
+    field :exportable_key, String, null: false, method: :to_export
+
+    belongs_to :user, Types::User
+  end
+end

--- a/app/graphql/types/user.rb
+++ b/app/graphql/types/user.rb
@@ -18,6 +18,7 @@ module Types
     belongs_to :default_location, Types::Location
     belongs_to :default_organization, Types::Organization
     has_many :personal_access_tokens, Types::PersonalAccessToken
+    has_many :ssh_keys, Types::SshKey
     has_many :usergroups, Types::Usergroup
   end
 end

--- a/test/graphql/queries/ssh_key_query_test.rb
+++ b/test/graphql/queries/ssh_key_query_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Queries::SshKeyQueryTest < GraphQLQueryTestCase
+  let(:query) do
+    <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        sshKey(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          key
+          fingerprint
+          length
+          comment
+          exportableKey
+          user {
+            id
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:ssh_key) { FactoryBot.create(:ssh_key) }
+
+  let(:global_id) { Foreman::GlobalId.for(ssh_key) }
+  let(:variables) {{ id: global_id }}
+  let(:data) { result['data']['sshKey'] }
+
+  test 'fetching ssh_key attributes' do
+    assert_empty result['errors']
+
+    assert_equal global_id, data['id']
+    assert_equal ssh_key.created_at.utc.iso8601, data['createdAt']
+    assert_equal ssh_key.updated_at.utc.iso8601, data['updatedAt']
+    assert_equal ssh_key.name, data['name']
+    assert_equal ssh_key.key, data['key']
+    assert_equal ssh_key.fingerprint, data['fingerprint']
+    assert_equal ssh_key.length, data['length']
+    assert_equal ssh_key.comment, data['comment']
+    assert_equal ssh_key.to_export, data['exportableKey']
+
+    assert_record ssh_key.user, data['user']
+  end
+end

--- a/test/graphql/queries/ssh_keys_query_test.rb
+++ b/test/graphql/queries/ssh_keys_query_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Queries::SshKeysQueryTest < GraphQLQueryTestCase
+  let(:query) do
+    <<-GRAPHQL
+      query {
+        sshKeys {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:data) { result['data']['sshKeys'] }
+
+  setup do
+    FactoryBot.create_list(:ssh_key, 2)
+  end
+
+  test 'fetching sshKeys attributes' do
+    assert_empty result['errors']
+
+    expected_count = SshKey.count
+
+    assert_not_equal 0, expected_count
+    assert_equal expected_count, data['totalCount']
+    assert_equal expected_count, data['edges'].count
+  end
+end

--- a/test/graphql/queries/user_query_test.rb
+++ b/test/graphql/queries/user_query_test.rb
@@ -34,6 +34,14 @@ class Queries::UserQueryTest < GraphQLQueryTestCase
               }
             }
           }
+          sshKeys {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
           usergroups {
             totalCount
             edges {
@@ -65,6 +73,7 @@ class Queries::UserQueryTest < GraphQLQueryTestCase
 
   setup do
     FactoryBot.create_list(:personal_access_token, 2, user: user)
+    FactoryBot.create_list(:ssh_key, 2, user: user)
   end
 
   test 'fetching user attributes' do
@@ -88,6 +97,7 @@ class Queries::UserQueryTest < GraphQLQueryTestCase
     assert_record user.default_organization, data['defaultOrganization']
 
     assert_collection user.personal_access_tokens, data['personalAccessTokens']
+    assert_collection user.ssh_keys, data['sshKeys']
     assert_collection user.usergroups, data['usergroups']
   end
 end


### PR DESCRIPTION
This patch adds SshKey queries to the GraphQL api.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
