### PR TITLE
Fixes #26754 - Change error when updating nested resource fails

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -7,8 +7,8 @@ module Api
       resource_description do
         api_version "v2"
         app_info N_("Foreman API v2 is currently the default API version.")
-        param :location_id, Integer, :required => false, :desc => N_("Scope by locations")
-        param :organization_id, Integer, :required => false, :desc => N_("Scope by organizations")
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
       end
 
       def_param_group :pagination do

--- a/test/controllers/api/v2/host_classes_controller_test.rb
+++ b/test/controllers/api/v2/host_classes_controller_test.rb
@@ -29,11 +29,11 @@ class Api::V2::HostClassesControllerTest < ActionController::TestCase
 
   test "should not add a puppetclass that does not exist to a host" do
     post :create, params: { :host_id => @host.to_param, :puppetclass_id => "invalid_id" }
-    assert_response :not_found
+    assert_response :unprocessable_entity
   end
 
   test "should not delete a puppetclass that does not exist from a host" do
     post :destroy, params: { :host_id => @host.to_param, :id => "invalid_id" }
-    assert_response :not_found
+    assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/api/v2/locations_controller_test.rb
+++ b/test/controllers/api/v2/locations_controller_test.rb
@@ -364,7 +364,7 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     deleted_id = domain.id
     domain.destroy
     post :create, params: { :location => { :domain_ids => [deleted_id] } }
-    assert_response 404
+    assert_response :unprocessable_entity
   end
 
   test "should update with valid name" do

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -57,8 +57,8 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
   test_attributes :pid => 'e6de9ceb-fe4b-43ce-b7e3-5453ca4bd164'
   test "should report correct error message for invalid association name" do
     post :create, params: { :provisioning_template => {:name => "no", :template_kind_name => 'kind_that_does_not_exist'} }
-    assert_response :missing
-    assert_includes JSON.parse(response.body)['message'], 'Could not find template_kind with name: kind_that_does_not_exist'
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)['error']['message'], 'Could not find template_kind with name: kind_that_does_not_exist'
   end
 
   test "should update valid" do

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -44,7 +44,7 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
 
   test "does not create subnet with non-existent domain" do
     post :create, params: { :subnet => valid_v4_attrs.merge(:domain_ids => [1, 2]) }
-    assert_response :not_found
+    assert_response :unprocessable_entity
   end
 
   test "should update subnet" do


### PR DESCRIPTION
The PR should fix these two issues:
1. updating a compute resource with a location_id that doesn't exist sends a wrong error message: {
"compute_resource": {
"location_ids": [5]
}
}
"Compute resource doesn't exists" instead "Couldn't find Taxonomy with 'id'=[5]"

2. Location_id description is not very clear