### PR TITLE
Fixes #27086 - Update hardcoded max values for oVirt CR

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -111,15 +111,15 @@ module Foreman::Model
     end
 
     def max_cpu_count
-      16
+      client.max_num_of_vm_cpus
     end
 
     def max_socket_count
-      16
+      client.max_num_of_vm_sockets
     end
 
     def max_memory
-      16.gigabytes
+      client.vm_max_memory_size_in_mb.megabytes
     end
 
     def use_v4=(value)


### PR DESCRIPTION
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
Change hardcoded values for max_cpu_count, max_socket_count and max_memory to values supported in oVirt 4.1. This fixes foreman error raised when creating new VM with greater values than defined in forman but acceptable on oVirt side.