### PR TITLE
Refs #26080 - dropped fixes from input value types

### DIFF
--- a/app/controllers/api/v2/template_inputs_controller.rb
+++ b/app/controllers/api/v2/template_inputs_controller.rb
@@ -34,6 +34,8 @@ module Api
           param :puppet_class_name, String, :required => false, :desc => N_('Puppet class name, used when input type is puppet_parameter')
           param :puppet_parameter_name, String, :required => false, :desc => N_('Puppet parameter name, used when input type is puppet_parameter')
           param :options, Array, :required => false, :desc => N_('Selectable values for user inputs')
+          param :value_type, TemplateInput::VALUE_TYPE, :required => false, :desc => N_('Value type, defaults to plain')
+          param :resource_type, Permission.resources, :required => false, :desc => N_('For values of type search, this is the resource the value searches in')
         end
       end
 

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -62,7 +62,7 @@ module TemplatesHelper
     return if input_value.nil?
 
     input = input_value.template_input
-    controller = input.resource_type.tableize
+    controller = input.resource_type&.tableize
 
     mount_react_component('TemplateInput', "#template-input-#{input.id}", {
       value: input_value.value.to_s,

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -11,7 +11,8 @@ class TemplateInput < ApplicationRecord
   VALUE_TYPE = ['plain', 'search', 'date']
 
   attr_exportable(:name, :required, :input_type, :fact_name, :variable_name, :puppet_class_name,
-                  :puppet_parameter_name, :description, :options, :advanced)
+                  :puppet_parameter_name, :description, :options, :advanced, :value_type,
+                  :resource_type)
 
   belongs_to :template
 


### PR DESCRIPTION
Contains the [fix](https://github.com/amirfefer/foreman/pull/10/) that was originally part of https://github.com/theforeman/foreman/pull/6531 but got accidentally dropped probably on rebase.

This is needed for 1.22, contains a fix for rendering date fields too. cc @ezr-ondrej and @amirfefer

<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
