### PR TITLE
Fixes #27544 - Add parameter_type and hidden_value to host/hostgroup API

### DIFF
--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -56,6 +56,8 @@ module Api
           param :group_parameters_attributes, Array, :required => false, :desc => N_("Array of parameters") do
             param :name, String, :desc => N_("Name of the parameter"), :required => true
             param :value, String, :desc => N_("Parameter value"), :required => true
+            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value"), :required => true
+            param :hidden_value, :bool
           end
           Hostgroup.registered_smart_proxies.each do |name, options|
             param :"#{name}_id", :number, :desc => options[:api_description]

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -100,6 +100,8 @@ module Api
           param :host_parameters_attributes, Array, :desc => N_("Host's parameters (array or indexed hash)") do
             param :name, String, :desc => N_("Name of the parameter"), :required => true
             param :value, String, :desc => N_("Parameter value"), :required => true
+            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value"), :required => true
+            param :hidden_value, :bool
           end
           param :build, :bool
           param :enabled, :bool, :desc => N_("Include this host within Foreman reporting")

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -221,7 +221,30 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_not_empty JSON.parse(response.body)['parameters']
   end
 
+  context 'parameters type' do
+    test "should create a group parameter with parameter type" do
+      hostgroup_params = [{:name => "foo", :value => 42, :parameter_type => 'integer'}]
+      post :create, params: { hostgroup: valid_attrs.merge(parameters: hostgroup_params) }
+      assert_response :success
+    end
+
+    test "should show a group parameter with parameter type" do
+      hostgroup = FactoryBot.create(:hostgroup)
+      hostgroup.group_parameters.create!(:name => "foo", :value => 42, :parameter_type => 'integer')
+      get :show, params: { :id => hostgroup.id }
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 42, show_response['parameters'].first['value'].to_i
+      assert_equal 'integer', show_response['parameters'].first['parameter_type']
+    end
+  end
+
   context 'hidden parameters' do
+    test "should create a group parameter with hidden_value" do
+      hostgroup_params = [{:name => "foo", :value => "bar", :hidden_value => true}]
+      post :create, params: { hostgroup: valid_attrs.merge(parameters: hostgroup_params) }
+      assert_response :success
+    end
+
     test "should show a group parameter as hidden unless show_hidden_parameters is true" do
       hostgroup = FactoryBot.create(:hostgroup)
       hostgroup.group_parameters.create!(:name => "foo", :value => "bar", :hidden_value => true)

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -978,7 +978,32 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal host.puppetclasses.first.name, puppet_class
   end
 
+  context 'parameters type' do
+    test "should create an host parameter with parameter type" do
+      host = FactoryBot.build(:host)
+      host_params = [{:name => "foo", :value => 42, :parameter_type => 'integer'}]
+      post :create, params: { host: host.attributes.merge(parameters: host_params) }
+      assert_response :success
+    end
+
+    test "should show an host parameter with parameter type" do
+      host = FactoryBot.create(:host)
+      host.host_parameters.create!(:name => "foo", :value => 42, :parameter_type => 'integer')
+      get :show, params: { :id => host.id }
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 42, show_response['parameters'].first['value'].to_i
+      assert_equal 'integer', show_response['parameters'].first['parameter_type']
+    end
+  end
+
   context 'hidden parameters' do
+    test "should create an host parameter with hidden_value" do
+      host = FactoryBot.build(:host)
+      host_params = [{:name => "foo", :value => "bar", :hidden_value => true}]
+      post :create, params: { host: host.attributes.merge(parameters: host_params) }
+      assert_response :success
+    end
+
     test "should show a host parameter as hidden unless show_hidden_parameters is true" do
       host = FactoryBot.create(:host)
       host.host_parameters.create!(:name => "foo", :value => "bar", :hidden_value => true)


### PR DESCRIPTION
API endpoints for host/hostgroups already show hidden_value and parameter_type didn't accept it when create/update host/hostgroup
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
