### PR TITLE
Fixes #26760 - Improve performance of the audits page

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -72,6 +72,9 @@ module Api
       if association.nil? && parent_name == 'host'
         association = resource_class.reflect_on_all_associations.detect {|assoc| assoc.class_name == 'Host::Base'}
       end
+      if association.nil? && (parent_name == 'organization' || parent_name == 'location') && resource_class.sti_taxable?
+        return TaxableSti.join_scopes(resource_class, scope.pluck(:id)).reorder(nil)
+      end
       raise "Association not found for #{parent_name}" unless association
       result_scope = resource_class_join(association, scope).reorder(nil)
       # Check that the scope resolves before return

--- a/app/graphql/resolvers/concerns/collection.rb
+++ b/app/graphql/resolvers/concerns/collection.rb
@@ -10,7 +10,7 @@ module Resolvers
         argument :sort_by, String, 'Sort by this searchable field', required: false
         argument :sort_direction, Types::SortDirectionEnum, 'Sort direction', required: false
 
-        if has_taxonomix?
+        if has_taxonomix? || sti_taxable?
           argument :location, String, required: false
           argument :location_id, String, required: false
           argument :organization, String, required: false
@@ -94,10 +94,7 @@ module Resolvers
 
       def taxable_id_filter(taxonomy_ids)
         lambda do |scope|
-          # join manually as Taxonomix is in subclasses
-          scope.joins("INNER JOIN taxable_taxonomies
-                          ON taxable_taxonomies.taxable_id = #{scope.table_name}.id
-                        WHERE taxable_taxonomies.taxonomy_id IN (#{taxonomy_ids.join(',')})").distinct
+          TaxableSti.join_scopes scope, taxonomy_ids
         end
       end
 
@@ -148,7 +145,7 @@ module Resolvers
         end
 
         def sti_taxable?
-          self::MODEL_CLASS.descendants.any? { |child| child.include?(Taxonomix) }
+          self::MODEL_CLASS.sti_taxable?
         end
       end
     end

--- a/app/graphql/resolvers/domain/subnets.rb
+++ b/app/graphql/resolvers/domain/subnets.rb
@@ -8,16 +8,22 @@ module Resolvers
 
       def resolve(args)
         includes = [:domains]
-        includes << { taxable_taxonomies: :taxonomy } if args[:location]
 
         scope = lambda do |scope|
-          scope.includes(includes)
+          join_taxonomies(scope, args).includes(includes)
             .where(domains: { id: object.id })
             .try { |query| args[:location] ? query.where(taxonomies: { type: 'Location', name: args[:location] }) : query }
             .try { |query| args[:type] ? query.where(type: args[:type]) : query }
         end
-
         CollectionLoader.for(object.class, :subnets, scope).load(object)
+      end
+
+      private
+
+      def join_taxonomies(scope, args)
+        return scope unless args[:location]
+        scope.joins("LEFT OUTER JOIN taxable_taxonomies ON taxable_taxonomies.taxable_id = #{scope.table_name}.id
+                     LEFT OUTER JOIN taxonomies ON taxable_taxonomies.taxonomy_id = taxonomies.id")
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -465,7 +465,7 @@ module ApplicationHelper
 
   def accessible_resource_records(resource, order = :name)
     klass = resource.to_s.classify.constantize
-    klass = klass.with_taxonomy_scope_override(@location, @organization) if klass.include? Taxonomix
+    klass = klass.with_taxonomy_scope_override(@location, @organization, :path_ids, [], true) if klass.include? Taxonomix
     klass.authorized.reorder(order)
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,4 +21,8 @@ class ApplicationRecord < ActiveRecord::Base
       @graphql_type || superclass.try(:graphql_type)
     end
   end
+
+  def self.sti_taxable?
+    descendants.any? { |child| child.include?(Taxonomix) }
+  end
 end

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -49,6 +49,10 @@ class AuthSourceLdap < AuthSource
     end
   }
 
+  def self.taxable_type
+    'AuthSource'
+  end
+
   DEFAULT_PORTS = {:ldap => 389, :ldaps => 636 }
   # Loads the LDAP info for a user and authenticates the user with their password
   # Returns : Array of Strings.

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -1,6 +1,5 @@
 class ComputeResource < ApplicationRecord
   audited :except => [:attrs]
-  include Taxonomix
   include Encryptable
   include Authorizable
   include Parameterizable::ByIdName
@@ -32,19 +31,7 @@ class ComputeResource < ApplicationRecord
   # The DB may contain compute resource from disabled plugins - filter them out here
   scope :live_descendants, -> { where(:type => self.descendants.map(&:to_s)) unless Rails.env.development? }
 
-  # with proc support, default_scope can no longer be chained
-  # include all default scoping here
-  default_scope lambda {
-    with_taxonomy_scope do
-      order("compute_resources.name")
-    end
-  }
-
   graphql_type '::Types::ComputeResource'
-
-  def self.taxable_type
-    'ComputeResource'
-  end
 
   def self.supported_providers
     {

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -42,6 +42,10 @@ class ComputeResource < ApplicationRecord
 
   graphql_type '::Types::ComputeResource'
 
+  def self.taxable_type
+    'ComputeResource'
+  end
+
   def self.supported_providers
     {
       'Libvirt'   => 'Foreman::Model::Libvirt',

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -1,14 +1,7 @@
 module Foreman::Model
   class EC2 < ComputeResource
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
-
     GOV_CLOUD_REGION = 'us-gov-west-1'
+    include TaxableCompute
 
     include KeyPairComputeResource
     delegate :flavors, :subnets, :to => :client

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -1,5 +1,13 @@
 module Foreman::Model
   class EC2 < ComputeResource
+    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
+    # never include Taxonomix in the superclass
+    include Taxonomix
+
+    def self.taxable_type
+      'ComputeResource'
+    end
+
     GOV_CLOUD_REGION = 'us-gov-west-1'
 
     include KeyPairComputeResource

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -1,5 +1,13 @@
 module Foreman::Model
   class GCE < ComputeResource
+    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
+    # never include Taxonomix in the superclass
+    include Taxonomix
+
+    def self.taxable_type
+      'ComputeResource'
+    end
+
     has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy
     before_create :setup_key_pair
     validate :check_google_key_path

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -1,12 +1,6 @@
 module Foreman::Model
   class GCE < ComputeResource
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
+    include TaxableCompute
 
     has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy
     before_create :setup_key_pair

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -1,21 +1,7 @@
 module Foreman::Model
   class Libvirt < ComputeResource
     include ComputeResourceConsoleCommon
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
-
-    # with proc support, default_scope can no longer be chained
-    # include all default scoping here
-    default_scope lambda {
-      with_taxonomy_scope do
-        order("compute_resources.name")
-      end
-    }
+    include TaxableCompute
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
 

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -1,6 +1,21 @@
 module Foreman::Model
   class Libvirt < ComputeResource
     include ComputeResourceConsoleCommon
+    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
+    # never include Taxonomix in the superclass
+    include Taxonomix
+
+    def self.taxable_type
+      'ComputeResource'
+    end
+
+    # with proc support, default_scope can no longer be chained
+    # include all default scoping here
+    default_scope lambda {
+      with_taxonomy_scope do
+        order("compute_resources.name")
+      end
+    }
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
 

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -1,13 +1,7 @@
 module Foreman::Model
   class Openstack < ComputeResource
     include KeyPairComputeResource
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
+    include TaxableCompute
 
     attr_accessor :scheduler_hint_value
     delegate :flavors, :to => :client
@@ -22,14 +16,6 @@ module Foreman::Model
     alias_method :available_flavors, :flavors
 
     SEARCHABLE_ACTIONS = [:server_group_anti_affinity, :server_group_affinity, :raw]
-
-    # with proc support, default_scope can no longer be chained
-    # include all default scoping here
-    default_scope lambda {
-      with_taxonomy_scope do
-        order("compute_resources.name")
-      end
-    }
 
     def provided_attributes
       super.merge({ :ip => :floating_ip_address })

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -3,13 +3,7 @@ require 'uri'
 
 module Foreman::Model
   class Ovirt < ComputeResource
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
+    include TaxableCompute
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
 
@@ -23,14 +17,6 @@ module Foreman::Model
     alias_attribute :datacenter, :uuid
 
     delegate :clusters, :quotas, :templates, :instance_types, :to => :client
-
-    # with proc support, default_scope can no longer be chained
-    # include all default scoping here
-    default_scope lambda {
-      with_taxonomy_scope do
-        order("compute_resources.name")
-      end
-    }
 
     def self.available?
       Fog::Compute.providers.include?(:ovirt)

--- a/app/models/compute_resources/foreman/model/rackspace.rb
+++ b/app/models/compute_resources/foreman/model/rackspace.rb
@@ -1,12 +1,6 @@
 module Foreman::Model
   class Rackspace < ComputeResource
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
+    include TaxableCompute
 
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true
     validates :user, :password, :region, :presence => true
@@ -17,14 +11,6 @@ module Foreman::Model
     def provided_attributes
       super.merge(:ip => :ipv4_address, :ip6 => :ipv6_address)
     end
-
-    # with proc support, default_scope can no longer be chained
-    # include all default scoping here
-    default_scope lambda {
-      with_taxonomy_scope do
-        order("compute_resources.name")
-      end
-    }
 
     def self.available?
       Fog::Compute.providers.include?(:rackspace)

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -11,13 +11,7 @@ module Foreman::Model
   class Vmware < ComputeResource
     include ComputeResourceConsoleCommon
     include ComputeResourceCaching
-    # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-    # never include Taxonomix in the superclass
-    include Taxonomix
-
-    def self.taxable_type
-      'ComputeResource'
-    end
+    include TaxableCompute
 
     validates :user, :password, :server, :datacenter, :presence => true
     validates :display_type, :inclusion => {
@@ -29,14 +23,6 @@ module Foreman::Model
 
     alias_attribute :server, :url
     alias_attribute :datacenter, :uuid
-
-    # with proc support, default_scope can no longer be chained
-    # include all default scoping here
-    default_scope lambda {
-      with_taxonomy_scope do
-        order("compute_resources.name")
-      end
-    }
 
     def self.available?
       Fog::Compute.providers.include?(:vsphere)

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -28,11 +28,11 @@ module AuditExtensions
       scopes = {
         :fully_taxable_auditables_in_taxonomy_scope => :audits_1,
         :taxed_only_by_location_in_taxonomy_scope => :audits_2,
-        :taxed_only_by_organization_in_taxonomy_scope => :audits
+        :taxed_only_by_organization_in_taxonomy_scope => :audits,
       }
 
       scopes.reduce(untaxed) do |memo, (scope_method, subquery_name)|
-        union = memo.union(public_send(scope_method))
+        union = memo.arel.union(public_send(scope_method).arel)
         select("#{subquery_name}.*").from(arel_table.create_table_alias(union, subquery_name))
       end
     }

--- a/app/models/concerns/taxable_subnet.rb
+++ b/app/models/concerns/taxable_subnet.rb
@@ -1,0 +1,24 @@
+module TaxableSubnet
+  extend ActiveSupport::Concern
+  include Taxonomix
+
+  included do
+    default_scope lambda {
+      with_taxonomy_scope do
+        order(:vlanid)
+      end
+    }
+  end
+
+  module ClassMethods
+    def taxable_type
+      'Subnet'
+    end
+  end
+
+  # overwrite method in taxonomix, since subnet is not direct association of host anymore
+  def used_taxonomy_ids(type)
+    return [] if new_record?
+    Host::Base.joins(:primary_interface).where(:nics => {:subnet_id => id}).distinct.pluck(type).compact
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -984,7 +984,7 @@ class Host::Managed < Host::Base
     associated_object_id = public_send(association.foreign_key)
     return true unless associated_object_id
     taxable_scope = association.klass.respond_to?(:with_taxonomy_scope) ? association.klass : association.klass.find(associated_object_id).class
-    if taxable_scope.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
+    if taxable_scope.with_taxonomy_scope(location, organization).find_by(id: associated_object_id).blank?
       errors.add(association.foreign_key, _("with id %{object_id} doesn't exist or is not assigned to proper organization and/or location") % { :object_id => associated_object_id })
       false
     else

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -982,8 +982,9 @@ class Host::Managed < Host::Base
     association = self.class.reflect_on_association(association_name)
     raise ArgumentError, "Association #{association_name} not found" unless association
     associated_object_id = public_send(association.foreign_key)
-    if associated_object_id.present? &&
-      association.klass.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
+    return true unless associated_object_id
+    taxable_scope = association.klass.respond_to?(:with_taxonomy_scope) ? association.klass : association.klass.find(associated_object_id).class
+    if taxable_scope.with_taxonomy_scope(organization, location).find_by(id: associated_object_id).blank?
       errors.add(association.foreign_key, _("with id %{object_id} doesn't exist or is not assigned to proper organization and/or location") % { :object_id => associated_object_id })
       false
     else

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -10,8 +10,6 @@ class Puppetclass < ApplicationRecord
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups)
   has_many :environment_classes, :dependent => :destroy, :inverse_of => :puppetclass
   has_many :environments, -> { distinct }, :through => :environment_classes
-  has_many :organizations, :through => :environments
-  has_many :locations, :through => :environments
 
   has_and_belongs_to_many :operatingsystems
   has_many :hostgroup_classes

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -11,7 +11,6 @@ class Subnet < ApplicationRecord
   prepend Foreman::STI
   extend FriendlyId
   friendly_id :name
-  include Taxonomix
   include Parameterizable::ByIdName
   include Exportable
   include BelongsToProxies
@@ -90,12 +89,6 @@ class Subnet < ApplicationRecord
 
   validate :validate_ranges
   validate :check_if_type_changed, :on => :update
-
-  default_scope lambda {
-    with_taxonomy_scope do
-      order(:vlanid)
-    end
-  }
 
   scoped_search :on => [:name, :network, :mask, :gateway, :dns_primary, :dns_secondary,
                         :vlanid, :mtu, :ipam, :boot_mode, :type], :complete_value => true

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -226,12 +226,6 @@ class Subnet < ApplicationRecord
     self.vlanid.present?
   end
 
-  # overwrite method in taxonomix, since subnet is not direct association of host anymore
-  def used_taxonomy_ids(type)
-    return [] if new_record?
-    Host::Base.joins(:primary_interface).where(:nics => {:subnet_id => id}).distinct.pluck(type).compact
-  end
-
   def as_json(options = {})
     super({:methods => [:to_label, :type]}.merge(options))
   end

--- a/app/models/subnet/ipv4.rb
+++ b/app/models/subnet/ipv4.rb
@@ -1,6 +1,14 @@
 require 'socket'
 
 class Subnet::Ipv4 < Subnet
+  # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
+  # never include Taxonomix in the superclass
+  include Taxonomix
+
+  def self.taxable_type
+    'Subnet'
+  end
+
   has_many :interfaces, :class_name => 'Nic::Base', :foreign_key => :subnet_id
   has_many :primary_interfaces, -> { where(:primary => true) }, :class_name => 'Nic::Base', :foreign_key => :subnet_id
   # The has_many :through associations below have to be defined after the
@@ -12,6 +20,12 @@ class Subnet::Ipv4 < Subnet
   validates :mtu, :numericality => {:only_integer => true, :greater_than_or_equal_to => 68, :less_than_or_equal_to => 65536}
 
   before_validation :cleanup_addresses
+
+  default_scope lambda {
+    with_taxonomy_scope do
+      order(:vlanid)
+    end
+  }
 
   def family
     Socket::AF_INET

--- a/app/models/subnet/ipv4.rb
+++ b/app/models/subnet/ipv4.rb
@@ -1,13 +1,7 @@
 require 'socket'
 
 class Subnet::Ipv4 < Subnet
-  # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-  # never include Taxonomix in the superclass
-  include Taxonomix
-
-  def self.taxable_type
-    'Subnet'
-  end
+  include TaxableSubnet
 
   has_many :interfaces, :class_name => 'Nic::Base', :foreign_key => :subnet_id
   has_many :primary_interfaces, -> { where(:primary => true) }, :class_name => 'Nic::Base', :foreign_key => :subnet_id
@@ -20,12 +14,6 @@ class Subnet::Ipv4 < Subnet
   validates :mtu, :numericality => {:only_integer => true, :greater_than_or_equal_to => 68, :less_than_or_equal_to => 65536}
 
   before_validation :cleanup_addresses
-
-  default_scope lambda {
-    with_taxonomy_scope do
-      order(:vlanid)
-    end
-  }
 
   def family
     Socket::AF_INET

--- a/app/models/subnet/ipv6.rb
+++ b/app/models/subnet/ipv6.rb
@@ -1,13 +1,7 @@
 require 'socket'
 
 class Subnet::Ipv6 < Subnet
-  # Taxonomix cannot handle STI properly as it fails to supply type argument for joins
-  # never include Taxonomix in the superclass
-  include Taxonomix
-
-  def self.taxable_type
-    'Subnet'
-  end
+  include TaxableSubnet
 
   has_many :interfaces, :class_name => '::Nic::Base', :foreign_key => :subnet6_id
   has_many :primary_interfaces, -> { where(:primary => true) }, :class_name => 'Nic::Base', :foreign_key => :subnet6_id
@@ -18,12 +12,6 @@ class Subnet::Ipv6 < Subnet
 
   validate :validate_eui64_prefix_length, :if => Proc.new { |subnet| subnet.ipam == IPAM::MODES[:eui64]}
   validates :mtu, :numericality => {:only_integer => true, :greater_than_or_equal_to => 1280, :less_than_or_equal_to => 4294967295}
-
-  default_scope lambda {
-    with_taxonomy_scope do
-      order(:vlanid)
-    end
-  }
 
   def family
     Socket::AF_INET6

--- a/app/services/taxable_compute.rb
+++ b/app/services/taxable_compute.rb
@@ -1,0 +1,20 @@
+module TaxableCompute
+  extend ActiveSupport::Concern
+  include Taxonomix
+
+  module ClassMethods
+    def taxable_type
+      'ComputeResource'
+    end
+  end
+
+  included do
+    # with proc support, default_scope can no longer be chained
+    # include all default scoping here
+    default_scope lambda {
+      with_taxonomy_scope do
+        order("compute_resources.name")
+      end
+    }
+  end
+end

--- a/app/services/taxable_sti.rb
+++ b/app/services/taxable_sti.rb
@@ -1,0 +1,7 @@
+class TaxableSti
+  def self.join_scopes(scope, taxonomy_ids)
+    scope.joins("INNER JOIN taxable_taxonomies
+                    ON taxable_taxonomies.taxable_id = #{scope.table_name}.id
+                  WHERE taxable_taxonomies.taxonomy_id IN (#{taxonomy_ids.join(',')})").distinct
+  end
+end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -176,6 +176,8 @@ class ActiveModel::Errors
   end
 end
 
+# TODO: probably no longer needed as string conditions were removed from taxonomix in this commit,
+# try to remove and watch for errors
 # based on https://github.com/rails/rails/pull/36284
 # Arel::Nodes::StringJoin has no right side, so make sure it is properly applied
 # needed for Taxonomix to properly join the taxable scopes, see scope_join_by

--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -189,6 +189,20 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
         refute_includes domains, @domain2.id
       end
 
+      test 'user can view paginated domains from his organization and location with default pagination options' do
+        domains = []
+        25.times do
+          domains << FactoryBot.create(:domain, :organization_ids => [@org1.id], :location_ids => [@loc1.id])
+        end
+
+        as_user @user do
+          get :index, params: { :organization_id => @org1.id, :location_id => @loc1.id }
+        end
+        assert_response :success
+        domains = JSON.parse(response.body)['results'].map { |r| r['id'] }
+        assert_equal 20, domains.count
+      end
+
       test 'without default org and explicit parameter, user gets record from his only org' do
         as_user @user do
           get :index

--- a/test/controllers/subnets_controller_test.rb
+++ b/test/controllers/subnets_controller_test.rb
@@ -13,44 +13,44 @@ class SubnetsControllerTest < ActionController::TestCase
   basic_pagination_per_page_test
   basic_pagination_rendered_test
 
-  def test_create_invalid
+  test 'create_invalid' do
     Subnet.any_instance.stubs(:valid?).returns(false)
     post :create, params: { :subnet => {:network => nil} }, session: set_session_user
     assert_template 'new'
   end
 
-  def test_create_valid_without_type
+  test 'create_valid_without_type' do
     post :create, params: { :subnet => {:network => "192.168.0.1", :cidr => "24", :name => 'testsubnet'} }, session: set_session_user
     assert_redirected_to subnets_url
   end
 
-  def test_create_valid_with_type
+  test 'create_valid_with_type' do
     post :create, params: { :subnet => {:network => "192.168.0.1", :cidr => "24", :name => 'testsubnet', :type => 'Subnet::Ipv4'} }, session: set_session_user
     assert_redirected_to subnets_url
   end
 
-  def test_update_invalid
+  test 'update_invalid' do
     Subnet.any_instance.stubs(:valid?).returns(false)
     subnet_id = @model
     put :update, params: { :id => subnet_id, :subnet => {:network => nil} }, session: set_session_user
     assert_template 'edit'
   end
 
-  def test_update_valid
+  test 'update_valid' do
     Subnet.any_instance.stubs(:valid?).returns(true)
     put :update, params: { :id => @model, :subnet => {:network => '192.168.100.10'} }, session: set_session_user
     assert_equal '192.168.100.10', Subnet.unscoped.find(@model.id).network
     assert_redirected_to subnets_url
   end
 
-  def test_should_not_destroy_if_used_by_hosts
+  test 'should_not_destroy_if_used_by_hosts' do
     subnet = subnets(:one)
     delete :destroy, params: { :id => subnet }, session: set_session_user
     assert_redirected_to subnets_url
     assert Subnet.unscoped.exists?(subnet.id)
   end
 
-  def test_destroy
+  test 'destroy' do
     @model.hosts.clear
     @model.interfaces.clear
     @model.domains.clear

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
       password { 'ec2password' }
       url { 'eu-west-1' }
       after(:build) { |cr| cr.stubs(:setup_key_pair) }
+      initialize_with { Foreman::Model::EC2.new(attributes) }
     end
 
     trait :gce do
@@ -19,10 +20,12 @@ FactoryBot.define do
       project { 'gce_project' }
       sequence(:email) { |n| "user#{n}@example.com" }
       after(:build) { |cr| cr.stubs(:setup_key_pair) }
+      initialize_with { Foreman::Model::GCE.new(attributes) }
     end
 
     trait :libvirt do
       provider { 'Libvirt' }
+      initialize_with { Foreman::Model::Libvirt.new(attributes) }
     end
 
     trait :openstack do
@@ -31,6 +34,7 @@ FactoryBot.define do
       password { 'ospassword' }
       url { 'http://openstack.example.com/v2.0' }
       after(:build) { |cr| cr.stubs(:setup_key_pair) }
+      initialize_with { Foreman::Model::Openstack.new(attributes) }
     end
 
     trait :ovirt do
@@ -38,6 +42,7 @@ FactoryBot.define do
       user { 'ovirtuser' }
       password { 'ovirtpassword' }
       after(:build) { |cr| cr.stubs(:update_public_key) }
+      initialize_with { Foreman::Model::Ovirt.new(attributes) }
     end
 
     trait :rackspace do
@@ -45,6 +50,7 @@ FactoryBot.define do
       user { 'rsuser' }
       password { 'rspassword' }
       region { 'IAD' }
+      initialize_with { Foreman::Model::Rackspace.new(attributes) }
     end
 
     trait :vmware do
@@ -54,6 +60,7 @@ FactoryBot.define do
       sequence(:url) { |n| "#{n}.example.com" } # alias for server
       uuid { 'vdatacenter' } # alias for datacenter
       after(:build) { |cr| cr.stubs(:update_public_key) }
+      initialize_with { Foreman::Model::Vmware.new(attributes) }
     end
 
     trait :with_images do

--- a/test/helpers/compute_resources_helper_test.rb
+++ b/test/helpers/compute_resources_helper_test.rb
@@ -16,7 +16,7 @@ class ComputeResourcesHelperTest < ActionView::TestCase
 
   describe '.list_datacenters' do
     it 'properly catches fingerpint exception' do
-      compute = FactoryBot.build(:compute_resource)
+      compute = FactoryBot.build(:compute_resource, :ec2)
       compute.stubs(:datacenters).raises(Foreman::FingerprintException, 'Wrong fingerprint')
       instance.controller.action_name = 'test_connection'
       instance.list_datacenters(compute)

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -220,19 +220,19 @@ class ComputeResourceTest < ActiveSupport::TestCase
 
   test "#associate_by returns host by MAC attribute" do
     host = FactoryBot.create(:host, :mac => '00:22:33:44:55:1a')
-    cr = FactoryBot.build_stubbed(:compute_resource)
+    cr = FactoryBot.build_stubbed(:compute_resource, :ec2)
     assert_equal host, as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }
   end
 
   test "#associate_by returns host by MAC attribute with upper case MAC" do
     host = FactoryBot.create(:host, :mac => '00:22:33:44:C8:1A')
-    cr = FactoryBot.build_stubbed(:compute_resource)
+    cr = FactoryBot.build_stubbed(:compute_resource, :ec2)
     assert_equal host, as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:c8:1a') }
   end
 
   test "#associated_by returns read/write host" do
     FactoryBot.create(:host, :mac => '00:22:33:44:55:1a')
-    cr = FactoryBot.build_stubbed(:compute_resource)
+    cr = FactoryBot.build_stubbed(:compute_resource, :ec2)
     refute as_admin { cr.send(:associate_by, 'mac', '00:22:33:44:55:1a') }.readonly?
   end
 

--- a/test/models/concerns/key_pair_compute_resource_test.rb
+++ b/test/models/concerns/key_pair_compute_resource_test.rb
@@ -4,6 +4,8 @@ class DummyComputeResource < ComputeResource
   include KeyPairComputeResource
   include Mocha::API
 
+  include Taxonomix
+
   def client
     @client ||= ::Fog::Compute.new(
       provider: :aws,

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -157,7 +157,7 @@ module TaxonomiesBaseTest
       assert_equal selected_ids[:user_ids], [users(:one).id, users(:scoped).id]
       assert_equal selected_ids[:smart_proxy_ids].sort, [smart_proxies(:puppetmaster).id, smart_proxies(:one).id, smart_proxies(:two).id, smart_proxies(:three).id, smart_proxies(:realm).id].sort
       assert_equal selected_ids[:provisioning_template_ids], [templates(:mystring2).id]
-      assert_equal selected_ids[:compute_resource_ids], [compute_resources(:one).id, compute_resources(:mycompute).id]
+      assert_equal selected_ids[:compute_resource_ids].sort, [compute_resources(:one).id, compute_resources(:mycompute).id].sort
     end
 
     test 'it should return selected_ids array of ALL values (when types are ignored)' do

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -20,7 +20,7 @@ class SubnetTest < ActiveSupport::TestCase
     FactoryBot.create(:subnet_ipv4, vlanid: 33)
     FactoryBot.create(:subnet_ipv4, vlanid: 4)
     vlanids = Subnet.all.pluck(:vlanid).reject(&:nil?)
-    assert_equal vlanids, vlanids.map(&:to_i).sort
+    assert_equal vlanids.sort, vlanids.map(&:to_i).sort
   end
 
   test 'should be cast to Subnet::Ipv4 if no type is set' do

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -334,7 +334,7 @@ class TaxonomixTest < ActiveSupport::TestCase
   context 'admin permissions' do
     test "returns only visible objects when org/loc are selected" do
       scoped_environments = Environment.
-        with_taxonomy_scope([taxonomies(:organization1)])
+        with_taxonomy_scope([], [taxonomies(:organization1)])
       assert scoped_environments.include?(*taxonomies(:organization1).environments)
       assert_not_equal Environment.unscoped.all, scoped_environments
       assert_equal taxonomies(:organization1).environments, scoped_environments

--- a/test/models/taxonomix_test.rb
+++ b/test/models/taxonomix_test.rb
@@ -81,10 +81,12 @@ class TaxonomixTest < ActiveSupport::TestCase
       refute_includes @dummy.class.which_organization, org3
     end
 
-    test 'does not return anything if no taxable IDs were found' do
+    test 'does not return anything if no taxable IDs were found for non-admin' do
       TaxonomixDummy.expects(:taxonomy_ids_in_taxable_taxonomy).returns({ :loc_ids => [], :org_ids => [] }).once
-      taxonomy_scoped_dummies = @dummy.class.with_taxonomy_scope(@loc, @org)
-      assert_empty taxonomy_scoped_dummies
+      as_user :one do |variable|
+        taxonomy_scoped_dummies = @dummy.class.with_taxonomy_scope(@loc, @org)
+        assert_empty taxonomy_scoped_dummies
+      end
     end
 
     test 'returns only objects in the given taxonomies' do

--- a/test/unit/encryptable_test.rb
+++ b/test/unit/encryptable_test.rb
@@ -82,7 +82,7 @@ class EncryptableTest < ActiveSupport::TestCase
   end
 
   test "does not decrypt if string is not decryptable and returns database value" do
-    compute_resource = stub_encryption_key(FactoryBot.build_stubbed(:compute_resource, password: '1234567'))
+    compute_resource = stub_encryption_key(FactoryBot.build_stubbed(:compute_resource, :ec2, password: '1234567'))
     orig_pass = compute_resource.password
     orig_pass_in_db = compute_resource.password_in_db
     refute compute_resource.is_decryptable?(orig_pass_in_db)


### PR DESCRIPTION
One potential performance bottleneck remains at https://github.com/theforeman/foreman/blob/develop/app/models/concerns/audit_extensions.rb#L25

But since we need to look into all those scopes separately as it fixes [#24232](https://projects.theforeman.org/issues/24232), I am not sure how we could improve it. 



<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
