### PR TITLE
Fixes #27457 - Add support for react router in plugins

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
@@ -3,7 +3,7 @@ import { getSlotComponents } from '../../../../services/SlotsRegistry';
 export const selectComponentByWeight = slotId =>
   getSlotComponents(slotId)
     .sort((a, b) => b.weight - a.weight)
-    .map(c => c.component);
+    .map(c => c.component) || {};
 
 export const selectMaxComponent = slotId => selectComponentByWeight(slotId)[0];
 

--- a/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/ForemanSwitcher.js
+++ b/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/ForemanSwitcher.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { fallbackRoute, renderRoute } from '../RoutingService';
+
+const ForemanSwitcher = ({ routes }) => (
+  <Switch>
+    {routes}
+    <Route
+      render={child => renderRoute(null, child, fallbackRoute)}
+      key="default-route"
+    />
+  </Switch>
+);
+
+ForemanSwitcher.propTypes = {
+  routes: PropTypes.arrayOf(PropTypes.node).isRequired,
+};
+
+export default ForemanSwitcher;

--- a/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/index.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+import ForemanSwitcher from './ForemanSwitcher';
+import { selectRoutes } from '../RouterSelector';
+
+const ConnectedForemanSwitcher = ({ children: coreRoutes }) => {
+  const routes = useSelector(() => selectRoutes(coreRoutes), shallowEqual);
+
+  return <ForemanSwitcher routes={routes} />;
+};
+
+ConnectedForemanSwitcher.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node).isRequired,
+};
+
+export default ConnectedForemanSwitcher;

--- a/webpack/assets/javascripts/react_app/routes/RouterSelector.js
+++ b/webpack/assets/javascripts/react_app/routes/RouterSelector.js
@@ -1,6 +1,10 @@
+import { selectComponentByWeight } from '../components/common/Slot/SlotSelectors';
+
 export const selectRouter = state => state.router;
 export const selectRouterLocation = state => selectRouter(state).location;
 export const selectRouterPath = state => selectRouterLocation(state).pathname;
 export const selectRouterSearch = state => selectRouterLocation(state).search;
 export const selectRouterHash = state => selectRouterLocation(state).hash;
 export const selectLastHistoryAction = state => selectRouter(state).action;
+export const selectRoutes = coreRoutes =>
+  coreRoutes.concat(selectComponentByWeight('routes'));

--- a/webpack/assets/javascripts/react_app/routes/RoutingService.js
+++ b/webpack/assets/javascripts/react_app/routes/RoutingService.js
@@ -1,0 +1,67 @@
+import { Route } from 'react-router-dom';
+import React from 'react';
+import { visit } from '../../foreman_navigation';
+import { addGlobalFill } from '../components/common/Fill/GlobalFill';
+
+let currentPath = window.location.href;
+
+/**
+ * Adds a plugin's routes into core
+ * @param  {String} id  plugin's id - can be its name
+ * @param  {Array}   routes an array that contains a plugin's routes
+ */
+export const registerRoutes = (id, routes) =>
+  routes.map(
+    ({ render, path, beforeRendering = undefined, ...routeProps }, index) =>
+      addGlobalFill(
+        'routes',
+        `${id}-${index}`,
+        <Route
+          path={path}
+          key={path}
+          {...routeProps}
+          render={renderProps =>
+            renderRoute(render, renderProps, beforeRendering)
+          }
+        />
+      )
+  );
+
+/**
+ * a Helper function for rendering a route
+ * @param {Function} renderFn - a component's rendering function
+ * @param {Object} props - routing props
+ * @param {Function} beforeRenderingCallback - a callback to run before the rendering, if it returns false the rendering will terminate
+ */
+export const renderRoute = (
+  renderFn,
+  props,
+  beforeRenderingCallback = () => true
+) => {
+  const {
+    location,
+    location: { pathname, search },
+  } = props;
+  if (!beforeRenderingCallback(location)) return null;
+  removeRailsContent();
+  location && updatePath(`${pathname}${search}`);
+  return renderFn(props);
+};
+
+export const fallbackRoute = () => {
+  const nextPath = window.location.href;
+  if (currentPath !== nextPath) {
+    updatePath(nextPath);
+    return visit(nextPath);
+  }
+  return null;
+};
+
+const updatePath = newPath => {
+  if (newPath) currentPath = newPath;
+};
+
+const removeRailsContent = () => {
+  const railsContainer = document.getElementById('rails-app-content');
+  if (railsContainer) railsContainer.remove();
+};

--- a/webpack/assets/javascripts/react_app/routes/__test__/ForemanSwitcher.test.js
+++ b/webpack/assets/javascripts/react_app/routes/__test__/ForemanSwitcher.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import ForemanSwitcher from '../ForemanSwitcher/ForemanSwitcher';
+
+const routes = {
+  routes: [<Route key="1" path="/path1" />, <Route key="2" path="path2" />],
+};
+
+const fixtures = {
+  'renders ForemanSwitcher with routes': routes,
+};
+describe('ForemanSwitcher', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(ForemanSwitcher, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/__test__/Routes.fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/__test__/Routes.fixtures.js
@@ -1,0 +1,4 @@
+export const routes = [
+  { path: 'path1', render: jest.fn() },
+  { path: 'path12', render: jest.fn() },
+];

--- a/webpack/assets/javascripts/react_app/routes/__test__/RoutingService.test.js
+++ b/webpack/assets/javascripts/react_app/routes/__test__/RoutingService.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderRoute, registerRoutes } from '../RoutingService';
+import { routes } from './Routes.fixtures';
+import store from '../../redux';
+
+jest.unmock('../../redux');
+jest.unmock('../RoutingService');
+
+const props = { location: { pathname: '/test' } };
+const renderFn = () => <div> Test </div>;
+const callback = location => location.pathname === '/test';
+const falseCallback = () => false;
+
+describe('Routing Service', () => {
+  it('rendering a route without a callback', () => {
+    expect(renderRoute(renderFn, props)).toMatchSnapshot();
+  });
+  it('rendering a route with a callback', () => {
+    expect(renderRoute(renderFn, props, callback)).toMatchSnapshot();
+  });
+  it('rendering a route with a falsy callback', () => {
+    expect(renderRoute(renderFn, props, falseCallback)).toMatchSnapshot();
+  });
+});
+
+describe('PluginRoutes', () => {
+  describe('rendering', () => {
+    it('Adding global routes', () => {
+      registerRoutes('some-id', routes);
+      expect(store.getState().extendable).toMatchSnapshot();
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/ForemanSwitcher.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/ForemanSwitcher.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanSwitcher rendering renders ForemanSwitcher with routes 1`] = `
+<Switch>
+  <Route
+    key="1"
+    path="/path1"
+  />
+  <Route
+    key="2"
+    path="path2"
+  />
+  <Route
+    key="default-route"
+    render={[Function]}
+  />
+</Switch>
+`;

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/RoutingService.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/RoutingService.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginRoutes rendering Adding global routes 1`] = `
+Object {
+  "routes": Object {
+    "some-id-0": undefined,
+    "some-id-1": undefined,
+  },
+}
+`;
+
+exports[`Routing Service rendering a route with a callback 1`] = `
+<div>
+   Test 
+</div>
+`;
+
+exports[`Routing Service rendering a route with a falsy callback 1`] = `null`;
+
+exports[`Routing Service rendering a route without a callback 1`] = `
+<div>
+   Test 
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -1,53 +1,22 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { routes } from './routes';
-import { visit } from '../../foreman_navigation';
+import { renderRoute } from './RoutingService';
+import ForemanSwitch from './ForemanSwitcher';
 
-let currentPath = window.location.href;
-
-const AppSwitcher = props => {
-  const updateCurrentPath = nextPath => {
-    currentPath = nextPath;
-  };
-
-  const handleRailsContainer = () => {
-    const railsContainer = document.getElementById('rails-app-content');
-    if (railsContainer) railsContainer.remove();
-  };
-
-  const handleRoute = (Component, componentProps) => {
-    handleRailsContainer();
-    updateCurrentPath();
-    return <Component {...componentProps} />;
-  };
-
-  const handleFallbackRoute = () => {
-    const nextPath = window.location.href;
-    if (currentPath !== nextPath) {
-      updateCurrentPath(nextPath);
-      visit(nextPath);
-    }
-    return null;
-  };
-
-  return (
-    <React.Fragment>
-      <Switch>
-        {routes.map(({ render: Component, path, ...routeProps }) => (
-          <Route
-            path={path}
-            key={path}
-            {...routeProps}
-            render={componentProps => handleRoute(Component, componentProps)}
-          />
-        ))}
-        <Route render={handleFallbackRoute} />
-      </Switch>
-      {props.children}
-    </React.Fragment>
-  );
-};
+const AppSwitcher = () => (
+  <ForemanSwitch>
+    {routes.map(({ render, path, ...routeProps }) => (
+      <Route
+        path={path}
+        key={path}
+        {...routeProps}
+        render={renderProps => renderRoute(render, renderProps)}
+      />
+    ))}
+  </ForemanSwitch>
+);
 
 AppSwitcher.propTypes = {
   children: PropTypes.object,

--- a/webpack/assets/javascripts/services/SlotsRegistry/index.js
+++ b/webpack/assets/javascripts/services/SlotsRegistry/index.js
@@ -15,6 +15,6 @@ export const remove = (SlotId, fillId) => {
 };
 
 export const getSlotComponents = id =>
-  slotsRegistry[id] && Object.values(slotsRegistry[id]);
+  slotsRegistry[id] ? Object.values(slotsRegistry[id]) : [];
 
 export const getFillsFromSlot = slotId => slotsRegistry[slotId];

--- a/webpack/stories/docs/ClientRouting.mdx
+++ b/webpack/stories/docs/ClientRouting.mdx
@@ -1,0 +1,97 @@
+import { Meta } from '@theforeman/stories';
+
+<Meta
+  title="Introduction|Client Routing"
+  parameters={{
+    storyWeight: 150,
+  }}
+/>
+
+
+# Client Routing
+Foreman uses `react-router` for rendering react pages without full page reload,
+
+## Core
+In order to add a new route in foreman core, please follow these steps:
+
+1. Create a folder under `/react_app/routes` directory
+2. Create an index file and import the wanted component:
+
+```js
+import React from 'react';
+import Page1 from './page1';
+import { PAGE1_URL } from './constants';
+
+export default {
+  path: PAGE1_URL,
+  render: props => <Page1 {...props} />,
+};
+```
+3. import that index in `routes.js` file:
+```js
+// Other routes...
+import Page1 from './Page1';
+import Page2 from './Page2'
+
+export const routes = [Page1, Page2];
+```
+4. Add a route that point to this page in `routes.rb` :
+```ruby
+match 'page1' => 'react#index', :via => :get
+```
+
+## Plugins
+You can use `react-router` in your plugin as well with no boilerplate.
+
+### Register global routes file
+In the plugin registeration please add:
+``` ruby
+Foreman::Plugin.register :"<plugin-name>" do
+  register_global_js_file 'routes'
+  # some code
+end
+```
+This tells foreman core to load a `routes_index.js` file.
+
+### Register routes
+Create `routes_index.js` file under `webpack` directory:
+
+```js
+import { registerRoutes } from 'foremanReact/routes/RoutingService';
+import Routes from './Routes';
+
+registerRoutes('<plugin-name>', Routes);
+
+```
+
+### Creating the routes
+Create a `routes.js`:
+
+```js
+import React from 'react';
+import IndexPage from './IndexPage';
+import ShowPage from './ShowPage';
+
+const ForemanPluginRoutes = [
+  {
+    path: '/<plugin>/index',
+    exact: true,
+    render: props => <IndexPage {...props} />,
+  },
+  {
+    path: '/<plugin>/:id',
+    render: props => <ShowPage {...props} />,
+  },
+];
+
+export default ForemanPluginRoutes;
+
+```
+
+### Adding the routes in routes.rb
+The plugin needs to identify that a page should be loaded via react router.
+Doing so by updating the plugin's `routes.rb`:
+```ruby
+ match '/plugin_page' => '/react#index', :via => [:get]
+```
+This will use the react template in foreman core.

--- a/webpack/stories/docs/plugins.stories.mdx
+++ b/webpack/stories/docs/plugins.stories.mdx
@@ -112,3 +112,6 @@ You can make sure Webpack knows about your plugin by executing script `plugin_we
     }
 }
 ```
+# How to extend core functionaly 
+
+You can use [Slot&Fill](?selectedKind=Introduction&selectedStory=Slot%26Fill) to extend react components (See Slot&Fill section)


### PR DESCRIPTION
With this PR plugins can add routes to react-router via `addRoutes` function, this removes the need for root components in plugins.