### PR TITLE
Fixes #26681 - new logger named taxonomy

### DIFF
--- a/app/models/concerns/foreman/thread_session.rb
+++ b/app/models/concerns/foreman/thread_session.rb
@@ -26,7 +26,7 @@ module Foreman
 
       def clear_thread
         if Thread.current[:user] && !Rails.env.test?
-          Rails.logger.warn("Current user is set, but not expected. Clearing")
+          Foreman::Logging.logger('taxonomy').warn("Current user is set, but not expected. Clearing")
           Thread.current[:user] = nil
         end
         yield
@@ -73,9 +73,9 @@ module Foreman
             user = o.login
             type = o.admin? ? 'admin' : 'regular'
             if o.hidden?
-              Rails.logger.debug("Current user set to #{user} (#{type})")
+              Foreman::Logging.logger('permissions').debug("Current user set to #{user} (#{type})")
             else
-              Rails.logger.info("Current user set to #{user} (#{type})")
+              Foreman::Logging.logger('permissions').info("Current user set to #{user} (#{type})")
             end
           end
           ::Logging.mdc['user_login'] = o&.login
@@ -126,7 +126,7 @@ module Foreman
             raise(ArgumentError, "Unable to set current organization, expected class '#{self}', got #{organization.inspect}")
           end
 
-          Rails.logger.debug "Current organization set to #{organization || 'none'}"
+          Foreman::Logging.logger('taxonomy').debug "Current organization set to #{organization || 'none'}"
           org_id = organization.try(:id)
           ::Logging.mdc['org_id'] = org_id if org_id
           Thread.current[:organization] = organization
@@ -163,7 +163,7 @@ module Foreman
             raise(ArgumentError, "Unable to set current location, expected class '#{self}'. got #{location.inspect}")
           end
 
-          Rails.logger.debug "Current location set to #{location || 'none'}"
+          Foreman::Logging.logger('taxonomy').debug "Current location set to #{location || 'none'}"
           loc_id = location.try(:id)
           ::Logging.mdc['loc_id'] = loc_id if loc_id
           Thread.current[:location] = location

--- a/config/application.rb
+++ b/config/application.rb
@@ -224,7 +224,8 @@ module Foreman
       :background => {:enabled => true},
       :dynflow => {:enabled => true},
       :telemetry => {:enabled => false},
-      :blob => {:enabled => false}
+      :blob => {:enabled => false},
+      :taxonomy => {:enabled => true}
     ))
 
     config.logger = Foreman::Logging.logger('app')

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -91,6 +91,9 @@
 #  :templates:
 #    :enabled: true
 #  :notifications:
+#    :enabled: false
+#  :taxonomy:
+#    :enabled: true
 #  :background:
 #    :enabled: true
 #  :dynflow:


### PR DESCRIPTION
This is mainly for smoother development purposes. Rails log is much
cleaner without these.