### PR TITLE
Fixes #27528 - reporting template input search type

### DIFF
--- a/webpack/assets/javascripts/foreman_template_inputs.js
+++ b/webpack/assets/javascripts/foreman_template_inputs.js
@@ -42,7 +42,7 @@ export const pollReportData = url => {
 export const inputValueOnchange = input => {
   const searchValue = input.value === 'search';
   const plainValue = input.value === 'plain';
-  const inputId = input.dataset.item;
+  const inputId = input.dataset.item || '';
 
   $(`.resource-type-${inputId}`).toggle(searchValue);
   $(`.input-options-${inputId}`).toggle(plainValue);


### PR DESCRIPTION
Rails nil to string is different than undefinte.toSring() so we are unable to find classes generated by `content_tag(:b, '', class: "name-#{item.id}", data: { item: item.id }`) as actual class is `name-`, but js is looking for `name-undefined` or `name-null`.

@amirfefer, could you take a look?
@tbrisker would it be ok to get it to 1.23, maybe even 1.22?