### PR TITLE
fixes #26487 - user login with graphql

### DIFF
--- a/app/graphql/mutations/sign_in_user.rb
+++ b/app/graphql/mutations/sign_in_user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  class SignInUser < BaseMutation
+    null true
+
+    argument :username, String, required: true
+    argument :password, String, required: true
+
+    field :token, String, null: false
+    field :user, Types::User, null: false
+
+    def resolve(username:, password:)
+      return unless username && password
+
+      user = User.try_to_login(username, password)
+      return unless user
+
+      {
+        token: user.jwt_token!,
+        user: user
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation.rb
+++ b/app/graphql/types/mutation.rb
@@ -2,6 +2,8 @@ module Types
   class Mutation < BaseObject
     graphql_name 'Mutation'
 
+    field :signInUser, mutation: Mutations::SignInUser
+
     field :create_model, mutation: Mutations::Models::Create
     field :update_model, mutation: Mutations::Models::Update
     field :delete_model, mutation: Mutations::Models::Delete

--- a/test/graphql/mutations/sign_in_user_mutation_test.rb
+++ b/test/graphql/mutations/sign_in_user_mutation_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+module Mutations
+  class SignInUserMutationTest < ActiveSupport::TestCase
+    let(:context) { {} }
+    let(:user) { FactoryBot.create(:user, firstname: 'Jane', lastname: 'Doe') }
+    let(:global_id) { Foreman::GlobalId.for(user) }
+    let(:variables) do
+      {
+        username: user.login,
+        password: 'password'
+      }
+    end
+    let(:query) do
+      <<-GRAPHQL
+          mutation SignInUserMutation (
+              $username: String!,
+              $password: String!,
+            ) {
+            signInUser(input: {
+              username: $username,
+              password: $password,
+            }) {
+              token
+              user {
+                id,
+                fullname,
+                login
+              }
+            }
+          }
+      GRAPHQL
+    end
+
+    test 'signs a user in' do
+      result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+      assert_empty result['errors']
+
+      data = result['data']['signInUser']
+
+      assert_equal user.id, JwtToken.new(data['token']).decode['user_id']
+      assert_equal global_id, data['user']['id']
+      assert_equal user.fullname, data['user']['fullname']
+      assert_equal user.login, data['user']['login']
+    end
+
+    test 'does not sign a user in when the credentials are wrong' do
+      variables[:password] = 'wrong-password'
+
+      result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+      assert_empty result['errors']
+
+      assert_nil result['data']['signInUser']
+    end
+  end
+end


### PR DESCRIPTION
This needs #5736, so the relevant changes are in ff47c1e.

This adds a mutation to graphql that signs in a user. A user provides username and password and a JWT is returned that the user can use to authenticiate further requests.