### PR TITLE
Fixes #27254 - add support for routes without layout

### DIFF
--- a/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
@@ -6,11 +6,9 @@ import history from '../history';
 import Layout from '../components/Layout';
 import AppSwitcher from '../routes';
 
-const ReactApp = ({ data: { layout } }) => (
+const ReactApp = ({ data }) => (
   <Router history={history}>
-    <Layout data={layout}>
-      <AppSwitcher />
-    </Layout>
+    <AppSwitcher data={data} />
   </Router>
 );
 

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.js
@@ -130,7 +130,7 @@ class Layout extends React.Component {
   }
 }
 
-Layout.propTypes = {
+export const layoutPropTypes = {
   children: PropTypes.node,
   history: PropTypes.shape({
     push: PropTypes.func,
@@ -213,7 +213,7 @@ Layout.propTypes = {
   }),
 };
 
-Layout.defaultProps = {
+export const layoutDefaults = {
   children: null,
   items: [],
   data: {},
@@ -229,5 +229,9 @@ Layout.defaultProps = {
   onExpand: noop,
   onCollapse: noop,
 };
+
+Layout.propTypes = layoutPropTypes;
+
+Layout.defaultProps = layoutDefaults;
 
 export default Layout;

--- a/webpack/assets/javascripts/react_app/routes/ForemanRoute.js
+++ b/webpack/assets/javascripts/react_app/routes/ForemanRoute.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { layoutPropTypes } from '../components/Layout/Layout';
+import RouteWithLayout from './RouteWithLayout';
+import { noop } from '../common/helpers';
+
+const ForemanRoute = ({
+  render,
+  layout,
+  skipLayout,
+  beforeRender,
+  path,
+  ...routeProps
+}) => {
+  if (skipLayout) {
+    return (
+      <Route
+        path={path}
+        key={path}
+        {...routeProps}
+        render={renderProps => {
+          beforeRender(renderProps);
+
+          return render(renderProps);
+        }}
+      />
+    );
+  }
+  return (
+    <RouteWithLayout
+      path={path}
+      key={path}
+      render={renderProps => {
+        beforeRender(renderProps);
+
+        return render(renderProps);
+      }}
+      layout={layout}
+    />
+  );
+};
+
+export default ForemanRoute;
+
+delete layoutPropTypes.history;
+
+ForemanRoute.propTypes = {
+  render: PropTypes.func.isRequired,
+  layout: PropTypes.shape(layoutPropTypes).isRequired,
+  beforeRender: PropTypes.func,
+  path: PropTypes.string.isRequired,
+  skipLayout: PropTypes.bool,
+};
+
+ForemanRoute.defaultProps = {
+  beforeRender: noop,
+  skipLayout: false,
+};

--- a/webpack/assets/javascripts/react_app/routes/RouteWithLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/RouteWithLayout.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import Layout from '../components/Layout';
+import { layoutPropTypes } from '../components/Layout/Layout';
+
+const RouteWithLayout = ({ render, layout, ...rest }) => (
+  <Route
+    {...rest}
+    render={matchProps => <Layout data={layout}>{render(matchProps)}</Layout>}
+  />
+);
+
+delete layoutPropTypes.history;
+
+RouteWithLayout.propTypes = {
+  render: PropTypes.func.isRequired,
+  layout: PropTypes.shape(layoutPropTypes).isRequired,
+};
+
+export default RouteWithLayout;

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -1,26 +1,38 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
 import { routes } from './routes';
+import LayoutRoute from './RouteWithLayout';
+import { layoutPropTypes } from '../components/Layout/Layout';
+import ForemanRoute from './ForemanRoute';
 
 let currentLocation = null;
 
-const AppSwitcher = () => (
-  <Switch>
-    {routes.map(({ render, path, ...routeProps }) => (
-      <Route
-        path={path}
-        key={path}
-        {...routeProps}
-        render={renderProps => {
-          const railsContainer = document.getElementById('rails-app-content');
-          if (railsContainer) railsContainer.remove();
-          currentLocation = renderProps.location;
+const removeRootContainer = renderProps => {
+  const railsContainer = document.getElementById('rails-app-content');
 
-          return render(renderProps);
-        }}
+  if (railsContainer) {
+    railsContainer.remove();
+  }
+  currentLocation = renderProps.location;
+};
+
+const AppSwitcher = ({ data: { layout } }) => (
+  <Switch>
+    {routes.map(({ render, path, skipLayout, ...routeProps }) => (
+      <ForemanRoute
+        key={path}
+        render={render}
+        layout={layout}
+        path={path}
+        skipLayout={skipLayout}
+        beforeRender={removeRootContainer}
+        {...routeProps}
       />
     ))}
-    <Route
+    <LayoutRoute
+      layout={layout}
       render={child => {
         if (
           currentLocation &&
@@ -39,5 +51,11 @@ const AppSwitcher = () => (
     />
   </Switch>
 );
+
+AppSwitcher.propTypes = {
+  data: PropTypes.shape({
+    layout: PropTypes.shape(layoutPropTypes),
+  }).isRequired,
+};
 
 export default AppSwitcher;


### PR DESCRIPTION
This PR adds `RouteLayout` which wraps a component with foreman's layout, therefore pages without this layout (i.e login page) can be rendered with client router, plus plugins would be able to generate their own layout.