### PR TITLE
Fixes #26852 - add mountpoint and partition exclude fact patterns

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -72,7 +72,7 @@ class Setting::Provisioning < Setting
       ),
       self.set(
         'excluded_facts',
-        N_("Exclude pattern for all types of imported facts (rhsm, puppet e.t.c.). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. macvtap*"),
+        N_("Exclude pattern for all types of imported facts (puppet, ansible, rhsm). Those facts won't be stored in foreman's database. You can use * wildcard to match names with indexes e.g. ignore* will filter out ignore, ignore123 as well as a::ignore or even a::ignore123::b"),
         default_excluded_facts,
         N_('Exclude pattern for facts stored in foreman')
       )
@@ -120,6 +120,6 @@ class Setting::Provisioning < Setting
   end
 
   def self.default_excluded_facts(ignored_interfaces = IGNORED_INTERFACES)
-    ignored_interfaces
+    ignored_interfaces + ['mountpoints', 'partitions', 'blockdevice*']
   end
 end

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -181,4 +181,23 @@ module FactsData
       }
     end
   end
+
+  class DefaultDisksFacts
+    def filter
+      Setting[:excluded_facts]
+    end
+
+    def good_facts
+      {
+        'good_fact' => 'a_value'
+      }
+    end
+
+    def ignored_facts
+      {
+        'partitions' => {"nvme0n1p5" => {}, "nvme0n1p3" => {"uuid" => "2bff39f0-8e86-4852-9ef5-a27d2d64064f", "mount" => "/"}},
+        'mountpoints' => {"/var/lib/kubelet/pods/18d36b62-526f-11e9-98b1-0200004190da/volumes/kubernetes.io~secret/certs" => {"used_bytes" => 13}}
+      }
+    end
+  end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -362,7 +362,7 @@ attribute77:
 attributes78:
   name: excluded_facts
   category: Setting::Provisioning
-  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
+  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*', 'mountpoints', 'partitions', 'blockdevice*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
 attribute79:
   name: append_domain_name_for_hosts

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -102,6 +102,17 @@ class FactImporterTest < ActiveSupport::TestCase
 
       assert_equal data.good_facts, actual_facts
     end
+
+    test 'filters default disk facts' do
+      data = FactsData::DefaultDisksFacts.new
+
+      facts = data.good_facts.merge(data.ignored_facts)
+
+      importer = FactImporter.new(nil, facts)
+      actual_facts = importer.send(:facts)
+
+      assert_equal data.good_facts, actual_facts
+    end
   end
 
   describe '#import!' do


### PR DESCRIPTION
Multiple customers and an upstream user reported severe performance issues with whole deployment thank to hosts with hundreds/thousands of blockdevies and/or hosts with containers which report many blockdevices and/or mountpoints and partitions. We already do this for NICs (e.g. veth - containers and OpenStack hosts) however it looks like there are different naming conventions container users use for mountpoints, therefore the exclude pattern needs to be generic.