### PR TITLE
Fixes #26909 - Validate fqdn matcher by hosts' primary nic name

### DIFF
--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -67,6 +67,19 @@ class LookupValueTest < ActiveSupport::TestCase
     end
   end
 
+  test "can create lookup value if match fqdn= does match existing host" do
+    as_admin do
+      Setting[:append_domain_name_for_hosts] = false
+      domain = FactoryBot.create(:domain)
+      host = FactoryBot.create(:host, interfaces: [FactoryBot.build(:nic_managed, identifier: 'fqdn_test', primary: true, domain: domain)])
+      attrs = { :match => "fqdn=#{host.primary_interface.fqdn}", :value => "123", :lookup_key_id => lookup_keys(:one).id }
+      refute_match /#{domain.name}/, host.name, "#{host.name} shouldn't be FQDN"
+      assert_difference('LookupValue.count') do
+        LookupValue.create!(attrs)
+      end
+    end
+  end
+
   test "can create lookup value if user has matching hostgroup " do
     as_user :one do
       lookup_value = LookupValue.new(valid_attrs2)


### PR DESCRIPTION
When "Append domain names to the host"  setting is set to "No", Foreman won't append the domain name to the host after provisioning so host.name will remain as short name. Without this patch, user cannot create/update a lookup value with matcher fqdn=host.domain.com because it will fail with validation error. The reason that it failed to validate is Foreman uses the host.name(shortname) to find for existing host that matches "host.domain.com" which will never match. This patch fixed the issue.