### PR TITLE
Fixes #26942 - no plan info retrieval if not done

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -201,7 +201,7 @@ module Api
       def load_and_authorize_plan
         @plan = load_dynflow_plan(params[:job_id])
         return not_found(_('Report not found, please ensure you used the correct job_id')) if @plan.nil?
-        return @plan if @plan.state == :scheduled || @plan.failure?
+        return @plan if @plan.progress < 1 || @plan.failure?
         composer_attrs, options = plan_arguments(@plan)
         if User.current.admin? || options['user_id'].to_i == User.current.id
           @composer = ReportComposer.new(composer_attrs)

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -312,14 +312,14 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
     describe 'failures' do
       it 'returns no_content if not ready' do
         stub_plan('progress' => 0.0)
-        stub_plan_arguments
+        @controller.expects(:plan_arguments).never
         get :report_data, params: { id: report_template.id, job_id: 'JOBID' }
         assert_response :no_content
       end
 
       it 'fails if underlying job failed ' do
         stub_plan('failure?' => true)
-        stub_plan_arguments
+        @controller.expects(:plan_arguments).never
         get :report_data, params: { id: report_template.id, job_id: 'JOBID' }
         assert_response :unprocessable_entity
       end


### PR DESCRIPTION
Report templates fail to retrieve plan arguments while in planning state.
It just means I have forgot completely to cover this state, because of my little knowledge about dynflow. :disappointed: 