### PR TITLE
Fixes #26634 - Handle (null) certificates in SmartProxyAuth

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -64,7 +64,7 @@ module Foreman::Controller::SmartProxyAuth
       # If we have the client certficate in the request environment we can extract the dn and sans from there
       # if not we use the dn in the request environment
       # SAN validation requires "SSLOptions +ExportCertData" in Apache httpd
-      if request.env.has_key?(Setting[:ssl_client_cert_env]) && request.env[Setting[:ssl_client_cert_env]].present?
+      if request.env.has_key?(Setting[:ssl_client_cert_env]) && request.env[Setting[:ssl_client_cert_env]].present? && request.env[Setting[:ssl_client_cert_env]] != '(null)'
         logger.debug "Examining client certificate to extract dn and sans"
         cert_raw = request.env[Setting[:ssl_client_cert_env]]
         certificate = CertificateExtract.new(cert_raw)


### PR DESCRIPTION
When visiting the page from behind a reverse proxy this value can end up as (null) and then fails to parse. This special cases it.

I don't know if this is the best approach (probably not). Should we perhaps attempt to parse it and treat exceptions as non-present instead?

It's good to note that Katello does something similar in https://github.com/Katello/katello/blob/abbff485b07e94f8dd1dc1caeff4fc23f4e1b356/app/services/katello/authentication/client_authentication.rb#L23-L26