### PR TITLE
Fixes #27500 - Use strings to register graphql types

### DIFF
--- a/app/registries/foreman/plugin/graphql_plugin_fields.rb
+++ b/app/registries/foreman/plugin/graphql_plugin_fields.rb
@@ -6,13 +6,13 @@ module Foreman
       module ClassMethods
         def realize_plugin_query_extensions(source = Foreman::Plugin.graphql_types_registry.plugin_query_fields)
           source.map do |plugin_type|
-            send plugin_type[:field_type], plugin_type[:field_name], plugin_type[:type]
+            send plugin_type[:field_type], plugin_type[:field_name], Foreman::Module.resolve(plugin_type[:type])
           end
         end
 
         def realize_plugin_mutation_extensions(source = Foreman::Plugin.graphql_types_registry.plugin_mutation_fields)
           source.map do |plugin_type|
-            send :field, plugin_type[:field_name], mutation: plugin_type[:mutation]
+            send :field, plugin_type[:field_name], mutation: Foreman::Module.resolve(plugin_type[:mutation])
           end
         end
       end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1931,8 +1931,8 @@ When you create a new graphql type in your plugin, you need to register it in yo
 
 [source, ruby]
 ....
-  register_graphql_query_field :duck, ::Types::Duck, :record_field
-  register_graphql_query_field :ducks, ::Types::Duck, :collection_field
+  register_graphql_query_field :duck, '::Types::Duck', :record_field
+  register_graphql_query_field :ducks, '::Types::Duck', :collection_field
 ....
 
 With the example above, server will know how to respond to `duck` and `ducks` queries. The first argument of `register_graphql_field` is query name, second is the type class and the third is whether the query is for a single record or a collection.
@@ -1941,7 +1941,7 @@ Similarly for mutations:
 
 [source, ruby]
 ....
-  register_graphql_mutation_field :delete_duck, ::Mutations::Ducks::Delete
+  register_graphql_mutation_field :delete_duck, '::Mutations::Ducks::Delete'
 ....
 
 where `::Mutations::Ducks::Delete` is your delete mutation class inheriting from `::Mutations::DeleteMutation`.

--- a/test/unit/foreman/plugin/graphql_plugin_fields_test.rb
+++ b/test/unit/foreman/plugin/graphql_plugin_fields_test.rb
@@ -33,7 +33,7 @@ class Foreman::Plugin::GraphqlPluginFieldsTest < ActiveSupport::TestCase
   describe 'graphql plugin query fields' do
     it 'adds a record field' do
       registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
-        reg.register_plugin_query_field :moo, Class, :record_field
+        reg.register_plugin_query_field :moo, 'Class', :record_field
       end
 
       klass = Class.new(GraphqlType)
@@ -49,7 +49,7 @@ class Foreman::Plugin::GraphqlPluginFieldsTest < ActiveSupport::TestCase
 
     it 'adds a collection field' do
       registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
-        reg.register_plugin_query_field :woof, Class, :collection_field
+        reg.register_plugin_query_field :woof, 'Class', :collection_field
       end
 
       klass = Class.new(GraphqlType)
@@ -67,7 +67,7 @@ class Foreman::Plugin::GraphqlPluginFieldsTest < ActiveSupport::TestCase
   describe 'graphql plugin mutation fields' do
     it 'adds a mutation field' do
       registry = Foreman::Plugin::GraphqlTypesRegistry.new.tap do |reg|
-        reg.register_plugin_mutation_field :quack, Class.new
+        reg.register_plugin_mutation_field :quack, 'Class'
       end
 
       klass = Class.new(GraphqlType)

--- a/test/unit/foreman/plugin/graphql_types_registry_test.rb
+++ b/test/unit/foreman/plugin/graphql_types_registry_test.rb
@@ -7,9 +7,6 @@ class Foreman::Plugin::GraphqlTypesRegistryTest < ActiveSupport::TestCase
     end
   end
 
-  class TestType
-  end
-
   let(:registry) { Foreman::Plugin::GraphqlTypesRegistry.new }
   let(:type_for_testing) { Class.new }
 
@@ -62,25 +59,25 @@ class Foreman::Plugin::GraphqlTypesRegistryTest < ActiveSupport::TestCase
     end
 
     it 'registers plugin query fields' do
-      registry.register_plugin_query_field :baz, TestType, :record_field
+      registry.register_plugin_query_field :baz, 'TestType', :record_field
       assert_equal 1, registry.plugin_query_fields.size
       assert_equal :baz, registry.plugin_query_fields.first[:field_name]
       assert_equal :record_field, registry.plugin_query_fields.first[:field_type]
-      assert_equal TestType, registry.plugin_query_fields.first[:type]
+      assert_equal 'TestType', registry.plugin_query_fields.first[:type]
     end
 
     it 'raises on invalid field type' do
       err = assert_raises RuntimeError do
-        registry.register_plugin_query_field :woof, TestType, :custom_field
+        registry.register_plugin_query_field :woof, 'TestType', :custom_field
       end
       assert_equal err.message, "expected :record_field or :collection_field as a field_type, got custom_field"
     end
 
     it 'registeres plugin mutation fields' do
-      registry.register_plugin_mutation_field :boom, TestType
+      registry.register_plugin_mutation_field :boom, 'TestType'
       assert_equal 1, registry.plugin_mutation_fields.size
       assert_equal :boom, registry.plugin_mutation_fields.first[:field_name]
-      assert_equal TestType, registry.plugin_mutation_fields.first[:mutation]
+      assert_equal 'TestType', registry.plugin_mutation_fields.first[:mutation]
     end
   end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
