### PR TITLE
Fixes #26828 - expect http_proxy to be empty string

### DIFF
--- a/lib/foreman/http_proxy.rb
+++ b/lib/foreman/http_proxy.rb
@@ -2,7 +2,7 @@ module Foreman
   module HTTPProxy
     def http_proxy
       ActiveRecord::Base.connection_pool.with_connection do
-        Setting[:http_proxy]
+        Setting[:http_proxy].presence
       end
     end
 

--- a/test/unit/foreman/http_proxy_test.rb
+++ b/test/unit/foreman/http_proxy_test.rb
@@ -81,6 +81,17 @@ class HTTPProxyTest < ActiveSupport::TestCase
         refute adapter.proxy_http_request?(nil, request_host, schema)
       end
 
+      test 'when settings are empty string - after unsetting' do
+        adapter.unstub(:http_proxy)
+        adapter.unstub(:http_proxy_except_list)
+        Setting::General.stubs(:find_by_name)
+                         .with('http_proxy').returns('')
+        Setting::General.stubs(:find_by_name)
+                         .with('http_proxy_except_list')
+                         .returns(nil)
+        refute adapter.proxy_http_request?(nil, request_host, schema)
+      end
+
       test 'when request_host is localhost' do
         refute adapter.proxy_http_request?(nil, 'localhost', schema)
       end


### PR DESCRIPTION
After unsetting http_proxy, the value is empty string not an nil.