### PR TITLE
fixes #26532 - graphql supports ui sessions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,11 +2,9 @@ module Api
   # TODO: inherit from application controller after cleanup
   class BaseController < ActionController::Base
     include ApplicationShared
+    include Foreman::Controller::RequireSsl
+    include Foreman::Controller::ApiCsrfProtection
     include Foreman::Controller::BruteforceProtection
-
-    protect_from_forgery
-    force_ssl :if => :require_ssl?
-    skip_before_action :verify_authenticity_token, :unless => :protect_api_from_forgery?
 
     before_action :set_default_response_format, :authorize, :set_taxonomy, :add_version_header, :set_gettext_locale
     before_action :session_expiry, :update_activity_time
@@ -105,10 +103,6 @@ module Api
     end
 
     protected
-
-    def require_ssl?
-      SETTINGS[:require_ssl]
-    end
 
     def not_found(options = nil)
       not_found_message = {}
@@ -408,10 +402,6 @@ module Api
     def prioritize_friendly_name_records(base_scope, friendly_field_query)
       field_query = friendly_field_query.to_sql
       base_scope.order("CASE WHEN #{field_query} THEN 1 ELSE 0 END")
-    end
-
-    def protect_api_from_forgery?
-      session[:user].present? && !session[:api_authenticated_session]
     end
 
     def parameter_filter_context

--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -5,10 +5,13 @@ module Api
     include Foreman::Controller::RequireSsl
     include Foreman::Controller::Session
     include Foreman::Controller::Authentication
+    include Foreman::Controller::ApiCsrfProtection
+    include Foreman::Controller::BruteforceProtection
 
-    rescue_from Exception, :with => :generic_exception if Rails.env.production?
+    rescue_from Exception, with: :generic_exception if Rails.env.production?
 
     before_action :authenticate
+    before_action :session_expiry, :update_activity_time
     around_action :set_timezone
 
     def execute

--- a/app/controllers/concerns/foreman/controller/api_csrf_protection.rb
+++ b/app/controllers/concerns/foreman/controller/api_csrf_protection.rb
@@ -1,0 +1,17 @@
+module Foreman
+  module Controller
+    module ApiCsrfProtection
+      extend ActiveSupport::Concern
+
+      included do
+        protect_from_forgery if: :protect_api_from_forgery?
+      end
+
+      private
+
+      def protect_api_from_forgery?
+        session[:user].present? && !session[:api_authenticated_session]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for CSRF protection and updating session expiry and activity time if the graphql API is used from a UI session.

cc: @mmoll