### PR TITLE
 Fixes #27534 - Allow migration of Dynflow data using prod2dev

### DIFF
--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -66,16 +66,44 @@ namespace :db do
   namespace :convert do
     desc 'Convert/import production data to development. Deletes ALL DATA in the development database. Assumes both schemas are already migrated.'
     task :prod2dev => :environment do
+      module ClassWorkarounds
+        def instance_method_already_implemented?(method_name)
+          # Some of Dynflow tables contain columns "class" and "frozen"
+          #   ActiveRecord doesn't like it so we tell it class and frozen? methods
+          #   are already defined and it shouldn't try to redefine them
+          return true if %w(class frozen?).include? method_name
+          super
+        end
+
+        # To actually read and write to the "class" column
+        #   helpers need to be defined
+        def override_attribute(new_name, column_name)
+          define_method new_name do
+            read_attribute column_name
+          end
+
+          define_method "#{new_name}=" do |value|
+            write_attribute column_name, value
+          end
+        end
+
+        def self.extended(other)
+          other.override_attribute(:class_attribute, :class)
+        end
+      end
+
       # We need unique classes so ActiveRecord can hash different connections
       # We do not want to use the real Model classes because any business
       # rules will likely get in the way of a database transfer
       class ProductionModelClass < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
         # disable STI
         self.inheritance_column = :_type_disabled
+        extend ClassWorkarounds
       end
       class DevelopmentModelClass < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
         # disable STI
         self.inheritance_column = :_type_disabled
+        extend ClassWorkarounds
       end
 
       ActiveRecord::Base.establish_connection(:production)
@@ -110,6 +138,8 @@ namespace :db do
             ProductionModelClass.primary_key = nil
           end
 
+          has_class_attribute = ProductionModelClass.column_names.include?('class')
+
           # Page through the data in case the table is too large to fit in RAM
           offset = count = 0
           print "Converting #{table_name}..."
@@ -137,6 +167,7 @@ namespace :db do
                 # as these columns are DEFAULT NOT NULL
                 new_model[:created_at] ||= time if new_model.attributes.include?('created_at')
                 new_model[:updated_at] ||= time if new_model.attributes.include?('updated_at')
+                new_model.class_attribute = model.class_attribute if has_class_attribute
 
                 new_model.save(:validate => false)
               end

--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -66,6 +66,12 @@ namespace :db do
   namespace :convert do
     desc 'Convert/import production data to development. Deletes ALL DATA in the development database. Assumes both schemas are already migrated.'
     task :prod2dev => :environment do
+      # dynflow:migrate migrates the db configured for the current rails env
+      # In this case, we need to make sure it migrates development
+      env_bak = ::Rails.env
+      Rake::Task['dynflow:migrate'].invoke
+      ::Rails.env = env_bak
+
       module ClassWorkarounds
         def instance_method_already_implemented?(method_name)
           # Some of Dynflow tables contain columns "class" and "frozen"

--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -69,6 +69,7 @@ namespace :db do
       # dynflow:migrate migrates the db configured for the current rails env
       # In this case, we need to make sure it migrates development
       env_bak = ::Rails.env
+      ::Rails.env = 'development'
       Rake::Task['dynflow:migrate'].invoke
       ::Rails.env = env_bak
 

--- a/lib/tasks/dynflow.rake
+++ b/lib/tasks/dynflow.rake
@@ -10,4 +10,11 @@ END_DESC
   task :executor => :environment do
     Dynflow::Rails::Daemon.new.run
   end
+
+  task :migrate => :environment do
+    world = OpenStruct.new(:config => OpenStruct.new(:queues => {}))
+    config = Dynflow::Rails::Configuration.new
+    # Persistence initialization automatically migrates the db
+    config.send(:initialize_persistence, world)
+  end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

This needs the user to run `rake dynflow:migrate` against the target db before running `prod2dev`.