### PR TITLE
Fixes #27391 - spinner byte value initialization

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -565,6 +565,7 @@ function onHostEditLoad() {
   if ($('#supports_update') && !$('#supports_update').data('supports-update'))
     disable_vm_form_fields();
   pxeLoaderCompatibilityCheck();
+  tfm.numFields.initAll();
 }
 
 $(document).on('submit', "[data-submit='progress_bar']", function() {

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
-
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-2", :disabled => !new_vm if show_vm_name? %>
 
 <%= counter_f f, :cpus, :disabled => !new_vm, :label => _('CPUs'), :label_size => 'col-md-2', :'data-soft-max' => compute_resource.max_cpu_count %>

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
-
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-3" if show_vm_name? %>
 <% clusters = compute_resource.clusters %>
 <%= select_f f, :cluster, clusters, :id, :name, { },
@@ -38,13 +36,13 @@
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2" } if new_vm && controller_name != "compute_attributes" %>
 
 <%= f.fields_for :display, OpenStruct.new(f.object.display) do |display_f| %>
-  <%= select_f display_f, :type, compute_resource.display_types, :downcase, :upcase, 
+  <%= select_f display_f, :type, compute_resource.display_types, :downcase, :upcase,
                 { },
                 { :label_size => "col-md-2",
                   :label => _("Display Type"),
                   :class => 'display_type',
                   :disabled => f.object.status != "down" && !new_vm } %>
-  <%= select_f display_f, :keyboard_layout, compute_resource.keyboard_layouts, :downcase, :to_s, 
+  <%= select_f display_f, :keyboard_layout, compute_resource.keyboard_layouts, :downcase, :to_s,
                 { },
                 { :label_size => "col-md-2",
                   :label => _("Keyboard"),


### PR DESCRIPTION
Fixes issue with byte spinner for libvirt and ovirt.

On form ajax load, the spinner is not initialized. This is far safer and it should not be a performance concern. I believe this should be backported and for 1.24 we should switch to React implementation.

It fixes the issue on edit form, not for host edit though, as #6258 disabled the initialization for disabled fields. So we see:
![uninitialized_spinner](https://user-images.githubusercontent.com/2884324/61860874-fd6e4580-aeca-11e9-8fba-1682ff872e47.png)
I would rather see the arrows, than this value, so I offer a revert for byte, but I would appreciate ACK