### PR TITLE
 Fixes #21592 - uses headless chrome instead of phantomjs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "webpack-stats-plugin": "^0.1.5"
   },
   "optionalDependencies": {
-    "phantomjs-prebuilt": "^2.1.0",
-    "chromedriver": "2.43.0"
+    "chromedriver": "2.46.0"
   },
   "dependencies": {
     "@novnc/novnc": "^1.0.0",

--- a/test/integration/breadcrumbs_switcher_test.rb
+++ b/test/integration/breadcrumbs_switcher_test.rb
@@ -19,8 +19,7 @@ class BreadcrumbsSwitcherTest < IntegrationTestWithJavascript
     click_button 'switcher'
     fill_in('breadcrumbs-search', :with => 'three')
     wait_for_ajax
-    all_items = page.all('.no-border.list-group-item')
-    assert all_items.count == 1
-    assert_equal all_items[0].text, 'three'
+    page.assert_selector('.no-border.list-group-item', count: 1)
+    page.assert_selector('.no-border.list-group-item', text: 'three')
   end
 end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -60,14 +60,8 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
       test 'has no out of sync link' do
         visit_dashboard
         within "li[data-name='Host Configuration Status for Puppet']" do
-          refute page.has_link?('Out of sync hosts')
-        end
-      end
-
-      test 'good hosts link drops time' do
-        visit_dashboard
-        within "li[data-name='Host Configuration Status for Puppet']" do
-          refute page.has_link?('Good host reports in the last')
+          assert page.has_no_link?('Out of sync hosts')
+          assert page.has_no_link?('Good host reports in the last')
           assert page.has_link?('Good host with reports')
         end
       end

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -202,13 +202,9 @@ class HostJSTest < IntegrationTestWithJavascript
       visit new_host_path
       select2(original_hostgroup.name, :from => 'host_hostgroup_id')
       wait_for_ajax
-
       click_on_inherit('environment')
       select2(overridden_hostgroup.name, :from => 'host_hostgroup_id')
-      wait_for_ajax
-
-      environment = find("#s2id_host_environment_id .select2-chosen").text
-      assert_equal overridden_hostgroup.environment.name, environment
+      assert page.find('#s2id_host_environment_id .select2-chosen').has_text? overridden_hostgroup.environment.name
     end
 
     test 'choosing a hostgroup with compute resource works' do
@@ -238,7 +234,6 @@ class HostJSTest < IntegrationTestWithJavascript
       find(:css, '#host_tab').click
       click_on_inherit('compute_profile')
       select2(compute_profile.name, :from => 'host_compute_profile_id')
-      wait_for_ajax
 
       click_link('Virtual Machine')
       cpus_field = page.find_field('host_compute_attributes_cpus')
@@ -262,23 +257,20 @@ class HostJSTest < IntegrationTestWithJavascript
       select2 'Location 1', :from => 'host_location_id'
       wait_for_ajax
       select2 env.name, :from => 'host_environment_id'
+
       click_link 'Operating System'
       wait_for_ajax
       select2 os.architectures.first.name, :from => 'host_architecture_id'
-      wait_for_ajax
       select2 os.title, :from => 'host_operatingsystem_id'
       uncheck('host_build')
-      wait_for_ajax
       select2 os.media.first.name, :from => 'host_medium_id'
-      wait_for_ajax
       select2 os.ptables.first.name, :from => 'host_ptable_id'
       fill_in 'host_root_pass', :with => '12345678'
+
       click_link 'Interfaces'
       click_button 'Edit'
       select2 domains(:unuseddomain).name, :from => 'host_interfaces_attributes_0_domain_id'
-      wait_for_ajax
       fill_in 'host_interfaces_attributes_0_mac', :with => '00:11:11:11:11:11'
-      wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
       close_interfaces_modal
       click_on_submit
@@ -302,31 +294,25 @@ class HostJSTest < IntegrationTestWithJavascript
       select2 'Location 1', :from => 'host_location_id'
       wait_for_ajax
       select2 env1.name, :from => 'host_environment_id'
-      wait_for_ajax
       select2 hg.name, :from => 'host_hostgroup_id'
-      wait_for_ajax
+
       click_link 'Operating System'
-      wait_for_ajax
       select2 os.architectures.first.name, :from => 'host_architecture_id'
-      wait_for_ajax
       select2 os.title, :from => 'host_operatingsystem_id'
       uncheck('host_build')
-      wait_for_ajax
+
       select2 os.media.first.name, :from => 'host_medium_id'
-      wait_for_ajax
       select2 os.ptables.first.name, :from => 'host_ptable_id'
       fill_in 'host_root_pass', :with => '12345678'
+
       click_link 'Interfaces'
       click_button 'Edit'
       select2 domains(:mydomain).name, :from => 'host_interfaces_attributes_0_domain_id'
-      wait_for_ajax
       fill_in 'host_interfaces_attributes_0_mac', :with => '00:11:11:11:11:11'
-      wait_for_ajax
       fill_in 'host_interfaces_attributes_0_ip', :with => '2.3.4.44'
-      wait_for_ajax
+
       close_interfaces_modal
 
-      wait_for_ajax
       click_on_submit
 
       host = Host::Managed.search_for('name ~ "myhost1"').first
@@ -337,11 +323,11 @@ class HostJSTest < IntegrationTestWithJavascript
       hostgroup = FactoryBot.create(:hostgroup, :with_parameter)
       visit new_host_path
       select2(hostgroup.name, :from => 'host_hostgroup_id')
-      wait_for_ajax
 
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
-      assert page.has_selector?("#inherited_parameters #name_#{hostgroup.group_parameters.first.name}")
+
+      assert page.has_selector?("#inherited_parameters #name_#{hostgroup.group_parameters.first.name}", visible: false)
     end
 
     test 'new parameters can be edited and removed' do
@@ -385,7 +371,7 @@ class HostJSTest < IntegrationTestWithJavascript
   describe "hosts index multiple actions" do
     test 'show action buttons' do
       visit hosts_path
-      page.find('#check_all').trigger('click')
+      check 'check_all'
 
       # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
       assert page.has_no_selector?('input.host_select_boxes:not(:checked)')
@@ -414,7 +400,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
     test 'redirect js' do
       visit hosts_path
-      page.find('#check_all').trigger('click')
+      check 'check_all'
 
       # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
       assert page.has_no_selector?('input.host_select_boxes:not(:checked)')
@@ -437,7 +423,6 @@ class HostJSTest < IntegrationTestWithJavascript
       visit edit_host_path(host)
 
       select2 env1.name, :from => 'host_environment_id'
-      wait_for_ajax
       click_on_submit
 
       host.reload
@@ -496,19 +481,16 @@ class HostJSTest < IntegrationTestWithJavascript
 
       visit edit_host_path(@host)
       select2(original_hostgroup.name, :from => 'host_hostgroup_id')
-      wait_for_ajax
 
       assert_equal original_hostgroup.puppet_proxy.name, find("#s2id_host_puppet_proxy_id .select2-chosen").text
 
       click_on_inherit('puppet_proxy')
       select2(overridden_hostgroup.name, :from => 'host_hostgroup_id')
-      wait_for_ajax
 
-      environment = find("#s2id_host_environment_id .select2-chosen").text
-      assert_equal original_hostgroup.environment.name, environment
+      assert find("#s2id_host_environment_id .select2-chosen", visible: false).has_text? original_hostgroup.environment.name
 
       # On host group change, the disabled select will be reset to an empty value
-      assert_equal '', find("#s2id_host_puppet_proxy_id .select2-chosen").text
+      assert find("#s2id_host_puppet_proxy_id .select2-chosen", visible: false).has_text? ''
     end
 
     test 'class parameters and overrides are displayed correctly for booleans' do
@@ -542,7 +524,6 @@ class HostJSTest < IntegrationTestWithJavascript
 
       click_link 'Host'
       select2(hostgroup2.name, :from => 'host_hostgroup_id')
-      wait_for_ajax
 
       click_link 'Parameters'
       assert page.has_no_selector?("#inherited_parameters #name_#{hostgroup1.group_parameters.first.name}")
@@ -630,7 +611,6 @@ class HostJSTest < IntegrationTestWithJavascript
 
         subnet_and_domain_are_selected(modal, domain)
 
-        wait_for_ajax
         modal.find(:button, "Ok").click
 
         assert table.find('td.fqdn').has_content?('name.' + domain.name)
@@ -640,21 +620,15 @@ class HostJSTest < IntegrationTestWithJavascript
       end
 
       test "selecting domain updates subnet list" do
+        domain = domains(:mydomain)
         disable_orchestration
         go_to_interfaces_tab
 
         table.first(:button, 'Edit').click
-
-        domain = domains(:mydomain)
+        wait_for_modal
         select2 domain.name, :from => 'host_interfaces_attributes_0_domain_id'
         subnet_and_domain_are_selected(modal, domain)
-
-        subnet_id = modal.find('#host_interfaces_attributes_0_subnet_id',
-                   :visible => false).value
-        subnet_label = modal.find('#s2id_host_interfaces_attributes_0_subnet_id span.select2-chosen').text
-
-        assert_equal '', subnet_id
-        assert_equal '', subnet_label
+        assert page.find('#host_interfaces_attributes_0_subnet_id option[selected="selected"]', visible: false).has_text? ""
       end
 
       test "selecting domain updates puppetclass parameters" do
@@ -676,7 +650,6 @@ class HostJSTest < IntegrationTestWithJavascript
         table.first(:button, 'Edit').click
 
         select2 domain.name, :from => 'host_interfaces_attributes_0_domain_id'
-        wait_for_ajax
         modal.find(:button, "Ok").click
 
         assert page.has_link?('Parameters', :href => '#params')
@@ -714,7 +687,9 @@ class HostJSTest < IntegrationTestWithJavascript
         add_interface
 
         flag_cols = table.all('td.flags')
-        flag_cols[1].find('.provision-flag').click
+        wait_for do
+          flag_cols[1].find('.provision-flag').click
+        end
 
         # only one flag switcher is active
         table.has_css?('.provision-flag.active', :count => 1)
@@ -730,7 +705,7 @@ class HostJSTest < IntegrationTestWithJavascript
         add_interface
 
         assert_interface_change(-1) do
-          table.all(:button, "Delete").last.click
+          table.first('tr:nth-child(2) td:last-child').find('button', :text => 'Delete').click
         end
       end
     end

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -120,7 +120,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     test 'build mode is not enabled for unmanaged hosts' do
       host = FactoryBot.create(:host)
       visit clone_host_path(host)
-      refute page.has_checked_field?('host_build')
+      assert page.has_no_checked_field?('host_build')
     end
   end
 end

--- a/test/integration/notifications_drawer_test.rb
+++ b/test/integration/notifications_drawer_test.rb
@@ -46,14 +46,8 @@ class NotificationsDrawerIntegrationTest < IntegrationTestWithJavascript
 
   def navigate_somewhere_with_turbolinks
     # check the outside click with turbolinks
-    page.find('a.navbar-brand').trigger('click')
-
-    wait_for_turbolinks
-  end
-
-  def wait_for_turbolinks
-    Timeout.timeout(Capybara.default_max_wait_time) do
-      loop until page.has_no_selector?('div.spinner')
-    end
+    page.find('a.navbar-brand').click
+    # wait for loader to dissapear
+    page.has_no_selector?('div.spinner')
   end
 end

--- a/test/integration/ptable_js_test.rb
+++ b/test/integration/ptable_js_test.rb
@@ -13,9 +13,11 @@ class PtableJSTest < IntegrationTestWithJavascript
     visit ptables_path
     click_link "ubuntu default"
     fill_in "ptable_name", :with => "debian default"
-    find('#editor').click
-    find('.ace_content').send_keys "d-i partman-auto/disk string /dev/sda\nd-i"
-    sleep 1 # Wait for the editor onChange debounce
+
+    editor_text = "d-i partman-auto/disk string /dev/sda\nd-i"
+    fill_in_editor_field('#react-ace', editor_text)
+    assert has_editor_display?('#react-ace', editor_text)
+
     assert_submit_button(ptables_path)
     assert page.has_link? 'debian default'
   end
@@ -24,13 +26,15 @@ class PtableJSTest < IntegrationTestWithJavascript
     visit ptables_path
     click_link "ubuntu default"
     fill_in "ptable_name", :with => "debian.default /dev/sda"
-    find('#editor').click
-    find('.ace_content').send_keys "d-i partman-auto/disk string /dev/sda\nd-i"
-    sleep 1 # Wait for the editor onChange debounce
+
+    editor_text = "d-i partman-auto/disk string /dev/sda\nd-i"
+    fill_in_editor_field('#react-ace', editor_text)
+
     assert_submit_button(ptables_path)
 
     assert page.has_link? 'debian.default /dev/sda'
     click_link "debian.default /dev/sda"
     assert page.has_field?("ptable_name") # not 404
+    assert has_editor_display?('#react-ace', editor_text)
   end
 end

--- a/test/integration/report_template_js_test.rb
+++ b/test/integration/report_template_js_test.rb
@@ -13,14 +13,16 @@ class ReportTemplateJSIntegrationTest < IntegrationTestWithJavascript
     assert page.has_link?('Create Report Template')
 
     click_link 'Create Report Template'
+
+    template_text = "CPUs,RAM,HDD\n<%= input(\'cpus\') -%>,<%= 1024 -%> MB,N/A"
+
     fill_in :id => 'report_template_name', :with => 'A testing report'
-    find('#editor').click
-    find('.ace_content').send_keys "CPUs,RAM,HDD\n<%= input('cpus') -%>,<%= 1024 -%> MB,N/A"
-    sleep 1 # Wait for the editor onChange debounce
+    fill_in_editor_field('#react-ace', template_text)
+    assert has_editor_display?('#react-ace', template_text)
 
     click_link('Inputs')
     within "#template_inputs" do
-      refute page.has_content?('Input Type')
+      assert page.has_no_content?('Input Type')
 
       click_link '+ Add Input'
       assert page.has_content?('Input Type')
@@ -34,6 +36,8 @@ class ReportTemplateJSIntegrationTest < IntegrationTestWithJavascript
     template = ReportTemplate.find_by_name('A testing report')
     visit generate_report_template_path(template)
 
+    assert_equal template.template, template_text
+
     assert page.has_content?('cpus')
   end
 
@@ -44,13 +48,13 @@ class ReportTemplateJSIntegrationTest < IntegrationTestWithJavascript
 
     visit generate_report_template_path(template)
     within '#content' do
-      refute page.has_content? input.name
+      assert page.has_no_content? input.name
 
       click_link 'Display advanced fields'
       assert page.has_content? input.name
 
       click_link 'Hide advanced fields'
-      refute page.has_content? input.name
+      assert page.has_no_content? input.name
     end
   end
 end

--- a/test/integration/search_bar_js_test.rb
+++ b/test/integration/search_bar_js_test.rb
@@ -3,7 +3,8 @@ require 'integration_test_helper'
 class SearchBarTest < IntegrationTestWithJavascript
   test "backslash key clicked should opens the search" do
     visit bookmarks_path
-    find('table').send_keys "/"
+    # needs to be interactive element
+    find('table thead').find('a', text: 'Name').send_keys("/")
     assert find('.search-input.focus')
   end
 end

--- a/test/integration/shared/host_finders.rb
+++ b/test/integration/shared/host_finders.rb
@@ -10,9 +10,8 @@ module HostFinders
 
   def add_interface
     page.find(:button, '+ Add Interface').click
-
-    modal = page.find('#interfaceModal')
-    modal.find(:button, "Ok").click
+    page.find('#interfaceModal')
+    close_interfaces_modal
   end
 
   def modal
@@ -24,7 +23,6 @@ module HostFinders
   end
 
   def assert_interface_change(change, &block)
-    table = page.find("table#interfaceList")
     original_interface_count = table.all('tr', :visible => true).count
     yield
     assert_equal original_interface_count + change, table.all('tr', :visible => true).count

--- a/test/integration/shared/host_finders.rb
+++ b/test/integration/shared/host_finders.rb
@@ -1,11 +1,24 @@
 module HostFinders
   extend ActiveSupport::Concern
 
+  def disable_interface_modal_animation
+    page.evaluate_script('document.getElementById("interfaceModal").classList.remove("fade")')
+  end
+
   def go_to_interfaces_tab
     # go to New Host page
     assert_new_button(hosts_path, "Create Host", new_host_path)
     # switch to interfaces tab
     page.find(:link, "Interfaces").click
+    disable_interface_modal_animation
+  end
+
+  def close_interfaces_modal
+    button = page.find(:button, 'Ok')
+    page.scroll_to(button)
+    button.click # close interfaces
+    # wait for the dialog to close
+    page.has_no_css?('#interfaceModal.in')
   end
 
   def add_interface
@@ -15,7 +28,7 @@ module HostFinders
   end
 
   def modal
-    page.find('#interfaceModal')
+    page.find('#interfaceModal.in')
   end
 
   def table

--- a/test/integration/smart_proxy_test.rb
+++ b/test/integration/smart_proxy_test.rb
@@ -71,7 +71,7 @@ class SmartProxyIntegrationTest < ActionDispatch::IntegrationTest
       proxy = smart_proxies(:one)
       visit smart_proxy_path(proxy)
       assert page.has_link?("VisibleTab")
-      refute page.has_link?("HiddenTab")
+      assert page.has_no_link?("HiddenTab")
     end
   end
 end

--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -1,11 +1,10 @@
 import Jed from 'jed';
 import { addLocaleData } from 'react-intl';
 import { deprecateObjectProperty } from './DeprecationService';
-import { runningInPhantomJS } from './helpers';
 
 class IntlLoader {
   constructor(locale, timezone) {
-    this.fallbackIntl = !global.Intl || runningInPhantomJS();
+    this.fallbackIntl = !global.Intl;
 
     [this.locale] = locale.split('-');
     this.timezone = this.fallbackIntl ? 'UTC' : timezone;

--- a/webpack/assets/javascripts/react_app/common/document.js
+++ b/webpack/assets/javascripts/react_app/common/document.js
@@ -1,11 +1,9 @@
-import { runningInPhantomJS } from './helpers';
-
 /**
  * Whether or not the page is focused (beeing used atm)
  * @return {boolean}
  */
 export const doesDocumentHasFocus = () =>
-  runningInPhantomJS() || (document.hasFocus ? document.hasFocus() : true);
+  document.hasFocus ? document.hasFocus() : true;
 
 /**
  * Update title of document

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -21,12 +21,6 @@ export const isoCompatibleDate = date => {
 };
 
 /**
- * Does it run in phantomjs test environment
- * @return {boolean}
- */
-export const runningInPhantomJS = () => window._phantom !== undefined;
-
-/**
  * Add a debounce timeout for your methods.
  * @param {Object} context - the context where your method is running.
  * @param {Number} time - the amount of debounce time in miliseconds.


### PR DESCRIPTION
Takes over a #5770 and tries to push forward, as phantomjs is not maintained for a while now.

Touches the tests only, so no manual tests needed. Every code review appreciated though.

As @ohadlevy requested below, I have started a [discussion](https://community.theforeman.org/t/drop-browser-support-deprecate-phantomjs/13887/19) about impacts of this for browser support.

I have made few minor improvement along the way to fix the tests for chrome:
- switch `refute` to `has_no` for performance, as capybara if not waiting for the elements in later.
- improves some waits to be more exact - thus stabilizes the tests a bit.