### PR TITLE
Refs #26198 - Replace foreman_url with tfm.tools.foremanURL

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -314,7 +314,7 @@ function get_pie_chart(div, url) {
         });
         expanded_pie(target, data.values);
         $('.modal-title').empty().append( __('Fact distribution chart') + ' - <b>' + _.escape(data.name) + ' </b><small> ('+ tfm.i18n.sprintf(n__("%s host", "%s hosts", hostsCount), hostsCount) +')</small>');
-        target.attr('data-url', foreman_url("/hosts?search=facts." + data.name + "~~VAL1~"));
+        target.attr('data-url', tfm.tools.foremanUrl("/hosts?search=facts." + data.name + "~~VAL1~"));
       });
     });
   } else {$("#"+div).modal('show');}

--- a/webpack/assets/javascripts/foreman_dashboard.js
+++ b/webpack/assets/javascripts/foreman_dashboard.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import { doesDocumentHasFocus } from './react_app/common/document';
 import { notify } from './foreman_toast_notifications';
-import { activateTooltips } from './foreman_tools';
+import { activateTooltips, foremanUrl } from './foreman_tools';
 import { translate as __ } from './react_app/common/I18n';
 
 $(document).on('ContentLoad', () => {
-  if (window.foreman_url('/') === window.location.pathname) {
+  if (foremanUrl('/') === window.location.pathname) {
     startGridster();
     autoRefresh();
   }


### PR DESCRIPTION
ac1fe0d moved the foreman_url js function to webpack and deprecated the
old version but there were still a couple of places calling it causing
warnings in the console. This replaces those use cases with the newer
function.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
