### PR TITLE
Fixes #26756 - drop invalid values for scsi_controller_type

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -426,7 +426,7 @@ module Foreman::Model
 
       # see #26402 - consume scsi_controller_type from hammer as a default scsi type
       scsi_type = args.delete(:scsi_controller_type)
-      args[:scsi_controllers] ||= [{ type: scsi_type }] if scsi_type
+      args[:scsi_controllers] ||= [{ type: scsi_type }] if scsi_controller_types.key?(scsi_type)
 
       add_cdrom = args.delete(:add_cdrom)
       args[:cdroms] = [new_cdrom] if add_cdrom == '1'

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -384,6 +384,14 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
         attrs_out = { scsi_controllers: [{ type: 'VirtualBusLogicController' }] }
         assert_equal attrs_out, @cr.parse_args(attrs_in)
       end
+
+      test 'drop invalid scsi_controller_type attribute' do
+        attrs_in = HashWithIndifferentAccess.new(
+          'scsi_controller_type' => 'ParaVirtualSCSICntrlr'
+        )
+        attrs_out = {}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
     end
   end
 


### PR DESCRIPTION
Passing of invalid attribute value to this compute_attribute fails with weird message - cannot provision.
This should be validated, but as it is not possible now, I suggest to accept only valid values.
The user need is described in the issue.

Prerequisites for testing:
* VMware cluster

Tests needed (anticipated impacts):
* create vmware host through hammer command.