### PR TITLE
Fixes #26441 - default value for React datetime

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,7 +83,7 @@ module ApplicationHelper
     date_id = generate_date_id
 
     content_tag(:span, '', :id => date_id).html_safe +
-    mount_react_component(component, "##{date_id}", { date: time.try(:iso8601), default: _('N/A'), seconds: seconds }.to_json, { :flatten_data => true })
+    mount_react_component(component, "##{date_id}", { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }.to_json, { :flatten_data => true })
   end
 
   def contract(model)


### PR DESCRIPTION
Pass the default value for React datetime properly.

See: https://github.com/theforeman/foreman/blob/3fd1e4728173505f103fc6fd7ab66244df191361/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.js#L33
https://github.com/theforeman/foreman/blob/3fd1e4728173505f103fc6fd7ab66244df191361/webpack/assets/javascripts/react_app/components/common/dates/RelativeDateTime.js#L34
https://github.com/theforeman/foreman/blob/3fd1e4728173505f103fc6fd7ab66244df191361/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.js#L34

<!--
Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
