### PR TITLE
Fixes #16818 - support slash in fact name

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -26,7 +26,7 @@ module FactValuesHelper
     if value_name != memo || value.compose
       parameters = { :parent_fact => memo }
       url = host_parent_fact_facts_path(parameters.merge({ :host_id => host_id || value.host.name }))
-      link_to(current_name, url,
+      link_to(current_name, url.gsub('%2F', '/'),
               :title => _("Show all %s children fact values") % memo)
     else
       link_to(current_name, fact_values_path(:search => "name = #{value_name}"),

--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -12,7 +12,7 @@ module FactValuesHelper
       memo = memo.empty? ? current_name : memo + FactName::SEPARATOR + current_name
       content_tag(:li) do
         if value.compose && current_name == name.split(FactName::SEPARATOR).last
-          url = host_parent_fact_facts_path(:parent_fact => value_name, :host_id => params[:host_id] || value.host.name)
+          url = url_with_parent(value_name, params[:host_id] || value.host.name)
           link_to(icon_text('angle-down', '', :kind => 'fa', :title => _('Expand nested items')), url) + ' ' + create_fact_name_link(parent, current_name, params[:host_id], value, value_name, memo)
         else
           create_fact_name_link(parent, current_name, params[:host_id], value, value_name, memo)
@@ -24,9 +24,8 @@ module FactValuesHelper
   def create_fact_name_link(parent, current_name, host_id, value, value_name, memo)
     return current_name if parent.present? && h(parent.name) == memo
     if value_name != memo || value.compose
-      parameters = { :parent_fact => memo }
-      url = host_parent_fact_facts_path(parameters.merge({ :host_id => host_id || value.host.name }))
-      link_to(current_name, url.gsub('%2F', '/'),
+      url = url_with_parent(memo, host_id || value.host.name)
+      link_to(current_name, url,
               :title => _("Show all %s children fact values") % memo)
     else
       link_to(current_name, fact_values_path(:search => "name = #{value_name}"),
@@ -83,5 +82,12 @@ module FactValuesHelper
 
   def print_escape_warning(column)
     fact_contains_escaped_values
+  end
+
+  private
+
+  def url_with_parent(parent, host_id)
+    opts = { parent_fact: parent, host_id: host_id }
+    host_parent_fact_facts_path(opts).gsub('%2F', '/')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,7 @@ Foreman::Application.routes.draw do
         resources :facts, :only => :index, :controller => :fact_values
         resources :puppetclasses, :only => :index
 
-        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\w.:_-]+/
+        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\/\w.:_-]+/
       end
     end
 

--- a/test/integration/fact_value_test.rb
+++ b/test/integration/fact_value_test.rb
@@ -3,7 +3,7 @@ require 'integration_test_helper'
 class ChildFactValueIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     @host = FactoryBot.create(:host)
-    @parent_name = FactoryBot.create(:fact_name, :compose => true)
+    @parent_name = FactoryBot.create(:fact_name, name: 'test/test', :compose => true)
     @parent_value = FactoryBot.create(:fact_value, :value => nil, :host => @host, :fact_name => @parent_name)
 
     @child_suffix = 'child'


### PR DESCRIPTION
Fixes a long standing Foreman issue (see redmine). Fact names can contain slashes (e.g. mountpoints). Our routes restrictions prohibited this in parent_fact identifier. Also the url helper returns the slash escaped so we need to unescape this for links to work. We don't want to unescape everything as there may be other properly escaped charaters, but we only need slahes.

In order to reproduce:
1) remove mountpoints from fact blacklist, go to settings, provisioning and remove mountpoints entry form "Exclude pattern for facts stored in foreman"
2) import puppet facts from some hosts
3) try to navigate to mountpoint fact for the host, you'll see 500 on unmatched route

with the fix
4) you will see the page rendered
5) links are also clickable (second part of the patch) and leading to children facts, without unescaping, user would get to 404