### PR TITLE
Fixes #27188 - TimePicker is failing in Node12

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/TimePicker.js
@@ -22,7 +22,7 @@ class TimePicker extends React.Component {
   formatDate = () => {
     const { locale } = this.props;
     const { value } = this.state;
-    const options = { hour: '2-digit', minute: '2-digit' };
+    const options = { hour: 'numeric', minute: 'numeric' };
     return value.toLocaleString(locale, options);
   };
   setSelected = date => {


### PR DESCRIPTION
The 'numeric' option for time format gives the same input as the '2-digit' option gives in Node 11.
The 'numeric' option is consistent between Node 10,11,12