### PR TITLE
Fixes #26097 - fix storybook build and deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-register": "^6.9.0",
     "compression-webpack-plugin": "~1.1.11",
     "coveralls": "^3.0.0",
+    "cross-env": "^5.2.0",
     "css-loader": "^0.23.1",
     "dotenv": "^5.0.0",
     "enzyme": "^3.4.0",
@@ -122,8 +123,8 @@
     "test:current": "node node_modules/.bin/jest --watch",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "deploy-storybook": "storybook-to-ghpages",
+    "build-storybook": "cross-env NODE_OPTIONS=--max_old_space_size=8192 build-storybook",
+    "deploy-storybook": "cross-env NODE_OPTIONS=--max_old_space_size=8192 storybook-to-ghpages",
     "postinstall": "node ./script/npm_install_plugins.js",
     "analyze": "./script/webpack-analyze",
     "create-react-component": "yo react-domain"


### PR DESCRIPTION
After git biscet, I found that [this](https://github.com/theforeman/foreman/pull/6280) PR (commit `Unify look of the storybook`)  caused the regression with the build process.  

One comment from that PR, caught my attention: 
> I had some troubles with js reaching out of memory when I was building the storybook. Could someone try if you experience the same or if it's just my setup?

I took the idea for the solution from https://github.com/webpack/webpack/issues/1914#issuecomment-418826942 using `cross-env` in order to lunch a node process with extra memory.

I've tried to understand why it takes high amount of memory though, apparently the sass-loader of patternfly sass  causes it.