### PR TITLE
Fixes #27442 - deprecation mysql warning

### DIFF
--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,1 +1,27 @@
 ActiveSupport::Deprecation.behavior = :silence if Rails.env.production?
+
+Foreman::Application.configure do |app|
+  config.after_initialize do
+    next if Foreman.in_rake?
+    next unless ActiveRecord::Base.connection.adapter_name.downcase.starts_with?('mysql')
+    blueprint = NotificationBlueprint.find_by_name('feature_deprecation')
+    next unless blueprint
+    message = UINotifications::StringParser.new(blueprint.message, {feature: 'MySQL as a backend database', version: '1.25'}).to_s
+    next if blueprint.notifications.where(message: message).any?
+    Notification.create!(
+      audience: Notification::AUDIENCE_ADMIN,
+      message: message,
+      notification_blueprint: blueprint,
+      initiator: User.anonymous_admin,
+      :actions => {
+        :links => [
+          {
+            :href => 'https://theforeman.org/2019/09/dropping-support-for-mysql.html',
+            :title => _('Further Information'),
+            :external => true,
+          },
+        ],
+      }
+    )
+  end
+end

--- a/db/seeds.d/170-notification_blueprints.rb
+++ b/db/seeds.d/170-notification_blueprints.rb
@@ -54,6 +54,13 @@ blueprints = [
     message: N_('The %{setting} setting has been deprecated and will be removed in version %{version}'),
     expires_in: 30.days,
   },
+  {
+    group: N_('Deprecations'),
+    name: 'feature_deprecation',
+    level: 'warning',
+    message: N_('Support for %{feature} has been deprecated and will be removed in version %{version}'),
+    expires_in: 30.days,
+  },
 ]
 
 blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }


### PR DESCRIPTION
A notification that warns about MySQL in a non-intrusive way similarly that we did for deprecated settings about a year ago.

Edit: Based off: https://github.com/theforeman/foreman/pull/6038/files