### PR TITLE
Fixes #26896 - Add tooltip for IPv4 Subnet on NIC base form

### DIFF
--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -31,6 +31,8 @@
                  :size => "col-md-8", :label_size => "col-md-3" } %>
   <%= nic_subnet_field f, :subnet_id, :"Subnet::Ipv4",
                 { :label => _("IPv4 Subnet"),
+                :label_help => _("IPv4 Subnet with TFTP Capsule is required for PXE based provisioning.").html_safe,
+                :label_help_options => { :rel => 'popover-modal' },
                 :class => 'interface_subnet' } %>
   <%= nic_subnet_field f, :subnet6_id, :"Subnet::Ipv6",
                 { :label => _("IPv6 Subnet"),


### PR DESCRIPTION
Fixes #26869 - Add tooltip for IPv4 Subnet on NIC base form

Adding a tooltip for IPv4 Subnet on NIC base form that will clarify that IPv4 Subnet with TFTP Capsule is required for PXE provisioning.

Subnet field was made optional with: https://projects.theforeman.org/issues/15133

We should have a note that says it is not optional when using PXE

RH bugzilla was opened at: https://bugzilla.redhat.com/show_bug.cgi?id=1712015
