### PR TITLE
Fixes #26664 - adds OpenStack project domain

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -41,7 +41,9 @@ module Api
           param :public_key, String, :desc => N_("for oVirt only")
           param :region, String, :desc => N_("for EC2 only, use '%s' for GovCloud region") % Foreman::Model::EC2::GOV_CLOUD_REGION
           param :tenant, String, :desc => N_("for OpenStack only")
-          param :domain, String, :desc => N_("for OpenStack only")
+          param :domain, String, :desc => N_("for OpenStack (v3) only")
+          param :project_domain_name, String, :desc => N_("for OpenStack (v3) only")
+          param :project_domain_id, String, :desc => N_("for OpenStack (v3) only")
           param :server, String, :desc => N_("for VMware")
           param :set_console_password, :bool, :desc => N_("for Libvirt and VMware only")
           param :display_type, %w(VNC SPICE), :desc => N_('for Libvirt only')

--- a/app/controllers/concerns/foreman/controller/parameters/compute_resource.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/compute_resource.rb
@@ -35,7 +35,9 @@ module Foreman::Controller::Parameters::ComputeResource
         filter.permit :allow_external_network,
           :key_pair,
           :tenant,
-          :domain
+          :domain,
+          :project_domain_name,
+          :project_domain_id
 
         # ovirt
         filter.permit :datacenter,

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -1,7 +1,7 @@
 module Foreman::Model
   class Openstack < ComputeResource
     include KeyPairComputeResource
-    attr_accessor :tenant, :scheduler_hint_value
+    attr_accessor :scheduler_hint_value
     delegate :flavors, :to => :client
     delegate :security_groups, :to => :client
 
@@ -43,10 +43,26 @@ module Foreman::Model
       attrs[:tenant] = name
     end
 
+    def project_domain_id
+      attrs[:project_domain_id]
+    end
+
+    def project_domain_id=(domain)
+      attrs[:project_domain_id] = domain
+    end
+
+    def project_domain_name
+      attrs[:project_domain_name]
+    end
+
+    def project_domain_name=(domain)
+      attrs[:project_domain_name] = domain
+    end
+
     def tenants
       if identity_version == 3
         user_id = identity_client.current_user_id
-        identity_client.list_user_projects(user_id).body["projects"].map { |p| Fog::Identity::OpenStack::V3::Project.new(p) }
+        identity_client.list_user_projects(user_id).body["projects"].map { |p| Fog::OpenStack::Identity::V3::Project.new(p) }
       else
         identity_client.tenants
       end
@@ -254,16 +270,21 @@ module Foreman::Model
         :openstack_api_key  => password,
         :openstack_username => user,
         :openstack_auth_url => url_for_fog,
-        :openstack_tenant   => tenant,
-        :openstack_identity_endpoint => url_for_fog,
-        :openstack_user_domain       => domain,
-        :openstack_endpoint_type     => "publicURL"
+        :openstack_identity_endpoint => url_for_fog
       }.tap do |h|
-        if tenant
-          h[:openstack_domain_name] = domain
-          h[:openstack_project_name] = tenant
+        if tenant.present?
+          if identity_version == 2
+            h[:openstack_tenant] = tenant
+          else
+            h[:openstack_project_name] = tenant
+          end
         end
+        h[:openstack_user_domain] = domain if domain.present?
+        h[:openstack_domain_id] = project_domain_id if project_domain_id.present?
+        h[:openstack_domain_name] = project_domain_name if project_domain_name.present?
         h[:openstack_identity_api_version] = 'v2.0' if identity_version == 2
+        logger.debug { "OpenStack fog credentials: " + h.dup.delete_if { |key, value| key == :openstack_api_key }.to_s }
+        h
       end
     end
 

--- a/app/views/api/v2/compute_resources/openstack.json.rabl
+++ b/app/views/api/v2/compute_resources/openstack.json.rabl
@@ -1,1 +1,1 @@
-attributes :user, :tenant, :domain
+attributes :user, :tenant, :domain, :project_domain_name, :project_domain_id

--- a/app/views/compute_resources/form/_openstack.html.erb
+++ b/app/views/compute_resources/form/_openstack.html.erb
@@ -1,11 +1,17 @@
-<%= text_f f, :url, :size => "col-md-8", :help_block => _("e.g. http://openstack:5000/v2.0/tokens or http://openstack:5000/v3/auth/tokens"), :help_inline => documentation_button('5.2.6OpenStackNotes') %>
+<%= text_f f, :url, :label => _("URL"), :size => "col-md-8", :help_block => _("Use /v2 or /v3 to force API version, e.g. http://openstack:5000/v2.0/tokens or http://openstack:5000/v3/auth/tokens"), :help_inline => documentation_button('5.2.6OpenStackNotes') %>
 <%= text_f f, :user %>
 <%= password_f f, :password, :unset => unset_password? %>
 
-<% tenants = f.object.tenants rescue [] %>
-<%= selectable_f(f, :tenant, tenants, {}, {:label => _('Project (Tenant)'), :help_block => _("Project (v3) or Tenant (v2)"), :disabled => tenants.empty?,
-                 :help_inline_permanent => load_button_f(f, !tenants.empty?, _("Load")) }) %>
+<%= text_f f, :tenant, :label => _("Project (Tenant) name"), :help_block => _("Project name (v3) or Tenant name (v2). Can be retrieved via CLI or RC file.") %>
 
-<%= text_f f, :domain, :help_block => _("Only for v3 authentication") %>
+<%= text_f f, :domain, :label => _("User domain"), :help_block => _("Can be retrieved via CLI or RC file, e.g. 'redhat.com'. Only for v3 authentication.") %>
+
+<%= text_f f, :project_domain_name, :label => _("Project domain name"), :help_block => _("Can be retrieved via CLI or RC file. Can be left blank. Only for v3 authentication.") %>
+
+<%= text_f f, :project_domain_id, :label => _("Project domain ID"), :help_block => _("Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication.") %>
 
 <%= checkbox_f f, :allow_external_network, {:checked => f.object.allow_external_network, :label => _("Allow external network as main network")} %>
+
+<div class="col-md-offset-2">
+  <%= test_connection_button_f(f, (f.object.tenants rescue false)) %>
+</div>


### PR DESCRIPTION
When creating new OpenStack CR against OSP v13 a permission denied (401)
error is returned. I have narrowed this down to the fact to missing flag
openstack_domain_id. When it's provided, the CR authenticates fine,
since it is mentioned as mandatory for V3 in
https://github.com/fog/fog-openstack this patch is going to add it.

The patch changes tenant not to be loaded from OpenStack because it's
chicken and egg problem - tenant presence makes for to think API V2 must
be used, however against V3 only openstacks it is no longer possible to
retrieve list of tenants anymore. It's now a free-form text field.

Two new fields (text) are added - project domain name and id. For
OpenStack I was testing with only id was required, however I am adding
also name and when set it is passed into fog.

I tested UI, API and hammer, a PR adding support to hammer is on the
way. I am going to propose this to 1.22 because essentially V3 OpenStack
CR is broken, however I think it was broken even before Fog upgrade.