### PR TITLE
fixes #26504 - host search current_user efficiently

### DIFF
--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -20,5 +20,92 @@ module Hostext
         assert_not_includes result, @host
       end
     end
+
+    describe 'a host with user search' do
+      let(:user) { FactoryBot.create(:user, :with_mail, firstname: 'Jane', lastname: 'Doe') }
+      let(:host) { FactoryBot.create(:host, owner: user) }
+      let(:other_host) { FactoryBot.create(:host) }
+
+      setup do
+        host
+        other_host
+      end
+
+      context 'with a standalone user' do
+        test 'can be searched by current_user' do
+          result = User.as(user.login) { Host.search_for('owner = current_user') }
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'can be searched by login' do
+          result = Host.search_for("owner = #{user.login}")
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'can be searched by firstname' do
+          result = Host.search_for("user.firstname = #{user.firstname}")
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'can be searched by lastname' do
+          result = Host.search_for("user.lastname = #{user.lastname}")
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'can be searched by mail' do
+          result = Host.search_for("user.mail = #{user.mail}")
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'can be searched by hostname and firstname' do
+          result = Host.search_for("name = \"#{host.name}\" and user.firstname = #{user.firstname}")
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+
+        test 'does not find hosts if condition does not match anything' do
+          result = Host.search_for('user.firstname = does_not_exist')
+          assert_empty result
+        end
+      end
+
+      context 'with a host owned by a usergroup' do
+        let(:usergroup) { FactoryBot.create(:usergroup) }
+        let(:usergroup_host) { FactoryBot.create(:host, owner: usergroup) }
+
+        setup do
+          usergroup_host
+          FactoryBot.create(:user_usergroup_member, usergroup: usergroup, member: user)
+        end
+
+        test 'current_user finds a host owned by a usergroup' do
+          result = User.as(user.login) { Host.search_for('owner = current_user') }
+          assert_same_elements result, [host, usergroup_host]
+          assert_not_includes result, other_host
+        end
+
+        test 'current_user finds a host owned by a parent usergroup' do
+          parent_usergroup = FactoryBot.create(:usergroup)
+          parent_usergroup_host = FactoryBot.create(:host, owner: parent_usergroup)
+
+          FactoryBot.create(:usergroup_usergroup_member, usergroup: parent_usergroup, member: usergroup)
+
+          result = User.as(user.login) { Host.search_for('owner = current_user') }
+          assert_same_elements result, [host, usergroup_host, parent_usergroup_host]
+          assert_not_includes result, other_host
+        end
+
+        test 'current_user finds a host by name and owned by a usergroup' do
+          result = User.as(user.login) { Host.search_for("name = \"#{host.name}\" and owner = current_user") }
+          assert_same_elements result, [host]
+          assert_not_includes result, other_host
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a bunch of tests for `search_by_user` and refactors the method to not use a recursive lookup to find the hosts where the current user is an owner. Instead, it uses the usergroup cache to determine the user groups where the user is a member of. It also saves a host query by using proper conditions directly in the search query.

cc: @tbrisker