### PR TITLE
Fixes #27266 - remove deprecated jed and i18n objects

### DIFF
--- a/webpack/assets/javascripts/bundle_novnc.js
+++ b/webpack/assets/javascripts/bundle_novnc.js
@@ -1,5 +1,6 @@
 import RFB from '@novnc/novnc/core/rfb';
 import $ from 'jquery';
+import { sprintf } from './react_app/common/I18n';
 
 let rfb;
 const StatusLevelLookup = {
@@ -30,7 +31,7 @@ function showStatus(state, message) {
 function securityFailed(e) {
   let msg = '';
   if ('reason' in e.detail) {
-    msg = window.Jed.sprintf(
+    msg = sprintf(
       __('New connection has been rejected with reason: %'),
       e.detail.reason
     );

--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -1,6 +1,5 @@
 import Jed from 'jed';
 import { addLocaleData } from 'react-intl';
-import { deprecateObjectProperty } from './DeprecationService';
 
 class IntlLoader {
   constructor(locale, timezone) {
@@ -78,8 +77,3 @@ export default i18n;
 
 window.__ = translate;
 window.n__ = ngettext;
-window.Jed = jed;
-window.i18n = jed;
-
-deprecateObjectProperty(window, 'i18n', 'tfm.i18n');
-deprecateObjectProperty(window, 'Jed', 'tfm.i18n.jed');

--- a/webpack/assets/javascripts/react_app/common/I18n.test.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.test.js
@@ -4,10 +4,6 @@ import { translate, ngettext } from './I18n';
 jest.unmock('./I18n');
 jest.unmock('jed');
 
-jest.mock('../../foreman_tools', () => ({
-  deprecateObjectProperty: jest.fn(),
-}));
-
 describe('gettext', () => {
   Jed.gettext = jest.fn(s => s);
   it('chevrons should not be presented', () => {


### PR DESCRIPTION
Jed and i18n global objects were moved to webpack and deprecated over a year ago, therefore these should be removed from 1.23.