### PR TITLE
Fixes #27228 - Remove webpack compile for unit tests

### DIFF
--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -13,7 +13,7 @@ begin
         ENV["CI_REPORTS"] = 'jenkins/reports/unit/'
         gem 'ci_reporter'
       end
-      minitest_plugins = [:pre_ci, 'webpack:try_compile', 'ci:setup:minitest']
+      minitest_plugins = [:pre_ci, 'ci:setup:minitest']
       minitest_plugins << 'robottelo:setup:minitest' if ENV['GENERATE_ROBOTTELO_REPORT'] == 'true'
       task :minitest => minitest_plugins
     end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -17,10 +17,3 @@ namespace :test do
     t.warning = false
   end
 end
-
-# Ensure webpack files are compiled in case integration tests are executed
-unless ENV['SKIP_WEBPACK']
-  Rake::Task[:test].enhance ['webpack:try_compile'] do
-    Rake::FileUtilsExt.verbose(false)
-  end
-end

--- a/lib/tasks/webpack_compile.rake
+++ b/lib/tasks/webpack_compile.rake
@@ -25,13 +25,4 @@ namespace :webpack do
 
     sh "node --max_old_space_size=#{max_old_space_size} #{webpack_bin} --config #{config_file} --bail"
   end
-
-  desc 'Try to compile webpack assets for integration tests, fails only with a warning'
-  task :try_compile do
-    begin
-      Rake::Task['webpack:compile'].invoke
-    rescue => e
-      puts "WARNING: `rake webpack:compile` failed to run. This is only important if running integration tests. (cause: #{e})"
-    end
-  end
 end


### PR DESCRIPTION
Updated from original change to stop building webpack even for Foreman unit tests - not just Katello.

Old description:
> We're looking at ways to speed up minitest runs for Katello and I found that we are doing a webpack compile prior to running the tests because of our usage of this rake task. The tests seem to run (at least they start OK) without this time consuming step. I'm making it configurable so we can opt-out. We already have a separate step in the pipeline to run the webpack tests, so it seems redundant. Please let me know if I'm missing something!