### PR TITLE
Fixes #26674 - blank NIC name removes DNS

### DIFF
--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -55,7 +55,7 @@ module Orchestration::DNS
   end
 
   def queue_dns
-    return log_orchestration_errors unless (dns? || dns6? || reverse_dns? || reverse_dns6?) && errors.empty?
+    return log_orchestration_errors unless (dns? || dns6? || reverse_dns? || reverse_dns6? || old&.dns? || old&.dns6? || old&.reverse_dns? || old&.reverse_dns6?) && errors.empty?
     queue_remove_dns_conflicts if overwrite?
     new_record? ? queue_dns_create : queue_dns_update
   end


### PR DESCRIPTION
We do not check for old.dns? in the codebase, however later on we actually allow update. Regression most likely.