### PR TITLE
Fixes #27281 - Add markdown's styling for tables in storybook

### DIFF
--- a/webpack/stories/docs/SlotAndFill.md
+++ b/webpack/stories/docs/SlotAndFill.md
@@ -1,6 +1,11 @@
 # Slot And Fill
 
-`Slot & Fill` allows plugins to extend foreman core functionality in the UI
+Slot & Fill allows plugins to extend foreman core functionality in the UI
+
+## Current Slots List
+| Name               | Id               | Path  |
+| ------------------ |:----------------:| -----:|
+| **About-footer**   | aboutFooterSlot  | *views/about/index.html.erb*
 
 ## Components
 

--- a/webpack/stories/docs/markdown.css
+++ b/webpack/stories/docs/markdown.css
@@ -1,0 +1,39 @@
+table {
+  padding: 0;
+}
+
+table tr {
+  border-top: 1px solid #ccc;
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
+
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
+table tr th {
+  font-weight: bold;
+  border: 1px solid #ccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr td {
+  border: 1px solid #ccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr th :first-child,
+table tr td :first-child {
+  margin-top: 0;
+}
+
+table tr th :last-child,
+table tr td :last-child {
+  margin-bottom: 0;
+}

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -10,6 +10,7 @@ import hoc from './docs/hoc.md';
 import addingDependencies from './docs/addingDependencies.md';
 import internationalization from './docs/internationalization.md';
 import plugins from './docs/plugins.md';
+import SlotAndFill from './docs/SlotAndFill.md';
 
 require('../assets/javascripts/bundle');
 require('../../app/assets/javascripts/application');
@@ -51,6 +52,11 @@ storiesOf('Introduction', module)
   .add('Plugins', () => (
     <Story>
       <Markdown source={plugins} />
+    </Story>
+  ))
+  .add('Slot&Fill', () => (
+    <Story>
+      <Markdown source={SlotAndFill} />
     </Story>
   ));
 

--- a/webpack/stories/index.scss
+++ b/webpack/stories/index.scss
@@ -4,3 +4,4 @@ $icon-font-path: '~patternfly/dist/fonts/';
 
 @import '~patternfly/dist/sass/patternfly';
 @import '~@theforeman/vendor/scss/vendor';
+@import './docs/markdown.css';


### PR DESCRIPTION
This PR adds github's markdown styling for tables, plus `Current Slots` table in slot&fill documentation 