### PR TITLE
Fixes #27468 - change key_type to parameter_type in js

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -270,7 +270,7 @@ function keyTypeChange(item) {
 
 function mergeOverridesChanged(item) {
   var fields = $(item).closest('.fields');
-  var keyType = fields.find("[id$='_key_type']").val();
+  var keyType = fields.find("[id$='_parameter_type']").val();
   var avoidDuplicates = fields.find("[id$='_avoid_duplicates']");
   var mergeDefault = fields.find("[id$='_merge_default']");
   changeCheckboxEnabledStatus(


### PR DESCRIPTION
`key_type` was changed to `parameter_type` as part of adding types to global parameters.
