### PR TITLE
Fixes #26580 - Translated Layout Menu items are not active

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -15,9 +15,11 @@ class IntlLoader {
   async init() {
     await this.fetchIntl();
     addLocaleData(
-      await import(/* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${
-        this.locale
-      }`)
+      await import(
+        /* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${
+          this.locale
+        }`
+      )
     );
     return true;
   }
@@ -25,9 +27,11 @@ class IntlLoader {
   async fetchIntl() {
     if (this.fallbackIntl) {
       global.Intl = await import(/* webpackChunkName: "intl" */ 'intl');
-      await import(/* webpackChunkName: 'intl/locale/[request]' */ `intl/locale-data/jsonp/${
-        this.locale
-      }`);
+      await import(
+        /* webpackChunkName: 'intl/locale/[request]' */ `intl/locale-data/jsonp/${
+          this.locale
+        }`
+      );
     }
   }
 }

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { VerticalNav } from 'patternfly-react';
+import { translate as __ } from '../../common/I18n';
 import { noop } from '../../common/helpers';
 
 import { getActive, getCurrentPath, handleMenuClick } from './LayoutHelper';
@@ -74,7 +75,7 @@ class Layout extends React.Component {
         onItemClick={primary =>
           handleMenuClick(primary, activeMenu, changeActiveMenu)
         }
-        activePath={`/${activeMenu}/`}
+        activePath={`/${__(activeMenu)}/`}
         {...this.props}
       >
         <VerticalNav.Masthead>

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutReducer.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutReducer.js
@@ -12,7 +12,7 @@ import {
 const initialState = Immutable({
   items: [],
   isLoading: false,
-  activeMenu: '',
+  activeMenu: 'initialActive',
   currentOrganization: { title: 'Any Organization' },
   currentLocation: { title: 'Any Location' },
 });

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutReducer.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layout reducer should handle LAYOUT_CHANGE_LOCATION 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": "yaml",
   "currentOrganization": Object {
     "title": "Any Organization",
@@ -14,7 +14,7 @@ Object {
 
 exports[`Layout reducer should handle LAYOUT_CHANGE_ORG 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": Object {
     "title": "Any Location",
   },
@@ -26,7 +26,7 @@ Object {
 
 exports[`Layout reducer should handle LAYOUT_HIDE_LOADING 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": Object {
     "title": "Any Location",
   },
@@ -40,7 +40,7 @@ Object {
 
 exports[`Layout reducer should handle LAYOUT_SHOW_LOADING 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": Object {
     "title": "Any Location",
   },
@@ -90,7 +90,7 @@ Object {
 
 exports[`Layout reducer should handle LAYOUT_UPDATE_ITEMS without changeActive 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": Object {
     "title": "Any Location",
   },
@@ -126,7 +126,7 @@ Object {
 
 exports[`Layout reducer should return the initial state 1`] = `
 Object {
-  "activeMenu": "",
+  "activeMenu": "initialActive",
   "currentLocation": Object {
     "title": "Any Location",
   },


### PR DESCRIPTION
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
