### PR TITLE
Fixes #27472 - adds before toolbar to page layout

### DIFF
--- a/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/AuditsPage/__snapshots__/AuditsPage.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`AuditsPage rendering render audits page 1`] = `
 <PageLayout
+  beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
   header="Audits"

--- a/webpack/assets/javascripts/react_app/pages/HostWizardPage/__snapshots__/HostWizard.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/HostWizardPage/__snapshots__/HostWizard.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`HostWizard rendering renders LoginPage 1`] = `
 <PageLayout
+  beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
   header="Host Wizard"

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.js
@@ -19,6 +19,7 @@ const PageLayout = ({
   breadcrumbOptions,
   toolbarButtons,
   toastNotifications,
+  beforeToolbarComponent,
   children,
 }) => {
   updateDocumentTitle(header);
@@ -43,6 +44,7 @@ const PageLayout = ({
             ? { customBreadcrumbs }
             : breadcrumbOptions && <BreadcrumbBar data={breadcrumbOptions} />}
         </div>
+        {beforeToolbarComponent}
         <Row>
           <Col className="title_filter" md={searchable ? 6 : 4}>
             {searchable && (
@@ -115,6 +117,7 @@ PageLayout.propTypes = {
   onSearch: PropTypes.func,
   onBookmarkClick: PropTypes.func,
   searchQuery: PropTypes.string,
+  beforeToolbarComponent: PropTypes.node,
 };
 
 PageLayout.defaultProps = {
@@ -128,6 +131,7 @@ PageLayout.defaultProps = {
   onSearch: searchQuery => changeQuery({ search: searchQuery.trim(), page: 1 }),
   onBookmarkClick: searchQuery =>
     changeQuery({ search: searchQuery.trim(), page: 1 }),
+  beforeToolbarComponent: null,
 };
 
 export default PageLayout;

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/PageLayout.test.js
@@ -21,6 +21,10 @@ const pageLayoutFixtures = {
     ...pageLayoutMock,
     toolbarButtons: 'toolbarButton',
   },
+  'render pageLayout w/beforeToolbarComponent': {
+    ...pageLayoutMock,
+    beforeToolbarComponent: 'beforeToolbarComponent',
+  },
 };
 
 testComponentSnapshotsWithFixtures(PageLayout, pageLayoutFixtures);

--- a/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/pages/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -1,5 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`render pageLayout w/beforeToolbarComponent 1`] = `
+<div
+  id="main"
+>
+  <div
+    id="react-content"
+  >
+    <div
+      id="breadcrumb"
+    >
+      <Connect(BreadcrumbBar)
+        data={
+          Object {
+            "data": Object {
+              "breadcrumbItems": Array [
+                Object {
+                  "caption": "root",
+                  "url": "/some-url",
+                },
+                Object {
+                  "caption": "child with onClick",
+                  "onClick": [MockFunction],
+                },
+                Object {
+                  "caption": "active child",
+                },
+              ],
+              "isSwitchable": false,
+              "resource": Object {
+                "nameField": "name",
+                "resourceUrl": "some/url",
+                "switcherItemUrl": "some/url/:id",
+              },
+            },
+          }
+        }
+      />
+    </div>
+    beforeToolbarComponent
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        className="title_filter"
+        componentClass="div"
+        md={6}
+      >
+        <div
+          id="search-bar"
+        >
+          <Connect(SearchBar)
+            data={
+              Object {
+                "data": Object {
+                  "autocomplete": Object {
+                    "id": "some-id",
+                    "searchQuery": null,
+                    "url": "model/auto_complete_search",
+                    "useKeyShortcuts": true,
+                  },
+                  "bookmarks": Object {
+                    "canCreate": true,
+                    "documentationUrl": "/doc/url",
+                    "url": "/api/bookmarks",
+                  },
+                  "controller": "models",
+                },
+              }
+            }
+            initialQuery=""
+            onBookmarkClick={[Function]}
+            onSearch={[Function]}
+          />
+        </div>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        id="title_action"
+        md={6}
+      >
+        <div
+          className="btn-toolbar pull-right"
+        />
+      </Col>
+    </Row>
+    body
+  </div>
+</div>
+`;
+
 exports[`render pageLayout w/search 1`] = `
 <div
   id="main"

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`StatisticsPage rendering render with props 1`] = `
 <PageLayout
+  beforeToolbarComponent={null}
   breadcrumbOptions={null}
   customBreadcrumbs={null}
   header="Statistics"


### PR DESCRIPTION
There should be an option to add components in the page layout after the title and breadcrumbs but before the search bar and toolbar buttons.
equivalent to :before_search_bar in the .erb files.