### PR TITLE
Fixes #27363 - resource_pools cache key with cluster

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -160,9 +160,8 @@ module Foreman::Model
     end
 
     def resource_pools(opts = {})
-      cluster = cluster(opts[:cluster_id])
-      cache.cache(:resource_pools) do
-        name_sort(cluster.resource_pools.all(:accessible => true))
+      cache.cache(:"resource_pools-#{opts[:cluster_id]}") do
+        name_sort(cluster(opts[:cluster_id]).resource_pools.all(:accessible => true))
       end
     end
 


### PR DESCRIPTION
Resource pool uses general cache key without cluster component. What makes it cache the result from first cluster.