### PR TITLE
Fixes #27471 - Add export and documentation to page layout

### DIFF
--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,7 +1,6 @@
 <div id="audits_page"></div>
 <%= mount_react_component('AuditsPage', '#audits_page', {
     searchProps: get_search_props,
-    docURL: documentation_url('4.1.4Auditing'),
     audits: {audits: construct_additional_info(@audits)},
     pagination: react_pagination_props(@audits, "audits-pagination"),
     searchable: true

--- a/webpack/assets/javascripts/react_app/common/urlHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.js
@@ -1,4 +1,5 @@
 import URI from 'urijs';
+import packageJson from '../../../../../package.json';
 
 /**
  * Build a url from given controller, action and id
@@ -68,4 +69,24 @@ export const changeQuery = (newQuery, navigateTo, uri = getURI()) => {
   uri.setQuery(newQuery);
   if (navigateTo) navigateTo(uri.toString());
   else window.Turbolinks.visit(uri.toString());
+};
+
+export const foremanshortVersion = () =>
+  packageJson.version
+    .split('.')
+    .slice(0, 2)
+    .join('.');
+
+export const documentationURL = (section = '', options = {}) => {
+  const shortVersion = foremanshortVersion();
+  const rootUrl =
+    options.rootUrl ||
+    `https://theforeman.org/manuals/${shortVersion}/index.html#`;
+  if (!section) return rootUrl;
+  return rootUrl + section;
+};
+
+export const exportURL = () => {
+  const href = new URI(window.location.href);
+  return `${href.pathname()}${href.search()}.csv`;
 };

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.js
@@ -1,25 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from 'patternfly-react';
 import { translate as __ } from '../../common/I18n';
 
 import PageLayout from '../common/PageLayout/PageLayout';
 import AuditsList from '../../components/AuditsList';
 import Pagination from '../../components/Pagination/Pagination';
+import { documentationURL } from '../../common/urlHelpers';
 
 const AuditsPage = ({
-  data: { searchProps, docURL, audits, pagination, searchable },
+  data: { searchProps, audits, pagination, searchable },
 }) => (
   <PageLayout
     header={__('Audits')}
     searchable={searchable}
     searchProps={searchProps}
-    toolbarButtons={
-      <Button href={docURL} className="btn-docs">
-        <Icon type="pf" name="help" />
-        {` ${__('Documentation')}`}
-      </Button>
-    }
+    documentationURL={documentationURL('4.1.4Auditing')}
   >
     <div id="audit-list">
       <AuditsList data={audits} />
@@ -45,7 +40,6 @@ AuditsPage.propTypes = {
         query: PropTypes.string,
       }),
     }),
-    docURL: PropTypes.string,
     audits: PropTypes.shape({
       audits: PropTypes.array.isRequired,
     }).isRequired,

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.test.js
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/AuditsPage.test.js
@@ -12,11 +12,14 @@ const auditsPageFixtures = {
     data: {
       audits: AuditsProps,
       pagination: paginationMock.data,
-      docURL: '/url',
       searchable: true,
     },
   },
 };
+
+jest.mock('../../../../../../package.json', () => ({
+  version: '1.2.3.4',
+}));
 
 describe('AuditsPage', () => {
   describe('rendering', () =>

--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
@@ -5,6 +5,8 @@ exports[`AuditsPage rendering render audits page 1`] = `
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
+  documentationURL="https://theforeman.org/manuals/1.2/index.html#4.1.4Auditing"
+  exportURL=""
   header="Audits"
   onBookmarkClick={[Function]}
   onSearch={[Function]}
@@ -12,23 +14,6 @@ exports[`AuditsPage rendering render audits page 1`] = `
   searchQuery=""
   searchable={true}
   toastNotifications={null}
-  toolbarButtons={
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      className="btn-docs"
-      disabled={false}
-      href="/url"
-    >
-      <Icon
-        name="help"
-        type="pf"
-      />
-       Documentation
-    </Button>
-  }
 >
   <div
     id="audit-list"

--- a/webpack/assets/javascripts/react_app/pages/HostWizardPage/__snapshots__/HostWizard.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/HostWizardPage/__snapshots__/HostWizard.test.js.snap
@@ -5,6 +5,8 @@ exports[`HostWizard rendering renders LoginPage 1`] = `
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
+  documentationURL=""
+  exportURL=""
   header="Host Wizard"
   onBookmarkClick={[Function]}
   onSearch={[Function]}
@@ -12,7 +14,6 @@ exports[`HostWizard rendering renders LoginPage 1`] = `
   searchQuery=""
   searchable={false}
   toastNotifications={null}
-  toolbarButtons={null}
 >
   <Button
     active={false}

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
@@ -7,6 +7,10 @@ import { changeQuery } from '../../../common/urlHelpers';
 import ToastsList from '../../../components/ToastsList';
 import BreadcrumbBar from '../../../components/BreadcrumbBar';
 import SearchBar from '../../../components/SearchBar';
+import ExportButton from './components/ExportButton';
+import DocumentationButton from './components/DocumentationButton';
+import Slot from '../../../components/common/Slot';
+import Fill from '../../../components/common/Fill';
 
 const PageLayout = ({
   header,
@@ -17,9 +21,10 @@ const PageLayout = ({
   onBookmarkClick,
   customBreadcrumbs,
   breadcrumbOptions,
-  toolbarButtons,
   toastNotifications,
   beforeToolbarComponent,
+  exportURL,
+  documentationURL,
   children,
 }) => {
   updateDocumentTitle(header);
@@ -61,7 +66,29 @@ const PageLayout = ({
             )}
           </Col>
           <Col id="title_action" md={searchable ? 6 : 8}>
-            <div className="btn-toolbar pull-right">{toolbarButtons}</div>
+            <div className="btn-toolbar pull-right">
+              <Slot multi id="layout-toolbar-button" />
+              {exportURL && (
+                <Fill
+                  id="exportButton"
+                  slotId="layout-toolbar-button"
+                  weight={100}
+                  key="exportButton"
+                >
+                  <ExportButton url={exportURL} />
+                </Fill>
+              )}
+              {documentationURL && (
+                <Fill
+                  id="documentationButton"
+                  slotId="layout-toolbar-button"
+                  weight={200}
+                  key="documentationButton"
+                >
+                  <DocumentationButton url={documentationURL} />
+                </Fill>
+              )}
+            </div>
           </Col>
         </Row>
         {children}
@@ -112,12 +139,13 @@ PageLayout.propTypes = {
       })
     ),
   }),
-  toolbarButtons: PropTypes.node,
   toastNotifications: PropTypes.string,
   onSearch: PropTypes.func,
   onBookmarkClick: PropTypes.func,
   searchQuery: PropTypes.string,
   beforeToolbarComponent: PropTypes.node,
+  exportURL: PropTypes.string,
+  documentationURL: PropTypes.string,
 };
 
 PageLayout.defaultProps = {
@@ -126,12 +154,13 @@ PageLayout.defaultProps = {
   searchQuery: '',
   toastNotifications: null,
   customBreadcrumbs: null,
-  toolbarButtons: null,
   breadcrumbOptions: null,
   onSearch: searchQuery => changeQuery({ search: searchQuery.trim(), page: 1 }),
   onBookmarkClick: searchQuery =>
     changeQuery({ search: searchQuery.trim(), page: 1 }),
   beforeToolbarComponent: null,
+  exportURL: '',
+  documentationURL: '',
 };
 
 export default PageLayout;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
@@ -21,9 +21,13 @@ const pageLayoutFixtures = {
     ...pageLayoutMock,
     toolbarButtons: 'toolbarButton',
   },
-  'render pageLayout w/beforeToolbarComponent': {
+  'render pageLayout w/Export': {
     ...pageLayoutMock,
-    beforeToolbarComponent: 'beforeToolbarComponent',
+    exportURL: 'urlExport',
+  },
+  'render pageLayout w/Docs': {
+    ...pageLayoutMock,
+    documentationURL: 'documentationURL',
   },
 };
 

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render pageLayout w/beforeToolbarComponent 1`] = `
+exports[`render pageLayout w/Docs 1`] = `
 <div
   id="main"
 >
@@ -38,7 +38,6 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
         }
       />
     </div>
-    beforeToolbarComponent
     <Row
       bsClass="row"
       componentClass="div"
@@ -85,7 +84,132 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+          <Connect(Fill)
+            id="documentationButton"
+            key="documentationButton"
+            slotId="layout-toolbar-button"
+            weight={200}
+          >
+            <DocumentationButton
+              text="Documentation"
+              url="documentationURL"
+            />
+          </Connect(Fill)>
+        </div>
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
+exports[`render pageLayout w/Export 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="react-content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "id": "some-id",
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+            initialQuery=""
+            onBookmarkClick={[Function]}
+            onSearch={[Function]}
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+          <Connect(Fill)
+            id="exportButton"
+            key="exportButton"
+            slotId="layout-toolbar-button"
+            weight={100}
+          >
+            <ExportButton
+              text="Export"
+              title="Export to CSV"
+              url="urlExport"
+            />
+          </Connect(Fill)>
+        </div>
       </Col>
     </Row>
     body
@@ -177,7 +301,12 @@ exports[`render pageLayout w/search 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+        </div>
       </Col>
     </Row>
     body
@@ -275,7 +404,12 @@ exports[`render pageLayout w/toastNotifications 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+        </div>
       </Col>
     </Row>
     body
@@ -368,7 +502,10 @@ exports[`render pageLayout w/toolBar 1`] = `
         <div
           className="btn-toolbar pull-right"
         >
-          toolbarButton
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
         </div>
       </Col>
     </Row>
@@ -435,7 +572,12 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+        </div>
       </Col>
     </Row>
     body
@@ -509,7 +651,12 @@ exports[`render pageLayout without breadcrumbs 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+        </div>
       </Col>
     </Row>
     body
@@ -573,7 +720,12 @@ exports[`render pageLayout without search 1`] = `
       >
         <div
           className="btn-toolbar pull-right"
-        />
+        >
+          <Connect(Slot)
+            id="layout-toolbar-button"
+            multi={true}
+          />
+        </div>
       </Col>
     </Row>
     body

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/DocumentationButton.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/DocumentationButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Icon } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { translate as __ } from '../../../../common/I18n';
+
+const DocumentationButton = ({ url, text }) => (
+  <Button href={url} className="btn-docs">
+    <Icon type="pf" name="help" />
+    {` ${text}`}
+  </Button>
+);
+
+DocumentationButton.propTypes = {
+  url: PropTypes.string.isRequired,
+  text: PropTypes.string,
+};
+
+DocumentationButton.defaultProps = {
+  text: __('Documentation'),
+};
+
+export default DocumentationButton;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/DocumentationButton.test.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/DocumentationButton.test.js
@@ -1,0 +1,10 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import DocumentationButton from './DocumentationButton';
+
+const fixtures = {
+  'render with minimal props': { url: 'url' },
+};
+
+describe('DocumentationButton', () =>
+  testComponentSnapshotsWithFixtures(DocumentationButton, fixtures));

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/ExportButton.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/ExportButton.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { translate as __ } from '../../../../common/I18n';
+
+const ExportButton = ({ url, title, text }) => (
+  <Button className="export-csv" href={url} title={title}>
+    {text}
+  </Button>
+);
+
+ExportButton.propTypes = {
+  url: PropTypes.string,
+  title: PropTypes.string,
+  text: PropTypes.string,
+};
+
+ExportButton.defaultProps = {
+  url: '',
+  title: __('Export to CSV'),
+  text: __('Export'),
+};
+
+export default ExportButton;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/ExportButton.test.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/ExportButton.test.js
@@ -1,0 +1,10 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import ExportButton from './ExportButton';
+
+const fixtures = {
+  'render with minimal props': { url: 'url' },
+};
+
+describe('ExportButton', () =>
+  testComponentSnapshotsWithFixtures(ExportButton, fixtures));

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/__snapshots__/DocumentationButton.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/__snapshots__/DocumentationButton.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentationButton render with minimal props 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  className="btn-docs"
+  disabled={false}
+  href="url"
+>
+  <Icon
+    name="help"
+    type="pf"
+  />
+   Documentation
+</Button>
+`;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/__snapshots__/ExportButton.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/components/__snapshots__/ExportButton.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExportButton render with minimal props 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  className="export-csv"
+  disabled={false}
+  href="url"
+  title="Export to CSV"
+>
+  Export
+</Button>
+`;

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
@@ -5,6 +5,8 @@ exports[`StatisticsPage rendering render with props 1`] = `
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
+  documentationURL=""
+  exportURL=""
   header="Statistics"
   onBookmarkClick={[Function]}
   onSearch={[Function]}
@@ -12,7 +14,6 @@ exports[`StatisticsPage rendering render with props 1`] = `
   searchQuery=""
   searchable={false}
   toastNotifications={null}
-  toolbarButtons={null}
 >
   <Component
     getStatisticsMeta={[Function]}


### PR DESCRIPTION
Adds Option to add documentation button using `documentationURL` variable for the section and `isDocs` flag.
Adds Option to add documentation button using `isExport` flag export URL is generated from the current url + '.csv'
