### PR TITLE
Fixes #26567 - improve vm listing performance

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -243,7 +243,8 @@ module ComputeResourcesVmsHelper
   end
 
   def vm_import_action(vm, html_options = {})
-    return unless Host.for_vm(@compute_resource, vm).empty?
+    @_linked_hosts_cache ||= Host.where(:compute_resource_id => @compute_resource.id).pluck(:uuid)
+    return if @_linked_hosts_cache.include?(vm.identity.to_s)
 
     import_managed_link = display_link_if_authorized(
       _("Import as managed Host"),


### PR DESCRIPTION
When we list vms, we check if the host exists in DB for each VM separately. That generates many similar queries.

Prerequisites for testing:
* VMware cluster or some other compute resource

Tests needed (anticipated impacts):
* see the SQL log when you list vms for the compute resource
* performance of this request should be better (smaller waiting time)

In my setup the performance was 25% but it was dev setup, and the page still loads quite long time. The boost is there it's also my slow vmware...

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
