### PR TITLE
Fixes #27330 - center the dashboard grid

### DIFF
--- a/webpack/assets/javascripts/dashboard/gridster.scss
+++ b/webpack/assets/javascripts/dashboard/gridster.scss
@@ -5,6 +5,7 @@ $row-margin: 10px;
   padding-left: 0;
   list-style: none;
   max-width: 100%;
+  margin: 0 auto;
 
   @media (min-width: 992px) {
     @for $i from 1 through 12 {


### PR DESCRIPTION
The new vendor causes the dashboard grid to be aligned to the left.

The new vendor migrated gridster from:
https://github.com/ducksboard/gridster.js

to:
https://github.com/dsmorse/gridster.js

The older version last commit was 5 years ago, while this repository is well maintained.
There was an issue with the way the older version consumed `jquery`.