### PR TITLE
Fixes #27346 - show audit records for host create

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -125,11 +125,17 @@ module AuditExtensions
 
   module ClassMethods
     def main_objects
-      audited_classes.reject { |cl| cl.audited_options.key?(:associated_with) }
+      main_classes = audited_classes.reject { |cl| cl.audited_options.key?(:associated_with) }
+      main_classes.concat(non_abstract_parents(main_classes))
     end
 
     def main_object_names
       main_objects.map(&:name)
+    end
+
+    def non_abstract_parents(classes_list)
+      parents_list = classes_list.map(&:superclass).uniq
+      parents_list.select { |cl| !cl.abstract_class? && cl.table_exists? }.compact
     end
   end
 

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -299,4 +299,14 @@ class AuditExtensionsTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#main_object_names" do
+    test "should contain 'Host::Base' classname along with audited_classes" do
+      host = FactoryBot.create(:host, :managed, :with_auditing)
+      audit = host.audits.last
+      assert_equal 'create', audit.action
+      assert_equal 'Host::Base', audit.auditable_type
+      assert_include Audit.main_object_names, audit.auditable_type
+    end
+  end
 end


### PR DESCRIPTION
adding @ares, @tbrisker  in loop.

Instead of adding hard-coded list into main objects, I have considered parent classes which are not abstract and having DB table.