### PR TITLE
Fixes #26735 - web component mounter for react

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,6 +3,7 @@ scss:
 
 stylelint:
   enabled: true
+  config_file: .stylelintrc
 
 rubocop:
   config_file: .rubocop.yml

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,5 +2,8 @@
   "extends": [
     "stylelint-config-standard",
   ],
+  "rules": {
+    "selector-type-no-unknown": null
+  },
+  "ignore": ["custom-elements"],
 }
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
   def mount_date_component(component, time, seconds)
     data = { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }
 
-    react_component(component, data, flatten_data: true)
+    react_component(component, data: data)
   end
 
   def contract(model)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,10 +52,9 @@ module ApplicationHelper
   end
 
   def mount_date_component(component, time, seconds)
-    date_id = generate_date_id
+    data = { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }
 
-    content_tag(:span, '', :id => date_id).html_safe +
-    mount_react_component(component, "##{date_id}", { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }.to_json, { :flatten_data => true })
+    react_component(component, data, flatten_data: true)
   end
 
   def contract(model)

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -5,8 +5,23 @@ module ReactjsHelper
     end
   end
 
+  # Mount react component in views
+  # Params:
+  # +name+:: the component name from the componentRegistry
+  # +data+:: data to pass to the component as props
+  #          available values: Hash, json-string, nil
+  # +opts[:flatten_data]+:: false = will pass the props to the component props.data
+  #                         true = will pass the props directly to the component props
   def react_component(name, data = [], opts = {})
-    content_tag('react-component', '', :name => name, :data => { props: data }, 'flatten-data' => opts[:flatten_data])
+    data = data.to_json if data.is_a?(Hash)
+
+    attributes = {
+      :name => name,
+      :data => { props: data },
+      'flatten-data' => opts[:flatten_data]
+    }
+
+    content_tag('react-component', '', attributes)
   end
 
   def webpacked_plugins_js_for(*plugin_names)

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -5,6 +5,10 @@ module ReactjsHelper
     end
   end
 
+  def react_component(name, data = [], opts = {})
+    content_tag('react-component', '', :name => name, :data => { props: data }, 'flatten-data' => opts[:flatten_data])
+  end
+
   def webpacked_plugins_js_for(*plugin_names)
     js_tags_for(select_requested_plugins(plugin_names)).join.html_safe
   end

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -18,7 +18,7 @@ module ReactjsHelper
     attributes = {
       :name => name,
       :data => { props: data },
-      'flatten-data' => opts[:flatten_data]
+      'flatten-data' => opts[:flatten_data],
     }
 
     content_tag('react-component', '', attributes)

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -8,20 +8,12 @@ module ReactjsHelper
   # Mount react component in views
   # Params:
   # +name+:: the component name from the componentRegistry
-  # +data+:: data to pass to the component as props
-  #          available values: Hash, json-string, nil
-  # +opts[:flatten_data]+:: false = will pass the props to the component props.data
-  #                         true = will pass the props directly to the component props
-  def react_component(name, data = [], opts = {})
-    data = data.to_json if data.is_a?(Hash)
+  # +props+:: props to pass to the component
+  #          valid value types: Hash, json-string, nil
+  def react_component(name, props = {})
+    props = props.to_json if props.is_a?(Hash)
 
-    attributes = {
-      :name => name,
-      :data => { props: data },
-      'flatten-data' => opts[:flatten_data],
-    }
-
-    content_tag('react-component', '', attributes)
+    content_tag('react-component', '', :name => name, :data => { props: props })
   end
 
   def webpacked_plugins_js_for(*plugin_names)

--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -4,9 +4,7 @@ module Tags
       options = @options.stringify_keys
       options['value'] = options.fetch('value') { value_before_type_cast }
       add_default_name_and_id(options)
-      wrapper_id = options.fetch('id') + '_wrapper'
-      content_tag('div', '', 'id' => wrapper_id) +
-        @template_object.mount_react_component('FormField', "##{wrapper_id}", reactify_options(options).to_json, flatten_data: true)
+      @template_object.react_component('FormField', reactify_options(options).to_json, flatten_data: true)
     end
 
     private

--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -4,7 +4,7 @@ module Tags
       options = @options.stringify_keys
       options['value'] = options.fetch('value') { value_before_type_cast }
       add_default_name_and_id(options)
-      @template_object.react_component('FormField', reactify_options(options), flatten_data: true)
+      @template_object.react_component('FormField', reactify_options(options))
     end
 
     private

--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -4,7 +4,7 @@ module Tags
       options = @options.stringify_keys
       options['value'] = options.fetch('value') { value_before_type_cast }
       add_default_name_and_id(options)
-      @template_object.react_component('FormField', reactify_options(options).to_json, flatten_data: true)
+      @template_object.react_component('FormField', reactify_options(options), flatten_data: true)
     end
 
     private

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -24,9 +24,7 @@
         </td>
         <% if power_status_visible? %>
           <td class="ca">
-            <% selector = dom_id(host, 'power') %>
-            <span id=<%= selector %>></span>
-            <%= mount_react_component('PowerStatus', '#' + selector, {:id => host.id, :url => power_api_host_path(host)}.to_json) %>
+            <%= react_component('PowerStatus', {:id => host.id, :url => power_api_host_path(host)}.to_json) %>
           </td>
         <% end %>
         <td class="ellipsis"><%= name_column(host) %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -24,7 +24,7 @@
         </td>
         <% if power_status_visible? %>
           <td class="ca">
-            <%= react_component('PowerStatus', {:id => host.id, :url => power_api_host_path(host)}.to_json) %>
+            <%= react_component('PowerStatus', :id => host.id, :url => power_api_host_path(host)) %>
           </td>
         <% end %>
         <td class="ellipsis"><%= name_column(host) %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -24,7 +24,7 @@
         </td>
         <% if power_status_visible? %>
           <td class="ca">
-            <%= react_component('PowerStatus', :id => host.id, :url => power_api_host_path(host)) %>
+            <%= react_component('PowerStatus', data: { id: host.id, url: power_api_host_path(host) }) %>
           </td>
         <% end %>
         <td class="ellipsis"><%= name_column(host) %>

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -47,18 +47,51 @@ export function mountNode(component, reactNode, data, flattenData = false) {
  * This is a html tag (Web component) that can be used for mounting react component from ComponentRegistry.
  */
 class ReactComponentElement extends HTMLElement {
-  connectedCallback() {
-    const mountPoint = document.createElement('span');
-    this.appendChild(mountPoint);
-    const componentName = this.getAttribute('name');
-    const props = JSON.parse(this.dataset.props);
-    const flattenData = this.hasAttribute('flatten-data');
+  get componentName() {
+    return this.getAttribute('name');
+  }
+  get props() {
+    return this.dataset.props !== '' ? JSON.parse(this.dataset.props) : {};
+  }
+  get flattenData() {
+    return this.hasAttribute('flatten-data');
+  }
+  get mountPoint() {
+    if (!this._mountPoint) {
+      this._mountPoint = document.createElement('span');
+      this.appendChild(this._mountPoint);
+    }
 
-    mountNode(componentName, mountPoint, props, flattenData);
+    return this._mountPoint;
+  }
+
+  connectedCallback() {
+    try {
+      mountNode(
+        this.componentName,
+        this.mountPoint,
+        this.props,
+        this.flattenData
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Unable to mount react-component: ${this.componentName}`,
+        error
+      );
+    }
   }
 
   disconnectedCallback() {
-    ReactDOM.unmountComponentAtNode(this.children.first);
+    try {
+      ReactDOM.unmountComponentAtNode(this.mountPoint);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Unable to unmount react-component: ${this.componentName}`,
+        error
+      );
+    }
   }
 }
 

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 import store from '../redux';
 import componentRegistry from '../components/componentRegistry';
+import './component-tag.scss';
 
 export { default as registerReducer } from '../redux/reducers/registerReducer';
 

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -1,7 +1,6 @@
 import ReactDOM from 'react-dom';
 import store from '../redux';
 import componentRegistry from '../components/componentRegistry';
-import './component-tag.scss';
 
 export { default as registerReducer } from '../redux/reducers/registerReducer';
 
@@ -54,13 +53,9 @@ class ReactComponentElement extends HTMLElement {
   get props() {
     return this.dataset.props !== '' ? JSON.parse(this.dataset.props) : {};
   }
-  get flattenData() {
-    return this.hasAttribute('flatten-data');
-  }
   get mountPoint() {
     if (!this._mountPoint) {
-      this._mountPoint = document.createElement('span');
-      this.appendChild(this._mountPoint);
+      this._mountPoint = this;
     }
 
     return this._mountPoint;
@@ -68,12 +63,7 @@ class ReactComponentElement extends HTMLElement {
 
   connectedCallback() {
     try {
-      mountNode(
-        this.componentName,
-        this.mountPoint,
-        this.props,
-        this.flattenData
-      );
+      mountNode(this.componentName, this, this.props, true);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(

--- a/webpack/assets/javascripts/react_app/common/component-tag.scss
+++ b/webpack/assets/javascripts/react_app/common/component-tag.scss
@@ -1,0 +1,3 @@
+react-component {
+  display: inline-block;
+}

--- a/webpack/assets/javascripts/react_app/common/component-tag.scss
+++ b/webpack/assets/javascripts/react_app/common/component-tag.scss
@@ -1,3 +1,0 @@
-react-component {
-  display: inline-block;
-}

--- a/webpack/stories/docs/addingNewComponent.md
+++ b/webpack/stories/docs/addingNewComponent.md
@@ -95,12 +95,22 @@ If you want your component to be available for mounting into erb templates, you 
 
 Then it will be possible to mount it with `mount_react_component` helper:
 ```ruby
-mount_react_component(component_name, html_node_selector, json_data)
+react_component(component_name, json_data)
 ```
 
 **Example:**
 ```erb
-<%= mount_react_component('PowerStatus', '#power', {:id => host.id, :url => power_host_path(host.id)}.to_json) %>
+<%= react_component('PowerStatus', { id: host.id, url: power_host_path(host.id) }.to_json) %>
+```
+Or you can use directly the html mounter tag:
+```html
+<react-component
+  name="PowerStatus"
+  data-props="<%= {
+    id: host.id,
+    url: power_host_path(host.id)
+  }.to_json %>"
+></react-component>
 ```
 
 ## Before you start writing a new component

--- a/webpack/stories/docs/addingNewComponent.md
+++ b/webpack/stories/docs/addingNewComponent.md
@@ -93,16 +93,16 @@ Linter (code style checking) can be executed with `npm run lint`. You can run it
 
 If you want your component to be available for mounting into erb templates, you have to add them to [the component registry](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js#L60-L71).
 
-Then it will be possible to mount it with `mount_react_component` helper:
+Then it will be possible to mount it with `react_component` helper:
 ```ruby
-react_component(component_name, json_data)
+react_component(component_name, props)
 ```
 
 **Example:**
 ```erb
-<%= react_component('PowerStatus', { id: host.id, url: power_host_path(host.id) }.to_json) %>
+<%= react_component('PowerStatus', id: host.id, url: power_host_path(host.id)) %>
 ```
-Or you can use directly the html mounter tag:
+Will render following HTML:
 ```html
 <react-component
   name="PowerStatus"


### PR DESCRIPTION
Mounts a React component from our `componentRegistry` to the page using web components. Enables mounting by:
```erb
<react-component
  name="ComponentInRegistry"
  data-props="<%= {
    someProp: 'val',
    anotherProp: 'val2'
  }.to_json %>"
></react-component>
```
Packaging: theforeman/foreman-js#26 ~theforeman/foreman-packaging#3711~

**Edit**: the #6734 has been simplified and squashed here and is no longer blocker.

For general discussion please follow [blog](https://community.theforeman.org/t/react-components-mounted-by-web-components/13767).