### PR TITLE
Fixes #26583 - Use ActiveSupport::JSON as RABL json engine

### DIFF
--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -21,4 +21,6 @@ end
 # compatibility
 attribute :omit => :use_puppet_default
 
-attribute :param_class, :as => :puppetclass_name
+node :puppetclass_name do |lk|
+  lk.param_class.name
+end

--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -75,7 +75,7 @@ Rabl.configure do |config|
   # config.cache_engine = Rabl::CacheEngine.new # Defaults to Rails cache
   # config.perform_caching = false
   # config.escape_all_output = false
-  # config.json_engine = nil # Class with #dump class method (defaults JSON)
+  config.json_engine = ActiveSupport::JSON # Class with #dump class method (defaults JSON)
   # config.msgpack_engine = nil # Defaults to ::MessagePack
   # config.bson_engine = nil # Defaults to ::BSON
   # config.plist_engine = nil # Defaults to ::Plist::Emit


### PR DESCRIPTION
Looking into a reported Katello issue: https://projects.theforeman.org/issues/26417

Throughout the app where we display dates from API responses 'Invalid Date' is shown seemingly only in Firefox. My understanding is that Firefox apparently doesn't like non-ISO8601 dates:


Firefox w/ Date generated by ::JSON
```
date = new Date('2019-04-04 22:56:08 -0400');
Invalid Date
```

Firefox w/ Date generated by ActiveSupport::JSON
```
date = new Date('2019-04-04T22:56:08.000-04:00');
Date 2019-04-05T02:56:08.000Z
```

<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
