### PR TITLE
Fixes #27453 - Make smart_proxy_id a parameter

### DIFF
--- a/app/controllers/api/v2/autosign_controller.rb
+++ b/app/controllers/api/v2/autosign_controller.rb
@@ -3,7 +3,7 @@ module Api
     class AutosignController < V2::BaseController
       before_action :find_required_nested_object, :setup_proxy
 
-      api :GET, "/smart_proxies/smart_proxy_id/autosign", N_("List all autosign entries")
+      api :GET, "/smart_proxies/:smart_proxy_id/autosign", N_("List all autosign entries")
 
       def index
         autosign = @api.autosign


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Apypie should be able to find smart_proxy_id as a parameter with this fix.
