### PR TITLE
Provision templates: pxe_kernel_options parameter is not rendered in the template

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -69,7 +69,7 @@ timeout=<%= host_param('loader_timeout') || 10 %>
 
 title <%= template_name %>
   root (nd)
-  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
+  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> <%= host_param('pxe_kernel_options') %> <%= ksoptions %>
   initrd (nd)/../<%= @initrd %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -80,7 +80,7 @@ set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
+  <%= linuxcmd %> <%= @kernel %> ks=<%= foreman_url('provision') %> <%= host_param('pxe_kernel_options') %> <%= ksoptions %>
   <%= initrdcmd %> <%= @initrd %>
 }
 

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -74,7 +74,7 @@ ONTIMEOUT installer
 LABEL installer
   MENU LABEL <%= template_name %>
   KERNEL <%= @kernel %>
-  APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= ksoptions %>
+  APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= host_param('pxe_kernel_options') %> <%= ksoptions %>
   IPAPPEND 2
 
 <%= snippet_if_exists(template_name + " custom menu") %>


### PR DESCRIPTION
fixes #26874 - Parameter in host "pxe_kernel_options" is not correctly rendered.

Prerequisites for testing:
* a host to provision with a Redhat based operating system (e.g.: centos)
* define a this parameter in the host (e.g.): pxe_kernel_options = console=ttyS0,115200

Actually tested with foreman 1.21.3

Thanks and keep up working :)

