### PR TITLE
Fixes #26974 - removed hardcoded timeout

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -18,7 +18,7 @@ class Setting::General < Setting
       self.set('max_trend', N_("Max days for Trends graphs"), 30, N_('Max trends')),
       self.set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true, N_('DB pending migration')),
       self.set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true, N_('DB pending seed')),
-      self.set('proxy_request_timeout', N_("Max timeout for REST client requests to smart-proxy"), 60, N_('Proxy request timeout')),
+      self.set('proxy_request_timeout', N_("Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"), 60, N_('Smart Proxy request timeout')),
       self.set('login_text', N_("Text to be shown in the login-page footer"), nil, N_('Login page footer text')),
       self.set('host_power_status', N_("Show power status on host index page. This feature calls to compute resource providers which may lead to decreased performance on host listing page."), true, N_('Show host power status')),
       self.set('http_proxy', N_('Sets a proxy for all outgoing HTTP connections.'), nil, N_('HTTP(S) proxy')),

--- a/lib/proxy_api/resource.rb
+++ b/lib/proxy_api/resource.rb
@@ -10,7 +10,6 @@ module ProxyAPI
 
       @connect_params = {
         :timeout => Setting[:proxy_request_timeout],
-        :open_timeout => 10,
         :headers => {
           :accept => :json,
           :x_request_id => request_id,


### PR DESCRIPTION
[skip ci]

We hardcode it to 10 seconds but timeout (read timeout) is configurable. This is confusing, let's drop the hardcoded value so "timeout" setting will set all three timeouts at once:

https://github.com/rest-client/rest-client#timeouts

Also this patch adds a note about hammer.