### PR TITLE
Fixes #26200 - call audit_hook_to_find_records for getting label

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -9,13 +9,13 @@ module AuditsHelper
         label = change.to_s(:short)
       when /.*_id$/
         begin
-          label = key_to_class(name, audit)&.find(change)&.to_label
+          label = key_to_class(name, change, audit)&.to_label
         rescue NameError
           # fallback to the value only instead of N/A that is in generic rescue below
           return _("Missing(ID: %s)") % change
         end
       when /.*_ids$/
-        existing = key_to_class(name, audit)&.where(id: change)&.index_by(&:id)
+        existing = key_to_class(name, change, audit)
         label = change.map do |id|
           if existing&.has_key?(id)
             existing[id].to_label
@@ -238,11 +238,26 @@ module AuditsHelper
     main_objects_names.include?(type)
   end
 
-  def key_to_class(key, audit)
+  def find_auditable_type_class(audit)
     auditable_type = (audit.auditable_type == 'Host::Base') ? 'Host::Managed' : audit.auditable_type
+    auditable_type.constantize
+  end
+
+  def key_to_class(key, change, audit)
+    auditable_class = find_auditable_type_class(audit)
     association_name = key.gsub(/_id(s?)$/, '')
     association_name = association_name.pluralize if key =~ /_ids$/
-    auditable_type.constantize.reflect_on_association(association_name)&.klass
+    reflection_obj = auditable_class.reflect_on_association(association_name)
+    if reflection_obj.nil? && auditable_class.respond_to?('audit_hook_to_find_records')
+      auditable_class.send('audit_hook_to_find_records', key, change, audit)
+    else
+      association_class = reflection_obj&.klass
+      if key =~ /_ids$/
+        association_class&.where(id: change)&.index_by(&:id)
+      elsif key =~ /_id$/
+        association_class&.find(change)
+      end
+    end
   end
 
   def rebuild_audit_changes(audit)

--- a/test/helpers/audits_helper_test.rb
+++ b/test/helpers/audits_helper_test.rb
@@ -21,32 +21,17 @@ end
 class AuditsHelperTest < ActionView::TestCase
   include AuditsHelper
 
-  describe ":key_to_class" do
-    test "with association_name '*y' and :has_many, :key_to_class should return correct klass" do
-      audit_rec = FactoryBot.build(
-        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
-        :auditable_id => "272", :version => "1",
-        :audited_changes => { "dummy_repository_ids" => [[12], [12, 3]] })
-      output = key_to_class('dummy_repository_ids', audit_rec)
-      assert_equal output, DummyRepository
+  describe ":key_to_association_class" do
+    test "with association_name '*y' and :has_many, :key_to_association_class should return correct klass" do
+      assert_equal key_to_association_class('dummy_repository_ids', DummyHostContent), DummyRepository
     end
 
-    test "with :has_many, :key_to_class should return correct klass" do
-      audit_rec = FactoryBot.build(
-        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
-        :auditable_id => "272", :version => "2",
-        :audited_changes => { "dummy_org_ids" => [[1], [1, 3]] })
-      output = key_to_class('dummy_org_ids', audit_rec)
-      assert_equal output, DummyOrg
+    test "with :has_many, :key_to_association_class should return correct klass" do
+      assert_equal key_to_association_class('dummy_org_ids', DummyHostContent), DummyOrg
     end
 
-    test 'with :has_one, :key_to_class should return correct association' do
-      audit_rec = FactoryBot.build(
-        :audit, :action => 'update', :auditable_type => 'DummyHostContent',
-        :auditable_id => "272", :version => "3",
-        :audited_changes => { "dummy_environment_id" => [1, 2] })
-      output = key_to_class('dummy_environment_id', audit_rec)
-      assert_equal output, DummyEnvironment
+    test 'with :has_one, :key_to_association_class should return correct association' do
+      assert_equal key_to_association_class('dummy_environment_id', DummyHostContent), DummyEnvironment
     end
   end
 end


### PR DESCRIPTION
@ares, @tbrisker,

Using `audit_hook_to_find_records` method on auditable_type class, anyone can write custom logic to get records from change to display label on audit UI. This is needed when attribute/method present and no association defined on auditable_type class. For example - content_id in root_repository.

Added Foreman as well as Katello side change. 
Any thoughts or suggestions?

EDIT - Katello side [PR](https://github.com/Katello/katello/pull/8090)