### PR TITLE
Fixes #26154 - implement pxedir method for operatingsystem base 

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -217,6 +217,10 @@ class Operatingsystem < ApplicationRecord
     end
   end
 
+  def pxedir
+    ""
+  end
+
   def kernel(medium_provider)
     bootfile(medium_provider, :kernel)
   end

--- a/app/models/operatingsystems/rancheros.rb
+++ b/app/models/operatingsystems/rancheros.rb
@@ -13,10 +13,6 @@ class Rancheros < Operatingsystem
     PXEFILES[file]
   end
 
-  def pxedir
-    ''
-  end
-
   def display_family
     'RancherOS'
   end

--- a/app/models/operatingsystems/xenserver.rb
+++ b/app/models/operatingsystems/xenserver.rb
@@ -10,10 +10,6 @@ class Xenserver < Operatingsystem
     "xenserver"
   end
 
-  def pxedir
-    ""
-  end
-
   def xen(medium_provider)
     bootfile(medium_provider, :xen)
   end


### PR DESCRIPTION
Windows OS doesn't implement the pxedir method, causing provisioining to
fail when trying to calculate the unique id for the medium provider.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
