### PR TITLE
Fixes #26270 - graphql: add PersonalAccessToken queries

### DIFF
--- a/app/graphql/types/personal_access_token.rb
+++ b/app/graphql/types/personal_access_token.rb
@@ -1,0 +1,17 @@
+module Types
+  class PersonalAccessToken < BaseObject
+    description 'A Personal Access Token'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+    field :expires_at, GraphQL::Types::ISO8601DateTime
+    field :last_used_at, GraphQL::Types::ISO8601DateTime
+    field :revoked, Boolean, method: :revoked?
+    field :expires, Boolean, method: :expires?
+    field :active, Boolean, method: :active?
+    field :used, Boolean, method: :used?
+
+    belongs_to :user, Types::User
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -36,6 +36,9 @@ module Types
     record_field :usergroup, Types::Usergroup
     collection_field :usergroups, Types::Usergroup
 
+    record_field :personal_access_token, Types::PersonalAccessToken
+    collection_field :personal_access_tokens, Types::PersonalAccessToken
+
     record_field :host, Types::Host
     collection_field :hosts, Types::Host
 

--- a/app/graphql/types/user.rb
+++ b/app/graphql/types/user.rb
@@ -17,5 +17,6 @@ module Types
 
     belongs_to :default_location, Types::Location
     belongs_to :default_organization, Types::Organization
+    has_many :personal_access_tokens, Types::PersonalAccessToken
   end
 end

--- a/test/graphql/queries/personal_access_token_query_test.rb
+++ b/test/graphql/queries/personal_access_token_query_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class Queries::PersonalAccessTokenQueryTest < ActiveSupport::TestCase
+  test 'fetching personalAccessToken attributes' do
+    personal_access_token = FactoryBot.create(:personal_access_token)
+
+    query = <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        personalAccessToken(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+          expiresAt
+          lastUsedAt
+          revoked
+          expires
+          active
+          used
+          user {
+            id
+          }
+        }
+      }
+    GRAPHQL
+
+    personal_access_token_global_id = Foreman::GlobalId.for(personal_access_token)
+    variables = { id: personal_access_token_global_id }
+    context = { current_user: FactoryBot.create(:user, :admin) }
+
+    result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+    expected_personal_access_token_attributes = {
+      'id' => personal_access_token_global_id,
+      'createdAt' => personal_access_token.created_at.utc.iso8601,
+      'updatedAt' => personal_access_token.updated_at.utc.iso8601,
+      'name' => personal_access_token.name,
+      'expiresAt' => personal_access_token.expires_at.utc.iso8601,
+      'lastUsedAt' => nil,
+      'revoked' => personal_access_token.revoked?,
+      'expires' => personal_access_token.expires?,
+      'active' => personal_access_token.active?,
+      'used' => personal_access_token.used?,
+      'user' => {
+        'id' => Foreman::GlobalId.for(personal_access_token.user)
+      }
+    }
+
+    assert_empty result['errors']
+    assert_equal expected_personal_access_token_attributes, result['data']['personalAccessToken']
+  end
+end

--- a/test/graphql/queries/personal_access_tokens_query_test.rb
+++ b/test/graphql/queries/personal_access_tokens_query_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Queries::PersonalAccessTokensQueryTest < ActiveSupport::TestCase
+  test 'fetching personalAccessTokens attributes' do
+    FactoryBot.create_list(:personal_access_token, 2)
+
+    query = <<-GRAPHQL
+      query {
+        personalAccessTokens {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    context = { current_user: FactoryBot.create(:user, :admin) }
+    result = ForemanGraphqlSchema.execute(query, variables: {}, context: context)
+
+    expected_count = PersonalAccessToken.count
+
+    assert_empty result['errors']
+    assert_equal expected_count, result['data']['personalAccessTokens']['totalCount']
+    assert_equal expected_count, result['data']['personalAccessTokens']['edges'].count
+  end
+end

--- a/test/graphql/queries/user_query_test.rb
+++ b/test/graphql/queries/user_query_test.rb
@@ -11,6 +11,7 @@ class Queries::UserQueryTest < ActiveSupport::TestCase
                                     default_organization: organization,
                                     locale: 'en',
                                     timezone: 'Berlin')
+    FactoryBot.create_list(:personal_access_token, 2, user: user)
 
     query = <<-GRAPHQL
       query (
@@ -35,6 +36,14 @@ class Queries::UserQueryTest < ActiveSupport::TestCase
           }
           defaultOrganization {
             id
+          }
+          personalAccessTokens {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
           }
         }
       }
@@ -64,6 +73,16 @@ class Queries::UserQueryTest < ActiveSupport::TestCase
       },
       'defaultOrganization' => {
         'id' => Foreman::GlobalId.for(user.default_organization)
+      },
+      'personalAccessTokens' => {
+        'totalCount' => user.personal_access_tokens.count,
+        'edges' => user.personal_access_tokens.sort_by(&:id).map do |personal_access_token|
+          {
+            'node' => {
+              'id' => Foreman::GlobalId.for(personal_access_token)
+            }
+          }
+        end
       }
     }
 


### PR DESCRIPTION
This patch adds PersonalAccessToken queries to the GraphQL api.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
