### PR TITLE
Fixes #26705 - switch required with tooltip help

### DIFF
--- a/webpack/assets/javascripts/react_app/components/bookmarks/form/__snapshots__/form.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/bookmarks/form/__snapshots__/form.test.js.snap
@@ -600,8 +600,7 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Name
-                                 
-                                *
+                                 *
                               </label>
                               <div
                                 className="col-md-4"
@@ -989,8 +988,7 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Query
-                                 
-                                *
+                                 *
                               </label>
                               <div
                                 className="col-md-8"
@@ -1347,7 +1345,6 @@ exports[`bookmark form should render the entire form 1`] = `
                                 className="col-md-2 control-label"
                               >
                                 Public
-                                 
                               </label>
                               <div
                                 className="col-md-4"

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
@@ -16,7 +16,8 @@ const CommonForm = ({
   >
     <label className="col-md-2 control-label">
       {label}
-      {tooltipHelp} {required && '*'}
+      {required && ' *'}
+      {tooltipHelp}
     </label>
     <div className={inputClassName}>{children}</div>
     {touched && error && (

--- a/webpack/assets/javascripts/react_app/components/common/forms/__snapshots__/CommonForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__snapshots__/CommonForm.test.js.snap
@@ -8,8 +8,7 @@ exports[`common Form should accept a required field 1`] = `
     className="col-md-2 control-label"
   >
     my label
-     
-    *
+     *
   </label>
   <div
     className="col-md-4"
@@ -25,7 +24,6 @@ exports[`common Form should display a label field 1`] = `
     className="col-md-2 control-label"
   >
     my label
-     
   </label>
   <div
     className="col-md-4"
@@ -41,7 +39,6 @@ exports[`common Form should display validation errors if touched 1`] = `
     className="col-md-2 control-label"
   >
     my label
-     
   </label>
   <div
     className="col-md-4"
@@ -66,7 +63,6 @@ exports[`common Form should not display validation errors if not touched 1`] = `
     className="col-md-2 control-label"
   >
     my label
-     
   </label>
   <div
     className="col-md-4"
@@ -82,7 +78,6 @@ exports[`common Form should not display validation errors if there are none 1`] 
     className="col-md-2 control-label"
   >
     my label
-     
   </label>
   <div
     className="col-md-4"
@@ -98,14 +93,13 @@ exports[`common Form should render tooltip help 1`] = `
     className="col-md-2 control-label"
   >
     Required form field
+     *
     <FieldLevelHelp
       buttonClass=""
       content="This is a helpful tooltip"
       placement="top"
       rootClose={true}
     />
-     
-    *
   </label>
   <div
     className="col-md-4"


### PR DESCRIPTION
Fix order of required indicator.
Before:
![require-before](https://user-images.githubusercontent.com/2884324/56903791-43b73280-6a9d-11e9-95fc-d16e8a8d8bf4.png)
After:
![require-after](https://user-images.githubusercontent.com/2884324/56903790-43b73280-6a9d-11e9-8e7e-2f56098b2453.png)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
