### PR TITLE
Fixes #27107 - make pagination expect numbers, not strings

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -12,8 +12,8 @@ module Api
       end
 
       def_param_group :pagination do
-        param :page, String, :desc => N_("paginate results")
-        param :per_page, String, :desc => N_("number of entries per request")
+        param :page, :number, :desc => N_("Page number, starting at 1")
+        param :per_page, :number, :desc => N_("Number of results per page to return")
       end
 
       def_param_group :search_and_pagination do

--- a/app/controllers/api/v2/interfaces_controller.rb
+++ b/app/controllers/api/v2/interfaces_controller.rb
@@ -16,8 +16,7 @@ module Api
       param :host_id, String, :required => true, :desc => N_("ID or name of host")
       param :domain_id, String, :required => false, :desc => N_('ID or name of domain')
       param :subnet_id, String, :required => false, :desc => N_('ID or name of subnet')
-      param :page, String, :desc => N_("paginate results")
-      param :per_page, String, :desc => N_("number of entries per request")
+      param_group :pagination, ::Api::V2::BaseController
 
       def index
         @interfaces = resource_scope.paginate(paginate_options)


### PR DESCRIPTION
This also updates the wording of the `page` param to reflect it's the
page to load, not a flag to enable pagination.

It also makes the InterfacesController use the pagination group from the
BaseController instead of defining the same params again.


<!--
Simple description of what is fixed/introduced.

Prerequisites for testing:
* VMware cluster
* Two smart proxies

Tests needed (anticipated impacts):
* Hosts list - mainly power column
* Power status on host page
-->

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [Translating section in the guide]
* Suggest prerequisites for testing and testing scenarios following example above.
(https://projects.theforeman.org/projects/foreman/wiki/Translating)
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* Be nice and respectful

We are running bots that will poke you if you miss an item from the list :-)

-->
