### PR TITLE
Fixes #26299 - add schedule for report generation

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -128,6 +128,7 @@ module Api
       param :input_values, Hash, :desc => N_('Hash of input values where key is the name of input, value is the value for this input')
       param :gzip, :bool, desc: N_('Compress the report using gzip')
       param :mail_to, String, desc: N_("If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses.") % ReportComposer::MailToValidator::MAIL_DELIMITER
+      param :schedule_on, String, desc: N_("UTC time to start report generating on")
       returns :code => 200, :desc => "a successful response" do
         property :job_id, String, :desc => "An ID of job, which generates report. To be used with report_data API endpoint for report data retrieval."
         property :data_url, String, :desc => "An url to get resulting report from. This is not available when report is delivered via e-mail."
@@ -148,7 +149,11 @@ module Api
       def schedule_report
         @composer = ReportComposer.from_api_params(params)
         if @composer.valid?
-          job = TemplateRenderJob.perform_later(@composer.to_params, user_id: User.current.id)
+          scheduler = TemplateRenderJob
+          if @composer.schedule_on
+            scheduler = scheduler.set(wait_until: @composer.schedule_on)
+          end
+          job = scheduler.perform_later(@composer.to_params, user_id: User.current.id)
           response = { job_id: job.provider_job_id }
           response[:data_url] = report_data_api_report_template_path(@report_template, job_id: job.provider_job_id) unless @composer.send_mail?
           render json: response
@@ -194,6 +199,7 @@ module Api
       def load_and_authorize_plan
         @plan = load_dynflow_plan(params[:job_id])
         return not_found(_('Report not found, please ensure you used the correct job_id')) if @plan.nil?
+        return @plan if @plan.state == :scheduled
         composer_attrs, options = plan_arguments(@plan)
         if User.current.admin? || options['user_id'].to_i == User.current.id
           @composer = ReportComposer.new(composer_attrs)

--- a/app/controllers/report_templates_controller.rb
+++ b/app/controllers/report_templates_controller.rb
@@ -17,13 +17,13 @@ class ReportTemplatesController < TemplatesController
   def schedule_report
     @composer = ReportComposer.from_ui_params(params)
     if @composer.valid?
-      scheduler = TemplateRenderJob
-      if @composer.schedule_on
-        scheduler = scheduler.set(wait_until: @composer.schedule_on)
-      end
-      job = scheduler.perform_later(@composer.to_params, user_id: User.current.id)
+      job = @composer.schedule_rendering
       if @composer.send_mail?
-        success _('Report is being rendered, it will be delivered via e-mail.')
+        if @composer.generate_at
+          success _('Report is going to be rendered at %s, it will be delivered via e-mail.', l(@composer.generate_at))
+        else
+          success _('Report is being rendered, it will be delivered via e-mail.')
+        end
         redirect_to report_templates_path
       else
         redirect_to report_data_report_template_path(@template, job_id: job.provider_job_id)

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -34,11 +34,16 @@ class ReportComposer
     end
 
     def send_mail?
-      raw_params['send_mail'] == '1'
+      raw_params['send_mail'].to_s == '1'
+    end
+
+    def schedule_on
+      raw_params['schedule_on']&.to_time
     end
 
     def params
       { template_id: raw_params[:id],
+        schedule_on: schedule_on,
         gzip: gzip?,
         send_mail: send_mail?,
         mail_to: mail_to }.with_indifferent_access
@@ -56,6 +61,10 @@ class ReportComposer
 
     def mail_to
       report_base_params[:mail_to]
+    end
+
+    def schedule_on
+      report_base_params['schedule_on']&.to_time
     end
 
     def params
@@ -106,12 +115,13 @@ class ReportComposer
     end
   end
 
-  attr_reader :template
+  attr_reader :template, :schedule_on
 
   validates :mail_to, mail_to: true, if: :send_mail?
 
   def initialize(params)
     @params = params.with_indifferent_access
+    @schedule_on = @params.delete('schedule_on')
     @template = load_report_template(@params[:template_id])
     @input_values = build_inputs(@template, @params[:input_values])
   end

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -64,7 +64,7 @@ class ReportComposer
     end
 
     def generate_at
-      report_base_params['generate_at']&.to_time
+      Time.zone.parse(report_base_params['generate_at']) if report_base_params['generate_at'].present?
     end
 
     def params

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -11,6 +11,8 @@
                 (_('This will generate a report %s. Based on its definition, it can take a long time to process.') % h(@template.name)) +
                 '</p>').html_safe) %>
 
+  <%= text_f f, :generate_at, label: _('Generate at'), label_help: _('Generate report on a given time. Both date and time are required. Please use format yyyy-mm-dd HH:MM +000') %>
+
   <%= checkbox_f f, :send_mail,
     label: _('Send report via e-mail'),
     label_help: _('By checking this, the report will be sent to e-mail address specified below. Keep unchecked if you prefer to download the report in your browser.'),
@@ -20,8 +22,6 @@
       label: _('Deliver to e-mail addresses'),
       label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
   </div>
-
-  <%= text_f f, :generate_at, label: _('Generate at'), label_help: _('Generate report on a given time. Both date and time are required. Please use format yyyy-mm-dd HH:MM +000') %>
 
   <%= f.fields_for :input_values do |input_values_fields| %>
     <% inputs = @template.template_inputs.select {|input| input.input_type == 'user'} %>

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -39,5 +39,7 @@
       label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
   </div>
 
+  <%= text_f f, :schedule_on, label: _('Schedule on'), label_help: _('Schedule report generating on a given time. Full datetime required.') %>
+
   <%= submit_or_cancel f, false, { data: { disable_with: false } } %>
 <% end %>

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -11,6 +11,18 @@
                 (_('This will generate a report %s. Based on its definition, it can take a long time to process.') % h(@template.name)) +
                 '</p>').html_safe) %>
 
+  <%= checkbox_f f, :send_mail,
+    label: _('Send report via e-mail'),
+    label_help: _('By checking this, the report will be sent to e-mail address specified below. Keep unchecked if you prefer to download the report in your browser.'),
+    onchange: 'tfm.templateInputs.toggleEmailFields(this)' %>
+  <div class="email-fields" <%= display?(!@composer.send_mail?) %> >
+    <%= text_f f, :mail_to,
+      label: _('Deliver to e-mail addresses'),
+      label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
+  </div>
+
+  <%= text_f f, :schedule_on, label: _('Schedule on'), label_help: _('Schedule report generating on a given time. Full datetime required.') %>
+
   <%= f.fields_for :input_values do |input_values_fields| %>
     <% inputs = @template.template_inputs.select {|input| input.input_type == 'user'} %>
 
@@ -28,18 +40,6 @@
       </div>
     <% end %>
   <% end %>
-
-  <%= checkbox_f f, :send_mail,
-    label: _('Send report via e-mail'),
-    label_help: _('By checking this, the report will be sent to e-mail address specified below. Keep unchecked if you prefer to download the report in your browser.'),
-    onchange: 'tfm.templateInputs.toggleEmailFields(this)' %>
-  <div class="email-fields" <%= display?(!@composer.send_mail?) %> >
-    <%= text_f f, :mail_to,
-      label: _('Deliver to e-mail addresses'),
-      label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
-  </div>
-
-  <%= text_f f, :schedule_on, label: _('Schedule on'), label_help: _('Schedule report generating on a given time. Full datetime required.') %>
 
   <%= submit_or_cancel f, false, { data: { disable_with: false } } %>
 <% end %>

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -21,7 +21,7 @@
       label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
   </div>
 
-  <%= text_f f, :schedule_on, label: _('Schedule on'), label_help: _('Schedule report generating on a given time. Full datetime required.') %>
+  <%= text_f f, :generate_at, label: _('Generate at'), label_help: _('Generate report on a given time. Both date and time are required. Please use format yyyy-mm-dd HH:MM +000') %>
 
   <%= f.fields_for :input_values do |input_values_fields| %>
     <% inputs = @template.template_inputs.select {|input| input.input_type == 'user'} %>

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -284,7 +284,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
       delay_to = Time.now + 2.hours
       expect_job_enque_with({}, delay_to: delay_to)
       ReportComposer::ApiParams.any_instance.stubs('convert_input_names_to_ids').returns({})
-      post :schedule_report, params: { :id => report_template.id, schedule_on: delay_to }
+      post :schedule_report, params: { :id => report_template.id, generate_at: delay_to }
       assert_response :success
       assert_equal 'application/json', response.content_type
       assert_match /JOB-UNIQUE-IDENTIFIER/, JSON.parse(response.body)['job_id']

--- a/test/controllers/report_templates_controller_test.rb
+++ b/test/controllers/report_templates_controller_test.rb
@@ -181,7 +181,7 @@ class ReportTemplatesControllerTest < ActionController::TestCase
     it 'schedule delayed report' do
       delay_to = Date.today.to_time + 2.hours
       expect_job_enque_with(nil, delay_to: delay_to)
-      get :schedule_report, params: { :id => @report_template.to_param, :report_template_report => { schedule_on: delay_to } }, session: set_session_user
+      get :schedule_report, params: { :id => @report_template.to_param, :report_template_report => { generate_at: delay_to } }, session: set_session_user
       assert_redirected_to report_data_report_template_url(@report_template, job_id: 'JOB-UNIQUE-IDENTIFIER')
     end
   end

--- a/test/models/report_composer_test.rb
+++ b/test/models/report_composer_test.rb
@@ -45,6 +45,24 @@ class ReportComposerTest < ActiveSupport::TestCase
     assert_equal 'hello', composer.template_input_values[@template_input.name]
   end
 
+  describe '#generate_at handling' do
+    context 'API' do
+      it 'translate generate_at as UTC time in API' do
+        params = { id: @report_template.id, generate_at: '2019-04-15 15:10' }
+        params.expects(:permit!).returns(params.with_indifferent_access)
+        composer = ReportComposer.from_api_params(params)
+        composer.generate_at.utc.hour == 15
+      end
+
+      it 'respect given timezone' do
+        params = { id: @report_template.id, generate_at: '2019-04-15 15:10 +2' }
+        params.expects(:permit!).returns(params.with_indifferent_access)
+        composer = ReportComposer.from_api_params(params)
+        composer.generate_at.utc.hour == 13
+      end
+    end
+  end
+
   describe '#render' do
     it 'render template' do
       @report_template.update_attribute :template, "<%= 1 + 1 %> <%= input('#{@template_input.name}') %>"


### PR DESCRIPTION
Introduces the ability to schedule report generating on given time.

Prerequisites for testing:
* Report template defined

Anticipated impacts: Report generation now and in the future.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
