### PR TITLE
fixes #26627 - rake task to render templates from dir

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -353,7 +353,7 @@ class Host::Managed < Host::Base
 
   # returns the host correct disk layout, custom or common
   def diskLayout
-    raise Foreman::Renderer::Errors::RenderingError, 'Neither disk nor partition table defined for host' unless disk_layout_source
+    raise Foreman::Exception, 'Neither disk nor partition table defined for host' unless disk_layout_source
     scope = Foreman::Renderer.get_scope(host: self, source: disk_layout_source)
     Foreman::Renderer.render(disk_layout_source, scope)
   end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -287,10 +287,14 @@ class Operatingsystem < ApplicationRecord
     description
   end
 
-  def deduce_family
-    self.family || self.class.families.find do |f|
+  def self.deduce_family(name)
+    families.find do |f|
       name =~ FAMILIES[f]
     end
+  end
+
+  def deduce_family
+    self.family || self.class.deduce_family(name)
   end
 
   def boot_files_uri(medium_provider, &block)

--- a/app/services/foreman/render_templates_from_folder.rb
+++ b/app/services/foreman/render_templates_from_folder.rb
@@ -1,0 +1,163 @@
+module Foreman
+  class RenderTemplatesFromFolder
+    class ProvisioningTemplateFromFolder < ::ProvisioningTemplate
+      self.table_name = 'templates'
+      attr_accessor :template_path, :source_directory
+    end
+
+    attr_reader :source_directory
+    attr_accessor :errors
+
+    delegate :logger, to: :Rails
+
+    def self.instance(source_directory:)
+      @instances ||= {}
+      @instances[source_directory] ||= new(source_directory: source_directory)
+    end
+
+    def self.clear_instances
+      @instances = {}
+    end
+
+    def initialize(source_directory:)
+      @source_directory = source_directory
+      @errors = {}
+    end
+
+    def render_all
+      self.errors = {}
+      templates.each do |template|
+        next if template.snippet
+        if template.operatingsystems.empty?
+          logger.debug "Skipping template #{template.name} because it's not associated to any operating system."
+          next
+        end
+        begin
+          render_template(template)
+        rescue StandardError => e
+          self.errors[template] = e.message
+        end
+      end
+      errors.empty?
+    end
+
+    def render_template(template)
+      source = source_klass.new(template)
+      scope = Foreman::Renderer.get_scope(host: host(template), source: source)
+      Foreman::Renderer.render(source, scope)
+    end
+
+    def templates
+      @templates ||= files.map { |filepath| load_file(filepath) }
+    end
+
+    def snippets
+      templates.select(&:snippet?)
+    end
+
+    def load_file(filepath)
+      content = File.read(filepath)
+      metadata = Template.parse_metadata(content).deep_symbolize_keys
+      name = metadata[:name]
+      raise "Could not read name from metadata in template #{filepath}." unless name.present?
+      kind = metadata[:kind]
+      snippet = (kind == 'snippet') || !!metadata[:snippet]
+      oses = metadata[:oses] || []
+      operatingsystems = oses.map { |os| build_operatingsystem(name: os) }.compact
+      ProvisioningTemplateFromFolder.new(
+        template_path: filepath, source_directory: source_directory,
+        name: name, template: content,
+        template_kind: TemplateKind.new(name: kind),
+        snippet: snippet, operatingsystems: operatingsystems
+      )
+    end
+
+    def host(template)
+      operatingsystem = template.operatingsystems.first
+      build_host(operatingsystem: operatingsystem)
+    end
+
+    private
+
+    def source_klass
+      Foreman::Renderer::Source::Directory
+    end
+
+    def files
+      @files ||= Dir.glob(File.join(source_directory, '**', '*.erb'))
+    end
+
+    def build_architecture(osfamily:)
+      architecture_name = case osfamily
+                          when 'Solaris'
+                            'sparc'
+                          when 'VRP'
+                            'ASIC'
+                          else
+                            'x86_64'
+                          end
+      Architecture.new(
+        name: architecture_name
+      )
+    end
+
+    def build_operatingsystem(name:)
+      family = Operatingsystem.deduce_family(name)
+      return unless family
+      architecture = build_architecture(osfamily: family)
+      family.constantize.new(
+        name: name,
+        major: 7,
+        minor: 6,
+        family: family,
+        architectures: [architecture]
+      )
+    end
+
+    def build_medium(operatingsystem:)
+      case operatingsystem.family
+      when 'Solaris'
+        Medium.new(
+          name: 'Solaris Medium',
+          path: 'http://www.example.com/vol/solgi_5.10/sol$minor_$release_$arch',
+          media_path: 'www.example.com:/vol/solgi_5.10/sol$minor_$release_$arch',
+          config_path: 'www.example.com:/vol/jumpstart',
+          image_path: 'www.example.com:/vol/solgi_5.10/sol$minor_$release_$arch/flash/',
+          os_family: operatingsystem.family
+        )
+      else
+        Medium.new(
+          name: 'Example Medium',
+          path: 'http://www.example.com/path/',
+          os_family: operatingsystem.family
+        )
+      end
+    end
+
+    def build_host(operatingsystem:)
+      medium = build_medium(operatingsystem: operatingsystem)
+      domain = Domain.new(
+        name: 'example.com'
+      )
+      subnet = Subnet.new(
+        name: 'TEST-NET-1',
+        network: '192.0.2.0'
+      )
+      medium.operatingsystems << operatingsystem
+      operatingsystem.media << medium
+      Host.new(
+        architecture: operatingsystem.architectures.first,
+        medium: medium,
+        domain: domain,
+        operatingsystem: operatingsystem,
+        subnet: subnet,
+        root_pass: 'securepassword',
+        disk: 'fake disk layout',
+        name: 'testhost',
+        pxe_loader: 'Grub2 UEFI SecureBoot',
+        mac: '00-11-22-33-44-55',
+        managed: true
+      )
+    end
+  end
+end

--- a/lib/foreman/renderer/source/directory.rb
+++ b/lib/foreman/renderer/source/directory.rb
@@ -1,0 +1,12 @@
+module Foreman
+  module Renderer
+    module Source
+      class Directory < Database
+        def find_snippet(snippet_name)
+          snippets = ::Foreman::RenderTemplatesFromFolder.instance(source_directory: template.source_directory).snippets
+          snippets.find { |snippet| snippet.name == snippet_name }
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/templates_renderer.rake
+++ b/lib/tasks/templates_renderer.rake
@@ -1,0 +1,37 @@
+# TRANSLATORS: do not translate
+desc <<-END_DESC
+Render templates from a directory
+
+Available conditions:
+  * DIRECTORY        => Path to the folder where the templates are stored
+
+  Example:
+    rake templates:render DIRECTORY=/tmp/community-templates/provisioning_templates
+
+END_DESC
+
+namespace :templates do
+  task render: :environment do
+    source_directory = ENV['DIRECTORY'].to_s
+
+    abort(Rainbow('Must provide a valid path to a directory.').red) unless File.directory?(source_directory)
+
+    User.as_anonymous_admin do
+      service = Foreman::RenderTemplatesFromFolder.new(source_directory: source_directory)
+      service.render_all
+      if service.errors.any?
+        puts Rainbow('Errors occured while rendering the templates.').red
+        puts ''
+        service.errors.each do |template, message|
+          puts " ==== #{template.name} ===="
+          puts Rainbow("(#{template.template_path})").blue
+          puts " -> #{message}"
+          puts ''
+        end
+        abort(Rainbow("Failed to render the templates.").red)
+      end
+
+      puts Rainbow('Successfully rendered all templates.').green
+    end
+  end
+end

--- a/test/static_fixtures/templates/snippet/three.erb
+++ b/test/static_fixtures/templates/snippet/three.erb
@@ -1,6 +1,6 @@
 <%#
 kind: snippet
-name: Three
+name: three
 model: ProvisioningTemplate
 snippet: true
 -%>

--- a/test/static_fixtures/templates/snippet/two.erb
+++ b/test/static_fixtures/templates/snippet/two.erb
@@ -1,6 +1,6 @@
 <%#
 kind: snippet
-name: Two
+name: two
 model: ProvisioningTemplate
 snippet: true
 -%>

--- a/test/unit/foreman/renderer_templates_from_folder_test.rb
+++ b/test/unit/foreman/renderer_templates_from_folder_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class Foreman::RenderTemplatesFromFolderTest < ActiveSupport::TestCase
+  let(:source_directory) { File.expand_path(File.join(__dir__, '../../static_fixtures/templates')) }
+  let(:instance) { Foreman::RenderTemplatesFromFolder.instance(source_directory: source_directory) }
+
+  teardown do
+    Foreman::RenderTemplatesFromFolder.clear_instances
+  end
+
+  it 'renders templates from static fixtures' do
+    instance.render_all
+    assert_empty instance.errors
+  end
+end


### PR DESCRIPTION
This adds a rake task that renders templates from a directory.
This could be used in the [community templates](https://github.com/theforeman/community-templates) CI like this:

```bash
git checkout https://github.com/theforeman/foreman.git
bundle install, ...

bundle exec rake templates:render PATH="path/to/community-templates/provisioning_templates/"
```

This commit also contains fixes so that the templates actually render. We should probably fix them in separate PRs (with proper test coverage).

See [Discourse](https://community.theforeman.org/t/provisioning-templates-testing-separate-repository/13654) for Details.