### PR TITLE
Fixes #27355 - add no-jquery eslint rule under react_app

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "enzyme-adapter-react-16": "^1.4.0",
     "enzyme-to-json": "^3.2.1",
     "eslint": "^4.10.0",
+    "eslint-plugin-jquery": "^1.5.1",
     "eslint-plugin-patternfly-react": "0.2.0",
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",

--- a/webpack/assets/javascripts/react_app/.eslintrc
+++ b/webpack/assets/javascripts/react_app/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "plugins": ["jquery"],
+  "extends": [
+    "plugin:jquery/deprecated"
+  ]
+}

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.test.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import 'select2';
 import { mount } from 'enzyme';
 import React from 'react';
@@ -20,14 +19,15 @@ describe('Select', () => {
       { attachTo: document.getElementById('select') }
     );
 
-    $('#select select').trigger('change');
+    wrapper.find('select').simulate('change', { target: { value: 'val' } });
+
     expect(onChangeMock).toHaveBeenCalledTimes(1);
 
     options.three = '3';
     wrapper.setProps(Object.assign({}, wrapper.props(), { options }));
 
     onChangeMock.mockClear();
-    $('#select select').trigger('change');
+    wrapper.find('select').simulate('change', { target: { value: 'val' } });
     expect(onChangeMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
as part of working on foreman's dev env, we'd like to add lint rules as part of our conventions
This PR removes jquery use from `react_app` directory.