### PR TITLE
Refs #26423 - pin fog-vsphere to <3.0

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,4 +1,4 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 2.3.0'
-  gem 'rbvmomi', '>= 1.9.0'
+  gem 'fog-vsphere', '~> 2.3'
+  gem 'rbvmomi', '~> 1.9'
 end


### PR DESCRIPTION
This pins fog-vsphere for `1.18-stable`. I know, we don't support this version anymore. But it'd help a lot for plugin tests that might want to support older versions.