### PR TITLE
Fixes #27359 - Bump audited to 4.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '>= 4.7.1', '< 4.9.0'
+gem 'audited', '>= 4.9.0', '< 5'
 gem 'will_paginate', '>= 3.1.7', '< 4'
 gem 'ancestry', '>= 2.0', '< 4'
 gem 'scoped_search', '>= 4.1.7', '< 5'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1225,7 +1225,7 @@ class UserTest < ActiveSupport::TestCase
       @user.save
 
       recent_audit = @user.audits.last
-      audited_changes = recent_audit.audited_changes[:role_ids]
+      audited_changes = recent_audit.audited_changes['role_ids']
 
       assert audited_changes, 'No audits found for user-roles'
       assert_empty audited_changes.first
@@ -1239,7 +1239,7 @@ class UserTest < ActiveSupport::TestCase
       @user.save
 
       recent_audit = @user.audits.last
-      audited_changes = recent_audit.audited_changes[:role_ids]
+      audited_changes = recent_audit.audited_changes['role_ids']
 
       assert audited_changes, 'No audits found for user-roles'
       assert_equal [[@role.id, Role.default.id], []], audited_changes
@@ -1253,9 +1253,9 @@ class UserTest < ActiveSupport::TestCase
 
       recent_audit = @user.audits.last
 
-      assert recent_audit.audited_changes[:firstname]
-      assert recent_audit.audited_changes[:description]
-      assert_nil recent_audit.audited_changes[:roles]
+      assert recent_audit.audited_changes['firstname']
+      assert recent_audit.audited_changes['description']
+      assert_nil recent_audit.audited_changes['roles']
     end
   end
 

--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -324,7 +324,7 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a child-usergroup is assigned to a parent-usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:usergroup_ids]
+        audited_changes = recent_audit.audited_changes['usergroup_ids']
         assert audited_changes, 'No audits found for usergroups'
         assert_empty audited_changes.first
         assert_equal [@child_usergroup.id], audited_changes.last
@@ -334,7 +334,7 @@ class UsergroupTest < ActiveSupport::TestCase
         @usergroup.usergroup_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:usergroup_ids]
+        audited_changes = recent_audit.audited_changes['usergroup_ids']
         assert audited_changes, 'No audits found for usergroups'
         assert_equal [@child_usergroup.id], audited_changes.first
         assert_empty audited_changes.last
@@ -350,7 +350,7 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a role is assigned to a usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:role_ids]
+        audited_changes = recent_audit.audited_changes['role_ids']
         assert audited_changes, 'No audits found for user-roles'
         assert_empty audited_changes.first
         assert_equal [@role.id], audited_changes.last
@@ -360,7 +360,7 @@ class UsergroupTest < ActiveSupport::TestCase
         @usergroup.role_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:role_ids]
+        audited_changes = recent_audit.audited_changes['role_ids']
         assert audited_changes, 'No audits found for usergroup-roles'
         assert_equal [@role.id], audited_changes.first
         assert_empty audited_changes.last
@@ -376,7 +376,7 @@ class UsergroupTest < ActiveSupport::TestCase
 
       test 'should audit when a user is assigned to a usergroup' do
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:user_ids]
+        audited_changes = recent_audit.audited_changes['user_ids']
         assert audited_changes, 'No audits found for users'
         assert_empty audited_changes.first
         assert_equal [@user.id], audited_changes.last
@@ -386,7 +386,7 @@ class UsergroupTest < ActiveSupport::TestCase
         @usergroup.user_ids = []
         @usergroup.save
         recent_audit = @usergroup.audits.last
-        audited_changes = recent_audit.audited_changes[:user_ids]
+        audited_changes = recent_audit.audited_changes['user_ids']
         assert audited_changes, 'No audits found for users'
         assert_equal [@user.id], audited_changes.first
         assert_empty audited_changes.last


### PR DESCRIPTION
Looking into the issue it seems `audited_changes` is a hash with strings as keys, but the tests expect symbols as keys.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
