### PR TITLE
Fixes #26949 - Use $version instead of $release for FreeBSD

### DIFF
--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -8,9 +8,9 @@ class Freebsd < Operatingsystem
 
   # Simple output of the media url
   def mediumpath(medium_provider)
-    medium_provider.to_s do |vars|
+    medium_provider.medium_uri do |vars|
       transform_vars(vars)
-    end
+    end.to_s
   end
 
   def pxe_type
@@ -26,9 +26,9 @@ class Freebsd < Operatingsystem
   end
 
   def initrd(medium_provider)
-    medium_provider.interpolate_vars("boot/FreeBSD-$arch-$release-mfs.img") do |vars|
+    medium_provider.interpolate_vars("boot/FreeBSD-$arch-$version-mfs.img") do |vars|
       transform_vars(vars)
-    end
+    end.to_s
   end
 
   def display_family

--- a/test/factories/medium.rb
+++ b/test/factories/medium.rb
@@ -51,6 +51,12 @@ FactoryBot.define do
       os_family { 'Solaris' }
     end
 
+    trait :freebsd do
+      sequence(:name) { |n| "Freebsd Mirror #{n}"}
+      sequence(:path) { 'http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$major.$minor-RELEASE' }
+      os_family { 'Freebsd' }
+    end
+
     trait :with_operatingsystem do
       operatingsystems { [FactoryBot.create(:operatingsystem, :with_archs)] }
     end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -129,5 +129,13 @@ FactoryBot.define do
       type { 'Rancheros' }
       title { 'Rancheros 1.4.3' }
     end
+
+    factory :freebsd, class: Freebsd do
+      sequence(:name) { 'FreeBSD' }
+      major { '11' }
+      minor { '2' }
+      type { 'Freebsd' }
+      title { 'FreeBSD 11.2' }
+    end
   end
 end

--- a/test/models/operatingsystems/freebsd_test.rb
+++ b/test/models/operatingsystems/freebsd_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class FreebsdTest < ActiveSupport::TestCase
+  let(:operatingsystem) { FactoryBot.create(:freebsd) }
+  let(:architecture) { architectures(:x86_64) }
+  let(:medium) { FactoryBot.create(:medium, :freebsd) }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+
+  describe '#mediumpath' do
+    test 'generates the medium path url' do
+      assert_equal 'http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/11.2-RELEASE', operatingsystem.mediumpath(medium_provider)
+    end
+  end
+
+  describe '#kernel' do
+    test 'defauls the kernel to memdisk' do
+      assert_equal 'memdisk', operatingsystem.kernel(medium_provider)
+    end
+  end
+
+  describe '#initrd' do
+    test 'builds initrd url' do
+      assert_equal 'boot/FreeBSD-x86_64-11.2-mfs.img', operatingsystem.initrd(medium_provider)
+    end
+  end
+end


### PR DESCRIPTION
The `$release` variable only exists for Debian and Solaris. On FreeBSD, the @initrd macro should use `$version`.

[Issue in Redmine](https://projects.theforeman.org/issues/26949)

<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
