### PR TITLE
Fixes #26709 - perform HTTP HEAD on inst media

### DIFF
--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -100,7 +100,7 @@ module Api
         host_mock = Openstruct.new(operatingsystem: @operatingsystem, medium: medium, architecture: arch)
         medium_provider = MediumProviders::Default.new(host_mock)
 
-        render :json => @operatingsystem.pxe_files(medium_provider)
+        render :json => host_mock.pxe_files
       rescue => e
         render_message(e.to_s, :status => :unprocessable_entity)
       end

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -224,6 +224,14 @@ module HostCommon
     environment.puppetclasses - parent_classes
   end
 
+  def pxe_files
+    @pxe_files ||= begin
+      operatingsystem.boot_files_uri(medium_provider).collect do |img|
+        { operatingsystem.pxe_prefix(medium_provider).to_sym => img.to_s}
+      end
+    end
+  end
+
   protected
 
   def set_lookup_value_matcher

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -111,7 +111,7 @@ module Orchestration::TFTP
     logger.info "Fetching required TFTP boot files for #{host.name}"
     valid = []
 
-    host.operatingsystem.pxe_files(host.medium_provider).each do |bootfile_info|
+    host.pxe_files.each do |bootfile_info|
       bootfile_info.each do |prefix, path|
         valid << each_unique_feasible_tftp_proxy do |proxy|
           proxy.fetch_boot_file(:prefix => prefix.to_s, :path => path)

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -203,18 +203,9 @@ class Operatingsystem < ApplicationRecord
   end
 
   def pxe_files(medium_provider, _arch = nil, host = nil)
-    # Try to maintain backwards compatibility, if medium_provider could be constructed - do it with a warning.
-    if host
-      Foreman::Deprecation.deprecation_warning("1.22", "Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers.find_provider(host)")
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
-    end
-
-    unless medium_provider.is_a? MediumProviders::Provider
-      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers.find_provider(host)'))
-    end
-    boot_files_uri(medium_provider).collect do |img|
-      { pxe_prefix(medium_provider).to_sym => img.to_s}
-    end
+    Foreman::Deprecation.deprecation_warning("1.24", "Use host.pxe_files instead operatingsystem.pxe_files")
+    raise Foreman::Exception.new(N_('Operatingsystem.pxe_files() no longer works without host')) unless host
+    host.pxe_files
   end
 
   def pxedir

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -191,8 +191,7 @@ class ProvisioningTemplate < Template
 
   def self.fetch_boot_files_combo(tftp)
     @profiles.each do |combo|
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(combo[:hostgroup])
-      combo[:hostgroup].operatingsystem.pxe_files(medium_provider).each do |bootfile_info|
+      combo[:hostgroup].pxe_files.each do |bootfile_info|
         bootfile_info.each do |prefix, path|
           tftp.fetch_boot_file(:prefix => prefix.to_s, :path => path)
         end

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -25,7 +25,7 @@ module Foreman
           end
 
           def load_variables_base
-            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if host
+            @medium_provider = host.medium_provider if host
             if operatingsystem&.respond_to?(:pxe_type)
               send "#{operatingsystem.pxe_type}_attributes"
               pxe_config

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -184,9 +184,7 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
       hg = FactoryBot.build(:hostgroup, :name => "hg", :operatingsystem => operatingsystems(:centos5_3), :architecture => architectures(:x86_64), :medium => media(:one))
       FactoryBot.create(:template_combination, :provisioning_template => templates(:mystring2), :hostgroup => hg)
       ProxyAPI::TFTP.any_instance.stubs(:create_default).returns(true)
-      Redhat.any_instance.expects(:pxe_files) do |_, __, host|
-        host.name == "hg"
-      end.at_least(1)
+      hg.expects(:pxe_files).at_least(1)
       get :build_pxe_default, session: set_session_user
       assert_redirected_to provisioning_templates_path
     end

--- a/test/factories/medium.rb
+++ b/test/factories/medium.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :medium do
     sequence(:name) {|n| "medium#{n}" }
-    sequence(:path) {|n| "http://www.example.com/path#{n}" }
+    sequence(:path) {|n| "http://mirror.centos.org/path#{n}" }
     os_family { 'Redhat' }
     organizations { [Organization.find_by_name('Organization 1')] }
     locations { [Location.find_by_name('Location 1')] }
@@ -26,7 +26,7 @@ FactoryBot.define do
 
     trait :suse do
       sequence(:name) { |n| "OpenSuse Mirror #{n}"}
-      sequence(:path) {'http://mirror.isoc.org.il/pub/opensuse/distribution/$major.$minor/repo/oss'}
+      sequence(:path) {'http://download.opensuse.org/pub/opensuse/distribution/$major.$minor/repo/oss'}
       os_family { 'Suse' }
     end
 

--- a/test/fixtures/media.yml
+++ b/test/fixtures/media.yml
@@ -5,18 +5,18 @@ one:
 
 ubuntu:
   name: Ubuntu Mirror
-  path: http://sg.archive.ubuntu.com
+  path: http://archive.ubuntu.com
 
 unused:
   name: unused
-  path: http://nothing.intersting.com
+  path: http://www.example.com
 
 solaris10:
   name: Solaris 10
-  path: http://brsla01/vol/solgi_5.10/sol$minor_$release_$arch
-  media_path: brsla01:/vol/solgi_5.10/sol$minor_$release_$arch
-  config_path: brsla01:/vol/jumpstart
-  image_path: brsla01:/vol/solgi_5.10/sol$minor_$release_$arch/flash/
+  path: http://www.example.com/vol/solgi_5.10/sol$minor_$release_$arch
+  media_path: www.example.com:/vol/solgi_5.10/sol$minor_$release_$arch
+  config_path: www.example.com:/vol/jumpstart
+  image_path: www.example.com:/vol/solgi_5.10/sol$minor_$release_$arch/flash/
 
 opensuse:
   name: OpenSUSE
@@ -24,4 +24,4 @@ opensuse:
 
 vrp5:
   name: Huawei VRP 5
-  path: http://firmware.fake-huawei.com
+  path: http://www.example.com

--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -18,26 +18,56 @@ class DefaultMediumProviderTest < ActiveSupport::TestCase
     assert result_path, 'http://foo.org/4'
   end
 
-  [["Redhat", "http://mirror.centos.org/centos/6.0/os/x86_64"],
-   ["Ubuntu", "http://sg.archive.ubuntu.com/"],
-   ["OpenSuse", "http://download.opensuse.org/distribution/12.3/repo/oss"],
-   ["Solaris", "http://brsla01/vol/solgi_5.10/sol10_hw0910_sparc"]].each do |osname, expected_uri|
+  [["Redhat", "http://mirror.centos.org/centos/6.0/os/x86_64", ["images/pxeboot/vmlinuz", "images/pxeboot/initrd.img"]],
+   ["Ubuntu", "http://archive.ubuntu.com/", ["dists/rn10/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux", "dists/rn10/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz"]],
+   ["OpenSuse", "http://download.opensuse.org/distribution/12.3/repo/oss", ["boot/x86_64/loader/linux", "boot/x86_64/loader/initrd"]],
+   ["Solaris", "http://www.example.com/vol/solgi_5.10/sol10_hw0910_sparc", ["Solaris_10/Tools/Boot/x86.miniroot", "Solaris_10/Tools/Boot/multiboot"]]].each do |osname, expected_uri, pxe_files|
     test "generates URI for #{osname}" do
+      pxe_files.each do |file|
+        stub_request(:head, "#{expected_uri}/#{file}").to_return(status: 200, body: "", headers: {'Last-Modified': 'xxx', 'ETag': "zzz"})
+      end
       host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name(osname))
       assert_equal expected_uri, MediumProviders::Default.new(host).medium_uri.to_s
     end
   end
 
-  [["Redhat", "http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot"],
-   ["Ubuntu", "http://sg.archive.ubuntu.com/dists/rn10/main/installer-x86_64/current/images/netboot/ubuntu-installer/x86_64"],
-   ["OpenSuse", "http://download.opensuse.org/distribution/12.3/repo/oss/boot/x86_64/loader"],
-   ["Solaris", "http://brsla01/vol/solgi_5.10/sol10_hw0910_sparc/Solaris_10/Tools/Boot"]].each do |osname, expected_uri|
+  test "handles HTTP HEAD redirect with last modified" do
+    redirection = "http://example.com/redirect"
+    stub_request(:head, %r'http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot/(vmlinuz|initrd.img)').to_return(status: 301, headers: { 'Location' => redirection })
+    stub_request(:head, %r'http://example.com/redirect').to_return(status: 200, body: "", headers: {'Last-Modified': 'xxx', 'ETag': "zzz"})
+    host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name('Redhat'))
+    assert_equal "centos-5-4-tg0SG0OK", MediumProviders::Default.new(host).unique_id.to_s
+  end
+
+  test "handles HTTP HEAD redirect with etag" do
+    redirection = "http://example.com/redirect"
+    stub_request(:head, %r'http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot/(vmlinuz|initrd.img)').to_return(status: 301, headers: { 'Location' => redirection })
+    stub_request(:head, %r'http://example.com/redirect').to_return(status: 200, body: "", headers: {'ETag': "zzz"})
+    host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name('Redhat'))
+    assert_equal "centos-5-4-QPo37ADH", MediumProviders::Default.new(host).unique_id.to_s
+  end
+
+  test "handles HTTP HEAD redirect without any headers" do
+    redirection = "http://example.com/redirect"
+    stub_request(:head, %r'http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot/(vmlinuz|initrd.img)').to_return(status: 301, headers: { 'Location' => redirection })
+    stub_request(:head, %r'http://example.com/redirect').to_return(status: 200, body: "")
+    host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name('Redhat'))
+    assert_equal "centos-5-4-B0hJnFEY", MediumProviders::Default.new(host).unique_id.to_s
+  end
+
+  [["centos-5-4-tg0SG0OK", "Redhat", "http://mirror.centos.org/centos/6.0/os/x86_64/images/pxeboot", ["vmlinuz", "initrd.img"]],
+   ["ubuntu-mirror-tg0SG0OK", "Ubuntu", "http://archive.ubuntu.com/dists/rn10/main/installer-x86_64/current/images/netboot/ubuntu-installer/x86_64", ["linux", "initrd.gz"]],
+   ["opensuse-tg0SG0OK", "OpenSuse", "http://download.opensuse.org/distribution/12.3/repo/oss/boot/x86_64/loader", ["linux", "initrd"]],
+   ["solaris-10-tg0SG0OK", "Solaris", "http://www.example.com/vol/solgi_5.10/sol10_hw0910_sparc/Solaris_10/Tools/Boot", ["x86.miniroot", "multiboot"]]].each do |expected_id, osname, expected_uri, pxe_files|
     test "generates unique ID based on base and pxedir for #{osname}" do
+      pxe_files.each do |file|
+        url = "#{expected_uri}/#{file}"
+        url.gsub!('x86_64', 'amd64') if osname == "Ubuntu"
+        stub_request(:head, url).to_return(status: 200, body: "", headers: {'Last-Modified': 'xxx', 'ETag': "zzz"})
+      end
       host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name(osname))
       medium_uri_with_path = MediumProviders::Default.new(host).medium_uri(host.operatingsystem.pxedir).to_s
       assert_equal expected_uri, medium_uri_with_path
-      digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri_with_path), padding: false)
-      expected_id = "#{host.medium.name.parameterize}-#{digest.gsub(/[-_]/, '')[1..12]}"
       assert_equal expected_id, MediumProviders::Default.new(host).unique_id.to_s
     end
   end


### PR DESCRIPTION
This change makes Foreman to perform HTTP HEAD request once per request
to solve two problems:

* When installation media points to incorrect host or 404 path, Foreman
will now nicely report error. Compare to success action but failure on
the TFTP proxy which led to provisioning error.

* Foreman also reads last-modified/etag headers and puts that into the
unique TFTP filename suffix which helps to avoid corrupted TFTP files
after OS updates.

I am putting the helper method into operating system intentionally
because we want to cache (memorize) the value. This can't be done in
Media Provider, then the HTTP HEAD request would be done not just once
but 4 or more times during orchestration which is too much to my taste.

Once merged, I am going to do Katello PR to make use of the helper method
to do the same (hash from REPO ID + LAST-MODIFIED). This will fix it for Katello
too.