### PR TITLE
Refs #27157 - Fix rubocop

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -238,7 +238,7 @@ module Foreman::Model
       end
       access_config = {
         :name => ::Fog::Compute::Google::Server::EXTERNAL_NAT_NAME,
-        :type => ::Fog::Compute::Google::Server::EXTERNAL_NAT_TYPE
+        :type => ::Fog::Compute::Google::Server::EXTERNAL_NAT_TYPE,
       }
       # Note - no support for external_ip from foreman
       # access_config[:nat_ip] = external_ip if external_ip


### PR DESCRIPTION
f2ee562ece5d5084f39160524ac57b23b7bde251 flipped the rubocop style but 862f09f24878b0e1c66beca094fc37bb291911c0 wasn't retested after and broke on merge.