### PR TITLE
Fixes #26387 - graphql: add network queries

### DIFF
--- a/app/graphql/resolvers/compute_resource/networks.rb
+++ b/app/graphql/resolvers/compute_resource/networks.rb
@@ -1,0 +1,13 @@
+module Resolvers
+  module ComputeResource
+    class Networks < Resolvers::BaseResolver
+      type [Types::Networks::Union], null: true
+
+      argument :cluster_id, String, required: false
+
+      def resolve(cluster_id: nil)
+        object.available_networks(cluster_id.presence)
+      end
+    end
+  end
+end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,4 +1,5 @@
 module Types
   class BaseUnion < GraphQL::Schema::Union
+    connection_type_class Connections::BaseConnection
   end
 end

--- a/app/graphql/types/compute_resource.rb
+++ b/app/graphql/types/compute_resource.rb
@@ -12,5 +12,6 @@ module Types
 
     has_many :compute_attributes, Types::ComputeAttribute
     has_many :hosts, Types::Host
+    has_many :networks, Types::Networks::Union, resolver: Resolvers::ComputeResource::Networks
   end
 end

--- a/app/graphql/types/networks/union.rb
+++ b/app/graphql/types/networks/union.rb
@@ -1,0 +1,16 @@
+module Types
+  module Networks
+    class Union < Types::BaseUnion
+      description 'Networks that are defined for a compute resource'
+      possible_types Vmware
+
+      def self.resolve_type(object, context)
+        return Vmware if object.is_a?(Fog::Vsphere::Compute::Network)
+
+        raise UnknownNetworkType.new(N_('Cannot resolve network type for %s'), object.class)
+      end
+
+      class UnknownNetworkType < ::Foreman::Exception; end
+    end
+  end
+end

--- a/app/graphql/types/networks/vmware.rb
+++ b/app/graphql/types/networks/vmware.rb
@@ -1,0 +1,14 @@
+module Types
+  module Networks
+    class Vmware < Types::BaseObject
+      description 'A Network on a VMWare Compute Resource'
+
+      field :id, ID, null: false
+      field :name, String, null: false
+      field :virtualswitch, String, null: true
+      field :datacenter, String, null: false
+      field :accessible, Boolean, null: true
+      field :vlanid, Integer, null: true
+    end
+  end
+end


### PR DESCRIPTION
This patch adds networks to the VMWare Compute Resource query.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
