### PR TITLE
Fixes #26781 - DateTimePicker placement

### DIFF
--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -13,7 +13,8 @@
 
   <%= datetime_local_f f, :generate_at,
       label: _('Generate at'),
-      label_help: _('Generate report on a given time.')
+      label_help: _('Generate report on a given time.'),
+      input_props: { placement: 'bottom' }
     %>
 
   <%= checkbox_f f, :send_mail,

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -52,7 +52,7 @@ class DateTimePicker extends React.Component {
   };
 
   render() {
-    const { locale, weekStartsOn, inputProps, id } = this.props;
+    const { locale, weekStartsOn, inputProps, id, placement } = this.props;
     const { value, typeOfDateInput, isTimeTableOpen, hiddenValue } = this.state;
     const popover = (
       <Popover
@@ -93,7 +93,7 @@ class DateTimePicker extends React.Component {
 
           <OverlayTrigger
             trigger="click"
-            placement="top"
+            placement={placement}
             overlay={popover}
             rootClose
             container={this}
@@ -125,6 +125,7 @@ DateTimePicker.propTypes = {
   inputProps: PropTypes.object,
   id: PropTypes.string,
   hiddenValue: PropTypes.bool,
+  placement: OverlayTrigger.propTypes.placement,
 };
 DateTimePicker.defaultProps = {
   value: new Date(),
@@ -133,5 +134,6 @@ DateTimePicker.defaultProps = {
   inputProps: {},
   id: 'datetime-picker-popover',
   hiddenValue: true,
+  placement: 'top',
 };
 export default DateTimePicker;

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
@@ -19,6 +19,7 @@ exports[`Report Template AutoComplete rendering renders Report Date input 1`] = 
       }
     }
     locale="EN"
+    placement="top"
     value="2019-01-04"
     weekStartsOn={1}
   />
@@ -55,6 +56,7 @@ exports[`Report Template AutoComplete rendering renders with Require and Info 1`
       }
     }
     locale="EN"
+    placement="top"
     value="2019-01-04"
     weekStartsOn={1}
   />


### PR DESCRIPTION
Before 1920 resolution:
![TimePicker-positioning](https://user-images.githubusercontent.com/2884324/57540299-b1d8e080-734c-11e9-8f04-073901cc0371.png)
Before 1920/2 resolution:
![DateTimePicker-owerflow-halfscreen](https://user-images.githubusercontent.com/2884324/57540292-ac7b9600-734c-11e9-97c1-a3e25c4f6fa9.png)
After 1920 resolution:
![DateTimePicker](https://user-images.githubusercontent.com/2884324/57540289-abe2ff80-734c-11e9-9179-918f50c9565d.png)
After 1920/2 resolution
![DateTimePicker-halfscreen](https://user-images.githubusercontent.com/2884324/57540291-abe2ff80-734c-11e9-9cc9-ce636febe912.png)


