### PR TITLE
Fixes #26712 - Layout isn't active on nested routes

### DIFF
--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -19,11 +19,12 @@ module Menu
       @last = options[:last] || false
       @context =  options[:engine] || Rails.application
       @turbolinks = options.fetch(:turbolinks, true)
+      @exact = options[:exact] || false
       super @name.to_sym
     end
 
     def to_hash
-      {type: :item, html_options: @html_options, name: @caption || @name, url: url} if authorized?
+      {type: :item, exact: @exact, html_options: @html_options, name: @caption || @name, url: url} if authorized?
     end
 
     def url

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -37,7 +37,7 @@ module Menu
 
       Manager.map :top_menu do |menu|
         menu.sub_menu :monitor_menu,    :caption => N_('Monitor'), :icon => 'fa fa-tachometer' do
-          menu.item :dashboard,         :caption => N_('Dashboard')
+          menu.item :dashboard,         :caption => N_('Dashboard'), :exact => true
           menu.item :fact_values,       :caption => N_('Facts')
           menu.item :statistics,        :caption => N_('Statistics')
           menu.item :trends,            :caption => N_('Trends')

--- a/test/unit/menu_manager_test.rb
+++ b/test/unit/menu_manager_test.rb
@@ -51,13 +51,13 @@ class MenuManagerTest < ActiveSupport::TestCase
       :name => "User",
       :icon => "fa-icon",
       :children =>
-        [{:type => :item, :html_options => {}, :name => "Item", :url => "some url"},
-         {:type => :item, :html_options => {}, :name => "Item 2", :url => "some url"},
-         {:type => :item, :html_options => {}, :name => "Test Items", :url => "some url"}]},
+        [{:type => :item, :exact => false, :html_options => {}, :name => "Item", :url => "some url"},
+         {:type => :item, :exact => false, :html_options => {}, :name => "Item 2", :url => "some url"},
+         {:type => :item, :exact => false, :html_options => {}, :name => "Test Items", :url => "some url"}]},
      {:type => :sub_menu,
       :name => "User",
       :icon => "fa-icon",
-      :children => [{:type => :item, :html_options => {}, :name => "Item 3", :url => "some url"}]}]
+      :children => [{:type => :item, :exact => false, :html_options => {}, :name => "Item 3", :url => "some url"}]}]
   end
 
   def create_nested_menu

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -9,14 +9,15 @@ import { removeLastSlashFromPath } from '../../common/helpers';
 export const getCurrentPath = () =>
   removeLastSlashFromPath(window.location.pathname);
 
-export const getActive = (data, path) => {
-  let activeItem = '';
-  data.forEach(item => {
-    item.children.forEach(child => {
-      if (child.url === path) activeItem = item.name;
-    });
-  });
-  return { title: activeItem };
+export const getActive = (items, path) => {
+  for (const item of items) {
+    for (const child of item.children) {
+      if (child.exact) {
+        if (path === child.url) return { title: item.name };
+      } else if (path.startsWith(child.url)) return { title: item.name };
+    }
+  }
+  return { title: '' };
 };
 
 export const handleMenuClick = (primary, activeMenu, changeActive) => {

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutHelper.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutHelper.test.js
@@ -10,6 +10,10 @@ describe('LayoutHelper', () => {
     const active = getActive(layoutMock.data.menu, '/fact_values');
     expect(active).toMatchSnapshot();
   });
+  it('should getActive(null)', () => {
+    const active = getActive([{ children: [] }], '/fact_values');
+    expect(active).toMatchSnapshot();
+  });
   it('should handleMenuClick', () => {
     const change = jest.fn();
     handleMenuClick({ title: 'Host' }, 'Infra', change);

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
@@ -138,3 +138,9 @@ Object {
   "title": "Monitor",
 }
 `;
+
+exports[`LayoutHelper should getActive(null) 1`] = `
+Object {
+  "title": "",
+}
+`;


### PR DESCRIPTION
navigating to nested routes doesn't show an active menu on the layout
e.g. `http://localhost:5000/architectures/2-i386/edit`
Instead of checking if the route is equal to the url, we should check if its part of it.

This PR fixes the issue and improves performance by using reverse loops and by breaking them after finding the right menu item instead of iterating through the whole array.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

--->
