### PR TITLE
Fixes #26804 - add_cmd requires second parameter [skip ci]

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -331,7 +331,7 @@ if [ $NOGENERIC -eq 0 ]; then
     [ $DEBUG -eq 0 ] && add_cmd "dpkg --list" "installed_packages"
   fi
 
-  add_cmd "virt-who -dop"
+  add_cmd "virt-who -dop" "virt_who"
 fi
 
 # FOREMAN RELATED ARTIFACTS


### PR DESCRIPTION
[skip ci]

Second parameter must be present. This is a quick fix, function could
raise an error or something but we are moving away from foreman-debug
anyway so let's just fix it. @ares