### PR TITLE
Fixes #27356 - Remove global vars from eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,16 +10,4 @@
       "trailingComma": "es5"
     }],
   },
-  "globals": {
-    "document": false,
-    "escape": false,
-    "navigator": false,
-    "unescape": false,
-    "window": false,
-    "$": true,
-    "_": true,
-    "__": true,
-    "n__": true,
-    "d3": true
-  }
 }

--- a/webpack/assets/javascripts/bundle_novnc.js
+++ b/webpack/assets/javascripts/bundle_novnc.js
@@ -1,6 +1,6 @@
 import RFB from '@novnc/novnc/core/rfb';
 import $ from 'jquery';
-import { sprintf } from './react_app/common/I18n';
+import { sprintf, translate as __ } from './react_app/common/I18n';
 
 let rfb;
 const StatusLevelLookup = {

--- a/webpack/assets/javascripts/foreman_class_edit.js
+++ b/webpack/assets/javascripts/foreman_class_edit.js
@@ -1,4 +1,5 @@
-import { sprintf } from './react_app/common/I18n';
+import $ from 'jquery';
+import { sprintf, translate as __ } from './react_app/common/I18n';
 
 export function filterPuppetClasses(item) {
   const term = $(item)

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import store from './react_app/redux';
 import * as LayoutActions from './react_app/components/Layout/LayoutActions';
 

--- a/webpack/assets/javascripts/react_app/components/LoginPage/components/LoginPageCaption.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/components/LoginPageCaption.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from '../../../common/I18n';
 
 const LoginPageCaption = ({ version, caption }) => (
   <Fragment>

--- a/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
@@ -1,3 +1,5 @@
+import { translate as __ } from '../../common/I18n';
+
 export const adjustAlerts = alerts => {
   const submitErrors = [];
   const modifiedAlerts = [];

--- a/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTableSchema.js
+++ b/webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTableSchema.js
@@ -1,3 +1,4 @@
+import { translate as __ } from '../../common/I18n';
 import {
   sortControllerFactory,
   column,

--- a/webpack/assets/javascripts/react_app/components/common/table/schemaHelpers/column.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/schemaHelpers/column.js
@@ -1,3 +1,4 @@
+import { translate as __ } from '../../../../common/I18n';
 /**
  * Generate a column for a patternfly-3 table.
  * See more in http://patternfly-react.surge.sh/patternfly-3/

--- a/webpack/assets/javascripts/react_app/pages/HostWizardPage/HostWizard.js
+++ b/webpack/assets/javascripts/react_app/pages/HostWizardPage/HostWizard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Wizard, Button, Icon } from 'patternfly-react';
 import PageLayout from '../common/PageLayout/PageLayout';
+import { translate as __ } from '../../common/I18n';
 
 class LoadingWizardExample extends React.Component {
   constructor(props) {

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PageLayout from '../../../pages/common/PageLayout/PageLayout';
 import Statistics from './Statistics/Statistics';
+import { translate as __ } from '../../../common/I18n';
 
 const StatisticsPage = ({ statisticsMeta, ...props }) => (
   <PageLayout header={__('Statistics')} searchable={false}>

--- a/webpack/assets/javascripts/services/charts/ChartService.js
+++ b/webpack/assets/javascripts/services/charts/ChartService.js
@@ -80,9 +80,11 @@ export const getChartConfig = ({
       shortNames.forEach((name, i) => {
         const nameOfClass = name.replace(/\W/g, '-');
         const selector = `.c3-legend-item-${nameOfClass} > title`;
+        // eslint-disable-next-line no-undef
         const hasTooltip = d3.select(selector)[0][0];
 
         if (!hasTooltip) {
+          // eslint-disable-next-line no-undef
           d3.select(`.c3-legend-item-${nameOfClass}`)
             .append('svg:title')
             .text(longNames[i]);

--- a/webpack/assets/javascripts/spice.js
+++ b/webpack/assets/javascripts/spice.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import {
   SpiceMainConn,
   sendCtrlAltDel as _sendCtrlAltDel,


### PR DESCRIPTION
Now we can import translation functions directly from `i18n` module, no need to use global vars for it nor for jquery. 