### PR TITLE
Fixes #26525 - conflict for iPXE Embedded loader

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -253,7 +253,7 @@ class Operatingsystem < ApplicationRecord
 
   def boot_filename(host = nil)
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
-    return host.foreman_url('iPXE') if host.pxe_loader == 'iPXE Embedded'
+    return host.foreman_url('iPXE').sub(/\?token=.*$/, '') if host.pxe_loader == 'iPXE Embedded'
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
     boot_uri = URI.parse((host.subnet&.httpboot?) ? host.subnet.httpboot.url : Setting[:unattended_url])
     self.class.all_loaders_map(architecture, "#{boot_uri.host}:#{boot_uri.port}")[host.pxe_loader]


### PR DESCRIPTION
I guess we cannot use tokens for iPXE Embedded PXE loaders due to DHCP
conflicts.