### PR TITLE
Fixes #26475 - Password Strength snapshot changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-intl": "^2.8.0",
     "react-numeric-input": "^2.0.7",
     "react-onclickoutside": "^6.6.2",
-    "react-password-strength": "^2.1.0",
+    "react-password-strength": "^2.4.0",
     "react-redux": "^5.0.6",
     "redux": "^3.6.0",
     "redux-form": "7.2.0",

--- a/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/__snapshots__/PasswordStrength.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/__snapshots__/PasswordStrength.test.js.snap
@@ -24,6 +24,7 @@ exports[`PasswordStrength component rendering renders password-strength 1`] = `
       }
       minLength={6}
       minScore={2}
+      namespaceClassName="ReactPasswordStrength"
       scoreWords={
         Array [
           "Weak",
@@ -64,6 +65,7 @@ exports[`PasswordStrength component rendering renders password-strength with pas
       }
       minLength={6}
       minScore={2}
+      namespaceClassName="ReactPasswordStrength"
       scoreWords={
         Array [
           "Weak",
@@ -121,6 +123,7 @@ exports[`PasswordStrength component rendering renders password-strength with unm
       }
       minLength={6}
       minScore={2}
+      namespaceClassName="ReactPasswordStrength"
       scoreWords={
         Array [
           "Weak",
@@ -178,6 +181,7 @@ exports[`PasswordStrength component rendering renders password-strength with use
       }
       minLength={6}
       minScore={2}
+      namespaceClassName="ReactPasswordStrength"
       scoreWords={
         Array [
           "Weak",


### PR DESCRIPTION
`namespaceClassName="ReactPasswordStrength"` was added to the snapshot caused tests to fail.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
