### PR TITLE
Fixes #25656 - Foreman redirects to logout page

### DIFF
--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -23,7 +23,7 @@ module Menu
     end
 
     def to_hash
-      {type: :item, name: @caption || @name, url: url} if authorized?
+      {type: :item, html_options: @html_options, name: @caption || @name, url: url} if authorized?
     end
 
     def url

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -16,7 +16,7 @@ module Menu
                     :url_hash => {:controller => '/users', :action => 'edit', :id => Proc.new { User.current.id }}
           menu.item :logout,
                     :caption => N_('Log Out'),
-                    :html => {:method => :post},
+                    :html => {:'data-method' => :post},
                     :url_hash => {:controller => '/users', :action => 'logout'}
         end
       end

--- a/test/unit/menu_manager_test.rb
+++ b/test/unit/menu_manager_test.rb
@@ -51,13 +51,13 @@ class MenuManagerTest < ActiveSupport::TestCase
       :name => "User",
       :icon => "fa-icon",
       :children =>
-        [{:type => :item, :name => "Item", :url => "some url"},
-         {:type => :item, :name => "Item 2", :url => "some url"},
-         {:type => :item, :name => "Test Items", :url => "some url"}]},
+        [{:type => :item, :html_options => {}, :name => "Item", :url => "some url"},
+         {:type => :item, :html_options => {}, :name => "Item 2", :url => "some url"},
+         {:type => :item, :html_options => {}, :name => "Test Items", :url => "some url"}]},
      {:type => :sub_menu,
       :name => "User",
       :icon => "fa-icon",
-      :children => [{:type => :item, :name => "Item 3", :url => "some url"}]}]
+      :children => [{:type => :item, :html_options => {}, :name => "Item 3", :url => "some url"}]}]
   end
 
   def create_nested_menu

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -42,6 +42,7 @@ const UserDropdowns = ({
                   onClick={() => {
                     changeActiveMenu({ title: 'User' });
                   }}
+                  {...item.html_options}
                 >
                   {__(item.name)}
                 </MenuItem>


### PR DESCRIPTION
This fixes the redirect after logout.
After testing a bit, it takes quite long before the redirect actually happens(3-4 seconds), long after a success response is returned form the `post` request. Therefore the spinner is showing without disabling it, after logging out the layout gets unmounted anyway so the spinner state is reset.
If the `post` request fails a toast notification is shown and the spinner stops.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
