### PR TITLE
Fixes #27157 - persist associate_external_ip value in GCE

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -83,7 +83,7 @@ module Foreman::Model
         args.except!(:network)
       end
 
-      if to_bool(args.delete(:associate_external_ip))
+      if to_bool(args[:associate_external_ip])
         args[:network_interfaces] = construct_network_interfaces(args[:network_interfaces])
       end
 
@@ -236,8 +236,10 @@ module Foreman::Model
           }
         ]
       end
-      access_config = { :name => "External NAT", :type => "ONE_TO_ONE_NAT" }
-
+      access_config = {
+        :name => ::Fog::Compute::Google::Server::EXTERNAL_NAT_NAME,
+        :type => ::Fog::Compute::Google::Server::EXTERNAL_NAT_TYPE
+      }
       # Note - no support for external_ip from foreman
       # access_config[:nat_ip] = external_ip if external_ip
       network_interfaces_list[0][:access_configs] = [access_config]

--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -81,15 +81,9 @@ module FogExtensions
 
       def external_nat_present?
         return false if network_interfaces.blank?
-        external_ip_flag = false
-        network_interfaces.each do |nic|
-          next if nic[:access_configs].blank?
-          access_config = nic[:access_configs].find { |c| c[:name].eql?(EXTERNAL_NAT_NAME) }
-          next if access_config.blank?
-          external_ip_flag = true
-          break
+        !!network_interfaces.detect do |nic|
+          nic[:access_configs].present? && nic[:access_configs].detect { |c| c[:name].eql?(EXTERNAL_NAT_NAME) }
         end
-        external_ip_flag
       end
 
       def construct_disk_filter(disks_arr)

--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -4,6 +4,9 @@ module FogExtensions
       extend ActiveSupport::Concern
       extend Fog::Attributes::ClassMethods
 
+      EXTERNAL_NAT_NAME = "External NAT".freeze
+      EXTERNAL_NAT_TYPE = "ONE_TO_ONE_NAT".freeze
+
       delegate :flavors, :to => :service
 
       attribute :network
@@ -71,10 +74,23 @@ module FogExtensions
       end
 
       def associate_external_ip
-        public_ip_address.present?
+        external_nat_present?
       end
 
       private
+
+      def external_nat_present?
+        return false if network_interfaces.blank?
+        external_ip_flag = false
+        network_interfaces.each do |nic|
+          next if nic[:access_configs].blank?
+          access_config = nic[:access_configs].find { |c| c[:name].eql?(EXTERNAL_NAT_NAME) }
+          next if access_config.blank?
+          external_ip_flag = true
+          break
+        end
+        external_ip_flag
+      end
 
       def construct_disk_filter(disks_arr)
         disks_arr.map { |d| "(name = \"#{d[:source][/([^\/]+)$/]}\")" }.join(' OR ')


### PR DESCRIPTION
Using this commit, it will persist associate_external_ip value after compute_profile as well as host creation fin case of GCE.

Adding @jyejare in cc.

