### PR TITLE
Fixes #26509 - notifications 'status' of undefined

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
@@ -37,8 +37,8 @@ const getNotifications = url => dispatch => {
     });
   }
 
-  function onGetNotificationsFailed(error) {
-    if (error.response.status === 401) {
+  function onGetNotificationsFailed({ response }) {
+    if (response && response.status === 401) {
       window.location.replace('/users/login');
     }
   }


### PR DESCRIPTION
calling `onGetNotificationsFailed` with `error.response.status` 
when response is undefined cause this error.