### PR TITLE
Fixes #27219 - better uniquness Rails errors

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -38,7 +38,8 @@ module Host
 
     alias_attribute :hostname, :name
 
-    validates :name, :presence => true, :uniqueness => true, :format => {:with => Net::Validations::HOST_REGEXP, :message => _(Net::Validations::HOST_REGEXP_ERR_MSG)}
+    validates :name, :presence => true, :uniqueness => {:message => _(Net::Validations::RECORD_UNIQUE_PRESENCE) % {field: 'Name', model: 'Host'}},
+      :format => {:with => Net::Validations::HOST_REGEXP, :message => _(Net::Validations::HOST_REGEXP_ERR_MSG)}
     validate :host_has_required_interfaces
     validate :uniq_interfaces_identifiers
     validate :build_managed_only

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -25,7 +25,7 @@ module Nic
 
     validates :host, :presence => true, :if => Proc.new { |nic| nic.require_host? }
 
-    validates :identifier, :uniqueness => { :scope => :host_id },
+    validates :identifier, :uniqueness => { :scope => :host_id, :message => _('NIC identifier must be unique within a host')},
       :if => ->(nic) { nic.identifier.present? && nic.host && nic.identifier_was.blank? }
 
     validate :exclusive_primary_interface
@@ -288,11 +288,11 @@ module Nic
 
     private
 
-    def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil))
+    def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil), message = :taken)
       in_memory_candidates = self.host.present? ? self.host.interfaces.select { |i| i.persisted? && !i.marked_for_destruction? } : [self]
       db_candidates = base.where(attr => self.public_send(attr))
       db_candidates = db_candidates.select { |c| c.id != self.id && in_memory_candidates.map(&:id).include?(c.id) }
-      errors.add(attr, :taken) if db_candidates.present?
+      errors.add(attr, message) if db_candidates.present?
     end
   end
 end

--- a/app/models/nic/interface.rb
+++ b/app/models/nic/interface.rb
@@ -94,7 +94,7 @@ module Nic
     end
 
     def name_uniqueness
-      interface_attribute_uniqueness(:name, Nic::Base.where(:domain_id => self.domain_id))
+      interface_attribute_uniqueness(:name, Nic::Base.where(:domain_id => self.domain_id), _('NIC Name must be unique within domain'))
     end
 
     def ip_presence_and_formats

--- a/lib/net/validations.rb
+++ b/lib/net/validations.rb
@@ -3,6 +3,9 @@ require 'socket'
 
 module Net
   module Validations
+    RECORD_UNIQUE_PRESENCE = N_("%{field} must be present and unique for %{model}")
+    RECORD_UNIQUE = N_("%{field} must be unique for %{model}")
+
     IP_REGEXP  ||= /\A((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}\z/
     MAC_REGEXP ||= /\A([a-f0-9]{1,2}:){5}[a-f0-9]{1,2}\z/i
     MAC_REGEXP_64BIT ||= /\A([a-f0-9]{1,2}:){19}[a-f0-9]{1,2}\z/i


### PR DESCRIPTION
Because we very often log errors via orchestration stack and all we have
is "Name has been already taken" without further context (is this a host
or a NIC)? Also other models can benefit from this.

Now, when I am testing this, it works fine for hostname. However when I
create two NICs with the same name in the same domain, I still get a
generic "has already been taken". Why?

I would like to add few more models: subnet, domain, template. Any other
candidates?