### PR TITLE
fixes #26488 - graphql: add currentUser query

### DIFF
--- a/app/graphql/resolvers/user/current.rb
+++ b/app/graphql/resolvers/user/current.rb
@@ -1,0 +1,11 @@
+module Resolvers
+  module User
+    class Current < ::Resolvers::BaseResolver
+      type ::Types::User, null: true
+
+      def resolve
+        context[:current_user]
+      end
+    end
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -15,6 +15,8 @@ module Types
     field :node, field: GraphQL::Relay::Node.field
     field :nodes, field: GraphQL::Relay::Node.plural_field
 
+    field :currentUser, Types::User, null: true, resolver: Resolvers::User::Current
+
     record_field :model, Types::Model
     collection_field :models, Types::Model
 

--- a/test/graphql/queries/current_user_query_test.rb
+++ b/test/graphql/queries/current_user_query_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class Queries::CurrentUserQueryTest < GraphQLQueryTestCase
+  let(:query) do
+    <<-GRAPHQL
+      query {
+        currentUser {
+          id
+          login
+          usergroups {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+  end
+  let(:user) { FactoryBot.create(:user, :with_usergroup) }
+  let(:global_id) { Foreman::GlobalId.for(user) }
+  let(:variables) {{}}
+  let(:data) { result['data']['currentUser'] }
+
+  context 'with logged in user' do
+    let(:context) {{ current_user: user }}
+    test 'fetching current user attributes' do
+      assert_empty result['errors']
+
+      assert_equal global_id, data['id']
+      assert_equal user.login, data['login']
+
+      assert_collection user.usergroups, data['usergroups']
+    end
+  end
+
+  context 'without logged in user' do
+    let(:context) {{ current_user: nil }}
+
+    test 'currentUser returns nil' do
+      assert_empty result['errors']
+      assert_nil data
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a currentUser query for graphql. If you're logged in you should be able to retrieve your own name with this query:

```graphql
query {
  currentUser {
    fullname
  }
}
```