### PR TITLE
Fixes #26939 - root_pass limit increased

### DIFF
--- a/db/migrate/20190604081000_change_root_pass_in_host.rb
+++ b/db/migrate/20190604081000_change_root_pass_in_host.rb
@@ -1,0 +1,15 @@
+class ChangeRootPassInHost < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      change_table :hosts do |t|
+        dir.up   { t.change :root_pass, :text }
+        dir.down { t.change :root_pass, :string, limit: 255 }
+      end
+
+      change_table :hostgroups do |t|
+        dir.up   { t.change :root_pass, :text }
+        dir.down { t.change :root_pass, :string, limit: 255 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Requires MySQL 5.0 which we have (oldest is EL7 with 5.5). So we are
good. Postgres supports up to 1GiB as far as I can remember.