### PR TITLE
Fixes #27350 - AuditsPage Documentation translation key

### DIFF
--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
@@ -17,7 +17,7 @@ const AuditsPage = ({
     toolbarButtons={
       <Button href={docURL} className="btn-docs">
         <Icon type="pf" name="help" />
-        {__(' Documentation')}
+        {` ${__('Documentation')}`}
       </Button>
     }
   >


### PR DESCRIPTION
Translation is missing, because of a space in the intl key.