### PR TITLE
fixes #26903 - update webpack-bundle-analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "uglifyjs-webpack-plugin": "^1.2.2",
     "url-loader": "^1.0.1",
     "webpack": "^3.4.1",
-    "webpack-bundle-analyzer": "^2.13.1",
+    "webpack-bundle-analyzer": ">=3.3.2",
     "webpack-dev-server": "^2.5.1",
     "webpack-stats-plugin": "^0.1.5"
   },


### PR DESCRIPTION
Versions of webpack-bundle-analyzer prior to 3.3.2 are vulnerable to Cross-Site Scripting. The package uses JSON.stringify() without properly escaping input which may lead to Cross-Site Scripting.