### PR TITLE
Fixes #27312 - Datetimepicker doesn't work with all locale

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -39,6 +39,9 @@ export const intl = new IntlLoader(langAttr, timezoneAttr);
 const cheveronPrefix = () => (window.I18N_MARK ? '\u00BB' : '');
 const cheveronSuffix = () => (window.I18N_MARK ? '\u00AB' : '');
 
+export const documentLocaleForJS = () =>
+  document.getElementsByTagName('html')[0].lang;
+
 export const documentLocale = () =>
   document.getElementsByTagName('html')[0].lang.replace(/-/g, '_');
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
@@ -14,6 +14,7 @@ import { noop } from '../../../common/helpers';
 import DateTimePicker from '../DateTimePicker/DateTimePicker';
 import DatePicker from '../DateTimePicker/DatePicker';
 import TimePicker from '../DateTimePicker/TimePicker';
+import { documentLocaleForJS } from '../../../common/I18n';
 
 const inputComponents = {
   date: DatePicker,
@@ -28,10 +29,15 @@ export const ControlContext = React.createContext();
 
 const InputFactory = ({ type }) => {
   const controlProps = useContext(ControlContext);
+  const currentLocale = documentLocaleForJS();
 
   if (inputComponents[type]) {
     return (
-      <FormControl componentClass={inputComponents[type]} {...controlProps} />
+      <FormControl
+        componentClass={inputComponents[type]}
+        locale={currentLocale}
+        {...controlProps}
+      />
     );
   }
   return <FormControl type={type} {...controlProps} />;


### PR DESCRIPTION
In foreman the locale is sometimes "en_GB" JavaScript accepts only "en-GB" with a '-' instead of '_'