### PR TITLE
Fixes #27160 - do not use Ruby Timeout for DNS

### DIFF
--- a/app/models/concerns/orchestration/dns.rb
+++ b/app/models/concerns/orchestration/dns.rb
@@ -122,11 +122,11 @@ module Orchestration::DNS
       end
     end
     !status # failure method returns 'false'
-  rescue Net::Error => e
+  rescue Resolv::ResolvTimeout, Net::Error => e
     if domain.nameservers.empty?
       failure(_("Error connecting to system DNS server(s) - check /etc/resolv.conf"), e)
     else
-      failure(_("Error connecting to '%{domain}' domain DNS servers: %{servers} - check query_local_nameservers and dns_conflict_timeout settings") % {:domain => domain.try(:name), :servers => domain.nameservers.join(',')}, e)
+      failure(_("Error connecting to '%{domain}' domain DNS servers: %{servers} - check query_local_nameservers and dns_timeout settings") % {:domain => domain.try(:name), :servers => domain.nameservers.join(',')}, e)
     end
   end
 end

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -58,7 +58,7 @@ class Setting::Provisioning < Setting
       self.set('libvirt_default_console_address', N_("The IP address that should be used for the console listen address when provisioning new virtual machines via Libvirt"), "0.0.0.0", N_('Libvirt default console address')),
       self.set('update_ip_from_built_request', N_("Foreman will update the host IP with the IP that made the built request"), false, N_('Update IP from built request')),
       self.set('use_shortname_for_vms', N_("Foreman will use the short hostname instead of the FQDN for creating new virtual machines"), false, N_('Use short name for VMs')),
-      self.set('dns_conflict_timeout', N_("Timeout for DNS conflict validation (in seconds)"), 3, N_('DNS conflict timeout')),
+      self.set('dns_timeout', N_("List of timeouts (in seconds) for DNS lookup attempts (dns_lookup macro and DNS record conflict validation)"), [5, 10, 15, 20], N_('DNS conflict timeout(s)')),
       self.set('clean_up_failed_deployment', N_("Foreman will delete virtual machine if provisioning script ends with non zero exit code"), true, N_('Clean up failed deployment')),
       self.set('name_generator_type', N_("Random gives unique names, MAC-based are longer but stable (and only works with bare-metal)"), 'Random-based', N_("Type of name generator"), nil, {:collection => Proc.new {NameGenerator::GENERATOR_TYPES} }),
       self.set('default_pxe_item_global', N_("Default PXE menu item in global template - 'local', 'discovery' or custom, use blank for template default"), nil, N_("Default PXE global template entry")),

--- a/db/migrate/20190801143210_convert_dns_conflict_timeout_setting.rb
+++ b/db/migrate/20190801143210_convert_dns_conflict_timeout_setting.rb
@@ -1,0 +1,46 @@
+class FakeSetting < ApplicationRecord
+  self.table_name = 'settings'
+
+  def default=(v)
+    write_attribute :default, v.to_yaml
+  end
+
+  def value=(v)
+    v = v.to_yaml unless v.nil?
+    write_attribute :value, v
+  end
+
+  def value
+    v = read_attribute(:value)
+    YAML.load(v) unless v.nil?
+  end
+end
+
+class ConvertDnsConflictTimeoutSetting < ActiveRecord::Migration[5.2]
+  def clean_cache
+    Rails.cache.delete(Setting.cache_key("dns_conflict_timeout"))
+    Rails.cache.delete(Setting.cache_key("dns_timeout"))
+  end
+
+  def up
+    Setting.without_auditing do
+      old_setting = FakeSetting.find_by_name("dns_conflict_timeout")
+      new_setting = FakeSetting.find_by_name("dns_timeout")
+      return if old_setting.nil? || new_setting.nil?
+      # only migrate the value if it was redefined (default was 3)
+      if old_setting.value != 3
+        new_setting.value = [old_setting.value]
+        new_setting.save!
+      end
+      old_setting.destroy!
+      clean_cache
+    end
+  end
+
+  def down
+    Setting.without_auditing do
+      FakeSetting.where("name = 'dns_timeout' or name = 'dns_conflict_timeout'").destroy_all
+      clean_cache
+    end
+  end
+end

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -76,7 +76,7 @@ module Foreman
         :ignored_interface_identifiers,
         :remote_addr,
         :token_duration,
-        :dns_conflict_timeout,
+        :dns_timeout,
         :name_generator_type,
         :default_pxe_item_global,
         :default_pxe_item_local,

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -68,15 +68,14 @@ module Foreman
 
           def dns_lookup(name_or_ip)
             resolver = Resolv::DNS.new
-            Timeout.timeout(Setting[:dns_conflict_timeout]) do
-              begin
-                resolver.getname(name_or_ip)
-              rescue Resolv::ResolvError
-                resolver.getaddress(name_or_ip)
-              end
+            resolver.timeouts = Setting[:dns_timeout]
+            begin
+              resolver.getname(name_or_ip)
+            rescue Resolv::ResolvError
+              resolver.getaddress(name_or_ip)
             end
           rescue StandardError => e
-            log_warn "Template helper dns_lookup failed: #{e}"
+            log_warn "Template helper dns_lookup failed: #{e} (timeout set to #{Setting[:dns_timeout]})"
             raise e
           end
 

--- a/lib/net/dns.rb
+++ b/lib/net/dns.rb
@@ -22,44 +22,41 @@ module Net
       proxy = options.fetch(:proxy, nil)
       resolver = options.fetch(:resolver, Resolv::DNS.new)
       ipfamily = options.fetch(:ipfamily, Socket::AF_INET)
+      resolver.timeouts = Setting[:dns_timeout]
 
-      Timeout.timeout(Setting[:dns_conflict_timeout]) do
-        ipquery = IPAddr.new(query) rescue nil
-        if ipquery&.ipv4?
-          hostname = resolver.getname(query).to_s
-          ip = query
-          type = "PTR4"
-        elsif ipquery&.ipv6?
-          hostname = resolver.getname(query).to_s
-          ip = query
-          type = "PTR6"
-        elsif ipfamily == Socket::AF_INET6
-          ip = resolver.getresource(query, Resolv::DNS::Resource::IN::AAAA).address.to_s
-          hostname = query
-          type = "AAAA"
-        else
-          ip = resolver.getresource(query, Resolv::DNS::Resource::IN::A).address.to_s
-          hostname = query
-          type = "A"
-        end
+      ipquery = IPAddr.new(query) rescue nil
+      if ipquery&.ipv4?
+        hostname = resolver.getname(query).to_s
+        ip = query
+        type = "PTR4"
+      elsif ipquery&.ipv6?
+        hostname = resolver.getname(query).to_s
+        ip = query
+        type = "PTR6"
+      elsif ipfamily == Socket::AF_INET6
+        ip = resolver.getresource(query, Resolv::DNS::Resource::IN::AAAA).address.to_s
+        hostname = query
+        type = "AAAA"
+      else
+        ip = resolver.getresource(query, Resolv::DNS::Resource::IN::A).address.to_s
+        hostname = query
+        type = "A"
+      end
 
-        attrs = { :hostname => hostname, :ip => ip, :resolver => resolver, :proxy => proxy }
+      attrs = { :hostname => hostname, :ip => ip, :resolver => resolver, :proxy => proxy }
 
-        case type
-          when "A"
-            ARecord.new attrs
-          when "AAAA"
-            AAAARecord.new attrs
-          when "PTR4"
-            PTR4Record.new attrs
-          when "PTR6"
-            PTR6Record.new attrs
-        end
+      case type
+        when "A"
+          ARecord.new attrs
+        when "AAAA"
+          AAAARecord.new attrs
+        when "PTR4"
+          PTR4Record.new attrs
+        when "PTR6"
+          PTR6Record.new attrs
       end
     rescue Resolv::ResolvError, SocketError
       nil
-    rescue Timeout::Error => e
-      raise Net::Error, e
     end
 
     class Record < Net::Record


### PR DESCRIPTION
We use Timeout Ruby class in our codebase to handle DNS queries which is not good approach. Actually Ruby DNS Resolver reads all "nameserver" entries and tries one after another, however the way this is implemented is that the default Ruby DNS timeout is high (5, 10, 20, 40 seconds) and it probably does not reply fast enough and the global timeout (in our codebase) fires off.

The solution is to remove the extra timeout we have there and rely only on the Ruby DNS resolver timeout. No idea why this wasn't there from the day one. Try the patch and let me know if it solved the problem.

This issue was reported by a community user.