### PR TITLE
Fixes #26493 - Pin Capybara on Ruby 2.3 to supported version

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -5,7 +5,7 @@ group :test do
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 5.3'
   gem 'ci_reporter_minitest', :require => false
-  gem 'capybara', '~> 3.0', :require => false
+  gem 'capybara', '~> 3.0', (RUBY_VERSION.start_with?('2.3') ? '< 3.16' : '< 4'), :require => false
   gem 'puma', :require => false
   gem 'show_me_the_cookies', '~> 4.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false


### PR DESCRIPTION
Capybara 3.16 requires Ruby >= 2.4


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
