### PR TITLE
fixes #26489 - graphql: create host mutation

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -143,7 +143,7 @@ module Api
 
         forward_request_url
         process_response @host.save
-      rescue InterfaceTypeMapper::UnknownTypeExeption => e
+      rescue InterfaceTypeMapper::UnknownTypeException => e
         render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => e.to_s }
       end
 
@@ -159,7 +159,7 @@ module Api
         apply_compute_profile(@host) if (params[:host] && params[:host][:compute_attributes].present?) || @host.compute_profile_id_changed?
 
         process_response @host.save
-      rescue InterfaceTypeMapper::UnknownTypeExeption => e
+      rescue InterfaceTypeMapper::UnknownTypeException => e
         render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => e.to_s }
       end
 

--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -107,7 +107,7 @@ module Api
         if params[:action] != 'update' || params[:interface].has_key?(:type)
           params[:interface][:type] = InterfaceTypeMapper.map(params[:interface][:type])
         end
-      rescue InterfaceTypeMapper::UnknownTypeExeption => e
+      rescue InterfaceTypeMapper::UnknownTypeException => e
         render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => e.to_s }
       end
     end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -65,7 +65,7 @@ module Mutations
                  end
 
         {
-          resource_class.name.downcase => resource,
+          result_key => resource,
           errors: errors
         }
       end
@@ -78,6 +78,13 @@ module Mutations
           message: message
         }
       end
+    end
+
+    def result_key
+      keys = self.class.fields.select { |field_name, field| field.owner == self.class }.keys.map(&:to_sym)
+      raise GraphQL::ExecutionError.new("Could not detect result key for #{self.class}. Did you define a result field for the mutation?") unless keys.any?
+      raise GraphQL::ExecutionError.new("Could not detect result key for #{self.class}. Possible values are #{keys.to_sentence}.") if keys.size > 1
+      keys.first
     end
   end
 end

--- a/app/graphql/mutations/hosts/create.rb
+++ b/app/graphql/mutations/hosts/create.rb
@@ -1,0 +1,71 @@
+module Mutations
+  module Hosts
+    class Create < CreateMutation
+      description 'Creates a new host.'
+      graphql_name 'CreateHostMutation'
+
+      resource_class Host::Managed
+
+      argument :name, String
+      argument :root_pass, String, required: false
+      argument :ip, String
+      argument :mac, String
+      argument :build, Boolean
+      argument :enabled, Boolean
+      argument :managed, Boolean, required: false
+      argument :overwrite, Boolean
+      argument :owner_id, ID, loads: Types::UserOrUsergroupUnion
+      argument :location_id, ID, loads: Types::Location
+      argument :organization_id, ID, loads: Types::Organization
+      argument :environment_id, ID, loads: Types::Environment
+      argument :architecture_id, ID, loads: Types::Architecture
+      argument :domain_id, ID, loads: Types::Domain
+      argument :operatingsystem_id, ID, loads: Types::Operatingsystem
+      argument :medium_id, ID, loads: Types::Medium
+      argument :ptable_id, ID, loads: Types::Ptable
+      argument :subnet_id, ID, loads: Types::Subnet
+      argument :compute_resource_id, ID, loads: Types::ComputeResource
+      argument :compute_profile_id, ID, loads: Types::ComputeProfile
+      argument :hostgroup_id, ID, loads: Types::Hostgroup
+      argument :puppet_proxy_id, ID, loads: Types::SmartProxy
+      argument :puppet_ca_proxy_id, ID, loads: Types::SmartProxy
+      argument :puppetclass_ids, [ID], loads: Types::Puppetclass
+      argument :compute_attributes, Types::RawJson, required: false
+      argument :interfaces_attributes, [Types::InterfaceAttributesInput], required: false
+
+      field :host, Types::Host, 'The new host.', null: true
+
+      private
+
+      def initialize_object(params)
+        host = resource_class.new(host_attributes(params.deep_symbolize_keys))
+        host.managed = true if params && params[:managed].nil?
+
+        apply_compute_profile(host)
+        host.suggest_default_pxe_loader if params && params[:pxe_loader].nil?
+        host
+      end
+
+      def apply_compute_profile(host)
+        host.apply_compute_profile(InterfaceMerge.new(merge_compute_attributes: true))
+        host.apply_compute_profile(ComputeAttributeMerge.new)
+      end
+
+      def host_attributes(params)
+        return {} if params.nil?
+
+        params[:interfaces_attributes] = params[:interfaces_attributes].map(&:to_h) if params[:interfaces_attributes]
+        params = params.deep_clone
+        parse_volumes_attributes(params)
+
+        params
+      end
+
+      def parse_volumes_attributes(params)
+        return unless params[:compute_attributes] && params[:compute_attributes][:volumes_attributes]
+        params[:compute_attributes][:volumes_attributes] =
+          params[:compute_attributes][:volumes_attributes].map.with_index { |v, i| [i.to_s, v] }.to_h
+      end
+    end
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -31,11 +31,12 @@ module Types
         else
           field name, type,
             resolve: (proc do |object|
-              foreign_key ||= object.class.reflect_on_association(name)&.foreign_key
-              raise "Could not determine foreign key for #{name}" unless foreign_key
-              RecordLoader.for(type.model_class).load(object.send(foreign_key))
-            end),
-            **kwargs.except(:resolver, :foreign_key)
+                        reflection = object.class.reflect_on_association(name)
+                        foreign_key ||= reflection.foreign_key
+                        target_class = (reflection&.polymorphic?) ? object.public_send(reflection.foreign_type).constantize : type.model_class
+                        RecordLoader.for(target_class).load(object.send(foreign_key))
+                      end),
+          **kwargs.except(:resolver, :foreign_key)
         end
       end
 

--- a/app/graphql/types/compute_profile.rb
+++ b/app/graphql/types/compute_profile.rb
@@ -1,0 +1,11 @@
+module Types
+  class ComputeProfile < BaseObject
+    description 'A Compute Profile'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+
+    has_many :compute_resources, Types::ComputeResource
+  end
+end

--- a/app/graphql/types/host.rb
+++ b/app/graphql/types/host.rb
@@ -8,6 +8,7 @@ module Types
     timestamps
     field :name, String
     field :build, Boolean
+    field :managed, Boolean
     field :ip, String
     field :ip6, String
     field :path, resolver: Resolvers::Host::Path
@@ -31,6 +32,9 @@ module Types
     belongs_to :puppet_proxy, Types::SmartProxy
     belongs_to :medium, Types::Medium
     belongs_to :hostgroup, Types::Hostgroup
+    belongs_to :owner, Types::UserOrUsergroupUnion
+    belongs_to :subnet, Types::Subnet
+    belongs_to :compute_profile, Types::ComputeProfile
     has_many :fact_names, Types::FactName
     has_many :fact_values, Types::FactValue
   end

--- a/app/graphql/types/interface_attributes_input.rb
+++ b/app/graphql/types/interface_attributes_input.rb
@@ -1,0 +1,17 @@
+module Types
+  class InterfaceAttributesInput < BaseInputObject
+    argument :type, Types::InterfaceTypeEnum, required: false,
+      prepare: ->(value, ctx) { InterfaceTypeMapper.map(value.downcase) }
+    argument :name, String, required: false
+    argument :mac, String, required: false
+    argument :ip, String, required: false
+    argument :ip6, String, required: false
+    argument :identifier, String, required: false
+    argument :primary, Boolean, required: false
+    argument :provision, Boolean, required: false
+    argument :managed, Boolean, required: false
+    argument :attached_to, [String], required: false,
+      prepare: ->(value, ctx) { value.join(', ') }
+    argument :compute_attributes, Types::RawJson, required: false
+  end
+end

--- a/app/graphql/types/interface_type_enum.rb
+++ b/app/graphql/types/interface_type_enum.rb
@@ -1,0 +1,7 @@
+module Types
+  class InterfaceTypeEnum < Types::BaseEnum
+    Nic::Base.allowed_types.each do |type|
+      value type.humanized_name.downcase
+    end
+  end
+end

--- a/app/graphql/types/mutation.rb
+++ b/app/graphql/types/mutation.rb
@@ -7,5 +7,7 @@ module Types
     field :create_model, mutation: Mutations::Models::Create
     field :update_model, mutation: Mutations::Models::Update
     field :delete_model, mutation: Mutations::Models::Delete
+
+    field :create_host, mutation: Mutations::Hosts::Create
   end
 end

--- a/app/graphql/types/raw_json.rb
+++ b/app/graphql/types/raw_json.rb
@@ -1,0 +1,11 @@
+module Types
+  class RawJson < GraphQL::Schema::Scalar
+    def self.coerce_input(val, ctx)
+      val
+    end
+
+    def self.coerce_result(val, ctx)
+      val
+    end
+  end
+end

--- a/app/graphql/types/user_or_usergroup_union.rb
+++ b/app/graphql/types/user_or_usergroup_union.rb
@@ -1,0 +1,6 @@
+module Types
+  class UserOrUsergroupUnion < BaseUnion
+    description 'A user or a usergroup'
+    possible_types ::Types::User, ::Types::Usergroup
+  end
+end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -40,6 +40,8 @@ class ComputeResource < ApplicationRecord
     end
   }
 
+  graphql_type '::Types::ComputeResource'
+
   def self.supported_providers
     {
       'Libvirt'   => 'Foreman::Model::Libvirt',

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -838,17 +838,17 @@ class Host::Managed < Host::Base
     host_params[key] || host_params[key.downcase] || Setting[key]
   end
 
+  # Permissions introduced by plugins for this class can cause resource <-> permission
+  # names mapping to fail randomly so as a safety precaution, we specify the name more explicitly.
+  def permission_name(action)
+    "#{action}_hosts"
+  end
+
   private
 
   def update_os_from_facts
     operatingsystem.architectures << architecture if operatingsystem && architecture && !operatingsystem.architectures.include?(architecture)
     self.medium = nil if medium&.operatingsystems&.exclude?(operatingsystem)
-  end
-
-  # Permissions introduced by plugins for this class can cause resource <-> permission
-  # names mapping to fail randomly so as a safety precaution, we specify the name more explicitly.
-  def permission_name(action)
-    "#{action}_hosts"
   end
 
   def compute_profile_present?

--- a/app/services/interface_type_mapper.rb
+++ b/app/services/interface_type_mapper.rb
@@ -1,5 +1,5 @@
 class InterfaceTypeMapper
-  class UnknownTypeExeption < Foreman::Exception; end
+  class UnknownTypeException < Foreman::Exception; end
 
   DEFAULT_TYPE = Nic::Managed
   ALLOWED_TYPE_NAMES = Nic::Base.allowed_types.map { |t| t.humanized_name.downcase }
@@ -15,7 +15,7 @@ class InterfaceTypeMapper
       # enable sending class names directly to keep backward compatibility
       nic_type
     else
-      raise UnknownTypeExeption.new(N_("Unknown interface type, must be one of [%s]") % ALLOWED_TYPE_NAMES.join(', '))
+      raise UnknownTypeException.new(N_("Unknown interface type, must be one of [%s]") % ALLOWED_TYPE_NAMES.join(', '))
     end
   end
 end

--- a/test/graphql/foreman_graphql_schema_test.rb
+++ b/test/graphql/foreman_graphql_schema_test.rb
@@ -40,6 +40,14 @@ class ForemanGraphqlSchemaTest < ActiveSupport::TestCase
       assert_equal 'Subnet', type&.graphql_name
     end
 
+    test 'resolves the type for a Compute Resource' do
+      compute_resource = FactoryBot.build_stubbed(:vmware_cr)
+      assert_kind_of ::Foreman::Model::Vmware, compute_resource
+      assert_kind_of ::ComputeResource, compute_resource
+      type = schema.resolve_type(nil, compute_resource, nil)
+      assert_equal 'ComputeResource', type&.graphql_name
+    end
+
     test 'resolves the type for Model' do
       model = FactoryBot.build_stubbed(:model)
       assert_kind_of ::Model, model

--- a/test/graphql/mutations/hosts/create_mutation_test.rb
+++ b/test/graphql/mutations/hosts/create_mutation_test.rb
@@ -1,0 +1,298 @@
+require 'test_helper'
+
+module Mutations
+  module Hosts
+    class CreateMutationTest < GraphQLQueryTestCase
+      let(:tax_location) { FactoryBot.create(:location) }
+      let(:location_id) { Foreman::GlobalId.for(tax_location) }
+      let(:organization) { FactoryBot.create(:organization) }
+      let(:organization_id) { Foreman::GlobalId.for(organization) }
+      let(:architecture) { FactoryBot.create(:architecture) }
+      let(:architecture_id) { Foreman::GlobalId.for(architecture) }
+      let(:subnet) { FactoryBot.create(:subnet_ipv4, network: '192.0.2.0', locations: [tax_location], organizations: [organization]) }
+      let(:subnet_id) { Foreman::GlobalId.for(subnet) }
+      let(:operatingsystem) { FactoryBot.create(:operatingsystem, :with_media, :with_ptables, architectures: [architecture]) }
+      let(:operatingsystem_id) { Foreman::GlobalId.for(operatingsystem) }
+      let(:compute_resource) { FactoryBot.create(:compute_resource, :vmware, locations: [tax_location], organizations: [organization]) }
+      let(:compute_resource_id) { Foreman::GlobalId.encode('ComputeResource', compute_resource.id) }
+      let(:compute_profile) { FactoryBot.create(:compute_profile, :with_compute_attribute, compute_resource: compute_resource) }
+      let(:compute_profile_id) { Foreman::GlobalId.for(compute_profile) }
+      let(:domain) { FactoryBot.create(:domain, subnets: [subnet]) }
+      let(:domain_id) { Foreman::GlobalId.for(domain) }
+      let(:medium) { operatingsystem.media.first }
+      let(:medium_id) { Foreman::GlobalId.for(medium) }
+      let(:ptable) { operatingsystem.ptables.first }
+      let(:ptable_id) { Foreman::GlobalId.for(ptable) }
+      let(:owner) { FactoryBot.create(:user, locations: [tax_location], organizations: [organization]) }
+      let(:owner_id) { Foreman::GlobalId.for(owner) }
+      let(:mac) { '00:11:22:33:44:55' }
+      let(:ip) { '192.0.2.1' }
+      let(:root_pass) { 'graphql-is-great' }
+      let(:hostname) { 'my-graphql-host' }
+
+      let(:base_variables) do
+        {
+          name: hostname,
+          ip: ip,
+          locationId: location_id,
+          organizationId: organization_id,
+          architectureId: architecture_id,
+          subnetId: subnet_id,
+          operatingsystemId: operatingsystem_id,
+          ptableId: ptable_id,
+          mediumId: medium_id,
+          domainId: domain_id,
+          ownerId: owner_id,
+          rootPass: root_pass,
+          build: true
+        }
+      end
+      let(:variables) do
+        base_variables.merge(
+          mac: mac
+        )
+      end
+      let(:query) do
+        <<-GRAPHQL
+          mutation createHostMutation(
+              $architectureId: ID!,
+              $build: Boolean,
+              $computeAttributes: RawJson,
+              $computeProfileId: ID,
+              $computeResourceId: ID,
+              $domainId: ID,
+              $interfacesAttributes: [InterfaceAttributesInput!]
+              $ip: String,
+              $locationId: ID!,
+              $mac: String,
+              $mediumId: ID!,
+              $name: String!,
+              $operatingsystemId: ID!,
+              $organizationId: ID!,
+              $ownerId: ID,
+              $ptableId: ID!,
+              $rootPass: String,
+              $subnetId: ID,
+            ) {
+            createHost(input: {
+              architectureId: $architectureId,
+              build: $build,
+              computeAttributes: $computeAttributes,
+              computeProfileId: $computeProfileId,
+              computeResourceId: $computeResourceId,
+              domainId: $domainId,
+              interfacesAttributes: $interfacesAttributes
+              ip: $ip,
+              locationId: $locationId,
+              mac: $mac,
+              mediumId: $mediumId,
+              name: $name,
+              operatingsystemId: $operatingsystemId,
+              organizationId: $organizationId,
+              ownerId: $ownerId,
+              ptableId: $ptableId,
+              rootPass: $rootPass,
+              subnetId: $subnetId,
+            }) {
+              host {
+                id,
+                name,
+                ip,
+                mac,
+                build,
+                managed,
+                location {
+                  id
+                },
+                organization {
+                  id
+                }
+                subnet {
+                  id
+                }
+                operatingsystem {
+                  id
+                }
+                domain {
+                  id
+                }
+                medium {
+                  id
+                }
+                ptable {
+                  id
+                }
+                owner {
+                  ... on User {
+                    id
+                  }
+                  ... on Usergroup {
+                    id
+                  }
+                }
+              },
+              errors {
+                path
+                message
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      setup :disable_orchestration
+
+      context 'with admin permissions' do
+        let(:context_user) { FactoryBot.create(:user, :admin, locations: [tax_location], organizations: [organization]) }
+        let(:data) { result['data']['createHost']['host'] }
+
+        context 'with bare metal parameters' do
+          it 'creates a bare metal host' do
+            assert_difference(-> {Host.count}, +1) do
+              assert_empty result['errors']
+              assert_empty result['data']['createHost']['errors']
+              assert_not_nil data
+
+              assert_equal "#{hostname}.#{domain.name}", data['name']
+              assert_equal ip, data['ip']
+              assert_equal mac, data['mac']
+              assert_equal true, data['build']
+              assert_equal true, data['managed']
+              assert_equal location_id, data['location']['id']
+              assert_equal organization_id, data['organization']['id']
+              assert_equal operatingsystem_id, data['operatingsystem']['id']
+              assert_equal subnet_id, data['subnet']['id']
+              assert_equal domain_id, data['domain']['id']
+              assert_equal medium_id, data['medium']['id']
+              assert_equal ptable_id, data['ptable']['id']
+              assert_equal owner_id, data['owner']['id']
+            end
+            assert_equal context_user.id, Audit.last.user_id
+          end
+
+          context 'with compute resource parameters' do
+            setup { Fog.mock! }
+            teardown { Fog.unmock! }
+
+            let(:variables) do
+              base_variables.merge(
+                computeResourceId: compute_resource_id,
+                computeAttributes: {
+                  cpus: 4,
+                  memory: 1024,
+                  volumes_attributes: [
+                    {
+                      size_gb: 50,
+                      storage_pod: 'DC1-Storage-01'
+                    }
+                  ]
+                },
+                interfacesAttributes: [
+                  {
+                    computeAttributes: {
+                      type: 'VirtualVmxnet3',
+                      network: 'dvportgroup-1288722'
+                    }
+                  }
+                ]
+              )
+            end
+
+            it 'creates a host on a compute resource' do
+              assert_difference(-> {Host.count}, +1) do
+                assert_empty result['errors']
+                assert_empty result['data']['createHost']['errors']
+                assert_not_nil data
+              end
+            end
+          end
+
+          context 'with compute profile parameters' do
+            setup { Fog.mock! }
+            teardown { Fog.unmock! }
+
+            let(:variables) do
+              base_variables.merge(
+                computeProfileId: compute_profile_id,
+                computeResourceId: compute_resource_id
+              )
+            end
+
+            it 'creates a host with a compute profile' do
+              Foreman::Model::Vmware.any_instance.expects(:parse_args).with(compute_profile.compute_attributes.first.vm_attrs).returns({})
+              assert_difference(-> {Host.count}, +1) do
+                assert_empty result['errors']
+                assert_empty result['data']['createHost']['errors']
+                assert_not_nil data
+              end
+            end
+          end
+
+          context 'with bare metal bond parameters' do
+            let(:variables) do
+              base_variables.merge(
+                interfacesAttributes: [
+                  {
+                    type: 'bond',
+                    attachedTo: ['eth0', 'eth1'],
+                    identifier: 'bond0',
+                    primary: true,
+                    provision: true,
+                    managed: true
+                  },
+                  {
+                    type: 'interface',
+                    identifier: 'eth0',
+                    mac: '00:11:22:33:44:11',
+                    primary: false,
+                    provision: false,
+                    managed: true
+                  },
+                  {
+                    type: 'interface',
+                    identifier: 'eth1',
+                    mac: '00:11:22:33:44:22',
+                    primary: false,
+                    provision: false,
+                    managed: true
+                  }
+                ]
+              )
+            end
+
+            it 'creates a host with a bonded interface' do
+              assert_difference(-> {Host.count}, +1) do
+                assert_empty result['errors']
+                assert_empty result['data']['createHost']['errors']
+                assert_not_nil data
+              end
+
+              host = Host.find_by(name: "#{hostname}.#{domain.name}")
+              assert_not_nil host
+
+              assert_equal 3, host.interfaces.count
+              assert_equal 'Nic::Bond', host.primary_interface.type
+              assert_equal subnet, host.primary_interface.subnet
+              assert_equal domain, host.primary_interface.domain
+              assert_equal 'Nic::Managed', host.interfaces.detect { |nic| nic.identifier == 'eth0' }.type
+              assert_equal 'Nic::Managed', host.interfaces.detect { |nic| nic.identifier == 'eth1' }.type
+            end
+          end
+        end
+      end
+
+      context 'with view only permissions' do
+        let(:context_user) { setup_user 'view', 'hosts' }
+
+        test 'cannot create a host' do
+          variables
+          context_user
+
+          assert_difference('Host.count', 0) do
+            assert_not_empty result['errors']
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/graphql/queries/hostgroup_query_test.rb
+++ b/test/graphql/queries/hostgroup_query_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
-class Queries::HostgroupQueryTest < GraphQLQueryTestCase
-  let(:query) do
-    <<-GRAPHQL
+module Queries
+  class HostgroupQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
       query (
         $id: String!
       ) {
@@ -84,61 +85,62 @@ class Queries::HostgroupQueryTest < GraphQLQueryTestCase
           }
         }
       }
-    GRAPHQL
-  end
+      GRAPHQL
+    end
 
-  let(:parent_hostgroup) { FactoryBot.create(:hostgroup) }
-  let(:medium) { FactoryBot.create(:medium) }
-  let(:operatingsystem) { FactoryBot.create(:operatingsystem, family: 'Redhat', media: [medium]) }
-  let(:hostgroup) do
-    FactoryBot.create(
-      :hostgroup,
-      :with_compute_resource,
-      :with_environment,
-      :with_puppetclass,
-      :with_subnet,
-      :with_os,
-      :with_domain,
-      :with_puppet_orchestration,
-      parent: parent_hostgroup,
-      operatingsystem: operatingsystem
-    )
-  end
-  let(:child_hostgroup) { FactoryBot.create(:hostgroup, parent: hostgroup) }
+    let(:parent_hostgroup) { FactoryBot.create(:hostgroup) }
+    let(:medium) { FactoryBot.create(:medium) }
+    let(:operatingsystem) { FactoryBot.create(:operatingsystem, family: 'Redhat', media: [medium]) }
+    let(:hostgroup) do
+      FactoryBot.create(
+        :hostgroup,
+        :with_compute_resource,
+        :with_environment,
+        :with_puppetclass,
+        :with_subnet,
+        :with_os,
+        :with_domain,
+        :with_puppet_orchestration,
+        parent: parent_hostgroup,
+        operatingsystem: operatingsystem
+      )
+    end
+    let(:child_hostgroup) { FactoryBot.create(:hostgroup, parent: hostgroup) }
 
-  let(:global_id) { Foreman::GlobalId.for(hostgroup) }
-  let(:variables) { { id: global_id } }
-  let(:data) { result['data']['hostgroup'] }
+    let(:global_id) { Foreman::GlobalId.for(hostgroup) }
+    let(:variables) { { id: global_id } }
+    let(:data) { result['data']['hostgroup'] }
 
-  setup do
-    child_hostgroup
-    FactoryBot.create(:host, hostgroup: hostgroup)
-  end
+    setup do
+      child_hostgroup
+      FactoryBot.create(:host, hostgroup: hostgroup)
+    end
 
-  test 'fetching hostgroup attributes' do
-    assert_empty result['errors']
-    assert_equal global_id, data['id']
-    assert_equal hostgroup.created_at.utc.iso8601, data['createdAt']
-    assert_equal hostgroup.updated_at.utc.iso8601, data['updatedAt']
-    assert_equal hostgroup.name, data['name']
-    assert_equal hostgroup.title, data['title']
+    test 'fetching hostgroup attributes' do
+      assert_empty result['errors']
+      assert_equal global_id, data['id']
+      assert_equal hostgroup.created_at.utc.iso8601, data['createdAt']
+      assert_equal hostgroup.updated_at.utc.iso8601, data['updatedAt']
+      assert_equal hostgroup.name, data['name']
+      assert_equal hostgroup.title, data['title']
 
-    assert_record hostgroup.environment, data['environment']
-    assert_record hostgroup.compute_resource, data['computeResource'], type_name: 'ComputeResource'
-    assert_record hostgroup.architecture, data['architecture']
-    assert_record hostgroup.domain, data['domain']
-    assert_record hostgroup.operatingsystem, data['operatingsystem'], type_name: 'Operatingsystem'
-    assert_record hostgroup.puppet_ca_proxy, data['puppetCaProxy']
-    assert_record hostgroup.puppet_proxy, data['puppetProxy']
-    assert_record hostgroup.ptable, data['ptable']
-    assert_record hostgroup.medium, data['medium']
+      assert_record hostgroup.environment, data['environment']
+      assert_record hostgroup.compute_resource, data['computeResource'], type_name: 'ComputeResource'
+      assert_record hostgroup.architecture, data['architecture']
+      assert_record hostgroup.domain, data['domain']
+      assert_record hostgroup.operatingsystem, data['operatingsystem'], type_name: 'Operatingsystem'
+      assert_record hostgroup.puppet_ca_proxy, data['puppetCaProxy']
+      assert_record hostgroup.puppet_proxy, data['puppetProxy']
+      assert_record hostgroup.ptable, data['ptable']
+      assert_record hostgroup.medium, data['medium']
 
-    assert_collection hostgroup.hosts, data['hosts'], type_name: 'Host'
-    assert_collection hostgroup.puppetclasses, data['puppetclasses']
-    assert_collection hostgroup.locations, data['locations']
-    assert_collection hostgroup.organizations, data['organizations']
+      assert_collection hostgroup.hosts, data['hosts'], type_name: 'Host'
+      assert_collection hostgroup.puppetclasses, data['puppetclasses']
+      assert_collection hostgroup.locations, data['locations']
+      assert_collection hostgroup.organizations, data['organizations']
 
-    assert_record hostgroup.parent, data['parent']
-    assert_collection hostgroup.children, data['children']
+      assert_record hostgroup.parent, data['parent']
+      assert_collection hostgroup.children, data['children']
+    end
   end
 end

--- a/test/graphql/queries/hostgroups_query_test.rb
+++ b/test/graphql/queries/hostgroups_query_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
-class Queries::HostgroupsQueryTest < GraphQLQueryTestCase
-  let(:query) do
-    <<-GRAPHQL
+module Queries
+  class HostgroupsQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
       query {
         hostgroups {
           totalCount
@@ -20,22 +21,23 @@ class Queries::HostgroupsQueryTest < GraphQLQueryTestCase
           }
         }
       }
-    GRAPHQL
-  end
+      GRAPHQL
+    end
 
-  let(:data) { result['data']['hostgroups'] }
+    let(:data) { result['data']['hostgroups'] }
 
-  setup do
-    FactoryBot.create_list(:hostgroup, 2)
-  end
+    setup do
+      FactoryBot.create_list(:hostgroup, 2)
+    end
 
-  test 'fetching hostgroups attributes' do
-    assert_empty result['errors']
+    test 'fetching hostgroups attributes' do
+      assert_empty result['errors']
 
-    expected_count = Hostgroup.count
+      expected_count = Hostgroup.count
 
-    assert_not_equal 0, expected_count
-    assert_equal expected_count, data['totalCount']
-    assert_equal expected_count, data['edges'].count
+      assert_not_equal 0, expected_count
+      assert_equal expected_count, data['totalCount']
+      assert_equal expected_count, data['edges'].count
+    end
   end
 end

--- a/test/unit/interface_type_mapper_test.rb
+++ b/test/unit/interface_type_mapper_test.rb
@@ -22,7 +22,7 @@ class InterfaceTypeMapperTest < ActiveSupport::TestCase
   end
 
   test "it raises exception on unknown name" do
-    assert_raises InterfaceTypeMapper::UnknownTypeExeption do
+    assert_raises InterfaceTypeMapper::UnknownTypeException do
       @mapper.map("unknown")
     end
   end


### PR DESCRIPTION
This commit allows to create a host with a graphql mutation. 🎱

This needs https://github.com/theforeman/foreman/pull/6656.