### PR TITLE
Fixes #26010 - boot_order by orderable select 

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -219,6 +219,15 @@ module Foreman::Model
       }
     end
 
+    def boot_devices
+      {
+        'disk' => _('Harddisk'),
+        'cdrom' => _('CD-ROM'),
+        'network' => _('Network'),
+        'floppy' => _('Floppy'),
+      }
+    end
+
     # vSphere guest OS type descriptions
     # list fetched from RbVmomi::VIM::VirtualMachineGuestOsIdentifier.values and
     # https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -21,6 +21,14 @@ end %>
 <%= checkbox_f f, :memoryHotAddEnabled, { :help_inline => _("Memory hot add lets you add memory resources for a virtual machine while the machine is powered on."), :label => _('Memory hot add'), :label_size => "col-md-2", :disabled => !new_vm } %>
 <%= checkbox_f f, :cpuHotAddEnabled, { :help_inline => _("CPU hot add lets you add CPU resources for a virtual machine while the machine is powered on."), :label => _('CPU hot add'), :label_size => "col-md-2", :disabled => !new_vm } %>
 <%= checkbox_f f, :add_cdrom, { :checked => f.object.attributes[:cdroms].present?, :help_inline => _("Add a CD-ROM drive to the virtual machine."), :label => _('CD-ROM drive'), :label_size => "col-md-2" } if new_vm %>
+<%= orderable_select_f f, :boot_order, compute_resource.boot_devices, {}, {
+                                                                            :label => _("Boot order"),
+                                                                            :label_help => _("Has effect only for network based provisioning"),
+                                                                            :class => "col-md-2",
+                                                                            :disabled => !new_vm,
+                                                                            :multiple => true
+                                                                          }
+  %>
 
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableSelect/OrderableSelect.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableSelect/OrderableSelect.js
@@ -14,6 +14,7 @@ import OrderableToken from './components/OrderableToken';
  * The value can not be changed through props once the component is rendered.
  */
 const OrderableSelect = ({
+  className,
   onChange,
   defaultValue,
   value,
@@ -27,6 +28,14 @@ const OrderableSelect = ({
   const moveDraggedOption = (dragIndex, hoverIndex) => {
     setInternalValue(orderDragged(internalValue, dragIndex, hoverIndex));
   };
+
+  // hack the form-control, which in TypeAhead so it will be duplicated
+  const classesWithoutFormControl =
+    className &&
+    className
+      .split(/\s+/)
+      .filter(el => el !== 'form-control')
+      .join(' ');
 
   return (
     <TypeAheadSelect
@@ -45,6 +54,7 @@ const OrderableSelect = ({
         </div>
       )}
       {...props}
+      className={classesWithoutFormControl}
       options={options}
       selected={internalValue}
       onChange={newValue => {
@@ -61,12 +71,14 @@ OrderableSelect.propTypes = {
   onChange: PropTypes.func,
   defaultValue: PropTypes.array,
   value: PropTypes.array,
+  className: PropTypes.string,
 };
 
 OrderableSelect.defaultProps = {
   onChange: noop,
   defaultValue: [],
   value: null,
+  className: '',
 };
 
 export default OrderableSelect;


### PR DESCRIPTION
Revival of #4400, with draggable multiselect.
![bootorder](https://user-images.githubusercontent.com/2884324/57852983-e33a2c00-77e4-11e9-8152-b2fc224c3290.gif)
Blocked by #6762 - the actual draggable multi select, which now needs to be reimplemented to bootstrap version.

Prerequisites  for testing:
* VMware cluster

Tests needed (anticipated impacts):
* Vmware host provisioning (mainly network based)
