### PR TITLE
Fixes #26543 - make generate_at a datetime field

### DIFF
--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -16,7 +16,7 @@
       label: _('Generate at'),
       label_help: _('Generate report on a given time.'),
       id: 'report_generate_at_datetime',
-      value: ( f.object.generate_at || Time.now ).try(:iso8601),
+      value: ( f.object.generate_at || Time.now ).iso8601,
       hideValue: f.object.generate_at.blank?,
       inputProps: { name: 'report_template_report[generate_at]' }
     }.to_json, flatten_data: true) %>

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -11,7 +11,16 @@
                 (_('This will generate a report %s. Based on its definition, it can take a long time to process.') % h(@template.name)) +
                 '</p>').html_safe) %>
 
-  <%= text_f f, :generate_at, label: _('Generate at'), label_help: _('Generate report on a given time. Both date and time are required. Please use format yyyy-mm-dd HH:MM +000') %>
+  <div id="report_generate_at"></div>
+  <%= mount_react_component('DateTime', '#report_generate_at', {
+      label: _('Generate at'),
+      label_help: _('Generate report on a given time.'),
+      id: 'report_generate_at_datetime',
+      value: ( f.object.generate_at || Time.now ).try(:iso8601),
+      hideValue: f.object.generate_at.blank?,
+      inputProps: { name: 'report_template_report[generate_at]' }
+    }.to_json, flatten_data: true) %>
+
 
   <%= checkbox_f f, :send_mail,
     label: _('Send report via e-mail'),

--- a/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
+++ b/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
@@ -45,8 +45,9 @@ const TemplateInput = ({
           isRequired={required}
           info={description || 'Format is yyyy-mm-dd HH-mm-ss'}
           initialError={initialError}
-          url={url}
-          template={template}
+          inputProps={{
+            name: `${template}[input_values][${id}][value]`
+          }}
           hideValue={!value.length}
           value={value || undefined}
         />

--- a/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
+++ b/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
@@ -46,7 +46,7 @@ const TemplateInput = ({
           info={description || 'Format is yyyy-mm-dd HH-mm-ss'}
           initialError={initialError}
           inputProps={{
-            name: `${template}[input_values][${id}][value]`
+            name: `${template}[input_values][${id}][value]`,
           }}
           hideValue={!value.length}
           value={value || undefined}

--- a/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
@@ -5,10 +5,14 @@ exports[`Report Template AutoComplete rendering renders report template with dat
   hideValue={false}
   id={4}
   info="Format is yyyy-mm-dd HH-mm-ss"
+  inputProps={
+    Object {
+      "name": "report_template_report[input_values][4][value]",
+    }
+  }
   isRequired={false}
   label="some-label"
   locale={null}
-  template="report_template_report"
   value="2019-01-04"
 />
 `;

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.fixtures.js
@@ -1,0 +1,15 @@
+export const DateTimeProps = {
+  id: 4,
+  label: 'some-label',
+  locale: 'EN',
+  inputProps: {
+    name: 'report_template_report[input_values][4][value]',
+  },
+  value: '2019-01-04',
+};
+
+export const DateTimeWithRequireAndInfo = {
+  ...DateTimeProps,
+  isRequired: true,
+  info: 'some description',
+};

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
@@ -56,7 +56,6 @@ DateTime.propTypes = {
   id: PropTypes.number.isRequired,
   locale: PropTypes.string,
   inputProps: PropTypes.object,
-  template: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
   initialError: PropTypes.string,
   hideValue: PropTypes.bool,

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
@@ -14,7 +14,7 @@ const DateTime = ({
   isRequired,
   hideValue,
   locale,
-  template,
+  inputProps,
   value,
   initialError,
 }) => {
@@ -40,8 +40,8 @@ const DateTime = ({
         value={value}
         id={`template-date-input-${id}`}
         inputProps={{
-          name: `${template}[input_values][${id}][value]`,
           autoComplete: 'off',
+          ...inputProps,
         }}
         locale={currentLocale}
       />
@@ -55,6 +55,7 @@ DateTime.propTypes = {
   isRequired: PropTypes.bool,
   id: PropTypes.number.isRequired,
   locale: PropTypes.string,
+  inputProps: PropTypes.object,
   template: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
   initialError: PropTypes.string,
@@ -68,6 +69,7 @@ DateTime.defaultProps = {
   value: new Date(),
   initialError: undefined,
   hideValue: false,
+  inputProps: {},
 };
 
 export default DateTime;

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
@@ -1,13 +1,10 @@
-import DateTime from './DateTime';
-import {
-  ReportDateTimePrpos,
-  ReportDateTimeWithRequireAndInfo,
-} from '../../../Template/Inputs/TemplateInput.fixures';
 import { testComponentSnapshotsWithFixtures } from '../../../../common/testHelpers';
+import { DateTimeProps, DateTimeWithRequireAndInfo } from './DateTime.fixtures';
+import DateTime from './DateTime';
 
 const fixtures = {
-  'renders Report Date input': ReportDateTimePrpos,
-  'With Require and Info': ReportDateTimeWithRequireAndInfo,
+  'renders Report Date input': DateTimeProps,
+  'renders with Require and Info': DateTimeWithRequireAndInfo,
 };
 
 describe('Report Template AutoComplete', () => {

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
@@ -1,23 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Report Template AutoComplete rendering With Require and Info 1`] = `
+exports[`Report Template AutoComplete rendering renders Report Date input 1`] = `
 <CommonForm
   className=""
   inputClassName="col-md-4"
   label="some-label"
-  required={true}
-  tooltipHelp={
-    <FieldLevelHelp
-      buttonClass="field-help"
-      content={
-        <React.Fragment>
-          some description
-        </React.Fragment>
-      }
-      placement="top"
-      rootClose={true}
-    />
-  }
+  required={false}
+  tooltipHelp={null}
   touched={true}
 >
   <DateTimePicker
@@ -36,13 +25,24 @@ exports[`Report Template AutoComplete rendering With Require and Info 1`] = `
 </CommonForm>
 `;
 
-exports[`Report Template AutoComplete rendering renders Report Date input 1`] = `
+exports[`Report Template AutoComplete rendering renders with Require and Info 1`] = `
 <CommonForm
   className=""
   inputClassName="col-md-4"
   label="some-label"
-  required={false}
-  tooltipHelp={null}
+  required={true}
+  tooltipHelp={
+    <FieldLevelHelp
+      buttonClass="field-help"
+      content={
+        <React.Fragment>
+          some description
+        </React.Fragment>
+      }
+      placement="top"
+      rootClose={true}
+    />
+  }
   touched={true}
 >
   <DateTimePicker

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -10,6 +10,7 @@ import RelativeDateTime from './common/dates/RelativeDateTime';
 import LongDateTime from './common/dates/LongDateTime';
 import ShortDateTime from './common/dates/ShortDateTime';
 import IsoDate from './common/dates/IsoDate';
+import DateTime from './common/forms/DateTime/DateTime';
 import StorageContainer from './hosts/storage/vmware/';
 import PasswordStrength from './PasswordStrength';
 import BreadcrumbBar from './BreadcrumbBar';
@@ -143,6 +144,7 @@ const coreComponets = [
     data: true,
     store: false,
   },
+  { name: 'DateTime', type: DateTime, store: false },
   { name: 'ModelsTable', type: ModelsTable },
 
   // Pages


### PR DESCRIPTION
On report templates generating page we introduced a generate_at field.
This makes it a react DateTime field.

Prerequisites for testing:
* Report templates

Tests needed (anticipated impacts):
* Report generating UI page - inputs

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
