### PR TITLE
fixes #26548 - graphql: support namespaced modules

### DIFF
--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -20,14 +20,17 @@ class ForemanGraphqlSchema < GraphQL::Schema
     return unless id.present?
 
     _, type_name, item_id = Foreman::GlobalId.decode(id)
-    model_class = type_name.safe_constantize
+    type_class = "::Types::#{type_name}".safe_constantize
+
+    model_class = type_class&.model_class
 
     return unless model_class
 
     RecordLoader.for(model_class).load(item_id.to_i)
   end
 
-  def self.resolve_type(_, obj, _)
-    types[obj.class.name]
+  def self.resolve_type(_, object, _)
+    klass = object.class
+    klass.try(:graphql_type)&.safe_constantize || types[klass.name]
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -13,4 +13,12 @@ class ApplicationRecord < ActiveRecord::Base
   def logger
     self.class.logger
   end
+
+  def self.graphql_type(new_graphql_type = nil)
+    if new_graphql_type
+      @graphql_type = new_graphql_type
+    else
+      @graphql_type || superclass.try(:graphql_type)
+    end
+  end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -81,6 +81,8 @@ class Host::Managed < Host::Base
   smart_proxy_reference :realm => [:realm_proxy_id]
   smart_proxy_reference :self => [:puppet_proxy_id, :puppet_ca_proxy_id]
 
+  graphql_type '::Types::Host'
+
   class Jail < ::Safemode::Jail
     allow :name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
       :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :ip6, :mac, :shortname, :architecture,

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -34,6 +34,8 @@ class Subnet < ApplicationRecord
     super
   end
 
+  graphql_type '::Types::Subnet'
+
   validates_lengths_from_database :except => [:gateway]
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups, :interfaces, :domains)
 

--- a/app/services/foreman/global_id.rb
+++ b/app/services/foreman/global_id.rb
@@ -27,7 +27,8 @@ module Foreman
     end
 
     def self.for(obj)
-      encode(obj.class.name, obj.id)
+      type_definition = ForemanGraphqlSchema.resolve_type(nil, obj, nil)
+      encode(type_definition.name, obj.id)
     end
 
     def self.base64_encoded?(string)

--- a/test/graphql/foreman_graphql_schema_test.rb
+++ b/test/graphql/foreman_graphql_schema_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class ForemanGraphqlSchemaTest < ActiveSupport::TestCase
+  let(:schema) { ForemanGraphqlSchema }
+
+  describe '#id_from_object' do
+    let(:object) { FactoryBot.create(:model) }
+    let(:type_definition) { ForemanGraphqlSchema.types['Model'] }
+    let(:global_id) { Foreman::GlobalId.encode('Model', object.id) }
+
+    test 'encodes type and object into a global id' do
+      assert_equal global_id, schema.id_from_object(object, type_definition, nil)
+    end
+  end
+
+  describe '#object_from_id' do
+    let(:model) { FactoryBot.create(:model) }
+    let(:global_id) { Foreman::GlobalId.encode('Model', model.id) }
+
+    test 'can resolve the model_class for all types' do
+      object = GraphQL::Batch.batch do
+        schema.object_from_id(global_id, nil)
+      end
+      assert_equal model, object
+    end
+  end
+
+  describe '#resolve_type' do
+    test 'resolves the type for Host::Managed' do
+      host = FactoryBot.build_stubbed(:host, :managed)
+      assert_kind_of ::Host::Managed, host
+      type = schema.resolve_type(nil, host, nil)
+      assert_equal 'Host', type&.graphql_name
+    end
+
+    test 'resolves the type for Subnet' do
+      subnet = FactoryBot.build_stubbed(:subnet_ipv4)
+      assert_kind_of ::Subnet::Ipv4, subnet
+      type = schema.resolve_type(nil, subnet, nil)
+      assert_equal 'Subnet', type&.graphql_name
+    end
+
+    test 'resolves the type for Model' do
+      model = FactoryBot.build_stubbed(:model)
+      assert_kind_of ::Model, model
+      type = schema.resolve_type(nil, model, nil)
+      assert_equal 'Model', type&.graphql_name
+    end
+  end
+end


### PR DESCRIPTION
The graphql schema has to contain [three methods to resolve id, types and objects](https://graphql-ruby.org/relay/object_identification.html).

* `id_from_object` converts an object (e.g. a instance of `Host::Managed`) to a global id
*  `object_from_id ` does the opposite: it resolves a global id to an object, basically a `Host::Managed.find(id)`
* `resolve_type` resolves the correcspoding graphql type given an object

These methods did not properly handle namespaced models, e.g. `Host::Managed` or `Subnet::Ipv4` or models from plugins, e.g. `ForemanAnsible::FactName`.

With this commit model classes can now link to the corresponding type by a small DSL:
```ruby
module Host
  class Managed
    graphql_type ::Types::Host
  end
end
```