### PR TITLE
Fixes #26564 - show OS on vmware VMs listing

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_server.rb
+++ b/app/services/fog_extensions/vsphere/mini_server.rb
@@ -1,7 +1,7 @@
 module FogExtensions
   module Vsphere
     class MiniServer
-      attr_reader :name, :identity, :cpus, :corespersocket, :memory, :state, :path
+      attr_reader :name, :identity, :cpus, :corespersocket, :memory, :state, :path, :operatingsystem
 
       def initialize(attrs = {})
         @name     = attrs[:name]
@@ -11,6 +11,7 @@ module FogExtensions
         @memory   = attrs[:memory].megabytes
         @state    = attrs[:state]
         @path     = attrs[:path]
+        @operatingsystem = attrs[:operatingsystem]
       end
 
       def ready?

--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -93,7 +93,8 @@ module FogExtensions
           :cpus => 'config.hardware.numCPU',
           :corespersocket => 'config.hardware.numCoresPerSocket',
           :memory => 'config.hardware.memoryMB',
-          :state => 'runtime.powerState'
+          :state => 'runtime.powerState',
+          :operatingsystem => 'config.guestFullName'
         }
       end
 

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -5,6 +5,7 @@
     <th><%= _('CPUs') %></th>
     <th><%= _('Memory') %></th>
     <th><%= _('Power') %></th>
+    <th><%= _('Operating system') %></th>
     <th><%= _('Actions') %></th>
   </tr>
 </thead>
@@ -18,6 +19,7 @@
       <td><span <%= vm_power_class(vm.ready?) %>>
           <%= vm_state(vm) %></span>
       </td>
+      <td><%= vm.operatingsystem %></td>
       <td>
         <%= action_buttons(vm_power_action(vm, authorizer),
                          (display_link_if_authorized(_('Console'), hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer)) if vm.ready?),


### PR DESCRIPTION
This brings an information about the `Operating system` of the host to the Vmware VMs listing to improve user comfort while importing VMs into foreman.

This is a first information intended to bring. As it has biggest additional value compared to the effort and should have almost none impact to the performance.

Prerequisites for testing:
* VMware cluster

Tests needed (anticipated impacts):
* Responsiveness of the vmware VMs listing table
* Vmware VMs listing for importing

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
