### PR TITLE
Fixes #26092 - Assign taxonomy in api when only one present

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -7,6 +7,7 @@ module Api
     include Foreman::Controller::BruteforceProtection
 
     before_action :set_default_response_format, :authorize, :set_taxonomy
+    before_action :assign_lone_taxonomies, :only => :create
     before_action :add_info_headers, :set_gettext_locale
     before_action :session_expiry, :update_activity_time
     around_action :set_timezone
@@ -223,6 +224,24 @@ module Api
         :page     => params[:page],
         :per_page => params[:per_page]
       }
+    end
+
+    def assign_lone_taxonomies
+      return unless resource_class_for(resource_name)
+      [Location, Organization].each do |taxonomy|
+        tax_name = taxonomy.to_s.downcase
+        if resource_class.reflections.has_key? tax_name.pluralize
+          tax_ids = "#{tax_name}_ids"
+          next if params[resource_name].try(:has_key?, tax_ids)
+          next unless taxonomy.one?
+          params[resource_name][tax_ids] = [taxonomy.first.id]
+        elsif resource_class.reflections.has_key? tax_name
+          tax_id = "#{tax_name}_id"
+          next if params[resource_name].try(:has_key?, tax_id)
+          next unless taxonomy.one?
+          params[resource_name][tax_id] = taxonomy.first.id
+        end
+      end
     end
 
     def add_version_header

--- a/test/controllers/api/v2/domains_controller_test.rb
+++ b/test/controllers/api/v2/domains_controller_test.rb
@@ -466,4 +466,28 @@ class Api::V2::DomainsControllerTest < ActionController::TestCase
     assert_equal org.domains.length, assigns(:domains).length
     assert_equal assigns(:domains), org.domains
   end
+
+  context "lone taxonomy assignment" do
+    it 'assigns single taxonomies when only one present' do
+      Location.stubs(:one?).returns(true)
+      Organization.stubs(:one?).returns(true)
+      post :create, params: { :domain => { :name => "domain.net" } }
+      assert_response :created
+      domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
+      assert_equal 1, domain.locations.size
+      assert_equal 1, domain.organizations.size
+      assert_equal Location.first.id, domain.locations.first.id
+      assert_equal Organization.first.id, domain.organizations.first.id
+    end
+
+    it "doesn't assign taxonomies when more than one present" do
+      Location.stubs(:one?).returns(false)
+      Organization.stubs(:one?).returns(false)
+      post :create, params: { :domain => { :name => "domain.net" } }
+      assert_response :created
+      domain = Domain.unscoped.find(JSON.parse(response.body)['id'])
+      assert_empty domain.locations
+      assert_empty domain.organizations
+    end
+  end
 end


### PR DESCRIPTION
When only one taxonomy of a certain type is present, we can
automatically assign it to created resources instead of requiring the
user to specify them. This is especially useful for resources created by
the installer such as smart proxies that will be assigned to the default
location and organization.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
