### PR TITLE
refs #26741 - use develop container tag vs latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - db:/var/lib/mysql/data
 
   app: &app_base
-    image: quay.io/foreman/foreman:latest
+    image: quay.io/foreman/foreman:develop
     command: bundle exec bin/rails server -b 0.0.0.0
     build:
       context: .


### PR DESCRIPTION
hopefully this makes it more obvious one is using the
latest development build vs a stable release.

[skip ci]