### PR TITLE
Fixes #26616 - Cast dates to be ISO compatible

### DIFF
--- a/webpack/assets/javascripts/react_app/common/__snapshots__/helpers.test.js.snap
+++ b/webpack/assets/javascripts/react_app/common/__snapshots__/helpers.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`isoCompatibleDate converts strings to ISO compatible format 1`] = `"2019-03-14T09:26:17-0400"`;
+
+exports[`isoCompatibleDate ignores non-matching date strings 1`] = `"2019/03/14 09:26:17 -0400"`;
+
+exports[`isoCompatibleDate preserves Date objects 1`] = `2019-03-14T13:26:17.000Z`;
+
 exports[`translateArray, translateObject should translate Array 1`] = `
 Array [
   "Hello",

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -4,6 +4,23 @@ import URI from 'urijs';
 import { translate as __ } from './I18n';
 
 /**
+ * Our API returns non-ISO8601 dates
+ * This method converts those strings into ISO8601 format
+ * @param {String} date - non-ISO date to convert
+ */
+export const isoCompatibleDate = date => {
+  if (
+    typeof date === 'string' &&
+    date.match(/\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d\s[+-]?\d{4}/)
+  ) {
+    // we've matched a date in the format: 2019-03-14 15:39:27 -0400
+    return date.replace(/\s/, 'T').replace(/\s/, '');
+  }
+
+  return date;
+};
+
+/**
  * Does it run in phantomjs test environment
  * @return {boolean}
  */
@@ -112,6 +129,7 @@ const propsToCase = (casingFn, errorMsg, ob) => {
 };
 
 export default {
+  isoCompatibleDate,
   bindMethods,
   noop,
   debounceMethods,

--- a/webpack/assets/javascripts/react_app/common/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.test.js
@@ -1,10 +1,28 @@
 import {
+  isoCompatibleDate,
   translateArray,
   translateObject,
   propsToSnakeCase,
   propsToCamelCase,
   removeLastSlashFromPath,
 } from './helpers';
+
+describe('isoCompatibleDate', () => {
+  it('converts strings to ISO compatible format', () => {
+    const nonIsoDate = '2019-03-14 09:26:17 -0400';
+    expect(isoCompatibleDate(nonIsoDate)).toMatchSnapshot();
+  });
+
+  it('ignores non-matching date strings', () => {
+    const nonMatchingDate = '2019/03/14 09:26:17 -0400';
+    expect(isoCompatibleDate(nonMatchingDate)).toMatchSnapshot();
+  });
+
+  it('preserves Date objects', () => {
+    const preserved = new Date('2019-03-14T09:26:17-0400');
+    expect(isoCompatibleDate(preserved)).toMatchSnapshot();
+  });
+});
 
 describe('translateArray, translateObject', () => {
   const arr = ['Hello', 'There'];

--- a/webpack/assets/javascripts/react_app/components/common/dates/IsoDate.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/IsoDate.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, intlShape } from 'react-intl';
+import { isoCompatibleDate } from '../../../common/helpers';
 
 const IsoDate = (props, context) => {
   const { date, defaultValue } = props;
   if (date) {
-    const title = context.intl.formatRelative(date);
+    const isoDate = isoCompatibleDate(date);
+    const title = context.intl.formatRelative(isoDate);
 
     return (
       <span title={title}>
         <FormattedDate
-          value={date}
+          value={isoDate}
           day="2-digit"
           month="2-digit"
           year="numeric"

--- a/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, intlShape } from 'react-intl';
+import { isoCompatibleDate } from '../../../common/helpers';
 
 const LongDateTime = (props, context) => {
   const { date, defaultValue } = props;
   if (date) {
-    const title = context.intl.formatRelative(date);
+    const isoDate = isoCompatibleDate(date);
+    const title = context.intl.formatRelative(isoDate);
     const seconds = props.seconds ? '2-digit' : undefined;
 
     return (
       <span title={title}>
         <FormattedDate
-          value={date}
+          value={isoDate}
           day="2-digit"
           month="long"
           hour="2-digit"

--- a/webpack/assets/javascripts/react_app/components/common/dates/RelativeDateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/RelativeDateTime.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedRelative, intlShape } from 'react-intl';
+import { isoCompatibleDate } from '../../../common/helpers';
 
 const RelativeDateTime = (props, context) => {
   const { date, defaultValue } = props;
   if (date) {
-    const title = context.intl.formatDate(date, {
+    const isoDate = isoCompatibleDate(date);
+    const title = context.intl.formatDate(isoDate, {
       day: '2-digit',
       month: 'short',
       hour: '2-digit',
@@ -16,7 +18,7 @@ const RelativeDateTime = (props, context) => {
     /* eslint-disable react/style-prop-object */
     return (
       <span title={title}>
-        <FormattedRelative value={date} style="numeric" />
+        <FormattedRelative value={isoDate} style="numeric" />
       </span>
     );
     /* eslint-enable react/style-prop-object */

--- a/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, intlShape } from 'react-intl';
+import { isoCompatibleDate } from '../../../common/helpers';
 
 const ShortDateTime = (props, context) => {
   const { date, defaultValue, seconds } = props;
   if (date) {
-    const title = context.intl.formatRelative(date);
+    const isoDate = isoCompatibleDate(date);
+    const title = context.intl.formatRelative(isoDate);
     const secondsFormat = seconds ? '2-digit' : undefined;
 
     return (
       <span title={title}>
         <FormattedDate
-          value={date}
+          value={isoDate}
           day="2-digit"
           month="short"
           hour="2-digit"


### PR DESCRIPTION
Our API doesn't return ISO8601 dates which breaks these components in Firefox - but now they work!