### PR TITLE
Revert "Fixes #26790 - Support ES6 in Uglifier"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,8 +22,7 @@ Foreman::Application.configure do |app|
   config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
-  # use support for ES6 syntax in uglifier
-  config.assets.js_compressor = Sprockets::UglifierCompressor.new(:harmony => true)
+  config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Reverts theforeman/foreman#6759

This seems to be causing migrations to fail to run (https://projects.theforeman.org/issues/26800), reverting from stable branch for now.