### PR TITLE
fixes #26644 - client certificate abstraction

### DIFF
--- a/app/services/foreman/client_certificate.rb
+++ b/app/services/foreman/client_certificate.rb
@@ -1,0 +1,65 @@
+module Foreman
+  class ClientCertificate
+    delegate :logger, to: :Rails
+    attr_reader :request
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def raw_cert_available?
+      @raw_cert_available ||= request.ssl? && raw_data.present? && raw_data != '(null)'
+    end
+
+    def raw_data
+      request.env[certificate_env_key]
+    end
+
+    def subject
+      return certificate_extract.subject if raw_cert_available?
+      dn = request.env[dn_key]
+      return unless dn && dn =~ /CN=([^\s\/,]+)/i
+
+      Regexp.last_match(1).downcase
+    end
+
+    def subject_alternative_names
+      return unless raw_cert_available?
+      certificate_extract.subject_alternative_names
+    end
+
+    def verify
+      request.env[verify_key]
+    end
+
+    def verified?
+      return true if verify == 'SUCCESS'
+      logger.info { "Client certificate is invalid: #{verify}" }
+      false
+    end
+
+    def hosts
+      return subject_alternative_names if subject_alternative_names.present?
+      return [subject] if subject.present?
+      []
+    end
+
+    private
+
+    def certificate_env_key
+      Setting[:ssl_client_cert_env]
+    end
+
+    def verify_key
+      Setting[:ssl_client_verify_env]
+    end
+
+    def dn_key
+      Setting[:ssl_client_dn_env]
+    end
+
+    def certificate_extract
+      @certificate_extract ||= CertificateExtract.new(raw_data)
+    end
+  end
+end

--- a/test/unit/foreman/client_certificate_test.rb
+++ b/test/unit/foreman/client_certificate_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+
+class Foreman::ClientCertificateTest < ActiveSupport::TestCase
+  let(:raw_certificate) { File.read(Rails.root.join('test/static_fixtures/certificates/example.com.crt')) }
+  # Can be SUCCESS, GENEROUS or NONE
+  let(:ssl_client_verify) { 'SUCCESS' }
+  let(:ssl_client_dn) { '/CN=example.com/serialNumber=123456789012/DC=FOO/C=US' }
+  let(:request) do
+    OpenStruct.new(
+      'ssl?': true,
+      env: {
+        'SSL_CLIENT_VERIFY' => ssl_client_verify,
+        'SSL_CLIENT_CERT' => raw_certificate,
+        'SSL_CLIENT_S_DN' => ssl_client_dn,
+      }
+    )
+  end
+  let(:client_certificate) { Foreman::ClientCertificate.new(request: request) }
+
+  setup do
+    Setting[:ssl_client_cert_env] = 'SSL_CLIENT_CERT'
+    Setting[:ssl_client_dn_env] = 'SSL_CLIENT_S_DN'
+    Setting[:ssl_client_verify_env] = 'SSL_CLIENT_VERIFY'
+  end
+
+  describe '#raw_cert_available?' do
+    context 'no ssl request' do
+      test 'raw client certificate not available' do
+        request.public_send(:'ssl?=', false)
+        assert_equal false, client_certificate.raw_cert_available?
+      end
+    end
+
+    context 'without a certificate' do
+      let(:raw_certificate) { nil }
+
+      test 'raw client certificate is not available' do
+        assert_equal false, client_certificate.raw_cert_available?
+      end
+    end
+
+    context 'with a null certificate' do
+      let(:raw_certificate) { '(null)' }
+
+      test 'raw client certificate is not available' do
+        assert_equal false, client_certificate.raw_cert_available?
+      end
+    end
+
+    context 'with a certificate' do
+      test 'raw client certificate is available' do
+        assert_equal true, client_certificate.raw_cert_available?
+      end
+    end
+  end
+
+  describe '#verify' do
+    context 'with SSL_CLIENT_VERIFY = SUCCESS' do
+      test 'the client certificate is valid' do
+        assert_equal true, client_certificate.verified?
+      end
+    end
+
+    context 'with SSL_CLIENT_VERIFY = GENEROUS' do
+      let(:ssl_client_verify) { 'GENEROUS' }
+
+      test 'the client certificate is invalid' do
+        assert_equal false, client_certificate.verified?
+      end
+    end
+
+    context 'with SSL_CLIENT_VERIFY = NONE' do
+      let(:ssl_client_verify) { 'NONE' }
+
+      test 'the client certificate is invalid' do
+        assert_equal false, client_certificate.verified?
+      end
+    end
+  end
+
+  describe '#subject' do
+    context 'with a certificate' do
+      test 'reads the subject from the certificate' do
+        assert_equal 'example.com', client_certificate.subject
+      end
+    end
+
+    context 'without a certificate' do
+      let(:raw_certificate) { nil }
+
+      test 'reads the subject from the SSL_CLIENT_S_DN header' do
+        assert_equal 'example.com', client_certificate.subject
+      end
+    end
+  end
+
+  describe '#subject_alternative_names' do
+    context 'with a certificate' do
+      it 'reads the SANs from the certificate' do
+        assert_equal ['www.example.com', 'www.example.net', 'www.example.org', '192.168.1.1', '2001:DB8:0:0:0:0:0:1'], client_certificate.subject_alternative_names
+      end
+    end
+
+    context 'without a certificate' do
+      let(:raw_certificate) { nil }
+
+      it 'returns no SANs' do
+        assert_nil client_certificate.subject_alternative_names
+      end
+    end
+  end
+
+  describe '#hosts' do
+    context 'with a certificate' do
+      it 'reads the SANs from the certificate' do
+        assert_equal ['www.example.com', 'www.example.net', 'www.example.org', '192.168.1.1', '2001:DB8:0:0:0:0:0:1'], client_certificate.hosts
+      end
+
+      it 'falls back to the CN if no sans are present' do
+        client_certificate.stubs(:subject_alternative_names).returns([])
+        assert_equal ['example.com'], client_certificate.hosts
+      end
+    end
+
+    context 'without a certificate' do
+      let(:raw_certificate) { nil }
+
+      it 'returns an empty list' do
+        client_certificate.stubs(:subject)
+        assert_equal [], client_certificate.hosts
+      end
+    end
+  end
+end


### PR DESCRIPTION
This simple refactoring provides a `Foreman::ClientCertificate` class that plugins can use to access the client certificate. The abstraction is a nice thing to have if we ever need to change any details (e.g. sunsetting mod_passenger in favor of puma).