### PR TITLE
Fixes #10359 - API doc does mention org/loc in create/update

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -33,6 +33,9 @@ module Api::V2::TaxonomiesController
       param :subnet_ids, Array, N_("Subnet IDs"), :required => false
       param :parent_id, :number, :desc => N_('Parent ID'), :required => false
       param :ignore_types, Array, N_("List of resources types that will be automatically associated"), :required => false
+      resource_name = (param_name == :location) ? 'organization' : 'location'
+      resource_ids = "#{resource_name}_ids".to_sym
+      param resource_ids, Array, N_("Associated %{resource} IDs") % { resource: _(resource_name) }, :required => false
     end
   end
 


### PR DESCRIPTION
`/api/v2/organizations/[create | update]`
enpoints now mention the possibility to assing locations via `location_ids` param.

`/api/v2/locations/[create | update]`
enpoints now mention the possibility to assing organizations via `organization_ids` param.