### PR TITLE
Fixes #27430: Allow for returning current user

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -37,6 +37,13 @@ module Api
       def show
       end
 
+      api :GET, "/current_user", N_("Show the currently logged-in user")
+
+      def show_current
+        @user = User.current
+        render :show
+      end
+
       def_param_group :user_params do
         param :login, String, :required => true
         param :firstname, String, :required => false

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -4,6 +4,7 @@ require_dependency 'foreman/access_control'
 Foreman::AccessControl.map do |permission_set|
   permission_set.security_block :public do |map|
     map.permission :user_logout, { :users => [:logout] }, :public => true
+    map.permission :view_current_user, { :"api/v2/users" => [:show_current] }, public: :true
     map.permission :my_account, { :users => [:edit],
       :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group ] }, :public => true
     map.permission :api_status, { :"api/v2/home" => [:status]}, :public => true

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -220,6 +220,7 @@ Foreman::Application.routes.draw do
 
       get '/', :to => 'home#index'
       get 'status', :to => 'home#status', :as => "v2_status"
+      get 'current_user', to: 'users#show_current', as: "current_user"
 
       resources :reports, :only => [:create]
 

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -48,6 +48,23 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     assert_not show_response.empty?
   end
 
+  test "should show current user" do
+    as_user(:one) do
+      get :show_current
+      assert_response :success
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal show_response['id'], users(:one).id
+    end
+  end
+
+  test "should not show current user when not logged in" do
+    User.current = nil
+    @request.session[:user] = nil
+    reset_api_credentials
+    get :show_current
+    assert_response :unauthorized
+  end
+
   test "shows default taxonomies on show response" do
     users(:one).update_attribute :locations, [taxonomies(:location1)]
     users(:one).update_attribute :default_location, taxonomies(:location1)


### PR DESCRIPTION
(Outdated)
* Add :id to scoped_search of User.
* Use the value_translation feature to allow for returning the current user.
Now, `GET /api/v2/users?search=id=current_user` will return the current user.

More info:
https://projects.theforeman.org/issues/27430