### PR TITLE
Fixes #26924 - Deprecate rake taks for puppet import

### DIFF
--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -28,6 +28,8 @@ namespace :puppet do
     Update puppet environments and classes. Optional batch flag triggers run with no prompting\nUse proxy=<proxy name> to import from or get the first one by default"
     task :puppet_classes, [:batch, :envname] => :environment do |t, args|
       User.as_anonymous_admin do
+        puts Foreman::Deprecation.deprecation_warning('1.24', 'use API/CLI commands instead of puppet:import:puppet_classes rake task')
+
         args.batch = args.batch == "true"
         proxies = SmartProxy.with_features("Puppet")
 
@@ -117,6 +119,7 @@ namespace :puppet do
     task :environments_only, [:batch] => :environment do |t, args|
       User.as_anonymous_admin do
         args.batch = args.batch == "true"
+        puts Foreman::Deprecation.deprecation_warning('1.24', 'use API/CLI commands instead of puppet:import:environments_only rake task')
         puts " ================================================================ "
         puts "Import starts: #{Time.now.strftime('%Y-%m-%d %H:%M:%S %Z')}"
 


### PR DESCRIPTION
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
