### PR TITLE
Fixes #27105 - env variable to disable redux-logger

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -195,7 +195,8 @@ module.exports = env => {
       new webpack.DefinePlugin({
         'process.env': {
           NODE_ENV: JSON.stringify(production ? 'production' : 'development'),
-          NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING
+          NOTIFICATIONS_POLLING: process.env.NOTIFICATIONS_POLLING,
+          REDUX_LOGGER: process.env.REDUX_LOGGER
         }
       }),
       // limit locales from intl only to supported ones

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -6,9 +6,17 @@ import reducers from './reducers';
 
 let middleware = [thunk];
 
-if (process.env.NODE_ENV !== 'production' && !global.__testing__) {
-  middleware = [...middleware, createLogger()];
-}
+const useLogger = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const isLogger = process.env.REDUX_LOGGER;
+
+  if (!isProduction && !global.__testing__) {
+    if (isLogger === undefined || isLogger === true) return true;
+  }
+  return isProduction && isLogger;
+};
+
+if (useLogger()) middleware = [...middleware, createLogger()];
 
 export const generateStore = () =>
   createStore(


### PR DESCRIPTION
create an environment variable to disable redux-logger if needed.
<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
