### PR TITLE
Fixes #27207 - send bmc_provider attribute

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -17,10 +17,14 @@ module Nic
     def proxy
       proxy = bmc_proxy
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?
-      ProxyAPI::BMC.new({ :host_ip  => ip,
-                          :url      => proxy.url,
-                          :user     => username,
-                          :password => password_unredacted })
+      args = {
+        :host_ip => ip,
+        :url => proxy.url,
+        :user => username,
+        :password => password_unredacted
+      }
+      args[:bmc_provider] = provider if provider != 'IPMI'
+      ProxyAPI::BMC.new(args)
     end
 
     def self.humanized_name


### PR DESCRIPTION
Our BMC API does support "bmc_provider" attribute, however it looks like Foreman core does not pass it, therefore Proxy always use the implementation which was configured.

We only want to send the provider if IPMI was not set tho because the
way this is implemented in the proxy BMC API is that it needs to
actually decide between FreeIPMI and IPMItool from its configuration.
This is only relevant for non-IPMI providers which is only SSH at this
point.