### PR TITLE
Fixes #27049 - Add onPopState HOC

### DIFF
--- a/webpack/assets/javascripts/react_app/common/HOC.js
+++ b/webpack/assets/javascripts/react_app/common/HOC.js
@@ -16,6 +16,23 @@ export const callOnMount = callback => WrappedComponent => componentProps => {
 };
 
 /**
+ * HOC that runs a function onPopState if search query has changed,
+ * assuming the component has withRouter
+ * @param {Function} callback - function to run
+ */
+export const callOnPopState = callback => WrappedComponent => componentProps => {
+  useEffect(() => {
+    const {
+      history: { action },
+    } = componentProps;
+
+    if (action === 'POP') callback(componentProps);
+  }, [componentProps.location.search]);
+
+  return <WrappedComponent {...componentProps} />;
+};
+
+/**
  * HOC That renders a component based on its state
  *
  * the following root Component props are required

--- a/webpack/assets/javascripts/react_app/common/HOC.test.js
+++ b/webpack/assets/javascripts/react_app/common/HOC.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { callOnMount, withRenderHandler } from './HOC';
+import { callOnMount, withRenderHandler, callOnPopState } from './HOC';
 
 const Component = () => <div>component mounted</div>;
 
@@ -50,6 +50,22 @@ describe('HOCs', () => {
     const callback = jest.fn();
     const OnMount = callOnMount(callback)(Component);
     mount(<OnMount />);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('test callOnPopState', () => {
+    const callback = jest.fn();
+    const props = {
+      history: { action: 'PUSH' },
+      location: { search: 'search' },
+    };
+
+    const OnPopState = callOnPopState(callback)(Component);
+    const wrapper = mount(<OnPopState {...props} />);
+    wrapper.setProps({
+      history: { action: 'POP' },
+      location: { search: 'changed' },
+    });
     expect(callback).toHaveBeenCalled();
   });
 });

--- a/webpack/stories/docs/hoc.md
+++ b/webpack/stories/docs/hoc.md
@@ -1,0 +1,83 @@
+
+# Higher Order Components
+
+A higher-order component (HOC) is an advanced technique in React for reusing component logic. We have created several HOCs which makes it easier to write, read and maintain new code.
+
+## `withRenderHandler({ Component, LoadingComponent, ErrorComponent, EmptyComponent})`
+This HOC help us get rid of conditional rendering inside a component.
+It renders the right component based on its state
+
+  the following root Component props are required
+  `{ isLoading, hasData, hasError }`
+
+  If the default Error and Empty Components are used
+  the following props are also required:
+  `{ message: { type, text }}`
+
+
+Here we can see all the optional states and their chosen view.
+
+| isLoading | hasData | hasError | VIEW | Comments |
+| ------------- | ------------- | ----------- | ------------ | ------------ |
+| TRUE💚   | FALSE🔴  | FALSE🔴 | **Loading** | Initial Loading **OR** after Message |
+| FALSE🔴  | TRUE💚  | FALSE🔴 | **Component** | Show Data |
+| TRUE💚  | TRUE💚  | FALSE🔴 | **Component** | Outdated data exists, should not show loading to avoid flickering so we still show the component with the outdated data until the new data arrives |
+| FALSE🔴  | FALSE🔴  | FALSE🔴 | **Empty** | query returned 0 results, this is not an error, and we display a message |
+| FALSE🔴  | FALSE🔴  | TRUE💚 | **Error** | query failed, and we display a message |
+
+### Example
+```js
+// before
+const Statistics = ({ isLoading, hasError, hasData, statisticsMeta }) => {
+  if (isLoading && !hasData) return <StatisticsLoadingPage />;
+
+  if (hasError) return <StatisticsErrorPage />;
+
+  if (hasData) return <StatisticsChartsList data={statisticsMeta} />;
+
+  return StatisticsEmptyPage;
+};
+
+export default Statistics;
+```
+```js
+// after
+const Statistics = ({ statisticsMeta }) => (
+  <StatisticsChartsList data={statisticsMeta} />
+);
+
+export default withRenderHandler({
+  Component: Statistics,
+  // Empty, Error, and Loading has a default Component if not received
+});
+```
+
+## `callOnMount(callback(props))`
+This HOC runs a function on the initial mount of the component using useEffect
+
+### Example
+```js
+// export connected component
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  callOnMount(({ getStatisticsMeta }) => getStatisticsMeta())
+)(StatisticsPage);
+```
+
+## `callOnPopState(callback(props))`
+This HOC runs a function onPopState if search query has changed, assuming the Page is wrapped withRouter
+
+### Example
+```js
+// export connected component
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  ),
+  callOnPopState(({ getStatisticsOnPop }) => getStatisticsOnPop())
+)(StatisticsPage);
+```

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -6,6 +6,7 @@ import Story from './components/Story';
 import './index.scss';
 import gettingStarted from './docs/gettingStarted.md';
 import addingNewComponent from './docs/addingNewComponent.md';
+import hoc from './docs/hoc.md';
 import addingDependencies from './docs/addingDependencies.md';
 import internationalization from './docs/internationalization.md';
 import plugins from './docs/plugins.md';
@@ -35,6 +36,11 @@ storiesOf('Introduction', module)
   .add('Adding new component', () => (
     <Story>
       <Markdown source={addingNewComponent} />
+    </Story>
+  ))
+  .add('HOCs', () => (
+    <Story>
+      <Markdown source={hoc} />
     </Story>
   ))
   .add('Adding dependencies', () => (


### PR DESCRIPTION
New pages that are wrapped with `withRouter` can use this HOC to trigger a callback when the search query changes.

Also hijacking this PR to add missing `ReactApp` selectors
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
