### PR TITLE
fixes #26796 - coreos: url_for_boot

### DIFF
--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -11,10 +11,6 @@ class Coreos < Operatingsystem
     end.to_s
   end
 
-  def url_for_boot(file)
-    PXEFILES[file]
-  end
-
   def pxedir
     '$arch-usr/$version'
   end

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -19,7 +19,7 @@ class NXOS < Operatingsystem
     "boot/$arch/images"
   end
 
-  def url_for_boot(file)
+  def url_for_boot(medium_provider, file)
     raise ::Foreman::Exception.new(N_("Function not available for %s"), self.display_family)
   end
 

--- a/app/models/operatingsystems/rancheros.rb
+++ b/app/models/operatingsystems/rancheros.rb
@@ -9,10 +9,6 @@ class Rancheros < Operatingsystem
     ''
   end
 
-  def url_for_boot(file)
-    PXEFILES[file]
-  end
-
   def display_family
     'RancherOS'
   end

--- a/test/factories/medium.rb
+++ b/test/factories/medium.rb
@@ -30,6 +30,12 @@ FactoryBot.define do
       os_family { 'Suse' }
     end
 
+    trait :rancheros do
+      sequence(:name) { |n| "Rancheros Mirror #{n}"}
+      sequence(:path) { 'https://github.com/rancher/os/releases/download/v$version' }
+      os_family { 'Rancheros' }
+    end
+
     trait :with_operatingsystem do
       operatingsystems { [FactoryBot.create(:operatingsystem, :with_archs)] }
     end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -113,5 +113,13 @@ FactoryBot.define do
       type { 'Solaris' }
       title { 'Solaris 10.8' }
     end
+
+    factory :rancheros, class: Rancheros do
+      sequence(:name) { 'Rancheros' }
+      major { '1' }
+      minor { '4.3' }
+      type { 'Rancheros' }
+      title { 'Rancheros 1.4.3' }
+    end
   end
 end

--- a/test/models/operatingsystems/coreos_test.rb
+++ b/test/models/operatingsystems/coreos_test.rb
@@ -1,19 +1,31 @@
 require 'test_helper'
 
 class CoreosTest < ActiveSupport::TestCase
+  let(:operatingsystem) { FactoryBot.create(:coreos) }
+  let(:architecture) { architectures(:x86_64) }
+  let(:medium) { FactoryBot.create(:medium, :coreos) }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+
   describe '#mediumpath' do
     test 'generates medium path url' do
-      operatingsystem = FactoryBot.create(:coreos)
-      architecture = architectures(:x86_64)
-      medium = FactoryBot.create(:medium, :coreos)
-      mock_entity = OpenStruct.new(
-        operatingsystem: operatingsystem,
-        architecture: architecture,
-        medium: medium
-      )
+      assert_equal 'http://stable.release.core-os.net/amd64-usr/', operatingsystem.mediumpath(medium_provider)
+    end
+  end
 
-      provider = MediumProviders::Default.new(mock_entity)
-      assert_equal 'http://stable.release.core-os.net/amd64-usr/', operatingsystem.mediumpath(provider)
+  describe '#url_for_boot' do
+    test 'generates kernel url' do
+      assert_equal 'http://stable.release.core-os.net/amd64-usr/494.5.0/coreos_production_pxe.vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+    end
+
+    test 'generates initrd url' do
+      assert_equal 'http://stable.release.core-os.net/amd64-usr/494.5.0/coreos_production_pxe_image.cpio.gz', operatingsystem.url_for_boot(medium_provider, :initrd)
     end
   end
 end

--- a/test/models/operatingsystems/rancheros_test.rb
+++ b/test/models/operatingsystems/rancheros_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class RancherosTest < ActiveSupport::TestCase
+  let(:operatingsystem) { FactoryBot.create(:rancheros) }
+  let(:architecture) { architectures(:x86_64) }
+  let(:medium) { FactoryBot.create(:medium, :rancheros) }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+
+  describe '#mediumpath' do
+    test 'generates empty medium path url' do
+      assert_equal '', operatingsystem.mediumpath(medium_provider)
+    end
+  end
+
+  describe '#url_for_boot' do
+    test 'generates kernel url' do
+      assert_equal 'https://github.com/rancher/os/releases/download/v1.4.3/vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+    end
+
+    test 'generates initrd url' do
+      assert_equal 'https://github.com/rancher/os/releases/download/v1.4.3/initrd', operatingsystem.url_for_boot(medium_provider, :initrd)
+    end
+  end
+end


### PR DESCRIPTION
Fixes:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
from app/models/operatingsystems/coreos.rb:14:in `url_for_boot'
from app/models/concerns/host_common.rb:83:in `url_for_boot'
```

TODOs:

- [x] Add tests