### PR TITLE
Fixes #27347 - Pin audited to <= 4.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '>= 4.7.1', '<= 4.8.0'
+gem 'audited', '>= 4.7.1', '< 4.9.0'
 gem 'will_paginate', '>= 3.1.7', '< 4'
 gem 'ancestry', '>= 2.0', '< 4'
 gem 'scoped_search', '>= 4.1.7', '< 5'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '>= 4.7.1', '< 5'
+gem 'audited', '>= 4.7.1', '<= 4.8.0'
 gem 'will_paginate', '>= 3.1.7', '< 4'
 gem 'ancestry', '>= 2.0', '< 4'
 gem 'scoped_search', '>= 4.1.7', '< 5'


### PR DESCRIPTION
Audited 4.9.0 was released on 18.7.2019. This release changed
audited_changes from hash with indifferent access to hash, where keys
are strings. This change made all tests which accessed parts of the hash
using symbols as keys fail.

Alternative fix for https://github.com/theforeman/foreman/pull/6913


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
