### PR TITLE
fixes #26955 - load boot settings from env variables

### DIFF
--- a/app/services/foreman/env_settings_loader.rb
+++ b/app/services/foreman/env_settings_loader.rb
@@ -1,0 +1,98 @@
+module Foreman
+  class EnvSettingsLoader
+    LOGGERS_FROM_ENV_REGEX = /^FOREMAN_LOGGERS_([A-Z0-9_]+)_[A-Z]+$/
+
+    attr_reader :env
+
+    def initialize(env: ENV)
+      @env = env
+    end
+
+    def to_h
+      result_hash = {}
+      settings_map.each do |env_key, definition|
+        value = env[env_key]
+        next unless value
+
+        type = definition.shift
+
+        value = cast_value(type: type, value: value)
+
+        path = definition + [value]
+        hsh = path.reverse.inject { |mem, key| {key => mem} }
+
+        result_hash.deep_merge!(hsh)
+      end
+      result_hash
+    end
+
+    private
+
+    def settings_map
+      {
+        'FOREMAN_UNATTENDED' => [:boolean, :unattended],
+        'FOREMAN_REQUIRE_SSL' => [:boolean, :require_ssl],
+        'FOREMAN_SUPPORT_JSONP' => [:boolean, :support_jsonp],
+        'FOREMAN_MARK_TRANSLATED' => [:boolean, :mark_translated],
+        'FOREMAN_WEBPACK_DEV_SERVER' => [:boolean, :webpack_dev_server],
+        'FOREMAN_WEBPACK_DEV_SERVER_HTTPS' => [:boolean, :webpack_dev_server_https],
+        'FOREMAN_ASSETS_DEBUG' => [:boolean, :assets_debug],
+        'FOREMAN_HSTS_ENABLED' => [:boolean, :hsts_enabled],
+        'FOREMAN_RAILS' => [:string, :rails],
+        'FOREMAN_DOMAIN' => [:string, :domain],
+        'FOREMAN_FQDN' => [:string, :fqdn],
+        'FOREMAN_CORS_DOMAINS' => [:list, :cors_domains],
+        'FOREMAN_LOGGING_LEVEL' => [:string, :logging, :level],
+        'FOREMAN_LOGGING_PRODUCTION_TYPE' => [:string, :logging, :production, :type],
+        'FOREMAN_LOGGING_PRODUCTION_LAYOUT' => [:string, :logging, :production, :layout],
+        'FOREMAN_TELEMETRY_PREFIX' => [:string, :telemetry, :prefix],
+        'FOREMAN_TELEMETRY_PROMETHEUS_ENABLED' => [:boolean, :telemetry, :prometheus, :enabled],
+        'FOREMAN_TELEMETRY_STATSD_ENABLED' => [:boolean, :telemetry, :statsd, :enabled],
+        'FOREMAN_TELEMETRY_STATSD_HOST' => [:string, :telemetry, :statsd, :host],
+        'FOREMAN_TELEMETRY_STATSD_PROTOCOL' => [:string, :telemetry, :statsd, :protocol],
+        'FOREMAN_TELEMETRY_LOGGER_ENABLED' => [:boolean, :telemetry, :logger, :enabled],
+        'FOREMAN_TELEMETRY_LOGGER_LEVEL' => [:string, :telemetry, :logger, :level],
+        'FOREMAN_DYNFLOW_POOL_SIZE' => [:integer, :dynflow, :pool_size],
+        'FOREMAN_RAILS_CACHE_STORE_TYPE' => [:string, :rails_cache_store, :type],
+        'FOREMAN_RAILS_CACHE_STORE_URLS' => [:list, :rails_cache_store, :urls],
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_COMPRESS' => [:boolean, :rails_cache_store, :options, :compress],
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_NAMESPACE' => [:string, :rails_cache_store, :options, :namespace],
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_CONNECT_TIMEOUT' => [:float, :rails_cache_store, :options, :connect_timeout],
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_READ_TIMEOUT' => [:float, :rails_cache_store, :options, :read_timeout],
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_WRITE_TIMEOUT' => [:float, :rails_cache_store, :options, :write_timeout]
+      }.merge(logger_settings_map)
+    end
+
+    def logger_settings_map
+      loggers_from_env.each_with_object({}) do |logger, hsh|
+        env_key = logger.to_s.upcase.gsub('/', '__')
+        hsh["FOREMAN_LOGGERS_#{env_key}_ENABLED"] = [:boolean, :loggers, logger, :enabled]
+        hsh["FOREMAN_LOGGERS_#{env_key}_LEVEL"] = [:string, :loggers, logger, :level]
+        hsh
+      end
+    end
+
+    def loggers_from_env
+      env.keys.grep(LOGGERS_FROM_ENV_REGEX).map { |key| key.gsub(LOGGERS_FROM_ENV_REGEX, '\1').downcase.gsub('__', '/').to_sym }.uniq
+    end
+
+    def cast_value(type:, value:)
+      case type
+      when :integer
+        value.to_i
+      when :float
+        value.to_f
+      when :boolean
+        !%w[0 false].include?(value.strip.downcase)
+      when :list
+        value.split(/[ ,]/)
+      when :dict
+        Hash[value.split(/[&,]/).map { |kv| kv.split('=') }]
+      when :string
+        value
+      else
+        raise "Unsupported type #{type} in definition for settings environment variable #{env_key}"
+      end
+    end
+  end
+end

--- a/config/boot_settings.rb
+++ b/config/boot_settings.rb
@@ -9,5 +9,6 @@ if File.exist?(settings_file)
   settings = YAML.load(ERB.new(File.read(settings_file)).result)
   SETTINGS[:rails] = settings[:rails] if settings[:rails]
 end
+SETTINGS[:rails] = ENV['FOREMAN_RAILS'] if ENV.key?('FOREMAN_RAILS')
 SETTINGS[:rails] ||= '5.2'
 SETTINGS[:rails] = '%.1f' % SETTINGS[:rails] if SETTINGS[:rails].is_a?(Float) # unquoted YAML value

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -1,11 +1,15 @@
 require_relative 'boot_settings'
 require_relative '../app/services/foreman/version'
+require_relative '../app/services/foreman/env_settings_loader'
 
 root = File.expand_path(File.dirname(__FILE__) + "/..")
 settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
 
 SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result) if File.exist?(settings_file)
 SETTINGS[:version] = Foreman::Version.new
+
+# Load settings from env variables
+SETTINGS.deep_merge!(Foreman::EnvSettingsLoader.new.to_h)
 
 # Force setting to true until all code using it is removed
 [:locations_enabled, :organizations_enabled].each do |setting|

--- a/test/unit/foreman/env_settings_loader_test.rb
+++ b/test/unit/foreman/env_settings_loader_test.rb
@@ -1,0 +1,123 @@
+require 'test_helper'
+
+class EnvSettingsLoaderTest < ActiveSupport::TestCase
+  let(:env) { {} }
+  let(:subject) { Foreman::EnvSettingsLoader.new(env: env) }
+
+  context 'with all settings' do
+    let(:env) do
+      {
+        'FOREMAN_UNATTENDED' => 'true',
+        'FOREMAN_REQUIRE_SSL' => 'true',
+        'FOREMAN_SUPPORT_JSONP' => 'false',
+        'FOREMAN_MARK_TRANSLATED' => 'false',
+        'FOREMAN_WEBPACK_DEV_SERVER' => 'false',
+        'FOREMAN_WEBPACK_DEV_SERVER_HTTPS' => 'false',
+        'FOREMAN_ASSETS_DEBUG' => 'false',
+        'FOREMAN_HSTS_ENABLED' => 'false',
+        'FOREMAN_RAILS' => '5.2',
+        'FOREMAN_DOMAIN' => 'example.com',
+        'FOREMAN_FQDN' => 'foreman.example.com',
+        'FOREMAN_CORS_DOMAINS' => 'https://foreman.example.com https://www.foreman.example.com',
+        'FOREMAN_LOGGING_LEVEL' => 'debug',
+        'FOREMAN_LOGGING_PRODUCTION_TYPE' => 'file',
+        'FOREMAN_LOGGING_PRODUCTION_LAYOUT' => 'multiline_pattern',
+        'FOREMAN_TELEMETRY_PREFIX' => 'fm_rails',
+        'FOREMAN_TELEMETRY_PROMETHEUS_ENABLED' => 'false',
+        'FOREMAN_TELEMETRY_STATSD_ENABLED' => 'false',
+        'FOREMAN_TELEMETRY_STATSD_HOST' => '127.0.0.1:8125',
+        'FOREMAN_TELEMETRY_STATSD_PROTOCOL' => 'statsd',
+        'FOREMAN_TELEMETRY_LOGGER_ENABLED' => 'false',
+        'FOREMAN_TELEMETRY_LOGGER_LEVEL' => 'DEBUG',
+        'FOREMAN_DYNFLOW_POOL_SIZE' => '5',
+        'FOREMAN_RAILS_CACHE_STORE_TYPE' => 'redis',
+        'FOREMAN_RAILS_CACHE_STORE_URLS' => 'redis://localhost:8479/0',
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_COMPRESS' => 'true',
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_NAMESPACE' => 'foreman',
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_CONNECT_TIMEOUT' => '30',
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_READ_TIMEOUT' => '0.2',
+        'FOREMAN_RAILS_CACHE_STORE_OPTIONS_WRITE_TIMEOUT' => '0.2'
+      }
+    end
+
+    test 'loads a settings hash' do
+      expected = {
+        unattended: true,
+        require_ssl: true,
+        support_jsonp: false,
+        mark_translated: false,
+        webpack_dev_server: false,
+        webpack_dev_server_https: false,
+        assets_debug: false,
+        hsts_enabled: false,
+        rails: '5.2',
+        domain: 'example.com',
+        fqdn: 'foreman.example.com',
+        cors_domains: ['https://foreman.example.com', 'https://www.foreman.example.com'],
+        logging: {
+          level: 'debug',
+          production: {
+            type: 'file',
+            layout: 'multiline_pattern'
+          }
+        },
+        telemetry: {
+          prefix: 'fm_rails',
+          prometheus: {
+            enabled: false
+          },
+          statsd: {
+            enabled: false,
+            host: '127.0.0.1:8125',
+            protocol: 'statsd'
+          },
+          logger: {
+            enabled: false,
+            level: 'DEBUG'
+          }
+        },
+        dynflow: {
+          pool_size: 5
+        },
+        rails_cache_store: {
+          type: 'redis',
+          urls: ['redis://localhost:8479/0'],
+          options: {
+            compress: true,
+            namespace: 'foreman',
+            connect_timeout: 30.0,
+            read_timeout: 0.2,
+            write_timeout: 0.2
+          }
+        }
+      }
+
+      assert_equal expected, subject.to_h
+    end
+  end
+
+  context 'with logger settings' do
+    let(:env) do
+      {
+        'FOREMAN_LOGGERS_SQL_ENABLED' => 'true',
+        'FOREMAN_LOGGERS_SQL_LEVEL' => 'info',
+        'FOREMAN_LOGGERS_PLUGIN__EXAMPLE_ENABLED' => 'true'
+      }
+    end
+
+    test 'loads a settings hash for loggers' do
+      expected = {
+        loggers: {
+          sql: {
+            enabled: true,
+            level: 'info'
+          },
+          'plugin/example': {
+            enabled: true
+          }
+        }
+      }
+      assert_equal expected, subject.to_h
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for defining the `SETTINGS` via env variables.

```sh
FOREMAN_HSTS_ENABLED=false bundle exec rails server
FOREMAN_LOGGERS_FOREMAN_WRECKINGBALL__IMPORT_ENABLED=false bundle exec rails server
```