### PR TITLE
Fixes #26617 - Properly expose puppetclass_name

### DIFF
--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -21,4 +21,6 @@ end
 # compatibility
 attribute :omit => :use_puppet_default
 
-attribute :param_class, :as => :puppetclass_name
+node :puppetclass_name do |lk|
+  lk.param_class.name
+end


### PR DESCRIPTION
Opening this in favor of #6669 for now to fix the issue that was uncovered.

In RABL, this is what the generated object looks like before being dumped to JSON:

```
{:description=>nil,
 :override=>true,
 :parameter_type=>"string",
 :hidden_value?=>false,
 :omit=>nil,
 :required=>false,
 :validator_type=>nil,
 :validator_rule=>nil,
 :merge_overrides=>false,
 :merge_default=>false,
 :avoid_duplicates=>false,
 :override_value_order=>"fqdn\norganization,location\nhostgroup",
 :created_at=>Mon, 15 Apr 2019 00:07:47 UTC +00:00,
 :updated_at=>Mon, 15 Apr 2019 00:07:47 UTC +00:00,
 :use_puppet_default=>nil,
 :puppetclass_name=>
  #<Puppetclass:0x000000000dcbd600
   id: 298486374,
   name: "apache",
   created_at: Mon, 15 Apr 2019 00:07:47 UTC +00:00,
   updated_at: Mon, 15 Apr 2019 00:07:47 UTC +00:00>,
 :parameter=>"custom_class_param",
 :id=>1018350795,
 :puppetclass_id=>298486374,
 :override_values_count=>0,
 :default_value=>"abcdef",
 :environments=>[{:id=>334344675, :name=>"production"}],
 :override_values=>[]}
```

Notice that puppetclass_name is the whole object, and not just the name ('apache' here)

Although the API is rendered properly, this attribute is relying on some off behavior of ::JSON encoding. This change makes sure that the above object will look like below which is the intention of the API:

```
:puppetclass_name=> "apache",
```
I did a cursory search and I don't see any other occurrences of us relying on this, ie:

```
:as => <something>_name
```