### PR TITLE
Refs #26423 - Fix fog-vsphere references in tests

### DIFF
--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -646,7 +646,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
       args = default_args.merge(
         user_data: "---\n{}"
       )
-      Fog::Compute::Vsphere::Real.any_instance.expects(:cloudinit_to_customspec).never
+      Fog::Vsphere::Compute::Real.any_instance.expects(:cloudinit_to_customspec).never
       cr.send(:client).stubs(:vm_clone).returns({'new_vm' => {'id' => 123}})
       cr.clone_vm(args)
     end

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -50,8 +50,8 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
       end
 
       test 'does not create an invalid domain' do
-        Fog::Compute::Vsphere::Server.any_instance.stubs(:name).returns('mytestvm')
-        Fog::Compute::Vsphere::Server.any_instance.stubs(:hostname).returns(nil)
+        Fog::Vsphere::Compute::Server.any_instance.stubs(:name).returns('mytestvm')
+        Fog::Vsphere::Compute::Server.any_instance.stubs(:hostname).returns(nil)
         assert_equal 'mytestvm', host.name
         assert_nil host.domain
       end


### PR DESCRIPTION
8b05fa95168456fb7193bf4303bc1eb2b2136671 updated fog-vsphere to 3.0, but missed these references.