### PR TITLE
Fixes #27369 - fix jest when updating a package in foremanjs

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   transform: {
     '^.+\\.js$': 'babel-jest',
   },
-  moduleDirectories: ['node_modules'],
+  moduleDirectories: ['node_modules/@theforeman/vendor-core/node_modules', 'node_modules'],
   setupFiles: [
     'raf/polyfill',
     'jest-prop-type-error',


### PR DESCRIPTION
Jest  might use an outdated package when updating an npm package in `foreman-js` and linking it to foreman via `npm run forema-js:link` 