### PR TITLE
Fixes #27104 - Editor replace toString with lodash

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
@@ -1,4 +1,5 @@
 import debounce from 'lodash/debounce';
+import { toString } from 'lodash';
 import API from '../../API';
 import { translate as __ } from '../../common/I18n';
 
@@ -122,7 +123,7 @@ export const previewTemplate = ({ host, renderPath }) => (
         payload: {
           renderedEditorValue: templateValue,
           selectedHost: {
-            id: id.toString(),
+            id: toString(id),
             name,
           },
           previewResult: response.data,
@@ -139,7 +140,7 @@ export const previewTemplate = ({ host, renderPath }) => (
           errorText: __(error.response.data),
           previewResult: __('Error during rendering, Return to Editor tab.'),
           selectedHost: {
-            id: id.toString(),
+            id: toString(id),
             name,
           },
         },


### PR DESCRIPTION
to avoid this error
`Error: Uncaught [TypeError: Cannot read property 'toString' of undefined]`
lodash's toString is safer.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
