### PR TITLE
Fixes #26457 - graphql: Allow filtering subnets in the Domain query

### DIFF
--- a/app/graphql/collection_loader.rb
+++ b/app/graphql/collection_loader.rb
@@ -1,7 +1,8 @@
 class CollectionLoader < GraphQL::Batch::Loader
-  def initialize(model, association_name)
+  def initialize(model, association_name, scope = nil)
     @model = model
     @association_name = association_name
+    @scope = scope
     validate
   end
 
@@ -30,7 +31,7 @@ class CollectionLoader < GraphQL::Batch::Loader
   end
 
   def preload_association(records)
-    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name, @scope)
   end
 
   def read_association(record)

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -10,17 +10,25 @@ module Types
         field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
       end
 
-      def has_many(name, type, null: true)
-        field name, type.connection_type, null: null,
-          resolve: proc { |object| CollectionLoader.for(object.class, name).load(object) }
+      def has_many(name, type, null: true, resolver: nil)
+        if resolver
+          field name, type.connection_type, null: null, resolver: resolver
+        else
+          field name, type.connection_type, null: null,
+            resolve: proc { |object| CollectionLoader.for(object.class, name).load(object) }
+        end
       end
 
-      def belongs_to(name, type, null: true)
-        field name, type, null: null,
-          resolve: (proc do |object|
-            foreign_key = object.class.reflect_on_association(name).foreign_key
-            RecordLoader.for(type.model_class).load(object.send(foreign_key))
-          end)
+      def belongs_to(name, type, null: true, resolver: nil)
+        if resolver
+          field name, type, null: null, resolver: resolver
+        else
+          field name, type, null: null,
+            resolve: (proc do |object|
+              foreign_key = object.class.reflect_on_association(name).foreign_key
+              RecordLoader.for(type.model_class).load(object.send(foreign_key))
+            end)
+        end
       end
 
       def model_class

--- a/app/graphql/types/domain.rb
+++ b/app/graphql/types/domain.rb
@@ -7,6 +7,6 @@ module Types
     field :name, String, null: true
     field :fullname, String, null: true
 
-    has_many :subnets, Types::Subnet
+    has_many :subnets, Types::Subnet, resolver: Resolvers::Domain::Subnets
   end
 end


### PR DESCRIPTION
It is now possible to filter subnets by type and location in the Domain query
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
