### PR TITLE
Fixes #27349 - use dashed style of intl key

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -39,12 +39,11 @@ export const intl = new IntlLoader(langAttr, timezoneAttr);
 const cheveronPrefix = () => (window.I18N_MARK ? '\u00BB' : '');
 const cheveronSuffix = () => (window.I18N_MARK ? '\u00AB' : '');
 
-export const documentLocale = () =>
-  document.getElementsByTagName('html')[0].lang.replace(/-/g, '_');
+export const documentLocale = () => langAttr;
 
 const getLocaleData = () => {
   const locales = window.locales || {};
-  const locale = documentLocale();
+  const locale = documentLocale().replace(/-/g, '_');
 
   if (locales[locale] === undefined) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Transfers the default style of the intl key to dashed for frontend.

The only place we need to have undescored key is to load backend translation data, as backend uses the underscored style.

What do you think @amirfefer, @MariaAga, I believe it would fix #6904.