### PR TITLE
Refs #27103 - Pin diff to a major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "classnames": "^2.2.5",
     "datatables.net": "~1.10.12",
     "datatables.net-bs": "~1.10.12",
-    "diff": ">=4.0.1",
+    "diff": "^4.0.1",
     "file-saver": "^2.0.1",
     "gridster": "^0.5.6",
     "history": "^4.7.2",


### PR DESCRIPTION
18649478cb128591738f97931f98632fd966d1f2 pinned it to a lower bound, but for our dependencies it's better to follow semver and not blindly allow new major versions.