### PR TITLE
Fixes #27353 - use vmware network id instead of name

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -460,10 +460,11 @@ module Foreman::Model
       args = args.deep_dup
       dc_networks = networks
       args["interfaces_attributes"]&.each do |key, interface|
-        # Convert network id into name
-        net = dc_networks.detect { |n| [n.id, n.name].include?(interface['network']) }
+        # Consolidate network to network id
+        net = dc_networks.detect { |n| n.id == interface['network'] }
+        net ||= dc_networks.detect { |n| n.name == interface['network'] }
         raise "Unknown Network ID: #{interface['network']}" if net.nil?
-        interface["network"] = net.name
+        interface["network"] = net.id
         interface["virtualswitch"] = net.virtualswitch
       end
       args


### PR DESCRIPTION
Use network id, not it's name. As if the name is ambigous, fog-vsphere uses the first one, which can be one we are unable to provision on.

Fog supports it from version [3.1.0](https://github.com/fog/fog-vsphere/commit/11469ccf5e66525dc45e157b1caef26602eed6b3), which is already in our packaging.