### PR TITLE
Fixes #26676 - improve setting initialization

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -193,11 +193,12 @@ class Setting < ApplicationRecord
 
   # in order to avoid code duplication, this method was introduced
   def self.create_find_by_name(opts)
+    @setting_cache ||= Hash[Setting.where(:category => self.to_s).map { |s| [s.name, s] }]
     # self.name can be set by default scope, e.g. from first_or_create use
     opts ||= { name: new.name }
     opts.symbolize_keys!
 
-    s = Setting.find_by_name(opts[:name].to_s)
+    s = @setting_cache[opts[:name].to_s] || Setting.find_by_name(opts[:name].to_s)
     return create_existing(s, opts) if s
 
     column_check(opts)
@@ -242,9 +243,16 @@ class Setting < ApplicationRecord
       attrs = column_check([:default, :description, :full_name, :encrypted])
       to_update = Hash[opts.select { |k, v| attrs.include? k }]
       to_update[:value] = readonly_value(s.name.to_sym) if s.has_readonly_value?
-      s.update(to_update)
+      # default is converted to yaml so we need to convert the yaml here too,
+      # in order to check, if the update of default is needed
+      # if it is the same, we don't try to update default, it would trigger
+      # update query for every setting
+      to_update.delete(:default) if to_update[:default].to_yaml.strip == s[:default]
+      s.attributes = to_update
+      s.save if s.changed?
       s.update_column :category, opts[:category] if s.category != opts[:category]
-      s.update_column :full_name, opts[:full_name] unless column_check([:full_name]).empty?
+      # we only update category (skipping validations) if it really differs
+      s.update_column :full_name, opts[:full_name] if s.full_name != opts[:full_name] && column_check([:full_name]).present?
       raw_value = s.read_attribute(:value)
       if s.is_encryptable?(raw_value) && attrs.include?(:encrypted) && opts[:encrypted]
         s.update_column :value, s.encrypt_field(raw_value)
@@ -271,7 +279,7 @@ class Setting < ApplicationRecord
 
   def self.load_defaults
     # We may be executing something like rake db:migrate:reset, which destroys this table; only continue if the table exists
-    Setting.first rescue return false
+    Setting.table_exists? rescue return false
     # STI classes will load their own defaults
     true
   end


### PR DESCRIPTION
The initialization of Foreman application loads and updates settings based on what is defined in settings/*.rb. It triest to update default value (and other attributes) if they have changed. The way we do the whole initialization has few leaks leading to hundreds of unnecessary SQL queries.

Prerequisites for testing:
* Foreman instance with SQL logger enabled

Tests needed (anticipated impacts):
* Start the Foreman app while watching the log
* See many queries before the patch, some updates even though the default value or category did not change, some "load" and some "exist" quieries for every setting.
* After applying the patch, you should only see ~10 queries (at least one per each setting category)
* It has small impact on startup time too, with trivial testing, I witnessed ~0.3s boost, in ~5s startup time. But performance increase is not the main goal

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
