### PR TITLE
Fixes #26871 - restore taxonomy name as ID in API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -421,38 +421,6 @@ module Api
       [parent_name, parent_scope]
     end
 
-    # This method adds a scope by resource id, taking into account possibility of parametrization or friendly find
-    def scope_by_resource_id(base_scope, resource_id)
-      # If resource id is nil or empty string, return empty scope
-      return base_scope.none if resource_id.blank?
-
-      if resource_id.is_a? String
-        # The class is parameterizable and the id is in '123-myname' format, extract the id from it
-        if base_scope.klass.respond_to?(:to_param) && resource_id.start_with?(/\d+-/)
-          return base_scope.where(id: resource_id.to_i)
-        end
-
-        # The class supports friendly id and the id is in a 'friendly_id' format, prefer the friendly field for search
-        if base_scope.klass.respond_to?(:friendly)
-          field = base_scope.klass.friendly_id_config.query_field
-          friendly_scope = base_scope.where(field => resource_id)
-          # the id could be a regular friendly id - e.g. 'name', or it could be a resource with a numeric name,
-          # e.g. '123' - in that case we want to return the friendly scope.
-          # if the id is numeric and there is no matching resources, fall back to numeric find
-          if resource_id.friendly_id? ||
-            (resource_id.integer? && friendly_scope.any?)
-            return friendly_scope
-          end
-        end
-      end
-
-      # The id is an integer (or an integer-like string), scope by it
-      return base_scope.where(id: resource_id) if resource_id.integer?
-
-      # The parameter doesn't match any supported format, return empty scope
-      base_scope.none
-    end
-
     def parameter_filter_context
       Foreman::ParameterFilter::Context.new(:api, controller_name, params[:action])
     end

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -33,9 +33,7 @@ module ApplicationShared
           if params["#{taxonomy}_id"].blank? # the key is present and explicitly set to nil which indicates "any" context
             determined_taxonomy = nil
           else
-            identifier = params["#{taxonomy}_id"]
-            determined_taxonomy = available.friendly.find(identifier) rescue ActiveRecord::RecordNotFound
-            determined_taxonomy ||= available.where(:id => identifier).first
+            determined_taxonomy = scope_by_resource_id(available, params["#{taxonomy}_id"]).first
 
             # in case user asked for taxonomy that does not exist or is not accessible, we reply with 404
             if determined_taxonomy.nil?
@@ -96,6 +94,38 @@ module ApplicationShared
       nil
     end
     # rubocop:enable Style/EmptyElse
+  end
+
+  # This method adds a scope by resource id, taking into account possibility of parametrization or friendly find
+  def scope_by_resource_id(base_scope, resource_id)
+    # If resource id is nil or empty string, return empty scope
+    return base_scope.none if resource_id.blank?
+
+    if resource_id.is_a? String
+      # The class is parameterizable and the id is in '123-myname' format, extract the id from it
+      if base_scope.klass.respond_to?(:to_param) && resource_id.start_with?(/\d+-/)
+        return base_scope.where(id: resource_id.to_i)
+      end
+
+      # The class supports friendly id and the id is in a 'friendly_id' format, prefer the friendly field for search
+      if base_scope.klass.respond_to?(:friendly)
+        field = base_scope.klass.friendly_id_config.query_field
+        friendly_scope = base_scope.where(field => resource_id)
+        # the id could be a regular friendly id - e.g. 'name', or it could be a resource with a numeric name,
+        # e.g. '123' - in that case we want to return the friendly scope.
+        # if the id is numeric and there is no matching resources, fall back to numeric find
+        if resource_id.friendly_id? ||
+          (resource_id.integer? && friendly_scope.any?)
+          return friendly_scope
+        end
+      end
+    end
+
+    # The id is an integer (or an integer-like string), scope by it
+    return base_scope.where(id: resource_id) if resource_id.integer?
+
+    # The parameter doesn't match any supported format, return empty scope
+    base_scope.none
   end
 
   def find_session_taxonomy(taxonomy, user)

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -33,7 +33,9 @@ module ApplicationShared
           if params["#{taxonomy}_id"].blank? # the key is present and explicitly set to nil which indicates "any" context
             determined_taxonomy = nil
           else
-            determined_taxonomy = available.where(:id => params["#{taxonomy}_id"]).first
+            identifier = params["#{taxonomy}_id"]
+            determined_taxonomy = available.friendly.find(identifier) rescue ActiveRecord::RecordNotFound
+            determined_taxonomy ||= available.where(:id => identifier).first
 
             # in case user asked for taxonomy that does not exist or is not accessible, we reply with 404
             if determined_taxonomy.nil?


### PR DESCRIPTION
This used to work a long time ago
```
url -u admin:changeme  --header "Content-Type:application/json" "https://foreman.example.tst/api/v2/organizations/Ares/parameters/"
```

but now returns 404 and only ID of organization can be used

Prerequisites for testing:
* have at least one org or loc

Tests needed (anticipated impacts):
* perform the API call and see you get reasonable response for existing org/loc
* check that regular work with API using taxonomies work

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
