### PR TITLE
Fixes #26286 - Audits page displays warning

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AuditsList/UserDetails.js
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/UserDetails.js
@@ -47,9 +47,9 @@ const UserDetails = ({ isAuditLogin, userInfo, remoteAddress }) => {
 
 UserDetails.propTypes = {
   userInfo: PropTypes.shape({
-    search_path: PropTypes.string.isRequired,
-    display_name: PropTypes.string.isRequired,
-    audit_path: PropTypes.string.isRequired,
+    search_path: PropTypes.string,
+    display_name: PropTypes.string,
+    audit_path: PropTypes.string,
   }).isRequired,
   isAuditLogin: PropTypes.bool,
   remoteAddress: PropTypes.string,


### PR DESCRIPTION
Some audits don't have `search_path` inside `UserDetails`, this PR makes the field optional to fix the warning
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
