### PR TITLE
Fixes #26984 - maximum subtree fact filter

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -76,6 +76,7 @@ class Setting::Provisioning < Setting
         default_excluded_facts,
         N_('Exclude pattern for facts stored in foreman')
       ),
+      self.set('maximum_structured_facts', N_("Maximum amount of keys in structured subtree, statistics stored in foreman::dropped_subtree_facts"), 100, N_('Maximum structured facts')),
     ] + default_global_templates + default_local_boot_templates
   end
 
@@ -120,6 +121,6 @@ class Setting::Provisioning < Setting
   end
 
   def self.default_excluded_facts(ignored_interfaces = IGNORED_INTERFACES)
-    ignored_interfaces + ['mountpoints', 'partitions', 'blockdevice*']
+    ignored_interfaces
   end
 end

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -181,23 +181,4 @@ module FactsData
       }
     end
   end
-
-  class DefaultDisksFacts
-    def filter
-      Setting[:excluded_facts]
-    end
-
-    def good_facts
-      {
-        'good_fact' => 'a_value',
-      }
-    end
-
-    def ignored_facts
-      {
-        'partitions' => {"nvme0n1p5" => {}, "nvme0n1p3" => {"uuid" => "2bff39f0-8e86-4852-9ef5-a27d2d64064f", "mount" => "/"}},
-        'mountpoints' => {"/var/lib/kubelet/pods/18d36b62-526f-11e9-98b1-0200004190da/volumes/kubernetes.io~secret/certs" => {"used_bytes" => 13}},
-      }
-    end
-  end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -362,7 +362,7 @@ attribute77:
 attributes78:
   name: excluded_facts
   category: Setting::Provisioning
-  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*', 'mountpoints', 'partitions', 'blockdevice*']"
+  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
 attribute79:
   name: append_domain_name_for_hosts
@@ -399,3 +399,8 @@ attribute85:
   category: Setting::Provisioning
   default: nil
   description: 'Intermidiate iPXE script'
+attribute86:
+  name: maximum_structured_facts
+  category: Setting::Provisioning
+  default: 100
+  description: 'Maximum structured facts'

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -102,17 +102,6 @@ class FactImporterTest < ActiveSupport::TestCase
 
       assert_equal data.good_facts, actual_facts
     end
-
-    test 'filters default disk facts' do
-      data = FactsData::DefaultDisksFacts.new
-
-      facts = data.good_facts.merge(data.ignored_facts)
-
-      importer = FactImporter.new(nil, facts)
-      actual_facts = importer.send(:facts)
-
-      assert_equal data.good_facts, actual_facts
-    end
   end
 
   describe '#import!' do


### PR DESCRIPTION
Adds filter that drops subtrees (hash or array) of bigger size than
defined in global setting, by default this is 100. Total number of
dropped items is stored in newly created
`foreman::dropped_subtree_facts` fact. It is rounded and human readable
to prevent repetetive changes of this value, usually it will be:

* 100
* 1 Thousand
* 5 Thousands
* 25 Thousands

This enables users to easily identify hosts which were dropped some
facts so they can investigate them later on. Additionally, we can also
report via `foreman-maintain` that these hosts are likely sending too
many facts and ask users to filter facts on the client side.

The idea introduces brand new `foreman` composite hash for other values
as well, we were thinking about introducing `foreman::boot_time` special
value in https://github.com/theforeman/foreman/pull/6843

It also puts warning in the log, if you going to ask for debug I am
intentionally putting warning here because I believe this is important
and one extra line in logs won't hurt we already log about dozens of
them.

Important thing to consider is that this only handles *structured*
facts, there are many hosts reporting via facter 2.x and this filter
will not help. The question is, shall I implement the same behavior? How
that would work? Only for particular prefixes like `blockdevice_*` or
similar? @ekohl can you name those prefixes which are likely be
offenders for puppet 2.x? It should be pretty easy to implement similar
behavior but I need a decent list of candidates.

What puzzles me is that facter can actually send both structured facts
and flat-formatted facts in one request. Example:

https://github.com/theforeman/foreman_discovery/blob/develop/test/facts/rhel-r730.json

Here I see `blockdevice_*` facts which can go out of control as well as
structured facts like "partitions" which is the same story. It looks
like I might need to implement it also for structured importer.

Additional question is if I should go deep, currently I only filter the 1st level.