### PR TITLE
Fixes #27294 - add prefer-await-to-then lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,14 @@
 {
-  "plugins": ["patternfly-react"],
+  "plugins": ["patternfly-react", "promise"],
   "extends": [
     "plugin:patternfly-react/recommended",
     "./node_modules/@theforeman/vendor-dev/eslint.extends.js"
   ],
   "rules": {
+    "promise/prefer-await-to-then": "error",
     "prettier/prettier": ["error", {
       "singleQuote": true,
       "trailingComma": "es5"
-    }],
+    }]
   },
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "^4.10.0",
     "eslint-plugin-jquery": "^1.5.1",
     "eslint-plugin-patternfly-react": "0.2.0",
+    "eslint-plugin-promise": "^4.2.1",
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -4,17 +4,16 @@ import store from './react_app/redux';
 import * as editorActions from './react_app/components/Editor/EditorActions';
 import { translate as __ } from './react_app/common/I18n';
 
-export const revertTemplate = ({ dataset: { version, url } }) => {
+export const revertTemplate = async ({ dataset: { version, url } }) => {
   if (
     window.confirm(__('Are you sure you would like to revert the Template?'))
   ) {
-    API.get(url, {}, { version })
-      .then(res => {
-        document.getElementById('primary_tab').click();
-        store.dispatch(editorActions.changeEditorValue(res.data));
-      })
-      .catch(res => {
-        alert(__(`Revert Failed, ${res}`));
-      });
+    try {
+      const response = await API.get(url, {}, { version });
+      document.getElementById('primary_tab').click();
+      store.dispatch(editorActions.changeEditorValue(response.data));
+    } catch (err) {
+      alert(__(`Revert Failed, ${err}`));
+    }
   }
 };

--- a/webpack/assets/javascripts/react_app/common/i18nProviderWrapperFactory.js
+++ b/webpack/assets/javascripts/react_app/common/i18nProviderWrapperFactory.js
@@ -14,6 +14,7 @@ const i18nProviderWrapperFactory = (
       super(props);
       this.state = { i18nLoaded: false };
 
+      // eslint-disable-next-line promise/prefer-await-to-then
       intl.ready.then(() => {
         this.setState({ i18nLoaded: true });
       });

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
@@ -84,6 +84,7 @@ export const loadSwitcherResourcesByResource = (
       per_page: 10,
       search: createSearch(nameField, searchQuery, resource.resourceFilter),
     }
+    // eslint-disable-next-line promise/prefer-await-to-then
   ).then(onRequestSuccess, onRequestFail);
 };
 

--- a/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
@@ -114,6 +114,7 @@ export const previewTemplate = ({ host, renderPath }) => (
   };
   dispatch({ type: EDITOR_SHOW_LOADING });
   fetchTemplatePreview(renderPath, params)
+    // eslint-disable-next-line promise/prefer-await-to-then
     .then(response => {
       if (isErrorShown) dispatch(dismissErrorToast());
       dispatch({ type: EDITOR_HIDE_LOADING });

--- a/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
@@ -6,6 +6,7 @@ import { addToast } from '../../../../redux/actions/toasts';
 export const stopImpersonating = (url, history) => dispatch =>
   api
     .delete(url)
+    // eslint-disable-next-line promise/prefer-await-to-then
     .then(({ data }) => {
       window.location.href = foremanUrl('/users');
 

--- a/webpack/assets/javascripts/react_app/components/Settings/SettingsActions.js
+++ b/webpack/assets/javascripts/react_app/components/Settings/SettingsActions.js
@@ -8,19 +8,22 @@ import {
 export const loadSetting = settingName => dispatch => {
   dispatch({ type: GET_SETTING_REQUEST });
 
-  return API.get(`/api/v2/settings/${settingName}`)
-    .then(({ data }) => {
-      dispatch({
-        type: GET_SETTING_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => {
-      dispatch({
-        type: GET_SETTING_FAILURE,
-        result,
-      });
-    });
+  return (
+    API.get(`/api/v2/settings/${settingName}`)
+      // eslint-disable-next-line promise/prefer-await-to-then
+      .then(({ data }) => {
+        dispatch({
+          type: GET_SETTING_SUCCESS,
+          response: data,
+        });
+      })
+      .catch(result => {
+        dispatch({
+          type: GET_SETTING_FAILURE,
+          result,
+        });
+      })
+  );
 };
 
 export default loadSetting;

--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGeneratorActions.js
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGeneratorActions.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import { saveAs } from 'file-saver';
 import API from '../../API';
 

--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/TemplateGeneratorActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/TemplateGeneratorActions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import { saveAs } from 'file-saver';
 import API from '../../../API';
 import { runActionInDepth } from '../../../common/testHelpers';

--- a/webpack/assets/javascripts/react_app/components/common/dates/IsoDate.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/IsoDate.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 // Configure Enzyme
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 // Configure Enzyme
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/webpack/assets/javascripts/react_app/components/common/dates/RelativeDateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/RelativeDateTime.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 // Configure Enzyme
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 // Configure Enzyme
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as actions from './index';

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import { SubmissionError } from 'redux-form';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import immutable from 'seamless-immutable';

--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import {
   NOTIFICATIONS_GET_NOTIFICATIONS,
   NOTIFICATIONS_TOGGLE_DRAWER,

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.test.js
@@ -29,9 +29,12 @@ describe('statistics actions', () => {
       url: '/statistics/operatingsystem',
       status: 422,
     });
-    return store
-      .dispatch(actions.getStatisticsData(failedRequestData))
-      .then(() => expect(store.getActions()).toEqual(onFailureActions));
+    return (
+      store
+        .dispatch(actions.getStatisticsData(failedRequestData))
+        // eslint-disable-next-line promise/prefer-await-to-then
+        .then(() => expect(store.getActions()).toEqual(onFailureActions))
+    );
   });
   it('creates STATISTICS_DATA_REQUEST and ends with success', () => {
     mockRequest({
@@ -48,8 +51,11 @@ describe('statistics actions', () => {
         data: [['x86_64', 6]],
       },
     });
-    return store
-      .dispatch(actions.getStatisticsData(successRequestData))
-      .then(() => expect(store.getActions()).toEqual(onSuccessActions));
+    return (
+      store
+        .dispatch(actions.getStatisticsData(successRequestData))
+        // eslint-disable-next-line promise/prefer-await-to-then
+        .then(() => expect(store.getActions()).toEqual(onSuccessActions))
+    );
   });
 });


### PR DESCRIPTION
`async - await` is an es7 syntax for promises, which make the code cleaner and readable
```js
    try {
      const response = await API.get(// some params);
      foo(response.data));
    } catch (err) {
      notification(__(`an Error has occured${err}`));
    }
  } 
```

Instead of replacing all promises at once, I think it would be better to start with adding that rule and refactor each promise gradually. 