### PR TITLE
Fixes #15626 - filters vmware vms by datacenter

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -169,8 +169,8 @@ class ComputeResource < ApplicationRecord
   end
 
   # return a list of virtual machines
-  def vms(opts = {})
-    client.servers
+  def vms(attrs = {})
+    client.servers(attrs)
   end
 
   def supports_vms_pagination?

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -52,7 +52,7 @@ module Foreman::Model
 
     def vms(opts = {})
       if opts[:eager_loading] == true
-        super()
+        super(datacenter: datacenter)
       else
         # VMware server loading is very slow
         # not using FOG models directly to save the time


### PR DESCRIPTION
Vmware association were trying to associate vms from all datacenters, even though the compute resource is just for one datacenter.

Prerequisites for testing:
* VMware instance with two datacenters

Tests needed (anticipated impacts):
* Hosts association

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
