### PR TITLE
Fixes #26442 - removes deleted additional volume in GCE

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -71,7 +71,7 @@ module Foreman::Model
       # convert rails nested_attributes into a plain hash
       [:volumes].each do |collection|
         nested_attrs = args.delete("#{collection}_attributes".to_sym)
-        args[collection] = nested_attributes_for(collection, nested_attrs) if nested_attrs
+        args[collection] = nested_attributes_for(collection, nested_attrs.deep_symbolize_keys) if nested_attrs
       end
 
       # Dots are not allowed in names


### PR DESCRIPTION
In [nested_attributes_for](https://github.com/theforeman/foreman/blob/develop/app/models/compute_resource.rb#L438), it was failing before as it is expecting symbol keys.

Adding @ezr-ondrej  and @jyejare in loop