### PR TITLE
Fixes #27060 - add launch vm wait time setting

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -201,6 +201,12 @@ module Orchestration::Compute
   end
 
   def setComputePowerUp
+    delay = (Setting[:launch_vm_wait].to_i rescue 0)
+    if delay && !ActiveRecord::Base.connection.transaction_open?
+      logger.warn "Waiting #{delay} seconds due to 'VM Launch Wait' global setting"
+      sleep delay
+    end
+
     logger.info "Powering up Compute instance for #{name}"
     compute_resource.start_vm uuid
   rescue => e

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -64,6 +64,7 @@ class Setting::Provisioning < Setting
       self.set('default_pxe_item_global', N_("Default PXE menu item in global template - 'local', 'discovery' or custom, use blank for template default"), nil, N_("Default PXE global template entry")),
       self.set('default_pxe_item_local', N_("Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"), nil, N_("Default PXE local template entry")),
       self.set('intermediate_ipxe_script', N_('Intermediate iPXE script for unattended installations'), 'iPXE intermediate script', N_('iPXE intermediate script'), nil, { :collection => Proc.new { Hash[ProvisioningTemplate.unscoped.of_kind(:iPXE).map { |tmpl| [tmpl.name, tmpl.name] }] } }),
+      self.set('launch_vm_wait', N_('Delay in seconds before a VM is launched'), 0, N_('VM Launch Wait')),
       self.set(
         'destroy_vm_on_host_delete',
         N_("Destroy associated VM on host delete. When enabled, VMs linked to Hosts will be deleted on Compute Resource. When disabled, VMs are unlinked when the host is deleted, meaning they remain on Compute Resource and can be re-associated or imported back to Foreman again. This does not automatically power off the VM"),

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -399,3 +399,8 @@ attribute85:
   category: Setting::Provisioning
   default: nil
   description: 'Intermidiate iPXE script'
+attribute86:
+  name: launch_vm_wait
+  category: Setting::Provisioning
+  default: 0
+  description: 'VM Launch Wait'


### PR DESCRIPTION
Some backend engines (e.g. Infoblox DHCP) takes 1-2 minutes to apply the changes which leads to boot errors of VMs orchestrated by Foreman. New setting "Launch VM Wait Time" should solve this easily.