### PR TITLE
Fixes #26834 - local boot template setting can be lowercase

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -113,7 +113,7 @@ class UnattendedController < ApplicationController
     return unless verify_found_host
 
     ipxe_template_kind = TemplateKind.find_by(name: 'iPXE')
-    name = @host.local_boot_template_name(:ipxe) || ProvisioningTemplate.local_boot_name(:iPXE)
+    name = @host.local_boot_template_name(:iPXE) || ProvisioningTemplate.local_boot_name(:iPXE)
     template = ProvisioningTemplate.find_by(name: name, template_kind: ipxe_template_kind)
 
     return safe_render(template) if template

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -833,7 +833,7 @@ class Host::Managed < Host::Base
 
   def local_boot_template_name(kind)
     key = "local_boot_#{kind}"
-    host_params[key] || Setting[key]
+    host_params[key] || host_params[key.downcase] || Setting[key]
   end
 
   private


### PR DESCRIPTION
Params are named local_boot_ipxe but local_boot_PXELinux. Let's make them all lowercase, but keep the old versions for backward compatibility.

Tests are present for normal case, I don't think it is necessary to copy
whole test just for this small thing, it's minor and small risk.