### PR TITLE
Fixes #27233 - Assign created resources to host taxonomies

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -261,13 +261,14 @@ module Host
           default_taxonomy = taxonomy_class.find_by_title(Setting["default_#{taxonomy}"])
         end
 
-        if self.send(taxonomy.to_s).present?
+        if self.send(taxonomy).present?
           # Change taxonomy to fact taxonomy if set, otherwise leave it as is
           self.send("#{taxonomy}=", taxonomy_from_fact) unless taxonomy_from_fact.nil?
         else
           # No taxonomy was set, set to fact taxonomy or default taxonomy
           self.send "#{taxonomy}=", (taxonomy_from_fact || default_taxonomy)
         end
+        taxonomy_class.current = self.send(taxonomy)
       end
     end
 

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -68,7 +68,7 @@ class PuppetFactParser < FactParser
   def environment
     # by default, puppet doesn't store an env name in the database
     name = facts[:environment] || facts[:agent_specified_environment] || Setting[:default_puppet_environment]
-    Environment.where(:name => name).first_or_create
+    Environment.unscoped.where(:name => name).first_or_create
   end
 
   def architecture
@@ -94,7 +94,7 @@ class PuppetFactParser < FactParser
 
   def domain
     name = facts[:domain]
-    Domain.where(:name => name).first_or_create if name.present?
+    Domain.unscoped.where(:name => name).first_or_create if name.present?
   end
 
   def ipmi_interface

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -637,26 +637,29 @@ class HostTest < ActiveSupport::TestCase
       raw = read_json_fixture('facts/facts.json')
       host = Host.import_host(raw['name'])
       assert host.import_facts(raw['facts'])
-      Host.find_by_name('sinn1636.lan').update_attribute(:location, taxonomies(:location2))
-      Host.find_by_name('sinn1636.lan').import_facts(raw['facts'])
+      host = Host.find_by_name('sinn1636.lan')
+      host.update_attribute(:location, taxonomies(:location2))
+      host.import_facts(raw['facts'])
+      host.reload
 
-      assert_equal taxonomies(:location2), Host.find_by_name('sinn1636.lan').location
+      assert_equal taxonomies(:location2), host.location
     end
 
     test 'taxonomies from facts override already existing taxonomies in hosts' do
       Setting[:create_new_host_when_facts_are_uploaded] = true
       Setting[:location_fact] = "foreman_location"
-      Setting[:organization_fact] = "foreman_organization"
 
       raw = read_json_fixture('facts/facts.json')
       raw['facts']['foreman_location'] = 'Location 2'
       host = Host.import_host(raw['name'])
       assert host.import_facts(raw['facts'])
 
-      Host.find_by_name('sinn1636.lan').update_attribute(:location, taxonomies(:location1))
-      Host.find_by_name('sinn1636.lan').import_facts(raw['facts'])
+      host = Host.find_by_name('sinn1636.lan')
+      host.update_attribute(:location, taxonomies(:location1))
+      host.import_facts(raw['facts'])
+      host.reload
 
-      assert_equal taxonomies(:location2), Host.find_by_name('sinn1636.lan').location
+      assert_equal taxonomies(:location2), host.location
     end
 
     test 'operatingsystem updated from facts' do


### PR DESCRIPTION
When a host is created from puppet fact import, taxable resources such
as domain and environment are created if they do not exist, but aren't
assigned to the host's taxonomies leading the host to report mismatch.
This commit changes this behaviour so that new resources will be
assigned to the same taxonomies. If a host uses an existing resource,
it does not get assigned to the host's taxonomies to prevent
unexpected modifications of existing resources.

Note to reviewers: hide whitespace changes to make test modification more readable. I took the time to refactor the fact import tests while writing tests for this.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
