### PR TITLE
fixes #27154 - bump net-ldap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '2.1.0'
 gem 'net-scp'
 gem 'net-ssh', '4.2.0'
-gem 'net-ldap', '>= 0.8.0'
+gem 'net-ldap', '>= 0.16.0'
 gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 1.1.0', '< 2'
 gem 'sprockets', '~> 3'


### PR DESCRIPTION
CVE-2017-17718 More information
moderate severity
Vulnerable versions: < 0.16.0
Patched version: 0.16.0
The Net::LDAP (aka net-ldap) gem before 0.16.0 for Ruby has Missing SSL Certificate Validation.