### PR TITLE
refs #26741 - update the location of the container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - db:/var/lib/mysql/data
 
   app: &app_base
-    image: quay.io/ohadlevy/foreman:containers
+    image: quay.io/foreman/foreman:latest
     command: bundle exec bin/rails server -b 0.0.0.0
     build:
       context: .


### PR DESCRIPTION
Container image is now enabled on quay.io, on every merge
to foreman repo, a new image would be built for every branch.

Currently, only the develop branch is enabled, and therefore
the latest tag would be used for it.

[skip ci]