### PR TITLE
Refs #26052 - skip menu items with no name

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -100,6 +100,7 @@ const userChildren = [
     url: '/architectures',
   },
 ];
+
 const infrastructureChildren = [
   {
     type: 'item',
@@ -110,6 +111,16 @@ const infrastructureChildren = [
     type: 'item',
     name: 'Realms',
     url: '/realms',
+  },
+];
+
+const namelessChildren = [
+  {
+    type: 'item',
+    url: '/nameless',
+  },
+  {
+    type: 'divider',
   },
 ];
 
@@ -143,7 +154,14 @@ const hashItemsB = [
   },
 ];
 
-export const serverItems = [...hashItemsA, ...hashItemsB];
+export const hashItemNameless = [
+  {
+    type: 'sub_menu',
+    name: 'Empty',
+    icon: 'pficon pficon-unplugged',
+    children: namelessChildren,
+  },
+];
 
 const logo =
   '/assets/header_logo-c9614c16f2ee399ae9cb7f36ec94b9a26bf8cf9eabaa7fe6099bf80d1f7940db.svg';

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
@@ -21,34 +21,31 @@ export const patternflyMenuItemsSelector = createSelector(
     patternflyItems(items, currentLocation, currentOrganization)
 );
 
-const patternflyItems = (data, currentLocation, currentOrganization) => {
-  if (data.length === 0) return [];
-  const items = [];
+const childToMenuItem = (child, currentLocation, currentOrganization) => ({
+  id: `menu_item_${snakeCase(child.name)}`,
+  title: child.name,
+  isDivider: child.type === 'divider',
+  className:
+    child.name === currentLocation || child.name === currentOrganization
+      ? 'mobile-active'
+      : '',
+  href: child.url || '#',
+  preventHref: true,
+  onClick: child.onClick || noop,
+});
 
-  data.forEach(item => {
-    const childrenArray = [];
-    item.children.forEach(child => {
-      const childObject = {
-        id: `menu_item_${snakeCase(child.name)}`,
-        title: child.name,
-        isDivider: child.type === 'divider' && !!child.name,
-        className:
-          child.name === currentLocation || child.name === currentOrganization
-            ? 'mobile-active'
-            : '',
-        href: child.url || '#',
-        preventHref: true,
-        onClick: child.onClick || noop,
-      };
-      childrenArray.push(childObject);
-    });
-    const itemObject = {
+const patternflyItems = (data, currentLocation, currentOrganization) =>
+  data.map(item => {
+    const childrenArray = item.children
+      .filter(child => child.name)
+      .map(child =>
+        childToMenuItem(child, currentLocation, currentOrganization)
+      );
+
+    return {
       title: item.name,
       iconClass: item.icon,
       subItems: childrenArray,
       className: item.className,
     };
-    items.push(itemObject);
   });
-  return items;
-};

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutSelectors.test.js
@@ -7,7 +7,7 @@ import {
   selectCurrentOrganization,
   selectIsCollapsed,
 } from '../LayoutSelectors';
-import { layoutMock } from '../Layout.fixtures';
+import { layoutMock, hashItemNameless } from '../Layout.fixtures';
 
 const state = {
   layout: {
@@ -26,12 +26,25 @@ const emptyState = {
   },
 };
 
+const namelessState = {
+  layout: {
+    items: hashItemNameless,
+    activeMenu: 'Empty',
+    currentOrganization: { title: 'org1' },
+    currentLocation: { title: 'loc1' },
+    isLoading: true,
+    isCollapsed: false,
+  },
+};
+
 const fixtures = {
   'should return Layout': () => selectLayout(state),
   'should return PF-React Compatible items': () =>
     patternflyMenuItemsSelector(state),
   'should return empty array of items': () =>
     patternflyMenuItemsSelector(emptyState),
+  'should filter out nameless items': () =>
+    patternflyMenuItemsSelector(namelessState),
 
   'should return isLoading from selector': () => selectIsLoading(state),
   'should return isCollapsed from selector': () => selectIsCollapsed(state),

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Layout selectors should filter out nameless items 1`] = `
+Array [
+  Object {
+    "className": undefined,
+    "iconClass": "pficon pficon-unplugged",
+    "subItems": Array [],
+    "title": "Empty",
+  },
+]
+`;
+
 exports[`Layout selectors should return Layout 1`] = `
 Object {
   "activeMenu": "Hosts",


### PR DESCRIPTION
Not all menu items have a name. If an item has no name, snakecase will
fail to generate the name for the item.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
