### PR TITLE
Fixes  #26452 - default disable autocomplete key shortcuts

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
@@ -224,7 +224,7 @@ AutoComplete.defaultProps = {
   getResults: noop,
   resetData: noop,
   initialUpdate: noop,
-  useKeyShortcuts: true,
+  useKeyShortcuts: false,
   placeholder: 'Filter ...',
   url: null,
 };

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/AutoComplete.test.js
@@ -43,7 +43,7 @@ describe('AutoComplete', () => {
 
     it('pressing "forward-slash" should trigger focus', () => {
       const props = getProps();
-      const component = mount(<AutoComplete {...props} />);
+      const component = mount(<AutoComplete {...props} useKeyShortcuts />);
       const instance = component.instance();
       const typeahead = instance._typeahead.current.getInstance();
       typeahead.focus = jest.fn();

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -25,7 +25,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
     ignoreDiacritics={true}
     inputProps={
       Object {
-        "className": "search-input use-shortcuts",
+        "className": "search-input",
         "data-autocomplete-id": "some-id",
         "spellCheck": "false",
       }
@@ -61,7 +61,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
     onClear={[Function]}
   />
   <AutoCompleteFocusShortcut
-    useKeyShortcuts={true}
+    useKeyShortcuts={false}
   />
   <AutoCompleteError
     error={null}

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteFocusShortcut.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/components/AutoCompleteFocusShortcut.js
@@ -32,7 +32,7 @@ AutoCompleteFocusShortcut.propTypes = {
 };
 
 AutoCompleteFocusShortcut.defaultProps = {
-  useKeyShortcuts: true,
+  useKeyShortcuts: false,
 };
 
 export default AutoCompleteFocusShortcut;

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
@@ -4,6 +4,7 @@ export const SearchBarProps = {
       searchQuery: null,
       url: 'model/auto_complete_search',
       id: 'some-id',
+      useKeyShortcuts: true,
     },
     bookmarks: {
       url: '/api/bookmarks',

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -10,6 +10,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
     id="some-id"
     initialQuery=""
     url="model/auto_complete_search"
+    useKeyShortcuts={true}
   />
   <div
     className="input-group-btn"

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -59,6 +59,7 @@ exports[`render pageLayout w/search 1`] = `
                     "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
                   },
                   "bookmarks": Object {
                     "canCreate": true,
@@ -153,6 +154,7 @@ exports[`render pageLayout w/toastNotifications 1`] = `
                     "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
                   },
                   "bookmarks": Object {
                     "canCreate": true,
@@ -241,6 +243,7 @@ exports[`render pageLayout w/toolBar 1`] = `
                     "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
                   },
                   "bookmarks": Object {
                     "canCreate": true,
@@ -305,6 +308,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
                     "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
                   },
                   "bookmarks": Object {
                     "canCreate": true,
@@ -375,6 +379,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
                     "id": "some-id",
                     "searchQuery": null,
                     "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
                   },
                   "bookmarks": Object {
                     "canCreate": true,


### PR DESCRIPTION
While using only the `SearchBar` it made sense to set `usekeyShortcuts` prop to `true` by default.
Now, while it is possible to consume the `Autocomplete` component independently, 
we don't want to use those key shortcuts by default.