### PR TITLE
Fixes #27549 - Do not show encrypted setting in webui in clear

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -20,7 +20,7 @@ module SettingsHelper
     when "array"
       "[ " + setting.value.join(", ") + " ]"
     else
-      setting.value
+      setting.safe_value
     end
   rescue
     setting.value

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -6,6 +6,7 @@ class Setting < ApplicationRecord
   friendly_id :name
   include ActiveModel::Validations
   include EncryptValue
+  include HiddenValue
   self.inheritance_column = 'category'
 
   TYPES = %w{integer boolean hash array string}
@@ -315,6 +316,10 @@ class Setting < ApplicationRecord
     else
       !default.nil?
     end
+  end
+
+  def hidden_value?
+    encrypted
   end
 
   private

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -78,6 +78,11 @@ class SettingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_should_hide_value_if_encrypted
+    setting = Setting.create(name: 'encrypted', value: 'clear', encrypted: true)
+    assert_equal '*****', setting.safe_value
+  end
+
   def test_should_provide_default_if_no_value_defined
     assert Setting.create(:name => "foo", :default => 5, :description => "test foo")
     assert_equal 5, Setting["foo"]


### PR DESCRIPTION
This reuses the HiddenValue module and shows only asterisks instead of
the full value for encrypted settings.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
