### PR TITLE
Fixes #26273 - numeric input unified onChange behaviour

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/Checkbox.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Checkbox.js
@@ -3,14 +3,22 @@ import PropTypes from 'prop-types';
 
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
+import { makeOnChangeHanler } from './helpers';
 
-const Checkbox = ({ className, checked, onChange, label, disabled }) => (
+const Checkbox = ({
+  className,
+  checked,
+  onValueChange,
+  onChange,
+  label,
+  disabled,
+}) => (
   <CommonForm label={label} className={`common-checkbox ${className}`}>
     <input
       disabled={disabled}
       type="checkbox"
       checked={checked}
-      onChange={onChange}
+      onChange={makeOnChangeHanler(onChange, onValueChange)}
     />
   </CommonForm>
 );
@@ -21,6 +29,7 @@ Checkbox.propTypes = {
   label: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  onValueChange: PropTypes.func,
 };
 
 Checkbox.defaultProps = {
@@ -29,6 +38,7 @@ Checkbox.defaultProps = {
   label: '',
   disabled: false,
   onChange: noop,
+  onValueChange: noop,
 };
 
 export default Checkbox;

--- a/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
@@ -1,11 +1,11 @@
-import NumericInput from 'react-numeric-input';
+import ReactNumericInput from 'react-numeric-input';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
 
-const TextInput = ({
+const NumericInput = ({
   label,
   className,
   value,
@@ -15,17 +15,17 @@ const TextInput = ({
   minValue,
 }) => (
   <CommonForm label={label} className={`common-numericInput ${className}`}>
-    <NumericInput
+    <ReactNumericInput
       format={format}
       min={minValue}
       value={value}
       precision={precision}
-      onChange={onChange}
+      onChange={v => onChange({ target: { value: v } })}
     />
   </CommonForm>
 );
 
-TextInput.propTypes = {
+NumericInput.propTypes = {
   label: PropTypes.string,
   className: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -35,7 +35,7 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
 };
 
-TextInput.defaultProps = {
+NumericInput.defaultProps = {
   label: '',
   className: '',
   value: 0,
@@ -45,4 +45,4 @@ TextInput.defaultProps = {
   onChange: noop,
 };
 
-export default TextInput;
+export default NumericInput;

--- a/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
@@ -9,7 +9,7 @@ const NumericInput = ({
   label,
   className,
   value,
-  onChange,
+  onValueChange,
   format,
   precision,
   minValue,
@@ -20,7 +20,7 @@ const NumericInput = ({
       min={minValue}
       value={value}
       precision={precision}
-      onChange={v => onChange({ target: { value: v } })}
+      onChange={onValueChange}
     />
   </CommonForm>
 );
@@ -32,7 +32,7 @@ NumericInput.propTypes = {
   format: PropTypes.func,
   precision: PropTypes.number,
   minValue: PropTypes.number,
-  onChange: PropTypes.func,
+  onValueChange: PropTypes.func,
 };
 
 NumericInput.defaultProps = {
@@ -42,7 +42,7 @@ NumericInput.defaultProps = {
   format: null,
   precision: 0,
   minValue: 0,
-  onChange: noop,
+  onValueChange: noop,
 };
 
 export default NumericInput;

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -20,16 +20,13 @@ class Select extends React.Component {
     }
   }
 
-  customOnChange() {
-    const { onChange, onValueChange } = this.props;
-    return makeOnChangeHanler(onChange, onValueChange);
-  }
-
   attachEvent() {
-    const { onChange } = this.props;
+    const { onChange, onValueChange } = this.props;
+    const newOnChange = makeOnChangeHanler(onChange, onValueChange);
     $(this.select)
-      .off('change')
-      .on('change', this.customOnChange());
+      .off('change', this.onChange)
+      .on('change', newOnChange);
+    this.onChange = newOnChange;
   }
 
   componentDidMount() {
@@ -76,7 +73,7 @@ class Select extends React.Component {
           }}
           className="form-control"
           value={value}
-          onChange={this.customOnChange()}
+          onChange={makeOnChangeHanler(onChange, onValueChange)}
         >
           <option />
           {renderOptions(options)}

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -9,6 +9,7 @@ import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
 import { STATUS } from '../../../constants';
 import MessageBox from '../MessageBox';
+import { makeOnChangeHanler } from './helpers';
 
 class Select extends React.Component {
   initializeSelect2() {
@@ -19,11 +20,16 @@ class Select extends React.Component {
     }
   }
 
+  customOnChange() {
+    const { onChange, onValueChange } = this.props;
+    return makeOnChangeHanler(onChange, onValueChange);
+  }
+
   attachEvent() {
     const { onChange } = this.props;
     $(this.select)
-      .off('change', onChange)
-      .on('change', onChange);
+      .off('change')
+      .on('change', this.customOnChange());
   }
 
   componentDidMount() {
@@ -52,6 +58,7 @@ class Select extends React.Component {
       className,
       value,
       onChange,
+      onValueChange,
       options,
       disabled,
       status = STATUS.RESOLVED,
@@ -69,7 +76,7 @@ class Select extends React.Component {
           }}
           className="form-control"
           value={value}
-          onChange={onChange}
+          onChange={this.customOnChange()}
         >
           <option />
           {renderOptions(options)}
@@ -116,6 +123,7 @@ Select.propTypes = {
   status: PropTypes.string,
   errorMessage: PropTypes.string,
   onChange: PropTypes.func,
+  onValueChange: PropTypes.func,
 };
 
 Select.defaultProps = {
@@ -128,6 +136,7 @@ Select.defaultProps = {
   status: STATUS.RESOLVED,
   errorMessage: __('An error occured.'),
   onChange: noop,
+  onValueChange: noop,
 };
 
 export default Select;

--- a/webpack/assets/javascripts/react_app/components/common/forms/TextInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/TextInput.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CommonForm from './CommonForm';
+import { makeOnChangeHanler } from './helpers';
 import { noop } from '../../../common/helpers';
 
-const TextInput = ({ label, className, value, onChange }) => (
+const TextInput = ({ label, className, value, onChange, onValueChange }) => (
   <CommonForm label={label} className={`common-textInput ${className}`}>
     <input
       type="text"
       className="form-control"
       value={value}
-      onChange={onChange}
+      onChange={makeOnChangeHanler(onChange, onValueChange)}
     />
   </CommonForm>
 );
@@ -19,6 +20,7 @@ TextInput.propTypes = {
   className: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,
+  onValueChange: PropTypes.func,
 };
 
 TextInput.defaultProps = {
@@ -26,6 +28,7 @@ TextInput.defaultProps = {
   className: '',
   value: '',
   onChange: noop,
+  onValueChange: noop,
 };
 
 export default TextInput;

--- a/webpack/assets/javascripts/react_app/components/common/forms/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/helpers.js
@@ -1,7 +1,14 @@
+import { noop } from '../../../common/helpers';
+import { deprecate } from '../../../common/DeprecationService';
+
 const getEventValue = ({ target: { type, checked, value } }) =>
   type === 'checkbox' ? checked : value;
 
-export const makeOnChangeHanler = (onChange, onValueChange) => evt => {
-  onChange(evt);
-  onValueChange(getEventValue(evt));
+export const makeOnChangeHanler = (onChange, onValueChange) => {
+  if (onChange !== noop) deprecate('onChange', 'onValueChange', '1.24');
+
+  return evt => {
+    onChange(evt);
+    onValueChange(getEventValue(evt));
+  };
 };

--- a/webpack/assets/javascripts/react_app/components/common/forms/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/helpers.js
@@ -1,0 +1,7 @@
+const getEventValue = ({ target: { type, checked, value } }) =>
+  type === 'checkbox' ? checked : value;
+
+export const makeOnChangeHanler = (onChange, onValueChange) => evt => {
+  onChange(evt);
+  onValueChange(getEventValue(evt));
+};

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/__snapshots__/controller.test.js.snap
@@ -24,6 +24,7 @@ exports[`StorageContainer should render controller 1`] = `
         errorMessage="An error occured."
         label=""
         onChange={[Function]}
+        onValueChange={[Function]}
         options={
           Object {
             "ParaVirtualSCSIController": "VMware Paravirtual",

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/disk.test.js
@@ -12,22 +12,4 @@ describe('StorageContainer', () => {
 
     expect(wrapper.find('.text-vmware-size').props().value).toEqual(10);
   });
-
-  test.each`
-    toChange        | htmlSelector      | toDismiss
-    ${'storagePod'} | ${'.storage-pod'} | ${'datastore'}
-    ${'datastore'}  | ${'.datastore'}   | ${'storagePod'}
-  `(
-    'hides $toDismiss on $toChange selection',
-    ({ toChange, htmlSelector, toDismiss }) => {
-      const updateDisk = jest.fn();
-      const wrapper = shallow(<Disk {...props} updateDisk={updateDisk} />);
-      const evt = { target: { value: `new_${toChange}_id` } };
-      wrapper.find(`Select${htmlSelector}`).simulate('change', evt);
-      expect(updateDisk).toHaveBeenCalledWith(toChange, evt);
-      expect(updateDisk).toHaveBeenCalledWith(toDismiss, {
-        target: { value: null },
-      });
-    }
-  );
 });

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
@@ -26,13 +26,13 @@ const Disk = ({
   storagePodsStatus,
   storagePodsError,
 }) => {
-  const updateStoragePod = newValues => {
-    updateDisk('storagePod', newValues);
-    updateDisk('datastore', { target: { value: null } });
+  const updateStoragePod = newValue => {
+    updateDisk('storagePod', newValue);
+    updateDisk('datastore', null);
   };
-  const updateDatastore = newValues => {
-    updateDisk('datastore', newValues);
-    updateDisk('storagePod', { target: { value: null } });
+  const updateDatastore = newValue => {
+    updateDisk('datastore', newValue);
+    updateDisk('storagePod', null);
   };
 
   return (
@@ -53,7 +53,7 @@ const Disk = ({
           label={__('Storage Pod')}
           value={storagePod}
           disabled={vmExists}
-          onChange={newValues => updateStoragePod(newValues)}
+          onValueChange={newValue => updateStoragePod(newValue)}
           options={storagePods}
           allowClear
           key="storagePodsSelect"
@@ -67,7 +67,7 @@ const Disk = ({
           disabled={vmExists}
           label={__('Data store')}
           value={datastore}
-          onChange={newValues => updateDatastore(newValues)}
+          onValueChange={newValue => updateDatastore(newValue)}
           options={datastores}
           allowClear
           key="datastoresSelect"
@@ -81,7 +81,7 @@ const Disk = ({
         label={__('Disk Mode')}
         value={mode}
         disabled={vmExists}
-        onChange={newValues => updateDisk('mode', newValues)}
+        onValueChange={newValue => updateDisk('mode', newValue)}
         options={diskModeTypes}
       />
 
@@ -90,7 +90,7 @@ const Disk = ({
         minValue={1}
         format={v => `${v} GB`}
         className="text-vmware-size"
-        onChange={newValues => updateDisk('sizeGb', newValues)}
+        onValueChange={newValue => updateDisk('sizeGb', newValue)}
         label={__('Size (GB)')}
       />
 
@@ -98,14 +98,14 @@ const Disk = ({
         label={__('Thin provision')}
         checked={thin}
         disabled={vmExists}
-        onChange={newValues => updateDisk('thin', newValues)}
+        onValueChange={newValue => updateDisk('thin', newValue)}
       />
 
       <Checkbox
         label={__('Eager zero')}
         checked={eagerzero}
         disabled={vmExists}
-        onChange={newValues => updateDisk('eagerzero', newValues)}
+        onValueChange={newValue => updateDisk('eagerzero', newValue)}
       />
     </div>
   );

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
@@ -25,91 +25,84 @@ const Disk = ({
   storagePods,
   storagePodsStatus,
   storagePodsError,
-}) => {
-  const updateStoragePod = newValue => {
-    updateDisk('storagePod', newValue);
-    updateDisk('datastore', null);
-  };
-  const updateDatastore = newValue => {
-    updateDisk('datastore', newValue);
-    updateDisk('storagePod', null);
-  };
-
-  return (
-    <div className="disk-container">
-      <div className="form-group">
-        <label className="col-md-2 control-label">{__('Disk name')}</label>
-        <div className="col-md-4">{name}</div>
-        <div className="col-md-2">
-          {!vmExists && (
-            <Button className="close" onClick={removeDisk}>
-              <span aria-hidden="true">&times;</span>
-            </Button>
-          )}
-        </div>
+}) => (
+  <div className="disk-container">
+    <div className="form-group">
+      <label className="col-md-2 control-label">{__('Disk name')}</label>
+      <div className="col-md-4">{name}</div>
+      <div className="col-md-2">
+        {!vmExists && (
+          <Button className="close" onClick={removeDisk}>
+            <span aria-hidden="true">&times;</span>
+          </Button>
+        )}
       </div>
-      {!(datastore && datastore.length) && (
-        <Select
-          label={__('Storage Pod')}
-          value={storagePod}
-          disabled={vmExists}
-          onValueChange={newValue => updateStoragePod(newValue)}
-          options={storagePods}
-          allowClear
-          key="storagePodsSelect"
-          status={storagePodsStatus}
-          errorMessage={storagePodsError}
-          className="storage-pod"
-        />
-      )}
-      {!(storagePod && storagePod.length) && (
-        <Select
-          disabled={vmExists}
-          label={__('Data store')}
-          value={datastore}
-          onValueChange={newValue => updateDatastore(newValue)}
-          options={datastores}
-          allowClear
-          key="datastoresSelect"
-          status={datastoresStatus}
-          errorMessage={datastoresError}
-          className="datastore"
-        />
-      )}
-
-      <Select
-        label={__('Disk Mode')}
-        value={mode}
-        disabled={vmExists}
-        onValueChange={newValue => updateDisk('mode', newValue)}
-        options={diskModeTypes}
-      />
-
-      <NumericInput
-        value={sizeGb}
-        minValue={1}
-        format={v => `${v} GB`}
-        className="text-vmware-size"
-        onValueChange={newValue => updateDisk('sizeGb', newValue)}
-        label={__('Size (GB)')}
-      />
-
-      <Checkbox
-        label={__('Thin provision')}
-        checked={thin}
-        disabled={vmExists}
-        onValueChange={newValue => updateDisk('thin', newValue)}
-      />
-
-      <Checkbox
-        label={__('Eager zero')}
-        checked={eagerzero}
-        disabled={vmExists}
-        onValueChange={newValue => updateDisk('eagerzero', newValue)}
-      />
     </div>
-  );
-};
+    {!(datastore && datastore.length) && (
+      <Select
+        label={__('Storage Pod')}
+        value={storagePod}
+        disabled={vmExists}
+        onValueChange={newValue =>
+          updateDisk({ storagePod: newValue, datastore: '' })
+        }
+        options={storagePods}
+        allowClear
+        key="storagePodsSelect"
+        status={storagePodsStatus}
+        errorMessage={storagePodsError}
+        className="storage-pod"
+      />
+    )}
+    {!(storagePod && storagePod.length) && (
+      <Select
+        disabled={vmExists}
+        label={__('Data store')}
+        value={datastore}
+        onValueChange={newValue =>
+          updateDisk({ datastore: newValue, storagePod: '' })
+        }
+        options={datastores}
+        allowClear
+        key="datastoresSelect"
+        status={datastoresStatus}
+        errorMessage={datastoresError}
+        className="datastore"
+      />
+    )}
+
+    <Select
+      label={__('Disk Mode')}
+      value={mode}
+      disabled={vmExists}
+      onValueChange={newValue => updateDisk({ mode: newValue })}
+      options={diskModeTypes}
+    />
+
+    <NumericInput
+      value={sizeGb}
+      minValue={1}
+      format={v => `${v} GB`}
+      className="text-vmware-size"
+      onValueChange={newValue => updateDisk({ sizeGb: newValue })}
+      label={__('Size (GB)')}
+    />
+
+    <Checkbox
+      label={__('Thin provision')}
+      checked={thin}
+      disabled={vmExists}
+      onValueChange={newValue => updateDisk({ thin: newValue })}
+    />
+
+    <Checkbox
+      label={__('Eager zero')}
+      checked={eagerzero}
+      disabled={vmExists}
+      onValueChange={newValue => updateDisk({ eagerzero: newValue })}
+    />
+  </div>
+);
 
 Disk.propTypes = {
   config: PropTypes.shape({

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
@@ -31,15 +31,12 @@ const Controller = ({
   storagePodsStatus,
   storagePodsError,
 }) => {
-  const getEventValue = e =>
-    e.target.type === 'checkbox' ? e.target.checked : e.target.value;
-
-  const _updateController = (attribute, e) => {
-    updateController({ [attribute]: getEventValue(e) });
+  const _updateController = (attribute, value) => {
+    updateController({ [attribute]: value });
   };
 
-  const _updateDisk = (uuid, attribute, e) => {
-    updateDisk(uuid, { [attribute]: getEventValue(e) });
+  const _updateDisk = (uuid, attribute, value) => {
+    updateDisk(uuid, { [attribute]: value });
   };
 
   const humanSize = number => number_to_human_size(number, { precision: 2 });
@@ -85,7 +82,7 @@ const Controller = ({
       <Disk
         key={disk.key}
         id={disk.key}
-        updateDisk={(attribute, e) => _updateDisk(disk.key, attribute, e)}
+        updateDisk={(attribute, val) => _updateDisk(disk.key, attribute, val)}
         removeDisk={() => removeDisk(disk.key)}
         config={config}
         datastores={datastoresStats()}
@@ -108,7 +105,7 @@ const Controller = ({
           <Select
             value={controller.type}
             disabled={config.vmExists}
-            onChange={e => _updateController('type', e)}
+            onValueChange={v => _updateController('type', v)}
             options={config.controllerTypes}
           />
           <Button

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
@@ -31,14 +31,6 @@ const Controller = ({
   storagePodsStatus,
   storagePodsError,
 }) => {
-  const _updateController = (attribute, value) => {
-    updateController({ [attribute]: value });
-  };
-
-  const _updateDisk = (uuid, attribute, value) => {
-    updateDisk(uuid, { [attribute]: value });
-  };
-
   const humanSize = number => number_to_human_size(number, { precision: 2 });
 
   const datastoresStats = () => {
@@ -82,7 +74,7 @@ const Controller = ({
       <Disk
         key={disk.key}
         id={disk.key}
-        updateDisk={(attribute, val) => _updateDisk(disk.key, attribute, val)}
+        updateDisk={newValues => updateDisk(disk.key, newValues)}
         removeDisk={() => removeDisk(disk.key)}
         config={config}
         datastores={datastoresStats()}
@@ -105,7 +97,7 @@ const Controller = ({
           <Select
             value={controller.type}
             disabled={config.vmExists}
-            onValueChange={v => _updateController('type', v)}
+            onValueChange={v => updateController({ type: v })}
             options={config.controllerTypes}
           />
           <Button

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
@@ -31,12 +31,8 @@ const Controller = ({
   storagePodsStatus,
   storagePodsError,
 }) => {
-  const getEventValue = e => {
-    if (!e.target) {
-      return e;
-    }
-    return e.target.type === 'checkbox' ? e.target.checked : e.target.value;
-  };
+  const getEventValue = e =>
+    e.target.type === 'checkbox' ? e.target.checked : e.target.value;
 
   const _updateController = (attribute, e) => {
     updateController({ [attribute]: getEventValue(e) });


### PR DESCRIPTION
NumericInput have different onChange definition from other inputs.
This introduced a bug with vmware storage disappearing if the value is null.
The problem is that NumericInput feeds the onChange with its value right away, but other onChange are feeded by whole change event.

Prerequisites for testing:
* VMware cluster

Tests needed (anticipated impacts):
* VMware storage definition/creation

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
