### PR TITLE
Fixes #27067 - IPAM Integration with phpIPAM

### DIFF
--- a/app/helpers/subnets_helper.rb
+++ b/app/helpers/subnets_helper.rb
@@ -33,4 +33,8 @@ module SubnetsHelper
     return [] unless Subnet::SUBNET_TYPES.key?(type.to_sym)
     type.safe_constantize.supported_ipam_modes_with_translations
   end
+
+  def external_ipam?(subnet)
+    subnet&.ipam&.downcase == "external ipam"
+  end
 end

--- a/app/models/concerns/orchestration/external_ipam.rb
+++ b/app/models/concerns/orchestration/external_ipam.rb
@@ -16,7 +16,7 @@ module Orchestration::ExternalIPAM
   protected
 
   def set_external_ip
-    if ip_available?
+    if ip_is_available?
       response = subnet.external_ipam_proxy.add_ip_to_subnet(ip, subnet)
       success?(response, 'Address created')
     else
@@ -45,7 +45,7 @@ module Orchestration::ExternalIPAM
     !old.ip.nil? && !old.subnet_id.nil?
   end
 
-  def ip_available?
+  def ip_is_available?
     response = subnet.external_ipam_proxy.ip_exists(ip, subnet)
     success?(response, 'No addresses found')
   end

--- a/app/models/concerns/orchestration/external_ipam.rb
+++ b/app/models/concerns/orchestration/external_ipam.rb
@@ -1,0 +1,79 @@
+module Orchestration::ExternalIPAM
+  extend ActiveSupport::Concern
+  include Orchestration::Common
+  include SubnetsHelper
+
+  included do
+    after_validation :queue_external_ipam
+    before_destroy :queue_external_ipam_destroy
+  end
+
+  def generate_external_ipam_task_id(action, interface = self)
+    id = [interface.mac, interface.ip, interface.identifier, interface.id].find {|x| x&.present?}
+    "external_ipam_#{action}_#{id}"
+  end
+
+  protected
+
+  def set_external_ip
+    if ip_available
+      subnet.external_ipam_proxy.add_ip_to_subnet(ip, subnet)
+    else
+      self.errors.add :ip, _('IP address ' + ip + ' has already been reserved in External IPAM')
+      self.errors.add :interfaces, _('Some interfaces are invalid')
+    end
+  end
+
+  # Empty method for rollbacks. We don't want to delete IP's from IPAM when there
+  # is a conflict(i.e. IP address already taken)
+  def del_external_ip
+  end
+
+  def remove_external_ip
+    subnet.external_ipam_proxy.delete_ip_from_subnet(ip, subnet)
+  end
+
+  def requires_update?
+    return false if new_record?
+    old.ip != self.ip
+  end
+
+  def requires_delete?
+    old = Nic::Base.find(id)
+    !old.ip.nil? && !old.subnet_id.nil?
+  end
+
+  def ip_available
+    subnet.external_ipam_proxy.ip_exists(ip, subnet)['exists'] == false
+  end
+
+  private
+
+  def queue_external_ipam
+    new_record? ? queue_external_ipam_create : queue_external_ipam_update
+  end
+
+  def queue_external_ipam_create
+    return unless external_ipam?(subnet) && errors.empty?
+    logger.debug "Scheduling new IP reservation in external IPAM for #{self}"
+    queue.create(id: generate_external_ipam_task_id("create"), name: _("Creating IP in External IPAM for %s") % self, priority: 10, action: [self, :set_external_ip]) if external_ipam?(subnet)
+    true
+  end
+
+  def queue_external_ipam_destroy
+    return unless external_ipam?(subnet) && errors.empty?
+    logger.debug "Removing IP reservation in external IPAM for #{self}"
+    queue.create(id: generate_external_ipam_task_id("remove"), name: _("Removing IP in External IPAM for %s") % self, priority: 5, action: [self, :remove_external_ip]) if external_ipam?(subnet) && requires_delete?
+    true
+  end
+
+  def queue_external_ipam_update
+    return unless external_ipam?(subnet) && errors.empty?
+    if requires_update?
+      logger.debug "Updating IP reservation in external IPAM for #{self}"
+      queue.create(id: generate_external_ipam_task_id("remove"), name: _("Removing IP in External IPAM for %s") % self, priority: 5, action: [old, :remove_external_ip]) if external_ipam?(subnet) && requires_delete?
+      queue.create(id: generate_external_ipam_task_id("create"), name: _("Creating IP in External IPAM for %s") % self, priority: 10, action: [self, :set_external_ip]) if external_ipam?(subnet)
+    end
+    true
+  end
+end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -4,6 +4,7 @@ module Nic
     include Orchestration::DHCP
     include Orchestration::DNS
     include Orchestration::TFTP
+    include Orchestration::ExternalIPAM
     include DnsInterface
     include InterfaceCloning
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -236,7 +236,7 @@ class Subnet < ApplicationRecord
   def validate_against_external_ipam
     return unless self.errors.full_messages.empty?
 
-    if self.ipam&.downcase == "external ipam"
+    if self.external_ipam?
       external_ipam_proxy = SmartProxy.with_features('external_ipam').first
 
       if external_ipam_proxy.nil?
@@ -248,8 +248,8 @@ class Subnet < ApplicationRecord
   end
 
   def subnet_exists_in_external_ipam
-    subnet = JSON.parse(self.external_ipam_proxy.get_subnet(self)) if self.external_ipam_proxy
-    !(!subnet.kind_of?(Array) && subnet['message'] && subnet['message'].downcase == 'no subnets found')
+    subnet = self.external_ipam_proxy.get_subnet(self) if self.external_ipam_proxy
+    !(!subnet.kind_of?(Array) && subnet['message'] && subnet['message'] == 'No subnets found')
   end
 
   def known_ips

--- a/app/models/subnet/ipv4.rb
+++ b/app/models/subnet/ipv4.rb
@@ -26,7 +26,7 @@ class Subnet::Ipv4 < Subnet
   end
 
   def self.supported_ipam_modes
-    [:dhcp, :db, :random_db, :none]
+    [:dhcp, :db, :random_db, :external_ipam, :none]
   end
 
   def self.show_mask?

--- a/app/services/ipam.rb
+++ b/app/services/ipam.rb
@@ -1,5 +1,5 @@
 module IPAM
-  MODES = {:dhcp => N_('DHCP'), :db => N_('Internal DB'), :random_db => N_('Random DB'), :eui64 => N_('EUI-64'), :none => N_('None')}
+  MODES = {:dhcp => N_('DHCP'), :db => N_('Internal DB'), :random_db => N_('Random DB'), :eui64 => N_('EUI-64'), :external_ipam => N_('External IPAM'), :none => N_('None')}
 
   def self.new(type, *args)
     case type
@@ -13,6 +13,8 @@ module IPAM
       IPAM::RandomDb.new(*args)
     when IPAM::MODES[:eui64]
       IPAM::Eui64.new(*args)
+    when IPAM::MODES[:external_ipam]
+      IPAM::ExternalIpam.new(*args)
     else
       raise ::Foreman::Exception.new(N_("Unknown IPAM type - can't continue"))
     end

--- a/app/services/ipam/external_ipam.rb
+++ b/app/services/ipam/external_ipam.rb
@@ -1,0 +1,33 @@
+module IPAM
+  class ExternalIpam < Base
+    delegate :external_ipam_proxy, :to => :subnet
+
+    def suggest_ip
+      if self.mac.nil?
+        errors.add(:mac, "You must specify a MAC address before selecting the External IPAM subnet")
+        return nil
+      end
+
+      cidr = @subnet.network + '/' + @subnet.cidr.to_s
+      logger.debug "Obtaining next available IP from IPAM for subnet #{cidr}"
+      response = external_ipam_proxy.next_ip(@subnet, self.mac)
+
+      if response.key?('error')
+        errors.add(:subnet, response['error'])
+        nil
+      else
+        next_ip = response["next_ip"]
+        logger.debug("IPAM returned #{next_ip} as the next available IP in subnet #{cidr}")
+        next_ip
+      end
+    rescue => e
+      logger.warn "Failed to fetch the next available IP address from IPAM: #{e}"
+      errors.add(:subnet, _('Failed to fetch the next available IP address from IPAM %{message}') % {:message => e})
+      nil
+    end
+
+    def suggest_new?
+      false
+    end
+  end
+end

--- a/app/services/ipam/external_ipam.rb
+++ b/app/services/ipam/external_ipam.rb
@@ -8,16 +8,15 @@ module IPAM
         return nil
       end
 
-      cidr = @subnet.network + '/' + @subnet.cidr.to_s
-      logger.debug "Obtaining next available IP from IPAM for subnet #{cidr}"
+      logger.debug "Obtaining next available IP from IPAM for subnet #{@subnet.network_address}"
       response = external_ipam_proxy.next_ip(@subnet, self.mac)
 
       if response.key?('error')
         errors.add(:subnet, response['error'])
         nil
       else
-        next_ip = response["next_ip"]
-        logger.debug("IPAM returned #{next_ip} as the next available IP in subnet #{cidr}")
+        next_ip = response["data"]
+        logger.debug("IPAM returned #{next_ip} as the next available IP in subnet #{@subnet.network_address}")
         next_ip
       end
     rescue => e

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -8,13 +8,14 @@
 <%= text_f f, :gateway, :label => _("Gateway Address"), :help_inline => _("Optional: Gateway for this subnet") %>
 <%= text_f f, :dns_primary, :label => _("Primary DNS Server"), :help_inline => _("Optional: Primary DNS for this subnet") %>
 <%= text_f f, :dns_secondary, :label => _("Secondary DNS Server"), :help_inline => _("Optional: Secondary DNS for this subnet") %>
-<%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64]]},
+<%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64], IPAM::MODES[:external_ipam]]},
                  :label => _('IPAM'),
                  :label_help => _("You can select one of the IPAM modes supported by the selected IP protocol:<br/>" +
                                    "<ul><li><strong>DHCP</strong> - will manage the IP on DHCP through assigned DHCP proxy, auto-suggested IPs come from DHCP <em>(IPv4)</em></li>" +
                                    "<li><strong>Internal DB</strong> - use internal DB to auto-suggest free IP based on other interfaces on same subnet respecting range if specified, useful mainly with static boot mode <em>(IPv4, IPv6)</em>, preserves natural ordering</li>" +
                                    "<li><strong>Random DB</strong> - same as Internal DB but randomizes results to prevent race conditions <em>(IPv4)</em></li>" +
                                    "<li><strong>EUI-64</strong> - will assign the IPv6 address based on the MAC address of the interface <em>(IPv6)</em></li>" +
+                                   "<li><strong>External IPAM</strong> - will auto-suggest the next available address via an external IPAM Smart-proxy plugin (IPv4)</li>" +
                                    "<li><strong>None</strong> - leave IP management solely on user, no auto-suggestion <em>(IPv4, IPv6)</em></li></ul>").html_safe,
                  :label_help_options => { :title => _("IP Address Management"), :'data-placement' => 'top' }%>
 <div id='ipam_options' class ='<%= f.object.ipam_needs_range? ? "" : "hide" %>'>

--- a/db/migrate/20190617165331_add_external_ipam_id_to_subnets.rb
+++ b/db/migrate/20190617165331_add_external_ipam_id_to_subnets.rb
@@ -1,0 +1,9 @@
+class AddExternalIpamIdToSubnets < ActiveRecord::Migration[5.2]
+  def up
+    add_column :subnets, :external_ipam_id, :integer
+  end
+
+  def down
+    remove_column :subnets, :external_ipam_id
+  end
+end

--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -7,32 +7,32 @@ module ProxyAPI
       super args
     end
 
-    # Queries External IPAM and retrieves the next available IP address for the given subnet. 
-    # The IP returned is NOT reserved in External IPAM database. It is however written to an in-memory, 
-    # thread safe cache, on the proxy side, with the subnet CIDR/mac address as the key(see 
-    # IP cache structure below). This will prevent the same IP being suggested for different mac addresses, 
+    # Queries External IPAM and retrieves the next available IP address for the given subnet.
+    # The IP returned is NOT reserved in External IPAM database. It is however written to an in-memory,
+    # thread safe cache, on the proxy side, with the subnet CIDR/mac address as the key(see
+    # IP cache structure below). This will prevent the same IP being suggested for different mac addresses,
     # and will handle race condition scenarios where multiple hosts are being provisioned simultaneously.
     #
-    # The IP address is only actually reserved in the External IPAM database upon successful host 
+    # The IP address is only actually reserved in the External IPAM database upon successful host
     # and/or interface creation.
-    # 
+    #
     # In-memory IP cache structure:
     # ===============================
-    #   "100.55.55.0/24":{  
+    #   "100.55.55.0/24":{
     #      "00:0a:95:9d:68:10": {"ip": "100.55.55.1", "timestamp": "2019-09-17 12:03:43 -D400"}
     #   },
-    #   "123.11.33.0/24":{  
+    #   "123.11.33.0/24":{
     #      "00:0a:95:9d:68:33": {"ip": "123.11.33.1", "timestamp": "2019-09-17 12:04:43 -0400"}
     #      "00:0a:95:9d:68:34": {"ip": "123.11.33.2", "timestamp": "2019-09-17 12:05:48 -0400"}
     #      "00:0a:95:9d:68:35": {"ip": "123.11.33.3", "timestamp:: "2019-09-17 12:06:50 -0400"}
     #   }
     # }
-    # 
+    #
     # Params: 1. subnet:  The Foreman subnet object
     #         2. mac:     The mac address of the interface obtaining the IP address for
-    # 
+    #
     # Returns: A hash with next available IP in the "data" field, or a hash with "error" on failure
-    # 
+    #
     # Examples:
     #   Response if success:
     #     {"code": 200, "success": true, "data": "100.55.55.3", "time": 0.012}
@@ -51,18 +51,18 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to retrieve the next available IP for subnet %s from External IPAM."), subnet.network_address)
     end
 
-    # Adds an IP address to the specified subnet in External IPAM. This will reserve the IP in the 
+    # Adds an IP address to the specified subnet in External IPAM. This will reserve the IP in the
     # External IPAM database.
     #
     # Params: 1. ip:     IP address to be added
     #         2. subnet: The Foreman subnet object
-    # 
+    #
     # Returns: A hash with a message of "Address created" on success, or a hash with "error" on failure
-    # 
+    #
     # Examples:
     #   Response if success:
     #     {"code": 201, "success": true, "message": "Address created", "id": "156", "time": 0.015}
-    #   Response if IP already reserved: 
+    #   Response if IP already reserved:
     #     {"code": 409, "success": false, "message": "IP address already exists", "time": 0.006}
     #   Response if subnet error:
     #     {"error": "The specified subnet does not exist in External IPAM."}
@@ -82,13 +82,13 @@ module ProxyAPI
     # Params: None
     #
     # Returns: An array of sections on success, or a hash with "error" otherwise.
-    # 
+    #
     # Examples
     #   Response if success: [
     #     {"id":"4","name":"Test Section","description":"A Test Section"},
     #     {"id":"5","name":"Awesome Section","description":"A totally awesome Section"}
     #   ]
-    #   Response if no sections exist: 
+    #   Response if no sections exist:
     #     {"code":200, "success":true, "message": "No sections available", "time": 0.004, "data": []}
     #   Response if can't connect to External IPAM server
     #     {"error": "Unable to connect to External IPAM server"}
@@ -98,7 +98,7 @@ module ProxyAPI
       raise ProxyException.new(url, e, N_("Unable to obtain sections from External IPAM."))
     end
 
-    # Get a list of subnets for the given External IPAM section. 
+    # Get a list of subnets for the given External IPAM section.
     #
     # Params:  1. section_name: The name of the External IPAM section
     #
@@ -123,8 +123,8 @@ module ProxyAPI
     end
 
     # Returns an array of subnets from External IPAM. If the "Require unique subnets" setting in External IPAM
-    # is enabled, this will return one subnet(or zero if not exists). If this setting is disabled(i.e. you can 
-    # have duplicate subnets and IP's), then it is possible to get more than one. 
+    # is enabled, this will return one subnet(or zero if not exists). If this setting is disabled(i.e. you can
+    # have duplicate subnets and IP's), then it is possible to get more than one.
     #
     # Params:  1. subnet: The Foreman subnet object
     #
@@ -153,7 +153,7 @@ module ProxyAPI
     #
     # Returns: A hash with "data" key if IP already reserved, a hash with a message of "No addresses found" if
     #          IP is available, or a hash with "error" otherwise
-    # 
+    #
     # Examples:
     #   Response if IP is already reserved:
     #     {"code": 200, "success": true, "data": [{"id":"157","subnetId":"32","ip":"10.10.10.1","is_gateway":null,"description":null,"hostname":null,"mac":null,"owner":null,"tag":"2","deviceId":null,"location":null,"port":null,"note":null,"lastSeen":null,"excludePing":"0","PTRignore":"0","PTR":"0","firewallAddressObject":null,"editDate":null,"customer_id":null}],"time":0.008}

--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -1,0 +1,142 @@
+require 'uri'
+
+module ProxyAPI
+  class ExternalIpam < ProxyAPI::Resource
+    def initialize(args)
+      @url = args[:url] + "/ipam"
+      super args
+    end
+
+    # Retrieves the next available IP address for the specified subnet
+    #
+    # Inputs: 1. subnet(object): The Foreman subnet
+    #         2. mac: The mac address of the interface obtaining the IP address for
+    # Returns: Hash with "next_ip", or hash with "error"
+    # Examples:
+    #   Response if success:
+    #     {"cidr":"100.20.20.0/24","next_ip":"100.20.20.11"}
+    #   Response if error:
+    #     {"error":"The specified subnet does not exist in external ipam."}
+    def next_ip(subnet, mac)
+      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
+      get("/next_ip?cidr=#{cidr}&mac=#{mac}")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve the next available IP for subnet %s from External IPAM."), cidr)
+    end
+
+    # Adds an IP address to the specified subnet
+    #
+    # Inputs: 1. ip(string). IP address to be added.
+    #         2. subnet(object): The Foreman subnet
+    # Returns: Hash with "message" on success, or hash with "error"
+    # Examples:
+    #   Response if success:
+    #     {"message":"IP 100.10.10.123 added to subnet 100.10.10.0/24 successfully."}
+    #   Response if error:
+    #     {"error":"The specified subnet does not exist in external ipam."}
+    def add_ip_to_subnet(ip, subnet)
+      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
+      parse(post({:ip => ip, :cidr => cidr}, "/add_ip_to_subnet"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to add IP %s to the subnet %s in External IPAM."), ip, cidr)
+    end
+
+    # Get a list of sections from external ipam
+    #
+    # Input: None
+    # Returns: An array of sections on success, hash with "error" key otherwise
+    # Examples
+    #   Response if success: [
+    #     {"id":"4","name":"Test Section","description":"A Test Section"},
+    #     {"id":"5","name":"Awesome Section","description":"A totally awesome Section"}
+    #   ]
+    #   Response if error:
+    #     {"error":"Unable to connect to external ipam server"}
+    def get_sections
+      get("/sections")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain sections from External IPAM."))
+    end
+
+    # Get a list of subnets for given external ipam section/group
+    #
+    # Input: group_name(string). The name of the external ipam section/group
+    # Returns: Array of subnets(as json) on success, hash with error otherwise
+    # Examples:
+    #   Response if success:
+    #     [
+    #       {"id":"9","subnet":"100.10.10.0","mask":"24","sectionId":"5","description":"Test Subnet 1"},
+    #       {"id":"10","subnet":"100.20.20.0","mask":"24","sectionId":"5","description":"Test Subnet 2"}
+    #     ]
+    #   Response if error:
+    #     {"error":"Unable to connect to external ipam server"}
+    def get_subnets(section_name)
+      get("/sections/#{URI.encode(section_name)}/subnets")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain subnets in section/group %s from External IPAM."), section_name)
+    end
+
+    # Gets a subnet from external ipam.
+    #
+    # Input:   subnet(object): The Foreman subnet
+    # Returns: JSON object with "data" key if exists, otherwise JSON object with "message" key
+    #          containing an error message.
+    # Examples:
+    #   Response if subnet exists:
+    #     [{"id":"9","subnet":"100.20.20.0","description":"Test Subnet","mask":"24"}]
+    #   Response if subnet not exists:
+    #     {"error": "No subnets found"}
+    def get_subnet(subnet)
+      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
+      get("/get_subnet?cidr=#{cidr}")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain subnet %s from External IPAM."), cidr)
+    end
+
+    # Checks whether an IP address has already been taken in external ipam.
+    #
+    # Inputs: 1. ip(string). IP address to be checked.
+    #         2. subnet(object): The Foreman subnet object
+    # Returns: JSON object with 'exists' field being either true or false
+    # Example:
+    #   Response if exists:
+    #     {"ip":"100.20.20.18","exists": true}
+    #   Response if not exists:
+    #     {"ip":"100.20.20.18","exists": false}
+    def ip_exists(ip, subnet)
+      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
+      get("/ip_exists?cidr=#{cidr}&ip=#{ip}")
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain IP address for subnet_id %s from External IPAM."), subnet['id'].to_s)
+    end
+
+    # Deletes IP address from a given subnet
+    #
+    # Inputs: 1. ip(string). IP address to be checked.
+    #         2. subnet(object): The Foreman subnet
+    # Returns: JSON object with "message" on success, or "error" if error
+    # Example:
+    #   Response if success:
+    #     {"message": "IP 100.20.20.18 deleted from subnet 100.20.20.0/24 successfully."}
+    #   Response if error:
+    #     {"error": "The specified subnet does not exist in external ipam."}
+    def delete_ip_from_subnet(ip, subnet)
+      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
+      parse(post({:ip => ip, :cidr => cidr}, "/delete_ip_from_subnet"))
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete IP %s from the subnet %s in External IPAM."), ip, cidr)
+    end
+
+    private
+
+    # TODO: Use ProxyAPI::Resource.parse instead for GET(for consistency), once it has been
+    #       refactored to handle error messages better
+    def get(path, body = nil)
+      uri = URI.parse(@url + path)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if @url =~ /^https/i
+      response = http.get(uri.request_uri)
+      JSON.parse(response.body)
+    end
+  end
+end

--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -7,136 +7,192 @@ module ProxyAPI
       super args
     end
 
-    # Retrieves the next available IP address for the specified subnet
+    # Queries External IPAM and retrieves the next available IP address for the given subnet. 
+    # The IP returned is NOT reserved in External IPAM database. It is however written to an in-memory, 
+    # thread safe cache, on the proxy side, with the subnet CIDR/mac address as the key(see 
+    # IP cache structure below). This will prevent the same IP being suggested for different mac addresses, 
+    # and will handle race condition scenarios where multiple hosts are being provisioned simultaneously.
     #
-    # Inputs: 1. subnet(object): The Foreman subnet
-    #         2. mac: The mac address of the interface obtaining the IP address for
-    # Returns: Hash with "next_ip", or hash with "error"
+    # The IP address is only actually reserved in the External IPAM database upon successful host 
+    # and/or interface creation.
+    # 
+    # In-memory IP cache structure:
+    # ===============================
+    #   "100.55.55.0/24":{  
+    #      "00:0a:95:9d:68:10": {"ip": "100.55.55.1", "timestamp": "2019-09-17 12:03:43 -D400"}
+    #   },
+    #   "123.11.33.0/24":{  
+    #      "00:0a:95:9d:68:33": {"ip": "123.11.33.1", "timestamp": "2019-09-17 12:04:43 -0400"}
+    #      "00:0a:95:9d:68:34": {"ip": "123.11.33.2", "timestamp": "2019-09-17 12:05:48 -0400"}
+    #      "00:0a:95:9d:68:35": {"ip": "123.11.33.3", "timestamp:: "2019-09-17 12:06:50 -0400"}
+    #   }
+    # }
+    # 
+    # Params: 1. subnet:  The Foreman subnet object
+    #         2. mac:     The mac address of the interface obtaining the IP address for
+    # 
+    # Returns: A hash with next available IP in the "data" field, or a hash with "error" on failure
+    # 
     # Examples:
     #   Response if success:
-    #     {"cidr":"100.20.20.0/24","next_ip":"100.20.20.11"}
-    #   Response if error:
-    #     {"error":"The specified subnet does not exist in external ipam."}
+    #     {"code": 200, "success": true, "data": "100.55.55.3", "time": 0.012}
+    #   Response if missing required params:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)","A 'mac' address must be provided(e.g. 00:0a:95:9d:68:10)"]}
+    #   Response if subnet error:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if there are no free addresses:
+    #     {"error": "No free addresses found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def next_ip(subnet, mac)
-      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
-      get("/next_ip?cidr=#{cidr}&mac=#{mac}")
+      raise "subnet.network cannot be nil" unless subnet.network.present?
+      parse get("/next_ip?cidr=#{subnet.network_address}&mac=#{mac}")
     rescue => e
-      raise ProxyException.new(url, e, N_("Unable to retrieve the next available IP for subnet %s from External IPAM."), cidr)
+      raise ProxyException.new(url, e, N_("Unable to retrieve the next available IP for subnet %s from External IPAM."), subnet.network_address)
     end
 
-    # Adds an IP address to the specified subnet
+    # Adds an IP address to the specified subnet in External IPAM. This will reserve the IP in the 
+    # External IPAM database.
     #
-    # Inputs: 1. ip(string). IP address to be added.
-    #         2. subnet(object): The Foreman subnet
-    # Returns: Hash with "message" on success, or hash with "error"
+    # Params: 1. ip:     IP address to be added
+    #         2. subnet: The Foreman subnet object
+    # 
+    # Returns: A hash with a message of "Address created" on success, or a hash with "error" on failure
+    # 
     # Examples:
     #   Response if success:
-    #     {"message":"IP 100.10.10.123 added to subnet 100.10.10.0/24 successfully."}
-    #   Response if error:
-    #     {"error":"The specified subnet does not exist in external ipam."}
+    #     {"code": 201, "success": true, "message": "Address created", "id": "156", "time": 0.015}
+    #   Response if IP already reserved: 
+    #     {"code": 409, "success": false, "message": "IP address already exists", "time": 0.006}
+    #   Response if subnet error:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if missing required params:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)","Missing 'ip' parameter. An IPv4 address must be provided(e.g. 100.10.10.22)"]}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def add_ip_to_subnet(ip, subnet)
-      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
-      parse(post({:ip => ip, :cidr => cidr}, "/add_ip_to_subnet"))
+      raise "subnet.network cannot be nil" unless subnet.network.present?
+      parse(post({:ip => ip, :cidr => subnet.network_address}, "/add_ip_to_subnet"))
     rescue => e
-      raise ProxyException.new(url, e, N_("Unable to add IP %s to the subnet %s in External IPAM."), ip, cidr)
+      raise ProxyException.new(url, e, N_("Unable to add IP %s to the subnet %s in External IPAM."), ip, subnet.network_address)
     end
 
-    # Get a list of sections from external ipam
+    # Get a list of sections from External IPAM. A section in phpIPAM is a logical grouping of subnets/ips.
     #
-    # Input: None
-    # Returns: An array of sections on success, hash with "error" key otherwise
+    # Params: None
+    #
+    # Returns: An array of sections on success, or a hash with "error" otherwise.
+    # 
     # Examples
     #   Response if success: [
     #     {"id":"4","name":"Test Section","description":"A Test Section"},
     #     {"id":"5","name":"Awesome Section","description":"A totally awesome Section"}
     #   ]
-    #   Response if error:
-    #     {"error":"Unable to connect to external ipam server"}
+    #   Response if no sections exist: 
+    #     {"code":200, "success":true, "message": "No sections available", "time": 0.004, "data": []}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def get_sections
-      get("/sections")
+      parse get("/sections")
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to obtain sections from External IPAM."))
     end
 
-    # Get a list of subnets for given external ipam section/group
+    # Get a list of subnets for the given External IPAM section. 
     #
-    # Input: group_name(string). The name of the external ipam section/group
-    # Returns: Array of subnets(as json) on success, hash with error otherwise
+    # Params:  1. section_name: The name of the External IPAM section
+    #
+    # Returns: An array of subnets on success, or a hash with "error" otherwise.
+    #
     # Examples:
-    #   Response if success:
-    #     [
-    #       {"id":"9","subnet":"100.10.10.0","mask":"24","sectionId":"5","description":"Test Subnet 1"},
-    #       {"id":"10","subnet":"100.20.20.0","mask":"24","sectionId":"5","description":"Test Subnet 2"}
-    #     ]
-    #   Response if error:
-    #     {"error":"Unable to connect to external ipam server"}
-    def get_subnets(section_name)
-      get("/sections/#{URI.encode(section_name)}/subnets")
+    #   Response if success: [
+    #     {"id":"9","subnet":"100.10.10.0","mask":"24","sectionId":"5","description":"Test Subnet 1"},
+    #     {"id":"10","subnet":"100.20.20.0","mask":"24","sectionId":"5","description":"Test Subnet 2"}
+    #   ]
+    #   Response if section not found:
+    #     {"error": "Section not found in External IPAM."}
+    #   Response if no subnets exist in section.
+    #     {"code": 200, "success": true, "data": [], "time": 0.007}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def get_subnets_by_section(section_name)
+      raise "section_name must be provided" if section_name.blank?
+      parse get("/sections/#{URI.encode(section_name)}/subnets")
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to obtain subnets in section/group %s from External IPAM."), section_name)
     end
 
-    # Gets a subnet from external ipam.
+    # Returns an array of subnets from External IPAM. If the "Require unique subnets" setting in External IPAM
+    # is enabled, this will return one subnet(or zero if not exists). If this setting is disabled(i.e. you can 
+    # have duplicate subnets and IP's), then it is possible to get more than one. 
     #
-    # Input:   subnet(object): The Foreman subnet
-    # Returns: JSON object with "data" key if exists, otherwise JSON object with "message" key
-    #          containing an error message.
+    # Params:  1. subnet: The Foreman subnet object
+    #
+    # Returns: A subnet with "data" key, or a hash with "error" otherwise
+    #
     # Examples:
-    #   Response if subnet exists:
-    #     [{"id":"9","subnet":"100.20.20.0","description":"Test Subnet","mask":"24"}]
+    #   Response if subnet(s) exists:
+    #     {"code": 200, "success": true, "data": [
+    #       {"id": "32", "subnet": "10.10.10.0", "description": "Test", "mask": "29"}
+    #     ], "time": 0.007}
     #   Response if subnet not exists:
     #     {"error": "No subnets found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def get_subnet(subnet)
-      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
-      get("/get_subnet?cidr=#{cidr}")
+      raise "subnet.network cannot be nil" unless subnet.network.present?
+      parse get("/get_subnet?cidr=#{subnet.network_address}")
     rescue => e
-      raise ProxyException.new(url, e, N_("Unable to obtain subnet %s from External IPAM."), cidr)
+      raise ProxyException.new(url, e, N_("Unable to obtain subnet %s from External IPAM."), subnet.network_address)
     end
 
-    # Checks whether an IP address has already been taken in external ipam.
+    # Checks whether an IP address has already been reserved in External IPAM.
     #
-    # Inputs: 1. ip(string). IP address to be checked.
-    #         2. subnet(object): The Foreman subnet object
-    # Returns: JSON object with 'exists' field being either true or false
-    # Example:
-    #   Response if exists:
-    #     {"ip":"100.20.20.18","exists": true}
-    #   Response if not exists:
-    #     {"ip":"100.20.20.18","exists": false}
+    # Inputs: 1. ip:     IP address to be checked
+    #         2. subnet: The Foreman subnet object
+    #
+    # Returns: A hash with "data" key if IP already reserved, a hash with a message of "No addresses found" if
+    #          IP is available, or a hash with "error" otherwise
+    # 
+    # Examples:
+    #   Response if IP is already reserved:
+    #     {"code": 200, "success": true, "data": [{"id":"157","subnetId":"32","ip":"10.10.10.1","is_gateway":null,"description":null,"hostname":null,"mac":null,"owner":null,"tag":"2","deviceId":null,"location":null,"port":null,"note":null,"lastSeen":null,"excludePing":"0","PTRignore":"0","PTR":"0","firewallAddressObject":null,"editDate":null,"customer_id":null}],"time":0.008}
+    #   Response if IP address is available
+    #     {"code": 200, "success": false, "message": "No addresses found", "time": 0.007}
+    #   Response if missing required parameters:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)", "Missing 'ip' parameter. An IPv4 address must be provided(e.g. 100.10.10.22)"]}
+    #   Response if subnet not exists:
+    #     {"code": 200, "success": false, "message": "No subnets found", "time": 0.007}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def ip_exists(ip, subnet)
-      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
-      get("/ip_exists?cidr=#{cidr}&ip=#{ip}")
+      raise "subnet.network cannot be nil" unless subnet.network.present?
+      parse get("/ip_exists?cidr=#{subnet.network_address}&ip=#{ip}")
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to obtain IP address for subnet_id %s from External IPAM."), subnet['id'].to_s)
     end
 
-    # Deletes IP address from a given subnet
+    # Frees up an IP address from a given subnet in External IPAM.
     #
-    # Inputs: 1. ip(string). IP address to be checked.
-    #         2. subnet(object): The Foreman subnet
-    # Returns: JSON object with "message" on success, or "error" if error
-    # Example:
+    # Inputs: 1. ip:     IP address to be freed up
+    #         2. subnet: The Foreman subnet object
+    #
+    # Returns: A hash with "message" on success, or a hash with "error" on failure
+    #
+    # Examples:
     #   Response if success:
-    #     {"message": "IP 100.20.20.18 deleted from subnet 100.20.20.0/24 successfully."}
-    #   Response if error:
-    #     {"error": "The specified subnet does not exist in external ipam."}
+    #     {"code": 200, "success": true, "message": "Address deleted", "time": 0.012}
+    #   Response if subnet error:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if IP already deleted:
+    #     {"code": 200, "success": false, "message": "No addresses found", "time": 0.006}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
     def delete_ip_from_subnet(ip, subnet)
-      cidr = subnet.network + '/' + subnet.cidr.to_s if subnet.network.present?
-      parse(post({:ip => ip, :cidr => cidr}, "/delete_ip_from_subnet"))
+      raise "subnet.network cannot be nil" unless subnet.network.present?
+      parse(post({:ip => ip, :cidr => subnet.network_address}, "/delete_ip_from_subnet"))
     rescue => e
-      raise ProxyException.new(url, e, N_("Unable to delete IP %s from the subnet %s in External IPAM."), ip, cidr)
-    end
-
-    private
-
-    # TODO: Use ProxyAPI::Resource.parse instead for GET(for consistency), once it has been
-    #       refactored to handle error messages better
-    def get(path, body = nil)
-      uri = URI.parse(@url + path)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true if @url =~ /^https/i
-      response = http.get(uri.request_uri)
-      JSON.parse(response.body)
+      raise ProxyException.new(url, e, N_("Unable to delete IP %s from the subnet %s in External IPAM."), ip, subnet.network_address)
     end
   end
 end

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -39,5 +39,9 @@ FactoryBot.define do
     trait :bmc do
       name { 'BMC' }
     end
+
+    trait :external_ipam do
+      name { 'External IPAM' }
+    end
   end
 end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -37,6 +37,12 @@ FactoryBot.define do
       end
     end
 
+    factory :ipam_smart_proxy do
+      after(:build) do |smart_proxy, _evaluator|
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :external_ipam, :smart_proxy => smart_proxy)
+      end
+    end
+
     factory :puppet_smart_proxy do
       before(:create, :build, :build_stubbed) do
         ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppet => {'state' => 'running'})
@@ -97,6 +103,10 @@ FactoryBot.define do
 
     trait :bmc do
       association :feature, :bmc
+    end
+
+    trait :external_ipam do
+      association :feature, :external_ipam
     end
   end
 end

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     organizations { [Organization.find_by_name('Organization 1')] }
     locations { [Location.find_by_name('Location 1')] }
 
+    # Skip the Subnet.after_validation hook that validates against external IPAM
+    after(:build) do |subnet|
+      subnet.class.skip_callback(:validation, :after, :validate_against_external_ipam, raise: false)
+    end
+
     trait :tftp do
       association :tftp, :factory => :template_smart_proxy
     end

--- a/test/helpers/subnets_helper_test.rb
+++ b/test/helpers/subnets_helper_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SubnetsHelperTest < ActionView::TestCase
+  include SubnetsHelper
+
+  let(:ipam_proxy) do
+    FactoryBot.create(:smart_proxy,
+      :features => [FactoryBot.create(:feature, :name => :external_ipam)])
+  end
+
+  test "external_ipam? method should return true for external ipam subnets" do
+    ipam_subnet = FactoryBot.create(:subnet,
+      :ipam => "External IPAM",
+      :network => '100.25.25.0',
+      :mask => '255.255.255.0',
+      :external_ipam => ipam_proxy)
+    assert external_ipam?(ipam_subnet)
+  end
+
+  test "external_ipam? method should return false for non external ipam subnets" do
+    non_ipam_subnet = FactoryBot.create(:subnet,
+      :ipam => "None",
+      :network => '100.25.25.0',
+      :mask => '255.255.255.0')
+    refute external_ipam?(non_ipam_subnet)
+  end
+end

--- a/test/models/orchestration/external_ipam_test.rb
+++ b/test/models/orchestration/external_ipam_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+class ExternalIPAMOrchestrationTest < ActiveSupport::TestCase
+  let(:ipam_proxy) do
+    FactoryBot.create(:smart_proxy,
+      :features => [FactoryBot.create(:feature, :name => :external_ipam)])
+  end
+
+  context 'host with interface using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet,
+        :ipam => "External IPAM",
+        :network => '100.25.25.0',
+        :mask => '255.255.255.0',
+        :external_ipam => ipam_proxy)
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip => '100.25.25.1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet => subnet,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "host should be valid" do
+      host = FactoryBot.create(:host, :managed, :interfaces => interfaces)
+      assert host.valid?
+    end
+
+    test "should queue a create task when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_equal ["external_ipam_create_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_equal :set_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00").action.last
+    end
+
+    test "should queue a remove task when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_equal :remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00").action.last
+    end
+
+    test 'should queue an update task when interface ip is updated in host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00", "external_ipam_create_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_equal :remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00").action.last
+      assert_equal :set_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00").action.last
+    end
+  end
+
+  context 'host with interface not using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet,
+        :ipam => "None",
+        :network => '100.25.25.0',
+        :mask => '255.255.255.0')
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip => '100.25.25.1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet => subnet,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "should not queue an external ipam create task when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_not_equal ["external_ipam_create_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00")
+    end
+
+    test "should not queue an external ipam remove task when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_not_equal ["external_ipam_remove_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00")
+    end
+
+    test 'should not queue an external ipam update task when interface ip is updated in host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.save!
+      assert_not_equal ["external_ipam_remove_00:53:67:ab:dd:00", "external_ipam_create_00:53:67:ab:dd:00"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00")
+      assert_nil host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00")
+    end
+  end
+end

--- a/test/models/subnet/external_ipam_test.rb
+++ b/test/models/subnet/external_ipam_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Subnet::ExternalIpamTest < ActiveSupport::TestCase
+  test 'external ipam is supported for IPv4' do
+    subnet = FactoryBot.build(:subnet_ipv4)
+    assert subnet.supports_ipam_mode?(:external_ipam)
+  end
+
+  test 'external ipam is not supported for IPv6' do
+    subnet = FactoryBot.build(:subnet_ipv6)
+    refute subnet.supports_ipam_mode?(:external_ipam)
+  end
+
+  test 'subnet with external ipam does not need IP range' do
+    subnet = FactoryBot.build(:subnet_ipv4)
+    subnet.ipam = IPAM::MODES[:external_ipam]
+    refute subnet.ipam_needs_range?
+  end
+end


### PR DESCRIPTION
This PR is a patch to support of the use of plugins for external IPAM use, with opensource provider phpIPAM(https://phpipam.net). The primary use case is to provide the next available IPv4 address from phpIPAM, for a given phpIPAM subnet. 

The functionality that Foreman will use for external IPAM is encompassed in the below plugins(which are both new).

**foreman_ipam(v0.0.7)**
**Git:** https://github.com/grizzthedj/foreman_ipam
**Gem:** https://rubygems.org/gems/foreman_ipam

**smart_proxy_ipam(v0.0.13)**
**Git:** https://github.com/grizzthedj/smart_proxy_ipam
**Gem:** https://rubygems.org/gems/smart_proxy_ipam

The `foreman_ipam` plugin provides a very basic dashboard to display sections and subnets from phpIPAM, and the `smart_proxy_ipam` plugin communicates with the phpIPAM API.

Features and functionality

* Simple IPAM Dashboard page(Infrastructure => IPAM Dashboard) to view sections and subnets for phpIPAM. More features will be added here based on internal user feedback and from the community.
* When creating a phpIPAM subnet(IPAM type = External IPAM) in Foreman, subnet/mask must exist in phpIPAM, or error will be thrown
* When creating a new host in Foreman, auto suggested IP's from phpIPAM will be persisted back to phpIPAM on Host submit.
* When updating the IP address on a NIC that uses a phpIPAM subnet, the old IP will be deleted from phpIPAM, and new one will be added.
* Deleting a host in Foreman will delete all NIC ip's that used a phpIPAM subnet
* Deleting a NIC from a host will also delete the IP from phpIPAM
* Deleting a subnet in Foreman will NOT delete the associated subnet in phpIPAM. This could easily be added later if it makes sense to the community, however initial thoughts are to not delete it. 

NOTE: When creating a host in Foreman and adding multiple nics/interfaces, the same IP will be suggested from phpIPAM since it is not actually reserved in phpIPAM until you submit the host. The workaround for multiple nics is to use the suggested ip for the first interface(e.g. 10.0.0.1), then manually increment the IP for the second interface(e.g. 10.0.0.2). Errors will be thrown however if IP's are already taken.

Prerequisites for testing:
* Working Foreman environment.
* A phpIPAM instance that the Forman Smart Proxy has network connectivity to.
* The API must be enabled in the phpIPAM settings, and `Prettify Links` also enabled.
* An API user in phpIPAM must be created. The credentials for this user are to be put in the `config/settings.d/external_ipam.yml` file in the Smart Proxy core
