### PR TITLE
Fixes #26646 - NumericInput change handler rename

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { pick, omit, keys } from 'lodash';
 import {
   Col,
   FormGroup,
@@ -24,6 +25,22 @@ const inputComponents = {
 export const registerInputComponent = (name, Component) => {
   inputComponents[name] = Component;
 };
+
+export const wrapInput = (type, Input) => {
+  registerInputComponent(type, Input);
+  const Field = props => (
+    <FormField
+      {...pick(props, keys(FormField.propTypes))}
+      inputProps={omit(props, keys(FormField.propTypes))}
+      type={type}
+    />
+  );
+  Field.displayName = `FormField(${Input.displayName ||
+    Input.name ||
+    'Input'})`;
+  return Field;
+};
+
 export const ControlContext = React.createContext();
 
 const InputFactory = ({ type }) => {

--- a/webpack/assets/javascripts/react_app/components/common/forms/FormInputs.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormInputs.stories.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { Row } from 'patternfly-react';
+
+import Story from '../../../../../../stories/components/Story';
+import NumericInput from './NumericInput';
+
+const NumericInputStory = props => {
+  const [value, setValue] = useState([5, '5', '5 Gb']);
+
+  return (
+    <div className="container">
+      <Row>
+        <NumericInput
+          value={value[0]}
+          label="NumericInput"
+          name="numeric"
+          onValueChange={(valueAsNumber, valueAsString, input) =>
+            setValue([valueAsNumber, valueAsString, input.value])
+          }
+          format={v => `${v} GB`}
+        />
+      </Row>
+      <Row>
+        <div className="col-md-12">
+          {`valueAsNumber: ${value[0]},
+            valueAsString: ${value[1]},
+            input.value: ${value[2]}`}
+        </div>
+      </Row>
+    </div>
+  );
+};
+
+storiesOf('Components/FormInputs', module).add('Numeric Input', () => (
+  <Story>
+    <NumericInputStory />
+  </Story>
+));

--- a/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
@@ -1,48 +1,59 @@
-import NumericInput from 'react-numeric-input';
+import ReactNumericInput from 'react-numeric-input';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { noop } from '../../../common/helpers';
-import CommonForm from './CommonForm';
+import { wrapInput } from './FormField';
 
-const TextInput = ({
-  label,
+/**
+ * NumericInput field.
+ *
+ * === Change handler
+ * It does not support *onChange* prop as a change handler,
+ * because the it has different behaviour and would confuse users.
+ * Use *onValueChange* instead.
+ */
+const NumericInput = ({
   className,
   value,
-  onChange,
+  onValueChange,
   format,
   precision,
   minValue,
 }) => (
-  <CommonForm label={label} className={`common-numericInput ${className}`}>
-    <NumericInput
-      format={format}
-      min={minValue}
-      value={value}
-      precision={precision}
-      onChange={onChange}
-    />
-  </CommonForm>
+  <ReactNumericInput
+    className={className}
+    format={format}
+    min={minValue}
+    value={value}
+    precision={precision}
+    onChange={onValueChange}
+  />
 );
 
-TextInput.propTypes = {
-  label: PropTypes.string,
+NumericInput.propTypes = {
   className: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   format: PropTypes.func,
   precision: PropTypes.number,
   minValue: PropTypes.number,
-  onChange: PropTypes.func,
+  /**
+   * Only supported change handler.
+   *
+   * @param valueAsNumber
+   * @param valueAsString
+   * @param input the underlying input
+   */
+  onValueChange: PropTypes.func,
 };
 
-TextInput.defaultProps = {
-  label: '',
+NumericInput.defaultProps = {
   className: '',
   value: 0,
   format: null,
   precision: 0,
   minValue: 0,
-  onChange: noop,
+  onValueChange: noop,
 };
 
-export default TextInput;
+export default wrapInput('numeric', NumericInput);

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
@@ -90,7 +90,7 @@ const Disk = ({
         minValue={1}
         format={v => `${v} GB`}
         className="text-vmware-size"
-        onChange={newValues => updateDisk('sizeGb', newValues)}
+        onValueChange={value => updateDisk('sizeGb', { target: { value } })}
         label={__('Size (GB)')}
       />
 

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/index.js
@@ -31,12 +31,8 @@ const Controller = ({
   storagePodsStatus,
   storagePodsError,
 }) => {
-  const getEventValue = e => {
-    if (!e || !e.target) {
-      return e;
-    }
-    return e.target.type === 'checkbox' ? e.target.checked : e.target.value;
-  };
+  const getEventValue = ({ target: { type, checked, value } }) =>
+    type === 'checkbox' ? checked : value;
 
   const _updateController = (attribute, e) => {
     updateController({ [attribute]: getEventValue(e) });


### PR DESCRIPTION
Followup for #6637.

NumericInput have different onChange definition from other inputs.
This introduced a bug with vmware storage disappearing if the value is null.
The problem is that NumericInput feeds the onChange with its value right away, but other onChange are feeded by whole change event, what creates confusion.

Prerequisites for testing:

- VMware cluster

Tests needed (anticipated impacts):

- VMware storage definition/creation


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
