### PR TITLE
Fixes #27055 - allow http for userdata controller

### DIFF
--- a/app/controllers/concerns/foreman/controller/require_ssl.rb
+++ b/app/controllers/concerns/foreman/controller/require_ssl.rb
@@ -12,6 +12,10 @@ module Foreman
       def require_ssl?
         SETTINGS[:require_ssl]
       end
+
+      def unattended_ssl?
+        SETTINGS[:require_ssl] && URI.parse(Setting[:unattended_url]).scheme == 'https'
+      end
     end
   end
 end

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -71,7 +71,7 @@ class UnattendedController < ApplicationController
   protected
 
   def require_ssl?
-    preview? ? super : false
+    preview? ? super : unattended_ssl?
   end
 
   private

--- a/app/controllers/userdata_controller.rb
+++ b/app/controllers/userdata_controller.rb
@@ -26,6 +26,12 @@ class UserdataController < ApplicationController
     render plain: data.map { |key, value| "#{key}: #{value}" }.join("\n")
   end
 
+  protected
+
+  def require_ssl?
+    unattended_ssl?
+  end
+
   private
 
   def render_userdata_template

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -42,7 +42,7 @@ class Setting::Provisioning < Setting
     [
       self.set('host_owner', N_("Default owner on provisioned hosts, if empty Foreman will use current user"), nil, N_('Host owner'), nil, {:collection => Proc.new { select }, :include_blank => _("Select an owner")}),
       self.set('root_pass', N_("Default encrypted root password on provisioned hosts"), nil, N_('Root password')),
-      self.set('unattended_url', N_("URL hosts will retrieve templates from during build (normally http as many installers don't support https)"), unattended_url, N_('Unattended URL')),
+      self.set('unattended_url', N_("URL hosts will retrieve templates from during build, when it starts with https unattended/userdata controllers cannot be accessed via HTTP"), unattended_url, N_('Unattended URL')),
       self.set('safemode_render', N_("Enable safe mode config templates rendering (recommended)"), true, N_('Safemode rendering')),
       self.set('access_unattended_without_build', N_("Allow access to unattended URLs without build mode being used"), false, N_('Access unattended without build')),
       self.set('manage_puppetca', N_("Foreman will automate certificate signing upon provision of new host"), true, N_('Manage PuppetCA')),


### PR DESCRIPTION
So users do not need to bake server CA cert into the cloud-init image.