### PR TITLE
Fixes #26859 - revert the changed seed order

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -4,7 +4,7 @@ skip_associations = [:associated_audits, :audits, :default_users, :hosts, :disco
                      :taxable_taxonomies, :reports ] + Template.descendants.map {|type| type.to_s.tableize.to_sym}
 
 User.as_anonymous_admin do
-  [Location, Organization].select(&:none?).each do |taxonomy|
+  [Organization, Location].select(&:none?).each do |taxonomy|
     taxonomy.without_auditing do
       tax_name = ENV.fetch("SEED_#{taxonomy.to_s.upcase}", "Default #{taxonomy}")
       tax = taxonomy.create!(name: tax_name)


### PR DESCRIPTION
In #6283 the seed order of default taxonomies has changed. There may be some users who hardcoded their ids in scripts which wouldn't work against newly installed instances. While it's not a good practice, it does not cause us any pain to revert this to original order.

Prerequisites for testing:
* clean migrated db

Tests needed (anticipated impacts):
* run `rake db:seed` and verify default org and loc ids
* they should be swapped with the patch

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
