### PR TITLE
Fixes #27185 - dirty association after save

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -376,10 +376,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "user cannot assign role he has not assigned himself" do
-    extra_role      = Role.where(:name => "foobar").first_or_create
+    extra_role = Role.where(:name => "foobar").first_or_create
+    setup_user "edit"
     record          = users(:one)
     record.role_ids = [extra_role.id]
-    setup_user "edit"
     refute record.save
     refute record.valid?
     assert_includes record.errors.keys, :role_ids

--- a/test/unit/dirty_associations_test.rb
+++ b/test/unit/dirty_associations_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
-class DummyDirtyAssociationsModel
+class DummyDirtyAssociationsModel < ApplicationRecord
+  self.table_name = 'dummy_dirty_association'
   def organization_ids
     @organization_ids ||= []
   end
@@ -10,8 +11,52 @@ class DummyDirtyAssociationsModel
   dirty_has_many_associations :organizations
 end
 
+class SecondMock < ApplicationRecord
+  self.table_name = 'second_mock'
+  belongs_to :first_mock
+end
+
+class ThirdMock < ApplicationRecord
+  self.table_name = 'third_mock'
+  belongs_to :first_mock
+end
+
+class FirstMock < ApplicationRecord
+  self.table_name = 'first_mock'
+  has_many :second_mocks
+  has_many :third_mocks
+
+  include DirtyAssociations
+  dirty_has_many_associations :second_mocks
+  dirty_has_many_associations :third_mocks
+end
+
 class DirtyAssociationsTest < ActiveSupport::TestCase
   def setup
+    unless ActiveRecord::Base.connection.table_exists? 'first_mock'
+      ActiveRecord::Base.connection.create_table :first_mock do |t|
+        t.text :name
+      end
+    end
+
+    unless ActiveRecord::Base.connection.table_exists? 'second_mock'
+      ActiveRecord::Base.connection.create_table :second_mock do |t|
+        t.references :first_mock
+      end
+    end
+
+    unless ActiveRecord::Base.connection.table_exists? 'third_mock'
+      ActiveRecord::Base.connection.create_table :third_mock do |t|
+        t.references :first_mock
+      end
+    end
+
+    unless ActiveRecord::Base.connection.table_exists? 'dummy_dirty_association'
+      ActiveRecord::Base.connection.create_table :dummy_dirty_association do |t|
+        t.text :mock_name
+      end
+    end
+
     @tester = DummyDirtyAssociationsModel.new
     @tester.organization_ids = [1, 2]
   end
@@ -29,5 +74,27 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
   test "association setter accepts single ids too" do
     @tester.organization_ids = 3
     assert_equal @tester.organization_ids, [3]
+  end
+
+  test "should return false if nothing _changed?" do
+    @tester = DummyDirtyAssociationsModel.new
+    refute @tester.organization_ids_changed?
+  end
+
+  test "_changed? should return false after saving" do
+    @first_mock = FirstMock.create(name: "test1")
+    @second_mock = SecondMock.create(first_mock_id: 1)
+    @third_mock = ThirdMock.create(first_mock_id: 1)
+
+    @first_mock.second_mock_ids = []
+    @first_mock.third_mock_ids = []
+
+    assert @first_mock.second_mock_ids_changed?
+    assert @first_mock.third_mock_ids_changed?
+
+    @first_mock.save!
+
+    refute @first_mock.second_mock_ids_changed?
+    refute @first_mock.third_mock_ids_changed?
   end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Created this PR to obtain consistent results for _changed? Dirty Associations was returning true even after saving the changes to the database.  