### PR TITLE
Fixes #27460 - Add comp_resource to hostgroup api

### DIFF
--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -6,7 +6,7 @@ extends "api/v2/smart_proxies/children_nodes"
 attributes :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name, :domain_id, :domain_name,
            :environment_id, :environment_name, :compute_profile_id, :compute_profile_name, :ancestry, :parent_id, :parent_name,
            :ptable_id, :ptable_name, :medium_id, :medium_name, :pxe_loader,
-           :subnet6_id, :subnet6_name,
+           :subnet6_id, :subnet6_name, :compute_resource_id, :compute_resource_name,
            :architecture_id, :architecture_name, :realm_id, :realm_name, :created_at, :updated_at
 
 if @parameters


### PR DESCRIPTION
The api/v2 response of hostgroup was missing informations of the
selected compute resource.

(cherry picked from commit bcbc930cec27c7af1c9f278c9a230175d4375438)

ping @tbrisker 
Did not know, what the protocol was for cherry-picking.