### PR TITLE
Fixes #26957 - send request id instead session to proxy

### DIFF
--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -8,9 +8,17 @@ module ProxyAPI
     def initialize(args)
       raise("Must provide a protocol and host when initialising a smart-proxy connection") unless (url =~ /^http/)
 
-      @connect_params = {:timeout => Setting[:proxy_request_timeout], :open_timeout => 10,
-                         :headers => { :accept => :json, :x_request_id => request_id },
-                         :user => args[:user], :password => args[:password]}
+      @connect_params = {
+        :timeout => Setting[:proxy_request_timeout],
+        :open_timeout => 10,
+        :headers => {
+          :accept => :json,
+          :x_request_id => request_id,
+          :x_session_id => session_id
+        },
+        :user => args[:user],
+        :password => args[:password]
+      }
 
       # We authenticate only if we are using SSL
       @connect_params.merge!(ssl_auth_params) if url =~ /^https/i && !Rails.env.test?
@@ -108,7 +116,11 @@ module ProxyAPI
     end
 
     def request_id
-      ::Logging.mdc['session'] || SecureRandom.hex(32)
+      ::Logging.mdc['request'] || SecureRandom.uuid
+    end
+
+    def session_id
+      ::Logging.mdc['session'] || SecureRandom.uuid
     end
 
     def ssl_auth_params

--- a/test/unit/proxy_api/resource_test.rb
+++ b/test/unit/proxy_api/resource_test.rb
@@ -9,10 +9,19 @@ class ProxyApiResourceTest < ActiveSupport::TestCase
     assert ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id].present?
   end
 
+  test "connect_params sets x_request_id to logger request ID" do
+    begin
+      ::Logging.mdc['request'] = '850ca7f1-c6de-481f-86a9-dc379a04b445'
+      assert_equal '850ca7f1-c6de-481f-86a9-dc379a04b445', ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id]
+    ensure
+      ::Logging.mdc.delete('request')
+    end
+  end
+
   test "connect_params sets x_request_id to logger safe session ID" do
     begin
-      ::Logging.mdc['session'] = 'test'
-      assert_equal 'test', ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_request_id]
+      ::Logging.mdc['session'] = '850ca7f1-c6de-481f-86a9-dc379a04b446'
+      assert_equal '850ca7f1-c6de-481f-86a9-dc379a04b446', ProxyAPI::Resource.new({}).send(:connect_params)[:headers][:x_session_id]
     ensure
       ::Logging.mdc.delete('session')
     end


### PR DESCRIPTION
We send the data to correlate logs but instead request we send session
id. This is confusing and this patch fixes that. Additionally, it also
now sends both so proxy can actually process and log both as both can be
useful when digging in logs.

Can I ask for this one into 1.22? We are targetting improving logging in
1.22 and this is a tiny bug that can make searching for logs confusing.
@tbrisker @ares