### PR TITLE
Fixes #24993 - Ensure token type doesn't exist in migrations

### DIFF
--- a/db/migrate/20180613100703_add_type_to_token.rb
+++ b/db/migrate/20180613100703_add_type_to_token.rb
@@ -5,7 +5,10 @@ class AddTypeToToken < ActiveRecord::Migration[5.1]
     add_index :tokens, :host_id
     add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })
     add_column :tokens, :type, :string, default: 'Token::Build', null: false, index: true
-    change_column :tokens, :value, :string, limit: 900
+    # mysql only allows indexing up to 767 bytes for text columns
+    remove_index :tokens, :value if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+    change_column :tokens, :value, :text
+    add_index :tokens, :value, length: 767 if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
   end
 
   def down

--- a/db/migrate/20190627083110_change_token_value_type.rb
+++ b/db/migrate/20190627083110_change_token_value_type.rb
@@ -1,0 +1,10 @@
+class ChangeTokenValueType < ActiveRecord::Migration[5.2]
+  def up
+    # in case the AddTypeToToken migration was already executed, we need to endure consistency since it was modified
+    unless column_exists? :tokens, :value, :text
+      remove_index :tokens, :value if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+      change_column :tokens, :value, :text
+      add_index :tokens, :value, length: 767 if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+    end
+  end
+end


### PR DESCRIPTION
Not sure why, but in some cases MySQL users report failures during
upgrades of this migration.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
