### PR TITLE
Fixes #27348 - make chromedriver hard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "coveralls": "^3.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^0.23.1",
+    "chromedriver": "2.46.0",
     "dotenv": "^5.0.0",
     "enzyme": "^3.4.0",
     "enzyme-adapter-react-16": "^1.4.0",
@@ -60,9 +61,6 @@
     "webpack-bundle-analyzer": ">=3.3.2",
     "webpack-dev-server": "^2.5.1",
     "webpack-stats-plugin": "^0.1.5"
-  },
-  "optionalDependencies": {
-    "chromedriver": "2.46.0"
   },
   "dependencies": {
     "@theforeman/vendor": "^0.1.0-alpha.11",


### PR DESCRIPTION
Makes the chromedriver a hard development dependency, as it is required now for running tests.