### PR TITLE
Fixes #26462 - Add 'Not implemented' error for refresh_cache

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -301,6 +301,10 @@ class ComputeResource < ApplicationRecord
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end
 
+  def refresh_cache
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
   # returs an array of translated errors that prevents to build a volume on this provider
   def new_volume_errors
     []

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -192,7 +192,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
 
     test 'should fail if unsupported' do
       put :refresh_cache, params: { :id => compute_resources(:ovirt).to_param }
-      assert_response :unprocessable_entity
+      assert_response :error
     end
   end
 

--- a/test/controllers/compute_resources_controller_test.rb
+++ b/test/controllers/compute_resources_controller_test.rb
@@ -213,9 +213,10 @@ class ComputeResourcesControllerTest < ActionController::TestCase
     end
 
     test 'should not refresh the cache if unsupported' do
-      put :refresh_cache, params: { :id => @compute_resource.to_param }, session: set_session_user
-      assert_redirected_to compute_resource_url(@compute_resource)
-      assert_match /Failed to refresh the cache/, flash[:error]
+      err = assert_raise Foreman::Exception do
+        put :refresh_cache, params: { :id => @compute_resource.to_param }, session: set_session_user
+      end
+      assert_match /Not implemented for Libvirt/, err.message
     end
   end
 


### PR DESCRIPTION
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
