### PR TITLE
Fixes #27556 - API errors as warning or higher

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -126,7 +126,7 @@ module Api
 
     def service_unavailable(exception = nil)
       logger.debug "service unavailable: #{exception}" if exception
-      render_message(exception.message, :status => :service_unavailable)
+      render_exception(exception, :status => :service_unavailable)
     end
 
     def process_resource_error(options = { })
@@ -159,6 +159,11 @@ module Api
     def render_message(msg, render_options = {})
       render_options[:json] = { :message => msg }
       render render_options
+    end
+
+    def render_exception(exception, render_options = {})
+      Foreman::Logging.exception(exception.to_s, exception)
+      render_message(exception.to_s, render_options)
     end
 
     def log_resource_errors(resource)

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -71,7 +71,7 @@ module Api
         begin
           @compute_resource = ComputeResource.new_provider(compute_resource_params)
         rescue Foreman::Exception => e
-          render_message(e.message, :status => :unprocessable_entity)
+          render_exception(e, :status => :unprocessable_entity)
           return
         end
 

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -41,7 +41,7 @@ module Api
         @config_report = ConfigReport.import(params.to_unsafe_h[:config_report], detected_proxy.try(:id))
         process_response @config_report.errors.empty?
       rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        render_exception(e, :status => :unprocessable_entity)
       end
 
       api :DELETE, "/config_reports/:id/", N_("Delete a report")

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -292,7 +292,7 @@ Return the host's compute attributes that can be used to create a clone of this 
           render :json => { :error => _("Unknown device: available devices are %s") % valid_devices.join(', ') }, :status => :unprocessable_entity
         end
       rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        render_exception(e, :status => :unprocessable_entity)
       end
 
       api :POST, "/hosts/facts", N_("Upload facts for a host, creating the host if required")
@@ -306,7 +306,7 @@ Return the host's compute attributes that can be used to create a clone of this 
         state = @host.import_facts(params[:facts].to_unsafe_h, detected_proxy)
         process_response state
       rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        render_exception(e, :status => :unprocessable_entity)
       end
 
       api :PUT, "/hosts/:id/rebuild_config", N_("Rebuild orchestration config")

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -102,7 +102,7 @@ module Api
 
         render :json => @operatingsystem.pxe_files(medium_provider)
       rescue => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        render_exception(e, :status => :unprocessable_entity)
       end
 
       private

--- a/app/controllers/api/v2/reports_controller.rb
+++ b/app/controllers/api/v2/reports_controller.rb
@@ -40,7 +40,7 @@ module Api
         @report = resource_class.import(params.to_unsafe_h[:report], detected_proxy.try(:id))
         process_response @report.errors.empty?
       rescue ::Foreman::Exception => e
-        render_message(e.to_s, :status => :unprocessable_entity)
+        render_exception(e, :status => :unprocessable_entity)
       end
 
       api :DELETE, "/reports/:id/", N_("Delete a report")


### PR DESCRIPTION
Many error messages were swalowed, this fixes it and files them as
"warning" level. Also small change - backtraces are now in debug level
by default which seems to me as a good improvement - many error states
repeats over and over again and can easily flood production logs. We do
have ERF error codes to find what exception was thrown in the codebase:

https://projects.theforeman.org/projects/foreman/wiki/ErrorCodes