### PR TITLE
Fixes #27092 - Current taxonomies in API response header

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,8 @@ module Api
     include Foreman::Controller::ApiCsrfProtection
     include Foreman::Controller::BruteforceProtection
 
-    before_action :set_default_response_format, :authorize, :set_taxonomy, :add_version_header, :set_gettext_locale
+    before_action :set_default_response_format, :authorize, :set_taxonomy
+    before_action :add_info_headers, :set_gettext_locale
     before_action :session_expiry, :update_activity_time
     around_action :set_timezone
 
@@ -227,6 +228,18 @@ module Api
     def add_version_header
       response.headers["Foreman_version"] = SETTINGS[:version].full
       response.headers["Foreman_api_version"] = api_version
+    end
+
+    def add_taxonomies_header
+      current_org = "#{Organization.current.id}; #{Organization.current.name}" if Organization.current
+      response.headers["Foreman_current_organization"] = current_org || '; ANY'
+      current_loc = "#{Location.current.id}; #{Location.current.name}" if Location.current
+      response.headers["Foreman_current_location"] = current_loc || '; ANY'
+    end
+
+    def add_info_headers
+      add_version_header
+      add_taxonomies_header
     end
 
     # this method is used with nested resources, where obj_id is passed into the parameters hash.

--- a/test/controllers/api/base_controller_subclass_test.rb
+++ b/test/controllers/api/base_controller_subclass_test.rb
@@ -57,6 +57,10 @@ class Api::TestableControllerTest < ActionController::TestCase
   tests Api::TestableController
 
   context "api base headers" do
+    setup do
+      @organization = FactoryBot.create :organization, :name => "org"
+      @location = FactoryBot.create :location, :name => "loc"
+    end
     test "should contain version in headers" do
       get :index
       assert_match /\d+\.\d+/, @response.headers["Foreman_version"]
@@ -65,6 +69,18 @@ class Api::TestableControllerTest < ActionController::TestCase
     test "should contain version as string in headers" do
       get :index
       assert @response.headers["Foreman_version"].is_a? String
+    end
+
+    test "should contain ANY location and ANY Organization in the headers" do
+      get :index
+      assert_equal @response.headers["Foreman_current_organization"], "; ANY"
+      assert_equal @response.headers["Foreman_current_location"], "; ANY"
+    end
+
+    test "should contain current location and organization in the headers" do
+      get :index, :params => { :location_id => @location.id, :organization_id => @organization.id }
+      assert_equal @response.headers["Foreman_current_organization"], "#{@organization.id}; #{@organization.name}"
+      assert_equal @response.headers["Foreman_current_location"], "#{@location.id}; #{@location.name}"
     end
   end
 


### PR DESCRIPTION
This PR adds to the API response headers of the current location and organizations.
In hammer it would be possible to see the current location and organization in debug mode:
 Response headers: {
                      :foreman_version => "1.23.0-develop",
                  :foreman_api_version => "2",
          :foreman_urrent_organization => "; ANY",
             :foreman_current_location => "4; tlv",
                         :content_type => "application/json; charset=utf-8",
                }
