### PR TITLE
Fixes #27052 - Convert ModelsTable to react hooks

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTable.js
+++ b/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Spinner } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import { Table } from '../common/table';
@@ -8,42 +8,40 @@ import { translate as __ } from '../../common/I18n';
 import createModelsTableSchema from './ModelsTableSchema';
 import { getURIQuery } from '../../common/helpers';
 
-class ModelsTable extends React.Component {
-  componentDidMount() {
-    this.props.getTableItems(getURIQuery(window.location.href));
-  }
+const ModelsTable = ({
+  getTableItems,
+  sortBy,
+  sortOrder,
+  error,
+  status,
+  results,
+}) => {
+  useEffect(() => {
+    getTableItems(getURIQuery(window.location.href));
+  }, []);
 
-  render() {
-    const {
-      getTableItems,
-      sortBy,
-      sortOrder,
-      error,
-      status,
-      results,
-    } = this.props;
-
-    const renderTable =
-      status === STATUS.ERROR ? (
-        <MessageBox
-          key="models-table-error"
-          icontype="error-circle-o"
-          msg={__(`Could not receive data: ${error && error.message}`)}
-        />
-      ) : (
-        <Table
-          key="models-table"
-          columns={createModelsTableSchema(getTableItems, sortBy, sortOrder)}
-          rows={results}
-        />
-      );
-
-    if (results.length > 0) {
-      return renderTable;
-    }
+  if (results.length === 0) {
     return <Spinner size="lg" loading />;
   }
-}
+
+  if (status === STATUS.ERROR) {
+    return (
+      <MessageBox
+        key="models-table-error"
+        icontype="error-circle-o"
+        msg={__(`Could not receive data: ${error && error.message}`)}
+      />
+    );
+  }
+
+  return (
+    <Table
+      key="models-table"
+      columns={createModelsTableSchema(getTableItems, sortBy, sortOrder)}
+      rows={results}
+    />
+  );
+};
 
 ModelsTable.propTypes = {
   results: PropTypes.array.isRequired,

--- a/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTable.test.js
+++ b/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTable.test.js
@@ -1,23 +1,29 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ModelsTable from './ModelsTable';
 import { Table } from '../common/table';
 import MessageBox from '../common/MessageBox';
 
-const data = {
-  pagination: {
-    vieType: 'table',
-    perPageOptions: [1, 2, 3],
-    itemCount: 5,
-    perPage: 1,
+const results = [
+  {
+    info: null,
+    created_at: '2018-03-26 09:54:21 +0300',
+    updated_at: '2018-03-26 09:54:21 +0300',
+    vendor_class: null,
+    hardware_model: null,
+    id: 29,
+    name: 'X8SIL',
+    can_edit: true,
+    can_delete: true,
+    hosts_count: 1,
   },
-};
+];
 
 describe('ModelsTable', () => {
   it('render table on sucess', () => {
     const getModelItems = jest.fn().mockReturnValue([]);
-    const view = shallow(
-      <ModelsTable results={[{}]} getTableItems={getModelItems} data={data} />
+    const view = mount(
+      <ModelsTable results={results} getTableItems={getModelItems} />
     );
     expect(getModelItems.mock.calls).toHaveLength(1);
     expect(view.find(Table)).toHaveLength(1);
@@ -30,7 +36,6 @@ describe('ModelsTable', () => {
         results={[{}]}
         error={Error('some error message')}
         status="ERROR"
-        data={data}
       />
     );
     expect(view.find(MessageBox)).toHaveLength(1);

--- a/webpack/assets/javascripts/react_app/components/common/table/formatters/ellipsisCellFormatter.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/formatters/ellipsisCellFormatter.js
@@ -3,4 +3,4 @@ import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import cellFormatter from './cellFormatter';
 
 export default value =>
-  cellFormatter(<EllipsisWithTooltip>{value}</EllipsisWithTooltip>);
+  cellFormatter(<EllipsisWithTooltip>{value || ''}</EllipsisWithTooltip>);


### PR DESCRIPTION
Also reordered the conditions to return earlier when possible.

Not sure why, the test currently fails claiming the mock isn't being called, but when viewing the actual page it is rendered properly. I'm guessing perhaps shallow() doesn't trigger hooks. @glekner any idea?
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
