### PR TITLE
Fixes #27190 - Add DSL for registering plugin fields

### DIFF
--- a/app/graphql/types/mutation.rb
+++ b/app/graphql/types/mutation.rb
@@ -9,5 +9,8 @@ module Types
     field :delete_model, mutation: Mutations::Models::Delete
 
     field :create_host, mutation: Mutations::Hosts::Create
+
+    include ::Foreman::Plugin::GraphqlPluginFields
+    realize_plugin_mutation_extensions
   end
 end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -12,6 +12,9 @@ module Types
       end
     end
 
+    include ::Foreman::Plugin::GraphqlPluginFields
+    realize_plugin_query_extensions
+
     field :node, field: GraphQL::Relay::Node.field
     field :nodes, field: GraphQL::Relay::Node.plural_field
 

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -536,6 +536,14 @@ module Foreman #:nodoc:
       graphql_types_registry.register_extension(type: type, with_module: with_module, &block)
     end
 
+    def register_graphql_query_field(field_name, type, field_type)
+      graphql_types_registry.register_plugin_query_field(field_name, type, field_type)
+    end
+
+    def register_graphql_mutation_field(field_name, mutation_class)
+      graphql_types_registry.register_plugin_mutation_field(field_name, mutation_class)
+    end
+
     private
 
     def extend_template_helpers_by_module(mod)

--- a/app/registries/foreman/plugin/graphql_plugin_fields.rb
+++ b/app/registries/foreman/plugin/graphql_plugin_fields.rb
@@ -1,0 +1,21 @@
+module Foreman
+  class Plugin
+    module GraphqlPluginFields
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def realize_plugin_query_extensions(source = Foreman::Plugin.graphql_types_registry.plugin_query_fields)
+          source.map do |plugin_type|
+            send plugin_type[:field_type], plugin_type[:field_name], plugin_type[:type]
+          end
+        end
+
+        def realize_plugin_mutation_extensions(source = Foreman::Plugin.graphql_types_registry.plugin_mutation_fields)
+          source.map do |plugin_type|
+            send :field, plugin_type[:field_name], mutation: plugin_type[:mutation]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/registries/foreman/plugin/graphql_types_registry.rb
+++ b/app/registries/foreman/plugin/graphql_types_registry.rb
@@ -2,11 +2,24 @@ module Foreman
   class Plugin
     class GraphqlTypesRegistry
       delegate :logger, to: Rails
-      attr_reader :type_block_extensions, :type_module_extensions
+      attr_reader :type_block_extensions, :type_module_extensions, :plugin_query_fields, :plugin_mutation_fields
 
       def initialize
         @type_block_extensions = {}
         @type_module_extensions = {}
+        @plugin_query_fields = []
+        @plugin_mutation_fields = []
+      end
+
+      def register_plugin_query_field(field_name, type, field_type)
+        unless [:record_field, :collection_field].any? { |field| field == field_type }
+          raise "expected :record_field or :collection_field as a field_type, got #{field_type}"
+        end
+        @plugin_query_fields << { :field_type => field_type, :field_name => field_name, :type => type }
+      end
+
+      def register_plugin_mutation_field(field_name, mutation)
+        @plugin_mutation_fields << { :field_name => field_name, :mutation => mutation }
       end
 
       # Register a new extension for a graphql type

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1921,6 +1921,32 @@ The module should `extend ActiveSupport::Concern`. Note that any code that is su
    extend_graphql_type type: Types::SmartProxy, with_module: ForemanOpenscap::SmartProxyTypeExtensions
 ....
 
+[[adding-graphql-types]]
+=== Adding new graphql types
+
+_Requires Foreman 1.23 or higher, set requires_foreman '>= 1.23' in
+engine.rb_
+
+When you create a new graphql type in your plugin, you need to register it in your `engine.rb` so that Foreman knows how it should be used in a query.
+
+[source, ruby]
+....
+  register_graphql_query_field :duck, ::Types::Duck, :record_field
+  register_graphql_query_field :ducks, ::Types::Duck, :collection_field
+....
+
+With the example above, server will know how to respond to `duck` and `ducks` queries. The first argument of `register_graphql_field` is query name, second is the type class and the third is whether the query is for a single record or a collection.
+
+Similarly for mutations:
+
+[source, ruby]
+....
+  register_graphql_mutation_field :delete_duck, ::Mutations::Ducks::Delete
+....
+
+where `::Mutations::Ducks::Delete` is your delete mutation class inheriting from `::Mutations::DeleteMutation`.
+
+
 [[translating]]
 == Translating
 

--- a/test/unit/foreman/plugin/graphql_plugin_fields_test.rb
+++ b/test/unit/foreman/plugin/graphql_plugin_fields_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class Foreman::Plugin::GraphqlPluginFieldsTest < ActiveSupport::TestCase
+  class GraphqlType
+    include ::Foreman::Plugin::GraphqlPluginFields
+
+    class << self
+      attr_accessor :record_fields, :collection_fields, :mutation_fields
+
+      def record_field(name, type)
+        push_item :record_fields, name, type
+      end
+
+      def collection_field(name, type)
+        push_item :collection_fields, name, type
+      end
+
+      def field(name, mutation)
+        item = { :name => name, :mutation => mutation }
+        @mutation_fields ? @mutation_fields << item : @mutation_fields = [item]
+      end
+
+      private
+
+      def push_item(place, name, type)
+        item = { :name => name, :type => type }
+        instance_var = instance_variable_get("@#{place}")
+        instance_var ? instance_var << item : instance_variable_set("@#{place}", [item])
+      end
+    end
+  end
+
+  describe 'graphql plugin query fields' do
+    it 'adds a record field' do
+      registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
+        reg.register_plugin_query_field :moo, Class, :record_field
+      end
+
+      klass = Class.new(GraphqlType)
+
+      assert_nil klass.record_fields
+      assert_nil klass.collection_fields
+      klass.realize_plugin_query_extensions registry.plugin_query_fields
+
+      assert_nil klass.collection_fields
+      assert_equal 1, klass.record_fields.size
+      assert_equal :moo, klass.record_fields.first[:name]
+    end
+
+    it 'adds a collection field' do
+      registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
+        reg.register_plugin_query_field :woof, Class, :collection_field
+      end
+
+      klass = Class.new(GraphqlType)
+
+      assert_nil klass.record_fields
+      assert_nil klass.collection_fields
+      klass.realize_plugin_query_extensions registry.plugin_query_fields
+
+      assert_nil klass.record_fields
+      assert_equal 1, klass.collection_fields.size
+      assert_equal :woof, klass.collection_fields.first[:name]
+    end
+  end
+
+  describe 'graphql plugin mutation fields' do
+    it 'adds a mutation field' do
+      registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
+        reg.register_plugin_mutation_field :quack, Class.new
+      end
+
+      klass = Class.new(GraphqlType)
+
+      assert_nil klass.mutation_fields
+      klass.realize_plugin_mutation_extensions registry.plugin_mutation_fields
+      assert_equal 1, klass.mutation_fields.size
+      assert_equal :quack, klass.mutation_fields.first[:name]
+    end
+  end
+end

--- a/test/unit/foreman/plugin/graphql_types_registry_test.rb
+++ b/test/unit/foreman/plugin/graphql_types_registry_test.rb
@@ -7,6 +7,9 @@ class Foreman::Plugin::GraphqlTypesRegistryTest < ActiveSupport::TestCase
     end
   end
 
+  class TestType
+  end
+
   let(:registry) { Foreman::Plugin::GraphqlTypesRegistry.new }
   let(:type_for_testing) { Class.new }
 
@@ -49,6 +52,35 @@ class Foreman::Plugin::GraphqlTypesRegistryTest < ActiveSupport::TestCase
       assert_not_includes type_for_testing.instance_methods, :foo
       registry.realise_extensions
       assert_includes type_for_testing.instance_methods, :foo
+    end
+  end
+
+  describe 'plugin fields' do
+    setup do
+      assert_equal 0, registry.plugin_query_fields.size
+      assert_equal 0, registry.plugin_mutation_fields.size
+    end
+
+    it 'registers plugin query fields' do
+      registry.register_plugin_query_field :baz, TestType, :record_field
+      assert_equal 1, registry.plugin_query_fields.size
+      assert_equal :baz, registry.plugin_query_fields.first[:field_name]
+      assert_equal :record_field, registry.plugin_query_fields.first[:field_type]
+      assert_equal TestType, registry.plugin_query_fields.first[:type]
+    end
+
+    it 'raises on invalid field type' do
+      err = assert_raises RuntimeError do
+        registry.register_plugin_query_field :woof, TestType, :custom_field
+      end
+      assert_equal err.message, "expected :record_field or :collection_field as a field_type, got custom_field"
+    end
+
+    it 'registeres plugin mutation fields' do
+      registry.register_plugin_mutation_field :boom, TestType
+      assert_equal 1, registry.plugin_mutation_fields.size
+      assert_equal :boom, registry.plugin_mutation_fields.first[:field_name]
+      assert_equal TestType, registry.plugin_mutation_fields.first[:mutation]
     end
   end
 end


### PR DESCRIPTION
```ruby
# engine.rb
Foreman::Plugin.register :foreman_openscap do
  register_graphql_query_field :tailoring_file, ::Types::TailoringFile, :record_field
end
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
