### PR TITLE
Fixes #26812,#26814 - display correct vm_details in notifications

### DIFF
--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -26,6 +26,10 @@ module FogExtensions
         machine_type.split('/')[-1]
       end
 
+      def pretty_image_name
+        image_name.split('/')[-1] if disks.present?
+      end
+
       def image_id
         image_name if disks.present?
       end

--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -10,6 +10,14 @@ module FogExtensions
       attribute :associate_external_ip
       attribute :external_ip
 
+      def to_s
+        name || identity
+      end
+
+      def state
+        status.downcase
+      end
+
       def persisted?
         creation_timestamp.present?
       end

--- a/app/views/compute_resources_vms/show/_gce.html.erb
+++ b/app/views/compute_resources_vms/show/_gce.html.erb
@@ -5,28 +5,16 @@
       <tr><th colspan="2"><%=_("Properties") %></th></tr>
     </thead>
     <tbody>
+      <%= prop :state %>
+      <%= prop :pretty_machine_type, "Machine Type" %>
+      <%= prop :zone_name, "Zone" %>
       <tr>
-        <td>State</td>
-        <td><%= @vm.status.downcase %></td>
+        <td>Created</td>
+        <td><%= date_time_relative_value(@vm.creation_timestamp) %></td>
       </tr>
-      <tr>
-        <td>Machine Type</td>
-        <td><%= @vm.pretty_machine_type %></td>
-      </tr>
-      <tr>
-        <td>Zone</td>
-        <td><%= @vm.zone_name %></td>
-      </tr>
-      <tr>
-        <td>Private IP</td>
-        <td><%= @vm.private_ip_address %></td>
-      </tr>
-      <% if @vm.public_ip_address.present? %>
-        <tr>
-          <td>Public IP</td>
-          <td><%= @vm.public_ip_address %></td>
-        </tr>
-      <% end %>
+      <%= prop :private_ip_address %>
+      <%= prop :public_ip_address %>
+      <%= prop :pretty_image_name, "Image" %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
Note that - state method is renamed to `status` in fog-google.