### PR TITLE
Fixes #26393 - fix uptime calculation for btime

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -276,7 +276,7 @@ module HostsHelper
     fields += [[_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => %{os_title = "#{host.operatingsystem.title}"}))]] if host.operatingsystem.present?
     fields += [[_("PXE Loader"), host.pxe_loader]] if host.operatingsystem.present? && !host.image_build?
     fields += [[_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))]] if host.hostgroup.present?
-    fields += [[_("Uptime"), time_ago_in_words(host.uptime_seconds.seconds.from_now)]] if host.uptime_seconds.present?
+    fields += [[_("Boot time"), (boot_time = host&.reported_data&.boot_time) ? date_time_relative(boot_time) : _('Not reported')]]
     fields += [[_("Location"), (link_to(host.location.title, hosts_path(:search => %{location = "#{host.location}"})) if host.location)]] if SETTINGS[:locations_enabled]
     fields += [[_("Organization"), (link_to(host.organization.title, hosts_path(:search => %{organization = "#{host.organization}"})) if host.organization)]] if SETTINGS[:organizations_enabled]
     if host.owner_type == _("User")

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -67,6 +67,8 @@ module Hostext
       scoped_search :relation => :fact_values, :on => :value, :in_key => :fact_names, :on_key => :name, :rename => :facts, :complete_value => true, :only_explicit => true, :ext_method => :search_cast_facts
       scoped_search :relation => :search_parameters, :on => :name, :complete_value => true, :rename => :params, :only_explicit => true
 
+      scoped_search :relation => :reported_data, :on => :boot_time, :rename => 'boot_time'
+
       if SETTINGS[:locations_enabled]
         scoped_search :relation => :location, :on => :title, :rename => :location, :complete_value => true, :only_explicit => true
         scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -366,7 +366,12 @@ module Host
     end
 
     def uptime_seconds
-      self.uptime_fact&.value&.to_i
+      fact = self.uptime_fact
+      if fact&.fact_name&.name == 'proc_stat::btime'
+        Time.now.to_i - fact&.value&.to_i
+      else
+        fact&.value&.to_i
+      end
     end
 
     private

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -1,7 +1,6 @@
 module Host
   class Base < ApplicationRecord
     KERNEL_RELEASE_FACTS = [ 'kernelrelease', 'ansible_kernel', 'kernel::release' ]
-    UPTIME_FACTS = [ 'system_uptime::seconds', 'ansible_uptime_seconds', 'uptime_seconds', 'proc_stat::btime' ]
 
     prepend Foreman::STI
     include Authorizable
@@ -29,7 +28,6 @@ module Host
     has_one :subnet, :through => :primary_interface
     has_one :subnet6, :through => :primary_interface
     has_one :kernel_release, -> { joins(:fact_name).where({ 'fact_names.name' => KERNEL_RELEASE_FACTS }).order('fact_names.type') }, :class_name => '::FactValue', :foreign_key => 'host_id'
-    has_one :uptime_fact, -> { joins(:fact_name).where({ 'fact_names.name' => UPTIME_FACTS }).order('fact_values.updated_at DESC') }, :class_name => '::FactValue', :foreign_key => 'host_id'
     accepts_nested_attributes_for :interfaces, :allow_destroy => true
 
     belongs_to :location
@@ -187,6 +185,7 @@ module Host
       build_required_interfaces(:managed => false)
       set_non_empty_values(parser, attributes_to_import_from_facts)
       set_interfaces(parser) if parser.parse_interfaces?
+      set_reported_data(parser)
     end
 
     def set_non_empty_values(parser, methods)
@@ -232,6 +231,16 @@ module Host
       telemetry_increment_counter(:importer_facts_count_interfaces, changed_count, type: parser.class_name_humanized)
 
       self.interfaces.reload
+    end
+
+    def set_reported_data(parser)
+      return unless parser.boot_timestamp
+
+      reported_data_facet.update!(boot_time: Time.at(parser.boot_timestamp)) if self.persisted?
+    end
+
+    def reported_data_facet
+      self.reported_data || self.build_reported_data
     end
 
     def facts_hash
@@ -366,12 +375,8 @@ module Host
     end
 
     def uptime_seconds
-      fact = self.uptime_fact
-      if fact&.fact_name&.name == 'proc_stat::btime'
-        Time.now.to_i - fact&.value&.to_i
-      else
-        fact&.value&.to_i
-      end
+      boot_time = self&.reported_data&.boot_time
+      boot_time.nil? ? nil : Time.zone.now.to_i - boot_time.to_i
     end
 
     private

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -300,6 +300,7 @@ class Host::Managed < Host::Base
     return unless respond_to?(:old) && old && build? && !old.build?
     clear_facts
     clear_reports
+    self.reported_data_facet.destroy
     self.build_errors = nil
   end
 

--- a/app/models/host_facets.rb
+++ b/app/models/host_facets.rb
@@ -1,0 +1,5 @@
+module HostFacets
+  def self.table_name_prefix
+    'host_facets_'
+  end
+end

--- a/app/models/host_facets/reported_data_facet.rb
+++ b/app/models/host_facets/reported_data_facet.rb
@@ -1,0 +1,4 @@
+module HostFacets
+  class ReportedDataFacet < Base
+  end
+end

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -102,6 +102,12 @@ class FactParser
     @class_name_humanized ||= self.class.name.demodulize.underscore
   end
 
+  # timestamp (unix epoch based) when the host has booted, e.g. 1563281738
+  # should return nil if the parser does not support this information
+  def boot_timestamp
+    nil
+  end
+
   private
 
   def find_interface_by_name(host_name)

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -132,6 +132,12 @@ class PuppetFactParser < FactParser
     true
   end
 
+  def boot_timestamp
+    # system_uptime::seconds is Facter 3, we also fallback to Facter 2 uptime_seconds
+    uptime_seconds = facts.fetch('system_uptime', {}).fetch('seconds', nil) || facts[:uptime_seconds]
+    uptime_seconds.nil? ? nil : (Time.zone.now.to_i - uptime_seconds.to_i)
+  end
+
   private
 
   # remove when dropping support for facter < 3.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -273,6 +273,10 @@ module Foreman
         child.helper helpers
       end
 
+      Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
+        set_dependent_action :destroy
+      end
+
       Plugin.all.each do |plugin|
         plugin.to_prepare_callbacks.each(&:call)
       end

--- a/db/migrate/20190630034751_create_host_facets_reported_data_facets.rb
+++ b/db/migrate/20190630034751_create_host_facets_reported_data_facets.rb
@@ -1,0 +1,10 @@
+class CreateHostFacetsReportedDataFacets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :host_facets_reported_data_facets do |t|
+      t.references :host, type: :integer, foreign_key: true, index: { unique: true }
+      t.datetime :boot_time
+
+      t.timestamps
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3754,6 +3754,13 @@ class HostTest < ActiveSupport::TestCase
       assert_equal 123, host.uptime_seconds
     end
 
+    test 'should return uptime in seconds also when based on boot time fact' do
+      host = FactoryBot.create(:host)
+      fact = FactoryBot.create(:fact_name, name: 'proc_stat::btime')
+      FactoryBot.create(:fact_value, fact_name: fact, host: host, :value => 1560178781)
+      assert_in_delta host.uptime_seconds, Time.now.to_i - 1560178781, 10
+    end
+
     test 'should return nil if no uptime fact is available' do
       host = FactoryBot.create(:host)
       assert_nil host.uptime_seconds
@@ -3761,8 +3768,8 @@ class HostTest < ActiveSupport::TestCase
 
     test 'should return uptime and based on backup facts even if there are multiple other facts' do
       host = FactoryBot.create(:host)
-      ansible_uptime_fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds', :type => 'FactName::Ansible')
-      chef_uptime_fact = FactoryBot.create(:fact_name, name: 'uptime_seconds', :type => 'FactName::Chef')
+      ansible_uptime_fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds')
+      chef_uptime_fact = FactoryBot.create(:fact_name, name: 'uptime_seconds')
       unrelated_fact = FactoryBot.create(:fact_name, name: 'os')
       puppet_fact = FactoryBot.create(:fact_name, name: 'system_uptime::seconds')
       ansible_fact = FactoryBot.create(:fact_value, fact_name: ansible_uptime_fact, host: host, :value => 123)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -266,6 +266,27 @@ class HostTest < ActiveSupport::TestCase
       host.expects(:enable_orchestration!).never
       assert host.import_facts(raw['facts'])
     end
+
+    test 'should import facts boot time to report data facet' do
+      refute Host.find_by_name('sinn1636.lan')
+      raw = read_json_fixture('facts/facts_with_certname.json')
+      first_boot_time = nil
+      host = nil
+      freeze_time do
+        host = Host.import_host(raw['name'], 'puppet')
+        assert host.import_facts(raw['facts'])
+        first_boot_time = host.reported_data.boot_time
+        refute_nil host.reported_data.boot_time
+        assert_equal Time.now - raw['facts']['uptime_seconds'].to_i.seconds, host.reported_data.boot_time
+      end
+
+      travel 1.minute do
+        # it gets updated if the facet exists
+        assert host.import_facts(raw['facts'])
+        second_boot_time = host.reported_data.boot_time
+        refute_equal first_boot_time, second_boot_time, "boot time didn't get updated during second import of facts"
+      end
+    end
   end
 
   context "when enable_orchestration_on_fact_import is true" do
@@ -3749,41 +3770,41 @@ class HostTest < ActiveSupport::TestCase
   describe '#uptime_seconds' do
     test 'should return uptime in seconds' do
       host = FactoryBot.create(:host)
-      fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds')
-      FactoryBot.create(:fact_value, fact_name: fact, host: host, :value => 123)
-      assert_equal 123, host.uptime_seconds
-    end
-
-    test 'should return uptime in seconds also when based on boot time fact' do
-      host = FactoryBot.create(:host)
-      fact = FactoryBot.create(:fact_name, name: 'proc_stat::btime')
-      FactoryBot.create(:fact_value, fact_name: fact, host: host, :value => 1560178781)
-      assert_in_delta host.uptime_seconds, Time.now.to_i - 1560178781, 10
+      boot_time = 1.day.ago
+      host.create_reported_data(:boot_time => boot_time)
+      now = Time.zone.now.to_i
+      assert_equal host.uptime_seconds, now - boot_time.to_i
     end
 
     test 'should return nil if no uptime fact is available' do
       host = FactoryBot.create(:host)
       assert_nil host.uptime_seconds
     end
+  end
 
-    test 'should return uptime and based on backup facts even if there are multiple other facts' do
+  describe '#uptime_seconds' do
+    test 'should not fail on host without reported data' do
       host = FactoryBot.create(:host)
-      ansible_uptime_fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds')
-      chef_uptime_fact = FactoryBot.create(:fact_name, name: 'uptime_seconds')
-      unrelated_fact = FactoryBot.create(:fact_name, name: 'os')
-      puppet_fact = FactoryBot.create(:fact_name, name: 'system_uptime::seconds')
-      ansible_fact = FactoryBot.create(:fact_value, fact_name: ansible_uptime_fact, host: host, :value => 123)
-      cf = FactoryBot.create(:fact_value, fact_name: chef_uptime_fact, host: host, :value => 222)
-      cf.update_attribute :updated_at, cf.updated_at + 1.second
-      FactoryBot.create(:fact_value, fact_name: unrelated_fact, host: host, :value => 'Fedora 29')
-      assert_equal 222, host.uptime_seconds
-      pf = FactoryBot.create(:fact_value, fact_name: puppet_fact, host: host, :value => 456)
-      pf.update_attribute :updated_at, cf.updated_at + 2.seconds
+      assert_nothing_raised do
+        host.clear_data_on_build
+      end
+    end
+
+    test 'should delete reported data on rebuild' do
+      host = FactoryBot.create(:host)
+      boot_time = 1.day.ago
+      host.create_reported_data(:boot_time => boot_time)
+      refute_nil host.uptime_seconds
+      host.instance_variable_set '@old', host.clone
+      host.build = true
+      host.clear_data_on_build
       host.reload
-      assert_equal 456, host.uptime_seconds
-      ansible_fact.update :value => 789, :updated_at => cf.updated_at + 3.seconds
-      host.reload
-      assert_equal 789, host.uptime_seconds
+      assert_nil host.uptime_seconds
+    end
+
+    test 'should return nil if no uptime fact is available' do
+      host = FactoryBot.create(:host)
+      assert_nil host.uptime_seconds
     end
   end
 

--- a/test/models/hosts/base_test.rb
+++ b/test/models/hosts/base_test.rb
@@ -15,7 +15,7 @@ module Host
     should allow_value('hostname.with.periods').for(:name)
 
     test "should import facts from json stream" do
-      host = Host::Base.new(:name => "sinn1636.lan")
+      host = Host::Managed.new(:name => "sinn1636.lan")
       assert host.import_facts(read_json_fixture('facts/facts.json')['facts'])
     end
 

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -69,9 +69,11 @@ class BaseMacrosTest < ActiveSupport::TestCase
   describe '#host_uptime_seconds' do
     test 'should return host uptime in seconds' do
       host = FactoryBot.create(:host)
-      fact = FactoryBot.create(:fact_name, name: 'ansible_uptime_seconds')
-      FactoryBot.create(:fact_value, fact_name: fact, host: host, :value => '123')
-      assert_equal 123, @scope.host_uptime_seconds(host)
+      facet = host.reported_data_facet
+      freeze_time do
+        facet.update!(:boot_time => 123.seconds.ago)
+        assert_equal 123, @scope.host_uptime_seconds(host)
+      end
     end
   end
 

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -396,6 +396,14 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     assert_nil parser.interfaces['eth1_1']
   end
 
+  test "#test boot time based on uptime" do
+    host = FactoryBot.build(:host, :hostgroup => FactoryBot.build(:hostgroup))
+    freeze_time do
+      parser = get_parser(host.facts_hash.merge({:uptime_seconds => (60 * 5).to_s}))
+      assert_equal 5.minutes.ago.to_i, parser.boot_timestamp
+    end
+  end
+
   private
 
   def get_parser(facts)


### PR DESCRIPTION
Thet source of uptime information coming from subscription manager does
not mean uptime but boot time, so we need to convert it in uptime
seconds method.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
