### PR TITLE
Fixes #26651 - Remount components after AJAX call

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -327,6 +327,7 @@ function update_form(element, options) {
       }
 
       $(document.body).trigger('ContentLoad');
+      $(document.body).trigger('RemountComponents')
     }
   })
 }

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -33,6 +33,7 @@ import hosts from './foreman_hosts';
 import * as foremanStore from './foreman_store';
 
 window.tfm = Object.assign(window.tfm || {}, {
+  ajaxRemount: require('./foreman_ajax_remount'),
   authSource: require('./foreman_auth_source'),
   tools: require('./foreman_tools'),
   users: require('./foreman_users'),

--- a/webpack/assets/javascripts/foreman_ajax_remount.js
+++ b/webpack/assets/javascripts/foreman_ajax_remount.js
@@ -1,0 +1,20 @@
+import $ from 'jquery';
+
+/* eslint-disable prefer-arrow-callback, func-names */
+
+$(document).on('RemountComponents', function() {
+  window.tfm.ajaxRemount.remountComponents();
+});
+
+export function remountComponents() {
+  const range = document.createRange();
+  range.selectNode(document.getElementsByTagName('body').item(0));
+
+  $('.react_mounted script').each(function() {
+    const inner = $(this).text();
+    const documentFragment = range.createContextualFragment(
+      `<script> ${inner} </script>`
+    );
+    document.body.appendChild(documentFragment);
+  });
+}


### PR DESCRIPTION
When host(group)s form partial is inserted into page,
remountComponents finds scripts with react components
by selector and inserts them as new nodes into page,
so that they are executed.

<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
