### PR TITLE
Fixes #26873 - fix vsphere networks (auto)-loading

### DIFF
--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -51,6 +51,8 @@ end
 
 if Foreman::Model::Vmware.available?
   require 'fog/vsphere'
+  require 'fog/vsphere/models/compute/cluster'
+  require 'fog/vsphere/models/compute/network'
   require 'fog/vsphere/models/compute/server'
   Fog::Vsphere::Compute::Server.send(:include, FogExtensions::Vsphere::Server)
 


### PR DESCRIPTION
Due to a race condition, sometimes the the failure 'uninitialized constant Fog::Compute::Vsphere::Network' happens when using the compute-resource networks API.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
