### PR TITLE
Fixes #15626 - Only associate vms in the correct datacenter

### DIFF
--- a/app/services/compute_resource_host_associator.rb
+++ b/app/services/compute_resource_host_associator.rb
@@ -19,9 +19,12 @@ class ComputeResourceHostAssociator
 
   def associate_vm(vm)
     host = compute_resource.associated_host(vm)
-    if host.present?
-      host.associate!(compute_resource, vm)
-      @hosts << host
+    datacenter = compute_resource.uuid
+    vm_datacenter = vm.datacenter
+    if host.present? && vm_datacenter == datacenter
+        host.associate!(compute_resource, vm)
+        @hosts << host
+      end
     end
   rescue StandardError => e
     @fail_count += 1


### PR DESCRIPTION
This patch prevents vms from one compute resource/datacenter from being associated with the incorrect compute resource/datacenter.

Here is the result of my testing:

```
2 datacenters

https://nimb.ws/iYBzPk

CR 1

https://nimb.ws/IRHsBr

CR 2

https://nimb.ws/YSdWQi

Old behavior

https://nimb.ws/6Xz5H0

Fixed behavior with patch on devel box

https://nimb.ws/KPC9Hg

Fixed behavior with patch on prod box

https://nimb.ws/dZu5ps

Fixed behavior with patch on downstream

https://nimb.ws/4PQX6j
```